### PR TITLE
Add ReadOnlyRepository::files

### DIFF
--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/TestRepository.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/TestRepository.java
@@ -174,6 +174,10 @@ class TestRepository implements ReadOnlyRepository {
         return Optional.of(new byte[0]);
     }
 
+    public List<FileEntry> files(Hash h, List<Path> paths) throws IOException {
+        return List.of();
+    }
+
     public Diff diff(Hash base, Hash head) throws IOException {
         return null;
     }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/FileEntry.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/FileEntry.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.vcs;
+
+import java.util.Objects;
+import java.nio.file.Path;
+
+public class FileEntry {
+    private final FileType type;
+    private final Hash hash;
+    private final Path path;
+
+    public FileEntry(FileType type, Hash hash, Path path) {
+        this.type = type;
+        this.hash = hash;
+        this.path = path;
+    }
+
+    public FileType type() {
+        return type;
+    }
+
+    public Hash hash() {
+        return hash;
+    }
+
+    public Path path() {
+        return path;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, hash, path);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof FileEntry)) {
+            return false;
+        }
+
+        var e = (FileEntry) o;
+        return Objects.equals(type, e.type) &&
+               Objects.equals(hash, e.hash) &&
+               Objects.equals(path, e.path);
+    }
+
+    @Override
+    public String toString() {
+        return type.toString() + " " + hash.toString() + "\t" + path.toString();
+    }
+}

--- a/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
@@ -60,6 +60,12 @@ public interface ReadOnlyRepository {
     default Optional<List<String>> lines(Path p, Hash h) throws IOException {
         return show(p, h).map(bytes -> new String(bytes, StandardCharsets.UTF_8).lines().collect(Collectors.toList()));
     }
+
+    List<FileEntry> files(Hash h, List<Path> paths) throws IOException;
+    default List<FileEntry> files(Hash h, Path... paths) throws IOException {
+        return files(h, Arrays.asList(paths));
+    }
+
     Diff diff(Hash base, Hash head) throws IOException;
     Diff diff(Hash head) throws IOException;
     List<String> config(String key) throws IOException;

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -671,36 +671,62 @@ public class GitRepository implements Repository {
     }
 
     @Override
-    public Optional<byte[]> show(Path path, Hash hash) throws IOException {
-        var entry = treeEntry(path, hash);
-        if (entry == null) {
-            return Optional.empty();
-        }
+    public List<FileEntry> files(Hash hash, List<Path> paths) throws IOException {
+        var cmd = new ArrayList<String>();
+        cmd.addAll(List.of("git", "ls-tree", "-r"));
+        cmd.add(hash.hex());
+        cmd.addAll(paths.stream().map(Path::toString).collect(Collectors.toList()));
+        try (var p = Process.capture(cmd.toArray(new String[0]))
+                            .workdir(root())
+                            .execute()) {
+            var res = await(p);
+            var entries = new ArrayList<FileEntry>();
+            for (var line : res.stdout()) {
+                var parts = line.split("\t");
+                var metadata = parts[0].split(" ");
+                var filename = parts[1];
 
-        var parts = entry.split(" ");
-        var mode = parts[0];
-        if (mode.equals("160000")) {
-            // submodule
-            var hashAndName = parts[2].split("\t");
-            return Optional.of(("Subproject commit " + hashAndName[0]).getBytes(StandardCharsets.UTF_8));
-        } else if (mode.equals("100644") || mode.equals("100755")) {
-            // blob
-            var blobAndName = parts[2].split("\t");
-            var blob = blobAndName[0];
-            try (var p = capture("git", "unpack-file", blob)) {
-                var res = await(p);
-                if (res.stdout().size() != 1) {
-                    throw new IOException("Unexpected output\n" + res);
-                }
-
-                var file = Path.of(root().toString(), res.stdout().get(0));
-                if (Files.exists(file)) {
-                    var bytes = Files.readAllBytes(file);
-                    Files.delete(file);
-                    return Optional.of(bytes);
-                }
+                var entry = new FileEntry(FileType.fromOctal(metadata[0]),
+                                          new Hash(metadata[2]),
+                                          Path.of(filename));
+                entries.add(entry);
             }
+            return entries;
         }
+    }
+
+    private Path unpackFile(String blob) throws IOException {
+        try (var p = capture("git", "unpack-file", blob)) {
+            var res = await(p);
+            if (res.stdout().size() != 1) {
+                throw new IOException("Unexpected output\n" + res);
+            }
+
+            return Path.of(root().toString(), res.stdout().get(0));
+        }
+    }
+
+    @Override
+    public Optional<byte[]> show(Path path, Hash hash) throws IOException {
+        var entries = files(hash, path);
+        if (entries.size() == 0) {
+            return Optional.empty();
+        } else if (entries.size() > 1) {
+            throw new IOException("Multiple files match path " + path.toString() + " in commit " + hash.hex());
+        }
+
+        var entry = entries.get(0);
+        var type = entry.type();
+        if (type.isVCSLink()) {
+            var content = "Subproject commit " + entry.hash().hex() + " " + entry.path().toString();
+            return Optional.of(content.getBytes(StandardCharsets.UTF_8));
+        } else if (type.isRegular()) {
+            var tmp = unpackFile(entry.hash().hex());
+            var content = Files.readAllBytes(tmp);
+            Files.delete(tmp);
+            return Optional.of(content);
+        }
+
         return Optional.empty();
     }
 

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -641,6 +641,31 @@ public class HgRepository implements Repository {
     }
 
     @Override
+    public List<FileEntry> files(Hash hash, List<Path> paths) throws IOException {
+        var ext = Files.createTempFile("ext", ".py");
+        copyResource(EXT_PY, ext);
+
+        var include = new HashSet<>(paths);
+
+        try (var p = capture("hg", "--config", "extensions.ls-tree=" + ext, "ls-tree", hash.hex())) {
+            var res = await(p);
+            var entries = new ArrayList<FileEntry>();
+            for (var line : res.stdout()) {
+                var parts = line.split("\t");
+                var metadata = parts[0].split(" ");
+                var path = Path.of(parts[1]);
+                if (include.isEmpty() || include.contains(path)) {
+                    var entry = new FileEntry(FileType.fromOctal(metadata[0]),
+                                              new Hash(metadata[2]),
+                                              path);
+                    entries.add(entry);
+                }
+            }
+            return entries;
+        }
+    }
+
+    @Override
     public void revert(Hash parent) throws IOException {
         try (var p = capture("hg", "revert", "--no-backup", "--all", "--rev", parent.hex())) {
             await(p);

--- a/vcs/src/main/resources/ext.py
+++ b/vcs/src/main/resources/ext.py
@@ -273,3 +273,17 @@ def dump(ui, repo, revs=None, **opts):
     for r in revrange(repo, [revs]):
         ctx = repo[r]
         __dump_metadata(ctx)
+
+@command('ls-tree', [],  'hg ls-tree')
+def ls_tree(ui, repo, rev, **opts):
+    nullHash = '0' * 40
+    ctx = revsingle(repo, rev)
+    for filename in ctx.manifest():
+        fctx = ctx.filectx(filename)
+        if 'x' in fctx.flags():
+            write('100755 blob ')
+        else:
+            write('100644 blob ')
+        write(nullHash)
+        write('\t')
+        writeln(filename)

--- a/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
@@ -1593,4 +1593,42 @@ public class RepositoryTests {
             assertEquals(List.of("Goodbye, world"), hunk.target().lines());
         }
     }
+
+    @ParameterizedTest
+    @EnumSource(VCS.class)
+    void testFiles(VCS vcs) throws IOException {
+        try (var dir = new TemporaryDirectory()) {
+            var r = Repository.init(dir.path(), vcs);
+            assertTrue(r.isClean());
+
+            var f = dir.path().resolve("README");
+            Files.writeString(f, "Hello\n");
+            r.add(f);
+            var initial = r.commit("Initial commit", "duke", "duke@openjdk.org");
+
+            var entries = r.files(initial);
+            assertEquals(1, entries.size());
+            var entry = entries.get(0);
+            assertEquals(Path.of("README"), entry.path());
+            assertTrue(entry.type().isRegularNonExecutable());
+
+            var f2 = dir.path().resolve("CONTRIBUTING");
+            Files.writeString(f2, "Hello\n");
+            r.add(f2);
+            var second = r.commit("Second commit", "duke", "duke@openjdk.org");
+
+            entries = r.files(second);
+            assertEquals(2, entries.size());
+            assertTrue(entries.stream().allMatch(e -> e.type().isRegularNonExecutable()));
+            var paths = entries.stream().map(FileEntry::path).collect(Collectors.toSet());
+            assertTrue(paths.contains(Path.of("README")));
+            assertTrue(paths.contains(Path.of("CONTRIBUTING")));
+
+            entries = r.files(second, Path.of("README"));
+            assertEquals(1, entries.size());
+            entry = entries.get(0);
+            assertEquals(Path.of("README"), entry.path());
+            assertTrue(entry.type().isRegularNonExecutable());
+        }
+    }
 }


### PR DESCRIPTION
Hi all,

this patch adds the `ReadOnlyRepository::files` method and also a unit test for the new method.

## Testing
- [x] `sh gradlew test` passes on Linux x86_64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)