### PR TITLE
Fine-tune testing on Windows

### DIFF
--- a/bots/hgbridge/src/test/java/org/openjdk/skara/bots/hgbridge/BridgeBotTests.java
+++ b/bots/hgbridge/src/test/java/org/openjdk/skara/bots/hgbridge/BridgeBotTests.java
@@ -31,6 +31,7 @@ import org.openjdk.skara.vcs.*;
 import org.openjdk.skara.vcs.openjdk.convert.*;
 
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.*;
 
 import java.io.*;
 import java.net.URI;
@@ -43,6 +44,7 @@ import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+@DisabledOnOs(OS.WINDOWS)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class BridgeBotTests {
     private List<String> runHgCommand(Repository repository, String... params) throws IOException {
@@ -128,6 +130,7 @@ class BridgeBotTests {
     void setup() throws IOException {
         // Export the beginning of the jtreg repository
         sourceFolder = new TemporaryDirectory();
+        Assumptions.assumeFalse(OS.WINDOWS.isCurrentOs(), "Running on Windows -- skipping tests");
         try {
             var localRepo = Repository.materialize(sourceFolder.path(), URIBuilder.base("http://hg.openjdk.java.net/code-tools/jtreg").build(), "default");
             runHgCommand(localRepo, "strip", "-r", "b2511c725d81");

--- a/bots/hgbridge/src/test/java/org/openjdk/skara/bots/hgbridge/BridgeBotTests.java
+++ b/bots/hgbridge/src/test/java/org/openjdk/skara/bots/hgbridge/BridgeBotTests.java
@@ -31,7 +31,6 @@ import org.openjdk.skara.vcs.*;
 import org.openjdk.skara.vcs.openjdk.convert.*;
 
 import org.junit.jupiter.api.*;
-import org.junit.jupiter.api.condition.*;
 
 import java.io.*;
 import java.net.URI;
@@ -44,7 +43,6 @@ import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-@DisabledOnOs(OS.WINDOWS)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class BridgeBotTests {
     private List<String> runHgCommand(Repository repository, String... params) throws IOException {
@@ -130,7 +128,6 @@ class BridgeBotTests {
     void setup() throws IOException {
         // Export the beginning of the jtreg repository
         sourceFolder = new TemporaryDirectory();
-        Assumptions.assumeFalse(OS.WINDOWS.isCurrentOs(), "Running on Windows -- skipping tests");
         try {
             var localRepo = Repository.materialize(sourceFolder.path(), URIBuilder.base("http://hg.openjdk.java.net/code-tools/jtreg").build(), "default");
             runHgCommand(localRepo, "strip", "-r", "b2511c725d81");

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
@@ -85,7 +85,7 @@ class WebrevStorage {
             if (!localStorage.isClean()) {
                 push(localStorage, outputFolder);
             }
-            return URIBuilder.base(baseUri).appendPath(relativeFolder.toString()).build();
+            return URIBuilder.base(baseUri).appendPath(relativeFolder.toString().replace('\\', '/')).build();
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/buildSrc/module/src/main/java/org/openjdk/skara/gradle/module/ModulePlugin.java
+++ b/buildSrc/module/src/main/java/org/openjdk/skara/gradle/module/ModulePlugin.java
@@ -103,6 +103,7 @@ public class ModulePlugin implements Plugin<Project> {
 
                         var jvmArgs = new ArrayList<String>(testTask.getJvmArgs());
                         jvmArgs.addAll(List.of(
+                                "-Djunit.jupiter.extensions.autodetection.enabled=true",
                                 "--module-path", classpath,
                                 "--add-modules", "ALL-MODULE-PATH",
                                 "--patch-module", moduleName + "=" + outputDir,

--- a/test/src/main/java/org/openjdk/skara/test/DisableAllBotsTestsOnWindows.java
+++ b/test/src/main/java/org/openjdk/skara/test/DisableAllBotsTestsOnWindows.java
@@ -20,24 +20,24 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-module org.openjdk.skara.test {
-    requires java.logging;
-    requires jdk.httpserver;
+package org.openjdk.skara.test;
 
-    requires org.openjdk.skara.census;
-    requires org.openjdk.skara.vcs;
-    requires org.openjdk.skara.bot;
-    requires org.openjdk.skara.json;
-    requires org.openjdk.skara.host;
-    requires org.openjdk.skara.email;
-    requires org.openjdk.skara.mailinglist;
-    requires org.openjdk.skara.proxy;
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled;
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
 
-    requires org.junit.jupiter.api;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
-    exports org.openjdk.skara.test;
-
-    provides org.junit.jupiter.api.extension.Extension
-        with org.openjdk.skara.test.DisableAllBotsTestsOnWindows;
+public class DisableAllBotsTestsOnWindows implements ExecutionCondition {
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+        if (!OS.WINDOWS.isCurrentOs()) {
+            return enabled("Non-Windows OS");
+        }
+        var test = context.getRequiredTestClass();
+        var bots = test.getPackageName().startsWith("org.openjdk.skara.bots.");
+        return bots ? disabled("All bots tests are disabled on Windows") : enabled("Non-bots test");
+    }
 }
-


### PR DESCRIPTION
### All Windows issues down

- **Skip all bots tests on Windows**
> [...] and since the bots are not really required to run on Windows any ways, it would also be fine to disable all the bots tests from running on Windows, to avoid any further compatibility problems.

- **Convert relative folder path to be URI-friendly**
On Windows Path::toString generates back slashes as path element separators. This yields invalid URI paths: like `"%s\webrev.%s"`.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)
 * Jorn Vernee ([jvernee](@JornVernee) - Committer)