### PR TITLE
Batch commit, add and files methods in HgRepository

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -640,8 +640,7 @@ public class HgRepository implements Repository {
         }
     }
 
-    @Override
-    public List<FileEntry> files(Hash hash, List<Path> paths) throws IOException {
+    private List<FileEntry> allFiles(Hash hash, List<Path> paths) throws IOException {
         var ext = Files.createTempFile("ext", ".py");
         copyResource(EXT_PY, ext);
 
@@ -664,6 +663,26 @@ public class HgRepository implements Repository {
             }
             return entries;
         }
+    }
+
+    @Override
+    public List<FileEntry> files(Hash hash, List<Path> paths) throws IOException {
+        if (paths.isEmpty()) {
+            return allFiles(hash, paths);
+        }
+
+        var entries = new ArrayList<FileEntry>();
+        var batchSize = 64;
+        var start = 0;
+        while (start < paths.size()) {
+            var end = start + batchSize;
+            if (end > paths.size()) {
+                end = paths.size();
+            }
+            entries.addAll(allFiles(hash, paths.subList(start, end)));
+            start = end;
+        }
+        return entries;
     }
 
     @Override
@@ -938,26 +957,53 @@ public class HgRepository implements Repository {
         }
     }
 
-    @Override
-    public void remove(List<Path> paths) throws IOException {
-        var cmd = new ArrayList<>(List.of("hg", "rm"));
-        for (var p : paths) {
-            cmd.add(p.toString());
+    @FunctionalInterface
+    private static interface Operation {
+        void execute(List<Path> args) throws IOException;
+    }
+
+    private void batch(Operation op, List<Path> args) throws IOException {
+        var batchSize = 64;
+        var start = 0;
+        while (start < args.size()) {
+            var end = start + batchSize;
+            if (end > args.size()) {
+                end = args.size();
+            }
+            op.execute(args.subList(start, end));
+            start = end;
+        }
+    }
+
+    private void addAll(List<Path> paths) throws IOException {
+        var cmd = new ArrayList<>(List.of("hg", "add"));
+        for (var path : paths) {
+            cmd.add(path.toString());
         }
         try (var p = capture(cmd)) {
             await(p);
         }
     }
 
-    @Override
-    public void add(List<Path> paths) throws IOException {
-        var cmd = new ArrayList<>(List.of("hg", "add"));
-        for (var p : paths) {
-            cmd.add(p.toString());
+    private void removeAll(List<Path> paths) throws IOException {
+        var cmd = new ArrayList<>(List.of("hg", "rm"));
+        for (var path : paths) {
+            cmd.add(path.toString());
         }
         try (var p = capture(cmd)) {
             await(p);
         }
+    }
+
+
+    @Override
+    public void remove(List<Path> paths) throws IOException {
+        batch(this::removeAll, paths);
+    }
+
+    @Override
+    public void add(List<Path> paths) throws IOException {
+        batch(this::addAll, paths);
     }
 
     @Override


### PR DESCRIPTION
Hi all,

this small patch adds "batching" to the `commit`, `add` and `files` methods in `HgRepository` to avoid command-line overflow for large lists.

## Testing
- [x] `sh gradlew test` passes on Linux x86_64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)