### PR TITLE
Use either the contributor mail or a host-specific noreply address

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
@@ -227,8 +227,7 @@ class ArchiveWorkItem implements WorkItem {
 
         var census = CensusInstance.create(bot.censusRepo(), bot.censusRef(), scratchPath.resolve("census"), pr);
         var prInstance = new PullRequestInstance(scratchPath.resolve("mlbridge-mergebase"), pr);
-        var reviewArchive = new ReviewArchive(bot.emailAddress(), prInstance, sentMails,
-                                              " via " + pr.repository().getUrl().getHost());
+        var reviewArchive = new ReviewArchive(bot.emailAddress(), prInstance, census, sentMails);
         var webrevPath = scratchPath.resolve("mlbridge-webrevs");
         var listServer = MailingListServerFactory.createMailmanServer(bot.listArchive(), bot.smtpServer());
         var list = listServer.getList(bot.listAddress().address());
@@ -280,7 +279,7 @@ class ArchiveWorkItem implements WorkItem {
             if (ignoreComment(review.reviewer(), review.body().orElse(""))) {
                 continue;
             }
-            reviewArchive.addReview(review, census);
+            reviewArchive.addReview(review);
         }
 
         // File specific comments

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBot.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBot.java
@@ -100,16 +100,17 @@ public class MailingListArchiveReaderBot implements Bot {
             parsedEmailIds.add(newMessage.id());
         }
 
-        // Filter out bridged comments
-        var bridgeCandidates = newMessages.stream()
-                .filter(email -> !email.author().address().equals(archivePoster.address()))
-                .collect(Collectors.toList());
+        var pr = parsedConversations.get(conversation.first().id());
+        var bridgeIdPattern = Pattern.compile("^[^.]+\\.[^.]+@" + pr.repository().getUrl().getHost() + "$");
 
+        // Filter out already bridged comments
+        var bridgeCandidates = newMessages.stream()
+                .filter(email -> !bridgeIdPattern.matcher(email.id().address()).matches())
+                .collect(Collectors.toList());
         if (bridgeCandidates.isEmpty()) {
             return;
         }
 
-        var pr = parsedConversations.get(conversation.first().id());
         var workItem = new CommentPosterWorkItem(pr, bridgeCandidates);
         commentQueue.add(workItem);
     }

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
@@ -14,8 +14,8 @@ import java.util.stream.*;
 
 class ReviewArchive {
     private final PullRequestInstance prInstance;
+    private final CensusInstance censusInstance;
     private final EmailAddress sender;
-    private final String nameDecoration;
     private final List<Email> existing;
     private final Map<String, Email> existingIds = new HashMap<>();
     private final List<Email> generated = new ArrayList<>();
@@ -24,8 +24,14 @@ class ReviewArchive {
     private final List<Hash> reportedBases;
 
     private EmailAddress getAuthorAddress(HostUserDetails originalAuthor) {
-        return EmailAddress.from(originalAuthor.fullName() + nameDecoration,
-                                 sender.address());
+        var contributor = censusInstance.namespace().get(originalAuthor.id());
+        if (contributor == null) {
+            return EmailAddress.from(originalAuthor.fullName(),
+                                     originalAuthor.id() + "+" + originalAuthor.userName() + "@users.noreply." + censusInstance.namespace().name());
+        } else {
+            return EmailAddress.from(contributor.fullName().orElse(originalAuthor.fullName()),
+                                     contributor.username() + "@" + censusInstance.configuration().census().domain());
+        }
     }
 
     private EmailAddress getUniqueMessageId(String identifier) {
@@ -127,10 +133,10 @@ class ReviewArchive {
         return parent;
     }
 
-    ReviewArchive(EmailAddress sender, PullRequestInstance prInstance, List<Email> sentMails, String nameDecoration) {
+    ReviewArchive(EmailAddress sender, PullRequestInstance prInstance, CensusInstance censusInstance, List<Email> sentMails) {
         this.sender = sender;
         this.prInstance = prInstance;
-        this.nameDecoration = nameDecoration;
+        this.censusInstance = censusInstance;
 
         existing = sentMails;
         for (var email : existing) {
@@ -308,7 +314,7 @@ class ReviewArchive {
         addReplyCommon(parent, comment.author(), "Re: RFR: " + prInstance.pr().getTitle(), comment.body(), id);
     }
 
-    private String projectRole(Contributor contributor, CensusInstance censusInstance) {
+    private String projectRole(Contributor contributor) {
         var version = censusInstance.configuration().census().version();
         if (censusInstance.project().isLead(contributor.username(), version)) {
             return "Lead";
@@ -322,7 +328,7 @@ class ReviewArchive {
         return "none";
     }
 
-    void addReview(Review review, CensusInstance censusInstance) {
+    void addReview(Review review) {
         var contributor = censusInstance.namespace().get(review.reviewer().id());
 
         // Post the review body as a regular comment
@@ -331,7 +337,7 @@ class ReviewArchive {
             if (!existingIds.containsKey(getStableMessageId(id))) {
                 var parent = topCommentForHash(review.hash());
                 var userName = contributor != null ? contributor.username() : review.reviewer().userName() + "@" + censusInstance.namespace().name();
-                var userRole = contributor != null ? projectRole(contributor, censusInstance) : "none";
+                var userRole = contributor != null ? projectRole(contributor) : "none";
                 var replyBody = ArchiveMessages.reviewCommentBody(review.body().get(), review.verdict(), userName, userRole);
                 addReplyCommon(parent, review.reviewer(), "Re: RFR: " + prInstance.pr().getTitle(), replyBody, id);
             }


### PR DESCRIPTION
Hi all,

Please review this change that uses either the contributor commit email `alias@openjdk.org` (or a hosting-specific noreply address in case the user is not a known author) when sending pull request comments to openjdk mailing lists. 

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)