### PR TITLE
Upgrade JUnit 5 to 5.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ To check that everything works as expected, run the command `git skara help`.
 
 ## Testing
 
-[JUnit](https://junit.org/junit5/) 5.3.1 or later is required to run the unit
+[JUnit](https://junit.org/junit5/) 5.5.1 or later is required to run the unit
 tests. To run the tests, execute following command from the source tree root:
 
 ```bash

--- a/build.gradle
+++ b/build.gradle
@@ -43,9 +43,12 @@ configure(subprojects.findAll() { it.name != 'bots' }) {
     }
 
     dependencies {
-        testImplementation 'org.junit.jupiter:junit-jupiter-api:5.3.1'
-        testImplementation 'org.junit.jupiter:junit-jupiter-params:5.3.1'
-        testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.3.1'
+        testImplementation 'org.junit.jupiter:junit-jupiter-api:5.5.1'
+        testImplementation 'org.junit.jupiter:junit-jupiter-params:5.5.1'
+        testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.5.1'
+        // Force Gradle to load the JUnit Platform Launcher from the module-path, as
+        // configured in buildSrc/.../ModulePlugin.java -- see SKARA-69 for details.
+        testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.5.1'
     }
 
     test {

--- a/jcheck/build.gradle
+++ b/jcheck/build.gradle
@@ -25,6 +25,7 @@ module {
     name = 'org.openjdk.skara.jcheck'
     test {
         requires 'org.junit.jupiter.api'
+        requires 'org.junit.jupiter.params'
         requires 'org.openjdk.skara.test'
         opens 'org.openjdk.skara.jcheck' to 'org.junit.platform.commons'
     }

--- a/storage/build.gradle
+++ b/storage/build.gradle
@@ -25,6 +25,7 @@ module {
     name = 'org.openjdk.skara.storage'
     test {
         requires 'org.junit.jupiter.api'
+        requires 'org.junit.jupiter.params'
         opens 'org.openjdk.skara.storage' to 'org.junit.platform.commons'
     }
 }

--- a/vcs/build.gradle
+++ b/vcs/build.gradle
@@ -26,6 +26,7 @@ module {
     test {
         requires 'org.openjdk.skara.test'
         requires 'org.junit.jupiter.api'
+        requires 'org.junit.jupiter.params'
         opens 'org.openjdk.skara.vcs' to 'org.junit.platform.commons'
         opens 'org.openjdk.skara.vcs.openjdk' to 'org.junit.platform.commons'
         opens 'org.openjdk.skara.vcs.openjdk.converter' to 'org.junit.platform.commons'

--- a/webrev/build.gradle
+++ b/webrev/build.gradle
@@ -25,6 +25,7 @@ module {
     name = 'org.openjdk.skara.webrev'
     test {
         requires 'org.junit.jupiter.api'
+        requires 'org.junit.jupiter.params'
         requires 'org.openjdk.skara.test'
         opens 'org.openjdk.skara.webrev' to 'org.junit.platform.commons'
     }


### PR DESCRIPTION
Upgrade JUnit 5 to Jupiter 5.5.1 and Platform 1.5.1

- Set Jupiter version number 5.5.1
- Introduce Platform Launcher 1.5.1 test runtime dependency in order to force Gradle to load the module from the module-path
- Add missing "requires 'org.junit.jupiter.params'" directives in modules: jcheck, storage, vcs, and webrev

Solves https://bugs.openjdk.java.net/projects/SKARA/issues/SKARA-69
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)