### PR TITLE
Add Repository::revert

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
@@ -42,6 +42,7 @@ public interface Repository extends ReadOnlyRepository {
     void push(Hash hash, URI uri, String ref, boolean force) throws IOException;
     void push(Branch branch, String remote, boolean setUpstream) throws IOException;
     void clean() throws IOException;
+    void revert(Hash parent) throws IOException;
     Repository reinitialize() throws IOException;
     void squash(Hash h) throws IOException;
     void add(List<Path> files) throws IOException;

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -292,6 +292,13 @@ public class GitRepository implements Repository {
     }
 
     @Override
+    public void revert(Hash h) throws IOException {
+        try (var p = capture("git", "checkout", h.hex(), "--", ".")) {
+            await(p);
+        }
+    }
+
+    @Override
     public Repository reinitialize() throws IOException {
         cachedRoot = null;
 

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -641,6 +641,13 @@ public class HgRepository implements Repository {
     }
 
     @Override
+    public void revert(Hash parent) throws IOException {
+        try (var p = capture("hg", "revert", "--no-backup", "--all", "--rev", parent.hex())) {
+            await(p);
+        }
+    }
+
+    @Override
     public Diff diff(Hash from) throws IOException {
         return diff(from, null);
     }

--- a/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
@@ -1545,4 +1545,31 @@ public class RepositoryTests {
             assertEquals(List.of("Initial commit corrected"), commit.message());
         }
     }
+
+    @ParameterizedTest
+    @EnumSource(VCS.class)
+    void testRevert(VCS vcs) throws IOException {
+        try (var dir = new TemporaryDirectory()) {
+            var r = Repository.init(dir.path(), vcs);
+            assertTrue(r.isClean());
+
+            var f = dir.path().resolve("README");
+            Files.writeString(f, "Hello\n");
+            r.add(f);
+            var initial = r.commit("Initial commit", "duke", "duke@openjdk.org");
+
+            Files.writeString(f, "Hello, world\n");
+            r.revert(initial);
+            Files.writeString(f, "Goodbye, world\n");
+            r.add(f);
+            var hash = r.commit("Second commit", "duke", "duke@openjdk.org");
+            var commit = r.lookup(hash).orElseThrow();
+            var patches = commit.parentDiffs().get(0).patches();
+            assertEquals(1, patches.size());
+            var patch = patches.get(0).asTextualPatch();
+            assertEquals(1, patch.hunks().size());
+            var hunk = patch.hunks().get(0);
+            assertEquals(List.of("Goodbye, world"), hunk.target().lines());
+        }
+    }
 }


### PR DESCRIPTION
Hi all,

this small patch adds the `Repository::revert` method, the corresponding git and hg implementations and a small test.

## Testing
- [x] `sh gradlew test` passes on Linux x86_64
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)