### PR TITLE
Convert path separators in patch file to unix explicitly

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/Patch.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Patch.java
@@ -104,10 +104,10 @@ public abstract class Patch {
 
     public void write(BufferedWriter w) throws IOException {
         // header
-        var sourcePath = source.path().isPresent() ?
-            source.path().get().toString() : target.path().get().toString();
-        var targetPath = target.path().isPresent() ?
-            target.path().get().toString() : source.path().get().toString();
+        var sourcePath = pathWithUnixSeps(source.path().isPresent() ?
+            source.path().get() : target.path().get());
+        var targetPath = pathWithUnixSeps(target.path().isPresent() ?
+            target.path().get() : source.path().get());
 
         w.append("diff --git ");
         w.append("a/" + sourcePath);
@@ -196,10 +196,10 @@ public abstract class Patch {
         }
 
         w.append("--- ");
-        w.append(source.path().isPresent() ? "a/" + source.path().get().toString() : "/dev/null");
+        w.append(source.path().isPresent() ? "a/" + sourcePath : "/dev/null");
         w.append("\n");
         w.append("+++ ");
-        w.append(target.path().isPresent() ? "b/" + target.path().get().toString() : "/dev/null");
+        w.append(target.path().isPresent() ? "b/" + targetPath : "/dev/null");
         w.newLine();
 
         if (isBinary()) {
@@ -219,5 +219,9 @@ public abstract class Patch {
         try (var w = Files.newBufferedWriter(p)) {
             write(w);
         }
+    }
+
+    public static String pathWithUnixSeps(Path p) {
+        return p.toString().replace('\\', '/');
     }
 }

--- a/webrev/src/main/java/org/openjdk/skara/webrev/AddedPatchView.java
+++ b/webrev/src/main/java/org/openjdk/skara/webrev/AddedPatchView.java
@@ -44,14 +44,14 @@ class AddedPatchView implements View {
 
         try (var fw = Files.newBufferedWriter(patchFile)) {
             fw.write("diff a/");
-            fw.write(patch.target().path().get().toString());
+            fw.write(ViewUtils.pathWithUnixSeps(patch.target().path().get()));
             fw.write(" b/");
-            fw.write(patch.target().path().get().toString());
+            fw.write(ViewUtils.pathWithUnixSeps(patch.target().path().get()));
             fw.write("\n");
             fw.write("--- /dev/null");
             fw.write("\n");
             fw.write("+++ b/");
-            fw.write(patch.target().path().get().toString());
+            fw.write(ViewUtils.pathWithUnixSeps(patch.target().path().get()));
             fw.write("\n");
 
             assert patch.hunks().size() == 1;

--- a/webrev/src/main/java/org/openjdk/skara/webrev/PatchView.java
+++ b/webrev/src/main/java/org/openjdk/skara/webrev/PatchView.java
@@ -56,15 +56,15 @@ class PatchView implements View {
 
         try (var fw = Files.newBufferedWriter(patchFile)) {
             fw.write("diff a/");
-            fw.write(patch.source().path().get().toString());
+            fw.write(ViewUtils.pathWithUnixSeps(patch.source().path().get()));
             fw.write(" b/");
-            fw.write(patch.target().path().get().toString());
+            fw.write(ViewUtils.pathWithUnixSeps(patch.target().path().get()));
             fw.write("\n");
             fw.write("--- a/");
-            fw.write(patch.source().path().get().toString());
+            fw.write(ViewUtils.pathWithUnixSeps(patch.source().path().get()));
             fw.write("\n");
             fw.write("+++ b/");
-            fw.write(patch.target().path().get().toString());
+            fw.write(ViewUtils.pathWithUnixSeps(patch.target().path().get()));
             fw.write("\n");
 
             var coalescer = new HunkCoalescer(NUM_CONTEXT_LINES, sourceContent, destContent);

--- a/webrev/src/main/java/org/openjdk/skara/webrev/RemovedPatchView.java
+++ b/webrev/src/main/java/org/openjdk/skara/webrev/RemovedPatchView.java
@@ -37,19 +37,18 @@ class RemovedPatchView implements View {
         this.file = file;
         this.patch = patch;
     }
-
     public void render(Writer w) throws IOException {
         var patchFile = out.resolve(file.toString() + ".patch");
         Files.createDirectories(patchFile.getParent());
 
         try (var fw = Files.newBufferedWriter(patchFile)) {
             fw.write("diff a/");
-            fw.write(patch.source().path().get().toString());
+            fw.write(ViewUtils.pathWithUnixSeps(patch.source().path().get()));
             fw.write(" b/");
-            fw.write(patch.source().path().get().toString());
+            fw.write(ViewUtils.pathWithUnixSeps(patch.source().path().get()));
             fw.write("\n");
             fw.write("--- a/");
-            fw.write(patch.source().path().get().toString());
+            fw.write(ViewUtils.pathWithUnixSeps(patch.source().path().get()));
             fw.write("\n");
             fw.write("+++ /dev/null");
             fw.write("\n");

--- a/webrev/src/main/java/org/openjdk/skara/webrev/ViewUtils.java
+++ b/webrev/src/main/java/org/openjdk/skara/webrev/ViewUtils.java
@@ -102,4 +102,8 @@ class ViewUtils {
         writer.write(" ");
         writer.write(HTML.escape(line));
     }
+
+    public static String pathWithUnixSeps(Path p) {
+        return p.toString().replace('\\', '/');
+    }
 }


### PR DESCRIPTION
I ran into trouble when trying to apply a patch file generated with Windows Git to a mercurial repository through cygwin. It wasn't recognizing the files since the paths in the patch file were using Windows path separators.

The spec doesn't seem to mention path separators: https://www.gnu.org/software/diffutils/manual/html_node/Detailed-Unified.html#Detailed-Unified

But, both the Windows Git and Mercurial clients I have installed are handling unix path separators just fine. So, in this PR I've changed the patch file generators to use unix path separators explicitly, which solves the problem.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)