### PR TITLE
Add ReadOnlyRepository::status

### DIFF
--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/TestRepository.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/TestRepository.java
@@ -212,4 +212,8 @@ class TestRepository implements ReadOnlyRepository {
     public Optional<String> upstreamFor(Branch b) throws IOException {
         return Optional.empty();
     }
+
+    public List<StatusEntry> status(Hash from, Hash to) throws IOException {
+        return Collections.emptyList();
+    }
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
@@ -67,6 +67,7 @@ public interface ReadOnlyRepository {
     }
 
     void dump(FileEntry entry, Path to) throws IOException;
+    List<StatusEntry> status(Hash from, Hash to) throws IOException;
     Diff diff(Hash base, Hash head) throws IOException;
     Diff diff(Hash head) throws IOException;
     List<String> config(String key) throws IOException;

--- a/vcs/src/main/java/org/openjdk/skara/vcs/StatusEntry.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/StatusEntry.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.vcs;
+
+import org.openjdk.skara.vcs.tools.PatchHeader;
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.Optional;
+
+public class StatusEntry {
+    public static final class Info {
+        private final Path path;
+        private final FileType type;
+        private final Hash hash;
+
+        private Info(Path path, FileType type, Hash hash) {
+            this.path = path;
+            this.type = type;
+            this.hash = hash;
+        }
+
+        private Info(Patch.Info info) {
+            this.path = info.path().orElse(null);
+            this.type = info.type().orElse(null);
+            this.hash = info.hash();
+        }
+
+        public Optional<Path> path() {
+            return Optional.ofNullable(path);
+        }
+
+        public Optional<FileType> type() {
+            return Optional.ofNullable(type);
+        }
+
+        public Hash hash() {
+            return hash;
+        }
+    }
+
+    private final Info source;
+    private final Info target;
+
+    private Status status;
+
+    public StatusEntry(Path sourcePath, FileType sourceFileType, Hash sourceHash,
+                       Path targetPath, FileType targetFileType, Hash targetHash,
+                       Status status) {
+        this.source = new Info(sourcePath, sourceFileType, sourceHash);
+        this.target = new Info(targetPath, targetFileType, targetHash);
+        this.status = status;
+    }
+
+    public StatusEntry(Patch patch) {
+        this.source = new Info(patch.source());
+        this.target = new Info(patch.target());
+        this.status = patch.status();
+    }
+
+    public Info source() {
+        return source;
+    }
+
+    public Info target() {
+        return target;
+    }
+
+    public Status status() {
+        return status;
+    }
+
+    public static StatusEntry fromRawLine(String line) {
+        var h = PatchHeader.fromRawLine(line);
+        return new StatusEntry(h.sourcePath(), h.sourceFileType(), h.sourceHash(),
+                               h.targetPath(), h.targetFileType(), h.targetHash(),
+                               h.status());
+    }
+}

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -742,6 +742,18 @@ public class GitRepository implements Repository {
     }
 
     @Override
+    public List<StatusEntry> status(Hash from, Hash to) throws IOException {
+        try (var p = capture("git", "diff", "--raw", "--find-renames=99%", "--find-copies=99%", "--find-copies-harder", "--no-abbrev", "--no-color", from.hex(), to.hex())) {
+            var res = await(p);
+            var entries = new ArrayList<StatusEntry>();
+            for (var line : res.stdout()) {
+                entries.add(StatusEntry.fromRawLine(line));
+            }
+            return entries;
+        }
+    }
+
+    @Override
     public Diff diff(Hash from) throws IOException {
         return diff(from, null);
     }


### PR DESCRIPTION
Hi all,

this patch adds the method `ReadOnlyRepository::status` and a corresponding unit test.

## Testing
- [x] `sh gradlew test` passes on Linux x86_64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)