### PR TITLE
42: Notifier tests can fail depending on execution order

### DIFF
--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdaterTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdaterTests.java
@@ -149,7 +149,8 @@ class UpdaterTests {
             var repoFolder = tempFolder.path().resolve("repo");
             var localRepo = CheckableRepository.init(repoFolder, repo.getRepositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, repo.getUrl(), "master", true);
+            credentials.commitLock(localRepo);
+            localRepo.pushAll(repo.getUrl());
 
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
@@ -185,7 +186,8 @@ class UpdaterTests {
             var repoFolder = tempFolder.path().resolve("repo");
             var localRepo = CheckableRepository.init(repoFolder, repo.getRepositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, repo.getUrl(), "master", true);
+            credentials.commitLock(localRepo);
+            localRepo.pushAll(repo.getUrl());
 
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
@@ -225,7 +227,8 @@ class UpdaterTests {
             var repoFolder = tempFolder.path().resolve("repo");
             var localRepo = CheckableRepository.init(repoFolder, repo.getRepositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, repo.getUrl(), "master", true);
+            credentials.commitLock(localRepo);
+            localRepo.pushAll(repo.getUrl());
 
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);


### PR DESCRIPTION
Hi all,

Please review this small test fix that solves an issue that can happen when running the notifier tests against a real host.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)