### PR TITLE
49: Add forwarder bot

### DIFF
--- a/bots/cli/build.gradle
+++ b/bots/cli/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     implementation project(':bots:notify')
     implementation project(':bots:mlbridge')
     implementation project(':bots:submit')
+    implementation project(':bots:forward')
     implementation project(':vcs')
     implementation project(':jcheck')
     implementation project(':host')
@@ -62,7 +63,8 @@ images {
                    'org.openjdk.skara.bots.hgbridge',
                    'org.openjdk.skara.bots.notify',
                    'org.openjdk.skara.bots.mlbridge',
-                   'org.openjdk.skara.bots.submit']
+                   'org.openjdk.skara.bots.submit',
+                   'org.openjdk.skara.bots.forward']
         launchers = ['skara-bots': 'org.openjdk.skara.bots.cli/org.openjdk.skara.bots.cli.BotLauncher']
         options = ["--module-path", "plugins"]
         bundles = ['zip', 'tar.gz']

--- a/bots/forward/build.gradle
+++ b/bots/forward/build.gradle
@@ -20,30 +20,22 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-rootProject.name = 'skara'
 
-include 'args'
-include 'bot'
-include 'cli'
-include 'census'
-include 'email'
-include 'encoding'
-include 'host'
-include 'ini'
-include 'jcheck'
-include 'json'
-include 'mailinglist'
-include 'process'
-include 'proxy'
-include 'storage'
-include 'test'
-include 'vcs'
-include 'webrev'
+module {
+    name = 'org.openjdk.skara.bots.forward'
+    test {
+        requires 'org.junit.jupiter.api'
+        requires 'org.openjdk.skara.test'
+        opens 'org.openjdk.skara.bots.forward' to 'org.junit.platform.commons'
+    }
+}
 
-include 'bots:cli'
-include 'bots:forward'
-include 'bots:hgbridge'
-include 'bots:mlbridge'
-include 'bots:notify'
-include 'bots:pr'
-include 'bots:submit'
+dependencies {
+    implementation project(':host')
+    implementation project(':bot')
+    implementation project(':census')
+    implementation project(':json')
+    implementation project(':vcs')
+
+    testImplementation project(':test')
+}

--- a/bots/forward/src/main/java/module-info.java
+++ b/bots/forward/src/main/java/module-info.java
@@ -20,30 +20,10 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-rootProject.name = 'skara'
+module org.openjdk.skara.bots.forward {
+    requires org.openjdk.skara.bot;
+    requires org.openjdk.skara.vcs;
+    requires java.logging;
 
-include 'args'
-include 'bot'
-include 'cli'
-include 'census'
-include 'email'
-include 'encoding'
-include 'host'
-include 'ini'
-include 'jcheck'
-include 'json'
-include 'mailinglist'
-include 'process'
-include 'proxy'
-include 'storage'
-include 'test'
-include 'vcs'
-include 'webrev'
-
-include 'bots:cli'
-include 'bots:forward'
-include 'bots:hgbridge'
-include 'bots:mlbridge'
-include 'bots:notify'
-include 'bots:pr'
-include 'bots:submit'
+    provides org.openjdk.skara.bot.BotFactory with org.openjdk.skara.bots.forward.ForwardBotFactory;
+}

--- a/bots/forward/src/main/java/org/openjdk/skara/bots/forward/ForwardBot.java
+++ b/bots/forward/src/main/java/org/openjdk/skara/bots/forward/ForwardBot.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.forward;
+
+import org.openjdk.skara.bot.*;
+import org.openjdk.skara.host.*;
+import org.openjdk.skara.vcs.*;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Files;
+import java.net.URLEncoder;
+import java.util.List;
+import java.util.logging.Logger;
+
+class ForwardBot implements Bot, WorkItem {
+    private final Logger log = Logger.getLogger("org.openjdk.skara.bots");;
+
+    private final HostedRepository fromHostedRepo;
+    private final Branch fromBranch;
+
+    private final HostedRepository toHostedRepo;
+    private final Branch toBranch;
+
+    ForwardBot(HostedRepository fromHostedRepo, Branch fromBranch,
+               HostedRepository toHostedRepo, Branch toBranch) {
+        this.fromHostedRepo = fromHostedRepo;
+        this.fromBranch = fromBranch;
+        this.toHostedRepo = toHostedRepo;
+        this.toBranch = toBranch;
+    }
+
+    @Override
+    public boolean concurrentWith(WorkItem other) {
+        if (!(other instanceof ForwardBot)) {
+            return true;
+        }
+        var otherBot = (ForwardBot) other;
+        return !toHostedRepo.getName().equals(otherBot.toHostedRepo.getName());
+    }
+
+    @Override
+    public void run(Path scratchPath) {
+        try {
+            var sanitizedUrl =
+                URLEncoder.encode(toHostedRepo.getUrl().toString(), StandardCharsets.UTF_8);
+            var toDir = scratchPath.resolve("forward").resolve(sanitizedUrl);
+            Repository toLocalRepo = null;
+            if (!Files.exists(toDir)) {
+                log.info("Cloning " + toHostedRepo.getName());
+                Files.createDirectories(toDir);
+                toLocalRepo = Repository.clone(toHostedRepo.getUrl(), toDir, true);
+            } else {
+                log.info("Found existing scratch directory for " + toHostedRepo.getName());
+                toLocalRepo = Repository.get(toDir).orElseThrow(() -> {
+                        return new RuntimeException("Repository in " + toDir + " has vanished");
+                });
+            }
+
+            log.info("Fetching " + fromHostedRepo.getName() + ":" + fromBranch.name() +
+                     " to " + toBranch.name());
+            var fetchHead = toLocalRepo.fetch(fromHostedRepo.getUrl(),
+                                              fromBranch.name() + ":" + toBranch.name());
+            log.info("Pushing " + toBranch.name() + " to " + toHostedRepo.getName());
+            toLocalRepo.push(fetchHead, toHostedRepo.getUrl(), toBranch.name(), false);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "FowardBot@(" + fromHostedRepo.getName() + ":" + fromBranch.name() +
+                           "-> " + toHostedRepo.getName() + ":" + toBranch.name() + ")";
+    }
+
+    @Override
+    public List<WorkItem> getPeriodicItems() {
+        return List.of(this);
+    }
+}

--- a/bots/forward/src/main/java/org/openjdk/skara/bots/forward/ForwardBot.java
+++ b/bots/forward/src/main/java/org/openjdk/skara/bots/forward/ForwardBot.java
@@ -38,14 +38,17 @@ import java.util.logging.Logger;
 class ForwardBot implements Bot, WorkItem {
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots");;
 
+    private final Path storage;
+
     private final HostedRepository fromHostedRepo;
     private final Branch fromBranch;
 
     private final HostedRepository toHostedRepo;
     private final Branch toBranch;
 
-    ForwardBot(HostedRepository fromHostedRepo, Branch fromBranch,
+    ForwardBot(Path storage, HostedRepository fromHostedRepo, Branch fromBranch,
                HostedRepository toHostedRepo, Branch toBranch) {
+        this.storage = storage;
         this.fromHostedRepo = fromHostedRepo;
         this.fromBranch = fromBranch;
         this.toHostedRepo = toHostedRepo;
@@ -66,7 +69,7 @@ class ForwardBot implements Bot, WorkItem {
         try {
             var sanitizedUrl =
                 URLEncoder.encode(toHostedRepo.getUrl().toString(), StandardCharsets.UTF_8);
-            var toDir = scratchPath.resolve("forward").resolve(sanitizedUrl);
+            var toDir = storage.resolve(sanitizedUrl);
             Repository toLocalRepo = null;
             if (!Files.exists(toDir)) {
                 log.info("Cloning " + toHostedRepo.getName());

--- a/bots/forward/src/main/java/org/openjdk/skara/bots/forward/ForwardBotFactory.java
+++ b/bots/forward/src/main/java/org/openjdk/skara/bots/forward/ForwardBotFactory.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.forward;
+
+import org.openjdk.skara.bot.*;
+import org.openjdk.skara.vcs.Branch;
+
+import java.nio.file.Path;
+import java.util.*;
+import java.util.logging.Logger;
+
+public class ForwardBotFactory implements BotFactory {
+    private final Logger log = Logger.getLogger("org.openjdk.skara.bots");;
+
+    @Override
+    public String name() {
+        return "forward";
+    }
+
+    @Override
+    public List<Bot> create(BotConfiguration configuration) {
+        var ret = new ArrayList<Bot>();
+        var specific = configuration.specific();
+
+        for (var repo : specific.get("repositories").fields()) {
+            var repoName = repo.name();
+            var from = repo.value().get("from").asString().split(":");
+            var fromRepo = configuration.repository(from[0]);
+            var fromBranch = new Branch(from[1]);
+
+            var to = repo.value().get("to").asString().split(":");
+            var toRepo = configuration.repository(to[0]);
+            var toBranch = new Branch(to[1]);
+
+            var bot = new ForwardBot(fromRepo, fromBranch, toRepo, toBranch);
+            log.info("Setting up forwarding from " +
+                     fromRepo.getName() + ":" + fromBranch.name() +
+                     "to " + toRepo.getName() + ":" + toBranch.name());
+            ret.add(bot);
+        }
+
+        return ret;
+    }
+}

--- a/bots/forward/src/main/java/org/openjdk/skara/bots/forward/ForwardBotFactory.java
+++ b/bots/forward/src/main/java/org/openjdk/skara/bots/forward/ForwardBotFactory.java
@@ -25,6 +25,9 @@ package org.openjdk.skara.bots.forward;
 import org.openjdk.skara.bot.*;
 import org.openjdk.skara.vcs.Branch;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.logging.Logger;
@@ -40,6 +43,12 @@ public class ForwardBotFactory implements BotFactory {
     @Override
     public List<Bot> create(BotConfiguration configuration) {
         var ret = new ArrayList<Bot>();
+        var storage = configuration.storageFolder();
+        try {
+            Files.createDirectories(storage);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
         var specific = configuration.specific();
 
         for (var repo : specific.get("repositories").fields()) {
@@ -52,7 +61,7 @@ public class ForwardBotFactory implements BotFactory {
             var toRepo = configuration.repository(to[0]);
             var toBranch = new Branch(to[1]);
 
-            var bot = new ForwardBot(fromRepo, fromBranch, toRepo, toBranch);
+            var bot = new ForwardBot(storage, fromRepo, fromBranch, toRepo, toBranch);
             log.info("Setting up forwarding from " +
                      fromRepo.getName() + ":" + fromBranch.name() +
                      "to " + toRepo.getName() + ":" + toBranch.name());

--- a/bots/forward/src/test/java/org/openjdk/skara/bots/forward/ForwardBotTests.java
+++ b/bots/forward/src/test/java/org/openjdk/skara/bots/forward/ForwardBotTests.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.forward;
+
+import org.openjdk.skara.host.*;
+import org.openjdk.skara.test.*;
+import org.openjdk.skara.vcs.*;
+
+import org.junit.jupiter.api.*;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SubmitBotTests {
+    private static final Branch master = new Branch("master");
+
+    @Test
+    void mirrorMasterBranches(TestInfo testInfo) throws IOException {
+        try (var temp = new TemporaryDirectory()) {
+            var host = TestHost.createNew(List.of(new HostUserDetails(0, "duke", "J. Duke")));
+
+            var fromDir = temp.path().resolve("from.git");
+            var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
+            var fromHostedRepo = new TestHostedRepository(host, "test", fromLocalRepo);
+
+            var toDir = temp.path().resolve("to.git");
+            var toLocalRepo = Repository.init(toDir, VCS.GIT);
+            var gitConfig = toDir.resolve(".git").resolve("config");
+            Files.write(gitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
+                        StandardOpenOption.APPEND);
+            var toHostedRepo = new TestHostedRepository(host, "test-mirror", toLocalRepo);
+
+            var newFile = fromDir.resolve("this-file-cannot-exist.txt");
+            Files.writeString(newFile, "Hello world\n");
+            fromLocalRepo.add(newFile);
+            var newHash = fromLocalRepo.commit("An additional commit", "duke", "duke@openjdk.org");
+            var fromCommits = fromLocalRepo.commits().asList();
+            assertEquals(1, fromCommits.size());
+            assertEquals(newHash, fromCommits.get(0).hash());
+
+            var toCommits = toLocalRepo.commits().asList();
+            assertEquals(0, toCommits.size());
+
+            var bot = new ForwardBot(fromHostedRepo, master, toHostedRepo, master);
+            TestBotRunner.runPeriodicItems(bot);
+
+            toCommits = toLocalRepo.commits().asList();
+            assertEquals(1, toCommits.size());
+            assertEquals(newHash, toCommits.get(0).hash());
+        }
+    }
+
+    @Test
+    void mirrorDifferentBranches(TestInfo testInfo) throws IOException {
+        try (var temp = new TemporaryDirectory()) {
+            var host = TestHost.createNew(List.of(new HostUserDetails(0, "duke", "J. Duke")));
+
+            var fromDir = temp.path().resolve("from.git");
+            var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
+            var fromHostedRepo = new TestHostedRepository(host, "test", fromLocalRepo);
+
+            var toDir = temp.path().resolve("to.git");
+            var toLocalRepo = Repository.init(toDir, VCS.GIT);
+            var gitConfig = toDir.resolve(".git").resolve("config");
+            Files.write(gitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
+                        StandardOpenOption.APPEND);
+            var toHostedRepo = new TestHostedRepository(host, "test-mirror", toLocalRepo);
+
+            var newFile = fromDir.resolve("this-file-cannot-exist.txt");
+            Files.writeString(newFile, "Hello world\n");
+            fromLocalRepo.add(newFile);
+            var newHash = fromLocalRepo.commit("An additional commit", "duke", "duke@openjdk.org");
+            var fromCommits = fromLocalRepo.commits().asList();
+            assertEquals(1, fromCommits.size());
+            assertEquals(newHash, fromCommits.get(0).hash());
+
+            var toCommits = toLocalRepo.commits().asList();
+            assertEquals(0, toCommits.size());
+
+            var bot = new ForwardBot(fromHostedRepo, master, toHostedRepo, new Branch("dev"));
+            TestBotRunner.runPeriodicItems(bot);
+
+            toCommits = toLocalRepo.commits().asList();
+            assertEquals(1, toCommits.size());
+            assertEquals(newHash, toCommits.get(0).hash());
+
+            var toBranches = toLocalRepo.branches();
+            assertEquals(1, toBranches.size());
+            assertEquals("dev", toBranches.get(0).name());
+        }
+    }
+}

--- a/bots/forward/src/test/java/org/openjdk/skara/bots/forward/ForwardBotTests.java
+++ b/bots/forward/src/test/java/org/openjdk/skara/bots/forward/ForwardBotTests.java
@@ -65,7 +65,8 @@ class SubmitBotTests {
             var toCommits = toLocalRepo.commits().asList();
             assertEquals(0, toCommits.size());
 
-            var bot = new ForwardBot(fromHostedRepo, master, toHostedRepo, master);
+            var storage = temp.path().resolve("storage");
+            var bot = new ForwardBot(storage, fromHostedRepo, master, toHostedRepo, master);
             TestBotRunner.runPeriodicItems(bot);
 
             toCommits = toLocalRepo.commits().asList();
@@ -101,7 +102,8 @@ class SubmitBotTests {
             var toCommits = toLocalRepo.commits().asList();
             assertEquals(0, toCommits.size());
 
-            var bot = new ForwardBot(fromHostedRepo, master, toHostedRepo, new Branch("dev"));
+            var storage = temp.path().resolve("storage");
+            var bot = new ForwardBot(storage, fromHostedRepo, master, toHostedRepo, new Branch("dev"));
             TestBotRunner.runPeriodicItems(bot);
 
             toCommits = toLocalRepo.commits().asList();

--- a/test/src/main/java/org/openjdk/skara/test/TestHost.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHost.java
@@ -58,7 +58,7 @@ public class TestHost implements Host {
         }
     }
 
-    static TestHost createNew(List<HostUserDetails> users) {
+    public static TestHost createNew(List<HostUserDetails> users) {
         var data = new HostData();
         data.users.addAll(users);
         var host = new TestHost(data, 0);

--- a/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
@@ -38,7 +38,7 @@ public class TestHostedRepository implements HostedRepository {
     private final Repository localRepository;
     private final Pattern pullRequestPattern;
 
-    TestHostedRepository(TestHost host, String projectName, Repository localRepository) {
+    public TestHostedRepository(TestHost host, String projectName, Repository localRepository) {
         this.host = host;
         this.projectName = projectName;
         this.localRepository = localRepository;
@@ -89,7 +89,8 @@ public class TestHostedRepository implements HostedRepository {
     public URI getUrl() {
         try {
             // We need a URL without a trailing slash
-            return new URI(localRepository.root().getParent().toUri().toString() + "hosted.git");
+            var fileName = localRepository.root().getFileName().toString();
+            return new URI(localRepository.root().getParent().toUri().toString() + fileName);
         } catch (IOException | URISyntaxException e) {
             throw new RuntimeException(e);
         }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
@@ -177,7 +177,11 @@ public interface Repository extends ReadOnlyRepository {
     }
 
     static Repository clone(URI from, Path to) throws IOException {
+        return clone(from, to, false);
+    }
+
+    static Repository clone(URI from, Path to, boolean isBare) throws IOException {
         return from.getPath().toString().endsWith(".git") ?
-            GitRepository.clone(from, to) : HgRepository.clone(from, to);
+            GitRepository.clone(from, to, isBare) : HgRepository.clone(from, to, isBare);
     }
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -84,6 +84,10 @@ public class GitRepository implements Repository {
                       .execute();
     }
 
+    private static Execution capture(Path cwd, List<String> cmd) {
+        return capture(cwd, cmd.toArray(new String[0]));
+    }
+
     private static Execution.Result await(Execution e) throws IOException {
         var result = e.await();
         if (result.status() != 0) {
@@ -829,8 +833,14 @@ public class GitRepository implements Repository {
         }
     }
 
-    public static Repository clone(URI from, Path to) throws IOException {
-        try (var p = capture(Path.of("").toAbsolutePath(), "git", "clone", from.toString(), to.toString())) {
+    public static Repository clone(URI from, Path to, boolean isBare) throws IOException {
+        var cmd = new ArrayList<String>();
+        cmd.addAll(List.of("git", "clone"));
+        if (isBare) {
+            cmd.add("--bare");
+        }
+        cmd.addAll(List.of(from.toString(), to.toString()));
+        try (var p = capture(Path.of("").toAbsolutePath(), cmd)) {
             await(p);
         }
         return new GitRepository(to);

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -84,6 +84,9 @@ public class HgRepository implements Repository {
         return capture(dir, cmd);
     }
 
+    private static Execution capture(Path cwd, List<String> cmd) {
+        return capture(cwd, cmd.toArray(new String[0]));
+    }
     private static Execution capture(Path cwd, String... cmd) {
         return Process.capture(cmd)
                       .environ("HGRCPATH", "")
@@ -847,8 +850,15 @@ public class HgRepository implements Repository {
         return Optional.of(b.name());
     }
 
-    public static Repository clone(URI from, Path to) throws IOException {
-        try (var p = capture(Path.of("").toAbsolutePath(), "hg", "clone", from.toString(), to.toString())) {
+    public static Repository clone(URI from, Path to, boolean isBare) throws IOException {
+        var cmd = new ArrayList<String>();
+        cmd.addAll(List.of("hg", "clone"));
+        if (isBare) {
+            cmd.add("--noupdate");
+        }
+        cmd.addAll(List.of(from.toString(), to.toString()));
+
+        try (var p = capture(Path.of("").toAbsolutePath(), cmd)) {
             await(p);
         }
         return new HgRepository(to);


### PR DESCRIPTION
Hi all,

this patch adds a "forwarder" bot that can forward commits between repositories and or branches. This is useful for e.g. a sandbox use-case where we want to forwards commits from jdk:master to e.g. sandbox:master.

# Testing
- [x] Run `sh gradlew test` on Linux x86-64
- [x] Added two new unit tests for the bot

I also did some manual testing of the bots to ensure it successfully forwarded commits between two remote repositories.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)