### PR TITLE
57: The hgbridge should push marks to a configurable repository

### DIFF
--- a/bots/hgbridge/src/main/java/org/openjdk/skara/bots/hgbridge/Exporter.java
+++ b/bots/hgbridge/src/main/java/org/openjdk/skara/bots/hgbridge/Exporter.java
@@ -159,7 +159,7 @@ class Exporter {
         }
     }
 
-    static Optional<Repository> export(Converter converter, URI source, Path destination) throws IOException {
+    static Optional<Repository> export(Converter converter, URI source, Path destination, Path finalMarks) throws IOException {
         final var successMarker = "success.txt";
         final var lastKnownGood = destination.resolve("lkg");
         final var current = destination.resolve("current");
@@ -199,6 +199,10 @@ class Exporter {
             Files.deleteIfExists(lastKnownGood.resolve(successMarker));
             syncFolder(current, lastKnownGood);
             lastKnownGood.resolve(successMarker).toFile().createNewFile();
+
+            // Update marks
+            var markSource = current.resolve("marks.txt");
+            Files.copy(markSource, finalMarks, StandardCopyOption.REPLACE_EXISTING);
         }
 
         return ret;

--- a/bots/hgbridge/src/main/java/org/openjdk/skara/bots/hgbridge/ExporterConfig.java
+++ b/bots/hgbridge/src/main/java/org/openjdk/skara/bots/hgbridge/ExporterConfig.java
@@ -39,6 +39,10 @@ class ExporterConfig {
     private URI source;
     private HostedRepository configurationRepo;
     private String configurationRef;
+    private HostedRepository marksRepo;
+    private String marksRef;
+    private String marksAuthorName;
+    private String marksAuthorEmail;
     private List<String> replacementsFile;
     private List<String> correctionsFile;
     private List<String> lowercaseFile;
@@ -69,6 +73,38 @@ class ExporterConfig {
 
     void configurationRef(String configurationRef) {
         this.configurationRef = configurationRef;
+    }
+
+    void marksRepo(HostedRepository marksRepo) {
+        this.marksRepo = marksRepo;
+    }
+
+    HostedRepository marksRepo() {
+        return marksRepo;
+    }
+
+    void marksRef(String marksRef) {
+        this.marksRef = marksRef;
+    }
+
+    String marksRef() {
+        return marksRef;
+    }
+
+    void marksAuthorName(String marksAuthorName) {
+        this.marksAuthorName = marksAuthorName;
+    }
+
+    String marksAuthorName() {
+        return marksAuthorName;
+    }
+
+    void marksAuthorEmail(String marksAuthorEmail) {
+        this.marksAuthorEmail = marksAuthorEmail;
+    }
+
+    String marksAuthorEmail() {
+        return marksAuthorEmail;
     }
 
     void replacements(List<String> replacements) {

--- a/bots/hgbridge/src/main/java/org/openjdk/skara/bots/hgbridge/JBridgeBotFactory.java
+++ b/bots/hgbridge/src/main/java/org/openjdk/skara/bots/hgbridge/JBridgeBotFactory.java
@@ -52,6 +52,12 @@ public class JBridgeBotFactory implements BotFactory {
         var specific = configuration.specific();
         var storage = configuration.storageFolder();
 
+        var marks = specific.get("marks").asObject();
+        var marksRepo = configuration.repository(marks.get("repository").asString());
+        var marksRef = marks.get("ref").asString();
+        var marksName = marks.get("name").asString();
+        var marksEmail = marks.get("email").asString();
+
         var converters = specific.get("converters").stream()
                                  .map(JSONValue::asObject)
                                  .flatMap(base -> base.get("repositories").stream()
@@ -61,6 +67,12 @@ public class JBridgeBotFactory implements BotFactory {
                                                           // Base configuration options
                                                           converterConfig.configurationRepo(configuration.repository(base.get("repository").asString()));
                                                           converterConfig.configurationRef(base.get("ref").asString());
+
+                                                          // Mark storage configuration
+                                                          converterConfig.marksRepo(marksRepo);
+                                                          converterConfig.marksRef(marksRef);
+                                                          converterConfig.marksAuthorName(marksName);
+                                                          converterConfig.marksAuthorEmail(marksEmail);
 
                                                           // Repository specific overrides
                                                           converterConfig.replacements(getSpecific("replacements", base, repo));

--- a/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/convert/HgToGitConverter.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/convert/HgToGitConverter.java
@@ -686,7 +686,7 @@ public class HgToGitConverter implements Converter {
                 for (var mark : marks) {
                     hgHashesToMarks.put(mark.hg(), mark.key());
                     marksToHgHashes.put(mark.key(), mark.hg());
-                    currentMark = mark.key() > currentMark ? mark.key() : currentMark;
+                    currentMark = Math.max(mark.key(), currentMark);
                 }
                 var gitMarks = writeMarks(marks);
                 convert(hg, git, hgRepo, gitMarks);


### PR DESCRIPTION
Hi all,

Please review the following change that enables the hgbridge bot to push the marks generated during conversion to a separate repository.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)