### PR TITLE
Avoid running PullRequestBot WorkItems for the same PR concurrently

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
@@ -22,49 +22,30 @@
  */
 package org.openjdk.skara.bots.pr;
 
-import org.openjdk.skara.bot.WorkItem;
 import org.openjdk.skara.host.PullRequest;
 import org.openjdk.skara.vcs.Hash;
 
 import java.io.*;
 import java.nio.file.Path;
 import java.util.*;
-import java.util.concurrent.*;
+import java.util.concurrent.ConcurrentMap;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-public class LabelerWorkItem implements WorkItem {
-    private final PullRequest pr;
+public class LabelerWorkItem extends PullRequestWorkItem {
     private final Map<String, List<Pattern>> labelPatterns;
     private final ConcurrentMap<Hash, Boolean> currentLabels;
-    private final Consumer<RuntimeException> errorHandler;
 
     LabelerWorkItem(PullRequest pr, Map<String, List<Pattern>> labelPatterns, ConcurrentMap<Hash, Boolean> currentLabels, Consumer<RuntimeException> errorHandler) {
-        this.pr = pr;
+        super(pr, errorHandler);
         this.labelPatterns = labelPatterns;
         this.currentLabels = currentLabels;
-        this.errorHandler = errorHandler;
     }
 
     @Override
     public String toString() {
         return "LabelerWorkItem@" + pr.repository().getName() + "#" + pr.getId();
-    }
-
-    @Override
-    public boolean concurrentWith(WorkItem other) {
-        if (!(other instanceof LabelerWorkItem)) {
-            return true;
-        }
-        LabelerWorkItem otherItem = (LabelerWorkItem) other;
-        if (!pr.getId().equals(otherItem.pr.getId())) {
-            return true;
-        }
-        if (!pr.repository().getName().equals(otherItem.pr.repository().getName())) {
-            return true;
-        }
-        return false;
     }
 
     private Set<String> getLabels(PullRequestInstance prInstance) throws IOException {
@@ -110,10 +91,5 @@ public class LabelerWorkItem implements WorkItem {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
-    }
-
-    @Override
-    public void handleRuntimeException(RuntimeException e) {
-        errorHandler.accept(e);
     }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestWorkItem.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.pr;
+
+import org.openjdk.skara.bot.WorkItem;
+import org.openjdk.skara.host.PullRequest;
+
+import java.util.function.Consumer;
+
+abstract class PullRequestWorkItem implements WorkItem {
+    private final Consumer<RuntimeException> errorHandler;
+    final PullRequest pr;
+
+    PullRequestWorkItem(PullRequest pr, Consumer<RuntimeException> errorHandler) {
+        this.pr = pr;
+        this.errorHandler = errorHandler;
+    }
+
+    @Override
+    public final boolean concurrentWith(WorkItem other) {
+        if (!(other instanceof PullRequestWorkItem)) {
+            return true;
+        }
+        PullRequestWorkItem otherItem = (PullRequestWorkItem)other;
+        if (!pr.getId().equals(otherItem.pr.getId())) {
+            return true;
+        }
+        if (!pr.repository().getName().equals(otherItem.pr.repository().getName())) {
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public final void handleRuntimeException(RuntimeException e) {
+        errorHandler.accept(e);
+    }
+}


### PR DESCRIPTION
Hi all,

Please review this change that ensures that the WorkItems used by the PullRequestBot are not run concurrently for the same PR. This avoids a race condition where two tasks try to update the `sponsor` label at the same time.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)