### PR TITLE
TestHostedRepository::getPullRequests should only return open PRs

### DIFF
--- a/test/src/main/java/org/openjdk/skara/test/TestHost.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHost.java
@@ -135,6 +135,7 @@ public class TestHost implements Host {
         return data.pullRequests.entrySet().stream()
                                 .sorted(Comparator.comparing(Map.Entry::getKey))
                                 .map(pr -> getPullRequest(repository, pr.getKey()))
+                                .filter(TestPullRequest::isOpen)
                                 .collect(Collectors.toList());
     }
 }

--- a/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
@@ -259,7 +259,7 @@ public class TestPullRequest implements PullRequest {
         data.lastUpdate = ZonedDateTime.now();
     }
 
-    public boolean isOpen() {
+    boolean isOpen() {
         return data.state.equals(PullRequest.State.OPEN);
     }
 

--- a/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
@@ -45,6 +45,7 @@ public class TestPullRequest implements PullRequest {
 
     private static class PullRequestData {
         private Hash headHash;
+        PullRequest.State state = PullRequest.State.OPEN;
         String body = "";
         final List<Comment> comments = new ArrayList<>();
         final List<ReviewComment> reviewComments = new ArrayList<>();
@@ -254,7 +255,12 @@ public class TestPullRequest implements PullRequest {
 
     @Override
     public void setState(State state) {
+        data.state = state;
         data.lastUpdate = ZonedDateTime.now();
+    }
+
+    public boolean isOpen() {
+        return data.state.equals(PullRequest.State.OPEN);
     }
 
     @Override


### PR DESCRIPTION
Hi,

this patch fixes `TestHostedRepository::getPullRequests` so that it only returns pull requests with state `PullRequest.State.OPEN` - this is how GitLab and GitHub works.

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**) **Note!** Review applies to d3b0c0ab51354afee83b0d0ac8a6b4edf78b43d4