### PR TITLE
Avoid using getUrl when creating folder names

### DIFF
--- a/bots/forward/src/main/java/org/openjdk/skara/bots/forward/ForwardBot.java
+++ b/bots/forward/src/main/java/org/openjdk/skara/bots/forward/ForwardBot.java
@@ -68,7 +68,7 @@ class ForwardBot implements Bot, WorkItem {
     public void run(Path scratchPath) {
         try {
             var sanitizedUrl =
-                URLEncoder.encode(toHostedRepo.getUrl().toString(), StandardCharsets.UTF_8);
+                URLEncoder.encode(toHostedRepo.getWebUrl().toString(), StandardCharsets.UTF_8);
             var toDir = storage.resolve(sanitizedUrl);
             Repository toLocalRepo = null;
             if (!Files.exists(toDir)) {

--- a/bots/mirror/src/main/java/org/openjdk/skara/bots/mirror/MirrorBot.java
+++ b/bots/mirror/src/main/java/org/openjdk/skara/bots/mirror/MirrorBot.java
@@ -60,7 +60,7 @@ class MirrorBot implements Bot, WorkItem {
     public void run(Path scratchPath) {
         try {
             var sanitizedUrl =
-                URLEncoder.encode(from.getUrl().toString(), StandardCharsets.UTF_8);
+                URLEncoder.encode(from.getWebUrl().toString(), StandardCharsets.UTF_8);
             var dir = storage.resolve(sanitizedUrl);
             Repository repo = null;
             if (!Files.exists(dir)) {

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/JNotifyBot.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/JNotifyBot.java
@@ -136,7 +136,7 @@ class JNotifyBot implements Bot, WorkItem {
 
     @Override
     public void run(Path scratchPath) {
-        var sanitizedUrl = URLEncoder.encode(repository.getUrl().toString(), StandardCharsets.UTF_8);
+        var sanitizedUrl = URLEncoder.encode(repository.getWebUrl().toString(), StandardCharsets.UTF_8);
         var path = storagePath.resolve(sanitizedUrl);
         var historyPath = scratchPath.resolve("notify").resolve("history");
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
@@ -87,7 +87,7 @@ public class IntegrateCommand implements CommandHandler {
 
         // Execute merge
         try {
-            var sanitizedUrl = URLEncoder.encode(pr.repository().getUrl().toString(), StandardCharsets.UTF_8);
+            var sanitizedUrl = URLEncoder.encode(pr.repository().getWebUrl().toString(), StandardCharsets.UTF_8);
             var path = scratchPath.resolve("pr.integrate").resolve(sanitizedUrl);
 
             var prInstance = new PullRequestInstance(path, pr);

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
@@ -68,7 +68,7 @@ public class SponsorCommand implements CommandHandler {
 
         // Execute merge
         try {
-            var sanitizedUrl = URLEncoder.encode(pr.repository().getUrl().toString(), StandardCharsets.UTF_8);
+            var sanitizedUrl = URLEncoder.encode(pr.repository().getWebUrl().toString(), StandardCharsets.UTF_8);
             var path = scratchPath.resolve("pr.sponsor").resolve(sanitizedUrl);
 
             var prInstance = new PullRequestInstance(path, pr);


### PR DESCRIPTION
Hi all,

Please review this change that replaces calls to getUrl with getWebUrl when creating names of folders to clone repositories into. The problem is that getUrl can contain credentials, which getWebUrl does not.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)