### PR TITLE
54: Add a mirror bot

### DIFF
--- a/bots/forward/src/test/java/org/openjdk/skara/bots/forward/ForwardBotTests.java
+++ b/bots/forward/src/test/java/org/openjdk/skara/bots/forward/ForwardBotTests.java
@@ -35,7 +35,7 @@ import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-class SubmitBotTests {
+class ForwardBotTests {
     private static final Branch master = new Branch("master");
 
     @Test

--- a/bots/mirror/build.gradle
+++ b/bots/mirror/build.gradle
@@ -20,31 +20,22 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-rootProject.name = 'skara'
 
-include 'args'
-include 'bot'
-include 'cli'
-include 'census'
-include 'email'
-include 'encoding'
-include 'host'
-include 'ini'
-include 'jcheck'
-include 'json'
-include 'mailinglist'
-include 'process'
-include 'proxy'
-include 'storage'
-include 'test'
-include 'vcs'
-include 'webrev'
+module {
+    name = 'org.openjdk.skara.bots.mirror'
+    test {
+        requires 'org.junit.jupiter.api'
+        requires 'org.openjdk.skara.test'
+        opens 'org.openjdk.skara.bots.mirror' to 'org.junit.platform.commons'
+    }
+}
 
-include 'bots:cli'
-include 'bots:forward'
-include 'bots:hgbridge'
-include 'bots:mirror'
-include 'bots:mlbridge'
-include 'bots:notify'
-include 'bots:pr'
-include 'bots:submit'
+dependencies {
+    implementation project(':host')
+    implementation project(':bot')
+    implementation project(':census')
+    implementation project(':json')
+    implementation project(':vcs')
+
+    testImplementation project(':test')
+}

--- a/bots/mirror/src/main/java/module-info.java
+++ b/bots/mirror/src/main/java/module-info.java
@@ -20,31 +20,10 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-rootProject.name = 'skara'
+module org.openjdk.skara.bots.mirror {
+    requires org.openjdk.skara.bot;
+    requires org.openjdk.skara.vcs;
+    requires java.logging;
 
-include 'args'
-include 'bot'
-include 'cli'
-include 'census'
-include 'email'
-include 'encoding'
-include 'host'
-include 'ini'
-include 'jcheck'
-include 'json'
-include 'mailinglist'
-include 'process'
-include 'proxy'
-include 'storage'
-include 'test'
-include 'vcs'
-include 'webrev'
-
-include 'bots:cli'
-include 'bots:forward'
-include 'bots:hgbridge'
-include 'bots:mirror'
-include 'bots:mlbridge'
-include 'bots:notify'
-include 'bots:pr'
-include 'bots:submit'
+    provides org.openjdk.skara.bot.BotFactory with org.openjdk.skara.bots.mirror.MirrorBotFactory;
+}

--- a/bots/mirror/src/main/java/org/openjdk/skara/bots/mirror/MirrorBot.java
+++ b/bots/mirror/src/main/java/org/openjdk/skara/bots/mirror/MirrorBot.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.mirror;
+
+import org.openjdk.skara.bot.*;
+import org.openjdk.skara.host.*;
+import org.openjdk.skara.vcs.*;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Files;
+import java.net.URLEncoder;
+import java.util.List;
+import java.util.logging.Logger;
+
+class MirrorBot implements Bot, WorkItem {
+    private final Logger log = Logger.getLogger("org.openjdk.skara.bots");;
+    private final Path storage;
+    private final HostedRepository from;
+    private final HostedRepository to;
+
+    MirrorBot(Path storage, HostedRepository from, HostedRepository to) {
+        this.storage = storage;
+        this.from = from;
+        this.to = to;
+    }
+
+    @Override
+    public boolean concurrentWith(WorkItem other) {
+        if (!(other instanceof MirrorBot)) {
+            return true;
+        }
+        var otherBot = (MirrorBot) other;
+        return !from.getName().equals(otherBot.from.getName());
+    }
+
+    @Override
+    public void run(Path scratchPath) {
+        try {
+            var sanitizedUrl =
+                URLEncoder.encode(from.getUrl().toString(), StandardCharsets.UTF_8);
+            var dir = storage.resolve(sanitizedUrl);
+            Repository repo = null;
+            if (!Files.exists(dir)) {
+                log.info("Cloning " + from.getName());
+                Files.createDirectories(dir);
+                repo = Repository.mirror(from.getUrl(), dir);
+            } else {
+                log.info("Found existing scratch directory for " + from.getName());
+                repo = Repository.get(dir).orElseThrow(() -> {
+                        return new RuntimeException("Repository in " + dir + " has vanished");
+                });
+            }
+
+            log.info("Pulling " + from.getName());
+            repo.fetchAll();
+            log.info("Pushing to " + to.getName());
+            repo.pushAll(to.getUrl());
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "MirrorBot@(" + from.getName() + "-> " + to.getName() + ")";
+    }
+
+    @Override
+    public List<WorkItem> getPeriodicItems() {
+        return List.of(this);
+    }
+}

--- a/bots/mirror/src/main/java/org/openjdk/skara/bots/mirror/MirrorBotFactory.java
+++ b/bots/mirror/src/main/java/org/openjdk/skara/bots/mirror/MirrorBotFactory.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.mirror;
+
+import org.openjdk.skara.bot.*;
+import org.openjdk.skara.vcs.Branch;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.logging.Logger;
+
+public class MirrorBotFactory implements BotFactory {
+    private final Logger log = Logger.getLogger("org.openjdk.skara.bots");;
+
+    @Override
+    public String name() {
+        return "mirror";
+    }
+
+    @Override
+    public List<Bot> create(BotConfiguration configuration) {
+        var storage = configuration.storageFolder();
+        try {
+            Files.createDirectories(storage);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        var specific = configuration.specific();
+
+        var bots = new ArrayList<Bot>();
+        for (var repo : specific.get("repositories").fields()) {
+            var fromName = repo.value().get("from").asString();
+            var fromRepo = configuration.repository(fromName);
+
+            var toName = repo.value().get("to").asString();
+            var toRepo = configuration.repository(toName);
+
+            log.info("Setting up mirroring from " + fromRepo.getName() + "to " + toRepo.getName());
+            bots.add(new MirrorBot(storage, fromRepo, toRepo));
+        }
+        return bots;
+    }
+}

--- a/bots/mirror/src/test/java/org/openjdk/skara/bots/mirror/MirrorBotTests.java
+++ b/bots/mirror/src/test/java/org/openjdk/skara/bots/mirror/MirrorBotTests.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.mirror;
+
+import org.openjdk.skara.host.*;
+import org.openjdk.skara.test.*;
+import org.openjdk.skara.vcs.*;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MirrorBotTests {
+    @Test
+    void mirrorMasterBranch(TestInfo testInfo) throws IOException {
+        try (var temp = new TemporaryDirectory()) {
+            var host = TestHost.createNew(List.of(new HostUserDetails(0, "duke", "J. Duke")));
+
+            var fromDir = temp.path().resolve("from.git");
+            var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
+            var fromHostedRepo = new TestHostedRepository(host, "test", fromLocalRepo);
+
+            var toDir = temp.path().resolve("to.git");
+            var toLocalRepo = Repository.init(toDir, VCS.GIT);
+            var gitConfig = toDir.resolve(".git").resolve("config");
+            Files.write(gitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
+                        StandardOpenOption.APPEND);
+            var toHostedRepo = new TestHostedRepository(host, "test-mirror", toLocalRepo);
+
+            var newFile = fromDir.resolve("this-file-cannot-exist.txt");
+            Files.writeString(newFile, "Hello world\n");
+            fromLocalRepo.add(newFile);
+            var newHash = fromLocalRepo.commit("An additional commit", "duke", "duke@openjdk.org");
+            var fromCommits = fromLocalRepo.commits().asList();
+            assertEquals(1, fromCommits.size());
+            assertEquals(newHash, fromCommits.get(0).hash());
+
+            var toCommits = toLocalRepo.commits().asList();
+            assertEquals(0, toCommits.size());
+
+            var storage = temp.path().resolve("storage");
+            var bot = new MirrorBot(storage, fromHostedRepo, toHostedRepo);
+            TestBotRunner.runPeriodicItems(bot);
+
+            toCommits = toLocalRepo.commits().asList();
+            assertEquals(1, toCommits.size());
+            assertEquals(newHash, toCommits.get(0).hash());
+        }
+    }
+
+    @Test
+    void mirrorMultipleBranches(TestInfo testInfo) throws IOException {
+        try (var temp = new TemporaryDirectory()) {
+            var host = TestHost.createNew(List.of(new HostUserDetails(0, "duke", "J. Duke")));
+
+            var fromDir = temp.path().resolve("from.git");
+            var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
+            var fromHostedRepo = new TestHostedRepository(host, "test", fromLocalRepo);
+
+            var toDir = temp.path().resolve("to.git");
+            var toLocalRepo = Repository.init(toDir, VCS.GIT);
+            var gitConfig = toDir.resolve(".git").resolve("config");
+            Files.write(gitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
+                        StandardOpenOption.APPEND);
+            var toHostedRepo = new TestHostedRepository(host, "test-mirror", toLocalRepo);
+
+            var newFile = fromDir.resolve("this-file-cannot-exist.txt");
+            Files.writeString(newFile, "Hello world\n");
+            fromLocalRepo.add(newFile);
+            var newHash = fromLocalRepo.commit("An additional commit", "duke", "duke@openjdk.org");
+            var fromCommits = fromLocalRepo.commits().asList();
+            assertEquals(1, fromCommits.size());
+            assertEquals(newHash, fromCommits.get(0).hash());
+
+            fromLocalRepo.branch(newHash, "second");
+            fromLocalRepo.branch(newHash, "third");
+
+            var toCommits = toLocalRepo.commits().asList();
+            assertEquals(0, toCommits.size());
+            assertEquals(0, toLocalRepo.branches().size());
+
+            var storage = temp.path().resolve("storage");
+            var bot = new MirrorBot(storage, fromHostedRepo, toHostedRepo);
+            TestBotRunner.runPeriodicItems(bot);
+
+            toCommits = toLocalRepo.commits().asList();
+            assertEquals(1, toCommits.size());
+            assertEquals(newHash, toCommits.get(0).hash());
+            var toBranches = toLocalRepo.branches();
+            assertEquals(3, toBranches.size());
+            assertTrue(toBranches.contains(new Branch("master")));
+            assertTrue(toBranches.contains(new Branch("second")));
+            assertTrue(toBranches.contains(new Branch("third")));
+        }
+    }
+
+    @Test
+    void mirrorMultipleTags(TestInfo testInfo) throws IOException {
+        try (var temp = new TemporaryDirectory()) {
+            var host = TestHost.createNew(List.of(new HostUserDetails(0, "duke", "J. Duke")));
+
+            var fromDir = temp.path().resolve("from.git");
+            var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
+            var fromHostedRepo = new TestHostedRepository(host, "test", fromLocalRepo);
+
+            var toDir = temp.path().resolve("to.git");
+            var toLocalRepo = Repository.init(toDir, VCS.GIT);
+            var gitConfig = toDir.resolve(".git").resolve("config");
+            Files.write(gitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
+                        StandardOpenOption.APPEND);
+            var toHostedRepo = new TestHostedRepository(host, "test-mirror", toLocalRepo);
+
+            var newFile = fromDir.resolve("this-file-cannot-exist.txt");
+            Files.writeString(newFile, "Hello world\n");
+            fromLocalRepo.add(newFile);
+            var newHash = fromLocalRepo.commit("An additional commit", "duke", "duke@openjdk.org");
+            var fromCommits = fromLocalRepo.commits().asList();
+            assertEquals(1, fromCommits.size());
+            assertEquals(newHash, fromCommits.get(0).hash());
+
+            fromLocalRepo.tag(newHash, "first", "add first tag", "duke", "duk@openjdk.org");
+            fromLocalRepo.tag(newHash, "second", "add second tag", "duke", "duk@openjdk.org");
+
+            var toCommits = toLocalRepo.commits().asList();
+            assertEquals(0, toCommits.size());
+            assertEquals(0, toLocalRepo.tags().size());
+
+            var storage = temp.path().resolve("storage");
+            var bot = new MirrorBot(storage, fromHostedRepo, toHostedRepo);
+            TestBotRunner.runPeriodicItems(bot);
+
+            toCommits = toLocalRepo.commits().asList();
+            assertEquals(1, toCommits.size());
+            assertEquals(newHash, toCommits.get(0).hash());
+            var toTags = toLocalRepo.tags();
+            assertEquals(2, toTags.size());
+            assertTrue(toTags.contains(new Tag("first")));
+            assertTrue(toTags.contains(new Tag("second")));
+        }
+    }
+
+    @Test
+    void mirrorRemovingBranch(TestInfo testInfo) throws IOException {
+        try (var temp = new TemporaryDirectory()) {
+            var host = TestHost.createNew(List.of(new HostUserDetails(0, "duke", "J. Duke")));
+
+            var fromDir = temp.path().resolve("from.git");
+            var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
+            var fromHostedRepo = new TestHostedRepository(host, "test", fromLocalRepo);
+
+            var toDir = temp.path().resolve("to.git");
+            var toLocalRepo = Repository.init(toDir, VCS.GIT);
+            var gitConfig = toDir.resolve(".git").resolve("config");
+            Files.write(gitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
+                        StandardOpenOption.APPEND);
+            var toHostedRepo = new TestHostedRepository(host, "test-mirror", toLocalRepo);
+
+            var newFile = fromDir.resolve("this-file-cannot-exist.txt");
+            Files.writeString(newFile, "Hello world\n");
+            fromLocalRepo.add(newFile);
+            var newHash = fromLocalRepo.commit("An additional commit", "duke", "duke@openjdk.org");
+            var fromCommits = fromLocalRepo.commits().asList();
+            assertEquals(1, fromCommits.size());
+            assertEquals(newHash, fromCommits.get(0).hash());
+
+            fromLocalRepo.branch(newHash, "second");
+            fromLocalRepo.branch(newHash, "third");
+
+            var toCommits = toLocalRepo.commits().asList();
+            assertEquals(0, toCommits.size());
+            assertEquals(0, toLocalRepo.branches().size());
+
+            var storage = temp.path().resolve("storage");
+            var bot = new MirrorBot(storage, fromHostedRepo, toHostedRepo);
+            TestBotRunner.runPeriodicItems(bot);
+
+            toCommits = toLocalRepo.commits().asList();
+            assertEquals(1, toCommits.size());
+            assertEquals(newHash, toCommits.get(0).hash());
+            var toBranches = toLocalRepo.branches();
+            assertEquals(3, toBranches.size());
+            assertTrue(toBranches.contains(new Branch("master")));
+            assertTrue(toBranches.contains(new Branch("second")));
+            assertTrue(toBranches.contains(new Branch("third")));
+
+            fromLocalRepo.delete(new Branch("second"));
+            assertEquals(2, fromLocalRepo.branches().size());
+
+            TestBotRunner.runPeriodicItems(bot);
+            toBranches = toLocalRepo.branches();
+            assertEquals(2, toBranches.size());
+            assertTrue(toBranches.contains(new Branch("master")));
+            assertTrue(toBranches.contains(new Branch("third")));
+        }
+    }
+}

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
@@ -38,6 +38,7 @@ public interface Repository extends ReadOnlyRepository {
     void checkout(Hash h, boolean force) throws IOException;
     void checkout(Branch b, boolean force) throws IOException;
     Hash fetch(URI uri, String refspec) throws IOException;
+    void fetchAll() throws IOException;
     void pushAll(URI uri) throws IOException;
     void push(Hash hash, URI uri, String ref, boolean force) throws IOException;
     void push(Branch branch, String remote, boolean setUpstream) throws IOException;
@@ -97,6 +98,7 @@ public interface Repository extends ReadOnlyRepository {
                String committerEmail) throws IOException;
     Tag tag(Hash hash, String tagName, String message, String authorName, String authorEmail) throws IOException;
     Branch branch(Hash hash, String branchName) throws IOException;
+    void delete(Branch b) throws IOException;
     void rebase(Hash hash, String committerName, String committerEmail) throws IOException;
     void merge(Hash hash) throws IOException;
     void merge(Hash hash, String strategy) throws IOException;
@@ -183,5 +185,11 @@ public interface Repository extends ReadOnlyRepository {
     static Repository clone(URI from, Path to, boolean isBare) throws IOException {
         return from.getPath().toString().endsWith(".git") ?
             GitRepository.clone(from, to, isBare) : HgRepository.clone(from, to, isBare);
+    }
+
+    static Repository mirror(URI from, Path to) throws IOException {
+        return from.getPath().toString().endsWith(".git") ?
+            GitRepository.mirror(from, to) :
+            HgRepository.clone(from, to, true); // hg does not have concept of "mirror"
     }
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -333,7 +333,17 @@ public class HgRepository implements Repository {
     public Hash fetch(URI uri, String refspec) throws IOException {
         var oldHeads = new HashSet<Hash>(heads());
 
-        try (var p = capture("hg", "pull", "--rev=" + refspec, uri.toString())) {
+        var cmd = new ArrayList<String>();
+        cmd.add("hg");
+        cmd.add("pull");
+        if (refspec != null) {
+            cmd.add("--rev");
+            cmd.add(refspec);
+        }
+        if (uri != null) {
+            cmd.add(uri.toString());
+        }
+        try (var p = capture(cmd)) {
             await(p);
         }
 
@@ -347,6 +357,31 @@ public class HgRepository implements Repository {
             return head();
         }
         return newHeads.iterator().next();
+    }
+
+    @Override
+    public void fetchAll() throws IOException {
+        var pullPaths = new ArrayList<URI>();
+        try (var p = capture("hg", "paths")) {
+            var res = await(p);
+            for (var line : res.stdout()) {
+                var parts = line.split("=");
+                var name = parts[0].trim();
+                var uri = parts[1].trim();
+                if (!name.endsWith("-push")) {
+                    pullPaths.add(URI.create(uri));
+                }
+            }
+        }
+
+        for (var uri : pullPaths) {
+            fetch(uri, null);
+        }
+    }
+
+    @Override
+    public void delete(Branch b) throws IOException {
+        throw new RuntimeException("Branches cannot be deleted in Mercurial");
     }
 
     @Override
@@ -866,17 +901,26 @@ public class HgRepository implements Repository {
 
     @Override
     public void pull() throws IOException {
-        pull("default", "default");
+        pull(null, null);
     }
 
     @Override
     public void pull(String remote) throws IOException {
-        pull(remote, "default");
+        pull(remote, null);
     }
 
     @Override
     public void pull(String remote, String refspec) throws IOException {
-        try (var p = capture("hg", "pull", "--update", "--branch", refspec, remote)) {
+        var cmd = new ArrayList<String>();
+        cmd.addAll(List.of("hg", "pull", "--update"));
+        if (refspec != null) {
+            cmd.add("--branch");
+            cmd.add(refspec);
+        }
+        if (remote != null) {
+            cmd.add(remote);
+        }
+        try (var p = capture(cmd)) {
             await(p);
         }
     }


### PR DESCRIPTION
Hi all,

this patch adds a bot that can mirror two repositories, including multiple branches and multiple tags (in contrast to the forwarder bot that only forwards between two branches).

# Testing
- [x] `sh gradlew test` passes
- [x] Added four new unit tests to test the mirror bot
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)