### PR TITLE
Implement HgRepository::amend

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -533,12 +533,21 @@ public class HgRepository implements Repository {
 
     @Override
     public Hash amend(String message, String authorName, String authorEmail) throws IOException {
-        throw new RuntimeException("Not implemented yet");
+        var user = authorEmail == null ? authorName : authorName + " <" + authorEmail + ">";
+        try (var p = capture("hg", "commit", "--amend", "--message=" + message, "--user=" + user)) {
+            await(p);
+        }
+        return resolve("tip").orElseThrow(() -> new IOException("Could not resolve 'tip'"));
     }
 
     @Override
     public Hash amend(String message, String authorName, String authorEmail, String committerName, String committerEmail) throws IOException {
-        throw new RuntimeException("Not implemented yet");
+        if (!Objects.equals(authorName, committerName) ||
+            !Objects.equals(authorEmail, committerEmail)) {
+            throw new IllegalArgumentException("hg does not support different author and committer data");
+        }
+
+        return amend(message, authorName, authorEmail);
     }
 
     @Override

--- a/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
@@ -1523,4 +1523,26 @@ public class RepositoryTests {
             assertEquals(List.of("An empty commit"), commit.message());
         }
     }
+
+    @ParameterizedTest
+    @EnumSource(VCS.class)
+    void testAmend(VCS vcs) throws IOException {
+        try (var dir = new TemporaryDirectory()) {
+            var r = Repository.init(dir.path(), vcs);
+            assertTrue(r.isClean());
+
+            var f = dir.path().resolve("README");
+            Files.writeString(f, "Hello\n");
+            r.add(f);
+            r.commit("Initial commit", "duke", "duke@openjdk.org");
+
+            Files.writeString(f, "Hello, world\n");
+            r.add(f);
+            r.amend("Initial commit corrected", "duke", "duke@openjdk.java.net");
+            var commits = r.commits().asList();
+            assertEquals(1, commits.size());
+            var commit = commits.get(0);
+            assertEquals(List.of("Initial commit corrected"), commit.message());
+        }
+    }
 }


### PR DESCRIPTION
Hi all,

this patch implements the `HgRepository::amend` method. I also added a test that tests `amend` for both git and hg.

## Testing
- [x] `sh gradlew test` passes on
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)