### PR TITLE
Add Mercurial mapping for skara command

### DIFF
--- a/skara.py
+++ b/skara.py
@@ -200,3 +200,7 @@ def pr(ui, repo, action, n=None, **opts):
     if n != None:
         args.append(n)
     _skara(ui, args, **opts)
+
+@command('skara', [], 'hg skara')
+def skara(ui, repo, action, **opts):
+    _skara(ui, [action, '--mercurial'], **opts)


### PR DESCRIPTION
Hi all,

this small patch just adds a Mercurial (hg) mapping for the `skara` command (used for help and update).

Thanks,
Erik

PR. This commit for this pull request was pushed with `hg` :smile:
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)