### PR TITLE
Fix some issues building on Windows

### DIFF
--- a/bot/src/test/java/org/openjdk/skara/bot/BotRunnerConfigurationTests.java
+++ b/bot/src/test/java/org/openjdk/skara/bot/BotRunnerConfigurationTests.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.skara.bot;
 
+import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 import org.openjdk.skara.json.JSON;
 
@@ -36,6 +37,6 @@ public class BotRunnerConfigurationTests {
         var cfg = BotRunnerConfiguration.parse(input);
         var botCfg = cfg.perBotConfiguration("xbot");
 
-        assertEquals("/x/xbot", botCfg.storageFolder().toString());
+        assertEquals(Path.of("/x/xbot"), botCfg.storageFolder());
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,9 @@ configure(subprojects.findAll() { it.name != 'bots' }) {
         testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.3.1'
     }
 
+    compileJava.options.encoding = 'UTF-8'
+    compileTestJava.options.encoding = 'UTF-8'
+
     test {
         useJUnitPlatform()
 

--- a/process/src/test/java/org/openjdk/skara/process/ProcessTests.java
+++ b/process/src/test/java/org/openjdk/skara/process/ProcessTests.java
@@ -23,15 +23,16 @@
 package org.openjdk.skara.process;
 
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.*;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.time.Duration;
-import java.util.concurrent.TimeoutException;
 import java.util.logging.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+@DisabledOnOs(OS.WINDOWS)
 class ProcessTests {
 
     private final static String invalidDirectory = "/askldjfoiuycvbsdf8778";


### PR DESCRIPTION
Building skara on Windows requires at least following changes:

- `build.gradle`: enforce UTF-8 as source code encoding
- `BotRunnerConfigurationTests.java`: make assertion file separator agnostic
- `ProcessTests.java`: disable test class on Windows, all tests call tools that are not present by default on Windows

After applying those changes, there're two more issues with building on Windows:

- `VersionPlugin.java`:  there's an `IOException` raised, which I _handled_ by setting the version property to `"unknown"`, around line 55:
```
        } catch (IOException e) {
            // throw new GradleException("could not read output from 'git rev-parse'", e);
            project.setProperty("version", "unknown");
        }
```
- All tests that use `VCS.HG`, e.g. `JCheckTests#checksForCommit(VCS.HG)`, fail with:
`java.io.UncheckedIOException: java.io.IOException: Num headers (1) differ from num hunks (0)` which might(!) be related to a) how `git.exe`/`hg.exe` are invoked and/or b) due to `UnixStreamReader` only interpreting `\n` as a new line character ... or c) something completely different.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)