### PR TITLE
28: JSON parser does not support empty objects or arrays with whitespace

### DIFF
--- a/json/src/main/java/org/openjdk/skara/json/JSONParser.java
+++ b/json/src/main/java/org/openjdk/skara/json/JSONParser.java
@@ -237,6 +237,7 @@ public class JSONParser {
         var list = new ArrayList<JSONValue>();
 
         advance(); // step beyond opening '['
+        consumeWhitespace();
         expectMoreInput(error);
 
         while (current() != ']') {
@@ -267,6 +268,7 @@ public class JSONParser {
         var map = new HashMap<String, JSONValue>();
 
         advance(); // step beyond opening '{'
+        consumeWhitespace();
         expectMoreInput(error);
 
         while (current() != '}') {

--- a/json/src/test/java/org/openjdk/skara/json/JSONParserTests.java
+++ b/json/src/test/java/org/openjdk/skara/json/JSONParserTests.java
@@ -486,4 +486,16 @@ public class JSONParserTests {
         var names = json.fields().stream().map(JSONObject.Field::name).collect(Collectors.toList());
         assertEquals(List.of("id", "type", "body"), names);
     }
+
+    @Test
+    public void testArrayWithWhitespace() {
+        var json = JSON.parse("{ \"foo\": [ ] }");
+        assertEquals(0, json.get("foo").asArray().size());
+    }
+
+    @Test
+    public void testObjectWithWhitespace() {
+        var json = JSON.parse("{ \"foo\": { } }");
+        assertEquals(0, json.get("foo").asObject().fields().size());
+    }
 }


### PR DESCRIPTION
Hi all,

this patch fixes the small issues that whitespace after `{` and `[` in the JSON parser isn't consumed. I also wrote two small unit tests, `sh gradlew test` now passes.

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)