### PR TITLE
51: Authentication token generation failure

### DIFF
--- a/host/src/main/java/org/openjdk/skara/host/github/GitHubApplication.java
+++ b/host/src/main/java/org/openjdk/skara/host/github/GitHubApplication.java
@@ -134,7 +134,7 @@ public class GitHubApplication {
 
     private String generateJsonWebToken() {
         var issuedAt = ZonedDateTime.now(ZoneOffset.UTC);
-        var expires = issuedAt.plus(Duration.ofMinutes(10));
+        var expires = issuedAt.plus(Duration.ofMinutes(8));
 
         var header = Base64.getUrlEncoder().encode(JSON.object()
                                                        .put("alg", "RS256")


### PR DESCRIPTION
Hi all,

Please review this minor change that adjusts the expiration time of GitHub authentication tokens to be slightly below the maximum allowed value.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)