### PR TITLE
53: Decouple review requirement from the jcheck status

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -165,7 +165,7 @@ class CheckRun {
         if (visitor.isReadyForReview() && additionalErrors.isEmpty()) {
             checkBuilder.complete(true);
         } else {
-            var summary = Stream.concat(visitor.getIssues().stream(), additionalErrors.stream())
+            var summary = Stream.concat(visitor.getMessages().stream(), additionalErrors.stream())
                                 .sorted()
                                 .map(m -> "- " + m)
                                 .collect(Collectors.joining("\n"));
@@ -179,7 +179,7 @@ class CheckRun {
 
     private void updateReadyForReview(PullRequestCheckIssueVisitor visitor, List<String> additionalErrors) {
         // If there are no issues at all, the PR is already reviewed
-        if (visitor.getIssues().isEmpty() && additionalErrors.isEmpty()) {
+        if (visitor.getMessages().isEmpty() && additionalErrors.isEmpty()) {
             pr.removeLabel("rfr");
             return;
         }
@@ -446,7 +446,7 @@ class CheckRun {
 
             var commit = prInstance.localRepo().lookup(localHash).orElseThrow();
             var commitMessage = String.join("\n", commit.message());
-            var readyForIntegration = visitor.getIssues().isEmpty() && additionalErrors.isEmpty();
+            var readyForIntegration = visitor.getMessages().isEmpty() && additionalErrors.isEmpty();
             updateMergeReadyComment(readyForIntegration, commitMessage, comments, activeReviews, rebasePossible);
             if (readyForIntegration) {
                 newLabels.add("ready");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -23,9 +23,7 @@
 package org.openjdk.skara.bots.pr;
 
 import org.openjdk.skara.host.*;
-import org.openjdk.skara.jcheck.JCheck;
 import org.openjdk.skara.vcs.*;
-import org.openjdk.skara.vcs.openjdk.CommitMessageParsers;
 
 import java.io.IOException;
 import java.util.*;
@@ -163,34 +161,19 @@ class CheckRun {
         return ret;
     }
 
-    private PullRequestCheckIssueVisitor executeChecks(Hash localHash) throws Exception {
-        log.fine("Changes committed to local repository, executing checks...");
-
-        var checks = JCheck.checks(prInstance.localRepo(), censusInstance.census(), localHash);
-        var visitor = new PullRequestCheckIssueVisitor(checks);
-        try (var issues = JCheck.check(prInstance.localRepo(), censusInstance.census(), CommitMessageParsers.v1, "HEAD~1..HEAD",
-                                       localHash, new HashMap<>(), new HashSet<>())) {
-            for (var issue : issues) {
-                issue.accept(visitor);
-            }
-        }
-
-        return visitor;
-    }
-
     private void updateCheckBuilder(CheckBuilder checkBuilder, PullRequestCheckIssueVisitor visitor, List<String> additionalErrors) {
-        var summary = Stream.concat(visitor.getIssues().stream(), additionalErrors.stream())
-                            .sorted()
-                            .map(m -> "- " + m)
-                            .collect(Collectors.joining("\n"));
-        if (summary.length() > 0) {
+        if (visitor.isReadyForReview() && additionalErrors.isEmpty()) {
+            checkBuilder.complete(true);
+        } else {
+            var summary = Stream.concat(visitor.getIssues().stream(), additionalErrors.stream())
+                                .sorted()
+                                .map(m -> "- " + m)
+                                .collect(Collectors.joining("\n"));
             checkBuilder.summary(summary);
             for (var annotation : visitor.getAnnotations()) {
                 checkBuilder.annotation(annotation);
             }
             checkBuilder.complete(false);
-        } else {
-            checkBuilder.complete(true);
         }
     }
 
@@ -446,7 +429,7 @@ class CheckRun {
             var localHash = prInstance.commit(censusInstance.namespace(), censusDomain, null);
 
             // Determine current status
-            var visitor = executeChecks(localHash);
+            var visitor = prInstance.executeChecks(localHash, censusInstance);
             var additionalErrors = botSpecificChecks();
             updateCheckBuilder(checkBuilder, visitor, additionalErrors);
             updateReadyForReview(visitor, additionalErrors);
@@ -463,9 +446,9 @@ class CheckRun {
 
             var commit = prInstance.localRepo().lookup(localHash).orElseThrow();
             var commitMessage = String.join("\n", commit.message());
-            updateMergeReadyComment(checkBuilder.build().status() == CheckStatus.SUCCESS, commitMessage,
-                                    comments, activeReviews, rebasePossible);
-            if (checkBuilder.build().status() == CheckStatus.SUCCESS) {
+            var readyForIntegration = visitor.getIssues().isEmpty() && additionalErrors.isEmpty();
+            updateMergeReadyComment(readyForIntegration, commitMessage, comments, activeReviews, rebasePossible);
+            if (readyForIntegration) {
                 newLabels.add("ready");
             } else {
                 newLabels.remove("ready");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
@@ -79,10 +79,10 @@ public class IntegrateCommand implements CommandHandler {
             var prInstance = new PullRequestInstance(path, pr);
             var hash = prInstance.commit(censusInstance.namespace(), censusInstance.configuration().census().domain(), null);
             var issues = prInstance.executeChecks(hash, censusInstance);
-            if (!issues.getIssues().isEmpty()) {
+            if (!issues.getMessages().isEmpty()) {
                 reply.print("Your merge request cannot be fulfilled at this time, as ");
                 reply.println("your changes failed the final jcheck:");
-                issues.getIssues().stream()
+                issues.getMessages().stream()
                       .map(line -> " * " + line)
                       .forEach(reply::println);
                 return;

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
@@ -53,7 +53,7 @@ class PullRequestCheckIssueVisitor implements IssueVisitor {
         readyForReview = true;
     }
 
-    List<String> getIssues() {
+    List<String> getMessages() {
         return new ArrayList<>(messages);
     }
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
@@ -101,6 +101,7 @@ class PullRequestCheckIssueVisitor implements IssueVisitor {
     {
         messages.add("Self-reviews are not allowed");
         failedChecks.add(e.check().getClass());
+        readyForReview = false;
     }
 
     @Override

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -61,11 +61,11 @@ class CheckTests {
             // Check the status
             TestBotRunner.runPeriodicItems(checkBot);
 
-            // Verify that the check failed
+            // Verify that the check succeeded
             var checks = pr.getChecks(editHash);
             assertEquals(1, checks.size());
             var check = checks.get("jcheck");
-            assertEquals(CheckStatus.FAILURE, check.status());
+            assertEquals(CheckStatus.SUCCESS, check.status());
 
             // The PR should now be ready for review
             assertTrue(pr.getLabels().contains("rfr"));
@@ -364,11 +364,11 @@ class CheckTests {
             // Check the status
             TestBotRunner.runPeriodicItems(checkBot);
 
-            // Verify that the check failed
+            // Verify that the check passed
             var checks = pr.getChecks(editHash);
             assertEquals(1, checks.size());
             var check = checks.get("jcheck");
-            assertEquals(CheckStatus.FAILURE, check.status());
+            assertEquals(CheckStatus.SUCCESS, check.status());
 
             // The PR should now be ready for review
             assertTrue(pr.getLabels().contains("rfr"));
@@ -410,6 +410,12 @@ class CheckTests {
             // The PR is now neither ready for review nor integration
             assertFalse(pr.getLabels().contains("rfr"));
             assertFalse(pr.getLabels().contains("ready"));
+
+            // The check should now be failing
+            checks = pr.getChecks(addedHash);
+            assertEquals(1, checks.size());
+            check = checks.get("jcheck");
+            assertEquals(CheckStatus.FAILURE, check.status());
         }
     }
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrateTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrateTests.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.*;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -178,7 +179,7 @@ class IntegrateTests {
     }
 
     @Test
-    void failedCheck(TestInfo testInfo) throws IOException {
+    void notReviewed(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
              var tempFolder = new TemporaryDirectory()) {
             var author = credentials.getHostedRepository();
@@ -195,6 +196,40 @@ class IntegrateTests {
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.getUrl(), "refs/heads/edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
+
+            // Attempt a merge
+            pr.addComment("/integrate");
+            TestBotRunner.runPeriodicItems(mergeBot);
+
+            // The bot should reply with an error message
+            var error = pr.getComments().stream()
+                          .filter(comment -> comment.body().contains("merge request cannot be fulfilled at this time"))
+                          .filter(comment -> comment.body().contains("failed the final jcheck"))
+                          .count();
+            assertEquals(1, error, pr.getComments().stream().map(Comment::body).collect(Collectors.joining("\n---\n")));
+        }
+    }
+
+    @Test
+    void failedCheck(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var integrator = credentials.getHostedRepository();
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addAuthor(author.host().getCurrentUserDetails().id());
+            var mergeBot = new PullRequestBot(integrator, censusBuilder.build(), "master");
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.getRepositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, author.getUrl(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo, "trailing whitespace   ");
             localRepo.push(editHash, author.getUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
@@ -226,8 +226,8 @@ class MergeTests {
             localRepo.push(masterHash, author.getUrl(), "master", true);
 
             // Make a change in another branch that will not pass jcheck
-            var otherHash = CheckableRepository.appendAndCommit(localRepo, "Change in other",
-                                                                "Unreviewed change in other");
+            var otherHash = CheckableRepository.appendAndCommit(localRepo, "Change in other with trails..   ",
+                                                                "Bad change in other");
             localRepo.push(otherHash, author.getUrl(), "other", true);
 
             // Go back to the original master


### PR DESCRIPTION
Hi all,

Please review this change that avoids marking a PR as having failed jcheck, if it is only missing reviews. This is similar to how the `rfr` label currently works.

Best regards,
robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**) **Note!** Review applies to 00eaf2ac15ef51cb6dcc30d87a2f8a5ac196f6be