### PR TITLE
50: Fix failing tests after e8d32c78dc

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitCombinedDiffParser.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitCombinedDiffParser.java
@@ -43,7 +43,7 @@ class GitCombinedDiffParser {
         this.delimiter = delimiter;
     }
 
-    private List<List<Hunk>> parseSingleFileMultiParentDiff(UnixStreamReader reader) throws IOException {
+    private List<List<Hunk>> parseSingleFileMultiParentDiff(UnixStreamReader reader, List<PatchHeader> headers) throws IOException {
         assert line.startsWith("diff --combined");
 
         while ((line = reader.readLine()) != null &&
@@ -64,7 +64,14 @@ class GitCombinedDiffParser {
             assert words[0].startsWith("@@@");
             var sourceRangesPerParent = new ArrayList<Range>(numParents);
             for (int i = 1; i <= numParents; i++) {
-                sourceRangesPerParent.add(Range.fromString(words[i].substring(1))); // skip initial '-'
+                var header = headers.get(i - 1);
+                if (header.status().isAdded()) {
+                    // git reports wrong start for added files, they should
+                    // always have range (0, 0), but git reports (1,0)
+                    sourceRangesPerParent.add(new Range(0, 0));
+                } else {
+                    sourceRangesPerParent.add(Range.fromString(words[i].substring(1))); // skip initial '-'
+                }
             }
             var targetRange = Range.fromString(words[numParents + 1].substring(1)); // skip initial '+'
 
@@ -174,8 +181,10 @@ class GitCombinedDiffParser {
             headersPerParent.add(new ArrayList<PatchHeader>());
         }
 
+        var headersForFiles = new ArrayList<List<PatchHeader>>();
         while (line != null && line.startsWith("::")) {
             var headersForFile = parseCombinedRawLine(line);
+            headersForFiles.add(headersForFile);
             assert headersForFile.size() == numParents;
 
             for (int i = 0; i < numParents; i++) {
@@ -193,13 +202,18 @@ class GitCombinedDiffParser {
         for (int i = 0; i < numParents; i++) {
             hunksPerFilePerParent.add(new ArrayList<List<Hunk>>());
         }
+
+        int headerIndex = 0;
         while (line != null && !line.equals(delimiter)) {
-            var hunksPerParentForFile = parseSingleFileMultiParentDiff(reader);
+            var headersForFile = headersForFiles.get(headerIndex);
+            var hunksPerParentForFile = parseSingleFileMultiParentDiff(reader, headersForFile);
             assert hunksPerParentForFile.size() == numParents;
 
             for (int i = 0; i < numParents; i++) {
                 hunksPerFilePerParent.get(i).add(hunksPerParentForFile.get(i));
             }
+
+            headerIndex++;
         }
 
         var patchesPerParent = new ArrayList<List<Patch>>(numParents);

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitCombinedDiffParser.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitCombinedDiffParser.java
@@ -67,7 +67,7 @@ class GitCombinedDiffParser {
                 var header = headers.get(i - 1);
                 if (header.status().isAdded()) {
                     // git reports wrong start for added files, they should
-                    // always have range (0, 0), but git reports (1,0)
+                    // always have range (0,0), but git reports (1,0)
                     sourceRangesPerParent.add(new Range(0, 0));
                 } else {
                     sourceRangesPerParent.add(Range.fromString(words[i].substring(1))); // skip initial '-'

--- a/vcs/src/main/java/org/openjdk/skara/vcs/tools/GitRange.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/tools/GitRange.java
@@ -35,7 +35,7 @@ class GitRange {
 
         var start = Integer.parseInt(s.substring(0, separatorIndex));
 
-        // Need to work arond a bug in git where git sometimes print -1
+        // Need to work around a bug in git where git sometimes print -1
         // as an unsigned int for the count part of the range
         var countString = s.substring(separatorIndex + 1, s.length());
         var count =

--- a/vcs/src/main/java/org/openjdk/skara/vcs/tools/GitRange.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/tools/GitRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,20 +20,12 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package org.openjdk.skara.vcs;
+package org.openjdk.skara.vcs.tools;
 
-import java.util.Objects;
+import org.openjdk.skara.vcs.Range;
 
-public class Range {
-    private final int start;
-    private final int count;
-
-    public Range(int start, int count) {
-        this.start = start;
-        this.count = count;
-    }
-
-    public static Range fromString(String s) {
+class GitRange {
+    static Range fromString(String s) {
         var separatorIndex = s.indexOf(",");
 
         if (separatorIndex == -1) {
@@ -42,40 +34,19 @@ public class Range {
         }
 
         var start = Integer.parseInt(s.substring(0, separatorIndex));
-        var count = Integer.parseInt(s.substring(separatorIndex + 1, s.length()));
 
-        return new Range(start, count);
-    }
+        // Need to work arond a bug in git where git sometimes print -1
+        // as an unsigned int for the count part of the range
+        var countString = s.substring(separatorIndex + 1, s.length());
+        var count =
+            countString.equals("18446744073709551615") ?  0 : Integer.parseInt(countString);
 
-    public int start() {
-        return this.start;
-    }
-
-    public int count() {
-        return this.count;
-    }
-
-    public int end() {
-        return start + count;
-    }
-
-    @Override
-    public String toString() {
-        return Integer.toString(start) + "," + Integer.toString(count);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(start, count);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (!(o instanceof Range)) {
-            return false;
+        if (count == 0 && start != 0) {
+            // start is off-by-one when count is 0.
+            // but if start == 0, a file was added and we need a 0 here.
+            start++;
         }
 
-        var other = (Range) o;
-        return start == other.start && count == other.count;
+        return new Range(start, count);
     }
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/tools/UnifiedDiffParser.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/tools/UnifiedDiffParser.java
@@ -149,8 +149,8 @@ public class UnifiedDiffParser {
                     throw new IllegalStateException("Unexpected diff line: " + line);
                 }
             }
-            hunks.add(new Hunk(Range.fromString(sourceRange), sourceLines, sourceHasNewlineAtEndOfFile,
-                               Range.fromString(targetRange), targetLines, targetHasNewlineAtEndOfFile));
+            hunks.add(new Hunk(GitRange.fromString(sourceRange), sourceLines, sourceHasNewlineAtEndOfFile,
+                               GitRange.fromString(targetRange), targetLines, targetHasNewlineAtEndOfFile));
         }
 
         return Hunks.ofTextual(hunks);
@@ -261,14 +261,6 @@ public class UnifiedDiffParser {
             }
 
             if (line.startsWith(" ")) {
-                // this is the start of another hunk
-                // TODO: explain this strange behaviour
-                if (sourceLines.size() == 0) {
-                    sourceStart--;
-                }
-                if (targetLines.size() == 0) {
-                    targetStart--;
-                }
                 hunks.add(new Hunk(new Range(sourceStart, sourceLines.size()), sourceLines,
                                    new Range(targetStart, targetLines.size()), targetLines));
 
@@ -287,12 +279,6 @@ public class UnifiedDiffParser {
         }
 
         if (sourceLines.size() > 0 || targetLines.size() > 0) {
-            if (sourceLines.size() == 0) {
-                sourceStart--;
-            }
-            if (targetLines.size() == 0) {
-                targetStart--;
-            }
             hunks.add(new Hunk(new Range(sourceStart, sourceLines.size()), sourceLines,
                                new Range(targetStart, targetLines.size()), targetLines));
         }

--- a/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
@@ -376,7 +376,7 @@ public class RepositoryTests {
             assertEquals(1, hunks.size());
 
             var hunk = hunks.get(0);
-            assertEquals(new Range(1, 0), hunk.source().range());
+            assertEquals(new Range(2, 0), hunk.source().range());
             assertEquals(new Range(2, 1), hunk.target().range());
 
             assertEquals(List.of(), hunk.source().lines());
@@ -508,7 +508,7 @@ public class RepositoryTests {
             assertEquals(1, hunks.size());
 
             var hunk = hunks.get(0);
-            assertEquals(new Range(1, 0), hunk.source().range());
+            assertEquals(new Range(2, 0), hunk.source().range());
             assertEquals(new Range(2, 2), hunk.target().range());
 
             assertEquals(List.of(), hunk.source().lines());
@@ -859,7 +859,7 @@ public class RepositoryTests {
             assertEquals(1, hunks.size());
 
             var hunk = hunks.get(0);
-            assertEquals(1, hunk.source().range().start());
+            assertEquals(2, hunk.source().range().start());
             assertEquals(0, hunk.source().range().count());
             assertEquals(0, hunk.source().lines().size());
 
@@ -1132,7 +1132,7 @@ public class RepositoryTests {
             assertEquals(1, hunks.size());
 
             var hunk = hunks.get(0);
-            assertEquals(1, hunk.source().range().start());
+            assertEquals(2, hunk.source().range().start());
             assertEquals(0, hunk.source().range().count());
             assertEquals(List.of(), hunk.source().lines());
 
@@ -1283,7 +1283,7 @@ public class RepositoryTests {
             assertEquals(List.of(), secondHunk.source().lines());
             assertEquals(List.of("One last line"), secondHunk.target().lines());
 
-            assertEquals(2, secondHunk.source().range().start());
+            assertEquals(3, secondHunk.source().range().start());
             assertEquals(0, secondHunk.source().range().count());
             assertEquals(3, secondHunk.target().range().start());
             assertEquals(1, secondHunk.target().range().count());
@@ -1302,7 +1302,7 @@ public class RepositoryTests {
             assertEquals(List.of(), thirdHunk.source().lines());
             assertEquals(List.of("One more line", "One last line"), thirdHunk.target().lines());
 
-            assertEquals(1, thirdHunk.source().range().start());
+            assertEquals(2, thirdHunk.source().range().start());
             assertEquals(0, thirdHunk.source().range().count());
             assertEquals(2, thirdHunk.target().range().start());
             assertEquals(2, thirdHunk.target().range().count());


### PR DESCRIPTION
Hi all,

this patch fixes some test failures after e8d32c78dc was integrated. Turns out there are different bugs in git with regards to unified diffs with zero context :cry: @JornVernee fixed the issues with the regular unified diff printer (when there is exactly one parent), this patch works around the issues with git's combined diff printer. The combined diff printer seems to print _correct_ start for empty hunks as long as the file the hunks belong to isn't added.

I also updated a number of tests to take the changes in e8d32c78dc into account.

## Testing
- [x] Run `sh gradlew test` on Linux x86-64
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**) **Note!** Review applies to 0914742fbd34787c12cc2fab29f69a1954fe65b3