### PR TITLE
Update to Gradle 5.6.2

### DIFF
--- a/deps.env
+++ b/deps.env
@@ -7,5 +7,5 @@ JDK_MACOS_SHA256="52164a04db4d3fdfe128cfc7b868bc4dae52d969f03d53ae9d4239fe783e1a
 JDK_WINDOWS_URL="https://download.java.net/java/GA/jdk12/GPL/openjdk-12_windows-x64_bin.zip"
 JDK_WINDOWS_SHA256="35a8d018f420fb05fe7c2aa9933122896ca50bd23dbd373e90d8e2f3897c4e92"
 
-GRADLE_URL="https://services.gradle.org/distributions/gradle-5.2.1-bin.zip"
-GRADLE_SHA256="748c33ff8d216736723be4037085b8dc342c6a0f309081acf682c9803e407357"
+GRADLE_URL="https://services.gradle.org/distributions/gradle-5.6.2-bin.zip"
+GRADLE_SHA256="32fce6628848f799b0ad3205ae8db67d0d828c10ffe62b748a7c0d9f4a5d9ee0"

--- a/test.dockerfile
+++ b/test.dockerfile
@@ -60,6 +60,8 @@ ENV LC_ALL en_US.UTF-8
 RUN yum -y install unzip rsync
 
 COPY gradlew ./
+COPY deps.env ./
+COPY Unzip.java ./
 
 ENV JAVA_TOOL_OPTIONS=$JAVA_OPTIONS
 RUN sh gradlew --no-daemon --version $GRADLE_OPTIONS


### PR DESCRIPTION
Hi all,

this patch updates Gradle to version 5.6.2.

## Testing
- [x] `sh gradlew images` produces correct images
- [x] `sh gradlew test` passes
- [x] `sh gradlew reproduce` passes

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)