### PR TITLE
Add ReadOnlyRepository::contains

### DIFF
--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/TestRepository.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/TestRepository.java
@@ -216,4 +216,8 @@ class TestRepository implements ReadOnlyRepository {
     public List<StatusEntry> status(Hash from, Hash to) throws IOException {
         return Collections.emptyList();
     }
+
+    public boolean contains(Branch b, Hash h) throws IOException {
+        return false;
+    }
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
@@ -55,6 +55,7 @@ public interface ReadOnlyRepository {
     Hash mergeBase(Hash first, Hash second) throws IOException;
     boolean isAncestor(Hash ancestor, Hash descendant) throws IOException;
     Optional<Hash> resolve(String ref) throws IOException;
+    boolean contains(Branch b, Hash h) throws IOException;
     Optional<String> username() throws IOException;
     Optional<byte[]> show(Path p, Hash h) throws IOException;
     default Optional<List<String>> lines(Path p, Hash h) throws IOException {

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -1019,4 +1019,18 @@ public class GitRepository implements Repository {
             await(p);
         }
     }
+
+    @Override
+    public boolean contains(Branch b, Hash h) throws IOException {
+        try (var p = capture("git", "for-each-ref", "--contains", h.hex(), "--format", "%(refname:short)")) {
+            var res = await(p);
+            for (var line : res.stdout()) {
+                if (line.equals(b.name())) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -997,4 +997,16 @@ public class HgRepository implements Repository {
             await(p);
         }
     }
+
+    @Override
+    public boolean contains(Branch b, Hash h) throws IOException {
+        try (var p = capture("hg", "log", "--template", "{branch}", "-r", h.hex())) {
+            var res = await(p);
+            if (res.stdout().size() != 1) {
+                throw new IOException("Unexpected output: " + String.join("\n", res.stdout()));
+            }
+            var line = res.stdout().get(0);
+            return line.equals(b.name());
+        }
+    }
 }

--- a/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
@@ -1737,4 +1737,26 @@ public class RepositoryTests {
                     hunk.target().lines());
         }
     }
+
+    @ParameterizedTest
+    @EnumSource(VCS.class)
+    void testContains(VCS vcs) throws IOException {
+        try (var dir = new TemporaryDirectory()) {
+            var r = Repository.init(dir.path(), vcs);
+            assertTrue(r.isClean());
+
+            var f = dir.path().resolve("README");
+            Files.writeString(f, "Hello\n");
+            r.add(f);
+            var initial = r.commit("Initial commit", "duke", "duke@openjdk.org");
+
+            assertTrue(r.contains(r.defaultBranch(), initial));
+
+            Files.writeString(f, "Hello again\n");
+            r.add(f);
+            var second = r.commit("Second commit", "duke", "duke@openjdk.org");
+
+            assertTrue(r.contains(r.defaultBranch(), initial));
+        }
+    }
 }


### PR DESCRIPTION
Hi all,

this patch adds `ReadOnlyRepository::contains` that checks if a given hash `h` resides in the given branch `b`. I also added small unit test case, it was hard to add more elaborate tests given that `HgRepository::branch` creates a bookmark and not a branch.

## Testing
- [x] `sh gradlew test` passes
- [x] Added a small unit test

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)