### PR TITLE
Allow reverse mapping of census namespace users

### DIFF
--- a/census/src/main/java/org/openjdk/skara/census/Namespace.java
+++ b/census/src/main/java/org/openjdk/skara/census/Namespace.java
@@ -29,10 +29,12 @@ import java.util.*;
 public class Namespace {
     private final String name;
     private final Map<String, Contributor> mapping;
+    private final Map<Contributor, String> reverse;
 
-    Namespace(String name, Map<String, Contributor> mapping) {
+    private Namespace(String name, Map<String, Contributor> mapping, Map<Contributor, String> reverse) {
         this.name = name;
         this.mapping = mapping;
+        this.reverse = reverse;
     }
 
     public String name() {
@@ -43,8 +45,13 @@ public class Namespace {
         return mapping.get(id);
     }
 
+    public String get(Contributor contributor) {
+        return reverse.get(contributor);
+    }
+
     static Namespace parse(Path p, Map<String, Contributor> contributors) throws IOException {
         var mapping = new HashMap<String, Contributor>();
+        var reverse = new HashMap<Contributor, String>();
 
         var document = XML.parse(p);
         var namespace = XML.child(document, "namespace");
@@ -59,8 +66,9 @@ public class Namespace {
             }
             var contributor = contributors.get(to);
             mapping.put(id, contributor);
+            reverse.put(contributor, id);
         }
 
-        return new Namespace(name, mapping);
+        return new Namespace(name, mapping, reverse);
     }
 }

--- a/census/src/test/java/org/openjdk/skara/census/CensusTests.java
+++ b/census/src/test/java/org/openjdk/skara/census/CensusTests.java
@@ -111,6 +111,13 @@ class CensusTests {
                              List.of(new Member(c1, 1)), List.of(new Member(c2, 1)), List.of(new Member(c3, 1)), List.of(new Member(c4, 1)));
         assertEquals(List.of(p1), census.projects());
 
+        var namespace = census.namespace("github.com");
+        assertEquals("github.com", namespace.name());
+        assertEquals(c1, namespace.get("1234567"));
+        assertEquals(c2, namespace.get("2345678"));
+        assertEquals("1234567", namespace.get(c1));
+        assertEquals("2345678", namespace.get(c2));
+
         assertEquals(1, census.version().format());
     }
 


### PR DESCRIPTION
Hi all,

Please review this small change that adds the possibility of mapping from a contributor to the corresponding namespace id.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)