### PR TITLE
Fix webrev generation issue when a source hunk is empty

### DIFF
--- a/webrev/build.gradle
+++ b/webrev/build.gradle
@@ -25,12 +25,15 @@ module {
     name = 'org.openjdk.skara.webrev'
     test {
         requires 'org.junit.jupiter.api'
+        requires 'org.openjdk.skara.test'
         opens 'org.openjdk.skara.webrev' to 'org.junit.platform.commons'
     }
 }
 
 dependencies {
     implementation project(':vcs')
+
+    testImplementation project(':test')
 }
 
 publishing {

--- a/webrev/src/main/java/org/openjdk/skara/webrev/FramesView.java
+++ b/webrev/src/main/java/org/openjdk/skara/webrev/FramesView.java
@@ -92,7 +92,9 @@ class FramesView implements View {
                 var hunk = hunks.get(hunkIndex);
                 var numSourceLines = hunk.source().lines().size();
                 var numDestLines = hunk.target().lines().size();
-                var start = hunk.source().range().start() - 1;
+                var start = numSourceLines == 0 ?
+                    hunk.source().range().start() :
+                    hunk.source().range().start() - 1;
 
                 for (var i = lastEnd; i < start; i++) {
                     ViewUtils.writeWithLineNumber(fw, sourceContent.get(i), i + 1, maxLineNum);

--- a/webrev/src/main/java/org/openjdk/skara/webrev/HunkCoalescer.java
+++ b/webrev/src/main/java/org/openjdk/skara/webrev/HunkCoalescer.java
@@ -256,9 +256,10 @@ class HunkCoalescer {
 
         var afterContextCount = Math.min(sourceAfterContextCount, destAfterContextCount);
 
-        var sourceEndingLineNum = sourceAfterContextStart + afterContextCount;
+        var sourceLineNumStart = hunk.source().lines().isEmpty() ? sourceAfterContextStart + 1 : sourceAfterContextStart;
+        var sourceEndingLineNum = sourceLineNumStart + afterContextCount;
         var sourceContextAfter = new ArrayList<Line>();
-        for (var lineNum = sourceAfterContextStart; lineNum < sourceEndingLineNum; lineNum++) {
+        for (var lineNum = sourceLineNumStart; lineNum < sourceEndingLineNum; lineNum++) {
             var text = sourceContent.get(lineNum - 1);
             sourceContextAfter.add(new Line(lineNum, text));
         }

--- a/webrev/src/test/java/org/openjdk/skara/webrev/WebrevTests.java
+++ b/webrev/src/test/java/org/openjdk/skara/webrev/WebrevTests.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.webrev;
+
+import org.openjdk.skara.test.TemporaryDirectory;
+import org.openjdk.skara.vcs.*;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.*;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class WebrevTests {
+    void assertContains(Path file, String text) throws IOException {
+        var contents = Files.readString(file);
+        assertTrue(contents.contains(text));
+    }
+
+    @ParameterizedTest
+    @EnumSource(VCS.class)
+    void emptySourceHunk(VCS vcs) throws IOException {
+        try (var repoFolder = new TemporaryDirectory();
+        var webrevFolder = new TemporaryDirectory()) {
+            var repo = Repository.init(repoFolder.path(), vcs);
+            var file = repoFolder.path().resolve("x.txt");
+            Files.writeString(file, "1\n2\n3\n", StandardCharsets.UTF_8);
+            repo.add(file);
+            var hash1 = repo.commit("Commit", "a", "a@a.a");
+            Files.writeString(file, "0\n1\n2\n3\n", StandardCharsets.UTF_8);
+            repo.add(file);
+            var hash2 = repo.commit("Commit 2", "a", "a@a.a");
+
+            new Webrev.Builder(repo, webrevFolder.path()).generate(hash1, hash2);
+            assertContains(webrevFolder.path().resolve("index.html"), "<td>1 lines changed; 1 ins; 0 del; 0 mod; 3 unchg</td>");
+        }
+    }
+}


### PR DESCRIPTION
Hi all,

Please review this fix for an index-out-of-bounds when generating a webrev containing an empty source hunk.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)