### PR TITLE
18: The fetch command in RFR emails does not work

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/PullRequestInstance.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/PullRequestInstance.java
@@ -70,7 +70,7 @@ class PullRequestInstance {
     String fetchCommand() {
         var repoUrl = pr.repository().getUrl();
         return "git fetch " + repoUrl.getScheme() + "://" + repoUrl.getHost() + repoUrl.getPath() + " " +
-                headHash().abbreviate() + ":pr/" + pr.getId();
+                pr.getSourceRef() + ":pull/" + pr.getId();
     }
 
     @FunctionalInterface

--- a/host/src/main/java/org/openjdk/skara/host/github/GitHubPullRequest.java
+++ b/host/src/main/java/org/openjdk/skara/host/github/GitHubPullRequest.java
@@ -179,7 +179,7 @@ public class GitHubPullRequest implements PullRequest {
 
     @Override
     public String getSourceRef() {
-        return json.get("head").get("ref").asString();
+        return "pull/" + getId() + "/head";
     }
 
     @Override

--- a/host/src/main/java/org/openjdk/skara/host/gitlab/GitLabMergeRequest.java
+++ b/host/src/main/java/org/openjdk/skara/host/gitlab/GitLabMergeRequest.java
@@ -232,7 +232,7 @@ public class GitLabMergeRequest implements PullRequest {
 
     @Override
     public String getSourceRef() {
-        return json.get("source_branch").asString();
+        return "merge-requests/" + getId() + "/head";
     }
 
     @Override


### PR DESCRIPTION
Hi all,

Please review the following change that uses a proper ref in the fetch command sent in RFR emails.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)