### PR TITLE
40: Fix failing tests after remote locking

### DIFF
--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdaterTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdaterTests.java
@@ -65,7 +65,7 @@ class UpdaterTests {
              var jsonFolder = new TemporaryDirectory()) {
             var repo = credentials.getHostedRepository();
             var localRepo = CheckableRepository.init(tempFolder.path(), repo.getRepositoryType());
-            localRepo.fetch(repo.getUrl(), "testlock:testlock");
+            credentials.commitLock(localRepo);
             localRepo.pushAll(repo.getUrl());
 
             var tagStorage = createTagStorage(repo);
@@ -99,7 +99,7 @@ class UpdaterTests {
              var jsonFolder = new TemporaryDirectory()) {
             var repo = credentials.getHostedRepository();
             var localRepo = CheckableRepository.init(tempFolder.path(), repo.getRepositoryType());
-            localRepo.fetch(repo.getUrl(), "testlock:testlock");
+            credentials.commitLock(localRepo);
             var masterHash = localRepo.resolve("master").orElseThrow();
             localRepo.tag(masterHash, "jdk-12+1", "Added tag 1", "Duke", "duke@openjdk.java.net");
             localRepo.pushAll(repo.getUrl());


### PR DESCRIPTION
Hi all,

Please remove this test-only fix that removes a few failures introduced by the recent credentials lock method update.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)