### PR TITLE
Add optional handler for workitem runtime errors

### DIFF
--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
@@ -79,6 +79,7 @@ public class BotRunner {
                 item.run(scratchPath);
             } catch (RuntimeException e) {
                 log.severe("Exception during item execution (" + item + "): " + e.getMessage());
+                item.handleRuntimeException(e);
                 log.throwing(item.toString(), "run", e);
             } finally {
                 log.log(Level.FINE, "Item " + item + " is now done", TaskPhases.END);

--- a/bot/src/main/java/org/openjdk/skara/bot/WorkItem.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/WorkItem.java
@@ -34,8 +34,15 @@ public interface WorkItem {
     boolean concurrentWith(WorkItem other);
 
     /**
-     *  Execute the appropriate tasks with the provided scratch folder.
+     * Execute the appropriate tasks with the provided scratch folder.
      * @param scratchPath
      */
     void run(Path scratchPath);
+
+    /**
+     * The BotRunner will catch <code>RuntimeException</code>s, implementing this method allows a WorkItem to
+     * perform additional cleanup if necessary (avoiding the need for catching and rethrowing the exception).
+     * @param e
+     */
+    default void handleRuntimeException(RuntimeException e) {}
 }

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
@@ -44,11 +44,13 @@ import java.util.stream.Collectors;
 class ArchiveWorkItem implements WorkItem {
     private final PullRequest pr;
     private final MailingListBridgeBot bot;
+    private final Consumer<RuntimeException> exceptionConsumer;
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots.mlbridge");
 
-    ArchiveWorkItem(PullRequest pr, MailingListBridgeBot bot) {
+    ArchiveWorkItem(PullRequest pr, MailingListBridgeBot bot, Consumer<RuntimeException> exceptionConsumer) {
         this.pr = pr;
         this.bot = bot;
+        this.exceptionConsumer = exceptionConsumer;
     }
 
     @Override
@@ -717,5 +719,10 @@ class ArchiveWorkItem implements WorkItem {
         for (var mail : listMails) {
             list.post(mail);
         }
+    }
+
+    @Override
+    public void handleRuntimeException(RuntimeException e) {
+        exceptionConsumer.accept(e);
     }
 }

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBot.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBot.java
@@ -25,14 +25,11 @@ package org.openjdk.skara.bots.mlbridge;
 import org.openjdk.skara.bot.*;
 import org.openjdk.skara.email.EmailAddress;
 import org.openjdk.skara.host.*;
-import org.openjdk.skara.jcheck.JCheckConfiguration;
 
 import java.net.URI;
 import java.nio.file.Path;
-import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 public class MailingListBridgeBot implements Bot {
     private final EmailAddress emailAddress;
@@ -113,7 +110,7 @@ public class MailingListBridgeBot implements Bot {
 
         for (var pr : codeRepo.getPullRequests()) {
             if (updateCache.needsUpdate(pr)) {
-                ret.add(new ArchiveWorkItem(pr, this));
+                ret.add(new ArchiveWorkItem(pr, this, e -> updateCache.invalidate(pr)));
             }
         }
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -32,6 +32,7 @@ import java.nio.file.Path;
 import java.security.*;
 import java.time.*;
 import java.util.*;
+import java.util.function.Consumer;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -41,15 +42,17 @@ class CheckWorkItem implements WorkItem {
     private final HostedRepository censusRepo;
     private final String censusRef;
     private final Map<String, String> blockingLabels;
+    private final Consumer<RuntimeException> errorHandler;
 
     private final Pattern metadataComments = Pattern.compile("<!-- (add|remove) contributor");
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots.pr");
 
-    CheckWorkItem(PullRequest pr, HostedRepository censusRepo, String censusRef, Map<String, String> blockingLabels) {
+    CheckWorkItem(PullRequest pr, HostedRepository censusRepo, String censusRef, Map<String, String> blockingLabels, Consumer<RuntimeException> errorHandler) {
         this.pr = pr;
         this.censusRepo = censusRepo;
         this.censusRef = censusRef;
         this.blockingLabels = blockingLabels;
+        this.errorHandler = errorHandler;
     }
 
     private String encodeReviewer(HostUserDetails reviewer, CensusInstance censusInstance) {
@@ -169,5 +172,10 @@ class CheckWorkItem implements WorkItem {
                 throw new UncheckedIOException(e);
             }
         }
+    }
+
+    @Override
+    public void handleRuntimeException(RuntimeException e) {
+        errorHandler.accept(e);
     }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandWorkItem.java
@@ -28,6 +28,7 @@ import org.openjdk.skara.host.*;
 import java.io.*;
 import java.nio.file.Path;
 import java.util.*;
+import java.util.function.Consumer;
 import java.util.logging.Logger;
 import java.util.regex.*;
 import java.util.stream.*;
@@ -37,6 +38,7 @@ public class CommandWorkItem implements WorkItem {
     private final HostedRepository censusRepo;
     private final String censusRef;
     private final Map<String, String> external;
+    private final Consumer<RuntimeException> errorHandler;
 
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots.pr");
 
@@ -71,11 +73,12 @@ public class CommandWorkItem implements WorkItem {
         }
     }
 
-    CommandWorkItem(PullRequest pr, HostedRepository censusRepo, String censusRef, Map<String, String> external) {
+    CommandWorkItem(PullRequest pr, HostedRepository censusRepo, String censusRef, Map<String, String> external, Consumer<RuntimeException> errorHandler) {
         this.pr = pr;
         this.censusRepo = censusRepo;
         this.censusRef = censusRef;
         this.external = external;
+        this.errorHandler = errorHandler;
 
         if (HelpCommand.external == null) {
             HelpCommand.external = external;
@@ -164,5 +167,10 @@ public class CommandWorkItem implements WorkItem {
         for (var entry : unprocessedCommands) {
             processCommand(pr, census, scratchPath.resolve("pr"), entry.getKey(), entry.getValue(), comments);
         }
+    }
+
+    @Override
+    public void handleRuntimeException(RuntimeException e) {
+        errorHandler.accept(e);
     }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
@@ -30,6 +30,7 @@ import java.io.*;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.function.Consumer;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -37,11 +38,13 @@ public class LabelerWorkItem implements WorkItem {
     private final PullRequest pr;
     private final Map<String, List<Pattern>> labelPatterns;
     private final ConcurrentMap<Hash, Boolean> currentLabels;
+    private final Consumer<RuntimeException> errorHandler;
 
-    LabelerWorkItem(PullRequest pr, Map<String, List<Pattern>> labelPatterns, ConcurrentMap<Hash, Boolean> currentLabels) {
+    LabelerWorkItem(PullRequest pr, Map<String, List<Pattern>> labelPatterns, ConcurrentMap<Hash, Boolean> currentLabels, Consumer<RuntimeException> errorHandler) {
         this.pr = pr;
         this.labelPatterns = labelPatterns;
         this.currentLabels = currentLabels;
+        this.errorHandler = errorHandler;
     }
 
     @Override
@@ -107,6 +110,10 @@ public class LabelerWorkItem implements WorkItem {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+    }
 
+    @Override
+    public void handleRuntimeException(RuntimeException e) {
+        errorHandler.accept(e);
     }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -103,17 +103,13 @@ class PullRequestBot implements Bot {
                     continue;
                 }
 
-                ret.add(new CheckWorkItem(pr, censusRepo, censusRef, blockingLabels));
-                ret.add(new CommandWorkItem(pr, censusRepo, censusRef, externalCommands));
-                ret.add(new LabelerWorkItem(pr, labelPatterns, currentLabels));
+                ret.add(new CheckWorkItem(pr, censusRepo, censusRef, blockingLabels, e -> updateCache.invalidate(pr)));
+                ret.add(new CommandWorkItem(pr, censusRepo, censusRef, externalCommands, e -> updateCache.invalidate(pr)));
+                ret.add(new LabelerWorkItem(pr, labelPatterns, currentLabels, e -> updateCache.invalidate(pr)));
             }
         }
 
         return ret;
-    }
-
-    HostedRepository repository() {
-        return remoteRepo;
     }
 
     @Override

--- a/test/src/main/java/org/openjdk/skara/test/TestBotRunner.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestBotRunner.java
@@ -29,11 +29,7 @@ import java.util.function.Predicate;
 
 public class TestBotRunner {
     public static void runPeriodicItems(Bot bot) throws IOException {
-        for (var item : bot.getPeriodicItems()) {
-            try (var scratchFolder = new TemporaryDirectory()) {
-                item.run(scratchFolder.path());
-            }
-        }
+        runPeriodicItems(bot, wi -> false);
     }
 
     public static void runPeriodicItems(Bot bot, Predicate<WorkItem> ignored) throws IOException {
@@ -41,6 +37,10 @@ public class TestBotRunner {
             if (!ignored.test(item)) {
                 try (var scratchFolder = new TemporaryDirectory()) {
                     item.run(scratchFolder.path());
+                } catch (RuntimeException e) {
+                    item.handleRuntimeException(e);
+                    // Allow tests to assert on these as well
+                    throw e;
                 }
             }
         }


### PR DESCRIPTION
Hi all,

Please review this change that allows `WorkItem`s that use the PullRequestUpdateCache to invalidate an entry if an RuntimeException occurs during the execution. Without this, operations are not retried automatically on transient errors.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)