### PR TITLE
Get resource path from URI to avoid getting spurious leading path separator on Windows

### DIFF
--- a/webrev/src/main/java/org/openjdk/skara/webrev/Webrev.java
+++ b/webrev/src/main/java/org/openjdk/skara/webrev/Webrev.java
@@ -25,6 +25,7 @@ package org.openjdk.skara.webrev;
 import org.openjdk.skara.vcs.*;
 
 import java.io.*;
+import java.net.URISyntaxException;
 import java.nio.channels.FileChannel;
 import java.nio.file.*;
 import java.util.*;
@@ -191,7 +192,12 @@ public class Webrev {
         private void copyResource(String name) throws IOException {
             var stream = this.getClass().getResourceAsStream("/" + name);
             if (stream == null) {
-                var classPath = Path.of(getClass().getProtectionDomain().getCodeSource().getLocation().getPath());
+                Path classPath;
+                try {
+                    classPath = Path.of(getClass().getProtectionDomain().getCodeSource().getLocation().toURI());
+                } catch (URISyntaxException e) {
+                    throw new IOException(e);
+                }
                 var extPath = classPath.getParent().resolve("resources").resolve(name);
                 stream = new FileInputStream(extPath.toFile());
             }


### PR DESCRIPTION
One more little pathing problem I ran into when running GitWebrev through a debugger.

The old code uses `URL::getPath`, but this results in a leading slash before the path, and on Windows absolute paths contain drive letters, so you get something like `/C:/a/b/c`, which is not a valid path syntax.

We can first convert the URL to a URI, for which `Path::of` has a special overload that does the right thing for us.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)