### PR TITLE
84: Default bug ID format should match the JDK default

### DIFF
--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdaterTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdaterTests.java
@@ -80,7 +80,7 @@ class UpdaterTests {
             TestBotRunner.runPeriodicItems(notifyBot);
             assertEquals(List.of(), findJsonFiles(jsonFolder, ""));
 
-            var editHash = CheckableRepository.appendAndCommit(localRepo, "One more line", "12345678: Fixes");
+            var editHash = CheckableRepository.appendAndCommit(localRepo, "One more line", "1234567: Fixes");
             localRepo.push(editHash, repo.getUrl(), "master");
             TestBotRunner.runPeriodicItems(notifyBot);
             var jsonFiles = findJsonFiles(jsonFolder, "");
@@ -89,7 +89,7 @@ class UpdaterTests {
             var json = JSON.parse(jsonData);
             assertEquals(1, json.asArray().size());
             assertEquals(repo.getWebUrl(editHash).toString(), json.asArray().get(0).get("url").asString());
-            assertEquals(List.of("12345678"), json.asArray().get(0).get("issue").asArray().stream()
+            assertEquals(List.of("1234567"), json.asArray().get(0).get("issue").asArray().stream()
                                                   .map(JSONValue::asString)
                                                   .collect(Collectors.toList()));
         }
@@ -119,7 +119,7 @@ class UpdaterTests {
             TestBotRunner.runPeriodicItems(notifyBot);
             assertEquals(List.of(), findJsonFiles(jsonFolder, ""));
 
-            var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", "23456789: More fixes");
+            var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", "2345678: More fixes");
             localRepo.fetch(repo.getUrl(), "history:history");
             localRepo.tag(editHash, "jdk-12+2", "Added tag 2", "Duke", "duke@openjdk.java.net");
             localRepo.pushAll(repo.getUrl());
@@ -132,7 +132,7 @@ class UpdaterTests {
                 var jsonData = Files.readString(file, StandardCharsets.UTF_8);
                 var json = JSON.parse(jsonData);
                 assertEquals(1, json.asArray().size());
-                assertEquals(List.of("23456789"), json.asArray().get(0).get("issue").asArray().stream()
+                assertEquals(List.of("2345678"), json.asArray().get(0).get("issue").asArray().stream()
                                                       .map(JSONValue::asString)
                                                       .collect(Collectors.toList()));
 
@@ -171,16 +171,16 @@ class UpdaterTests {
             TestBotRunner.runPeriodicItems(notifyBot);
             assertThrows(RuntimeException.class, () -> smtpServer.receive(Duration.ofMillis(1)));
 
-            var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", "23456789: More fixes");
+            var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", "2345678: More fixes");
             localRepo.push(editHash, repo.getUrl(), "master");
             TestBotRunner.runPeriodicItems(notifyBot);
             var email = smtpServer.receive(Duration.ofSeconds(10));
             assertEquals(email.sender(), sender);
             assertEquals(email.recipients(), List.of(recipient));
-            assertTrue(email.subject().contains(": 23456789: More fixes"));
+            assertTrue(email.subject().contains(": 2345678: More fixes"));
             assertFalse(email.subject().contains("master"));
             assertTrue(email.body().contains("Changeset: " + editHash.abbreviate()));
-            assertTrue(email.body().contains("23456789: More fixes"));
+            assertTrue(email.body().contains("2345678: More fixes"));
             assertFalse(email.body().contains("Committer"));
             assertFalse(email.body().contains(masterHash.abbreviate()));
         }
@@ -211,7 +211,7 @@ class UpdaterTests {
             TestBotRunner.runPeriodicItems(notifyBot);
             assertThrows(RuntimeException.class, () -> smtpServer.receive(Duration.ofMillis(1)));
 
-            var editHash1 = CheckableRepository.appendAndCommit(localRepo, "Another line", "23456789: More fixes");
+            var editHash1 = CheckableRepository.appendAndCommit(localRepo, "Another line", "2345678: More fixes");
             localRepo.push(editHash1, repo.getUrl(), "master");
             var editHash2 = CheckableRepository.appendAndCommit(localRepo, "Yet another line", "3456789A: Even more fixes");
             localRepo.push(editHash2, repo.getUrl(), "master");
@@ -223,7 +223,7 @@ class UpdaterTests {
             assertTrue(email.subject().contains(": 2 new changesets"));
             assertFalse(email.subject().contains("master"));
             assertTrue(email.body().contains("Changeset: " + editHash1.abbreviate()));
-            assertTrue(email.body().contains("23456789: More fixes"));
+            assertTrue(email.body().contains("2345678: More fixes"));
             assertTrue(email.body().contains("Changeset: " + editHash2.abbreviate()));
             assertTrue(email.body().contains("3456789A: Even more fixes"));
             assertFalse(email.body().contains(masterHash.abbreviate()));
@@ -255,7 +255,7 @@ class UpdaterTests {
             TestBotRunner.runPeriodicItems(notifyBot);
             assertThrows(RuntimeException.class, () -> smtpServer.receive(Duration.ofMillis(1)));
 
-            var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", "23456789: More fixes",
+            var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", "2345678: More fixes",
                                                                "author", "author@test.test",
                                                                "committer", "committer@test.test");
             localRepo.push(editHash, repo.getUrl(), "master");
@@ -264,7 +264,7 @@ class UpdaterTests {
             assertEquals(email.sender(), sender);
             assertEquals(email.recipients(), List.of(recipient));
             assertTrue(email.body().contains("Changeset: " + editHash.abbreviate()));
-            assertTrue(email.body().contains("23456789: More fixes"));
+            assertTrue(email.body().contains("2345678: More fixes"));
             assertTrue(email.body().contains("Author:    author <author@test.test>"));
             assertTrue(email.body().contains("Committer: committer <committer@test.test>"));
             assertFalse(email.body().contains(masterHash.abbreviate()));
@@ -297,7 +297,7 @@ class UpdaterTests {
             TestBotRunner.runPeriodicItems(notifyBot);
             assertThrows(RuntimeException.class, () -> smtpServer.receive(Duration.ofMillis(1)));
 
-            var editHash1 = CheckableRepository.appendAndCommit(localRepo, "Another line", "23456789: More fixes");
+            var editHash1 = CheckableRepository.appendAndCommit(localRepo, "Another line", "2345678: More fixes");
             localRepo.push(editHash1, repo.getUrl(), "master");
             var editHash2 = CheckableRepository.appendAndCommit(localRepo, "Yet another line", "3456789A: Even more fixes");
             localRepo.push(editHash2, repo.getUrl(), "master");
@@ -309,7 +309,7 @@ class UpdaterTests {
             assertFalse(email.subject().contains("another"));
             assertTrue(email.subject().contains(": master: 2 new changesets"));
             assertTrue(email.body().contains("Changeset: " + editHash1.abbreviate()));
-            assertTrue(email.body().contains("23456789: More fixes"));
+            assertTrue(email.body().contains("2345678: More fixes"));
             assertTrue(email.body().contains("Changeset: " + editHash2.abbreviate()));
             assertTrue(email.body().contains("3456789A: Even more fixes"));
             assertFalse(email.body().contains(masterHash.abbreviate()));

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/IssuesCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/IssuesCheckTests.java
@@ -91,7 +91,7 @@ class IssuesCheckTests {
 
     @Test
     void singleIssueReferenceShouldPass() {
-        var commit = commit(List.of("0123457: A bug"));
+        var commit = commit(List.of("1234570: A bug"));
         var check = new IssuesCheck(utils);
         var issues = toList(check.check(commit, message(commit), conf()));
         assertEquals(0, issues.size());
@@ -99,10 +99,74 @@ class IssuesCheckTests {
 
     @Test
     void multipleIssueReferencesShouldPass() {
-        var commit = commit(List.of("0123457: A bug", "12345678: Another bug"));
+        var commit = commit(List.of("1234570: A bug", "1234567: Another bug"));
         var message = message(commit);
         var check = new IssuesCheck(utils);
         var issues = toList(check.check(commit, message, conf()));
         assertEquals(0, issues.size());
+    }
+
+    @Test
+    void issueWithLeadingZeroShouldFail() {
+        var commit = commit(List.of("0123456: A bug"));
+        var message = message(commit);
+        var check = new IssuesCheck(utils);
+        var issues = toList(check.check(commit, message, conf()));
+
+        assertEquals(1, issues.size());
+        assertTrue(issues.get(0) instanceof IssuesIssue);
+        var issue = (IssuesIssue) issues.get(0);
+        assertEquals(commit, issue.commit());
+        assertEquals(message, issue.message());
+        assertEquals(Severity.ERROR, issue.severity());
+        assertEquals(check.getClass(), issue.check().getClass());
+    }
+
+    @Test
+    void issueWithTooFewDigitsShouldFail() {
+        var commit = commit(List.of("123456: A bug"));
+        var message = message(commit);
+        var check = new IssuesCheck(utils);
+        var issues = toList(check.check(commit, message, conf()));
+
+        assertEquals(1, issues.size());
+        assertTrue(issues.get(0) instanceof IssuesIssue);
+        var issue = (IssuesIssue) issues.get(0);
+        assertEquals(commit, issue.commit());
+        assertEquals(message, issue.message());
+        assertEquals(Severity.ERROR, issue.severity());
+        assertEquals(check.getClass(), issue.check().getClass());
+    }
+
+    @Test
+    void issueWithTooManyDigitsShouldFail() {
+        var commit = commit(List.of("12345678: A bug"));
+        var message = message(commit);
+        var check = new IssuesCheck(utils);
+        var issues = toList(check.check(commit, message, conf()));
+
+        assertEquals(1, issues.size());
+        assertTrue(issues.get(0) instanceof IssuesIssue);
+        var issue = (IssuesIssue) issues.get(0);
+        assertEquals(commit, issue.commit());
+        assertEquals(message, issue.message());
+        assertEquals(Severity.ERROR, issue.severity());
+        assertEquals(check.getClass(), issue.check().getClass());
+    }
+
+    @Test
+    void issueWithPrefixShouldFail() {
+        var commit = commit(List.of("JDK-7654321: A bug"));
+        var message = message(commit);
+        var check = new IssuesCheck(utils);
+        var issues = toList(check.check(commit, message, conf()));
+
+        assertEquals(1, issues.size());
+        assertTrue(issues.get(0) instanceof IssuesIssue);
+        var issue = (IssuesIssue) issues.get(0);
+        assertEquals(commit, issue.commit());
+        assertEquals(message, issue.message());
+        assertEquals(Severity.ERROR, issue.severity());
+        assertEquals(check.getClass(), issue.check().getClass());
     }
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/CommitMessageSyntax.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/CommitMessageSyntax.java
@@ -31,7 +31,7 @@ public class CommitMessageSyntax {
         private static final String REAL_NAME_AND_EMAIL_ATTR_REGEX = REAL_NAME_REGEX + " +<" + EMAIL_ADDR_REGEX + ">";
         private static final String ATTR_REGEX = "(?:(?:" + EMAIL_ADDR_REGEX + ")|(?:" + REAL_NAME_AND_EMAIL_ATTR_REGEX + "))";
 
-        public static final Pattern ISSUE_PATTERN = Pattern.compile("((?:[A-Z][A-Z0-9]+-)?[0-9]+): (\\S.*)$");
+        public static final Pattern ISSUE_PATTERN = Pattern.compile("([1-9][0-9]{6}): (\\S.*)$");
         public static final Pattern SUMMARY_PATTERN = Pattern.compile("Summary: (\\S.*)");
         public static final Pattern REVIEWED_BY_PATTERN = Pattern.compile("Reviewed-by: ((?:" + OPENJDK_USERNAME_REGEX + ")(?:, " + OPENJDK_USERNAME_REGEX + ")*)$");
         public static final Pattern CONTRIBUTED_BY_PATTERN = Pattern.compile("Contributed-by: (" + ATTR_REGEX + "(?:, " + ATTR_REGEX + ")*)$");

--- a/vcs/src/test/java/org/openjdk/skara/vcs/openjdk/CommitMessageParsersTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/openjdk/CommitMessageParsersTests.java
@@ -32,12 +32,12 @@ import org.openjdk.skara.vcs.Author;
 public class CommitMessageParsersTests {
     @Test
     void parseVersion0Commit() {
-        var text = List.of("01234567: A bug",
+        var text = List.of("1234567: A bug",
                            "Reviewed-by: foo",
                            "Contributed-by: Bar O'Baz <bar.obaz@localhost.com>");
         var message = CommitMessageParsers.v0.parse(text);
 
-        assertEquals(List.of(new Issue("01234567", "A bug")), message.issues());
+        assertEquals(List.of(new Issue("1234567", "A bug")), message.issues());
         assertEquals(List.of(new Author("Bar O'Baz", "bar.obaz@localhost.com")),
                      message.contributors());
         assertEquals(List.of("foo"), message.reviewers());
@@ -47,13 +47,13 @@ public class CommitMessageParsersTests {
 
     @Test
     void parseVersion0CommitWithExtraNewline() {
-        var text = List.of("01234567: A bug",
+        var text = List.of("1234567: A bug",
                            "",
                            "Summary: summary",
                            "Reviewed-by: foo");
         var message = CommitMessageParsers.v0.parse(text);
 
-        assertEquals(List.of(new Issue("01234567", "A bug")), message.issues());
+        assertEquals(List.of(new Issue("1234567", "A bug")), message.issues());
         assertEquals(List.of(), message.contributors());
         assertEquals(List.of(), message.reviewers());
         assertEquals(List.of(), message.summaries());
@@ -62,13 +62,13 @@ public class CommitMessageParsersTests {
 
     @Test
     void parseVersion0CommitWithSummary() {
-        var text = List.of("01234567: A bug",
+        var text = List.of("1234567: A bug",
                            "Summary: This is a summary",
                            "Reviewed-by: foo",
                            "Contributed-by: Bar O'Baz <bar.obaz@localhost.com>");
         var message = CommitMessageParsers.v0.parse(text);
 
-        assertEquals(List.of(new Issue("01234567", "A bug")), message.issues());
+        assertEquals(List.of(new Issue("1234567", "A bug")), message.issues());
         assertEquals(List.of(new Author("Bar O'Baz", "bar.obaz@localhost.com")),
                      message.contributors());
         assertEquals(List.of("foo"), message.reviewers());
@@ -79,13 +79,13 @@ public class CommitMessageParsersTests {
 
     @Test
     void parseVersion1Commit() {
-        var text = List.of("01234567: A bug",
+        var text = List.of("1234567: A bug",
                            "",
                            "Co-authored-by: Bar O'Baz <bar.obaz@localhost.com>",
                            "Reviewed-by: foo");
         var message = CommitMessageParsers.v1.parse(text);
 
-        assertEquals(List.of(new Issue("01234567", "A bug")), message.issues());
+        assertEquals(List.of(new Issue("1234567", "A bug")), message.issues());
         assertEquals(List.of(new Author("Bar O'Baz", "bar.obaz@localhost.com")),
                      message.contributors());
         assertEquals(List.of("foo"), message.reviewers());
@@ -95,7 +95,7 @@ public class CommitMessageParsersTests {
 
     @Test
     void parseVersion1CommitWithSummary() {
-        var text = List.of("01234567: A bug",
+        var text = List.of("1234567: A bug",
                            "",
                            "This is a summary",
                            "",
@@ -103,7 +103,7 @@ public class CommitMessageParsersTests {
                            "Reviewed-by: foo");
         var message = CommitMessageParsers.v1.parse(text);
 
-        assertEquals(List.of(new Issue("01234567", "A bug")), message.issues());
+        assertEquals(List.of(new Issue("1234567", "A bug")), message.issues());
         assertEquals(List.of(new Author("Bar O'Baz", "bar.obaz@localhost.com")),
                      message.contributors());
         assertEquals(List.of("foo"), message.reviewers());
@@ -113,7 +113,7 @@ public class CommitMessageParsersTests {
 
     @Test
     void parseVersion1CommitWithMultiPargraphSummary() {
-        var text = List.of("01234567: A bug",
+        var text = List.of("1234567: A bug",
                            "",
                            "This is a summary",
                            "",
@@ -123,7 +123,7 @@ public class CommitMessageParsersTests {
                            "Reviewed-by: foo");
         var message = CommitMessageParsers.v1.parse(text);
 
-        assertEquals(List.of(new Issue("01234567", "A bug")), message.issues());
+        assertEquals(List.of(new Issue("1234567", "A bug")), message.issues());
         assertEquals(List.of(new Author("Bar O'Baz", "bar.obaz@localhost.com")),
                      message.contributors());
         assertEquals(List.of("foo"), message.reviewers());
@@ -134,14 +134,14 @@ public class CommitMessageParsersTests {
 
     @Test
     void parseVersion1CommitWithoutTrailers() {
-        var text = List.of("01234567: A bug",
+        var text = List.of("1234567: A bug",
                            "",
                            "This is a summary",
                            "",
                            "This is another summary paragraph");
         var message = CommitMessageParsers.v1.parse(text);
 
-        assertEquals(List.of(new Issue("01234567", "A bug")), message.issues());
+        assertEquals(List.of(new Issue("1234567", "A bug")), message.issues());
         assertEquals(List.of(), message.contributors());
         assertEquals(List.of(), message.reviewers());
         assertEquals(List.of("This is a summary","","This is another summary paragraph"),
@@ -182,13 +182,13 @@ public class CommitMessageParsersTests {
 
     @Test
     void parseVersion1CommitWithIssueAndReview() {
-        var text = List.of("01234567: An issue",
+        var text = List.of("1234567: An issue",
                            "",
                            "Reviewed-by: foo");
         var message = CommitMessageParsers.v1.parse(text);
 
-        assertEquals("01234567: An issue", message.title());
-        assertEquals(List.of(new Issue("01234567", "An issue")), message.issues());
+        assertEquals("1234567: An issue", message.title());
+        assertEquals(List.of(new Issue("1234567", "An issue")), message.issues());
         assertEquals(List.of(), message.contributors());
         assertEquals(List.of("foo"), message.reviewers());
         assertEquals(List.of(), message.summaries());
@@ -197,12 +197,12 @@ public class CommitMessageParsersTests {
 
     @Test
     void parseVersion1WithAdditionalLines() {
-        var text = List.of("01234567: An issue",
+        var text = List.of("1234567: An issue",
                            "Reviewed-by: foo");
         var message = CommitMessageParsers.v1.parse(text);
 
-        assertEquals("01234567: An issue", message.title());
-        assertEquals(List.of(new Issue("01234567", "An issue")), message.issues());
+        assertEquals("1234567: An issue", message.title());
+        assertEquals(List.of(new Issue("1234567", "An issue")), message.issues());
         assertEquals(List.of(), message.contributors());
         assertEquals(List.of(), message.reviewers());
         assertEquals(List.of(), message.summaries());
@@ -211,14 +211,14 @@ public class CommitMessageParsersTests {
 
     @Test
     void parseVersion1WithUknownTrailer() {
-        var text = List.of("01234567: An issue",
+        var text = List.of("1234567: An issue",
                            "",
                            "Reviewed-by: foo",
                            "Unknown-trailer: bar");
         var message = CommitMessageParsers.v1.parse(text);
 
-        assertEquals("01234567: An issue", message.title());
-        assertEquals(List.of(new Issue("01234567", "An issue")), message.issues());
+        assertEquals("1234567: An issue", message.title());
+        assertEquals(List.of(new Issue("1234567", "An issue")), message.issues());
         assertEquals(List.of(), message.contributors());
         assertEquals(List.of("foo"), message.reviewers());
         assertEquals(List.of(), message.summaries());


### PR DESCRIPTION
Fix for [SKARA-84](https://bugs.openjdk.java.net/browse/SKARA-84) to change the default issue pattern to require exactly 7 digits with no prefix to match `hg jcheck`.

I updated all of the tests to account for this and added new tests for now-invalid formats.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed