### PR TITLE
Allow the notify bot to watch multiple branches

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/JNotifyBot.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/JNotifyBot.java
@@ -40,15 +40,17 @@ class JNotifyBot implements Bot, WorkItem {
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots");;
     private final HostedRepository repository;
     private final Path storagePath;
-    private final Branch branch;
+    private final List<Branch> branches;
     private final StorageBuilder<Tag> tagStorageBuilder;
     private final StorageBuilder<ResolvedBranch> branchStorageBuilder;
     private final List<UpdateConsumer> updaters;
 
-    JNotifyBot(HostedRepository repository, Path storagePath, String branch, StorageBuilder<Tag> tagStorageBuilder, StorageBuilder<ResolvedBranch> branchStorageBuilder, List<UpdateConsumer> updaters) {
+    JNotifyBot(HostedRepository repository, Path storagePath, List<String> branches, StorageBuilder<Tag> tagStorageBuilder, StorageBuilder<ResolvedBranch> branchStorageBuilder, List<UpdateConsumer> updaters) {
         this.repository = repository;
         this.storagePath = storagePath;
-        this.branch = new Branch(branch);
+        this.branches = branches.stream()
+                                .map(Branch::new)
+                                .collect(Collectors.toList());
         this.tagStorageBuilder = tagStorageBuilder;
         this.branchStorageBuilder = branchStorageBuilder;
         this.updaters = updaters;
@@ -66,9 +68,7 @@ class JNotifyBot implements Bot, WorkItem {
         return false;
     }
 
-    private void handleBranch(Repository localRepo, UpdateHistory history, Branch branch) throws IOException {
-        var curHead = localRepo.resolve("FETCH_HEAD").orElseThrow(IOException::new);
-
+    private void handleBranch(Repository localRepo, UpdateHistory history, Branch branch, Hash curHead) throws IOException {
         var lastRef = history.branchHash(branch);
         if (lastRef.isEmpty()) {
             log.warning("No previous history found for branch '" + branch + "' - resetting mark");
@@ -87,7 +87,7 @@ class JNotifyBot implements Bot, WorkItem {
 
         Collections.reverse(newCommits);
         for (var updater : updaters) {
-            updater.handleCommits(repository, newCommits);
+            updater.handleCommits(repository, newCommits, branch);
         }
     }
 
@@ -141,10 +141,14 @@ class JNotifyBot implements Bot, WorkItem {
         var historyPath = scratchPath.resolve("notify").resolve("history");
 
         try {
-            var localRepo = Repository.materialize(path, repository.getUrl(), branch.name(), false);
+            var localRepo = Repository.materialize(path, repository.getUrl(), "master", false);
             var history = UpdateHistory.create(tagStorageBuilder, historyPath.resolve("tags"), branchStorageBuilder, historyPath.resolve("branches"));
-            handleBranch(localRepo, history, branch);
             handleTags(localRepo, history);
+
+            for (var branch : branches) {
+                var hash = localRepo.fetch(repository.getUrl(), branch.name());
+                handleBranch(localRepo, history, branch, hash);
+            }
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/JNotifyBotFactory.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/JNotifyBotFactory.java
@@ -24,12 +24,14 @@ package org.openjdk.skara.bots.notify;
 
 import org.openjdk.skara.bot.*;
 import org.openjdk.skara.email.EmailAddress;
+import org.openjdk.skara.json.JSONValue;
 import org.openjdk.skara.storage.StorageBuilder;
-import org.openjdk.skara.vcs.Tag;
+import org.openjdk.skara.vcs.*;
 
 import java.nio.file.Path;
 import java.util.*;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 public class JNotifyBotFactory implements BotFactory {
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots");;
@@ -52,7 +54,9 @@ public class JNotifyBotFactory implements BotFactory {
 
         for (var repo : specific.get("repositories").fields()) {
             var repoName = repo.name();
-            var branch = repo.value().get("branch").asString();
+            var branches = repo.value().get("branches").stream()
+                               .map(JSONValue::asString)
+                               .collect(Collectors.toList());
             var build = repo.value().get("build").asString();
             var version = repo.value().get("version").asString();
 
@@ -77,7 +81,7 @@ public class JNotifyBotFactory implements BotFactory {
                     .remoteRepository(databaseRepo, databaseRef, databaseName, databaseEmail, "Added tag for " + repoName);
             var branchStorageBuilder = new StorageBuilder<ResolvedBranch>(repoName + ".branches.txt")
                     .remoteRepository(databaseRepo, databaseRef, databaseName, databaseEmail, "Added branch hash for " + repoName);
-            var bot = new JNotifyBot(configuration.repository(repoName), configuration.storageFolder(), branch, tagStorageBuilder, branchStorageBuilder, updaters);
+            var bot = new JNotifyBot(configuration.repository(repoName), configuration.storageFolder(), branches, tagStorageBuilder, branchStorageBuilder, updaters);
             ret.add(bot);
         }
 

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/JNotifyBotFactory.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/JNotifyBotFactory.java
@@ -69,7 +69,7 @@ public class JNotifyBotFactory implements BotFactory {
                 var senderName = mailcfg.get("name").asString();
                 var senderMail = mailcfg.get("email").asString();
                 var sender = EmailAddress.from(senderName, senderMail);
-                updaters.add(new MailingListUpdater(mailcfg.get("smtp").asString(), EmailAddress.parse(mailcfg.get("recipient").asString()), sender));
+                updaters.add(new MailingListUpdater(mailcfg.get("smtp").asString(), EmailAddress.parse(mailcfg.get("recipient").asString()), sender, branches.size() > 1));
             }
 
             if (updaters.isEmpty()) {

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/JsonUpdater.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/JsonUpdater.java
@@ -24,7 +24,7 @@ package org.openjdk.skara.bots.notify;
 
 import org.openjdk.skara.host.HostedRepository;
 import org.openjdk.skara.json.*;
-import org.openjdk.skara.vcs.Commit;
+import org.openjdk.skara.vcs.*;
 import org.openjdk.skara.vcs.openjdk.*;
 
 import java.nio.file.Path;
@@ -76,7 +76,7 @@ public class JsonUpdater implements UpdateConsumer {
     }
 
     @Override
-    public void handleCommits(HostedRepository repository, List<Commit> commits) {
+    public void handleCommits(HostedRepository repository, List<Commit> commits, Branch branch) {
         try (var writer = new JsonUpdateWriter(path, repository.getName())) {
             for (var commit : commits) {
                 var json = commitToChanges(repository, commit, defaultBuild);

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/MailingListUpdater.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/MailingListUpdater.java
@@ -78,11 +78,13 @@ public class MailingListUpdater implements UpdateConsumer {
         return writer.toString();
     }
 
-    private String commitsToSubject(HostedRepository repository, List<Commit> commits) {
+    private String commitsToSubject(HostedRepository repository, List<Commit> commits, Branch branch) {
         var subject = new StringBuilder();
         subject.append(repository.getRepositoryType().shortName());
         subject.append(": ");
         subject.append(repository.getName());
+        subject.append(": ");
+        subject.append(branch.name());
         subject.append(": ");
         if (commits.size() > 1) {
             subject.append(commits.size());
@@ -94,11 +96,11 @@ public class MailingListUpdater implements UpdateConsumer {
     }
 
     @Override
-    public void handleCommits(HostedRepository repository, List<Commit> commits) {
+    public void handleCommits(HostedRepository repository, List<Commit> commits, Branch branch) {
         var writer = new StringWriter();
         var printer = new PrintWriter(writer);
 
-        var subject = commitsToSubject(repository, commits);
+        var subject = commitsToSubject(repository, commits, branch);
 
         for (var commit : commits) {
             printer.println(commitToText(repository, commit));

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/MailingListUpdater.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/MailingListUpdater.java
@@ -35,11 +35,13 @@ public class MailingListUpdater implements UpdateConsumer {
     private final String host;
     private final EmailAddress recipient;
     private final EmailAddress sender;
+    private final boolean includeBranch;
 
-    MailingListUpdater(String host, EmailAddress recipient, EmailAddress sender) {
+    MailingListUpdater(String host, EmailAddress recipient, EmailAddress sender, boolean includeBranch) {
         this.host = host;
         this.recipient = recipient;
         this.sender = sender;
+        this.includeBranch = includeBranch;
     }
 
     private String patchToText(Patch patch) {
@@ -84,8 +86,10 @@ public class MailingListUpdater implements UpdateConsumer {
         subject.append(": ");
         subject.append(repository.getName());
         subject.append(": ");
-        subject.append(branch.name());
-        subject.append(": ");
+        if (includeBranch) {
+            subject.append(branch.name());
+            subject.append(": ");
+        }
         if (commits.size() > 1) {
             subject.append(commits.size());
             subject.append(" new changesets");

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/UpdateConsumer.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/UpdateConsumer.java
@@ -23,12 +23,12 @@
 package org.openjdk.skara.bots.notify;
 
 import org.openjdk.skara.host.HostedRepository;
-import org.openjdk.skara.vcs.Commit;
-import org.openjdk.skara.vcs.openjdk.*;
+import org.openjdk.skara.vcs.*;
+import org.openjdk.skara.vcs.openjdk.OpenJDKTag;
 
 import java.util.List;
 
 public interface UpdateConsumer {
-    void handleCommits(HostedRepository repository, List<Commit> commits);
+    void handleCommits(HostedRepository repository, List<Commit> commits, Branch branch);
     void handleTagCommits(HostedRepository repository, List<Commit> commits, OpenJDKTag tag);
 }

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdaterTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdaterTests.java
@@ -75,7 +75,7 @@ class UpdaterTests {
             var storageFolder = tempFolder.path().resolve("storage");
 
             var updater = new JsonUpdater(jsonFolder, "12", "team");
-            var notifyBot = new JNotifyBot(repo, storageFolder, "master", tagStorage, branchStorage, List.of(updater));
+            var notifyBot = new JNotifyBot(repo, storageFolder, List.of("master"), tagStorage, branchStorage, List.of(updater));
 
             TestBotRunner.runPeriodicItems(notifyBot);
             assertEquals(List.of(), findJsonFiles(jsonFolder, ""));
@@ -114,7 +114,7 @@ class UpdaterTests {
             var storageFolder =tempFolder.path().resolve("storage");
 
             var updater = new JsonUpdater(jsonFolder, "12", "team");
-            var notifyBot = new JNotifyBot(repo, storageFolder, "master", tagStorage, branchStorage, List.of(updater));
+            var notifyBot = new JNotifyBot(repo, storageFolder, List.of("master"), tagStorage, branchStorage, List.of(updater));
 
             TestBotRunner.runPeriodicItems(notifyBot);
             assertEquals(List.of(), findJsonFiles(jsonFolder, ""));
@@ -165,7 +165,7 @@ class UpdaterTests {
             var sender = EmailAddress.from("duke", "duke@duke.duke");
             var recipient = EmailAddress.from("list", "list@list.list");
             var updater = new MailingListUpdater(smtpServer.address(), recipient, sender);
-            var notifyBot = new JNotifyBot(repo, storageFolder, "master", tagStorage, branchStorage, List.of(updater));
+            var notifyBot = new JNotifyBot(repo, storageFolder, List.of("master"), tagStorage, branchStorage, List.of(updater));
 
             // No mail should be sent on the first run as there is no history
             TestBotRunner.runPeriodicItems(notifyBot);
@@ -203,7 +203,7 @@ class UpdaterTests {
             var sender = EmailAddress.from("duke", "duke@duke.duke");
             var recipient = EmailAddress.from("list", "list@list.list");
             var updater = new MailingListUpdater(smtpServer.address(), recipient, sender);
-            var notifyBot = new JNotifyBot(repo, storageFolder, "master", tagStorage, branchStorage, List.of(updater));
+            var notifyBot = new JNotifyBot(repo, storageFolder, List.of("master"), tagStorage, branchStorage, List.of(updater));
 
             // No mail should be sent on the first run as there is no history
             TestBotRunner.runPeriodicItems(notifyBot);
@@ -245,7 +245,7 @@ class UpdaterTests {
             var sender = EmailAddress.from("duke", "duke@duke.duke");
             var recipient = EmailAddress.from("list", "list@list.list");
             var updater = new MailingListUpdater(smtpServer.address(), recipient, sender);
-            var notifyBot = new JNotifyBot(repo, storageFolder, "master", tagStorage, branchStorage, List.of(updater));
+            var notifyBot = new JNotifyBot(repo, storageFolder, List.of("master"), tagStorage, branchStorage, List.of(updater));
 
             // No mail should be sent on the first run as there is no history
             TestBotRunner.runPeriodicItems(notifyBot);
@@ -267,4 +267,64 @@ class UpdaterTests {
         }
     }
 
+    @Test
+    void testMailingListMultipleBranches(TestInfo testInfo) throws IOException {
+        try (var smtpServer = new SMTPServer();
+             var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var repo = credentials.getHostedRepository();
+            var repoFolder = tempFolder.path().resolve("repo");
+            var localRepo = CheckableRepository.init(repoFolder, repo.getRepositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            credentials.commitLock(localRepo);
+            var branch = localRepo.branch(masterHash, "another");
+            localRepo.pushAll(repo.getUrl());
+
+            var tagStorage = createTagStorage(repo);
+            var branchStorage = createBranchStorage(repo);
+            var storageFolder = tempFolder.path().resolve("storage");
+
+            var sender = EmailAddress.from("duke", "duke@duke.duke");
+            var recipient = EmailAddress.from("list", "list@list.list");
+            var updater = new MailingListUpdater(smtpServer.address(), recipient, sender);
+            var notifyBot = new JNotifyBot(repo, storageFolder, List.of("master", "another"), tagStorage, branchStorage, List.of(updater));
+
+            // No mail should be sent on the first run as there is no history
+            TestBotRunner.runPeriodicItems(notifyBot);
+            assertThrows(RuntimeException.class, () -> smtpServer.receive(Duration.ofMillis(1)));
+
+            var editHash1 = CheckableRepository.appendAndCommit(localRepo, "Another line", "23456789: More fixes");
+            localRepo.push(editHash1, repo.getUrl(), "master");
+            var editHash2 = CheckableRepository.appendAndCommit(localRepo, "Yet another line", "3456789A: Even more fixes");
+            localRepo.push(editHash2, repo.getUrl(), "master");
+
+            TestBotRunner.runPeriodicItems(notifyBot);
+            var email = smtpServer.receive(Duration.ofSeconds(10));
+            assertEquals(email.sender(), sender);
+            assertEquals(email.recipients(), List.of(recipient));
+            assertFalse(email.subject().contains("another"));
+            assertTrue(email.subject().contains("master"));
+            assertTrue(email.body().contains("Changeset: " + editHash1.abbreviate()));
+            assertTrue(email.body().contains("23456789: More fixes"));
+            assertTrue(email.body().contains("Changeset: " + editHash2.abbreviate()));
+            assertTrue(email.body().contains("3456789A: Even more fixes"));
+            assertFalse(email.body().contains(masterHash.abbreviate()));
+            assertFalse(email.body().contains("456789AB: Yet more fixes"));
+
+            localRepo.checkout(branch, true);
+            var editHash3 = CheckableRepository.appendAndCommit(localRepo, "Another branch", "456789AB: Yet more fixes");
+            localRepo.push(editHash3, repo.getUrl(), "another");
+
+            TestBotRunner.runPeriodicItems(notifyBot);
+            email = smtpServer.receive(Duration.ofSeconds(10));
+            assertEquals(email.sender(), sender);
+            assertEquals(email.recipients(), List.of(recipient));
+            assertTrue(email.subject().contains("another"));
+            assertFalse(email.subject().contains("master"));
+            assertTrue(email.body().contains("Changeset: " + editHash3.abbreviate()));
+            assertTrue(email.body().contains("456789AB: Yet more fixes"));
+            assertFalse(email.body().contains("Changeset: " + editHash2.abbreviate()));
+            assertFalse(email.body().contains("3456789A: Even more fixes"));
+        }
+    }
 }

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdaterTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdaterTests.java
@@ -164,7 +164,7 @@ class UpdaterTests {
 
             var sender = EmailAddress.from("duke", "duke@duke.duke");
             var recipient = EmailAddress.from("list", "list@list.list");
-            var updater = new MailingListUpdater(smtpServer.address(), recipient, sender);
+            var updater = new MailingListUpdater(smtpServer.address(), recipient, sender, false);
             var notifyBot = new JNotifyBot(repo, storageFolder, List.of("master"), tagStorage, branchStorage, List.of(updater));
 
             // No mail should be sent on the first run as there is no history
@@ -177,6 +177,8 @@ class UpdaterTests {
             var email = smtpServer.receive(Duration.ofSeconds(10));
             assertEquals(email.sender(), sender);
             assertEquals(email.recipients(), List.of(recipient));
+            assertTrue(email.subject().contains(": 23456789: More fixes"));
+            assertFalse(email.subject().contains("master"));
             assertTrue(email.body().contains("Changeset: " + editHash.abbreviate()));
             assertTrue(email.body().contains("23456789: More fixes"));
             assertFalse(email.body().contains("Committer"));
@@ -202,7 +204,7 @@ class UpdaterTests {
 
             var sender = EmailAddress.from("duke", "duke@duke.duke");
             var recipient = EmailAddress.from("list", "list@list.list");
-            var updater = new MailingListUpdater(smtpServer.address(), recipient, sender);
+            var updater = new MailingListUpdater(smtpServer.address(), recipient, sender, false);
             var notifyBot = new JNotifyBot(repo, storageFolder, List.of("master"), tagStorage, branchStorage, List.of(updater));
 
             // No mail should be sent on the first run as there is no history
@@ -218,6 +220,8 @@ class UpdaterTests {
             var email = smtpServer.receive(Duration.ofSeconds(10));
             assertEquals(email.sender(), sender);
             assertEquals(email.recipients(), List.of(recipient));
+            assertTrue(email.subject().contains(": 2 new changesets"));
+            assertFalse(email.subject().contains("master"));
             assertTrue(email.body().contains("Changeset: " + editHash1.abbreviate()));
             assertTrue(email.body().contains("23456789: More fixes"));
             assertTrue(email.body().contains("Changeset: " + editHash2.abbreviate()));
@@ -244,7 +248,7 @@ class UpdaterTests {
 
             var sender = EmailAddress.from("duke", "duke@duke.duke");
             var recipient = EmailAddress.from("list", "list@list.list");
-            var updater = new MailingListUpdater(smtpServer.address(), recipient, sender);
+            var updater = new MailingListUpdater(smtpServer.address(), recipient, sender, false);
             var notifyBot = new JNotifyBot(repo, storageFolder, List.of("master"), tagStorage, branchStorage, List.of(updater));
 
             // No mail should be sent on the first run as there is no history
@@ -286,7 +290,7 @@ class UpdaterTests {
 
             var sender = EmailAddress.from("duke", "duke@duke.duke");
             var recipient = EmailAddress.from("list", "list@list.list");
-            var updater = new MailingListUpdater(smtpServer.address(), recipient, sender);
+            var updater = new MailingListUpdater(smtpServer.address(), recipient, sender, true);
             var notifyBot = new JNotifyBot(repo, storageFolder, List.of("master", "another"), tagStorage, branchStorage, List.of(updater));
 
             // No mail should be sent on the first run as there is no history
@@ -303,7 +307,7 @@ class UpdaterTests {
             assertEquals(email.sender(), sender);
             assertEquals(email.recipients(), List.of(recipient));
             assertFalse(email.subject().contains("another"));
-            assertTrue(email.subject().contains("master"));
+            assertTrue(email.subject().contains(": master: 2 new changesets"));
             assertTrue(email.body().contains("Changeset: " + editHash1.abbreviate()));
             assertTrue(email.body().contains("23456789: More fixes"));
             assertTrue(email.body().contains("Changeset: " + editHash2.abbreviate()));
@@ -319,7 +323,7 @@ class UpdaterTests {
             email = smtpServer.receive(Duration.ofSeconds(10));
             assertEquals(email.sender(), sender);
             assertEquals(email.recipients(), List.of(recipient));
-            assertTrue(email.subject().contains("another"));
+            assertTrue(email.subject().contains(": another: 456789AB: Yet more fixes"));
             assertFalse(email.subject().contains("master"));
             assertTrue(email.body().contains("Changeset: " + editHash3.abbreviate()));
             assertTrue(email.body().contains("456789AB: Yet more fixes"));


### PR DESCRIPTION
Hi all,

Please review the following change that adds support to the notifier bot for watching multiple branches. It also adds the branch name to the subject of the email if more than one branch is watched.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)