### PR TITLE
Fix implementation of addremove

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
@@ -73,7 +73,7 @@ class ArchiveWorkItem implements WorkItem {
 
     private void pushMbox(Repository localRepo, String message) {
         try {
-            localRepo.addremove(localRepo.root().resolve("."));
+            localRepo.add(localRepo.root().resolve("."));
             var hash = localRepo.commit(message, bot.emailAddress().fullName().orElseThrow(), bot.emailAddress().address());
             localRepo.push(hash, bot.archiveRepo().getUrl(), "master");
         } catch (IOException e) {

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
@@ -30,8 +30,7 @@ import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Files;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Optional;
+import java.util.*;
 
 public interface Repository extends ReadOnlyRepository {
     Repository init() throws IOException;
@@ -45,30 +44,18 @@ public interface Repository extends ReadOnlyRepository {
     void clean() throws IOException;
     Repository reinitialize() throws IOException;
     void squash(Hash h) throws IOException;
-    void add(Path... files) throws IOException;
-    void remove(Path... files) throws IOException;
+    void add(List<Path> files) throws IOException;
+    default void add(Path... files) throws IOException {
+        add(Arrays.asList(files));
+    }
+    void remove(List<Path> files) throws IOException;
+    default void remove(Path... files) throws IOException {
+        remove(Arrays.asList(files));
+    }
     void pull() throws IOException;
     void pull(String remote) throws IOException;
     void pull(String remote, String refspec) throws IOException;
-    default void addremove(Path... files) throws IOException {
-        var exists = new ArrayList<Path>();
-        var missing = new ArrayList<Path>();
-        for (var file : files) {
-            if (Files.exists(file)) {
-                exists.add(file);
-            } else {
-                missing.add(file);
-            }
-        }
-
-        if (!exists.isEmpty()) {
-            add(exists.toArray(new Path[0]));
-        }
-
-        if (!missing.isEmpty()) {
-            remove(missing.toArray(new Path[0]));
-        }
-    }
+    void addremove() throws IOException;
     Hash commit(String message,
                 String authorName,
                 String authorEmail) throws IOException;

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -426,7 +426,7 @@ public class GitRepository implements Repository {
     }
 
     @Override
-    public void add(Path... paths) throws IOException {
+    public void add(List<Path> paths) throws IOException {
         var cmd = new ArrayList<>(List.of("git", "add"));
         for (var path : paths) {
             cmd.add(path.toString());
@@ -437,7 +437,7 @@ public class GitRepository implements Repository {
     }
 
     @Override
-    public void remove(Path... paths) throws IOException {
+    public void remove(List<Path> paths) throws IOException {
         var cmd = new ArrayList<>(List.of("git", "rm"));
         for (var path : paths) {
             cmd.add(path.toString());
@@ -450,6 +450,13 @@ public class GitRepository implements Repository {
     @Override
     public void delete(Branch b) throws IOException {
         try (var p = capture("git", "branch", "-D", b.name())) {
+            await(p);
+        }
+    }
+
+    @Override
+    public void addremove() throws IOException {
+        try (var p = capture("git", "add", "--all")) {
             await(p);
         }
     }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -857,7 +857,7 @@ public class HgRepository implements Repository {
     }
 
     @Override
-    public void remove(Path... paths) throws IOException {
+    public void remove(List<Path> paths) throws IOException {
         var cmd = new ArrayList<>(List.of("hg", "rm"));
         for (var p : paths) {
             cmd.add(p.toString());
@@ -868,12 +868,19 @@ public class HgRepository implements Repository {
     }
 
     @Override
-    public void add(Path... paths) throws IOException {
+    public void add(List<Path> paths) throws IOException {
         var cmd = new ArrayList<>(List.of("hg", "add"));
         for (var p : paths) {
             cmd.add(p.toString());
         }
         try (var p = capture(cmd)) {
+            await(p);
+        }
+    }
+
+    @Override
+    public void addremove() throws IOException {
+        try (var p = capture("hg", "addremove")) {
             await(p);
         }
     }


### PR DESCRIPTION
Hi,

this patch fix the implementation of `Repository::addremove` to use the proper underlying VCS primitives.

# Testing
- [x] `sh gradlew test` passes on Linux x86_64
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)