### PR TITLE
Expect carriage return to be part of lines when testing on Windows.

### DIFF
--- a/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
@@ -311,7 +311,7 @@ public class RepositoryTests {
             assertEquals(new Range(0, 0), hunk.source().range());
             assertEquals(new Range(1, 1), hunk.target().range());
 
-            assertEquals(List.of(), hunk.source().lines());
+            assertLinesEquals(List.of(), hunk.source().lines());
             assertLinesEquals(List.of("Hello, readme!"), hunk.target().lines());
         }
     }
@@ -387,7 +387,7 @@ public class RepositoryTests {
             assertEquals(new Range(2, 0), hunk.source().range());
             assertEquals(new Range(2, 1), hunk.target().range());
 
-            assertEquals(List.of(), hunk.source().lines());
+            assertLinesEquals(List.of(), hunk.source().lines());
             assertLinesEquals(List.of("Another line"), hunk.target().lines());
         }
     }
@@ -519,7 +519,7 @@ public class RepositoryTests {
             assertEquals(new Range(2, 0), hunk.source().range());
             assertEquals(new Range(2, 2), hunk.target().range());
 
-            assertEquals(List.of(), hunk.source().lines());
+            assertLinesEquals(List.of(), hunk.source().lines());
             assertLinesEquals(List.of("Another line", "A final line"), hunk.target().lines());
         }
     }
@@ -1073,7 +1073,7 @@ public class RepositoryTests {
 
             assertEquals(0, hunk.target().range().start());
             assertEquals(0, hunk.target().range().count());
-            assertEquals(List.of(), hunk.target().lines());
+            assertLinesEquals(List.of(), hunk.target().lines());
 
             assertEquals(0, hunk.added());
             assertEquals(1, hunk.removed());
@@ -1118,7 +1118,7 @@ public class RepositoryTests {
             var hunk = hunks.get(0);
             assertEquals(0, hunk.source().range().start());
             assertEquals(0, hunk.source().range().count());
-            assertEquals(List.of(), hunk.source().lines());
+            assertLinesEquals(List.of(), hunk.source().lines());
 
             assertEquals(1, hunk.target().range().start());
             assertEquals(1, hunk.target().range().count());
@@ -1164,7 +1164,7 @@ public class RepositoryTests {
             var hunk = hunks.get(0);
             assertEquals(2, hunk.source().range().start());
             assertEquals(0, hunk.source().range().count());
-            assertEquals(List.of(), hunk.source().lines());
+            assertLinesEquals(List.of(), hunk.source().lines());
 
             assertEquals(2, hunk.target().range().start());
             assertEquals(1, hunk.target().range().count());
@@ -1310,7 +1310,7 @@ public class RepositoryTests {
             assertEquals(1, secondPatch.hunks().size());
 
             var secondHunk = secondPatch.hunks().get(0);
-            assertEquals(List.of(), secondHunk.source().lines());
+            assertLinesEquals(List.of(), secondHunk.source().lines());
             assertLinesEquals(List.of("One last line"), secondHunk.target().lines());
 
             assertEquals(3, secondHunk.source().range().start());
@@ -1329,7 +1329,7 @@ public class RepositoryTests {
             assertEquals(1, thirdPatch.hunks().size());
 
             var thirdHunk = thirdPatch.hunks().get(0);
-            assertEquals(List.of(), thirdHunk.source().lines());
+            assertLinesEquals(List.of(), thirdHunk.source().lines());
             assertLinesEquals(List.of("One more line", "One last line"), thirdHunk.target().lines());
 
             assertEquals(2, thirdHunk.source().range().start());

--- a/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
@@ -312,8 +312,16 @@ public class RepositoryTests {
             assertEquals(new Range(1, 1), hunk.target().range());
 
             assertEquals(List.of(), hunk.source().lines());
-            assertEquals(List.of("Hello, readme!"), hunk.target().lines());
+            assertEquals(suffixPlatformLineEndings("Hello, readme!"), hunk.target().lines());
         }
+    }
+
+    static List<String> suffixPlatformLineEndings(String... lines) {
+        var newLine = System.lineSeparator();
+        var suffix = newLine.endsWith("\n")
+                ? newLine.substring(0, newLine.length() - 1) // drop trailing '\n' (keeping any '\r')
+                : newLine;
+        return Arrays.stream(lines).map(l -> l + suffix).collect(Collectors.toList());
     }
 
     @ParameterizedTest
@@ -380,7 +388,7 @@ public class RepositoryTests {
             assertEquals(new Range(2, 1), hunk.target().range());
 
             assertEquals(List.of(), hunk.source().lines());
-            assertEquals(List.of("Another line"), hunk.target().lines());
+            assertEquals(suffixPlatformLineEndings("Another line"), hunk.target().lines());
         }
     }
 
@@ -512,7 +520,7 @@ public class RepositoryTests {
             assertEquals(new Range(2, 2), hunk.target().range());
 
             assertEquals(List.of(), hunk.source().lines());
-            assertEquals(List.of("Another line", "A final line"), hunk.target().lines());
+            assertEquals(suffixPlatformLineEndings("Another line", "A final line"), hunk.target().lines());
         }
     }
 
@@ -609,7 +617,7 @@ public class RepositoryTests {
             var hunks = patch.hunks();
             assertEquals(1, hunks.size());
             var hunk = hunks.get(0);
-            assertEquals(List.of("Keep the patches coming"), hunk.target().lines());
+            assertEquals(suffixPlatformLineEndings("Keep the patches coming"), hunk.target().lines());
         }
     }
 
@@ -887,7 +895,7 @@ public class RepositoryTests {
 
             assertEquals(2, hunk.target().range().start());
             assertEquals(1, hunk.target().range().count());
-            assertEquals(List.of("One more line"), hunk.target().lines());
+            assertEquals(suffixPlatformLineEndings("One more line"), hunk.target().lines());
 
             assertEquals(1, hunk.added());
             assertEquals(0, hunk.removed());
@@ -937,11 +945,11 @@ public class RepositoryTests {
             var hunk1 = hunks1.get(0);
             assertEquals(1, hunk1.source().range().start());
             assertEquals(1, hunk1.source().range().count());
-            assertEquals(List.of("make"), hunk1.source().lines());
+            assertEquals(suffixPlatformLineEndings("make"), hunk1.source().lines());
 
             assertEquals(1, hunk1.target().range().start());
             assertEquals(1, hunk1.target().range().count());
-            assertEquals(List.of("make images"), hunk1.target().lines());
+            assertEquals(suffixPlatformLineEndings("make images"), hunk1.target().lines());
 
             var patch2 = patches.get(1).asTextualPatch();
             assertEquals(Path.of("README"), patch2.source().path().get());
@@ -956,11 +964,11 @@ public class RepositoryTests {
             var hunk2 = hunks2.get(0);
             assertEquals(1, hunk2.source().range().start());
             assertEquals(1, hunk2.source().range().count());
-            assertEquals(List.of("Hello, readme!"), hunk2.source().lines());
+            assertEquals(suffixPlatformLineEndings("Hello, readme!"), hunk2.source().lines());
 
             assertEquals(1, hunk2.target().range().start());
             assertEquals(1, hunk2.target().range().count());
-            assertEquals(List.of("Hello, Skara!"), hunk2.target().lines());
+            assertEquals(suffixPlatformLineEndings("Hello, Skara!"), hunk2.target().lines());
         }
     }
 
@@ -1000,11 +1008,11 @@ public class RepositoryTests {
             var hunk1 = hunks.get(0);
             assertEquals(1, hunk1.source().range().start());
             assertEquals(1, hunk1.source().range().count());
-            assertEquals(List.of("A"), hunk1.source().lines());
+            assertEquals(suffixPlatformLineEndings("A"), hunk1.source().lines());
 
             assertEquals(1, hunk1.target().range().start());
             assertEquals(2, hunk1.target().range().count());
-            assertEquals(List.of("1", "2"), hunk1.target().lines());
+            assertEquals(suffixPlatformLineEndings("1", "2"), hunk1.target().lines());
 
             assertEquals(1, hunk1.added());
             assertEquals(0, hunk1.removed());
@@ -1013,11 +1021,11 @@ public class RepositoryTests {
             var hunk2 = hunks.get(1);
             assertEquals(3, hunk2.source().range().start());
             assertEquals(1, hunk2.source().range().count());
-            assertEquals(List.of("C"), hunk2.source().lines());
+            assertEquals(suffixPlatformLineEndings("C"), hunk2.source().lines());
 
             assertEquals(4, hunk2.target().range().start());
             assertEquals(1, hunk2.target().range().count());
-            assertEquals(List.of("3"), hunk2.target().lines());
+            assertEquals(suffixPlatformLineEndings("3"), hunk2.target().lines());
 
             assertEquals(0, hunk2.added());
             assertEquals(0, hunk2.removed());
@@ -1061,7 +1069,7 @@ public class RepositoryTests {
             var hunk = hunks.get(0);
             assertEquals(1, hunk.source().range().start());
             assertEquals(1, hunk.source().range().count());
-            assertEquals(List.of("Hello, world!"), hunk.source().lines());
+            assertEquals(suffixPlatformLineEndings("Hello, world!"), hunk.source().lines());
 
             assertEquals(0, hunk.target().range().start());
             assertEquals(0, hunk.target().range().count());
@@ -1114,7 +1122,7 @@ public class RepositoryTests {
 
             assertEquals(1, hunk.target().range().start());
             assertEquals(1, hunk.target().range().count());
-            assertEquals(List.of("make"), hunk.target().lines());
+            assertEquals(suffixPlatformLineEndings("make"), hunk.target().lines());
 
             assertEquals(1, hunk.added());
             assertEquals(0, hunk.removed());
@@ -1160,7 +1168,7 @@ public class RepositoryTests {
 
             assertEquals(2, hunk.target().range().start());
             assertEquals(1, hunk.target().range().count());
-            assertEquals(List.of("One more line"), hunk.target().lines());
+            assertEquals(suffixPlatformLineEndings("One more line"), hunk.target().lines());
 
             assertEquals(1, hunk.added());
             assertEquals(0, hunk.removed());
@@ -1303,7 +1311,7 @@ public class RepositoryTests {
 
             var secondHunk = secondPatch.hunks().get(0);
             assertEquals(List.of(), secondHunk.source().lines());
-            assertEquals(List.of("One last line"), secondHunk.target().lines());
+            assertEquals(suffixPlatformLineEndings("One last line"), secondHunk.target().lines());
 
             assertEquals(3, secondHunk.source().range().start());
             assertEquals(0, secondHunk.source().range().count());
@@ -1322,7 +1330,7 @@ public class RepositoryTests {
 
             var thirdHunk = thirdPatch.hunks().get(0);
             assertEquals(List.of(), thirdHunk.source().lines());
-            assertEquals(List.of("One more line", "One last line"), thirdHunk.target().lines());
+            assertEquals(suffixPlatformLineEndings("One more line", "One last line"), thirdHunk.target().lines());
 
             assertEquals(2, thirdHunk.source().range().start());
             assertEquals(0, thirdHunk.source().range().count());

--- a/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
@@ -312,16 +312,16 @@ public class RepositoryTests {
             assertEquals(new Range(1, 1), hunk.target().range());
 
             assertEquals(List.of(), hunk.source().lines());
-            assertEquals(suffixPlatformLineEndings("Hello, readme!"), hunk.target().lines());
+            assertLinesEquals(List.of("Hello, readme!"), hunk.target().lines());
         }
     }
 
-    static List<String> suffixPlatformLineEndings(String... lines) {
+    static void assertLinesEquals(List<String> expected, List<String> actual) {
         var newLine = System.lineSeparator();
         var suffix = newLine.endsWith("\n")
                 ? newLine.substring(0, newLine.length() - 1) // drop trailing '\n' (keeping any '\r')
                 : newLine;
-        return Arrays.stream(lines).map(l -> l + suffix).collect(Collectors.toList());
+        assertEquals(expected.stream().map(l -> l + suffix).collect(Collectors.toList()), actual);
     }
 
     @ParameterizedTest
@@ -388,7 +388,7 @@ public class RepositoryTests {
             assertEquals(new Range(2, 1), hunk.target().range());
 
             assertEquals(List.of(), hunk.source().lines());
-            assertEquals(suffixPlatformLineEndings("Another line"), hunk.target().lines());
+            assertLinesEquals(List.of("Another line"), hunk.target().lines());
         }
     }
 
@@ -520,7 +520,7 @@ public class RepositoryTests {
             assertEquals(new Range(2, 2), hunk.target().range());
 
             assertEquals(List.of(), hunk.source().lines());
-            assertEquals(suffixPlatformLineEndings("Another line", "A final line"), hunk.target().lines());
+            assertLinesEquals(List.of("Another line", "A final line"), hunk.target().lines());
         }
     }
 
@@ -617,7 +617,7 @@ public class RepositoryTests {
             var hunks = patch.hunks();
             assertEquals(1, hunks.size());
             var hunk = hunks.get(0);
-            assertEquals(suffixPlatformLineEndings("Keep the patches coming"), hunk.target().lines());
+            assertLinesEquals(List.of("Keep the patches coming"), hunk.target().lines());
         }
     }
 
@@ -895,7 +895,7 @@ public class RepositoryTests {
 
             assertEquals(2, hunk.target().range().start());
             assertEquals(1, hunk.target().range().count());
-            assertEquals(suffixPlatformLineEndings("One more line"), hunk.target().lines());
+            assertLinesEquals(List.of("One more line"), hunk.target().lines());
 
             assertEquals(1, hunk.added());
             assertEquals(0, hunk.removed());
@@ -945,11 +945,11 @@ public class RepositoryTests {
             var hunk1 = hunks1.get(0);
             assertEquals(1, hunk1.source().range().start());
             assertEquals(1, hunk1.source().range().count());
-            assertEquals(suffixPlatformLineEndings("make"), hunk1.source().lines());
+            assertLinesEquals(List.of("make"), hunk1.source().lines());
 
             assertEquals(1, hunk1.target().range().start());
             assertEquals(1, hunk1.target().range().count());
-            assertEquals(suffixPlatformLineEndings("make images"), hunk1.target().lines());
+            assertLinesEquals(List.of("make images"), hunk1.target().lines());
 
             var patch2 = patches.get(1).asTextualPatch();
             assertEquals(Path.of("README"), patch2.source().path().get());
@@ -964,11 +964,11 @@ public class RepositoryTests {
             var hunk2 = hunks2.get(0);
             assertEquals(1, hunk2.source().range().start());
             assertEquals(1, hunk2.source().range().count());
-            assertEquals(suffixPlatformLineEndings("Hello, readme!"), hunk2.source().lines());
+            assertLinesEquals(List.of("Hello, readme!"), hunk2.source().lines());
 
             assertEquals(1, hunk2.target().range().start());
             assertEquals(1, hunk2.target().range().count());
-            assertEquals(suffixPlatformLineEndings("Hello, Skara!"), hunk2.target().lines());
+            assertLinesEquals(List.of("Hello, Skara!"), hunk2.target().lines());
         }
     }
 
@@ -1008,11 +1008,11 @@ public class RepositoryTests {
             var hunk1 = hunks.get(0);
             assertEquals(1, hunk1.source().range().start());
             assertEquals(1, hunk1.source().range().count());
-            assertEquals(suffixPlatformLineEndings("A"), hunk1.source().lines());
+            assertLinesEquals(List.of("A"), hunk1.source().lines());
 
             assertEquals(1, hunk1.target().range().start());
             assertEquals(2, hunk1.target().range().count());
-            assertEquals(suffixPlatformLineEndings("1", "2"), hunk1.target().lines());
+            assertLinesEquals(List.of("1", "2"), hunk1.target().lines());
 
             assertEquals(1, hunk1.added());
             assertEquals(0, hunk1.removed());
@@ -1021,11 +1021,11 @@ public class RepositoryTests {
             var hunk2 = hunks.get(1);
             assertEquals(3, hunk2.source().range().start());
             assertEquals(1, hunk2.source().range().count());
-            assertEquals(suffixPlatformLineEndings("C"), hunk2.source().lines());
+            assertLinesEquals(List.of("C"), hunk2.source().lines());
 
             assertEquals(4, hunk2.target().range().start());
             assertEquals(1, hunk2.target().range().count());
-            assertEquals(suffixPlatformLineEndings("3"), hunk2.target().lines());
+            assertLinesEquals(List.of("3"), hunk2.target().lines());
 
             assertEquals(0, hunk2.added());
             assertEquals(0, hunk2.removed());
@@ -1069,7 +1069,7 @@ public class RepositoryTests {
             var hunk = hunks.get(0);
             assertEquals(1, hunk.source().range().start());
             assertEquals(1, hunk.source().range().count());
-            assertEquals(suffixPlatformLineEndings("Hello, world!"), hunk.source().lines());
+            assertLinesEquals(List.of("Hello, world!"), hunk.source().lines());
 
             assertEquals(0, hunk.target().range().start());
             assertEquals(0, hunk.target().range().count());
@@ -1122,7 +1122,7 @@ public class RepositoryTests {
 
             assertEquals(1, hunk.target().range().start());
             assertEquals(1, hunk.target().range().count());
-            assertEquals(suffixPlatformLineEndings("make"), hunk.target().lines());
+            assertLinesEquals(List.of("make"), hunk.target().lines());
 
             assertEquals(1, hunk.added());
             assertEquals(0, hunk.removed());
@@ -1168,7 +1168,7 @@ public class RepositoryTests {
 
             assertEquals(2, hunk.target().range().start());
             assertEquals(1, hunk.target().range().count());
-            assertEquals(suffixPlatformLineEndings("One more line"), hunk.target().lines());
+            assertLinesEquals(List.of("One more line"), hunk.target().lines());
 
             assertEquals(1, hunk.added());
             assertEquals(0, hunk.removed());
@@ -1311,7 +1311,7 @@ public class RepositoryTests {
 
             var secondHunk = secondPatch.hunks().get(0);
             assertEquals(List.of(), secondHunk.source().lines());
-            assertEquals(suffixPlatformLineEndings("One last line"), secondHunk.target().lines());
+            assertLinesEquals(List.of("One last line"), secondHunk.target().lines());
 
             assertEquals(3, secondHunk.source().range().start());
             assertEquals(0, secondHunk.source().range().count());
@@ -1330,7 +1330,7 @@ public class RepositoryTests {
 
             var thirdHunk = thirdPatch.hunks().get(0);
             assertEquals(List.of(), thirdHunk.source().lines());
-            assertEquals(suffixPlatformLineEndings("One more line", "One last line"), thirdHunk.target().lines());
+            assertLinesEquals(List.of("One more line", "One last line"), thirdHunk.target().lines());
 
             assertEquals(2, thirdHunk.source().range().start());
             assertEquals(0, thirdHunk.source().range().count());


### PR DESCRIPTION
One more patch to address failing `vcs` tests on Windows.

The tests in `RepositoryTest` use `Files::write` to create some test files, but this also means the files will have Windows line endings (i.e. CRLF). When these are parsed by the skara tooling the LF part is dropped as a delimiter, but the CR part ends up being part of the line. This is all correct and as expected, since patch files are supposed to have unix line endings, so the carriage return ends up as part of the content.

The problem comes when testing what is written to the file. The tests are not expecting the Windows line endings to be there, so a lot of them fail.

This PR changes the tests to expect the Windows line endings as well. Or rather, it tries to stick what's in the system line separator (minus a trailing '\n', since that is dropped as a delimiter) at the end of the checked line.

With this patch, I have all the `vcs` tests passing locally.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)