### PR TITLE
Topological bot tests needs to read org.junit.jupiter.params

### DIFF
--- a/bots/topological/build.gradle
+++ b/bots/topological/build.gradle
@@ -25,6 +25,7 @@ module {
     name = 'org.openjdk.skara.bots.topological'
     test {
         requires 'org.junit.jupiter.api'
+        requires 'org.junit.jupiter.params'
         requires 'org.openjdk.skara.test'
         opens 'org.openjdk.skara.bots.topological' to 'org.junit.platform.commons'
     }


### PR DESCRIPTION
Hi all,

this small patch makes all tests pass again, I had to add `requires 'org.junit.jupiter.params'` to `topological/build.gradle`.

## Testing
- [x] `sh gradlew test` passes

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)