### PR TITLE
37: Make mailing list bridge ready check configurable

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
@@ -545,10 +545,34 @@ class ArchiveWorkItem implements WorkItem {
 
         // First determine if this PR should be inspected further or not
         if (archiveMails.isEmpty()) {
-            // Wait until the PR is ready for review
-            if (!pr.getLabels().contains("rfr")) {
-                log.fine("PR is not yet ready for review");
-                return;
+            var labels = new HashSet<>(pr.getLabels());
+            for (var readyLabel : bot.readyLabels()) {
+                if (!labels.contains(readyLabel)) {
+                    log.fine("PR is not yet ready - missing label '" + readyLabel + "'");
+                    return;
+                }
+            }
+        }
+
+        // Also inspect comments before making the first post
+        var comments = pr.getComments();
+        if (archiveMails.isEmpty()) {
+            for (var readyComment : bot.readyComments().entrySet()) {
+                var commentFound = false;
+                for (var comment : comments) {
+                    if (comment.author().userName().equals(readyComment.getKey())) {
+                        var matcher = readyComment.getValue().matcher(comment.body());
+                        if (matcher.find()) {
+                            commentFound = true;
+                            break;
+                        }
+                    }
+                }
+                if (!commentFound) {
+                    log.fine("PR is not yet ready - missing ready comment from '" + readyComment.getKey() +
+                                     "containing '" + readyComment.getValue().pattern() + "'");
+                    return;
+                }
             }
         }
 
@@ -558,7 +582,6 @@ class ArchiveWorkItem implements WorkItem {
         var newMails = new ArrayList<Email>();
         var stableIdToMail = archiveMails.stream().collect(Collectors.toMap(email -> getStableMessageId(email.id()),
                                                                             Function.identity()));
-        var comments = pr.getComments();
         var prInstance = new PullRequestInstance(scratchPath.resolve("mlbridge-mergebase"), pr);
 
         // First post

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBot.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBot.java
@@ -30,6 +30,7 @@ import org.openjdk.skara.jcheck.JCheckConfiguration;
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.*;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class MailingListBridgeBot implements Bot {
@@ -41,11 +42,14 @@ public class MailingListBridgeBot implements Bot {
     private final URI listArchive;
     private final String smtpServer;
     private final WebrevStorage webrevStorage;
+    private final Set<String> readyLabels;
+    private final Map<String, Pattern> readyComments;
 
     MailingListBridgeBot(EmailAddress from, HostedRepository repo, HostedRepository archive, EmailAddress list,
                          Set<String> ignoredUsers, URI listArchive, String smtpServer,
                          HostedRepository webrevStorageRepository, String webrevStorageRef,
-                         Path webrevStorageBase, URI webrevStorageBaseUri) {
+                         Path webrevStorageBase, URI webrevStorageBaseUri, Set<String> readyLabels,
+                         Map<String, Pattern> readyComments) {
         emailAddress = from;
         codeRepo = repo;
         archiveRepo = archive;
@@ -53,14 +57,11 @@ public class MailingListBridgeBot implements Bot {
         this.ignoredUsers = ignoredUsers;
         this.listArchive = listArchive;
         this.smtpServer = smtpServer;
+        this.readyLabels = readyLabels;
+        this.readyComments = readyComments;
 
         this.webrevStorage = new WebrevStorage(webrevStorageRepository, webrevStorageRef, webrevStorageBase,
                                                webrevStorageBaseUri, from);
-    }
-
-    JCheckConfiguration configuration() {
-        var confFile = codeRepo.getFileContents(".jcheck/conf", "master");
-        return JCheckConfiguration.parse(confFile.lines().collect(Collectors.toList()));
     }
 
     HostedRepository codeRepo() {
@@ -93,6 +94,14 @@ public class MailingListBridgeBot implements Bot {
 
     WebrevStorage webrevStorage() {
         return webrevStorage;
+    }
+
+    Set<String> readyLabels() {
+        return readyLabels;
+    }
+
+    Map<String, Pattern> readyComments() {
+        return readyComments;
     }
 
     @Override

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBotTests.java
@@ -68,7 +68,8 @@ class MailingListArchiveReaderBotTests {
                                                  Set.of(ignored.host().getCurrentUserDetails().userName()),
                                                  listServer.getArchive(), listServer.getSMTP(),
                                                  archive, "webrev", Path.of("test"),
-                                                 URIBuilder.base("http://www.test.test/").build());
+                                                 URIBuilder.base("http://www.test.test/").build(),
+                                                 Set.of(), Map.of());
 
             // The mailing list as well
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP());
@@ -87,7 +88,6 @@ class MailingListArchiveReaderBotTests {
             localRepo.push(editHash, author.getUrl(), "edit", true);
             var pr = credentials.createPullRequest(archive, "master", "edit", "This is a pull request");
             pr.setBody("This should now be ready");
-            pr.addLabel("rfr");
 
             // Run an archive pass
             TestBotRunner.runPeriodicItems(mlBot);
@@ -129,7 +129,8 @@ class MailingListArchiveReaderBotTests {
                                                  Set.of(ignored.host().getCurrentUserDetails().userName()),
                                                  listServer.getArchive(), listServer.getSMTP(),
                                                  archive, "webrev", Path.of("test"),
-                                                 URIBuilder.base("http://www.test.test/").build());
+                                                 URIBuilder.base("http://www.test.test/").build(),
+                                                 Set.of(), Map.of());
 
             // The mailing list as well
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP());
@@ -148,7 +149,6 @@ class MailingListArchiveReaderBotTests {
             localRepo.push(editHash, author.getUrl(), "edit", true);
             var pr = credentials.createPullRequest(archive, "master", "edit", "This is a pull request");
             pr.setBody("This should now be ready");
-            pr.addLabel("rfr");
 
             // Run an archive pass
             TestBotRunner.runPeriodicItems(mlBot);


### PR DESCRIPTION
Hi all,

Please review the following change that removes the hardcoded check for the "rfr" label in the mailing list bridge bot, and instead makes it configurable.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)