### PR TITLE
TestPullRequest::getBody always returns empty string

### DIFF
--- a/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
@@ -79,6 +79,7 @@ public class TestPullRequest implements PullRequest {
 
     static TestPullRequest createNew(TestHostedRepository repository, String id, String targetRef, String sourceRef, String title, List<String> body) {
         var data = new PullRequestData();
+        data.body = String.join("\n", body);
         var pr = new TestPullRequest(repository, id, repository.host().getCurrentUserDetails(), repository.host().getCurrentUserDetails(), targetRef, sourceRef, title, body, data);
         return pr;
     }


### PR DESCRIPTION
Hi all,

this tiny patch fixes a bug with `TestPullRequest` - `getBody()` always returns the empty string.

## Testing
- [x] `sh gradlew test` passes on Linux x86_64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)