### PR TITLE
Add merge bot

### DIFF
--- a/bots/merge/build.gradle
+++ b/bots/merge/build.gradle
@@ -20,33 +20,22 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-rootProject.name = 'skara'
 
-include 'args'
-include 'bot'
-include 'cli'
-include 'census'
-include 'email'
-include 'encoding'
-include 'host'
-include 'ini'
-include 'jcheck'
-include 'json'
-include 'mailinglist'
-include 'process'
-include 'proxy'
-include 'storage'
-include 'ssh'
-include 'test'
-include 'vcs'
-include 'webrev'
+module {
+    name = 'org.openjdk.skara.bots.merge'
+    test {
+        requires 'org.junit.jupiter.api'
+        requires 'org.openjdk.skara.test'
+        opens 'org.openjdk.skara.bots.merge' to 'org.junit.platform.commons'
+    }
+}
 
-include 'bots:cli'
-include 'bots:forward'
-include 'bots:hgbridge'
-include 'bots:merge'
-include 'bots:mirror'
-include 'bots:mlbridge'
-include 'bots:notify'
-include 'bots:pr'
-include 'bots:submit'
+dependencies {
+    implementation project(':host')
+    implementation project(':bot')
+    implementation project(':census')
+    implementation project(':json')
+    implementation project(':vcs')
+
+    testImplementation project(':test')
+}

--- a/bots/merge/src/main/java/module-info.java
+++ b/bots/merge/src/main/java/module-info.java
@@ -20,33 +20,10 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-rootProject.name = 'skara'
+module org.openjdk.skara.bots.merge {
+    requires org.openjdk.skara.bot;
+    requires org.openjdk.skara.vcs;
+    requires java.logging;
 
-include 'args'
-include 'bot'
-include 'cli'
-include 'census'
-include 'email'
-include 'encoding'
-include 'host'
-include 'ini'
-include 'jcheck'
-include 'json'
-include 'mailinglist'
-include 'process'
-include 'proxy'
-include 'storage'
-include 'ssh'
-include 'test'
-include 'vcs'
-include 'webrev'
-
-include 'bots:cli'
-include 'bots:forward'
-include 'bots:hgbridge'
-include 'bots:merge'
-include 'bots:mirror'
-include 'bots:mlbridge'
-include 'bots:notify'
-include 'bots:pr'
-include 'bots:submit'
+    provides org.openjdk.skara.bot.BotFactory with org.openjdk.skara.bots.merge.MergeBotFactory;
+}

--- a/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
+++ b/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.merge;
+
+import org.openjdk.skara.bot.*;
+import org.openjdk.skara.host.*;
+import org.openjdk.skara.vcs.*;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Files;
+import java.net.URLEncoder;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.logging.Logger;
+
+class MergeBot implements Bot, WorkItem {
+    private final Logger log = Logger.getLogger("org.openjdk.skara.bots");;
+    private final Path storage;
+    private final HostedRepository from;
+    private final Branch fromBranch;
+    private final HostedRepository to;
+    private final Branch toBranch;
+
+    MergeBot(Path storage, HostedRepository from, Branch fromBranch,
+              HostedRepository to, Branch toBranch) {
+        this.storage = storage;
+        this.from = from;
+        this.fromBranch = fromBranch;
+        this.to = to;
+        this.toBranch = toBranch;
+    }
+
+    @Override
+    public boolean concurrentWith(WorkItem other) {
+        if (!(other instanceof MergeBot)) {
+            return true;
+        }
+        var otherBot = (MergeBot) other;
+        return !to.getName().equals(otherBot.to.getName());
+    }
+
+    @Override
+    public void run(Path scratchPath) {
+        try {
+            var sanitizedUrl =
+                URLEncoder.encode(to.getWebUrl().toString(), StandardCharsets.UTF_8);
+            var dir = storage.resolve(sanitizedUrl);
+            Repository repo = null;
+            if (!Files.exists(dir)) {
+                log.info("Cloning " + to.getName());
+                Files.createDirectories(dir);
+                repo = Repository.clone(to.getUrl(), dir);
+            } else {
+                log.info("Found existing scratch directory for " + to.getName());
+                repo = Repository.get(dir).orElseThrow(() -> {
+                        return new RuntimeException("Repository in " + dir + " has vanished");
+                });
+            }
+
+            repo.fetchAll();
+            var originToBranch = new Branch("origin/" + toBranch.name());
+
+            // Check if pull request already created
+            var title = "Cannot automatically merge " + from.getName() + ":" + fromBranch.name();
+            var marker = "<!-- MERGE CONFLICTS -->";
+            for (var pr : to.getPullRequests()) {
+                if (pr.getTitle().equals(title) &&
+                    pr.getBody().startsWith(marker) &&
+                    to.host().getCurrentUserDetails().equals(pr.getAuthor())) {
+                    var lines = pr.getBody().split("\n");
+                    var head = new Hash(lines[1].substring(5, 45));
+                    if (repo.contains(originToBranch, head)) {
+                        log.info("Closing resolved merge conflict PR " + pr.getId());
+                        pr.addComment("Merge conflicts have been resolved, closing this PR");
+                        pr.setState(PullRequest.State.CLOSED);
+                    } else {
+                        log.info("Outstanding unresolved merge already present");
+                        return;
+                    }
+                }
+            }
+
+            log.info("Fetching " + from.getName() + ":" + fromBranch.name());
+            var fetchHead = repo.fetch(from.getUrl(), fromBranch.name());
+            var head = repo.resolve(toBranch.name()).orElseThrow(() ->
+                    new IOException("Could not resolve branch " + toBranch.name())
+            );
+            if (repo.contains(originToBranch, fetchHead)) {
+                log.info("Nothing to merge");
+                return;
+            }
+
+            var isAncestor = repo.isAncestor(head, fetchHead);
+
+            log.info("Trying to merge into " + toBranch.name());
+            repo.checkout(toBranch, false);
+            IOException error = null;
+            try {
+                repo.merge(fetchHead);
+            } catch (IOException e) {
+                error = e;
+            }
+
+            if (error == null) {
+                log.info("Pushing successful merge");
+                if (!isAncestor) {
+                    repo.commit("Merge", "duke", "duke@openjdk.org");
+                }
+                repo.push(toBranch, to.getUrl().toString(), false);
+            } else {
+                log.info("Got error: " + error.getMessage());
+                log.info("Aborting unsuccesful merge");
+                repo.abortMerge();
+
+                log.info("Creating pull request to alert");
+                var mergeBase = repo.mergeBase(fetchHead, head);
+                var commits = repo.commits(mergeBase.hex() + ".." + fetchHead.hex(), true).asList();
+
+                var message = new ArrayList<String>();
+                message.add(marker);
+                message.add("<!-- " + fetchHead.hex() + " -->");
+                message.add("The following commits from `" + from.getName() + ":" + fromBranch.name() +
+                            "` could *not* be automatically merged into `" + toBranch.name() + "`:");
+                message.add("");
+                for (var commit : commits) {
+                    message.add("- " + commit.hash().abbreviate() + ": " + commit.message().get(0));
+                }
+                message.add("");
+                message.add("To manually resolve these merge conflicts, please create a personal fork of " +
+                            to.getWebUrl() + " and execute the following commands:");
+                message.add("");
+                message.add("```bash");
+                message.add("$ git checkout " + toBranch.name());
+                message.add("$ git pull " + from.getWebUrl() + " " + fromBranch.name());
+                message.add("```");
+                message.add("");
+                message.add("When you have resolved the conflicts resulting from the above commands, run:");
+                message.add("");
+                message.add("```bash");
+                message.add("$ git add paths/to/files/with/conflicts");
+                message.add("$ git commit -m 'Merge'");
+                message.add("```");
+                message.add("");
+                message.add("Push the resulting merge conflict to your personal fork and " +
+                            "create a pull request towards this repository. Finally close this pull request " +
+                            "once the pull request with the resolved conflicts has been integrated.");
+                var pr = from.createPullRequest(to,
+                                                toBranch.name(),
+                                                fromBranch.name(),
+                                                title,
+                                                message);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "MergeBot@(" + from.getName() + ":" + fromBranch.name() + "-> "
+                            + to.getName() + ":" + toBranch.name() + ")";
+    }
+
+    @Override
+    public List<WorkItem> getPeriodicItems() {
+        return List.of(this);
+    }
+}

--- a/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
+++ b/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
@@ -165,8 +165,9 @@ class MergeBot implements Bot, WorkItem {
                 message.add("```");
                 message.add("");
                 message.add("Push the resulting merge conflict to your personal fork and " +
-                            "create a pull request towards this repository. Finally close this pull request " +
-                            "once the pull request with the resolved conflicts has been integrated.");
+                            "create a pull request towards this repository. This pull request " +
+                            "will be closed automatically once the pull request with the resolved " +
+                            "conflicts has been integrated.");
                 var pr = from.createPullRequest(to,
                                                 toBranch.name(),
                                                 fromBranch.name(),

--- a/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBotFactory.java
+++ b/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBotFactory.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.merge;
+
+import org.openjdk.skara.bot.*;
+import org.openjdk.skara.vcs.Branch;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.util.*;
+import java.util.logging.Logger;
+
+public class MergeBotFactory implements BotFactory {
+    private final Logger log = Logger.getLogger("org.openjdk.skara.bots");;
+
+    @Override
+    public String name() {
+        return "merge";
+    }
+
+    @Override
+    public List<Bot> create(BotConfiguration configuration) {
+        var storage = configuration.storageFolder();
+        try {
+            Files.createDirectories(storage);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        var specific = configuration.specific();
+
+        var bots = new ArrayList<Bot>();
+        for (var repo : specific.get("repositories").asArray()) {
+            var from = repo.get("from").asString().split(":");
+            var fromRepo = configuration.repository(from[0]);
+            var fromBranch = new Branch(from[1]);
+
+            var to = repo.get("to").asString().split(":");
+            var toRepo = configuration.repository(to[0]);
+            var toBranch = new Branch(to[1]);
+
+            log.info("Setting up merging from " + fromRepo.getName() + ":" + fromBranch.name() +
+                     " to " + toRepo.getName() + ":" + toBranch.name());
+            bots.add(new MergeBot(storage, fromRepo, fromBranch, toRepo, toBranch));
+        }
+        return bots;
+    }
+}

--- a/bots/merge/src/test/java/org/openjdk/skara/bots/merge/MergeBotTests.java
+++ b/bots/merge/src/test/java/org/openjdk/skara/bots/merge/MergeBotTests.java
@@ -1,0 +1,396 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.merge;
+
+import org.openjdk.skara.host.*;
+import org.openjdk.skara.test.*;
+import org.openjdk.skara.vcs.*;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.time.ZonedDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MergeBotTests {
+    @Test
+    void mergeMasterBranch(TestInfo testInfo) throws IOException {
+        try (var temp = new TemporaryDirectory()) {
+            var host = TestHost.createNew(List.of(new HostUserDetails(0, "duke", "J. Duke")));
+
+            var fromDir = temp.path().resolve("from.git");
+            var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
+            var fromHostedRepo = new TestHostedRepository(host, "test", fromLocalRepo);
+
+            var toDir = temp.path().resolve("to.git");
+            var toLocalRepo = Repository.init(toDir, VCS.GIT);
+            var gitConfig = toDir.resolve(".git").resolve("config");
+            Files.write(gitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
+                        StandardOpenOption.APPEND);
+            var toHostedRepo = new TestHostedRepository(host, "test-mirror", toLocalRepo);
+
+            var now = ZonedDateTime.now();
+            var fromFileA = fromDir.resolve("a.txt");
+            Files.writeString(fromFileA, "Hello A\n");
+            fromLocalRepo.add(fromFileA);
+            var fromHashA = fromLocalRepo.commit("Adding a.txt", "duke", "duke@openjdk.org", now);
+            var fromCommits = fromLocalRepo.commits().asList();
+            assertEquals(1, fromCommits.size());
+            assertEquals(fromHashA, fromCommits.get(0).hash());
+
+            var toFileA = toDir.resolve("a.txt");
+            Files.writeString(toFileA, "Hello A\n");
+            toLocalRepo.add(toFileA);
+            var toHashA = toLocalRepo.commit("Adding a.txt", "duke", "duke@openjdk.org", now);
+            var toCommits = toLocalRepo.commits().asList();
+            assertEquals(1, toCommits.size());
+            assertEquals(toHashA, toCommits.get(0).hash());
+            assertEquals(fromHashA, toHashA);
+
+            var fromFileB = fromDir.resolve("b.txt");
+            Files.writeString(fromFileB, "Hello B\n");
+            fromLocalRepo.add(fromFileB);
+            var fromHashB = fromLocalRepo.commit("Adding b.txt", "duke", "duke@openjdk.org");
+
+            var toFileC = toDir.resolve("c.txt");
+            Files.writeString(toFileC, "Hello C\n");
+            toLocalRepo.add(toFileC);
+            var toHashC = toLocalRepo.commit("Adding c.txt", "duke", "duke@openjdk.org");
+
+            var storage = temp.path().resolve("storage");
+            var master = new Branch("master");
+            var bot = new MergeBot(storage, fromHostedRepo, master, toHostedRepo, master);
+            TestBotRunner.runPeriodicItems(bot);
+
+            toCommits = toLocalRepo.commits().asList();
+            assertEquals(4, toCommits.size());
+            var hashes = toCommits.stream().map(Commit::hash).collect(Collectors.toSet());
+            assertTrue(hashes.contains(toHashA));
+            assertTrue(hashes.contains(fromHashB));
+            assertTrue(hashes.contains(toHashC));
+
+            var known = Set.of(toHashA, fromHashB, toHashC);
+            var merge = toCommits.stream().filter(c -> !known.contains(c.hash())).findAny().get();
+            assertTrue(merge.isMerge());
+            assertEquals(List.of("Merge"), merge.message());
+            assertEquals("duke", merge.author().name());
+            assertEquals("duke@openjdk.org", merge.author().email());
+
+            assertEquals(0, toHostedRepo.getPullRequests().size());
+        }
+    }
+
+    @Test
+    void failingMergeTest(TestInfo testInfo) throws IOException {
+        try (var temp = new TemporaryDirectory()) {
+            var host = TestHost.createNew(List.of(new HostUserDetails(0, "duke", "J. Duke")));
+
+            var fromDir = temp.path().resolve("from.git");
+            var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
+            var fromHostedRepo = new TestHostedRepository(host, "test", fromLocalRepo);
+
+            var toDir = temp.path().resolve("to.git");
+            var toLocalRepo = Repository.init(toDir, VCS.GIT);
+            var gitConfig = toDir.resolve(".git").resolve("config");
+            Files.write(gitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
+                        StandardOpenOption.APPEND);
+            var toHostedRepo = new TestHostedRepository(host, "test-mirror", toLocalRepo);
+
+            var now = ZonedDateTime.now();
+            var fromFileA = fromDir.resolve("a.txt");
+            Files.writeString(fromFileA, "Hello A\n");
+            fromLocalRepo.add(fromFileA);
+            var fromHashA = fromLocalRepo.commit("Adding a.txt", "duke", "duke@openjdk.org", now);
+            var fromCommits = fromLocalRepo.commits().asList();
+            assertEquals(1, fromCommits.size());
+            assertEquals(fromHashA, fromCommits.get(0).hash());
+
+            var toFileA = toDir.resolve("a.txt");
+            Files.writeString(toFileA, "Hello A\n");
+            toLocalRepo.add(toFileA);
+            var toHashA = toLocalRepo.commit("Adding a.txt", "duke", "duke@openjdk.org", now);
+            var toCommits = toLocalRepo.commits().asList();
+            assertEquals(1, toCommits.size());
+            assertEquals(toHashA, toCommits.get(0).hash());
+            assertEquals(fromHashA, toHashA);
+
+            var fromFileB = fromDir.resolve("b.txt");
+            Files.writeString(fromFileB, "Hello B1\n");
+            fromLocalRepo.add(fromFileB);
+            var fromHashB = fromLocalRepo.commit("Adding b1.txt", "duke", "duke@openjdk.org");
+
+            var toFileB = toDir.resolve("b.txt");
+            Files.writeString(toFileB, "Hello B2\n");
+            toLocalRepo.add(toFileB);
+            var toHashB = toLocalRepo.commit("Adding b2.txt", "duke", "duke@openjdk.org");
+
+            var storage = temp.path().resolve("storage");
+            var master = new Branch("master");
+            var bot = new MergeBot(storage, fromHostedRepo, master, toHostedRepo, master);
+            TestBotRunner.runPeriodicItems(bot);
+
+            toCommits = toLocalRepo.commits().asList();
+            assertEquals(2, toCommits.size());
+            var toHashes = toCommits.stream().map(Commit::hash).collect(Collectors.toSet());
+            assertTrue(toHashes.contains(toHashA));
+            assertTrue(toHashes.contains(toHashB));
+
+            var pullRequests = toHostedRepo.getPullRequests();
+            assertEquals(1, pullRequests.size());
+            var pr = pullRequests.get(0);
+            assertEquals("Cannot automatically merge test:master", pr.getTitle());
+        }
+    }
+
+    @Test
+    void failingMergeShouldResultInOnlyOnePR(TestInfo testInfo) throws IOException {
+        try (var temp = new TemporaryDirectory()) {
+            var host = TestHost.createNew(List.of(new HostUserDetails(0, "duke", "J. Duke")));
+
+            var fromDir = temp.path().resolve("from.git");
+            var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
+            var fromHostedRepo = new TestHostedRepository(host, "test", fromLocalRepo);
+
+            var toDir = temp.path().resolve("to.git");
+            var toLocalRepo = Repository.init(toDir, VCS.GIT);
+            var gitConfig = toDir.resolve(".git").resolve("config");
+            Files.write(gitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
+                        StandardOpenOption.APPEND);
+            var toHostedRepo = new TestHostedRepository(host, "test-mirror", toLocalRepo);
+
+            var now = ZonedDateTime.now();
+            var fromFileA = fromDir.resolve("a.txt");
+            Files.writeString(fromFileA, "Hello A\n");
+            fromLocalRepo.add(fromFileA);
+            var fromHashA = fromLocalRepo.commit("Adding a.txt", "duke", "duke@openjdk.org", now);
+            var fromCommits = fromLocalRepo.commits().asList();
+            assertEquals(1, fromCommits.size());
+            assertEquals(fromHashA, fromCommits.get(0).hash());
+
+            var toFileA = toDir.resolve("a.txt");
+            Files.writeString(toFileA, "Hello A\n");
+            toLocalRepo.add(toFileA);
+            var toHashA = toLocalRepo.commit("Adding a.txt", "duke", "duke@openjdk.org", now);
+            var toCommits = toLocalRepo.commits().asList();
+            assertEquals(1, toCommits.size());
+            assertEquals(toHashA, toCommits.get(0).hash());
+            assertEquals(fromHashA, toHashA);
+
+            var fromFileB = fromDir.resolve("b.txt");
+            Files.writeString(fromFileB, "Hello B1\n");
+            fromLocalRepo.add(fromFileB);
+            var fromHashB = fromLocalRepo.commit("Adding b1.txt", "duke", "duke@openjdk.org");
+
+            var toFileB = toDir.resolve("b.txt");
+            Files.writeString(toFileB, "Hello B2\n");
+            toLocalRepo.add(toFileB);
+            var toHashB = toLocalRepo.commit("Adding b2.txt", "duke", "duke@openjdk.org");
+
+            var storage = temp.path().resolve("storage");
+            var master = new Branch("master");
+            var bot = new MergeBot(storage, fromHostedRepo, master, toHostedRepo, master);
+            TestBotRunner.runPeriodicItems(bot);
+            TestBotRunner.runPeriodicItems(bot);
+
+            toCommits = toLocalRepo.commits().asList();
+            assertEquals(2, toCommits.size());
+            var toHashes = toCommits.stream().map(Commit::hash).collect(Collectors.toSet());
+            assertTrue(toHashes.contains(toHashA));
+            assertTrue(toHashes.contains(toHashB));
+
+            var pullRequests = toHostedRepo.getPullRequests();
+            assertEquals(1, pullRequests.size());
+            var pr = pullRequests.get(0);
+            assertEquals("Cannot automatically merge test:master", pr.getTitle());
+        }
+    }
+
+    @Test
+    void resolvedMergeConflictShouldResultInClosedPR(TestInfo testInfo) throws IOException {
+        try (var temp = new TemporaryDirectory(false)) {
+            var host = TestHost.createNew(List.of(new HostUserDetails(0, "duke", "J. Duke")));
+
+            var fromDir = temp.path().resolve("from.git");
+            var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
+            var fromHostedRepo = new TestHostedRepository(host, "test", fromLocalRepo);
+
+            var toDir = temp.path().resolve("to.git");
+            var toLocalRepo = Repository.init(toDir, VCS.GIT);
+            var gitConfig = toDir.resolve(".git").resolve("config");
+            Files.write(gitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
+                        StandardOpenOption.APPEND);
+            var toHostedRepo = new TestHostedRepository(host, "test-mirror", toLocalRepo);
+
+            var now = ZonedDateTime.now();
+            var fromFileA = fromDir.resolve("a.txt");
+            Files.writeString(fromFileA, "Hello A\n");
+            fromLocalRepo.add(fromFileA);
+            var fromHashA = fromLocalRepo.commit("Adding a.txt", "duke", "duke@openjdk.org", now);
+            var fromCommits = fromLocalRepo.commits().asList();
+            assertEquals(1, fromCommits.size());
+            assertEquals(fromHashA, fromCommits.get(0).hash());
+
+            var toFileA = toDir.resolve("a.txt");
+            Files.writeString(toFileA, "Hello A\n");
+            toLocalRepo.add(toFileA);
+            var toHashA = toLocalRepo.commit("Adding a.txt", "duke", "duke@openjdk.org", now);
+            var toCommits = toLocalRepo.commits().asList();
+            assertEquals(1, toCommits.size());
+            assertEquals(toHashA, toCommits.get(0).hash());
+            assertEquals(fromHashA, toHashA);
+
+            var fromFileB = fromDir.resolve("b.txt");
+            Files.writeString(fromFileB, "Hello B1\n");
+            fromLocalRepo.add(fromFileB);
+            var fromHashB = fromLocalRepo.commit("Adding b1.txt", "duke", "duke@openjdk.org", now);
+
+            var toFileB = toDir.resolve("b.txt");
+            Files.writeString(toFileB, "Hello B2\n");
+            toLocalRepo.add(toFileB);
+            var toHashB = toLocalRepo.commit("Adding b2.txt", "duke", "duke@openjdk.org", now);
+
+            var storage = temp.path().resolve("storage");
+            var master = new Branch("master");
+            var bot = new MergeBot(storage, fromHostedRepo, master, toHostedRepo, master);
+            TestBotRunner.runPeriodicItems(bot);
+            TestBotRunner.runPeriodicItems(bot);
+
+            toCommits = toLocalRepo.commits().asList();
+            assertEquals(2, toCommits.size());
+            var toHashes = toCommits.stream().map(Commit::hash).collect(Collectors.toSet());
+            assertTrue(toHashes.contains(toHashA));
+            assertTrue(toHashes.contains(toHashB));
+
+            var pullRequests = toHostedRepo.getPullRequests();
+            assertEquals(1, pullRequests.size());
+            var pr = pullRequests.get(0);
+            assertEquals("Cannot automatically merge test:master", pr.getTitle());
+
+            var fetchHead = toLocalRepo.fetch(fromHostedRepo.getWebUrl(), "master");
+            toLocalRepo.merge(fetchHead, "ours");
+            toLocalRepo.commit("Merge", "duke", "duke@openjdk.org", now);
+
+            toCommits = toLocalRepo.commits().asList();
+            assertEquals(4, toCommits.size());
+
+            TestBotRunner.runPeriodicItems(bot);
+            pullRequests = toHostedRepo.getPullRequests();
+            assertEquals(0, pullRequests.size());
+        }
+    }
+
+    @Test
+    void resolvedMergeConflictAndThenNewConflict(TestInfo testInfo) throws IOException {
+        try (var temp = new TemporaryDirectory(false)) {
+            var host = TestHost.createNew(List.of(new HostUserDetails(0, "duke", "J. Duke")));
+
+            var fromDir = temp.path().resolve("from.git");
+            var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
+            var fromHostedRepo = new TestHostedRepository(host, "test", fromLocalRepo);
+
+            var toDir = temp.path().resolve("to.git");
+            var toLocalRepo = Repository.init(toDir, VCS.GIT);
+            var gitConfig = toDir.resolve(".git").resolve("config");
+            Files.write(gitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
+                        StandardOpenOption.APPEND);
+            var toHostedRepo = new TestHostedRepository(host, "test-mirror", toLocalRepo);
+
+            var now = ZonedDateTime.now();
+            var fromFileA = fromDir.resolve("a.txt");
+            Files.writeString(fromFileA, "Hello A\n");
+            fromLocalRepo.add(fromFileA);
+            var fromHashA = fromLocalRepo.commit("Adding a.txt", "duke", "duke@openjdk.org", now);
+            var fromCommits = fromLocalRepo.commits().asList();
+            assertEquals(1, fromCommits.size());
+            assertEquals(fromHashA, fromCommits.get(0).hash());
+
+            var toFileA = toDir.resolve("a.txt");
+            Files.writeString(toFileA, "Hello A\n");
+            toLocalRepo.add(toFileA);
+            var toHashA = toLocalRepo.commit("Adding a.txt", "duke", "duke@openjdk.org", now);
+            var toCommits = toLocalRepo.commits().asList();
+            assertEquals(1, toCommits.size());
+            assertEquals(toHashA, toCommits.get(0).hash());
+            assertEquals(fromHashA, toHashA);
+
+            var fromFileB = fromDir.resolve("b.txt");
+            Files.writeString(fromFileB, "Hello B1\n");
+            fromLocalRepo.add(fromFileB);
+            var fromHashB = fromLocalRepo.commit("Adding b1.txt", "duke", "duke@openjdk.org", now);
+
+            var toFileB = toDir.resolve("b.txt");
+            Files.writeString(toFileB, "Hello B2\n");
+            toLocalRepo.add(toFileB);
+            var toHashB = toLocalRepo.commit("Adding b2.txt", "duke", "duke@openjdk.org", now);
+
+            var storage = temp.path().resolve("storage");
+            var master = new Branch("master");
+            var bot = new MergeBot(storage, fromHostedRepo, master, toHostedRepo, master);
+            TestBotRunner.runPeriodicItems(bot);
+            TestBotRunner.runPeriodicItems(bot);
+
+            toCommits = toLocalRepo.commits().asList();
+            assertEquals(2, toCommits.size());
+            var toHashes = toCommits.stream().map(Commit::hash).collect(Collectors.toSet());
+            assertTrue(toHashes.contains(toHashA));
+            assertTrue(toHashes.contains(toHashB));
+
+            var pullRequests = toHostedRepo.getPullRequests();
+            assertEquals(1, pullRequests.size());
+            var pr = pullRequests.get(0);
+            assertEquals("Cannot automatically merge test:master", pr.getTitle());
+
+            var fetchHead = toLocalRepo.fetch(fromHostedRepo.getWebUrl(), "master");
+            toLocalRepo.merge(fetchHead, "ours");
+            toLocalRepo.commit("Merge", "duke", "duke@openjdk.org", now);
+
+            toCommits = toLocalRepo.commits().asList();
+            assertEquals(4, toCommits.size());
+
+            TestBotRunner.runPeriodicItems(bot);
+            pullRequests = toHostedRepo.getPullRequests();
+            assertEquals(0, pullRequests.size());
+
+            var fromFileC = fromDir.resolve("c.txt");
+            Files.writeString(fromFileC, "Hello C1\n");
+            fromLocalRepo.add(fromFileC);
+            fromLocalRepo.commit("Adding c1", "duke", "duke@openjdk.org", now);
+
+            var toFileC = toDir.resolve("c.txt");
+            Files.writeString(toFileC, "Hello C2\n");
+            toLocalRepo.add(toFileC);
+            toLocalRepo.commit("Adding c2", "duke", "duke@openjdk.org", now);
+
+            TestBotRunner.runPeriodicItems(bot);
+            pullRequests = toHostedRepo.getPullRequests();
+            assertEquals(1, pullRequests.size());
+            assertEquals("Cannot automatically merge test:master", pr.getTitle());
+        }
+    }
+}


### PR DESCRIPTION
Hi,

this patch adds a merge bot. The merge automatically tries to merge a branch from one repository to another. If the merge fails then the bot will open a PR describing the commits that couldn't be merge. Once the conflicts have been resolved and pushed/integrated by a human contributor, then the bot will automatically close the PR.

## Testing
- [x] `sh gradlew test` passes on Linux x86_64
- [x] Added four new unit tests

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**) **Note!** Review applies to 7fc5a814d27118a58b247f36619416d0d2f20f37