### PR TITLE
Add default safe methods for Repository::checkout

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
@@ -35,7 +35,13 @@ import java.util.*;
 public interface Repository extends ReadOnlyRepository {
     Repository init() throws IOException;
     void checkout(Hash h, boolean force) throws IOException;
+    default void checkout(Hash h) throws IOException {
+        checkout(h, false);
+    }
     void checkout(Branch b, boolean force) throws IOException;
+    default void checkout(Branch b) throws IOException {
+        checkout(b, false);
+    }
     Hash fetch(URI uri, String refspec) throws IOException;
     void fetchAll() throws IOException;
     void pushAll(URI uri) throws IOException;


### PR DESCRIPTION
Hi all,

this tiny patch just adds two default implementations for `Repository::checkout` that are safe to use (I got annoyed at having to add `false` to all my `checkout` calls).

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)