### PR TITLE
Extend the repository configuration syntax

### DIFF
--- a/bot/src/main/java/org/openjdk/skara/bot/BotConfiguration.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotConfiguration.java
@@ -25,12 +25,12 @@ package org.openjdk.skara.bot;
 import org.openjdk.skara.census.Census;
 import org.openjdk.skara.host.HostedRepository;
 import org.openjdk.skara.json.JSONObject;
+import org.openjdk.skara.vcs.Branch;
 
 import java.nio.file.Path;
 import java.util.Optional;
 
 public interface BotConfiguration {
-
     /**
      * Folder that WorkItems may use to store permanent data.
      * @return
@@ -43,6 +43,14 @@ public interface BotConfiguration {
      * @return
      */
     HostedRepository repository(String name);
+
+    /**
+     * Retrieves the ref name that optionally follows the configuration-specific repository name.
+     * If not configured, returns the name of the VCS default branch.
+     * @param name
+     * @return
+     */
+    String repositoryRef(String name);
 
     /**
      * Additional bot-specific configuration.

--- a/bot/src/test/java/org/openjdk/skara/bot/BotRunnerConfigurationTests.java
+++ b/bot/src/test/java/org/openjdk/skara/bot/BotRunnerConfigurationTests.java
@@ -23,13 +23,14 @@
 package org.openjdk.skara.bot;
 
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
-import org.openjdk.skara.json.JSON;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.openjdk.skara.json.*;
 
-public class BotRunnerConfigurationTests {
+import static org.junit.jupiter.api.Assertions.*;
 
+class BotRunnerConfigurationTests {
     @Test
     void storageFolder() throws ConfigurationError {
         var input = JSON.object().put("storage", JSON.object().put("path", "/x"))
@@ -38,5 +39,29 @@ public class BotRunnerConfigurationTests {
         var botCfg = cfg.perBotConfiguration("xbot");
 
         assertEquals(Path.of("/x/xbot"), botCfg.storageFolder());
+    }
+
+    @Test
+    void parseHost() throws ConfigurationError {
+        var input = JSON.object()
+                        .put("xbot",
+                             JSON.object().put("repository", "test/x/y"));
+        var cfg = BotRunnerConfiguration.parse(input);
+        var botCfg = cfg.perBotConfiguration("xbot");
+
+        var error = assertThrows(RuntimeException.class, () -> botCfg.repository("test/x/y"));
+        assertEquals("Repository entry test/x/y uses undefined host 'test'", error.getCause().getMessage());
+    }
+
+    @Test
+    void parseRef() throws ConfigurationError {
+        var input = JSON.object()
+                        .put("xbot",
+                             JSON.object().put("repository", "test/x/y:z"));
+        var cfg = BotRunnerConfiguration.parse(input);
+        var botCfg = cfg.perBotConfiguration("xbot");
+
+        var error = assertThrows(RuntimeException.class, () -> botCfg.repositoryRef("test/x/y:z"));
+        assertEquals("Repository entry test/x/y uses undefined host 'test'", error.getCause().getMessage());
     }
 }


### PR DESCRIPTION
Hi all,

Please review this change that extends the BotRunner configuration parsing of repository names. Previously, every repository had to be described one time for each host/credential set it was to be used with. Now it is allowed to specify this directly as a string of the form `<host definition name>/<actual repository name>`. Additionally, a ref name can optionally be appended of the form `:<ref name>` at the end of the string.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)