### PR TITLE
git combined diffs suffer from underflow

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitCombinedDiffParser.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitCombinedDiffParser.java
@@ -70,10 +70,10 @@ class GitCombinedDiffParser {
                     // always have range (0,0), but git reports (1,0)
                     sourceRangesPerParent.add(new Range(0, 0));
                 } else {
-                    sourceRangesPerParent.add(Range.fromString(words[i].substring(1))); // skip initial '-'
+                    sourceRangesPerParent.add(GitRange.fromCombinedString(words[i].substring(1))); // skip initial '-'
                 }
             }
-            var targetRange = Range.fromString(words[numParents + 1].substring(1)); // skip initial '+'
+            var targetRange = GitRange.fromCombinedString(words[numParents + 1].substring(1)); // skip initial '+'
 
             var linesPerParent = new ArrayList<List<String>>(numParents);
             for (int i = 0; i < numParents; i++) {

--- a/vcs/src/main/java/org/openjdk/skara/vcs/tools/GitRange.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/tools/GitRange.java
@@ -24,7 +24,7 @@ package org.openjdk.skara.vcs.tools;
 
 import org.openjdk.skara.vcs.Range;
 
-class GitRange {
+public class GitRange {
     static Range fromString(String s) {
         var separatorIndex = s.indexOf(",");
 
@@ -46,6 +46,25 @@ class GitRange {
             // but if start == 0, a file was added and we need a 0 here.
             start++;
         }
+
+        return new Range(start, count);
+    }
+
+    public static Range fromCombinedString(String s) {
+        var separatorIndex = s.indexOf(",");
+
+        if (separatorIndex == -1) {
+            var start = Integer.parseInt(s);
+            return new Range(start, 1);
+        }
+
+        var start = Integer.parseInt(s.substring(0, separatorIndex));
+
+        // Need to work around a bug in git where git sometimes print -1
+        // as an unsigned int for the count part of the range
+        var countString = s.substring(separatorIndex + 1, s.length());
+        var count =
+            countString.equals("18446744073709551615") ?  0 : Integer.parseInt(countString);
 
         return new Range(start, count);
     }


### PR DESCRIPTION
Hi all,

seems like `git diff -c --unified=0` also suffers from underflow, but _not_ the off-by-one bug for empty hunks that `git diff --unified=0` suffers from. I updated the code to work around this issue.

## Testing
- [x] `sh gradlew test` passes on Linux x86_64
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)