### PR TITLE
Use positional argument if present

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitWebrev.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitWebrev.java
@@ -255,6 +255,6 @@ public class GitWebrev {
               .username(username)
               .issue(issue)
               .version(version)
-              .generate(rev);
+              .generate(rev, arguments.at(0).isPresent()?resolve(repo, arguments.at(0).asString()):null);
     }
 }


### PR DESCRIPTION
I hope this implements what is documented in the help message:
```usage: git webrev [options] [<rev>]```
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed