### PR TITLE
43: Repository.get should return Optional.empty on non-existing directory

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -701,6 +701,10 @@ public class GitRepository implements Repository {
     }
 
     public static Optional<Repository> get(Path p) throws IOException {
+        if (!Files.exists(p)) {
+            return Optional.empty();
+        }
+
         var r = new GitRepository(p);
         return r.exists() ? Optional.of(new GitRepository(r.root())) : Optional.empty();
     }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -395,6 +395,10 @@ public class HgRepository implements Repository {
 
     @Override
     public boolean exists() throws IOException {
+        if (!Files.exists(dir)) {
+            return false;
+        }
+
         try {
             root();
             return true;
@@ -657,6 +661,10 @@ public class HgRepository implements Repository {
     }
 
     public static Optional<Repository> get(Path p) throws IOException {
+        if (!Files.exists(p)) {
+            return Optional.empty();
+        }
+
         var r = new HgRepository(p);
         return r.exists() ? Optional.of(new HgRepository(r.root())) : Optional.empty();
     }

--- a/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
@@ -24,6 +24,7 @@ package org.openjdk.skara.vcs;
 
 import org.openjdk.skara.test.TemporaryDirectory;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
@@ -1429,5 +1430,12 @@ public class RepositoryTests {
             var hash2 = r.commit("Added read-write executable file", "duke", "duke@openjdk.java.net");
             assertEquals(Optional.of(List.of("echo 'goodbye'")), r.lines(readWriteExecutableFile, hash2));
         }
+    }
+
+    @Test
+    void testGetAndExistsOnNonExistingDirectory() throws IOException {
+        var nonExistingDirectory = Path.of("this", "does", "not", "exist");
+        assertEquals(Optional.empty(), Repository.get(nonExistingDirectory));
+        assertEquals(false, Repository.exists(nonExistingDirectory));
     }
 }


### PR DESCRIPTION
Hi all,

this small patch ensures that Repository.get returns Optional.empty() for non-existing paths.

Thanks,
Erik

## Testing
- [x] `sh gradlew test` on Linux x86-64
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)