### PR TITLE
Add currentBookmark method to TestRepository

### DIFF
--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/TestRepository.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/TestRepository.java
@@ -44,6 +44,10 @@ class TestRepository implements ReadOnlyRepository {
         currentBranch = branch;
     }
 
+    public Optional<Bookmark> currentBookmark() {
+        return Optional.empty();
+    }
+
     public Branch defaultBranch() throws IOException {
         return defaultBranch;
     }


### PR DESCRIPTION
Hi all,

please review this small patch that adds the method `currentBookmark` to `TestRepository` (I forgot to add it in the previous patch, sorry).

## Testing
- [x] `sh gradlew test` passes

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)