### PR TITLE
61: Remove sponsor label if PR is updated after flagged for integration

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -476,6 +476,16 @@ class CheckRun {
                 newLabels.remove("outdated");
             }
 
+            // Ensure that the ready for sponsor label is up to date
+            newLabels.remove("sponsor");
+            var readyHash = ReadyForSponsorTracker.latestReadyForSponsor(pr.repository().host().getCurrentUserDetails(), comments);
+            if (readyHash.isPresent()) {
+                var acceptedHash = readyHash.get();
+                if (pr.getHeadHash().equals(acceptedHash)) {
+                    newLabels.add("sponsor");
+                }
+            }
+
             // Calculate current metadata to avoid unnecessary future checks
             var metadata = workItem.getMetadata(pr.getTitle(), updatedBody, pr.getComments(), activeReviews, newLabels, censusInstance, pr.getTargetHash());
             checkBuilder.metadata(metadata);

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/SponsorTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/SponsorTests.java
@@ -269,6 +269,7 @@ class SponsorTests {
                           .filter(comment -> comment.body().contains("at version " + editHash.hex()))
                           .count();
             assertEquals(1, ready);
+            assertTrue(pr.getLabels().contains("sponsor"));
 
             // Push another change
             var updateHash = CheckableRepository.appendAndCommit(localRepo,"Yet more stuff");
@@ -283,6 +284,10 @@ class SponsorTests {
                     fail("The PR did not update after the new push");
                 }
             } while (pr.getHeadHash().equals(lastHeadHash));
+
+            // The label should have been dropped
+            TestBotRunner.runPeriodicItems(mergeBot);
+            assertFalse(pr.getLabels().contains("sponsor"));
 
             // Reviewer now tries to sponsor
             var reviewerPr = reviewer.getPullRequest(pr.getId());
@@ -302,6 +307,7 @@ class SponsorTests {
             // It should now be possible to sponsor
             reviewerPr.addComment("/sponsor");
             TestBotRunner.runPeriodicItems(mergeBot);
+            assertTrue(pr.getLabels().contains("sponsor"));
 
             // The bot should have pushed the commit
             var pushed = pr.getComments().stream()


### PR DESCRIPTION
Hi all,

Please review this change that ensures that the sponsor label is removed if additional changes are added to a PR after it has been flagged as ready for integration.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)