### PR TITLE
Allow output path to be created with arbitrary directory nesting

### DIFF
--- a/webrev/src/main/java/org/openjdk/skara/webrev/Webrev.java
+++ b/webrev/src/main/java/org/openjdk/skara/webrev/Webrev.java
@@ -107,9 +107,7 @@ public class Webrev {
         }
 
         public void generate(Hash tailEnd, Hash head) throws IOException {
-            if (!Files.exists(output)) {
-                Files.createDirectory(output);
-            }
+            Files.createDirectories(output);
 
             copyResource(ANCNAV_HTML);
             copyResource(ANCNAV_JS);


### PR DESCRIPTION
createDirectories works like ```mkdir -p``` and the _exists_ check is no longer needed
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)