### PR TITLE
Update to JUnit 5.5.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,12 +43,12 @@ configure(subprojects.findAll() { it.name != 'bots' }) {
     }
 
     dependencies {
-        testImplementation 'org.junit.jupiter:junit-jupiter-api:5.5.1'
-        testImplementation 'org.junit.jupiter:junit-jupiter-params:5.5.1'
-        testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.5.1'
+        testImplementation 'org.junit.jupiter:junit-jupiter-api:5.5.2'
+        testImplementation 'org.junit.jupiter:junit-jupiter-params:5.5.2'
+        testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.5.2'
         // Force Gradle to load the JUnit Platform Launcher from the module-path, as
         // configured in buildSrc/.../ModulePlugin.java -- see SKARA-69 for details.
-        testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.5.1'
+        testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.5.2'
     }
 
     compileJava.options.encoding = 'UTF-8'


### PR DESCRIPTION
Hi all,

this small patch updates the JUnit dependency to 5.5.2.

## Testing
- [x] `sh gradlew test` passes on Linux x86_64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)