### PR TITLE
25: The GitHub parsePullRequestUrl method is not pattern aware

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ configure(subprojects.findAll() { it.name != 'bots' }) {
 
         if (findProperty('credentials')) {
             systemProperty "credentials", findProperty('credentials')
-            systemProperties(System.getProperties())
+            System.getProperties().findAll { it.key.toString().toLowerCase().contains('proxy') }.each { systemProperty it.key, it.value }
         }
 
         testLogging {

--- a/host/src/main/java/org/openjdk/skara/host/github/GitHubRepository.java
+++ b/host/src/main/java/org/openjdk/skara/host/github/GitHubRepository.java
@@ -54,9 +54,8 @@ public class GitHubRepository implements HostedRepository {
                 "Accept", "application/vnd.github.machine-man-preview+json",
                 "Accept", "application/vnd.github.antiope-preview+json"));
         json = gitHubHost.getProjectInfo(repository);
-        var urlPattern = URIBuilder.base(gitHubHost.getURI())
-                .setPath("/" + repository + "/pull/").build();
-        pullRequestPattern = Pattern.compile(urlPattern.toString() + "(\\d+)");
+        var urlPattern = gitHubHost.getWebURI("/" + repository + "/pull/").toString();
+        pullRequestPattern = Pattern.compile(urlPattern + "(\\d+)");
     }
 
     @Override


### PR DESCRIPTION
Hi all,

Please review the following change that uses the replacement pattern for PR links when parsing them as well.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)