### PR TITLE
Improve the previous empty hunks fix

### DIFF
--- a/webrev/build.gradle
+++ b/webrev/build.gradle
@@ -36,6 +36,15 @@ dependencies {
     testImplementation project(':test')
 }
 
+task copyResources(type: Copy) {
+    from "${projectDir}/src/main/resources"
+    into "${buildDir}/classes/java/test"
+}
+
+test {
+    dependsOn 'copyResources'
+}
+
 publishing {
     publications {
         webrev(MavenPublication) {

--- a/webrev/src/main/java/org/openjdk/skara/webrev/FramesView.java
+++ b/webrev/src/main/java/org/openjdk/skara/webrev/FramesView.java
@@ -92,7 +92,7 @@ class FramesView implements View {
                 var hunk = hunks.get(hunkIndex);
                 var numSourceLines = hunk.source().lines().size();
                 var numDestLines = hunk.target().lines().size();
-                var start = numSourceLines == 0 ?
+                var start = numSourceLines == 0 && hunk.source().range().start() == 0 ?
                     hunk.source().range().start() :
                     hunk.source().range().start() - 1;
 

--- a/webrev/src/test/java/org/openjdk/skara/webrev/WebrevTests.java
+++ b/webrev/src/test/java/org/openjdk/skara/webrev/WebrevTests.java
@@ -42,6 +42,25 @@ class WebrevTests {
 
     @ParameterizedTest
     @EnumSource(VCS.class)
+    void simple(VCS vcs) throws IOException {
+        try (var repoFolder = new TemporaryDirectory();
+             var webrevFolder = new TemporaryDirectory()) {
+            var repo = Repository.init(repoFolder.path(), vcs);
+            var file = repoFolder.path().resolve("x.txt");
+            Files.writeString(file, "1\n2\n3\n", StandardCharsets.UTF_8);
+            repo.add(file);
+            var hash1 = repo.commit("Commit", "a", "a@a.a");
+            Files.writeString(file, "1\n2\n3\n4\n", StandardCharsets.UTF_8);
+            repo.add(file);
+            var hash2 = repo.commit("Commit 2", "a", "a@a.a");
+
+            new Webrev.Builder(repo, webrevFolder.path()).generate(hash1, hash2);
+            assertContains(webrevFolder.path().resolve("index.html"), "<td>1 lines changed; 1 ins; 0 del; 0 mod; 3 unchg</td>");
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(VCS.class)
     void emptySourceHunk(VCS vcs) throws IOException {
         try (var repoFolder = new TemporaryDirectory();
         var webrevFolder = new TemporaryDirectory()) {


### PR DESCRIPTION
Hi all,

The previous fix for generating webrevs with empty source hunks broke other cases. Here's more fixes and tests.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)