### PR TITLE
Special domain for OpenJDK Contributors is openjdk.org

### DIFF
--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/JCheckConfiguration.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/JCheckConfiguration.java
@@ -106,7 +106,7 @@ public class JCheckConfiguration {
 
         config.add("[census]");
         config.add("version=0");
-        config.add("domain=openjdk.java.net");
+        config.add("domain=openjdk.org");
 
         if (shouldCheckWhitespace) {
             config.add("[checks \"whitespace\"]");


### PR DESCRIPTION
Hi all,

as part of the last re-coversion the special domain used to recognize OpenJDK Contributors changed from openjdk.java.net to openjdk.org. This patch updates the backwards compatible interpretation of .jcheck/conf to use openjdk.org correctly.

## Testing
- [x] `sh gradlew test` passes on Linux x86_64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)