### PR TITLE
44: GitHubApplication should not use a JSONParser instance

### DIFF
--- a/host/src/main/java/org/openjdk/skara/host/github/GitHubApplication.java
+++ b/host/src/main/java/org/openjdk/skara/host/github/GitHubApplication.java
@@ -97,7 +97,6 @@ public class GitHubApplication {
     private final Token installationToken;
 
     private final Logger log;
-    private final JSONParser jsonParser;
 
     static class GitHubConfigurationError extends RuntimeException {
         public GitHubConfigurationError(String message) {
@@ -108,7 +107,6 @@ public class GitHubApplication {
     public GitHubApplication(String keyFile, String issue, String id) {
 
         log = Logger.getLogger("org.openjdk.host.github");
-        jsonParser = new JSONParser();
 
         apiBase = URIBuilder.base("https://api.github.com/").build();
         this.issue = issue;
@@ -194,7 +192,7 @@ public class GitHubApplication {
                     HttpResponse.BodyHandlers.ofString()
             );
 
-            var data = jsonParser.parse(response.body());
+            var data = JSON.parse(response.body());
             if (!data.contains("token")) {
                 throw new Token.GeneratorError("Unknown data returned: " + data);
             }
@@ -228,7 +226,7 @@ public class GitHubApplication {
                     HttpResponse.BodyHandlers.ofString()
             );
 
-            var data = jsonParser.parse(response.body());
+            var data = JSON.parse(response.body());
             return data.asObject();
         } catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/json/src/main/java/org/openjdk/skara/json/JSONParser.java
+++ b/json/src/main/java/org/openjdk/skara/json/JSONParser.java
@@ -24,11 +24,11 @@ package org.openjdk.skara.json;
 
 import java.util.*;
 
-public class JSONParser {
+class JSONParser {
     private int pos = 0;
     private String input;
 
-    public JSONParser() {
+    JSONParser() {
     }
 
     private IllegalStateException failure(String message) {


### PR DESCRIPTION
Hi all,

a `JSONParser` instance is not thread-safe and it is therefore a little dangerous to create instances of it _if_ that instance might end up being accessible by multiple threads. We have such a case in `GitHubApplication`. Since a `JSONParser` is very cheap to allocate (it only has an `int` and a pointer) I decided to make `JSONParser` package private thereby forcing all callers to use `JSON.parse`.

Thanks,
Erik

## Testing
- [x] `sh gradlew test` on Linux x86-64
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)