### PR TITLE
76: Remove the "ready" label from a PR once it is integrated

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -146,6 +146,11 @@ class CheckWorkItem extends PullRequestWorkItem {
         // Filter out the active reviews
         var activeReviews = PullRequestInstance.filterActiveReviews(allReviews);
         if (!currentCheckValid(census, comments, activeReviews, labels)) {
+            if (labels.contains("integrated")) {
+                log.info("Skipping check of integrated PR");
+                return;
+            }
+
             try {
                 var prInstance = new PullRequestInstance(scratchPath.resolve("pr"), pr);
                 CheckRun.execute(this, pr, prInstance, comments, allReviews, activeReviews, labels, census, blockingLabels);

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandWorkItem.java
@@ -22,7 +22,6 @@
  */
 package org.openjdk.skara.bots.pr;
 
-import org.openjdk.skara.bot.WorkItem;
 import org.openjdk.skara.host.*;
 
 import java.io.*;
@@ -137,8 +136,12 @@ public class CommandWorkItem extends PullRequestWorkItem {
     public void run(Path scratchPath) {
         log.info("Looking for merge commands");
 
-        var comments = pr.getComments();
+        if (pr.getLabels().contains("integrated")) {
+            log.info("Skip checking for commands in integrated PR");
+            return;
+        }
 
+        var comments = pr.getComments();
         var unprocessedCommands = findCommandComments(comments);
         if (unprocessedCommands.isEmpty()) {
             log.fine("No new merge commands found, stopping further processing");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
@@ -110,6 +110,7 @@ public class IntegrateCommand implements CommandHandler {
                 prInstance.localRepo().push(rebasedHash.get(), pr.repository().getUrl(), pr.getTargetRef());
                 pr.setState(PullRequest.State.CLOSED);
                 pr.addLabel("integrated");
+                pr.removeLabel("ready");
             }
 
         } catch (Exception e) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
@@ -80,6 +80,8 @@ public class SponsorCommand implements CommandHandler {
                 prInstance.localRepo().push(rebasedHash.get(), pr.repository().getUrl(), pr.getTargetRef());
                 pr.setState(PullRequest.State.CLOSED);
                 pr.addLabel("integrated");
+                pr.removeLabel("sponsor");
+                pr.removeLabel("ready");
             }
         } catch (IOException e) {
             log.throwing("SponsorCommand", "handle", e);

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrateTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrateTests.java
@@ -43,9 +43,11 @@ class IntegrateTests {
 
             var author = credentials.getHostedRepository();
             var integrator = credentials.getHostedRepository();
+            var reviewer = credentials.getHostedRepository();
             var censusBuilder = credentials.getCensusBuilder()
                                            .addCommitter(author.host().getCurrentUserDetails().id())
-                                           .addReviewer(integrator.host().getCurrentUserDetails().id());
+                                           .addReviewer(integrator.host().getCurrentUserDetails().id())
+                                           .addReviewer(reviewer.host().getCurrentUserDetails().id());
             var mergeBot = new PullRequestBot(integrator, censusBuilder.build(), "master");
 
             // Populate the projects repository
@@ -88,6 +90,9 @@ class IntegrateTests {
             assertEquals("Generated Committer 1", headCommit.committer().name());
             assertEquals("integrationcommitter1@openjdk.java.net", headCommit.committer().email());
             assertTrue(pr.getLabels().contains("integrated"));
+
+            // Ready label should have been removed
+            assertFalse(pr.getLabels().contains("ready"));
         }
     }
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/SponsorTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/SponsorTests.java
@@ -111,6 +111,8 @@ class SponsorTests {
             assertEquals("Generated Reviewer 1", headCommit.committer().name());
             assertEquals("integrationreviewer1@openjdk.java.net", headCommit.committer().email());
             assertTrue(pr.getLabels().contains("integrated"));
+            assertFalse(pr.getLabels().contains("ready"));
+            assertFalse(pr.getLabels().contains("sponsor"));
         }
     }
 
@@ -303,11 +305,12 @@ class SponsorTests {
             // Flag it as ready for integration again
             pr.addComment("/integrate");
             TestBotRunner.runPeriodicItems(mergeBot);
+            assertTrue(pr.getLabels().contains("sponsor"));
 
             // It should now be possible to sponsor
             reviewerPr.addComment("/sponsor");
             TestBotRunner.runPeriodicItems(mergeBot);
-            assertTrue(pr.getLabels().contains("sponsor"));
+            assertFalse(pr.getLabels().contains("sponsor"));
 
             // The bot should have pushed the commit
             var pushed = pr.getComments().stream()


### PR DESCRIPTION
Hi all,

Please review this change that removes the ready (and sponsor) labels from a PR after it has been integrated.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)