### PR TITLE
Proper parsing of git diff --raw lines

### DIFF
--- a/vcs/src/main/resources/ext.py
+++ b/vcs/src/main/resources/ext.py
@@ -67,11 +67,11 @@ def _diff_git_raw(repo, ctx1, ctx2, modified, added, removed):
     for path in sorted(modified | added | removed_copy):
         if path in modified:
             fctx = ctx2.filectx(path)
-            writeln(':{} {} {} {} M {}'.format(mode(ctx1.filectx(path)), mode(fctx), nullHash, nullHash, fctx.path()))
+            writeln(':{} {} {} {} M\t{}'.format(mode(ctx1.filectx(path)), mode(fctx), nullHash, nullHash, fctx.path()))
         elif path in added:
             fctx = ctx2.filectx(path)
             if not fctx.renamed():
-                writeln(':000000 {} {} {} A {}'.format(mode(fctx), nullHash, nullHash, fctx.path()))
+                writeln(':000000 {} {} {} A\t{}'.format(mode(fctx), nullHash, nullHash, fctx.path()))
             else:
                 parent = fctx.p1()
                 score = int(ratio(parent.data(), fctx.data(), 0.5) * 100)
@@ -82,10 +82,10 @@ def _diff_git_raw(repo, ctx1, ctx2, modified, added, removed):
                 else:
                     operation = 'C'
 
-                writeln(':{} {} {} {} {}{} {} {}'.format(mode(parent), mode(fctx), nullHash, nullHash, operation, score, old_path, path))
+                writeln(':{} {} {} {} {}{}\t{}\t{}'.format(mode(parent), mode(fctx), nullHash, nullHash, operation, score, old_path, path))
         elif path in removed_copy:
             fctx = ctx1.filectx(path)
-            writeln(':{} 000000 {} {} D {}'.format(mode(fctx), nullHash, nullHash, path))
+            writeln(':{} 000000 {} {} D\t{}'.format(mode(fctx), nullHash, nullHash, path))
 
     writeln('')
 

--- a/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
@@ -1438,4 +1438,28 @@ public class RepositoryTests {
         assertEquals(Optional.empty(), Repository.get(nonExistingDirectory));
         assertEquals(false, Repository.exists(nonExistingDirectory));
     }
+
+    @ParameterizedTest
+    @EnumSource(VCS.class)
+    void testDiffOnFilenamesWithSpace(VCS vcs) throws IOException {
+        try (var dir = new TemporaryDirectory()) {
+            var r = Repository.init(dir.path(), vcs);
+            assertTrue(r.isClean());
+
+            var fileWithSpaceInName = dir.path().resolve("hello world.txt");
+            Files.writeString(fileWithSpaceInName, "Hello world\n");
+            r.add(fileWithSpaceInName);
+            var hash1 = r.commit("Added file with space in name", "duke", "duke@openjdk.java.net");
+            Files.writeString(fileWithSpaceInName, "Goodbye world\n");
+            r.add(fileWithSpaceInName);
+            var hash2 = r.commit("Modified file with space in name", "duke", "duke@openjdk.java.net");
+            var diff = r.diff(hash1, hash2);
+            var patches = diff.patches();
+            assertEquals(1, patches.size());
+            var patch = patches.get(0);
+            assertTrue(patch.target().path().isPresent());
+            var path = patch.target().path().get();
+            assertEquals(Path.of("hello world.txt"), path);
+        }
+    }
 }


### PR DESCRIPTION
Hi,

this patch introduces stricter (and more correct) parsing of the output from `git diff --raw`. The previous parsing code could not handle spaces in file names.

## Testing
- [x] `sh gradlew test`
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**) **Note!** Review applies to e95a4ccd65a55e6b0cf2cea87a127a8e9bbae2c0