### PR TITLE
Use ZonedDateTime for date in Commit

### DIFF
--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/AuthorCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/AuthorCheckTests.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.*;
-import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.io.IOException;
 
 class AuthorCheckTests {
@@ -45,9 +45,9 @@ class AuthorCheckTests {
         var committer = new Author("Foo", "foo@bar.org");
         var hash = new Hash("0123456789012345678901234567890123456789");
         var parents = List.of(new Hash("12345789012345789012345678901234567890"));
-        var timestamp = Instant.now();
+        var date = ZonedDateTime.now();
         var message = List.of("Initial commit");
-        var metadata = new CommitMetadata(hash, parents, author, committer, timestamp, message);
+        var metadata = new CommitMetadata(hash, parents, author, committer, date, message);
         return new Commit(metadata, List.of());
     }
 

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/BlacklistCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/BlacklistCheckTests.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.*;
-import java.time.Instant;
+import java.time.ZonedDateTime;
 
 class BlacklistCheckTests {
     private static final JCheckConfiguration conf = JCheckConfiguration.parse(List.of(
@@ -44,9 +44,9 @@ class BlacklistCheckTests {
         var author = new Author("Foo", "foo@bar.org");
         var committer = author;
         var parents = List.of(new Hash("12345789012345789012345678901234567890"));
-        var timestamp = Instant.now();
+        var date = ZonedDateTime.now();
         var message = List.of("Initial commit");
-        var metadata = new CommitMetadata(hash, parents, author, committer, timestamp, message);
+        var metadata = new CommitMetadata(hash, parents, author, committer, date, message);
         return new Commit(metadata, List.of());
     }
 

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/CommitterCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/CommitterCheckTests.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ArrayList;
-import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.io.IOException;
 
 class CommitterCheckTests {
@@ -78,9 +78,9 @@ class CommitterCheckTests {
     private static Commit commit(Author author, Author committer) {
         var hash = new Hash("0123456789012345678901234567890123456789");
         var parents = List.of(new Hash("12345789012345789012345678901234567890"));
-        var timestamp = Instant.now();
+        var date = ZonedDateTime.now();
         var message = List.of("Initial commit");
-        var metadata = new CommitMetadata(hash, parents, author, committer, timestamp, message);
+        var metadata = new CommitMetadata(hash, parents, author, committer, date, message);
         return new Commit(metadata, List.of());
     }
 

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/ExecutableCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/ExecutableCheckTests.java
@@ -33,7 +33,7 @@ import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ArrayList;
-import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.io.IOException;
 
 class ExecutableCheckTests {
@@ -61,8 +61,8 @@ class ExecutableCheckTests {
         var hash = new Hash("0123456789012345678901234567890123456789");
         var parents = List.of(hash, hash);
         var message = List.of("A commit");
-        var timestamp = Instant.now();
-        var metadata = new CommitMetadata(hash, parents, author, author, timestamp, message);
+        var date = ZonedDateTime.now();
+        var metadata = new CommitMetadata(hash, parents, author, author, date, message);
         return new Commit(metadata, parentDiffs);
     }
 

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/HgTagCommitCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/HgTagCommitCheckTests.java
@@ -34,7 +34,7 @@ import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ArrayList;
-import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.io.IOException;
 
 class HgTagCommitCheckTests {
@@ -61,8 +61,8 @@ class HgTagCommitCheckTests {
     private static Commit commit(Hash hash, List<String> message, List<Diff> parentDiffs) {
         var author = new Author("Foo Bar", "foo@bar.org");
         var parents = List.of(new Hash("12345789012345789012345678901234567890"));
-        var timestamp = Instant.now();
-        var metadata = new CommitMetadata(hash, parents, author, author, timestamp, message);
+        var date = ZonedDateTime.now();
+        var metadata = new CommitMetadata(hash, parents, author, author, date, message);
         return new Commit(metadata, parentDiffs);
     }
 
@@ -72,8 +72,8 @@ class HgTagCommitCheckTests {
         var parents = List.of(new Hash("12345789012345789012345678901234567890"),
                               new Hash("12345789012345789012345678901234567890"));
         var message = List.of("Merge");
-        var timestamp = Instant.now();
-        var metadata = new CommitMetadata(hash, parents, author, author, timestamp, message);
+        var date = ZonedDateTime.now();
+        var metadata = new CommitMetadata(hash, parents, author, author, date, message);
         return new Commit(metadata, List.of());
     }
 

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/IssuesCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/IssuesCheckTests.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ArrayList;
-import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.io.IOException;
 
 class IssuesCheckTests {
@@ -56,8 +56,8 @@ class IssuesCheckTests {
         var author = new Author("foo", "foo@host.org");
         var hash = new Hash("0123456789012345678901234567890123456789");
         var parents = List.of(hash);
-        var timestamp = Instant.now();
-        var metadata = new CommitMetadata(hash, parents, author, author, timestamp, message);
+        var date = ZonedDateTime.now();
+        var metadata = new CommitMetadata(hash, parents, author, author, date, message);
         return new Commit(metadata, List.of());
     }
 

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/MergeMessageCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/MergeMessageCheckTests.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ArrayList;
-import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.io.IOException;
 
 class MergeMessageCheckTests {
@@ -56,8 +56,8 @@ class MergeMessageCheckTests {
         var author = new Author("foo", "foo@host.org");
         var hash = new Hash("0123456789012345678901234567890123456789");
         var parents = List.of(hash, hash);
-        var timestamp = Instant.now();
-        var metadata = new CommitMetadata(hash, parents, author, author, timestamp, message);
+        var date = ZonedDateTime.now();
+        var metadata = new CommitMetadata(hash, parents, author, author, date, message);
         return new Commit(metadata, List.of());
     }
 

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/MessageCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/MessageCheckTests.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ArrayList;
-import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.io.IOException;
 
 class MessageCheckTests {
@@ -56,8 +56,8 @@ class MessageCheckTests {
         var author = new Author("foo", "foo@host.org");
         var hash = new Hash("0123456789012345678901234567890123456789");
         var parents = List.of(hash);
-        var timestamp = Instant.now();
-        var metadata = new CommitMetadata(hash, parents, author, author, timestamp, message);
+        var date = ZonedDateTime.now();
+        var metadata = new CommitMetadata(hash, parents, author, author, date, message);
         return new Commit(metadata, List.of());
     }
 

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/ReviewersCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/ReviewersCheckTests.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ArrayList;
-import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.io.IOException;
 
 class ReviewersCheckTests {
@@ -91,9 +91,9 @@ class ReviewersCheckTests {
     private static Commit commit(Author author, List<String> reviewers) {
         var hash = new Hash("0123456789012345678901234567890123456789");
         var parents = List.of(new Hash("12345789012345789012345678901234567890"));
-        var timestamp = Instant.now();
+        var date = ZonedDateTime.now();
         var message = List.of("Initial commit", "", "Reviewed-by: " + String.join(", ", reviewers));
-        var metadata = new CommitMetadata(hash, parents, author, author, timestamp, message);
+        var metadata = new CommitMetadata(hash, parents, author, author, date, message);
         return new Commit(metadata, List.of());
     }
 

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/WhitespaceCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/WhitespaceCheckTests.java
@@ -34,7 +34,7 @@ import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ArrayList;
-import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.io.IOException;
 
 class WhitespaceCheckTests {
@@ -67,9 +67,9 @@ class WhitespaceCheckTests {
         var author = new Author("Foo Bar", "foo@bar.org");
         var hash = new Hash("0123456789012345678901234567890123456789");
         var parents = List.of(new Hash("12345789012345789012345678901234567890"));
-        var timestamp = Instant.now();
+        var date = ZonedDateTime.now();
         var message = List.of("Initial commit", "", "Reviewed-by: baz");
-        var metadata = new CommitMetadata(hash, parents, author, author, timestamp, message);
+        var metadata = new CommitMetadata(hash, parents, author, author, date, message);
         return new Commit(metadata, parentDiffs);
     }
 

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Commit.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Commit.java
@@ -55,10 +55,6 @@ public class Commit {
         return metadata.parents();
     }
 
-    public Instant timestamp() {
-        return metadata.timestamp();
-    }
-
     public List<Diff> parentDiffs() {
         return parentDiffs;
     }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/CommitMetadata.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/CommitMetadata.java
@@ -33,17 +33,17 @@ public class CommitMetadata {
     private final List<Hash> parents;
     private final Author author;
     private final Author committer;
-    private final Instant timestamp;
+    private final ZonedDateTime date;
     private final List<String> message;
 
     public CommitMetadata(Hash hash, List<Hash> parents,
                           Author author, Author committer,
-                          Instant timestamp, List<String> message) {
+                          ZonedDateTime date, List<String> message) {
         this.hash = hash;
         this.parents = parents;
         this.author = author;
         this.committer = committer;
-        this.timestamp = timestamp;
+        this.date = date;
         this.message = message;
     }
 
@@ -67,16 +67,12 @@ public class CommitMetadata {
         return parents;
     }
 
-    public Instant timestamp() {
-        return timestamp;
+    public ZonedDateTime date() {
+        return date;
     }
 
     public boolean isInitialCommit() {
         return numParents() == 1 && parents.get(0).equals(NULL_HASH);
-    }
-
-    public ZonedDateTime date() {
-        return ZonedDateTime.ofInstant(timestamp(), ZoneOffset.UTC);
     }
 
     public boolean isMerge() {
@@ -89,17 +85,15 @@ public class CommitMetadata {
 
     @Override
     public String toString() {
-        final var formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")
-                                               .withLocale(Locale.getDefault())
-                                               .withZone(ZoneOffset.UTC);
-        final var displayDate = formatter.format(timestamp);
+        final var formatter = DateTimeFormatter.RFC_1123_DATE_TIME;
+        final var displayDate = date.format(formatter);
         return String.format("%s  %-12s  %s  %s",
                              hash().toString(), author(), displayDate, message.get(0));
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(hash, parents, author, committer, timestamp, message);
+        return Objects.hash(hash, parents, author, committer, date, message);
     }
 
     @Override
@@ -113,7 +107,7 @@ public class CommitMetadata {
                Objects.equals(parents, other.parents) &&
                Objects.equals(author, other.author) &&
                Objects.equals(committer, other.committer) &&
-               Objects.equals(timestamp, other.timestamp) &&
+               Objects.equals(date, other.date) &&
                Objects.equals(message, other.message);
     }
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Files;
-import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.util.*;
 
 public interface Repository extends ReadOnlyRepository {
@@ -62,7 +62,7 @@ public interface Repository extends ReadOnlyRepository {
     Hash commit(String message,
                 String authorName,
                 String authorEmail,
-                Instant timestamp) throws IOException;
+                ZonedDateTime date) throws IOException;
     Hash commit(String message,
                 String authorName,
                 String authorEmail,
@@ -71,10 +71,10 @@ public interface Repository extends ReadOnlyRepository {
     Hash commit(String message,
                 String authorName,
                 String authorEmail,
-                Instant authorDate,
+                ZonedDateTime authorDate,
                 String committerName,
                 String committerEmail,
-                Instant committerDate) throws IOException;
+                ZonedDateTime committerDate) throws IOException;
     Hash amend(String message,
                String authorName,
                String authorEmail) throws IOException;

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitCommitMetadata.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitCommitMetadata.java
@@ -41,7 +41,7 @@ class GitCommitMetadata {
     private static final String authorEmailFormat = "%ae";
     private static final String committerNameFormat = "%cn";
     private static final String committerEmailFormat = "%ce";
-    private static final String timestampFormat = "%at";
+    private static final String timestampFormat = "%aI";
 
     private static final String messageDelimiter = "=@=@=@=@=@";
     private static final String messageFormat = "%B" + messageDelimiter;
@@ -81,7 +81,8 @@ class GitCommitMetadata {
         log.finer("committerEmail " + committerName);
         var committer = new Author(committerName, committerEmail);
 
-        var timestamp = Instant.ofEpochSecond(Long.parseLong(reader.readLine()));
+        var formatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+        var date = ZonedDateTime.parse(reader.readLine(), formatter);
 
         var message = new ArrayList<String>();
         var line = reader.readLine();
@@ -95,6 +96,6 @@ class GitCommitMetadata {
             message.add(prefix);
         }
 
-        return new CommitMetadata(hash, parents, author, committer, timestamp, message);
+        return new CommitMetadata(hash, parents, author, committer, date, message);
     }
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgCommitMetadata.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgCommitMetadata.java
@@ -47,7 +47,7 @@ class HgCommitMetadata {
         var author = Author.fromString(reader.readLine());
 
         var formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd H:m:sZ");
-        var timestamp = ZonedDateTime.parse(reader.readLine(), formatter).toInstant();
+        var date = ZonedDateTime.parse(reader.readLine(), formatter);
 
         var messageSize = Integer.parseInt(reader.readLine());
         var messageBuffer = reader.read(messageSize);
@@ -64,6 +64,6 @@ class HgCommitMetadata {
             }
         }
 
-        return new CommitMetadata(hash, parents, author, author, timestamp, message);
+        return new CommitMetadata(hash, parents, author, author, date, message);
     }
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -29,9 +29,8 @@ import org.openjdk.skara.vcs.tools.*;
 
 import java.io.*;
 import java.nio.file.*;
-import java.time.Instant;
-import java.time.ZonedDateTime;
-import java.time.ZoneOffset;
+import java.time.*;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.logging.Logger;
 import java.util.stream.*;
@@ -492,13 +491,13 @@ public class HgRepository implements Repository {
     }
 
     @Override
-    public Hash commit(String message, String authorName, String authorEmail, Instant authorDate)  throws IOException {
+    public Hash commit(String message, String authorName, String authorEmail, ZonedDateTime authorDate)  throws IOException {
         var user = authorEmail == null ? authorName : authorName + " <" + authorEmail + ">";
         var cmd = new ArrayList<String>();
         cmd.addAll(List.of("hg", "commit", "--message=" + message, "--user=" + user));
         if (authorDate != null) {
-            var date = ZonedDateTime.ofInstant(authorDate, ZoneOffset.UTC);
-            cmd.add("--date=" + date.toEpochSecond() + " 0");
+            var formatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+            cmd.add("--date=" + authorDate.format(formatter));
         }
         try (var p = capture(cmd)) {
             await(p);
@@ -519,10 +518,10 @@ public class HgRepository implements Repository {
     public Hash commit(String message,
                        String authorName,
                        String authorEmail,
-                       Instant authorDate,
+                       ZonedDateTime authorDate,
                        String committerName,
                        String committerEmail,
-                       Instant committerDate) throws IOException {
+                       ZonedDateTime committerDate) throws IOException {
         if (!Objects.equals(authorName, committerName) ||
             !Objects.equals(authorEmail, committerEmail) ||
             !Objects.equals(authorDate, committerDate)) {

--- a/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/convert/GitToHgConverter.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/convert/GitToHgConverter.java
@@ -174,7 +174,7 @@ public class GitToHgConverter implements Converter {
             var hgHash = hgRepo.commit(hgMessage,
                                        username(committer),
                                        null,
-                                       commit.timestamp());
+                                       commit.date());
             log.finer("Hg hash: " + hgHash.hex());
             gitToHg.put(commit.hash(), hgHash);
             hgToGit.put(hgHash, commit.hash());

--- a/vcs/src/test/java/org/openjdk/skara/vcs/openjdk/converter/GitToHgConverterTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/openjdk/converter/GitToHgConverterTests.java
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class GitToHgConverterTests {
     void assertCommitEquals(Commit gitCommit, Commit hgCommit) {
-        assertEquals(gitCommit.timestamp(), hgCommit.timestamp());
+        assertEquals(gitCommit.date(), hgCommit.date());
         assertEquals(gitCommit.isInitialCommit(), hgCommit.isInitialCommit());
         assertEquals(gitCommit.isMerge(), hgCommit.isMerge());
         assertEquals(gitCommit.numParents(), hgCommit.numParents());

--- a/vcs/src/test/java/org/openjdk/skara/vcs/openjdk/converter/HgToGitConverterTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/openjdk/converter/HgToGitConverterTests.java
@@ -64,7 +64,7 @@ class HgToGitConverterTests {
             assertEquals(gitCommit.author(), new Author("Foo Bar", "foo@openjdk.java.net"));
             assertEquals(gitCommit.committer(), new Author("Foo Bar", "foo@openjdk.java.net"));
             assertEquals(hgCommit.message(), gitCommit.message());
-            assertEquals(hgCommit.timestamp(), gitCommit.timestamp());
+            assertEquals(hgCommit.date(), gitCommit.date());
             assertEquals(hgCommit.isInitialCommit(), gitCommit.isInitialCommit());
             assertEquals(hgCommit.isMerge(), gitCommit.isMerge());
             assertEquals(hgCommit.numParents(), gitCommit.numParents());


### PR DESCRIPTION
Hi,

this patch changes from `Instant` to `ZonedDateTime` in `CommitMetadata`. This is done to preserve the time zone recorded in the underlying VCS commit (both git and hg store the time zone of the developer's machine in the commit).

# Testing
- [x] `sh gradlew test` passes on Linux x86_64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)