### PR TITLE
Fix webrev generation when target hunk is empty

### DIFF
--- a/webrev/src/main/java/org/openjdk/skara/webrev/FramesView.java
+++ b/webrev/src/main/java/org/openjdk/skara/webrev/FramesView.java
@@ -140,7 +140,9 @@ class FramesView implements View {
                 var hunk = hunks.get(hunkIndex);
                 var numSourceLines = hunk.source().lines().size();
                 var numDestLines = hunk.target().lines().size();
-                var start = hunk.target().range().start() - 1;
+                var start = numDestLines == 0 && hunk.target().range().start() == 0 ?
+                    hunk.target().range().start() :
+                    hunk.target().range().start() - 1;
 
                 for (var i = lastEnd; i < start; i++) {
                     ViewUtils.writeWithLineNumber(fw, destContent.get(i), i + 1, maxLineNum);

--- a/webrev/src/main/java/org/openjdk/skara/webrev/HunkCoalescer.java
+++ b/webrev/src/main/java/org/openjdk/skara/webrev/HunkCoalescer.java
@@ -256,7 +256,8 @@ class HunkCoalescer {
 
         var afterContextCount = Math.min(sourceAfterContextCount, destAfterContextCount);
 
-        var sourceLineNumStart = hunk.source().lines().isEmpty() && hunk.source().range().start() == 0 ? sourceAfterContextStart + 1 : sourceAfterContextStart;
+        var sourceLineNumStart = hunk.source().lines().isEmpty() && hunk.source().range().start() == 0 ?
+            sourceAfterContextStart + 1 : sourceAfterContextStart;
         var sourceEndingLineNum = sourceLineNumStart + afterContextCount;
         var sourceContextAfter = new ArrayList<Line>();
         for (var lineNum = sourceLineNumStart; lineNum < sourceEndingLineNum; lineNum++) {
@@ -264,9 +265,11 @@ class HunkCoalescer {
             sourceContextAfter.add(new Line(lineNum, text));
         }
 
-        var destEndingLineNum = destAfterContextStart + afterContextCount;
+        var destLineNumStart = hunk.target().lines().isEmpty() && hunk.target().range().start() == 0 ?
+            destAfterContextStart + 1 : destAfterContextStart;
+        var destEndingLineNum = destLineNumStart + afterContextCount;
         var destContextAfter = new ArrayList<Line>();
-        for (var lineNum = destAfterContextStart; lineNum < destEndingLineNum; lineNum++) {
+        for (var lineNum = destLineNumStart; lineNum < destEndingLineNum; lineNum++) {
             var text = destContent.get(lineNum - 1);
             destContextAfter.add(new Line(lineNum, text));
         }

--- a/webrev/src/test/java/org/openjdk/skara/webrev/WebrevTests.java
+++ b/webrev/src/test/java/org/openjdk/skara/webrev/WebrevTests.java
@@ -96,4 +96,23 @@ class WebrevTests {
             assertContains(webrevFolder.path().resolve("index.html"), "<td>1 lines changed; 1 ins; 0 del; 0 mod; 3 unchg</td>");
         }
     }
+
+    @ParameterizedTest
+    @EnumSource(VCS.class)
+    void removedHeader(VCS vcs) throws IOException {
+        try (var repoFolder = new TemporaryDirectory();
+             var webrevFolder = new TemporaryDirectory()) {
+            var repo = Repository.init(repoFolder.path(), vcs);
+            var file = repoFolder.path().resolve("x.txt");
+            Files.writeString(file, "1\n2\n3\n4\n5\n6\n7\n8\n9\n", StandardCharsets.UTF_8);
+            repo.add(file);
+            var hash1 = repo.commit("Commit", "a", "a@a.a");
+            Files.writeString(file, "5\n6\n7\n8\n9\n", StandardCharsets.UTF_8);
+            repo.add(file);
+            var hash2 = repo.commit("Commit 2", "a", "a@a.a");
+
+            new Webrev.Builder(repo, webrevFolder.path()).generate(hash1, hash2);
+            assertContains(webrevFolder.path().resolve("index.html"), "<td>4 lines changed; 0 ins; 4 del; 0 mod; 1 unchg</td>");
+        }
+    }
 }


### PR DESCRIPTION
Hi all,

this patch similar to one Robin did a few days ago. Robin fixed generation of webrevs when a source hunk in a patch was empty, this change fixes generation of webrevs when a target hunk in the patch is empty and starts at 0 (i.e. the user has removed lines from the start of a file).

## Testing
- [x] `sh gradlew test` passes on Linux x86_64
- Added new unit test

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)