### PR TITLE
14: Only use git.openjdk.java.net links in emails

### DIFF
--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunnerConfiguration.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunnerConfiguration.java
@@ -70,10 +70,17 @@ public class BotRunnerConfiguration {
                 } else {
                     uri = URIBuilder.base("https://github.com/").build();
                 }
+                URI webUri;
+                if (github.contains("weburl")) {
+                    webUri = URIBuilder.base(github.get("weburl").asString()).build();
+                } else {
+                    webUri = uri;
+                }
 
                 var keyFile = cwd.resolve(github.get("app").get("key").asString());
-                ret.put(entry.name(), HostFactory.createGitHubHost(uri, keyFile.toString(),
-                                                                   github.get("app").get("id").asString(), github.get("app").get("installation").asString()));
+                ret.put(entry.name(), HostFactory.createGitHubHost(uri, webUri, keyFile.toString(),
+                                                                   github.get("app").get("id").asString(),
+                                                                   github.get("app").get("installation").asString()));
             } else {
                 throw new ConfigurationError("Host " + entry.name());
             }

--- a/host/src/main/java/org/openjdk/skara/host/HostFactory.java
+++ b/host/src/main/java/org/openjdk/skara/host/HostFactory.java
@@ -28,9 +28,9 @@ import org.openjdk.skara.host.gitlab.GitLabHost;
 import java.net.URI;
 
 public class HostFactory {
-    public static Host createGitHubHost(URI uri, String keyFile, String issue, String id) {
+    public static Host createGitHubHost(URI uri, URI webUri, String keyFile, String issue, String id) {
         var app = new GitHubApplication(keyFile, issue, id);
-        return new GitHubHost(uri, app);
+        return new GitHubHost(uri, app, webUri);
     }
 
     public static Host createGitHubHost(URI uri, PersonalAccessToken pat) {

--- a/host/src/main/java/org/openjdk/skara/host/github/GitHubHost.java
+++ b/host/src/main/java/org/openjdk/skara/host/github/GitHubHost.java
@@ -32,12 +32,14 @@ import java.util.Arrays;
 
 public class GitHubHost implements Host {
     private final URI uri;
+    private final URI webUri;
     private final GitHubApplication application;
     private final PersonalAccessToken pat;
     private final RestRequest request;
 
-    public GitHubHost(URI uri, GitHubApplication application) {
+    public GitHubHost(URI uri, GitHubApplication application, URI webUri) {
         this.uri = uri;
+        this.webUri = webUri;
         this.application = application;
         this.pat = null;
 
@@ -54,6 +56,7 @@ public class GitHubHost implements Host {
 
     public GitHubHost(URI uri, PersonalAccessToken pat) {
         this.uri = uri;
+        this.webUri = uri;
         this.pat = pat;
         this.application = null;
 
@@ -68,6 +71,7 @@ public class GitHubHost implements Host {
 
     public GitHubHost(URI uri) {
         this.uri = uri;
+        this.webUri = uri;
         this.pat = null;
         this.application = null;
 
@@ -81,6 +85,10 @@ public class GitHubHost implements Host {
 
     public URI getURI() {
         return uri;
+    }
+
+    URI getWebURI() {
+        return webUri;
     }
 
     String getInstallationToken() {

--- a/host/src/main/java/org/openjdk/skara/host/github/GitHubRepository.java
+++ b/host/src/main/java/org/openjdk/skara/host/github/GitHubRepository.java
@@ -134,13 +134,13 @@ public class GitHubRepository implements HostedRepository {
 
     @Override
     public URI getWebUrl() {
-        return URIBuilder.base(gitHubHost.getURI())
+        return URIBuilder.base(gitHubHost.getWebURI())
                          .setPath("/" + repository)
                          .build();    }
 
     @Override
     public URI getWebUrl(Hash hash) {
-        return URIBuilder.base(gitHubHost.getURI())
+        return URIBuilder.base(gitHubHost.getWebURI())
                 .setPath("/" + repository + "/commit/" + hash.abbreviate())
                 .build();
     }

--- a/test/src/main/java/org/openjdk/skara/test/HostCredentials.java
+++ b/test/src/main/java/org/openjdk/skara/test/HostCredentials.java
@@ -67,6 +67,7 @@ public class HostCredentials implements AutoCloseable {
             var apps = config.get("apps").asArray();
             var key = configDir.resolve(apps.get(userIndex).get("key").asString());
             return HostFactory.createGitHubHost(hostUri,
+                                                hostUri,
                                                 key.toString(),
                                                 apps.get(userIndex).get("id").asString(),
                                                 apps.get(userIndex).get("installation").asString());


### PR DESCRIPTION
Hi all,

Please review the following change that makes it possible to configure an alternative base url to use when constructing web links for GitHub, which will allow us to use our host-neutral forwarder.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)