### PR TITLE
19: Allow GitHub bots to use a PAT for authentication as well

### DIFF
--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunnerConfiguration.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunnerConfiguration.java
@@ -78,10 +78,15 @@ public class BotRunnerConfiguration {
                     webUriReplacement = github.get("weburl").get("replacement").asString();
                 }
 
-                var keyFile = cwd.resolve(github.get("app").get("key").asString());
-                ret.put(entry.name(), HostFactory.createGitHubHost(uri, webUriPattern, webUriReplacement, keyFile.toString(),
-                                                                   github.get("app").get("id").asString(),
-                                                                   github.get("app").get("installation").asString()));
+                if (github.contains("app")) {
+                    var keyFile = cwd.resolve(github.get("app").get("key").asString());
+                    ret.put(entry.name(), HostFactory.createGitHubHost(uri, webUriPattern, webUriReplacement, keyFile.toString(),
+                                                                       github.get("app").get("id").asString(),
+                                                                       github.get("app").get("installation").asString()));
+                } else {
+                    var pat = new PersonalAccessToken(github.get("username").asString(), github.get("pat").asString());
+                    ret.put(entry.name(), HostFactory.createGitHubHost(uri, pat));
+                }
             } else {
                 throw new ConfigurationError("Host " + entry.name());
             }


### PR DESCRIPTION
Hi all,

Please review the following change that allows configuration of GitHub bots to use either app or pat authentication. Normally app authentication should be used, but for certain cases (like pushing to a repository that should trigger pages rebuilds) app credentials cannot be used.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)