### PR TITLE
27: Push notification email should contain ev. sponsor

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/MailingListUpdater.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/MailingListUpdater.java
@@ -60,6 +60,9 @@ public class MailingListUpdater implements UpdateConsumer {
 
         printer.println("Changeset: " + commit.hash().abbreviate());
         printer.println("Author:    " + commit.author().name() + " <" + commit.author().email() + ">");
+        if (!commit.author().equals(commit.committer())) {
+            printer.println("Committer: " + commit.committer().name() + " <" + commit.committer().email() + ">");
+        }
         printer.println("Date:      " + commit.date().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss +0000")));
         printer.println("URL:       " + repository.getWebUrl(commit.hash()));
         printer.println();

--- a/test/src/main/java/org/openjdk/skara/test/CheckableRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/CheckableRepository.java
@@ -96,6 +96,11 @@ public class CheckableRepository {
     }
 
     public static Hash appendAndCommit(Repository repo, String body, String message, String authorName, String authorEmail) throws IOException {
+        return appendAndCommit(repo, body, message, authorName, authorEmail, authorName, authorEmail);
+    }
+
+    public static Hash appendAndCommit(Repository repo, String body, String message, String authorName, String authorEmail,
+                                       String committerName, String committerEmail) throws IOException {
         var file = checkableFile(repo.root());
         try (var output = Files.newBufferedWriter(file, StandardOpenOption.APPEND)) {
             output.append(body);
@@ -103,7 +108,7 @@ public class CheckableRepository {
         }
         repo.add(file);
 
-        return repo.commit(message, authorName, authorEmail);
+        return repo.commit(message, authorName, authorEmail, committerName, committerEmail);
     }
 
     public static Hash replaceAndCommit(Repository repo, String body) throws IOException {


### PR DESCRIPTION
Hi all,

Please review the following change that adds information about sponsors to the commit notification emails.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)