### PR TITLE
Check if census endpoint is a URL before trying to parse it as a path.

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitJCheck.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitJCheck.java
@@ -34,10 +34,14 @@ import java.io.IOException;
 import java.net.*;
 import java.nio.file.*;
 import java.util.*;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.logging.Level;
 
 public class GitJCheck {
+
+    private static final Pattern urlPattern = Pattern.compile("^https?://.*", Pattern.CASE_INSENSITIVE);
+
     public static void main(String[] args) throws Exception {
         var flags = List.of(
             Option.shortcut("r")
@@ -156,7 +160,9 @@ public class GitJCheck {
                 return fallback;
             }
         });
-        var census = Files.exists(Path.of(endpoint)) ? Census.parse(Path.of(endpoint)) : Census.from(URI.create(endpoint));
+        var census = !isURL(endpoint)
+                ? Census.parse(Path.of(endpoint))
+                : Census.from(URI.create(endpoint));
         var isLocal = arguments.contains("local");
         if (!isLocal) {
             var lines = repo.config("jcheck.local");
@@ -171,5 +177,9 @@ public class GitJCheck {
                 error.accept(visitor);
             }
         }
+    }
+
+    private static boolean isURL(String pathOrURL) {
+        return urlPattern.matcher(pathOrURL).matches();
     }
 }

--- a/cli/src/main/java/org/openjdk/skara/cli/GitJCheck.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitJCheck.java
@@ -179,7 +179,7 @@ public class GitJCheck {
         }
     }
 
-    private static boolean isURL(String pathOrURL) {
-        return urlPattern.matcher(pathOrURL).matches();
+    private static boolean isURL(String s) {
+        return urlPattern.matcher(s).matches();
     }
 }


### PR DESCRIPTION
When running `git jcheck --local` I'm getting the following exception:

```
Exception in thread "main" java.nio.file.InvalidPathException: Illegal char <:> at index 5: https://openjdk.java.net/census.xml
        at java.base/sun.nio.fs.WindowsPathParser.normalize(WindowsPathParser.java:182)
        at java.base/sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:153)
        at java.base/sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:77)
        at java.base/sun.nio.fs.WindowsPath.parse(WindowsPath.java:92)
        at java.base/sun.nio.fs.WindowsFileSystem.getPath(WindowsFileSystem.java:229)
        at java.base/java.nio.file.Path.of(Path.java:147)
        at org.openjdk.skara.cli/org.openjdk.skara.cli.GitJCheck.main(GitJCheck.java:159)
        at org.openjdk.skara.cli/org.openjdk.skara.cli.GitSkara.main(GitSkara.java:130)
```

Looking into the source code this seems to be because the fallback endpoint for getting the OpenJDK census is used, a URL, which is not a valid path (at least not on Windows), so the check to see if we're dealing with a path or not fails when parsing the path.

This PR switches to a regular expression for checking whether the endpoint is a URL or not (by checking if it starts with `http(s)://`).
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)