### PR TITLE
Fix problem with finding a collapsed parent

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
@@ -112,7 +112,8 @@ class ReviewArchive {
             var parentId = getStableMessageId(getMessageId(reviewComment.parent().get()));
             var last = Stream.concat(existing.stream(), generated.stream())
                              .filter(email -> (email.hasHeader("References") && email.headerValue("References").contains(parentId)) ||
-                                     (getStableMessageId(email.id()).equals(parentId)))
+                                     (getStableMessageId(email.id()).equals(parentId)) ||
+                                     (email.hasHeader("PR-Collapsed-IDs") && email.headerValue("PR-Collapsed-IDs").contains(parentId)))
                              .max(Comparator.comparingInt(email -> Integer.parseInt(email.headerValue("PR-Sequence"))));
 
             if (last.isEmpty()) {

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -367,7 +367,7 @@ class MailingListBridgeBotTests {
             listServer.processIncoming();
 
             // Make two file specific comments
-            pr.addReviewComment(masterHash, editHash, reviewFile.toString(), 2, "Review comment");
+            var first = pr.addReviewComment(masterHash, editHash, reviewFile.toString(), 2, "Review comment");
             pr.addReviewComment(masterHash, editHash, reviewFile.toString(), 2, "Another review comment");
             TestBotRunner.runPeriodicItems(mlBot);
             listServer.processIncoming();
@@ -395,6 +395,15 @@ class MailingListBridgeBotTests {
             assertEquals("Re: RFR: This is a pull request", reviewReply.subject());
             assertTrue(reviewReply.body().contains("Review comment\n\n"), reviewReply.body());
             assertTrue(reviewReply.body().contains("Another review comment"), reviewReply.body());
+
+            // Now reply to the first (collapsed) comment
+            pr.addReviewCommentReply(first, "I agree");
+            TestBotRunner.runPeriodicItems(mlBot);
+            listServer.processIncoming();
+
+            // The archive should contain a new entry
+            Repository.materialize(archiveFolder.path(), archive.getUrl(), "master");
+            assertEquals(3, archiveContainsCount(archiveFolder.path(), "^On.*wrote:"));
         }
     }
 


### PR DESCRIPTION
Hi all,

Please review this change that fixes a problem with finding the correct parent for a review comment, if the parent was combined with another comment before it was sent.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)