### PR TITLE
Use the web url in the displayed fetch command

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/PullRequestInstance.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/PullRequestInstance.java
@@ -68,9 +68,8 @@ class PullRequestInstance {
     }
 
     String fetchCommand() {
-        var repoUrl = pr.repository().getUrl();
-        return "git fetch " + repoUrl.getScheme() + "://" + repoUrl.getHost() + repoUrl.getPath() + " " +
-                pr.getSourceRef() + ":pull/" + pr.getId();
+        var repoUrl = pr.repository().getWebUrl();
+        return "git fetch " + repoUrl + " " + pr.getSourceRef() + ":pull/" + pr.getId();
     }
 
     @FunctionalInterface


### PR DESCRIPTION
Hi all,

Please review this small change that uses the already-filtered web url instead of the possibly-credentials-containing regular url in the fetch command shown in mails.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)