### PR TITLE
58: Add mirror and forward bots to skara-bots CLI image

### DIFF
--- a/bots/cli/build.gradle
+++ b/bots/cli/build.gradle
@@ -38,8 +38,10 @@ module {
 dependencies {
     implementation project(':bots:pr')
     implementation project(':bots:hgbridge')
+    implementation project(':bots:forward')
     implementation project(':bots:notify')
     implementation project(':bots:mlbridge')
+    implementation project(':bots:mirror')
     implementation project(':bots:submit')
     implementation project(':bots:forward')
     implementation project(':vcs')
@@ -61,8 +63,10 @@ images {
         modules = ['jdk.crypto.ec',
                    'org.openjdk.skara.bots.pr',
                    'org.openjdk.skara.bots.hgbridge',
+                   'org.openjdk.skara.bots.forward',
                    'org.openjdk.skara.bots.notify',
                    'org.openjdk.skara.bots.mlbridge',
+                   'org.openjdk.skara.bots.mirror',
                    'org.openjdk.skara.bots.submit',
                    'org.openjdk.skara.bots.forward']
         launchers = ['skara-bots': 'org.openjdk.skara.bots.cli/org.openjdk.skara.bots.cli.BotLauncher']


### PR DESCRIPTION
HI all,

when I added the `mirror` and `forward` bots I forgot to add them to the bots CLI image (sigh). This is now fixed in this patch.

# Testing
- [x] Ensured `mirror` and `forward` bots are present in `skara-bots --list-bots` output
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)