### PR TITLE
62: Proper parsing of GitLab discussions outside of a diff context

### DIFF
--- a/host/src/main/java/org/openjdk/skara/host/gitlab/GitLabMergeRequest.java
+++ b/host/src/main/java/org/openjdk/skara/host/gitlab/GitLabMergeRequest.java
@@ -208,6 +208,10 @@ public class GitLabMergeRequest implements PullRequest {
             if (note.get("system").asBoolean()) {
                 continue;
             }
+            // Ignore plain comments
+            if (!note.contains("position")) {
+                continue;
+            }
 
             var comment = parseReviewComment(discussion.get("id").asString(), parent, note.asObject());
             parent = comment;
@@ -279,9 +283,8 @@ public class GitLabMergeRequest implements PullRequest {
 
     @Override
     public List<Comment> getComments() {
-        // FIXME: sort order doesn't seem to affect anything
         return request.get("notes").param("sort", "asc").execute().stream()
-                      .filter(entry -> !entry.get("resolvable").asBoolean()) // Ignore discussions - they are review comments
+                      .filter(entry -> !entry.contains("position")) // Ignore comments with a position - they are review comments
                       .filter(entry -> !entry.get("system").asBoolean()) // Ignore system generated comments
                 .map(this::parseComment)
                 .collect(Collectors.toList());


### PR DESCRIPTION
Hi all,

Please review this small fix of a GitLab discussion parsing bug.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)