### PR TITLE
Fix start of hunk range off-by-one error when parsing range string

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/Range.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Range.java
@@ -49,6 +49,12 @@ public class Range {
         var count =
             countString.equals("18446744073709551615") ?  0 : Integer.parseInt(countString);
 
+        if (count == 0 && start != 0) {
+            // start is off-by-one when count is 0.
+            // but if start == 0, a file was added and we need a 0 here.
+            start++;
+        }
+
         return new Range(start, count);
     }
 

--- a/webrev/src/main/java/org/openjdk/skara/webrev/HunkCoalescer.java
+++ b/webrev/src/main/java/org/openjdk/skara/webrev/HunkCoalescer.java
@@ -174,14 +174,6 @@ class HunkCoalescer {
         var sourceCount = sourceEnd - sourceStart;
         var destCount = destEnd - destStart;
 
-        // For some reason git wants the start to be +1 when no lines have changed
-        if (sourceCount == numContextLines * 2) {
-            sourceStart++;
-        }
-        if (destCount == numContextLines * 2) {
-            destStart++;
-        }
-
         return new Header(new Range(sourceStart, sourceCount),
                           new Range(destStart, destCount));
     }
@@ -189,16 +181,10 @@ class HunkCoalescer {
     private Context createContextBeforeGroup(Header header, Hunk first) {
         var sourceContextBeforeStart = header.source().start();
         var sourceContextBeforeEnd = first.source().range().start();
-        if (first.source().range().count() == 0) {
-            sourceContextBeforeEnd++;
-        }
         var sourceBeforeContextCount = sourceContextBeforeEnd - sourceContextBeforeStart;
 
         var destContextBeforeStart = header.target().start();
         var destContextBeforeEnd = first.target().range().start();
-        if (first.target().range().count() == 0) {
-            destContextBeforeEnd++;
-        }
         var destBeforeContextCount = destContextBeforeEnd - destContextBeforeStart;
 
         var beforeContextCount = Math.min(destBeforeContextCount, sourceBeforeContextCount);
@@ -250,15 +236,8 @@ class HunkCoalescer {
     }
 
     private Context createContextAfterHunk(Hunk hunk, Hunk nextNonEmptySourceHunk, Hunk nextNonEmptyTargetHunk) {
-        boolean isOneRangeEmpty = hunk.source().range().count() == 0 ||
-                                  hunk.target().range().count() == 0;
-
         var sourceAfterContextStart = hunk.source().range().end();
         var sourceAfterContextEnd = hunk.source().range().end() + numContextLines;
-        if (hunk.source().range().count() == 0) {
-            sourceAfterContextStart++;
-            sourceAfterContextEnd++;
-        }
         sourceAfterContextEnd = Math.min(sourceAfterContextEnd, sourceContent.size() + 1);
         if (nextNonEmptySourceHunk != null) {
             var nextNonEmptySourceHunkStart = nextNonEmptySourceHunk.source().range().start();
@@ -268,10 +247,6 @@ class HunkCoalescer {
 
         var destAfterContextStart = hunk.target().range().end();
         var destAfterContextEnd = hunk.target().range().end() + numContextLines;
-        if (hunk.target().range().count() == 0) {
-            destAfterContextStart++;
-            destAfterContextEnd++;
-        }
         destAfterContextEnd = Math.min(destAfterContextEnd, destContent.size() + 1);
         if (nextNonEmptyTargetHunk != null) {
             var nextNonEmptyTargetHunkStart = nextNonEmptyTargetHunk.target().range().start();


### PR DESCRIPTION
I kept running into off-by-one errors in hunk headers when exporting a patch from a git repo, and then importing into a mercurial repo (for pushing, since git repos are currently read-only)

The problem seems to be that unified diffs generated by git report a line number 1 before the modified line if the line count is 0. For instance, if I just remove a few lines from a file, the hunk destination start line is one before the first deleted line. (similarly when only adding lines). And actually, this seems to be wrong according to the spec: https://www.gnu.org/software/diffutils/manual/html_node/Detailed-Unified.html#Detailed-Unified

> An empty hunk is considered to start at the line that follows the hunk. 

The problem is that when hunks are then coalesced together, the starting line, and computed line counts are off-by-one as well, and as a result, the generated patch fails to apply.

I noticed there was already some code dealing with this in HunkCoalescer, but this wasn't catching all the cases. I first made a version that patched the starting line in the missing cases, but it seemed cleaner to try and fix this at the source, i.e. when parsing the Range string from the unified diff. So, that is what I've done in this PR, as well as removing the previous patching code in HunkCoalescer, which was no longer needed.

If wanted I could also go the other route of patching the starting line in HunkCoalescer in the missing cases (there were 4 of these).
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)