### PR TITLE
jcheck "repository" property in [general] section not read from .jcheck/conf

### DIFF
--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/GeneralConfiguration.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/GeneralConfiguration.java
@@ -53,7 +53,7 @@ public class GeneralConfiguration {
         }
 
         var project = s.get("project", DEFAULT.project());
-        var repository = s.get("project", DEFAULT.repository());
+        var repository = s.get("repository", DEFAULT.repository());
         return new GeneralConfiguration(project, repository);
     }
 }


### PR DESCRIPTION
This PR fixes a typo in the `GeneralConfiguration` class of `jcheck` that causes the `repository` property to be set to the same value as `project` rather than being read from the `.jcheck/conf` file.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)