### PR TITLE
Filter out huge files to avoid excessive storage use

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
@@ -61,6 +61,14 @@ class WebrevStorage {
         try (var files = Files.walk(webrevFolder)) {
             // Try to push 1000 files at a time
             var batches = files.filter(Files::isRegularFile)
+                               .filter(file -> {
+                                   // Huge files are not that useful in a webrev
+                                   try {
+                                       return Files.size(file) < 1000 * 1000;
+                                   } catch (IOException e) {
+                                       return false;
+                                   }
+                               })
                                .collect(Collectors.groupingBy(path -> {
                                    int curIndex = batchIndex.incrementAndGet();
                                    return Math.floorDiv(curIndex, 1000);


### PR DESCRIPTION
Hi all,

Please review this minor change that avoids storing huge files in webrev repositories, as they are not that useful anyway.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)