### PR TITLE
 Make sure Commits are closed when using Commits::stream

### DIFF
--- a/bots/hgbridge/src/test/java/org/openjdk/skara/bots/hgbridge/BridgeBotTests.java
+++ b/bots/hgbridge/src/test/java/org/openjdk/skara/bots/hgbridge/BridgeBotTests.java
@@ -116,9 +116,11 @@ class BridgeBotTests {
     }
 
     private Set<String> getCommitHashes(Repository repo) throws IOException {
-        return repo.commits().stream()
-                   .map(c -> c.hash().hex())
-                   .collect(Collectors.toSet());
+        try (var commits = repo.commits()) {
+            return commits.stream()
+                    .map(c -> c.hash().hex())
+                    .collect(Collectors.toSet());
+        }
     }
 
     private TemporaryDirectory sourceFolder;

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/PullRequestInstance.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/PullRequestInstance.java
@@ -78,8 +78,7 @@ class PullRequestInstance {
     }
 
     String formatCommitMessages(Hash first, Hash last, CommitFormatter formatter) {
-        try {
-            var commits = localRepo().commits(first.hex() + ".." + last.hex());
+        try (var commits = localRepo().commits(first.hex() + ".." + last.hex())) {
             return commits.stream()
                           .map(formatter::format)
                           .collect(Collectors.joining("\n"));

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/JNotifyBot.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/JNotifyBot.java
@@ -76,8 +76,7 @@ class JNotifyBot implements Bot, WorkItem {
             return;
         }
 
-        var newCommits = localRepo.commits(lastRef.get() + ".." + curHead).stream()
-                                  .collect(Collectors.toList());
+        var newCommits = localRepo.commits(lastRef.get() + ".." + curHead).asList();
         if (newCommits.size() == 0) {
             return;
         }
@@ -118,8 +117,7 @@ class JNotifyBot implements Bot, WorkItem {
                 log.warning("No previous tag found for '" + tag.tag() + "' - ignoring");
                 continue;
             }
-            var commits = localRepo.commits(previous.get().tag() + ".." + tag.tag()).stream()
-                                   .collect(Collectors.toList());
+            var commits = localRepo.commits(previous.get().tag() + ".." + tag.tag()).asList();
             if (commits.size() == 0) {
                 continue;
             }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.*;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -101,9 +102,12 @@ class MergeTests {
 
             // The commits from the "other" branch should be preserved and not squashed (but not the merge commit)
             var headHash = pushedRepo.resolve("HEAD").orElseThrow();
-            var commits = pushedRepo.commits(masterHash.hex() + ".." + headHash.hex()).stream()
-                                    .map(Commit::hash)
-                                    .collect(Collectors.toSet());
+            Set<Hash> commits;
+            try (var tempCommits = pushedRepo.commits(masterHash.hex() + ".." + headHash.hex())) {
+                commits = tempCommits.stream()
+                        .map(Commit::hash)
+                        .collect(Collectors.toSet());
+            }
             assertTrue(commits.contains(otherHash1));
             assertTrue(commits.contains(otherHash2));
             assertFalse(commits.contains(mergeHash));
@@ -190,9 +194,12 @@ class MergeTests {
 
             // The commits from the "other" branch should be preserved and not squashed (but not the merge commit)
             var headHash = pushedRepo.resolve("HEAD").orElseThrow();
-            var commits = pushedRepo.commits(masterHash.hex() + ".." + headHash.hex()).stream()
-                                    .map(Commit::hash)
-                                    .collect(Collectors.toSet());
+            Set<Hash> commits;
+            try (var tempCommits = pushedRepo.commits(masterHash.hex() + ".." + headHash.hex())) {
+                commits = tempCommits.stream()
+                        .map(Commit::hash)
+                        .collect(Collectors.toSet());
+            }
             assertTrue(commits.contains(otherHash1));
             assertTrue(commits.contains(otherHash2));
             assertFalse(commits.contains(mergeHash));

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/JCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/JCheck.java
@@ -146,10 +146,11 @@ public class JCheck {
     }
 
     private Set<Check> checksForCommits() throws IOException {
-        var commits = repository.commits(revisionRange);
-        return commits.stream()
-                .flatMap(commit -> checksForCommit(commit).stream())
-                .collect(Collectors.toSet());
+        try (var commits = repository.commits(revisionRange)) {
+            return commits.stream()
+                    .flatMap(commit -> checksForCommit(commit).stream())
+                    .collect(Collectors.toSet());
+        }
     }
 
     public static class Issues implements Iterable<Issue>, AutoCloseable {

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Commits.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Commits.java
@@ -24,6 +24,7 @@ package org.openjdk.skara.vcs;
 
 import java.io.*;
 import java.util.*;
+import java.util.function.Consumer;
 import java.util.stream.*;
 
 public interface Commits extends Closeable, Iterable<Commit> {
@@ -46,5 +47,15 @@ public interface Commits extends Closeable, Iterable<Commit> {
                 throw new UncheckedIOException(e);
             }
         });
+    }
+
+    @Override
+    default void forEach(Consumer<? super Commit> action) {
+        Iterable.super.forEach(action);
+        try {
+            close();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Commits.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Commits.java
@@ -39,6 +39,12 @@ public interface Commits extends Closeable, Iterable<Commit> {
     }
 
     default Stream<Commit> stream() {
-        return StreamSupport.stream(spliterator(), false);
+        return StreamSupport.stream(spliterator(), false).onClose(() -> {
+            try {
+                close();
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        });
     }
 }


### PR DESCRIPTION
I noticed most places that are using `Commits::stream` are not actually closing the underlying resource.

I've added an `onClose` handler to the returned stream, and also overrode `forEach` (from `Iterable`) to call close. Unfortunately, the stream `onClose` handler is not called automatically when a terminal operation occurs, so we still have to use try-with-resources when using `Commits::stream` (which I've addressed).
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)