### PR TITLE
Filter out PR-headers before sending mails

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
@@ -5,7 +5,6 @@ import org.openjdk.skara.email.*;
 import org.openjdk.skara.host.*;
 import org.openjdk.skara.vcs.Hash;
 
-import java.io.*;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.security.*;
@@ -184,12 +183,7 @@ class ReviewArchive {
     }
 
     private String latestHeadPrefix() {
-        try {
-            var latestCommit = prInstance.localRepo().lookup(prInstance.headHash()).orElseThrow(RuntimeException::new);
-            return String.format("[Rev %02d]", revisionCount());
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+        return String.format("[Rev %02d]", revisionCount());
     }
 
     void addFull(URI webrev) {

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -881,6 +881,7 @@ class MailingListBridgeBotTests {
             for (var newMail : conversations.get(0).allMessages()) {
                 assertEquals(noreplyAddress(archive), newMail.author().address());
                 assertEquals(sender, newMail.sender());
+                assertFalse(newMail.hasHeader("PR-Head-Hash"));
             }
             assertEquals("Re: [Rev 01]: RFR: This is a pull request", conversations.get(0).allMessages().get(1).subject());
         }

--- a/email/src/main/java/org/openjdk/skara/email/EmailBuilder.java
+++ b/email/src/main/java/org/openjdk/skara/email/EmailBuilder.java
@@ -92,6 +92,12 @@ public class EmailBuilder {
         return this;
     }
 
+    public EmailBuilder replaceHeaders(Map<String, String> headers) {
+        this.headers.clear();
+        this.headers.putAll(headers);
+        return this;
+    }
+
     public EmailBuilder date(ZonedDateTime date) {
         this.date = date;
         return this;


### PR DESCRIPTION
Hi all,

Please review this change that removes the "internal" PR-headers used by the mailinglist bridge to keep track of certain metadata. This data is used within the internal archives, but does not need to be sent out to actual mailinglists.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)