### PR TITLE
GitCommitIterator should handle empty commits

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitCommitIterator.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitCommitIterator.java
@@ -62,6 +62,15 @@ class GitCommitIterator implements Iterator<Commit> {
             var metadata = GitCommitMetadata.read(reader);
 
             line = reader.readLine();   // read empty line before patches
+            if (line == null || line.equals(commitDelimiter)) {
+                // commit without patches
+                var parentDiffs = new ArrayList<Diff>();
+                for (var parentHash : metadata.parents()) {
+                    parentDiffs.add(new Diff(parentHash, metadata.hash(), Collections.emptyList()));
+                }
+                return new Commit(metadata, parentDiffs);
+            }
+
             if (!line.equals("")) {
                 throw new IllegalStateException("Unexpected line: " + line);
             }


### PR DESCRIPTION
HI all,

the `GitCommitIterator` should be able to handle empty commits. Although empty commits are rare, there are a few in the OpenJDK repositories.

## Testing
- [x] Added two new unit tests
- [x] `sh gradlew test` passes on Linux x86_64
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)