### PR TITLE
29: ModulePlugin removes compiler options

### DIFF
--- a/buildSrc/module/src/main/java/org/openjdk/skara/gradle/module/ModulePlugin.java
+++ b/buildSrc/module/src/main/java/org/openjdk/skara/gradle/module/ModulePlugin.java
@@ -50,7 +50,7 @@ public class ModulePlugin implements Plugin<Project> {
                     var compileJavaTask = (JavaCompile) task;
                     compileJavaTask.doFirst(t -> {
                         var classpath = compileJavaTask.getClasspath().getAsPath();
-                        compileJavaTask.getOptions().setCompilerArgs(List.of("--module-path", classpath));
+                        compileJavaTask.getOptions().getCompilerArgs().addAll(List.of("--module-path", classpath));
                         compileJavaTask.setClasspath(project.files());
                     });
                 }


### PR DESCRIPTION
Hi all,

please review this small patch that ensures that the "module" Gradle plugin does not override the compiler arguments, but instead just add "--module-path".

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)