### PR TITLE
Fix 2 failing tests due to URI syntax errors

### DIFF
--- a/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
@@ -737,7 +737,8 @@ public class RepositoryTests {
             try (var dir2 = new TemporaryDirectory()) {
                 var downstream = Repository.init(dir2.path(), vcs);
 
-                var upstreamURI = URI.create("file://" + dir.toString());
+                 // note: forcing unix path separators for URI
+                var upstreamURI = URI.create("file:///" + dir.toString().replace('\\', '/'));
 
                 var fetchHead = downstream.fetch(upstreamURI, downstream.defaultBranch().name());
                 downstream.checkout(fetchHead, false);


### PR DESCRIPTION
There were 2 tests failing due to incorrect URI syntax resulting from directly using a path string as URI, which on Windows will contain incorrect path separators.

This PR forces the path separators to be unix ones, and inserts an explicit leading slash before the local path starts (both are needed according to the URI spec).
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)