### PR TITLE
A generated webrev should always include index.html

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
@@ -62,9 +62,13 @@ class WebrevStorage {
             // Try to push 1000 files at a time
             var batches = files.filter(Files::isRegularFile)
                                .filter(file -> {
-                                   // Huge files are not that useful in a webrev
+                                   // Huge files are not that useful in a webrev - but make an exception for the index
                                    try {
-                                       return Files.size(file) < 1000 * 1000;
+                                       if (file.getFileName().toString().equals("index.html")) {
+                                           return true;
+                                       } else {
+                                           return Files.size(file) < 1000 * 1000;
+                                       }
                                    } catch (IOException e) {
                                        return false;
                                    }


### PR DESCRIPTION
Hi all,

Please review this small change that ensures that the file size filter used when generating webrevs is not applied to the index.html file.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)