### PR TITLE
60: Add `integrated` to closed pull requests that have been integrated

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
@@ -97,6 +97,7 @@ public class IntegrateCommand implements CommandHandler {
                 reply.println("Pushed as commit " + rebasedHash.get().hex() + ".");
                 prInstance.localRepo().push(rebasedHash.get(), pr.repository().getUrl(), pr.getTargetRef());
                 pr.setState(PullRequest.State.CLOSED);
+                pr.addLabel("integrated");
             }
         } catch (IOException e) {
             log.throwing("IntegrateCommand", "handle", e);

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
@@ -79,6 +79,7 @@ public class SponsorCommand implements CommandHandler {
                 reply.println("Pushed as commit " + rebasedHash.get().hex() + ".");
                 prInstance.localRepo().push(rebasedHash.get(), pr.repository().getUrl(), pr.getTargetRef());
                 pr.setState(PullRequest.State.CLOSED);
+                pr.addLabel("integrated");
             }
         } catch (IOException e) {
             log.throwing("SponsorCommand", "handle", e);

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrateTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrateTests.java
@@ -86,6 +86,7 @@ class IntegrateTests {
             assertEquals("integrationcommitter1@openjdk.java.net", headCommit.author().email());
             assertEquals("Generated Committer 1", headCommit.committer().name());
             assertEquals("integrationcommitter1@openjdk.java.net", headCommit.committer().email());
+            assertTrue(pr.getLabels().contains("integrated"));
         }
     }
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/SponsorTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/SponsorTests.java
@@ -110,6 +110,7 @@ class SponsorTests {
 
             assertEquals("Generated Reviewer 1", headCommit.committer().name());
             assertEquals("integrationreviewer1@openjdk.java.net", headCommit.committer().email());
+            assertTrue(pr.getLabels().contains("integrated"));
         }
     }
 


### PR DESCRIPTION
Hi all,

Please review this change that adds an 'integrated' label to a PR after it has been integrated.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)