### PR TITLE
Stop throwing when unable to find a matching PR

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/MailingListUpdater.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/MailingListUpdater.java
@@ -177,10 +177,7 @@ public class MailingListUpdater implements UpdateConsumer {
     public void handleCommits(HostedRepository repository, List<Commit> commits, Branch branch) {
         switch (mode) {
             case PR_ONLY:
-                var remaining = filterAndSendPrCommits(repository, commits);
-                if (remaining.size() > 0) {
-                    throw new RuntimeException("Failed to match a commit with a PR!");
-                }
+                filterAndSendPrCommits(repository, commits);
                 break;
             case PR:
                 commits = filterAndSendPrCommits(repository, commits);

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdaterTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdaterTests.java
@@ -423,9 +423,10 @@ class UpdaterTests {
             assertFalse(email.body().contains("Committer"));
             assertFalse(email.body().contains(masterHash.abbreviate()));
 
-            // Now push the other one without a matching PR - PR_ONLY should make us throw an exception
+            // Now push the other one without a matching PR - PR_ONLY will not generate a mail
             localRepo.push(otherHash, repo.getUrl(), "master");
-            assertThrows(RuntimeException.class, () -> TestBotRunner.runPeriodicItems(notifyBot));
+            TestBotRunner.runPeriodicItems(notifyBot);
+            assertThrows(RuntimeException.class, () -> listServer.processIncoming(Duration.ofSeconds(1)));
         }
     }
 


### PR DESCRIPTION
Hi all,

Please review this change that stops throwing an exception when failing to match a change to an existing PR in the PR-only mode, as this is not very useful.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)