### PR TITLE
Add support for Mercurial

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitFork.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitFork.java
@@ -55,21 +55,22 @@ public class GitFork {
         }
     }
 
-    private static Repository clone(URI from, Path dest) throws IOException {
+    private static Repository clone(URI from, Path dest, boolean isMercurial) throws IOException {
         try {
             var to = dest == null ? Path.of(from.getPath()).getFileName() : dest;
             if (to.toString().endsWith(".git")) {
                 to = Path.of(to.toString().replace(".git", ""));
             }
 
-            var pb = new ProcessBuilder("git", "clone", from.toString(), to.toString());
+            var vcs = isMercurial ? "hg" : "git";
+            var pb = new ProcessBuilder(vcs, "clone", from.toString(), to.toString());
             pb.inheritIO();
             var p = pb.start();
             var res = p.waitFor();
             if (res != 0) {
-                exit("'git clone " + from.toString() + " " + to.toString() + "' failed with exit code: " + res);
+                exit("'" + vcs + " clone " + from.toString() + " " + to.toString() + "' failed with exit code: " + res);
             }
-            return Repository.get(to).orElseThrow(() -> new IOException("Could not find git repository"));
+            return Repository.get(to).orElseThrow(() -> new IOException("Could not find repository"));
         } catch (InterruptedException e) {
             throw new IOException(e);
         }
@@ -93,6 +94,10 @@ public class GitFork {
             Switch.shortcut("")
                   .fullname("version")
                   .helptext("Print the version of this tool")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("mercurial")
+                  .helptext("Force use of mercurial")
                   .optional());
 
         var inputs = List.of(
@@ -107,6 +112,7 @@ public class GitFork {
 
         var parser = new ArgumentParser("git-fork", flags, inputs);
         var arguments = parser.parse(args);
+        var isMercurial = arguments.contains("mercurial");
 
         if (arguments.contains("version")) {
             System.out.println("git-fork version: " + Version.fromManifest().orElse("unknown"));
@@ -140,27 +146,39 @@ public class GitFork {
         }
 
         var host = Host.from(uri, new PersonalAccessToken(credentials.username(), credentials.password()));
-        path = credentials.path();
         if (path.endsWith(".git")) {
             path = path.substring(0, path.length() - 4);
         }
+        if (path.startsWith("/")) {
+            path = path.substring(1);
+        }
 
+        System.out.println("path: " + path);
         var fork = host.getRepository(path).fork();
 
         if (token == null) {
             GitCredentials.approve(credentials);
         }
 
+        var webUrl = fork.getWebUrl();
+        if (isMercurial) {
+            webUrl = URI.create("git+" + webUrl.toString());
+        }
         if (arguments.at(1).isPresent()) {
             System.out.println("Fork available at: " + fork.getWebUrl());
             var dest = arguments.at(1).asString();
-            System.out.println("Cloning " + fork.getWebUrl() + "...");
-            var repo = clone(fork.getWebUrl(), Path.of(dest));
-            System.out.print("Adding remote 'upstream' for " + uri.toString() + "...");
-            repo.addRemote("upstream", uri.toString());
+            System.out.println("Cloning " + webUrl + "...");
+            var repo = clone(webUrl, Path.of(dest), isMercurial);
+            var remoteWord = isMercurial ? "path" : "remote";
+            System.out.print("Adding " + remoteWord + " 'upstream' for " + uri.toString() + "...");
+            var upstreamUrl = uri.toString();
+            if (isMercurial) {
+                upstreamUrl = "git+" + upstreamUrl;
+            }
+            repo.addRemote("upstream", upstreamUrl);
             System.out.println("done");
         } else {
-            System.out.println(fork.getWebUrl());
+            System.out.println(webUrl);
         }
     }
 }

--- a/cli/src/main/java/org/openjdk/skara/cli/GitFork.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitFork.java
@@ -153,7 +153,6 @@ public class GitFork {
             path = path.substring(1);
         }
 
-        System.out.println("path: " + path);
         var fork = host.getRepository(path).fork();
 
         if (token == null) {

--- a/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
@@ -156,6 +156,9 @@ public class GitPr {
     }
 
     private static URI toURI(String remotePath) throws IOException {
+        if (remotePath.startsWith("git+")) {
+            remotePath = remotePath.substring(4);
+        }
         if (remotePath.startsWith("http")) {
             return URI.create(remotePath);
         } else if (remotePath.startsWith("ssh://")) {
@@ -238,6 +241,10 @@ public class GitPr {
                   .helptext("Hide any decorations when listing PRs")
                   .optional(),
             Switch.shortcut("")
+                  .fullname("mercurial")
+                  .helptext("Force use of Mercurial (hg)")
+                  .optional(),
+            Switch.shortcut("")
                   .fullname("verbose")
                   .helptext("Turn on verbose output")
                   .optional(),
@@ -276,9 +283,10 @@ public class GitPr {
 
         HttpProxy.setup();
 
+        var isMercurial = arguments.contains("mercurial");
         var cwd = Path.of("").toAbsolutePath();
         var repo = Repository.get(cwd).orElseThrow(() -> new IOException("no git repository found at " + cwd.toString()));
-        var remote = arguments.get("remote").orString("origin");
+        var remote = arguments.get("remote").orString(isMercurial ? "default" : "origin");
         var remotePullPath = repo.pullPath(remote);
         var username = arguments.contains("username") ? arguments.get("username").asString() : null;
         var token = System.getenv("GIT_TOKEN");

--- a/cli/src/main/java/org/openjdk/skara/cli/GitWebrev.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitWebrev.java
@@ -97,7 +97,7 @@ public class GitWebrev {
                   .helptext("Use that username instead of 'guessing' one")
                   .optional(),
             Option.shortcut("")
-                  .fullname("repository")
+                  .fullname("upstream")
                   .describe("URL")
                   .helptext("The URL to the upstream repository")
                   .optional(),
@@ -150,7 +150,7 @@ public class GitWebrev {
         var repo = repository.get();
         var isMercurial = arguments.contains("mercurial");
 
-        var upstream = arg("repository", arguments, repo);
+        var upstream = arg("upstream", arguments, repo);
         if (upstream == null) {
             try {
                 var remote = isMercurial ? "default" : "origin";

--- a/skara.py
+++ b/skara.py
@@ -1,0 +1,155 @@
+# Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+
+import mercurial
+import os.path
+import subprocess
+import sys
+import shutil
+
+cmdtable = {}
+if hasattr(mercurial, 'registrar') and hasattr(mercurial.registrar, 'command'):
+    command = mercurial.registrar.command(cmdtable)
+elif hasattr(mercurial.cmdutil, 'command'):
+    command = mercurial.cmdutil.command(cmdtable)
+else:
+    def command(name, options, synopsis):
+        def decorator(func):
+            cmdtable[name] = func, list(options), synopsis
+            return func
+        return decorator
+
+def _skara(ui, args, **opts):
+    for k in opts:
+        if opts[k] == True:
+            args.append('--' + k.replace('_', '-'))
+        elif opts[k] != '' and opts[k] != False:
+            args.append('--' + k)
+            args.append(opts[k])
+    skara = os.path.dirname(os.path.realpath(__file__))
+    git_skara = os.path.join(skara, 'bin', 'bin', 'git-skara')
+    if not os.path.isfile(git_skara):
+        ui.status("Bootstrapping Skara itself...\n")
+        p = subprocess.Popen(['/bin/sh', 'gradlew'], cwd=skara)
+        ret = p.wait()
+        if ret != 0:
+            ui.error("Error: could not bootstrap Skara\n")
+            sys.exit(1)
+
+    skara_bin = os.path.join(skara, 'bin')
+    skara_build = os.path.join(skara, 'build')
+    if os.path.isdir(skara_build):
+        if os.path.isdir(skara_bin):
+            shutil.rmtree(skara_bin)
+        shutil.move(skara_build, skara_bin)
+
+    sys.exit(subprocess.call([git_skara] + args))
+
+fork_opts = [
+    ('u', 'username', '', 'Username on host'),
+]
+@command('fork', fork_opts, 'hg fork URL [DEST]', norepo=True)
+def fork(ui, url, dest=None, **opts):
+    username = None
+    if opts['username'] != '' and url.startswith('http'):
+        username = ui.config('credential "' + url + '"', 'username')
+        if username == None:
+            protocol, rest = url.split('://')
+            hostname = rest[:rest.find('/')]
+            username = ui.config('credential "' + protocol + '://' + hostname + '"', 'username')
+            if username == None:
+                username = ui.config('credential', 'username')
+    args = ['fork', '--mercurial']
+    if username != None:
+        args.append("--username")
+        args.append(username)
+    args.append(url)
+    if dest != None:
+        args.append(dest)
+    _skara(ui, args)
+
+webrev_opts = [
+    ('r', 'rev', '', 'Compare against specified revision'),
+    ('o', 'output', '', 'Output directory'),
+    ('u', 'username', '', 'Use that username instead "guessing" one'),
+    ('',  'upstream', '', 'The URL to the upstream repository'),
+    ('t', 'title', '', 'The title of the webrev'),
+    ('c', 'cr', '', 'Include a link to CR (aka bugid) in the main page'),
+    ('b', 'b', False, 'Do not ignore changes in whitespace'),
+    ('C', 'no-comments', False, "Don't show comments"),
+    ('N', 'no-outgoing', False, "Do not compare against remote, use only 'status'"),
+
+]
+@command('webrev', webrev_opts, 'hg webrev')
+def webrev(ui, repo, **opts):
+    _skara(ui, ['webrev', '--mercurial'], **opts)
+
+jcheck_opts = [
+    ('r', 'rev', '', 'Check the specified revision or range (default: tip)'),
+    ('',  'whitelist', '', 'Use specified whitelist (default: .jcheck/whitelist.json)'),
+    ('',  'blacklist', '', 'Use specified blacklist (default: .jcheck/blacklist.json)'),
+    ('',  'census', '', 'Use the specified census (default: https://openjdk.java.net/census.xml)'),
+    ('',  'local', False, 'Run jcheck in "local" mode'),
+    ('',  'lax', False, 'Check comments, tags and whitespace laxly'),
+    ('s', 'strict', False, 'Check everything')
+]
+@command('jcheck', jcheck_opts, 'hg jcheck')
+def jcheck(ui, repo, **opts):
+    _skara(ui, ['jcheck', '--mercurial'], **opts)
+
+defpath_opts = [
+    ('u', 'username', '', 'Username for push URL'),
+    ('r', 'remote', '', 'Remote for which to set paths'),
+    ('s', 'secondary', '', 'Secondary peer repostiory base URL'),
+    ('d', 'default', False, 'Use current default path to compute push path'),
+    ('g', 'gated', False, 'Created gated push URL'),
+    ('n', 'dry-run', False, 'Do not perform actions, just print output'),
+]
+@command('defpath', defpath_opts, 'hg defpath')
+def defpath(ui, repo, **opts):
+    _skara(ui, ['defpath', '--mercurial'], **opts)
+
+info_opts = [
+    ('', 'no-decoration', False, 'Do not prefix lines with any decoration'),
+    ('', 'issues', False, 'Show issues'),
+    ('', 'reviewers', False, 'Show reviewers'),
+    ('', 'summary', False, 'Show summary (if present)'),
+    ('', 'sponsor', False, 'Show sponsor (if present)'),
+    ('', 'author', False, 'Show author'),
+    ('', 'contributors', False, 'Show contributors')
+]
+@command('info', info_opts, 'hg info')
+def info(ui, repo, rev, **opts):
+    _skara(ui, ['info', '--mercurial', rev], **opts)
+
+pr_opts = [
+    ('u', 'username', '', 'Username on host'),
+    ('r', 'remote', '', 'Name of remote, defaults to "origin"'),
+    ('b', 'branch', '', 'Name of target branch, defaults to "master"'),
+    ('',  'authors', '', 'Comma separated list of authors'),
+    ('',  'assignees', '', 'Comma separated list of assignees'),
+    ('',  'labels', '', 'Comma separated list of labels'),
+    ('',  'columns', '', 'Comma separated list of columns to show'),
+    ('', 'no-decoration', False, 'Do not prefix lines with any decoration')
+]
+@command('pr', info_opts, 'hg pr <list|fetch|show|checkout|apply|integrate|approve|create|close|update>')
+def pr(ui, repo, action, **opts):
+    _skara(ui, ['pr', '--mercurial', action], **opts)

--- a/skara.py
+++ b/skara.py
@@ -25,6 +25,8 @@ import subprocess
 import sys
 import shutil
 
+testedwith = '4.9.2'
+
 cmdtable = {}
 if hasattr(mercurial, 'registrar') and hasattr(mercurial.registrar, 'command'):
     command = mercurial.registrar.command(cmdtable)


### PR DESCRIPTION
Hi all,

this patch adds skara.py which makes it quite a bit more convenient to use the Skara tools from Mercurial (hg). I also added `--mercurial` to `git-pr` and `git-fork` so they can be used with [hg-git](https://bitbucket.org/durin42/hg-git). There are still a few minor things to work out, for example `hg pr create` does not work yet and I need to do add some help texts, but it is a start.

## Testing
- [x] Manual testing with git token

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**) **Note!** Review applies to fadd0cd8aab3d351ec697fd83ab0ba547a6738b0