### PR TITLE
11: git-skara update should only rebuild if updates are found

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitSkara.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitSkara.java
@@ -80,23 +80,32 @@ public class GitSkara {
             System.exit(1);
         }
 
+        var head = repo.get().head();
+        System.out.print("Checking for updates ...");
         repo.get().pull();
+        var newHead = repo.get().head();
 
-        var cmd = new ArrayList<String>();
-        if (System.getProperty("os.name").toLowerCase().startsWith("win")) {
-            cmd.add("gradlew.bat");
+        if (!head.equals(newHead)) {
+            System.out.println("updates downloaded");
+            System.out.println("Rebuilding ...");
+            var cmd = new ArrayList<String>();
+            if (System.getProperty("os.name").toLowerCase().startsWith("win")) {
+                cmd.add("gradlew.bat");
+            } else {
+                cmd.addAll(List.of("sh", "gradlew"));
+            }
+
+            var pb = new ProcessBuilder(cmd);
+            pb.inheritIO();
+            pb.directory(parent.toFile());
+            var p = pb.start();
+            var res = p.waitFor();
+            if (res != 0) {
+                System.err.println("error: could not build Skara tooling");
+                System.exit(1);
+            }
         } else {
-            cmd.addAll(List.of("sh", "gradlew"));
-        }
-
-        var pb = new ProcessBuilder(cmd);
-        pb.inheritIO();
-        pb.directory(parent.toFile());
-        var p = pb.start();
-        var res = p.waitFor();
-        if (res != 0) {
-            System.err.println("error: could not build Skara tooling");
-            System.exit(1);
+            System.out.println("no updates found");
         }
     }
 


### PR DESCRIPTION
Hi,

this small patch ensures that we only rebuild the Skara tooling during `git skara update` if the tool actually pulled down some commits.

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)