### PR TITLE
Put the credentials lock in the remote repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,11 @@ configure(subprojects.findAll() { it.name != 'bots' }) {
     test {
         useJUnitPlatform()
 
+        if (findProperty('credentials')) {
+            systemProperty "credentials", findProperty('credentials')
+            systemProperties(System.getProperties())
+        }
+
         testLogging {
             events "passed", "skipped", "failed"
         }

--- a/test/src/main/java/org/openjdk/skara/test/HostCredentials.java
+++ b/test/src/main/java/org/openjdk/skara/test/HostCredentials.java
@@ -214,7 +214,7 @@ public class HostCredentials implements AutoCloseable {
             localRepo.push(lockHash, repo.getUrl(), "testlock");
             log.info("Obtained credentials lock");
 
-            // If no exception occurs, we have obtained the lock
+            // If no exception occurs (such as the push fails), we have obtained the lock
             return true;
         }
     }
@@ -226,7 +226,7 @@ public class HostCredentials implements AutoCloseable {
             Repository localRepo;
             localRepo = Repository.materialize(repoFolder, repo.getUrl(), "testlock");
             localRepo.remove(lockFile);
-            var lockHash = localRepo.commit("Lock", "test", "test@test.test");
+            var lockHash = localRepo.commit("Unlock", "test", "test@test.test");
             localRepo.push(lockHash, repo.getUrl(), "testlock");
         }
     }


### PR DESCRIPTION
Hi all,

Please review the following change that puts the credentials lock (used when running integration tests) in the remote repository instead of a local file, to allow the tests to be launched from multiple hosts.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)