### PR TITLE
20: Do not send emails that a reviewer has added a comment

### DIFF
--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -765,6 +765,9 @@ class MailingListBridgeBotTests {
             // The archive should contain a note
             Repository.materialize(archiveFolder.path(), archive.getUrl(), "master");
             assertEquals(1, archiveContainsCount(archiveFolder.path(), "This PR has been reviewed.*more changes are needed"));
+            if (author.host().supportsReviewBody()) {
+                assertEquals(1, archiveContainsCount(archiveFolder.path(), "Reason 1"));
+            }
 
             // Then approve it
             reviewedPr.addReview(Review.Verdict.APPROVED, "Reason 2");
@@ -775,6 +778,9 @@ class MailingListBridgeBotTests {
             // The archive should contain another note
             Repository.materialize(archiveFolder.path(), archive.getUrl(), "master");
             assertEquals(1, archiveContainsCount(archiveFolder.path(), "This PR.*approved"));
+            if (author.host().supportsReviewBody()) {
+                assertEquals(1, archiveContainsCount(archiveFolder.path(), "Reason 2"));
+            }
 
             // Yet another change
             reviewedPr.addReview(Review.Verdict.DISAPPROVED, "Reason 3");
@@ -785,6 +791,9 @@ class MailingListBridgeBotTests {
             // The archive should contain another note
             Repository.materialize(archiveFolder.path(), archive.getUrl(), "master");
             assertEquals(2, archiveContainsCount(archiveFolder.path(), "This PR.*more changes"));
+            if (author.host().supportsReviewBody()) {
+                assertEquals(1, archiveContainsCount(archiveFolder.path(), "Reason 3"));
+            }
         }
     }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -454,8 +454,10 @@ class CheckRun {
             var statusMessage = getStatusMessage(activeReviews, visitor);
             var updatedBody = updateStatusMessage(statusMessage);
 
-            // Post / update approval messages
-            updateReviewedMessages(comments, allReviews);
+            // Post / update approval messages (only needed if the review itself can't contain a body)
+            if (!pr.repository().host().supportsReviewBody()) {
+                updateReviewedMessages(comments, allReviews);
+            }
 
             var commit = prInstance.localRepo().lookup(localHash).orElseThrow();
             var commitMessage = String.join("\n", commit.message());

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -32,6 +32,7 @@ import java.nio.file.Files;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 class CheckTests {
     @Test
@@ -375,6 +376,9 @@ class CheckTests {
              var tempFolder = new TemporaryDirectory()) {
             var author = credentials.getHostedRepository();
             var reviewer = credentials.getHostedRepository();
+
+            // This test is only relevant on hosts not supporting proper review comment bodies
+            assumeTrue(!author.host().supportsReviewBody());
 
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.host().getCurrentUserDetails().id())

--- a/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
@@ -425,7 +425,7 @@ public class GitPr {
             if (action.equals("integrate")) {
                 pr.addComment("/integrate");
             } else if (action.equals("approve")) {
-                pr.addReview(Review.Verdict.APPROVED);
+                pr.addReview(Review.Verdict.APPROVED, "Looks good!");
             } else {
                 throw new IllegalStateException("unexpected action: " + action);
             }

--- a/host/src/main/java/org/openjdk/skara/host/Host.java
+++ b/host/src/main/java/org/openjdk/skara/host/Host.java
@@ -29,6 +29,7 @@ public interface Host {
     HostedRepository getRepository(String name);
     HostUserDetails getUserDetails(String username);
     HostUserDetails getCurrentUserDetails();
+    boolean supportsReviewBody();
 
     static Host from(URI uri, PersonalAccessToken pat) {
         return HostFactory.createFromURI(uri, pat);

--- a/host/src/main/java/org/openjdk/skara/host/github/GitHubHost.java
+++ b/host/src/main/java/org/openjdk/skara/host/github/GitHubHost.java
@@ -178,4 +178,9 @@ public class GitHubHost implements Host {
         }
         return currentUser;
     }
+
+    @Override
+    public boolean supportsReviewBody() {
+        return true;
+    }
 }

--- a/host/src/main/java/org/openjdk/skara/host/gitlab/GitLabHost.java
+++ b/host/src/main/java/org/openjdk/skara/host/gitlab/GitLabHost.java
@@ -115,6 +115,12 @@ public class GitLabHost implements Host {
         return parseUserDetails(details);
     }
 
+    @Override
+    public boolean supportsReviewBody() {
+        // GitLab CE does not support this
+        return false;
+    }
+
     boolean isProjectForkComplete(String name) {
         var project = getProjectInfo(name);
         if (project.contains("import_status")) {

--- a/test/src/main/java/org/openjdk/skara/test/TestHost.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHost.java
@@ -105,6 +105,11 @@ public class TestHost implements Host {
         return data.users.get(currentUser);
     }
 
+    @Override
+    public boolean supportsReviewBody() {
+        return true;
+    }
+
     void close() {
         if (currentUser == 0) {
             data.folders.forEach(TemporaryDirectory::close);


### PR DESCRIPTION
Hi all,

Please review the following change that stops adding PR comments when a review is updated, if the host supports attaching comments directly to reviews (such as GitHub, but not GitLab CE).

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)