### PR TITLE
79: jcheck allows self-reviews when processing pull requests

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
@@ -97,8 +97,10 @@ class PullRequestCheckIssueVisitor implements IssueVisitor {
     }
 
     @Override
-    public void visit(SelfReviewIssue e) {
-        log.fine("ignored: self-reviews are not allowed");
+    public void visit(SelfReviewIssue e)
+    {
+        messages.add("Self-reviews are not allowed");
+        failedChecks.add(e.check().getClass());
     }
 
     @Override


### PR DESCRIPTION
Hi all,

Please review the following change that makes the PullRequestBot flag a PR as failing jcheck when a self-review is detected. Creating such a review is only possible on recent versions of GitLab, but doesn't hurt to check it anyway.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)