### PR TITLE
Ignore `path=` lines in git credential fill output.

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitCredentials.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitCredentials.java
@@ -97,6 +97,8 @@ class GitCredentials {
                     password = line.split("=")[1];
                 } else if (line.startsWith("protocol=")) {
                     protocol = line.split("=")[1];
+                } else if (line.startsWith("path=")) {
+                    // ignore for now
                 } else {
                     throw new IOException("'git credential' returned unexpected line: " + line);
                 }

--- a/cli/src/main/java/org/openjdk/skara/cli/GitFork.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitFork.java
@@ -124,10 +124,11 @@ public class GitFork {
             exit("Not a valid URI: " + uri);
         }
         final var hostName = uri.getHost();
+        final var fillPath = uri.getPath();
         final var protocol = uri.getScheme();
         final var token = System.getenv("GIT_TOKEN");
         final var username = arguments.contains("username") ? arguments.get("username").asString() : null;
-        final var credentials = GitCredentials.fill(hostName, username, token, protocol);
+        final var credentials = GitCredentials.fill(hostName, fillPath, username, token, protocol);
 
         if (credentials.password() == null) {
             exit("No token for host " + hostName + " found, use git-credentials or the environment variable GIT_TOKEN");

--- a/cli/src/main/java/org/openjdk/skara/cli/GitFork.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitFork.java
@@ -124,11 +124,11 @@ public class GitFork {
             exit("Not a valid URI: " + uri);
         }
         final var hostName = uri.getHost();
-        final var fillPath = uri.getPath();
+        var path = uri.getPath().substring(1); // trim leading '/'
         final var protocol = uri.getScheme();
         final var token = System.getenv("GIT_TOKEN");
         final var username = arguments.contains("username") ? arguments.get("username").asString() : null;
-        final var credentials = GitCredentials.fill(hostName, fillPath, username, token, protocol);
+        final var credentials = GitCredentials.fill(hostName, path, username, token, protocol);
 
         if (credentials.password() == null) {
             exit("No token for host " + hostName + " found, use git-credentials or the environment variable GIT_TOKEN");
@@ -139,7 +139,6 @@ public class GitFork {
         }
 
         var host = Host.from(uri, new PersonalAccessToken(credentials.username(), credentials.password()));
-        var path = uri.getPath().substring(1);
         if (path.endsWith(".git")) {
             path = path.substring(0, path.length() - 4);
         }

--- a/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
@@ -260,7 +260,7 @@ public class GitPr {
         var username = arguments.contains("username") ? arguments.get("username").asString() : null;
         var token = System.getenv("GIT_TOKEN");
         var uri = toURI(remotePullPath);
-        var credentials = GitCredentials.fill(uri.getHost(), username, token, uri.getScheme());
+        var credentials = GitCredentials.fill(uri.getHost(), uri.getPath(), username, token, uri.getScheme());
         var host = Host.from(uri, new PersonalAccessToken(credentials.username(), credentials.password()));
 
         var action = arguments.at(0).asString();

--- a/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
@@ -260,7 +260,7 @@ public class GitPr {
         var username = arguments.contains("username") ? arguments.get("username").asString() : null;
         var token = System.getenv("GIT_TOKEN");
         var uri = toURI(remotePullPath);
-        var credentials = GitCredentials.fill(uri.getHost(), uri.getPath(), username, token, uri.getScheme());
+        var credentials = GitCredentials.fill(uri.getHost(), uri.getPath().substring(1), username, token, uri.getScheme());
         var host = Host.from(uri, new PersonalAccessToken(credentials.username(), credentials.password()));
 
         var action = arguments.at(0).asString();

--- a/cli/src/main/java/org/openjdk/skara/cli/GitToken.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitToken.java
@@ -78,10 +78,10 @@ public class GitToken {
         var uri = arguments.at(1).via(URI::create);
 
         if (command.equals("store")) {
-            var credentials = GitCredentials.fill(uri.getHost(), null, null, uri.getScheme());
+            var credentials = GitCredentials.fill(uri.getHost(), uri.getPath(), null, null, uri.getScheme());
             GitCredentials.approve(credentials);
         } else if (command.equals("revoke")) {
-            var credentials = GitCredentials.fill(uri.getHost(), null, null, uri.getScheme());
+            var credentials = GitCredentials.fill(uri.getHost(), uri.getPath(), null, null, uri.getScheme());
             GitCredentials.reject(credentials);
         } else {
             exit("error: unknown command: " + command);

--- a/cli/src/main/java/org/openjdk/skara/cli/GitToken.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitToken.java
@@ -78,10 +78,10 @@ public class GitToken {
         var uri = arguments.at(1).via(URI::create);
 
         if (command.equals("store")) {
-            var credentials = GitCredentials.fill(uri.getHost(), uri.getPath(), null, null, uri.getScheme());
+            var credentials = GitCredentials.fill(uri.getHost(), uri.getPath().substring(1), null, null, uri.getScheme());
             GitCredentials.approve(credentials);
         } else if (command.equals("revoke")) {
-            var credentials = GitCredentials.fill(uri.getHost(), uri.getPath(), null, null, uri.getScheme());
+            var credentials = GitCredentials.fill(uri.getHost(), uri.getPath().substring(1), null, null, uri.getScheme());
             GitCredentials.reject(credentials);
         } else {
             exit("error: unknown command: " + command);


### PR DESCRIPTION
Hi,

I'm trying out skara, but when running `git fork https://github.com/openjdk/panama git-panama` I'm getting the following exception:

```
Exception in thread "main" java.io.IOException: 'git credential' returned unexpected line: path=
        at org.openjdk.skara.cli/org.openjdk.skara.cli.GitCredentials.fill(GitCredentials.java:101)
        at org.openjdk.skara.cli/org.openjdk.skara.cli.GitFork.main(GitFork.java:130)
        at org.openjdk.skara.cli/org.openjdk.skara.cli.GitSkara.main(GitSkara.java:130)
```

Looks like `path=` is not handled yet?

This PR adds some handling that ignores lines starting with `path=` for now, but maybe any unknown line should be ignored instead of throwing an exception, what do you think?
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)