### PR TITLE
Update to Oracle Linux 7.6

### DIFF
--- a/test.dockerfile
+++ b/test.dockerfile
@@ -19,7 +19,7 @@
 # or visit www.oracle.com if you need additional information or have any
 # questions.
 
-FROM oraclelinux:7.5 as prerequisites-runtime
+FROM oraclelinux:7.6 as prerequisites-runtime
 
 WORKDIR /bots-build
 
@@ -46,7 +46,7 @@ RUN curl -sSO https://mirrors.edge.kernel.org/pub/software/scm/git/git-${GIT_VER
     make install
 
 
-FROM oraclelinux:7.5
+FROM oraclelinux:7.6
 
 WORKDIR /bots-build
 


### PR DESCRIPTION
Hi all,

this small patch updates the base image in `test.dockerfile` from Oracle Linux 7.5 to 7.6.

## Testing
- [x] `sh gradlew reproduce`

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)