### PR TITLE
88: git token store https://github.com does not work

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitCredentials.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitCredentials.java
@@ -72,6 +72,9 @@ class GitCredentials {
             var gitStdin = p.getOutputStream();
             String input = "host=" + host + "\n";
             if (path != null) {
+                if (path.startsWith("/")) {
+                    path = path.substring(1);
+                }
                 input += "path=" + path + "\n";
             }
             if (username != null) {

--- a/cli/src/main/java/org/openjdk/skara/cli/GitFork.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitFork.java
@@ -125,7 +125,7 @@ public class GitFork {
             exit("Not a valid URI: " + uri);
         }
         final var hostName = uri.getHost();
-        var path = uri.getPath().substring(1); // trim leading '/'
+        var path = uri.getPath();
         final var protocol = uri.getScheme();
         final var token = System.getenv("GIT_TOKEN");
         final var username = arguments.contains("username") ? arguments.get("username").asString() : null;
@@ -140,6 +140,7 @@ public class GitFork {
         }
 
         var host = Host.from(uri, new PersonalAccessToken(credentials.username(), credentials.password()));
+        path = credentials.path();
         if (path.endsWith(".git")) {
             path = path.substring(0, path.length() - 4);
         }

--- a/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
@@ -283,7 +283,7 @@ public class GitPr {
         var username = arguments.contains("username") ? arguments.get("username").asString() : null;
         var token = System.getenv("GIT_TOKEN");
         var uri = toURI(remotePullPath);
-        var credentials = GitCredentials.fill(uri.getHost(), uri.getPath().substring(1), username, token, uri.getScheme());
+        var credentials = GitCredentials.fill(uri.getHost(), uri.getPath(), username, token, uri.getScheme());
         var host = Host.from(uri, new PersonalAccessToken(credentials.username(), credentials.password()));
 
         var action = arguments.at(0).asString();

--- a/cli/src/main/java/org/openjdk/skara/cli/GitToken.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitToken.java
@@ -78,10 +78,10 @@ public class GitToken {
         var uri = arguments.at(1).via(URI::create);
 
         if (command.equals("store")) {
-            var credentials = GitCredentials.fill(uri.getHost(), uri.getPath().substring(1), null, null, uri.getScheme());
+            var credentials = GitCredentials.fill(uri.getHost(), uri.getPath(), null, null, uri.getScheme());
             GitCredentials.approve(credentials);
         } else if (command.equals("revoke")) {
-            var credentials = GitCredentials.fill(uri.getHost(), uri.getPath().substring(1), null, null, uri.getScheme());
+            var credentials = GitCredentials.fill(uri.getHost(), uri.getPath(), null, null, uri.getScheme());
             GitCredentials.reject(credentials);
         } else {
             exit("error: unknown command: " + command);


### PR DESCRIPTION
Hi, 

Please review this fix to avoid getting exceptions when having URIs with empty paths. Instead of assuming a leading '/' we now check the path in GitCredentials.fill and only removes a leading '/' if it is present.

Basic tests pass, but the affected commands have not yet been tested thoroughly.

Thanks,
Stefan
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Jorn Vernee ([jvernee](@JornVernee) - Committer)
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)