### PR TITLE
Force unix line endings when writing patch files

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/Hunk.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Hunk.java
@@ -91,26 +91,26 @@ public class Hunk {
         w.append(" +");
         w.append(target.range().toString());
         w.append(" @@");
-        w.newLine();
+        w.write("\n");
 
         for (var line : source.lines()) {
             w.append("-");
             w.append(line);
-            w.newLine();
+            w.write("\n");
         }
         if (!source.hasNewlineAtEndOfFile()) {
             w.append("\\ No newline at end of file");
-            w.newLine();
+            w.write("\n");
         }
 
         for (var line : target.lines()) {
             w.append("+");
             w.append(line);
-            w.newLine();
+            w.write("\n");
         }
         if (!target.hasNewlineAtEndOfFile()) {
             w.append("\\ No newline at end of file");
-            w.newLine();
+            w.write("\n");
         }
     }
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Patch.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Patch.java
@@ -113,18 +113,18 @@ public abstract class Patch {
         w.append("a/" + sourcePath);
         w.append(" ");
         w.append("b/" + targetPath);
-        w.newLine();
+        w.write("\n");
 
         // extended headers
         if (status.isModified()) {
             if (!source.type().get().equals(target.type().get())) {
                 w.append("old mode ");
                 w.append(source.type().get().toOctal());
-                w.newLine();
+                w.write("\n");
 
                 w.append("new mode ");
                 w.append(target.type().get().toOctal());
-                w.newLine();
+                w.write("\n");
             }
             w.append("index ");
             w.append(source().hash().hex());
@@ -132,39 +132,39 @@ public abstract class Patch {
             w.append(target().hash().hex());
             w.append(" ");
             w.append(target.type().get().toOctal());
-            w.newLine();
+            w.write("\n");
         } else if (status.isAdded()) {
             w.append("new file mode ");
             w.append(target.type().get().toOctal());
-            w.newLine();
+            w.write("\n");
 
             w.append("index ");
             w.append("0".repeat(40));
             w.append("..");
             w.append(target.hash().hex());
-            w.newLine();
+            w.write("\n");
         } else if (status.isDeleted()) {
             w.append("deleted file mode ");
             w.append(source.type().get().toOctal());
-            w.newLine();
+            w.write("\n");
 
             w.append("index ");
             w.append(source.hash().hex());
             w.append("..");
             w.append("0".repeat(40));
-            w.newLine();
+            w.write("\n");
         } else if (status.isCopied()) {
             w.append("similarity index ");
             w.append(Integer.toString(status.score()));
             w.append("%");
-            w.newLine();
+            w.write("\n");
 
             w.append("copy from ");
             w.append(source.path().get().toString());
-            w.newLine();
+            w.write("\n");
             w.append("copy to ");
             w.append(target.path().get().toString());
-            w.newLine();
+            w.write("\n");
 
             w.append("index ");
             w.append(source().hash().hex());
@@ -172,19 +172,19 @@ public abstract class Patch {
             w.append(target().hash().hex());
             w.append(" ");
             w.append(target.type().get().toOctal());
-            w.newLine();
+            w.write("\n");
         } else if (status.isRenamed()) {
             w.append("similarity index ");
             w.append(Integer.toString(status.score()));
             w.append("%");
-            w.newLine();
+            w.write("\n");
 
             w.append("rename from ");
             w.append(source.path().get().toString());
-            w.newLine();
+            w.write("\n");
             w.append("rename to ");
             w.append(target.path().get().toString());
-            w.newLine();
+            w.write("\n");
 
             w.append("index ");
             w.append(source().hash().hex());
@@ -192,7 +192,7 @@ public abstract class Patch {
             w.append(target().hash().hex());
             w.append(" ");
             w.append(target.type().get().toOctal());
-            w.newLine();
+            w.write("\n");
         }
 
         w.append("--- ");
@@ -200,11 +200,11 @@ public abstract class Patch {
         w.append("\n");
         w.append("+++ ");
         w.append(target.path().isPresent() ? "b/" + targetPath : "/dev/null");
-        w.newLine();
+        w.write("\n");
 
         if (isBinary()) {
             w.append("GIT binary patch");
-            w.newLine();
+            w.write("\n");
             for (var hunk : asBinaryPatch().hunks()) {
                 hunk.write(w);
             }


### PR DESCRIPTION
Mercurial needs its patch files to end with unix line endings, so we need to use those explicitly when writing patch files (I've also been told on the hg irc that this is according to patch file spec).
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)