### PR TITLE
32: GitRepository::show does not work with executable files

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -629,11 +629,12 @@ public class GitRepository implements Repository {
         }
 
         var parts = entry.split(" ");
-        if (parts[0].equals("160000")) {
+        var mode = parts[0];
+        if (mode.equals("160000")) {
             // submodule
             var hashAndName = parts[2].split("\t");
             return Optional.of(("Subproject commit " + hashAndName[0]).getBytes(StandardCharsets.UTF_8));
-        } else if (parts[0].equals("100644")) {
+        } else if (mode.equals("100644") || mode.equals("100755")) {
             // blob
             var blobAndName = parts[2].split("\t");
             var blob = blobAndName[0];

--- a/webrev/src/main/java/org/openjdk/skara/webrev/ModifiedFileView.java
+++ b/webrev/src/main/java/org/openjdk/skara/webrev/ModifiedFileView.java
@@ -43,17 +43,30 @@ class ModifiedFileView implements FileView {
         this.navigation = navigation;
         if (patch.isTextual()) {
             binaryContent = null;
-            oldContent = repo.lines(patch.source().path().get(), base).orElseThrow(IllegalArgumentException::new);
+            oldContent = repo.lines(patch.source().path().get(), base).orElseThrow(() -> {
+                throw new IllegalArgumentException("Could not get content for file " +
+                                                   patch.source().path().get() +
+                                                   " at revision " + base);
+            });
             if (head == null) {
                 var path = repo.root().resolve(patch.target().path().get());
                 if (patch.target().type().get().isVCSLink()) {
-                    var content = repo.lines(patch.target().path().get(), repo.head()).orElseThrow(IllegalArgumentException::new);
+                    var tip = repo.head();
+                    var content = repo.lines(patch.target().path().get(), tip).orElseThrow(() -> {
+                        throw new IllegalArgumentException("Could not get content for file " +
+                                                           patch.target().path().get() +
+                                                           " at revision " + tip);
+                    });
                     newContent = List.of(content.get(0) + "-dirty");
                 } else {
                     newContent = Files.readAllLines(path);
                 }
             } else {
-                newContent = repo.lines(patch.target().path().get(), head).orElseThrow(IllegalArgumentException::new);
+                newContent = repo.lines(patch.target().path().get(), head).orElseThrow(() -> {
+                    throw new IllegalArgumentException("Could not get content for file " +
+                                                       patch.target().path().get() +
+                                                       " at revision " + head);
+                });
             }
             stats = new WebrevStats(patch.asTextualPatch().stats(), newContent.size());
         } else {
@@ -62,7 +75,11 @@ class ModifiedFileView implements FileView {
             if (head == null) {
                 binaryContent = Files.readAllBytes(repo.root().resolve(patch.target().path().get()));
             } else {
-                binaryContent = repo.show(patch.target().path().get(), head).orElseThrow(IllegalArgumentException::new);
+                binaryContent = repo.show(patch.target().path().get(), head).orElseThrow(() -> {
+                    throw new IllegalArgumentException("Could not get content for file " +
+                                                       patch.target().path().get() +
+                                                       " at revision " + head);
+                });
             }
             stats = WebrevStats.empty();
         }


### PR DESCRIPTION
Hi all,

this small patch fixes a bug that `GitRepository::show` did not work with executable files. I also added unit test for the scenario.

Testing: passes `sh gradlew test` on Linux x86-64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)