### PR TITLE
Add ReadOnlyRepository::dump

### DIFF
--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/TestRepository.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/TestRepository.java
@@ -178,6 +178,10 @@ class TestRepository implements ReadOnlyRepository {
         return List.of();
     }
 
+    public boolean dump(FileEntry entry, Path to) throws IOException {
+        return false;
+    }
+
     public Diff diff(Hash base, Hash head) throws IOException {
         return null;
     }

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/TestRepository.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/TestRepository.java
@@ -178,8 +178,7 @@ class TestRepository implements ReadOnlyRepository {
         return List.of();
     }
 
-    public boolean dump(FileEntry entry, Path to) throws IOException {
-        return false;
+    public void dump(FileEntry entry, Path to) throws IOException {
     }
 
     public Diff diff(Hash base, Hash head) throws IOException {

--- a/vcs/src/main/java/org/openjdk/skara/vcs/FileEntry.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/FileEntry.java
@@ -26,14 +26,20 @@ import java.util.Objects;
 import java.nio.file.Path;
 
 public class FileEntry {
+    private final Hash commit;
     private final FileType type;
     private final Hash hash;
     private final Path path;
 
-    public FileEntry(FileType type, Hash hash, Path path) {
+    public FileEntry(Hash commit, FileType type, Hash hash, Path path) {
+        this.commit = commit;
         this.type = type;
         this.hash = hash;
         this.path = path;
+    }
+
+    public Hash commit() {
+        return commit;
     }
 
     public FileType type() {
@@ -50,7 +56,7 @@ public class FileEntry {
 
     @Override
     public int hashCode() {
-        return Objects.hash(type, hash, path);
+        return Objects.hash(commit, type, hash, path);
     }
 
     @Override
@@ -60,13 +66,14 @@ public class FileEntry {
         }
 
         var e = (FileEntry) o;
-        return Objects.equals(type, e.type) &&
+        return Objects.equals(commit, e.commit) &&
+               Objects.equals(type, e.type) &&
                Objects.equals(hash, e.hash) &&
                Objects.equals(path, e.path);
     }
 
     @Override
     public String toString() {
-        return type.toString() + " " + hash.toString() + "\t" + path.toString();
+        return type.toString() + " blob " + hash.toString() + "\t" + path.toString();
     }
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
@@ -66,7 +66,7 @@ public interface ReadOnlyRepository {
         return files(h, Arrays.asList(paths));
     }
 
-    boolean dump(FileEntry entry, Path to) throws IOException;
+    void dump(FileEntry entry, Path to) throws IOException;
     Diff diff(Hash base, Hash head) throws IOException;
     Diff diff(Hash head) throws IOException;
     List<String> config(String key) throws IOException;

--- a/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
@@ -66,6 +66,7 @@ public interface ReadOnlyRepository {
         return files(h, Arrays.asList(paths));
     }
 
+    boolean dump(FileEntry entry, Path to) throws IOException;
     Diff diff(Hash base, Hash head) throws IOException;
     Diff diff(Hash head) throws IOException;
     List<String> config(String key) throws IOException;

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -732,15 +732,13 @@ public class GitRepository implements Repository {
     }
 
     @Override
-    public boolean dump(FileEntry entry, Path to) throws IOException {
+    public void dump(FileEntry entry, Path to) throws IOException {
         var type = entry.type();
         if (type.isRegular()) {
             var path = unpackFile(entry.hash().hex());
             Files.createDirectories(to.getParent());
             Files.move(path, to, StandardCopyOption.REPLACE_EXISTING);
-            return true;
         }
-        return false;
     }
 
     @Override

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -686,7 +686,8 @@ public class GitRepository implements Repository {
                 var metadata = parts[0].split(" ");
                 var filename = parts[1];
 
-                var entry = new FileEntry(FileType.fromOctal(metadata[0]),
+                var entry = new FileEntry(hash,
+                                          FileType.fromOctal(metadata[0]),
                                           new Hash(metadata[2]),
                                           Path.of(filename));
                 entries.add(entry);
@@ -728,6 +729,18 @@ public class GitRepository implements Repository {
         }
 
         return Optional.empty();
+    }
+
+    @Override
+    public boolean dump(FileEntry entry, Path to) throws IOException {
+        var type = entry.type();
+        if (type.isRegular()) {
+            var path = unpackFile(entry.hash().hex());
+            Files.createDirectories(to.getParent());
+            Files.move(path, to, StandardCopyOption.REPLACE_EXISTING);
+            return true;
+        }
+        return false;
     }
 
     @Override

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -667,13 +667,12 @@ public class HgRepository implements Repository {
     }
 
     @Override
-    public boolean dump(FileEntry entry, Path to) throws IOException {
+    public void dump(FileEntry entry, Path to) throws IOException {
         var output = to.toAbsolutePath();
         try (var p = capture("hg", "cat", "--output=" + output.toString(),
                                           "--rev=" + entry.commit(),
                                           entry.path().toString())) {
-            var res = await(p);
-            return Files.exists(output);
+            await(p);
         }
     }
 

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -655,13 +655,25 @@ public class HgRepository implements Repository {
                 var metadata = parts[0].split(" ");
                 var path = Path.of(parts[1]);
                 if (include.isEmpty() || include.contains(path)) {
-                    var entry = new FileEntry(FileType.fromOctal(metadata[0]),
+                    var entry = new FileEntry(hash,
+                                              FileType.fromOctal(metadata[0]),
                                               new Hash(metadata[2]),
                                               path);
                     entries.add(entry);
                 }
             }
             return entries;
+        }
+    }
+
+    @Override
+    public boolean dump(FileEntry entry, Path to) throws IOException {
+        var output = to.toAbsolutePath();
+        try (var p = capture("hg", "cat", "--output=" + output.toString(),
+                                          "--rev=" + entry.commit(),
+                                          entry.path().toString())) {
+            var res = await(p);
+            return Files.exists(output);
         }
     }
 

--- a/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
@@ -1632,4 +1632,25 @@ public class RepositoryTests {
             assertTrue(entry.type().isRegularNonExecutable());
         }
     }
+
+    @ParameterizedTest
+    @EnumSource(VCS.class)
+    void testDump(VCS vcs) throws IOException {
+        try (var dir = new TemporaryDirectory()) {
+            var r = Repository.init(dir.path(), vcs);
+            assertTrue(r.isClean());
+
+            var f = dir.path().resolve("README");
+            Files.writeString(f, "Hello\n");
+            r.add(f);
+            var initial = r.commit("Initial commit", "duke", "duke@openjdk.org");
+
+            var readme = r.files(initial).get(0);
+
+            var tmp = Files.createTempFile("README", "txt");
+            r.dump(readme, tmp);
+            assertEquals("Hello\n", Files.readString(tmp));
+            Files.delete(tmp);
+        }
+    }
 }


### PR DESCRIPTION
Hi all,

this patch adds the `ReadOnlyRepository::dump` method and a corresponding unit test.

## Testing
- [x] `sh gradlew test` passes on Linux x86_64

Thanks!
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)