### PR TITLE
Handle binary patches in webrev

### DIFF
--- a/webrev/src/main/java/org/openjdk/skara/webrev/AddedFileView.java
+++ b/webrev/src/main/java/org/openjdk/skara/webrev/AddedFileView.java
@@ -79,7 +79,10 @@ class AddedFileView implements FileView {
             var rawView = new RawView(out, patch.target().path().get(), newContent);
             rawView.render(w);
         } else {
-            w.write("------ ------ ------ ------ --- --- ----- ");
+            w.write("------ ------ ------ ------ --- --- ");
+
+            var addedPatchView = new AddedPatchView(out, patch.target().path().get(), patch.asBinaryPatch());
+            addedPatchView.render(w);
 
             var rawView = new RawView(out, patch.target().path().get(), binaryContent);
             rawView.render(w);

--- a/webrev/src/main/java/org/openjdk/skara/webrev/ModifiedFileView.java
+++ b/webrev/src/main/java/org/openjdk/skara/webrev/ModifiedFileView.java
@@ -120,7 +120,10 @@ class ModifiedFileView implements FileView {
     }
 
     private void renderBinary(Writer w) throws IOException {
-        w.write("------ ------ ------ ------ --- --- ----- ");
+        w.write("------ ------ ------ ------ --- --- ");
+
+        var patchView = new PatchView(out, patch.target().path().get(), patch.asBinaryPatch());
+        patchView.render(w);
 
         var rawView = new RawView(out, patch.target().path().get(), binaryContent);
         rawView.render(w);

--- a/webrev/src/main/java/org/openjdk/skara/webrev/PatchView.java
+++ b/webrev/src/main/java/org/openjdk/skara/webrev/PatchView.java
@@ -23,6 +23,7 @@
 package org.openjdk.skara.webrev;
 
 import org.openjdk.skara.vcs.TextualPatch;
+import org.openjdk.skara.vcs.BinaryPatch;
 
 import java.io.*;
 import java.nio.file.*;
@@ -31,7 +32,8 @@ import java.util.List;
 class PatchView implements View {
     private final Path out;
     private final Path file;
-    private final TextualPatch patch;
+    private final TextualPatch textualPatch;
+    private final BinaryPatch binaryPatch;
     private final List<String> sourceContent;
     private final List<String> destContent;
     private static final int NUM_CONTEXT_LINES = 5;
@@ -39,9 +41,19 @@ class PatchView implements View {
     public PatchView(Path out, Path file, TextualPatch patch, List<String> sourceContent, List<String> destContent) {
         this.out = out;
         this.file = file;
-        this.patch = patch;
+        this.textualPatch = patch;
+        this.binaryPatch = null;
         this.sourceContent = sourceContent;
         this.destContent = destContent;
+    }
+
+    public PatchView(Path out, Path file, BinaryPatch patch) {
+        this.out = out;
+        this.file = file;
+        this.textualPatch = null;
+        this.binaryPatch = patch;
+        this.sourceContent = null;
+        this.destContent = null;
     }
 
     private void writeLine(Writer w, String prepend, Line line) throws IOException {
@@ -50,25 +62,56 @@ class PatchView implements View {
         w.write("\n");
     }
 
+    @Override
     public void render(Writer w) throws IOException {
         var patchFile = out.resolve(file.toString() + ".patch");
         Files.createDirectories(patchFile.getParent());
 
+        if (binaryPatch != null) {
+            renderBinary(patchFile);
+        } else {
+            renderTextual(patchFile);
+        }
+
+        w.write("<a href=\"");
+        w.write(Webrev.relativeToIndex(out, patchFile));
+        w.write("\">Patch</a>\n");
+    }
+
+    private void renderBinary(Path patchFile) throws IOException {
+        try (var fw = Files.newBufferedWriter(patchFile)) {
+            var sourcePath = ViewUtils.pathWithUnixSeps(binaryPatch.source().path().get());
+            var targetPath = ViewUtils.pathWithUnixSeps(binaryPatch.target().path().get());
+            fw.write("diff a/");
+            fw.write(sourcePath);
+            fw.write(" b/");
+            fw.write(targetPath);
+            fw.write("\n");
+            fw.write("Binary files ");
+            fw.write(sourcePath);
+            fw.write(" and ");
+            fw.write(targetPath);
+            fw.write(" differ\n");
+        }
+
+    }
+
+    private void renderTextual(Path patchFile) throws IOException {
         try (var fw = Files.newBufferedWriter(patchFile)) {
             fw.write("diff a/");
-            fw.write(ViewUtils.pathWithUnixSeps(patch.source().path().get()));
+            fw.write(ViewUtils.pathWithUnixSeps(textualPatch.source().path().get()));
             fw.write(" b/");
-            fw.write(ViewUtils.pathWithUnixSeps(patch.target().path().get()));
+            fw.write(ViewUtils.pathWithUnixSeps(textualPatch.target().path().get()));
             fw.write("\n");
             fw.write("--- a/");
-            fw.write(ViewUtils.pathWithUnixSeps(patch.source().path().get()));
+            fw.write(ViewUtils.pathWithUnixSeps(textualPatch.source().path().get()));
             fw.write("\n");
             fw.write("+++ b/");
-            fw.write(ViewUtils.pathWithUnixSeps(patch.target().path().get()));
+            fw.write(ViewUtils.pathWithUnixSeps(textualPatch.target().path().get()));
             fw.write("\n");
 
             var coalescer = new HunkCoalescer(NUM_CONTEXT_LINES, sourceContent, destContent);
-            for (var group : coalescer.coalesce(patch.hunks())) {
+            for (var group : coalescer.coalesce(textualPatch.hunks())) {
                 var sourceRange = group.header().source();
                 var destRange = group.header().target();
 
@@ -99,9 +142,5 @@ class PatchView implements View {
                 }
             }
         }
-
-        w.write("<a href=\"");
-        w.write(Webrev.relativeToIndex(out, patchFile));
-        w.write("\">Patch</a>\n");
     }
 }

--- a/webrev/src/main/java/org/openjdk/skara/webrev/RemovedFileView.java
+++ b/webrev/src/main/java/org/openjdk/skara/webrev/RemovedFileView.java
@@ -72,7 +72,10 @@ class RemovedFileView implements FileView {
             var rawView = new RawView(out, patch.source().path().get(), oldContent);
             rawView.render(w);
         } else {
-            w.write("------ ------ ------ ------ --- --- ----- ");
+            w.write("------ ------ ------ ------ --- --- ");
+
+            var patchView = new RemovedPatchView(out, patch.source().path().get(), patch.asBinaryPatch());
+            patchView.render(w);
 
             var rawView = new RawView(out, patch.source().path().get(), binaryContent);
             rawView.render(w);


### PR DESCRIPTION
Hi all,

this patch makes `git webrev` generate `.patch` files for binary files. Thanks @rwestberg for the initial reproducer!

## Testing
- [x] Added three new unit tests

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)