### PR TITLE
Add an issue link to RFR mails if the PR title contains one

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
@@ -59,12 +59,14 @@ class ArchiveMessages {
         if (filteredBody.isEmpty()) {
             filteredBody = prInstance.pr().getTitle().strip();
         }
+        var issueString = prInstance.issueUrl().map(url -> "  Issue: " + url + "\n").orElse("");
         return filteredBody + "\n\n" +
                 infoSeparator + "\n\n" +
                 "Commits:\n" +
                 commitMessages + "\n\n" +
                 "Changes: " + prInstance.changeUrl() + "\n" +
                 " Webrev: " + webrev.toString() + "\n" +
+                issueString +
                 "  Stats: " + prInstance.stats(prInstance.baseHash(), prInstance.headHash()) + "\n" +
                 "  Patch: " + prInstance.diffUrl() + "\n" +
                 "  Fetch: " + prInstance.fetchCommand() + "\n\n" +
@@ -73,12 +75,14 @@ class ArchiveMessages {
 
     static String composeRebaseComment(PullRequestInstance prInstance, URI fullWebrev) {
         var commitMessages = prInstance.formatCommitMessages(prInstance.baseHash(), prInstance.headHash(), ArchiveMessages::formatCommit);
+        var issueString = prInstance.issueUrl().map(url -> "  Issue: " + url + "\n").orElse("");
         return "The pull request has been updated with a complete new set of changes (possibly due to a rebase).\n\n" +
                 infoSeparator + "\n\n" +
                 "Commits:\n" +
                 commitMessages + "\n\n" +
                 "Changes: " + prInstance.changeUrl() + "\n" +
                 " Webrev: " + fullWebrev.toString() + "\n" +
+                issueString +
                 "  Stats: " + prInstance.stats(prInstance.baseHash(), prInstance.headHash()) + "\n" +
                 "  Patch: " + prInstance.diffUrl() + "\n" +
                 "  Fetch: " + prInstance.fetchCommand() + "\n\n" +
@@ -86,6 +90,7 @@ class ArchiveMessages {
 
     static String composeIncrementalComment(Hash lastHead, PullRequestInstance prInstance, URI fullWebrev, URI incrementalWebrev) {
         var newCommitMessages = prInstance.formatCommitMessages(lastHead, prInstance.headHash(), ArchiveMessages::formatCommit);
+        var issueString = prInstance.issueUrl().map(url -> "  Issue: " + url + "\n").orElse("");
         return "The pull request has been updated with additional changes.\n\n" +
                 infoSeparator + "\n\n" +
                 "Added commits:\n" +
@@ -96,6 +101,7 @@ class ArchiveMessages {
                 "Webrevs:\n" +
                 " - full: " + fullWebrev.toString() + "\n" +
                 " - incr: " + incrementalWebrev.toString() + "\n\n" +
+                issueString +
                 "  Stats: " + prInstance.stats(lastHead, prInstance.headHash()) + "\n" +
                 "  Patch: " + prInstance.diffUrl() + "\n" +
                 "  Fetch: " + prInstance.fetchCommand() + "\n\n" +

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
@@ -227,7 +227,12 @@ class ArchiveWorkItem implements WorkItem {
         }
 
         var census = CensusInstance.create(bot.censusRepo(), bot.censusRef(), scratchPath.resolve("census"), pr);
-        var prInstance = new PullRequestInstance(scratchPath.resolve("mlbridge-mergebase"), pr);
+        var jbs = census.configuration().general().jbs();
+        if (jbs == null) {
+            jbs = census.configuration().general().project();
+        }
+        var prInstance = new PullRequestInstance(scratchPath.resolve("mlbridge-mergebase"), pr, bot.issueTracker(),
+                                                 jbs.toUpperCase());
         var reviewArchive = new ReviewArchive(bot.emailAddress(), prInstance, census, sentMails);
         var webrevPath = scratchPath.resolve("mlbridge-webrevs");
         var listServer = MailingListServerFactory.createMailmanServer(bot.listArchive(), bot.smtpServer());

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBot.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBot.java
@@ -45,6 +45,7 @@ public class MailingListBridgeBot implements Bot {
     private final WebrevStorage webrevStorage;
     private final Set<String> readyLabels;
     private final Map<String, Pattern> readyComments;
+    private final URI issueTracker;
     private final PullRequestUpdateCache updateCache;
 
     MailingListBridgeBot(EmailAddress from, HostedRepository repo, HostedRepository archive,
@@ -52,7 +53,7 @@ public class MailingListBridgeBot implements Bot {
                          Set<String> ignoredUsers, Set<Pattern> ignoredComments, URI listArchive, String smtpServer,
                          HostedRepository webrevStorageRepository, String webrevStorageRef,
                          Path webrevStorageBase, URI webrevStorageBaseUri, Set<String> readyLabels,
-                         Map<String, Pattern> readyComments) {
+                         Map<String, Pattern> readyComments, URI issueTracker) {
         emailAddress = from;
         codeRepo = repo;
         archiveRepo = archive;
@@ -65,6 +66,7 @@ public class MailingListBridgeBot implements Bot {
         this.smtpServer = smtpServer;
         this.readyLabels = readyLabels;
         this.readyComments = readyComments;
+        this.issueTracker = issueTracker;
 
         this.webrevStorage = new WebrevStorage(webrevStorageRepository, webrevStorageRef, webrevStorageBase,
                                                webrevStorageBaseUri, from);
@@ -121,6 +123,10 @@ public class MailingListBridgeBot implements Bot {
 
     Map<String, Pattern> readyComments() {
         return readyComments;
+    }
+
+    URI issueTracker() {
+        return issueTracker;
     }
 
     @Override

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotFactory.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotFactory.java
@@ -61,6 +61,7 @@ public class MailingListBridgeBotFactory implements BotFactory {
         var webrevWeb = specific.get("webrevs").get("web").asString();
 
         var archiveRepo = configuration.repository(specific.get("archive").asString());
+        var issueTracker = URIBuilder.base(specific.get("issues").asString()).build();
 
         var allListNames = new HashSet<EmailAddress>();
         var allRepositories = new HashSet<HostedRepository>();
@@ -84,7 +85,8 @@ public class MailingListBridgeBotFactory implements BotFactory {
                                                censusRepo, censusRef,
                                                list, ignoredUsers, ignoredComments, listArchive, listSmtp,
                                                webrevRepo, webrevRef, Path.of(folder),
-                                               URIBuilder.base(webrevWeb).build(), readyLabels, readyComments);
+                                               URIBuilder.base(webrevWeb).build(), readyLabels, readyComments,
+                                               issueTracker);
             ret.add(bot);
 
             allListNames.add(list);

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/PullRequestInstance.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/PullRequestInstance.java
@@ -23,10 +23,14 @@
 package org.openjdk.skara.bots.mlbridge;
 
 import org.openjdk.skara.host.PullRequest;
+import org.openjdk.skara.host.network.URIBuilder;
 import org.openjdk.skara.vcs.*;
+import org.openjdk.skara.vcs.openjdk.Issue;
 
 import java.io.*;
+import java.net.URI;
 import java.nio.file.Path;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 class PullRequestInstance {
@@ -35,9 +39,13 @@ class PullRequestInstance {
     private final Hash targetHash;
     private final Hash headHash;
     private final Hash baseHash;
+    private final URI issueTracker;
+    private final String projectPrefix;
 
-    PullRequestInstance(Path localRepoPath, PullRequest pr) {
+    PullRequestInstance(Path localRepoPath, PullRequest pr, URI issueTracker, String projectPrefix) {
         this.pr = pr;
+        this.issueTracker = issueTracker;
+        this.projectPrefix = projectPrefix;
 
         // Materialize the PR's target ref
         try {
@@ -99,6 +107,11 @@ class PullRequestInstance {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+    }
+
+    Optional<String> issueUrl() {
+        var issue = Issue.fromString(pr.getTitle());
+        return issue.map(value -> URIBuilder.base(issueTracker).appendPath(projectPrefix + "-" + value.id()).build().toString());
     }
 
     @FunctionalInterface

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBotTests.java
@@ -71,7 +71,8 @@ class MailingListArchiveReaderBotTests {
                                                  listServer.getArchive(), listServer.getSMTP(),
                                                  archive, "webrev", Path.of("test"),
                                                  URIBuilder.base("http://www.test.test/").build(),
-                                                 Set.of(), Map.of());
+                                                 Set.of(), Map.of(),
+                                                 URIBuilder.base("http://issues.test/browse/").build());
 
             // The mailing list as well
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP());
@@ -134,7 +135,8 @@ class MailingListArchiveReaderBotTests {
                                                  listServer.getArchive(), listServer.getSMTP(),
                                                  archive, "webrev", Path.of("test"),
                                                  URIBuilder.base("http://www.test.test/").build(),
-                                                 Set.of(), Map.of());
+                                                 Set.of(), Map.of(),
+                                                 URIBuilder.base("http://issues.test/browse/").build());
 
             // The mailing list as well
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP());

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -111,7 +111,8 @@ class MailingListBridgeBotTests {
                                                  archive, "webrev", Path.of("test"),
                                                  URIBuilder.base("http://www.test.test/").build(),
                                                  Set.of("rfr"), Map.of(ignored.host().getCurrentUserDetails().userName(),
-                                                                       Pattern.compile("ready")));
+                                                                       Pattern.compile("ready")),
+                                                 URIBuilder.base("http://issues.test/browse/").build());
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.getRepositoryType());
@@ -123,7 +124,7 @@ class MailingListBridgeBotTests {
             var editHash = CheckableRepository.appendAndCommit(localRepo, "A simple change",
                                                                "Change msg\n\nWith several lines");
             localRepo.push(editHash, author.getUrl(), "edit", true);
-            var pr = credentials.createPullRequest(archive, "master", "edit", "This is a pull request");
+            var pr = credentials.createPullRequest(archive, "master", "edit", "1234: This is a pull request");
             pr.setBody("This should not be ready");
 
             // Run an archive pass
@@ -170,6 +171,8 @@ class MailingListBridgeBotTests {
             assertTrue(archiveContains(archiveFolder.path(), "Webrev:"));
             assertTrue(archiveContains(archiveFolder.path(), "http://www.test.test/"));
             assertTrue(archiveContains(archiveFolder.path(), "webrev.00"));
+            assertTrue(archiveContains(archiveFolder.path(), "Issue:"));
+            assertTrue(archiveContains(archiveFolder.path(), "http://issues.test/browse/TSTPRJ-1234"));
             assertTrue(archiveContains(archiveFolder.path(), "Fetch:"));
             assertTrue(archiveContains(archiveFolder.path(), "^ - " + editHash.abbreviate() + ": Change msg"));
             assertFalse(archiveContains(archiveFolder.path(), "With several lines"));
@@ -181,7 +184,7 @@ class MailingListBridgeBotTests {
             var conversations = mailmanList.conversations(Duration.ofDays(1));
             assertEquals(1, conversations.size());
             var mail = conversations.get(0).first();
-            assertEquals("RFR: This is a pull request", mail.subject());
+            assertEquals("RFR: 1234: This is a pull request", mail.subject());
             assertEquals(pr.getAuthor().fullName(), mail.author().fullName().orElseThrow());
             assertEquals(noreplyAddress(archive), mail.author().address());
             assertEquals(from, mail.sender());
@@ -260,7 +263,8 @@ class MailingListBridgeBotTests {
                                                  listServer.getArchive(), listServer.getSMTP(),
                                                  archive, "webrev", Path.of("test"),
                                                  URIBuilder.base("http://www.test.test/").build(),
-                                                 Set.of(), Map.of());
+                                                 Set.of(), Map.of(),
+                                                 URIBuilder.base("http://issues.test/browse/").build());
 
             // Populate the projects repository
             var reviewFile = Path.of("reviewfile.txt");
@@ -346,7 +350,8 @@ class MailingListBridgeBotTests {
                                                  listServer.getSMTP(),
                                                  archive, "webrev", Path.of("test"),
                                                  URIBuilder.base("http://www.test.test/").build(),
-                                                 Set.of(), Map.of());
+                                                 Set.of(), Map.of(),
+                                                 URIBuilder.base("http://issues.test/browse/").build());
 
             // Populate the projects repository
             var reviewFile = Path.of("reviewfile.txt");
@@ -418,7 +423,8 @@ class MailingListBridgeBotTests {
                                                  listServer.getSMTP(),
                                                  archive, "webrev", Path.of("test"),
                                                  URIBuilder.base("http://www.test.test/").build(),
-                                                 Set.of(), Map.of());
+                                                 Set.of(), Map.of(),
+                                                 URIBuilder.base("http://issues.test/browse/").build());
 
             // Populate the projects repository
             var reviewFile = Path.of("reviewfile.txt");
@@ -526,7 +532,8 @@ class MailingListBridgeBotTests {
                                                  listServer.getSMTP(),
                                                  archive, "webrev", Path.of("test"),
                                                  URIBuilder.base("http://www.test.test/").build(),
-                                                 Set.of(), Map.of());
+                                                 Set.of(), Map.of(),
+                                                 URIBuilder.base("http://issues.test/browse/").build());
 
             // Populate the projects repository
             var reviewFile = Path.of("reviewfile.txt");
@@ -575,7 +582,8 @@ class MailingListBridgeBotTests {
                                                  listServer.getSMTP(),
                                                  archive, "webrev", Path.of("test"),
                                                  URIBuilder.base("http://www.test.test/").build(),
-                                                 Set.of(), Map.of());
+                                                 Set.of(), Map.of(),
+                                                 URIBuilder.base("http://issues.test/browse/").build());
 
             // Populate the projects repository
             var reviewFile = Path.of("reviewfile.txt");
@@ -642,7 +650,8 @@ class MailingListBridgeBotTests {
                                                  listServer.getArchive(), listServer.getSMTP(),
                                                  archive, "webrev", Path.of("test"),
                                                  URIBuilder.base("http://www.test.test/").build(),
-                                                 Set.of(), Map.of());
+                                                 Set.of(), Map.of(),
+                                                 URIBuilder.base("http://issues.test/browse/").build());
 
             // Populate the projects repository
             var reviewFile = Path.of("reviewfile.txt");
@@ -699,7 +708,8 @@ class MailingListBridgeBotTests {
                                                  listServer.getArchive(), listServer.getSMTP(),
                                                  archive, "webrev", Path.of("test"),
                                                  URIBuilder.base("http://www.test.test/").build(),
-                                                 Set.of(), Map.of());
+                                                 Set.of(), Map.of(),
+                                                 URIBuilder.base("http://issues.test/browse/").build());
 
             // Populate the projects repository
             var reviewFile = Path.of("reviewfile.txt");
@@ -818,7 +828,8 @@ class MailingListBridgeBotTests {
                                                  listServer.getArchive(), listServer.getSMTP(),
                                                  archive, "webrev", Path.of("test"),
                                                  URIBuilder.base("http://www.test.test/").build(),
-                                                 Set.of(), Map.of());
+                                                 Set.of(), Map.of(),
+                                                 URIBuilder.base("http://issues.test/browse/").build());
 
             // Populate the projects repository
             var reviewFile = Path.of("reviewfile.txt");
@@ -909,7 +920,8 @@ class MailingListBridgeBotTests {
                                                  listServer.getArchive(), listServer.getSMTP(),
                                                  archive, "webrev", Path.of("test"),
                                                  URIBuilder.base("http://www.test.test/").build(),
-                                                 Set.of(), Map.of());
+                                                 Set.of(), Map.of(),
+                                                 URIBuilder.base("http://issues.test/browse/").build());
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.getRepositoryType());
@@ -980,7 +992,8 @@ class MailingListBridgeBotTests {
                                                  listServer.getArchive(), listServer.getSMTP(),
                                                  archive, "webrev", Path.of("test"),
                                                  URIBuilder.base("http://www.test.test/").build(),
-                                                 Set.of(), Map.of());
+                                                 Set.of(), Map.of(),
+                                                 URIBuilder.base("http://issues.test/browse/").build());
 
             // Populate the projects repository
             var reviewFile = Path.of("reviewfile.txt");
@@ -1062,7 +1075,8 @@ class MailingListBridgeBotTests {
                                                  listServer.getArchive(), listServer.getSMTP(),
                                                  archive, "webrev", Path.of("test"),
                                                  URIBuilder.base("http://www.test.test/").build(),
-                                                 Set.of(), Map.of());
+                                                 Set.of(), Map.of(),
+                                                 URIBuilder.base("http://issues.test/browse/").build());
 
             // Populate the projects repository
             var reviewFile = Path.of("reviewfile.txt");

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/WebrevStorageTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/WebrevStorageTests.java
@@ -62,7 +62,7 @@ class WebrevStorageTests {
                                             URIBuilder.base("http://www.test.test/").build(), from);
 
             var prFolder = tempFolder.path().resolve("pr");
-            var prInstance = new PullRequestInstance(prFolder, pr);
+            var prInstance = new PullRequestInstance(prFolder, pr, URIBuilder.base("http://issues.test/browse/").build(), "TEST");
             var scratchFolder = tempFolder.path().resolve("scratch");
             storage.createAndArchive(prInstance, scratchFolder, masterHash, editHash, "00");
 

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/GeneralConfiguration.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/GeneralConfiguration.java
@@ -25,14 +25,16 @@ package org.openjdk.skara.jcheck;
 import org.openjdk.skara.ini.Section;
 
 public class GeneralConfiguration {
-    private static final GeneralConfiguration DEFAULT = new GeneralConfiguration(null, null);
+    private static final GeneralConfiguration DEFAULT = new GeneralConfiguration(null, null, null);
 
     private final String project;
     private final String repository;
+    private final String jbs;
 
-    GeneralConfiguration(String project, String repository) {
+    private GeneralConfiguration(String project, String repository, String jbs) {
         this.project = project;
         this.repository = repository;
+        this.jbs = jbs;
     }
 
     public String project() {
@@ -41,6 +43,10 @@ public class GeneralConfiguration {
 
     public String repository() {
         return repository;
+    }
+
+    public String jbs() {
+        return jbs;
     }
 
     static String name() {
@@ -54,6 +60,7 @@ public class GeneralConfiguration {
 
         var project = s.get("project", DEFAULT.project());
         var repository = s.get("repository", DEFAULT.repository());
-        return new GeneralConfiguration(project, repository);
+        var jbs = s.get("jbs", DEFAULT.jbs());
+        return new GeneralConfiguration(project, repository, jbs);
     }
 }

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/JCheckConfiguration.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/JCheckConfiguration.java
@@ -70,12 +70,13 @@ public class JCheckConfiguration {
         var config = new ArrayList<String>();
         config.add("[general]");
         config.add("project=" + project);
+        config.add("jbs=JDK");
 
         config.add("[checks]");
         var error = "error=blacklist,author,committer,reviewers,merge,hg-tag,message,issues,executable";
         var shouldCheckWhitespace = false;
         var checkWhitespace = old.get("whitespace");
-        if (checkWhitespace == null || !checkWhitespace.equals("lax")) {
+        if (checkWhitespace == null || !checkWhitespace.asString().equals("lax")) {
             error += ",whitespace";
             shouldCheckWhitespace = true;
         }
@@ -86,7 +87,7 @@ public class JCheckConfiguration {
 
             var tags = "tags=";
             var checkTags = old.get("tags");
-            if (checkTags == null || !checkTags.equals("lax")) {
+            if (checkTags == null || !checkTags.asString().equals("lax")) {
                 var jdkTag = "(?:jdk-(?:[1-9]([0-9]*)(?:\\.(?:0|[1-9][0-9]*)){0,4})(?:\\+(?:(?:[0-9]+))|(?:-ga)))";
                 var jdkuTag = "(?:jdk[4-9](?:u\\d{1,3})?-(?:(?:b\\d{2,3})|(?:ga)))";
                 var hsTag = "(?:hs\\d\\d(?:\\.\\d{1,2})?-b\\d\\d)";
@@ -98,7 +99,7 @@ public class JCheckConfiguration {
 
             var branches = "branches=";
             var checkBranches = old.get("branches");
-            if (checkBranches != null && checkBranches.equals("lax")) {
+            if (checkBranches != null && checkBranches.asString().equals("lax")) {
                 branches += ".*\n";
             }
             config.add(branches);

--- a/test/src/main/java/org/openjdk/skara/test/CheckableRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/CheckableRepository.java
@@ -58,6 +58,7 @@ public class CheckableRepository {
         try (var output = Files.newBufferedWriter(checkConf)) {
             output.append("[general]\n");
             output.append("project=test\n");
+            output.append("jbs=tstprj\n");
             output.append("\n");
             output.append("[checks]\n");
             output.append("error=author,reviewers,whitespace\n");


### PR DESCRIPTION
Hi all,

Please review this change that adds an issue link to RFR emails if the PR title contains one. It also allows projects to specify their issue key in case it is different from the project name.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)
 * Kevin Rushforth ([kcr](@kevinrushforth) - no project role)