### PR TITLE
39: Use the lastUpdated field of pull requests to avoid unnecessary polls

### DIFF
--- a/bots/submit/src/main/java/org/openjdk/skara/bots/submit/SubmitBot.java
+++ b/bots/submit/src/main/java/org/openjdk/skara/bots/submit/SubmitBot.java
@@ -23,7 +23,7 @@
 package org.openjdk.skara.bots.submit;
 
 import org.openjdk.skara.bot.*;
-import org.openjdk.skara.host.HostedRepository;
+import org.openjdk.skara.host.*;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -31,15 +31,18 @@ import java.util.stream.Collectors;
 public class SubmitBot implements Bot {
     private final HostedRepository repository;
     private final List<SubmitExecutor> executors;
+    private final PullRequestUpdateCache updateCache;
 
     SubmitBot(HostedRepository repository, List<SubmitExecutor> executors) {
         this.repository = repository;
         this.executors = executors;
+        this.updateCache = new PullRequestUpdateCache();
     }
 
     @Override
     public List<WorkItem> getPeriodicItems() {
         return repository.getPullRequests().stream()
+                         .filter(updateCache::needsUpdate)
                          .flatMap(pr -> executors.stream()
                                                  .map(executor -> new SubmitBotWorkItem(this, executor, pr)))
                          .collect(Collectors.toList());

--- a/host/src/main/java/org/openjdk/skara/host/PullRequestUpdateCache.java
+++ b/host/src/main/java/org/openjdk/skara/host/PullRequestUpdateCache.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.host;
+
+import org.openjdk.skara.host.gitlab.GitLabMergeRequest;
+
+import java.time.ZonedDateTime;
+import java.util.*;
+import java.util.logging.Logger;
+
+public class PullRequestUpdateCache {
+    private final Map<HostedRepository, String> repositoryIds = new HashMap<>();
+    private final Map<String, ZonedDateTime> lastUpdates = new HashMap<>();
+
+    private final Logger log = Logger.getLogger("org.openjdk.skara.host");
+
+    public boolean needsUpdate(PullRequest pr) {
+        // GitLab CE does not update this field on events such as adding an award
+        if (pr instanceof GitLabMergeRequest) {
+            return true;
+        }
+
+        var repo = pr.repository();
+        if (!repositoryIds.containsKey(repo)) {
+            repositoryIds.put(repo, Integer.toString(repositoryIds.size()));
+        }
+        var uniqueId = repositoryIds.get(repo) + ";" + pr.getId();
+        var update = pr.getUpdated();
+
+        if (!lastUpdates.containsKey(uniqueId)) {
+            lastUpdates.put(uniqueId, update);
+            return true;
+        }
+        var lastUpdate = lastUpdates.get(uniqueId);
+        if (lastUpdate.isBefore(update)) {
+            lastUpdates.put(uniqueId, update);
+            return true;
+        }
+        log.info("Skipping update for " + repo.getName() + "#" + pr.getId());
+        return false;
+    }
+}

--- a/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
@@ -41,10 +41,10 @@ public class TestPullRequest implements PullRequest {
     private final String sourceRef;
     private final String title;
     private final List<String> body;
-    private final Hash headHash;
     private final PullRequestData data;
 
     private static class PullRequestData {
+        private Hash headHash;
         String body = "";
         final List<Comment> comments = new ArrayList<>();
         final List<ReviewComment> reviewComments = new ArrayList<>();
@@ -67,7 +67,11 @@ public class TestPullRequest implements PullRequest {
         this.data = data;
 
         try {
-            headHash = repository.localRepository().resolve(sourceRef).orElseThrow();
+            var headHash = repository.localRepository().resolve(sourceRef).orElseThrow();
+            if (!headHash.equals(data.headHash)) {
+                data.headHash = headHash;
+                data.lastUpdate = ZonedDateTime.now();
+            }
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -143,7 +147,7 @@ public class TestPullRequest implements PullRequest {
 
     @Override
     public Hash getHeadHash() {
-        return headHash;
+        return data.headHash;
     }
 
     @Override


### PR DESCRIPTION
Hi all,

Please review the following change that introduces an in-memory cache of the lastUpdated field of pull requests, to avoid unnecessary polls.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)