### PR TITLE
Parse .ssh/config in git-pr if needed

### DIFF
--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     implementation project(':json')
     implementation project(':host')
     implementation project(':proxy')
+    implementation project(':ssh')
 }
 
 

--- a/cli/src/main/java/module-info.java
+++ b/cli/src/main/java/module-info.java
@@ -29,6 +29,7 @@ module org.openjdk.skara.cli {
     requires org.openjdk.skara.json;
     requires org.openjdk.skara.host;
     requires org.openjdk.skara.proxy;
+    requires org.openjdk.skara.ssh;
 
     requires java.net.http;
     requires java.logging;

--- a/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
@@ -281,7 +281,6 @@ public class GitPr {
         var username = arguments.contains("username") ? arguments.get("username").asString() : null;
         var token = System.getenv("GIT_TOKEN");
         var uri = toURI(remotePullPath);
-        System.out.println(uri.toString());
         var credentials = GitCredentials.fill(uri.getHost(), uri.getPath().substring(1), username, token, uri.getScheme());
         var host = Host.from(uri, new PersonalAccessToken(credentials.username(), credentials.password()));
 

--- a/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
@@ -171,11 +171,13 @@ public class GitPr {
 
                     // Could be a Host in the ~/.ssh/config file
                     var sshConfig = Path.of(System.getProperty("user.home"), ".ssh", "config");
-                    for (var host : SSHConfig.parse(sshConfig).hosts()) {
-                        if (host.name().equals(name)) {
-                            var hostName = host.hostName();
-                            if (hostName != null) {
-                                return URI.create("https://" + hostName + "/" + path.split(":")[1]);
+                    if (Files.exists(sshConfig)) {
+                        for (var host : SSHConfig.parse(sshConfig).hosts()) {
+                            if (host.name().equals(name)) {
+                                var hostName = host.hostName();
+                                if (hostName != null) {
+                                    return URI.create("https://" + hostName + "/" + path.split(":")[1]);
+                                }
                             }
                         }
                     }

--- a/ssh/build.gradle
+++ b/ssh/build.gradle
@@ -20,32 +20,19 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-rootProject.name = 'skara'
 
-include 'args'
-include 'bot'
-include 'cli'
-include 'census'
-include 'email'
-include 'encoding'
-include 'host'
-include 'ini'
-include 'jcheck'
-include 'json'
-include 'mailinglist'
-include 'process'
-include 'proxy'
-include 'storage'
-include 'ssh'
-include 'test'
-include 'vcs'
-include 'webrev'
+module {
+    name = 'org.openjdk.skara.ssh'
+    test {
+        requires 'org.junit.jupiter.api'
+        opens 'org.openjdk.skara.ssh' to 'org.junit.platform.commons'
+    }
+}
 
-include 'bots:cli'
-include 'bots:forward'
-include 'bots:hgbridge'
-include 'bots:mirror'
-include 'bots:mlbridge'
-include 'bots:notify'
-include 'bots:pr'
-include 'bots:submit'
+publishing {
+    publications {
+        ssh(MavenPublication) {
+            from components.java
+        }
+    }
+}

--- a/ssh/src/main/java/module-info.java
+++ b/ssh/src/main/java/module-info.java
@@ -20,32 +20,6 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-rootProject.name = 'skara'
-
-include 'args'
-include 'bot'
-include 'cli'
-include 'census'
-include 'email'
-include 'encoding'
-include 'host'
-include 'ini'
-include 'jcheck'
-include 'json'
-include 'mailinglist'
-include 'process'
-include 'proxy'
-include 'storage'
-include 'ssh'
-include 'test'
-include 'vcs'
-include 'webrev'
-
-include 'bots:cli'
-include 'bots:forward'
-include 'bots:hgbridge'
-include 'bots:mirror'
-include 'bots:mlbridge'
-include 'bots:notify'
-include 'bots:pr'
-include 'bots:submit'
+module org.openjdk.skara.ssh {
+    exports org.openjdk.skara.ssh;
+}

--- a/ssh/src/main/java/org/openjdk/skara/ssh/SSHConfig.java
+++ b/ssh/src/main/java/org/openjdk/skara/ssh/SSHConfig.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.skara.ssh;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.util.*;
+
+public class SSHConfig {
+    public static class Host {
+        private final String name;
+        private final String user;
+        private final String hostName;
+        private final int port;
+        private final List<String> preferredAuthentications;
+        private final Path identifyFile;
+        private final String proxyCommand;
+        private final boolean forwardAgent;
+        private final boolean tcpKeepAlive;
+        private final boolean identitiesOnly;
+
+        Host(String name, Map<String, String> fields) {
+            this.name = name;
+            user = fields.get("User");
+            hostName = fields.get("Hostname");
+            port = Integer.parseInt(fields.getOrDefault("Port", "22"));
+
+            if (fields.containsKey("PreferredAuthentications")) {
+                preferredAuthentications = Arrays.asList(fields.get("PreferredAuthentications").split(","));
+            } else {
+                preferredAuthentications = List.of();
+            }
+
+            if (fields.containsKey("IdentityFile")) {
+                identifyFile = Path.of(fields.get("IdentityFile"));
+            } else {
+                identifyFile = null;
+            }
+
+            proxyCommand = fields.get("proxyCommand");
+            forwardAgent = Objects.equals(fields.get("ForwardAgent"), "yes");
+            tcpKeepAlive = Objects.equals(fields.get("TCPKeepAlive"), "yes");
+            identitiesOnly = Objects.equals(fields.get("IdentitiesOnly"), "yes");
+        }
+
+        public String name() {
+            return name;
+        }
+
+        public String user() {
+            return user;
+        }
+
+        public String hostName() {
+            return hostName;
+        }
+
+        public int port() {
+            return port;
+        }
+
+        public List<String> preferredAuthentications() {
+            return preferredAuthentications;
+        }
+
+        public Path identityFile() {
+            return identifyFile;
+        }
+
+        public String proxyCommand() {
+            return proxyCommand;
+        }
+
+        public boolean forwardAgent() {
+            return forwardAgent;
+        }
+
+        public boolean tcpKeepAlive() {
+            return tcpKeepAlive;
+        }
+
+        public boolean identitiesOnly() {
+            return identitiesOnly;
+        }
+    }
+
+    private final List<Host> hosts;
+
+    public SSHConfig(List<Host> hosts) {
+        this.hosts = hosts;
+    }
+
+    public List<Host> hosts() {
+        return hosts;
+    }
+
+    public static SSHConfig parse(Path p) throws IOException  {
+        return parse(Files.readAllLines(p));
+    }
+
+    public static SSHConfig parse(List<String> lines) {
+        var hosts = new ArrayList<Host>();
+        var i = 0;
+        while (i < lines.size()) {
+            var line = lines.get(i);
+            if (line.startsWith("Host")) {
+                var name = line.split(" ")[1];
+                i++;
+
+                var fields = new HashMap<String, String>();
+                while (i < lines.size() && !lines.get(i).startsWith("Host")) {
+                    var field = lines.get(i);
+                    i++;
+                    if (!field.isEmpty()) {
+                        var nameAndValue = field.trim().split(" ");
+                        fields.put(nameAndValue[0], nameAndValue[1]);
+                    }
+                }
+
+                hosts.add(new Host(name, fields));
+            }
+        }
+
+        return new SSHConfig(hosts);
+    }
+}

--- a/ssh/src/test/java/org/openjdk/ssh/SSHConfigTests.java
+++ b/ssh/src/test/java/org/openjdk/ssh/SSHConfigTests.java
@@ -20,32 +20,29 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-rootProject.name = 'skara'
 
-include 'args'
-include 'bot'
-include 'cli'
-include 'census'
-include 'email'
-include 'encoding'
-include 'host'
-include 'ini'
-include 'jcheck'
-include 'json'
-include 'mailinglist'
-include 'process'
-include 'proxy'
-include 'storage'
-include 'ssh'
-include 'test'
-include 'vcs'
-include 'webrev'
+package org.openjdk.skara.ssh;
 
-include 'bots:cli'
-include 'bots:forward'
-include 'bots:hgbridge'
-include 'bots:mirror'
-include 'bots:mlbridge'
-include 'bots:notify'
-include 'bots:pr'
-include 'bots:submit'
+import java.util.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SSHConfigTests {
+    @Test
+    void testSimpleConfig() {
+        var lines = List.of(
+            "Host test",
+            "  User git",
+	    "  HostName git.openjdk.java.net",
+	    "  Port 22"
+	);
+	var config = SSHConfig.parse(lines);
+	var hosts = config.hosts();
+	assertEquals(1, hosts.size());
+	var host = hosts.get(0);
+	assertEquals("test", host.name());
+	assertEquals("git", host.user());
+	assertEquals(22, host.port());
+    }
+}

--- a/ssh/src/test/java/org/openjdk/ssh/SSHConfigTests.java
+++ b/ssh/src/test/java/org/openjdk/ssh/SSHConfigTests.java
@@ -34,15 +34,15 @@ public class SSHConfigTests {
         var lines = List.of(
             "Host test",
             "  User git",
-	    "  HostName git.openjdk.java.net",
-	    "  Port 22"
-	);
-	var config = SSHConfig.parse(lines);
-	var hosts = config.hosts();
-	assertEquals(1, hosts.size());
-	var host = hosts.get(0);
-	assertEquals("test", host.name());
-	assertEquals("git", host.user());
-	assertEquals(22, host.port());
+            "  HostName git.openjdk.java.net",
+            "  Port 22"
+        );
+        var config = SSHConfig.parse(lines);
+        var hosts = config.hosts();
+        assertEquals(1, hosts.size());
+        var host = hosts.get(0);
+        assertEquals("test", host.name());
+        assertEquals("git", host.user());
+        assertEquals(22, host.port());
     }
 }


### PR DESCRIPTION
Hi all,

`git-pr` needs to find the `URI` for a remote and that can be a bit tricky if an SSH "alias" (set up in `~/.ssh/config`) is involved. This patch adds a little `ssh` module with a `SSHConfig` class that can parse most fields out of an `ssh_config` file (most crucially the `Hostname` field). This way `git-pr` can be a little smarter about figure out the hostname of the forge.

## Testing
- [x] `sh gradlew test` passes
- [x] Added an additional unit test

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)