### PR TITLE
Add Repository::abortMerge

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
@@ -96,6 +96,7 @@ public interface Repository extends ReadOnlyRepository {
     void rebase(Hash hash, String committerName, String committerEmail) throws IOException;
     void merge(Hash hash) throws IOException;
     void merge(Hash hash, String strategy) throws IOException;
+    void abortMerge() throws IOException;
     void addRemote(String name, String path) throws IOException;
     void setPaths(String remote, String pullPath, String pushPath) throws IOException;
     void apply(Diff diff, boolean force) throws IOException;

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -882,6 +882,13 @@ public class GitRepository implements Repository {
     }
 
     @Override
+    public void abortMerge() throws IOException {
+        try (var p = capture("git", "merge", "--abort")) {
+            await(p);
+        }
+    }
+
+    @Override
     public void addRemote(String name, String pullPath) throws IOException {
         try (var p = capture("git", "remote", "add", name, pullPath)) {
             await(p);

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -802,6 +802,20 @@ public class HgRepository implements Repository {
     }
 
     @Override
+    public void abortMerge() throws IOException {
+        try (var p = capture("hg", "merge", "--abort")) {
+            await(p);
+        }
+
+        try (var p = capture("hg", "status", "--unknown", "--no-status")) {
+            var res = await(p);
+            for (var path : res.stdout()) {
+                Files.delete(root().resolve(path));
+            }
+        }
+    }
+
+    @Override
     public void addRemote(String name, String path) throws IOException {
         setPaths(name, path, path);
     }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -810,7 +810,9 @@ public class HgRepository implements Repository {
         try (var p = capture("hg", "status", "--unknown", "--no-status")) {
             var res = await(p);
             for (var path : res.stdout()) {
-                Files.delete(root().resolve(path));
+                if (path.toString().endsWith(".orig")) {
+                    Files.delete(root().resolve(path));
+                }
             }
         }
     }

--- a/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
@@ -1759,4 +1759,32 @@ public class RepositoryTests {
             assertTrue(r.contains(r.defaultBranch(), initial));
         }
     }
+
+    @ParameterizedTest
+    @EnumSource(VCS.class)
+    void testAbortMerge(VCS vcs) throws IOException {
+        try (var dir = new TemporaryDirectory(false)) {
+            var r = Repository.init(dir.path(), vcs);
+            assertTrue(r.isClean());
+
+            var f = dir.path().resolve("README");
+            Files.writeString(f, "Hello\n");
+            r.add(f);
+            var initial = r.commit("Initial commit", "duke", "duke@openjdk.org");
+
+            Files.writeString(f, "Hello again\n");
+            r.add(f);
+            var second = r.commit("Second commit", "duke", "duke@openjdk.org");
+
+            r.checkout(initial);
+            Files.writeString(f, "Conflicting hello\n");
+            r.add(f);
+            var third = r.commit("Third commit", "duke", "duke@openjdk.org");
+
+            assertThrows(IOException.class, () -> { r.merge(second); });
+
+            r.abortMerge();
+            assertTrue(r.isClean());
+        }
+    }
 }


### PR DESCRIPTION
Hi all,

this patch add `Repository::abortMerge` and a corresponding unit test.

## Testing
- [x] `sh gradlew test`
- [x] Added new unit test

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)