### PR TITLE
Adjust collapsing of multiple emails

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
@@ -154,8 +154,4 @@ class ArchiveMessages {
         }
         return result.toString();
     }
-
-    static String reviewApprovalBodyReviewer(String reviewer) {
-        return "This PR has been marked as Reviewed by " + reviewer + ".";
-    }
 }

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
@@ -244,7 +244,10 @@ class ReviewArchive {
 
         // Is it a self-reply?
         if (parent.author().equals(getAuthorAddress(author)) && generatedIds.containsKey(parentId)) {
-            return Optional.of(parent);
+            // But avoid extending top-level parents
+            if (!parent.hasHeader("PR-Head-Hash")) {
+                return Optional.of(parent);
+            }
         }
 
         // Have we already replied to the same parent?

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
@@ -64,16 +64,8 @@ class ReviewArchive {
         return getUniqueMessageId("ha" + hash.hex());
     }
 
-    private EmailAddress getMessageId(String raw) {
-        return getUniqueMessageId("rw" + raw);
-    }
-
-    private EmailAddress getMessageId(Review review, boolean verdict) {
-        if (verdict) {
-            return getUniqueMessageId("rvvd" + review.id());
-        } else {
-            return getUniqueMessageId("rv" + review.id());
-        }
+    private EmailAddress getMessageId(Review review) {
+        return getUniqueMessageId("rv" + review.id());
     }
 
     private String getStableMessageId(EmailAddress uniqueMessageId) {
@@ -239,14 +231,17 @@ class ReviewArchive {
         generatedIds.put(getStableMessageId(id), email);
     }
 
-    private Optional<Email> findCollapsable(Email parent, HostUserDetails author) {
+    private Optional<Email> findCollapsable(Email parent, HostUserDetails author, String subject) {
         var parentId = getStableMessageId(parent.id());
 
         // Is it a self-reply?
         if (parent.author().equals(getAuthorAddress(author)) && generatedIds.containsKey(parentId)) {
             // But avoid extending top-level parents
             if (!parent.hasHeader("PR-Head-Hash")) {
-                return Optional.of(parent);
+                // And only collapse identical subjects
+                if (parent.subject().equals(subject)) {
+                    return Optional.of(parent);
+                }
             }
         }
 
@@ -258,7 +253,10 @@ class ReviewArchive {
             var inReplyTo = EmailAddress.parse(candidate.headerValue("In-Reply-To"));
             var candidateParentId = getStableMessageId(inReplyTo);
             if (candidateParentId.equals(parentId) && candidate.author().equals(getAuthorAddress(author))) {
-                return Optional.of(candidate);
+                // Only collapse identical subjects
+                if (candidate.subject().equals(subject)) {
+                    return Optional.of(candidate);
+                }
             }
         }
 
@@ -275,7 +273,7 @@ class ReviewArchive {
         }
 
         // Collapse self-replies and replies-to-same that have been created in this run
-        var collapsable = findCollapsable(parent, author);
+        var collapsable = findCollapsable(parent, author, subject);
         if (collapsable.isPresent()) {
             // Drop the parent
             var parentEmail = collapsable.get();
@@ -336,31 +334,29 @@ class ReviewArchive {
     }
 
     void addReview(Review review) {
+        var id = getMessageId(review);
+        if (existingIds.containsKey(getStableMessageId(id))) {
+            return;
+        }
+
         var contributor = censusInstance.namespace().get(review.reviewer().id());
+        var isReviewer = contributor != null && censusInstance.project().isReviewer(contributor.username(), censusInstance.configuration().census().version());
 
-        // Post the review body as a regular comment
-        if (review.body().isPresent()) {
-            var id = getMessageId(review, false);
-            if (!existingIds.containsKey(getStableMessageId(id))) {
-                var parent = topCommentForHash(review.hash());
-                var userName = contributor != null ? contributor.username() : review.reviewer().userName() + "@" + censusInstance.namespace().name();
-                var userRole = contributor != null ? projectRole(contributor) : "none";
-                var replyBody = ArchiveMessages.reviewCommentBody(review.body().get(), review.verdict(), userName, userRole);
-                addReplyCommon(parent, review.reviewer(), parent.subject(), replyBody, id);
-            }
+        // Default parent and subject
+        var parent = topCommentForHash(review.hash());
+        var subject = parent.subject();
+
+        // Approvals by Reviewers get special treatment - post these as top-level comments
+        if (review.verdict() == Review.Verdict.APPROVED && isReviewer) {
+            parent = topEmail();
+            subject = "Approved and Reviewed by " + contributor.username();
         }
 
-        if (contributor != null) {
-            var isReviewer = censusInstance.project().isReviewer(contributor.username(), censusInstance.configuration().census().version());
-            if (review.verdict() == Review.Verdict.APPROVED && isReviewer) {
-                var id = getMessageId(review, true);
-                if (!existingIds.containsKey(getStableMessageId(id))) {
-                    var parent = topEmail();
-                    var replyBody = ArchiveMessages.reviewApprovalBodyReviewer(contributor.username());
-                    addReplyCommon(parent, review.reviewer(), "Approved and Reviewed by " + contributor.username(), replyBody, id);
-                }
-            }
-        }
+        var userName = contributor != null ? contributor.username() : review.reviewer().userName() + "@" + censusInstance.namespace().name();
+        var userRole = contributor != null ? projectRole(contributor) : "none";
+        var replyBody = ArchiveMessages.reviewCommentBody(review.body().orElse(""), review.verdict(), userName, userRole);
+
+        addReplyCommon(parent, review.reviewer(), subject, replyBody, id);
     }
 
     void addReviewComment(ReviewComment reviewComment) {

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -359,7 +359,10 @@ class MailingListBridgeBotTests {
             localRepo.push(editHash, author.getUrl(), "edit", true);
             var pr = credentials.createPullRequest(archive, "master", "edit", "This is a pull request");
             pr.setBody("This is now ready");
+            pr.addComment("Avoid combining");
+
             TestBotRunner.runPeriodicItems(mlBot);
+            listServer.processIncoming();
             listServer.processIncoming();
 
             // Make two file specific comments
@@ -370,7 +373,7 @@ class MailingListBridgeBotTests {
 
             // The archive should contain a combined entry
             Repository.materialize(archiveFolder.path(), archive.getUrl(), "master");
-            assertEquals(1, archiveContainsCount(archiveFolder.path(), "^On.*wrote:"));
+            assertEquals(2, archiveContainsCount(archiveFolder.path(), "^On.*wrote:"));
 
             // As well as the mailing list
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP());
@@ -379,14 +382,18 @@ class MailingListBridgeBotTests {
             assertEquals(1, conversations.size());
             var mail = conversations.get(0).first();
             assertEquals("RFR: This is a pull request", mail.subject());
-            assertEquals(2, conversations.get(0).allMessages().size());
+            assertEquals(3, conversations.get(0).allMessages().size());
 
-            var reply = conversations.get(0).replies(mail).get(0);
-            assertEquals(2, reply.body().split("^On.*wrote:").length);
-            assertEquals(2, reply.body().split("> This is now ready").length, reply.body());
-            assertEquals("Re: RFR: This is a pull request", reply.subject());
-            assertTrue(reply.body().contains("Review comment\n\n"), reply.body());
-            assertTrue(reply.body().contains("Another review comment"), reply.body());
+            var commentReply = conversations.get(0).replies(mail).get(0);
+            assertEquals(2, commentReply.body().split("^On.*wrote:").length);
+            assertTrue(commentReply.body().contains("Avoid combining\n\n"), commentReply.body());
+
+            var reviewReply = conversations.get(0).replies(mail).get(1);
+            assertEquals(2, reviewReply.body().split("^On.*wrote:").length);
+            assertEquals(2, reviewReply.body().split("> This is now ready").length, reviewReply.body());
+            assertEquals("Re: RFR: This is a pull request", reviewReply.subject());
+            assertTrue(reviewReply.body().contains("Review comment\n\n"), reviewReply.body());
+            assertTrue(reviewReply.body().contains("Another review comment"), reviewReply.body());
         }
     }
 

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -453,9 +453,16 @@ class MailingListBridgeBotTests {
             listServer.processIncoming();
             listServer.processIncoming();
 
+            // Finally some approvals
+            pr.addReview(Review.Verdict.APPROVED, "Nice");
+            reviewPr.addReview(Review.Verdict.APPROVED, "Looks fine");
+            TestBotRunner.runPeriodicItems(mlBot);
+            listServer.processIncoming();
+            listServer.processIncoming();
+
             // Sanity check the archive
             Repository.materialize(archiveFolder.path(), archive.getUrl(), "master");
-            assertEquals(6, archiveContainsCount(archiveFolder.path(), "^On.*wrote:"));
+            assertEquals(8, archiveContainsCount(archiveFolder.path(), "^On.*wrote:"));
 
             // Check the mailing list
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP());
@@ -464,9 +471,9 @@ class MailingListBridgeBotTests {
             assertEquals(1, conversations.size());
             var mail = conversations.get(0).first();
             assertEquals("RFR: This is a pull request", mail.subject());
-            assertEquals(7, conversations.get(0).allMessages().size());
+            assertEquals(9, conversations.get(0).allMessages().size());
 
-            // There should be two separate threads
+            // There should be four separate threads
             var thread1 = conversations.get(0).replies(mail).get(0);
             assertEquals(2, thread1.body().split("^On.*wrote:").length);
             assertEquals(2, thread1.body().split("> This is now ready").length, thread1.body());
@@ -492,6 +499,11 @@ class MailingListBridgeBotTests {
             assertTrue(thread2reply1.body().contains("Sounds good"));
             var thread2reply2 = conversations.get(0).replies(thread2reply1).get(0);
             assertTrue(thread2reply2.body().contains("Thanks"));
+
+            var thread3 = conversations.get(0).replies(mail).get(2);
+            assertEquals("Re: RFR: This is a pull request", thread3.subject());
+            var thread4 = conversations.get(0).replies(mail).get(3);
+            assertEquals("Re: Approved and Reviewed by integrationreviewer1", thread4.subject());
         }
     }
 
@@ -1011,7 +1023,7 @@ class MailingListBridgeBotTests {
             if (author.host().supportsReviewBody()) {
                 assertEquals(1, archiveContainsCount(archiveFolder.path(), "Reason 2"));
             }
-            assertEquals(1, archiveContainsCount(archiveFolder.path(), "This PR has been marked as Reviewed by integrationreviewer1."));
+            assertEquals(1, archiveContainsCount(archiveFolder.path(), "Re: Approved and Reviewed by integrationreviewer1"));
 
             // Yet another change
             reviewedPr.addReview(Review.Verdict.DISAPPROVED, "Reason 3");


### PR DESCRIPTION
Hi all,

Please review this change that improves the collapse handling of multiple emails generated in a single archival run. It should only combine multiple review comments, and avoid merging top-level comments.

Best regards,
Robin