### PR TITLE
24: Allow lazy evaluation of the fullName field in HostUserDetails

### DIFF
--- a/host/src/main/java/org/openjdk/skara/host/HostUserDetails.java
+++ b/host/src/main/java/org/openjdk/skara/host/HostUserDetails.java
@@ -28,20 +28,18 @@ import java.util.function.Supplier;
 public class HostUserDetails {
     private final int id;
     private final String username;
-    private String name;
     private final Supplier<String> nameSupplier;
+    private String name;
 
     public HostUserDetails(int id, String username, String name) {
         this.id = id;
         this.username = username;
-        this.name = name;
-        this.nameSupplier = null;
+        this.nameSupplier = () -> name;
     }
 
     public HostUserDetails(int id, String username, Supplier<String> nameSupplier) {
         this.id = id;
         this.username = username;
-        this.name = null;
         this.nameSupplier = nameSupplier;
     }
 
@@ -75,7 +73,6 @@ public class HostUserDetails {
         if (name != null) {
             return name;
         }
-        assert nameSupplier != null;
         name = nameSupplier.get();
         return name;
     }

--- a/host/src/main/java/org/openjdk/skara/host/HostUserDetails.java
+++ b/host/src/main/java/org/openjdk/skara/host/HostUserDetails.java
@@ -23,16 +23,26 @@
 package org.openjdk.skara.host;
 
 import java.util.Objects;
+import java.util.function.Supplier;
 
 public class HostUserDetails {
-    private int id;
-    private String username;
+    private final int id;
+    private final String username;
     private String name;
+    private final Supplier<String> nameSupplier;
 
     public HostUserDetails(int id, String username, String name) {
         this.id = id;
         this.username = username;
         this.name = name;
+        this.nameSupplier = null;
+    }
+
+    public HostUserDetails(int id, String username, Supplier<String> nameSupplier) {
+        this.id = id;
+        this.username = username;
+        this.name = null;
+        this.nameSupplier = nameSupplier;
     }
 
     @Override
@@ -45,13 +55,12 @@ public class HostUserDetails {
         }
         HostUserDetails that = (HostUserDetails) o;
         return id == that.id &&
-                Objects.equals(username, that.username) &&
-                Objects.equals(name, that.name);
+                Objects.equals(username, that.username);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, username, name);
+        return Objects.hash(id, username);
     }
 
     public String id() {
@@ -63,6 +72,11 @@ public class HostUserDetails {
     }
 
     public String fullName() {
+        if (name != null) {
+            return name;
+        }
+        assert nameSupplier != null;
+        name = nameSupplier.get();
         return name;
     }
 

--- a/host/src/main/java/org/openjdk/skara/host/HostUserDetails.java
+++ b/host/src/main/java/org/openjdk/skara/host/HostUserDetails.java
@@ -70,10 +70,9 @@ public class HostUserDetails {
     }
 
     public String fullName() {
-        if (name != null) {
-            return name;
+        if (name == null) {
+            name = nameSupplier.get();
         }
-        name = nameSupplier.get();
         return name;
     }
 

--- a/host/src/main/java/org/openjdk/skara/host/github/GitHubRepository.java
+++ b/host/src/main/java/org/openjdk/skara/host/github/GitHubRepository.java
@@ -84,10 +84,11 @@ public class GitHubRepository implements HostedRepository {
         }
 
         var upstream = (GitHubRepository) target;
-        var namespace = host().getCurrentUserDetails().userName();
+        var user = host().getCurrentUserDetails().userName();
+        var namespace = user.endsWith("[bot]") ? "" : user + ":";
         var pr = upstream.request.post("pulls")
                                  .body("title", title)
-                                 .body("head", namespace + ":" + sourceRef)
+                                 .body("head", namespace + sourceRef)
                                  .body("base", targetRef)
                                  .body("body", String.join("\n", body))
                                  .execute();


### PR DESCRIPTION
Hi all,

Please review the following change that allows lazy evaluation of the fullName field in HostUserDetails. Most GitHub API calls only return the id and username, so to populate the full name we have to do a separate request. However, the full name is rarely used, so we can save a few API calls by only fetching it when needed.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)