### PR TITLE
Add git-sync command

### DIFF
--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -62,7 +62,8 @@ images {
         'git-info': 'org.openjdk.skara.cli/org.openjdk.skara.cli.GitInfo',
         'git-translate': 'org.openjdk.skara.cli/org.openjdk.skara.cli.GitTranslate',
         'git-skara': 'org.openjdk.skara.cli/org.openjdk.skara.cli.GitSkara',
-        'hg-openjdk-import': 'org.openjdk.skara.cli/org.openjdk.skara.cli.HgOpenJDKImport'
+        'hg-openjdk-import': 'org.openjdk.skara.cli/org.openjdk.skara.cli.HgOpenJDKImport',
+        'git-sync': 'org.openjdk.skara.cli/org.openjdk.skara.cli.GitSync'
     ]
 
     ext.modules = ['jdk.crypto.ec']

--- a/cli/src/main/java/org/openjdk/skara/cli/GitFork.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitFork.java
@@ -29,7 +29,7 @@ import org.openjdk.skara.proxy.HttpProxy;
 
 import java.io.IOException;
 import java.net.URI;
-import java.nio.file.Path;
+import java.nio.file.*;
 import java.util.List;
 import java.util.function.Supplier;
 import java.util.logging.Level;
@@ -175,6 +175,14 @@ public class GitFork {
                 upstreamUrl = "git+" + upstreamUrl;
             }
             repo.addRemote("upstream", upstreamUrl);
+            var gitConfig = repo.root().resolve(".git").resolve("config");
+            if (!isMercurial && Files.exists(gitConfig)) {
+                var lines = List.of(
+                    "[sync]",
+                    "        remote = upstream"
+                );
+                Files.write(gitConfig, lines, StandardOpenOption.WRITE, StandardOpenOption.APPEND);
+            }
             System.out.println("done");
         } else {
             System.out.println(webUrl);

--- a/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
@@ -212,46 +212,6 @@ public class GitPr {
         await(pb.start());
     }
 
-    private static URI toURI(String remotePath) throws IOException {
-        if (remotePath.startsWith("git+")) {
-            remotePath = remotePath.substring("git+".length());
-        }
-        if (remotePath.startsWith("http")) {
-            return URI.create(remotePath);
-        } else {
-            if (remotePath.startsWith("ssh://")) {
-                remotePath = remotePath.substring("ssh://".length()).replaceFirst("/", ":");
-            }
-            var indexOfColon = remotePath.indexOf(':');
-            var indexOfSlash = remotePath.indexOf('/');
-            if (indexOfColon != -1) {
-                if (indexOfSlash == -1 || indexOfColon < indexOfSlash) {
-                    var path = remotePath.contains("@") ? remotePath.split("@")[1] : remotePath;
-                    var name = path.split(":")[0];
-
-                    // Could be a Host in the ~/.ssh/config file
-                    var sshConfig = Path.of(System.getProperty("user.home"), ".ssh", "config");
-                    if (Files.exists(sshConfig)) {
-                        for (var host : SSHConfig.parse(sshConfig).hosts()) {
-                            if (host.name().equals(name)) {
-                                var hostName = host.hostName();
-                                if (hostName != null) {
-                                    return URI.create("https://" + hostName + "/" + path.split(":")[1]);
-                                }
-                            }
-                        }
-                    }
-
-                    // Otherwise is must be a domain
-                    return URI.create("https://" + path.replace(":", "/"));
-                }
-            }
-        }
-
-        exit("error: cannot find remote repository for " + remotePath);
-        return null; // will never reach here
-    }
-
     private static int longest(List<String> strings) {
         return strings.stream().mapToInt(String::length).max().orElse(0);
     }
@@ -347,7 +307,7 @@ public class GitPr {
         var remotePullPath = repo.pullPath(remote);
         var username = arguments.contains("username") ? arguments.get("username").asString() : null;
         var token = isMercurial ? System.getenv("HG_TOKEN") :  System.getenv("GIT_TOKEN");
-        var uri = toURI(remotePullPath);
+        var uri = Remote.toWebURI(remotePullPath);
         var credentials = GitCredentials.fill(uri.getHost(), uri.getPath(), username, token, uri.getScheme());
         var host = Host.from(uri, new PersonalAccessToken(credentials.username(), credentials.password()));
 

--- a/cli/src/main/java/org/openjdk/skara/cli/GitSkara.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitSkara.java
@@ -116,6 +116,7 @@ public class GitSkara {
         commands.put("token", GitToken::main);
         commands.put("info", GitInfo::main);
         commands.put("translate", GitTranslate::main);
+        commands.put("sync", GitSync::main);
         commands.put("update", GitSkara::update);
         commands.put("help", GitSkara::usage);
 

--- a/cli/src/main/java/org/openjdk/skara/cli/GitSync.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitSync.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.cli;
+
+import org.openjdk.skara.args.*;
+import org.openjdk.skara.vcs.*;
+
+import java.io.*;
+import java.net.URI;
+import java.nio.file.*;
+import java.util.*;
+import java.util.logging.*;
+
+public class GitSync {
+    private static IOException die(String message) {
+        System.err.println(message);
+        System.exit(1);
+        return new IOException("will never reach here");
+    }
+
+    public static void main(String[] args) throws IOException {
+        var flags = List.of(
+            Option.shortcut("")
+                  .fullname("branches")
+                  .describe("BRANCHES")
+                  .helptext("Comma separated list of branches to sync")
+                  .optional(),
+            Switch.shortcut("m")
+                  .fullname("mercurial")
+                  .helptext("Force use of mercurial")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("verbose")
+                  .helptext("Turn on verbose output")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("debug")
+                  .helptext("Turn on debugging output")
+                  .optional(),
+            Switch.shortcut("v")
+                  .fullname("version")
+                  .helptext("Print the version of this tool")
+                  .optional()
+        );
+
+        var inputs = List.of(
+            Input.position(0)
+                 .describe("REMOTE")
+                 .singular()
+                 .required()
+        );
+
+        var parser = new ArgumentParser("git sync", flags, inputs);
+        var arguments = parser.parse(args);
+
+        if (arguments.contains("version")) {
+            System.out.println("git-sync version: " + Version.fromManifest().orElse("unknown"));
+            System.exit(0);
+        }
+
+        if (arguments.contains("verbose") || arguments.contains("debug")) {
+            var level = arguments.contains("debug") ? Level.FINER : Level.FINE;
+            Logging.setup(level);
+        }
+
+        var cwd = Paths.get("").toAbsolutePath();
+        var repo = Repository.get(cwd).orElseThrow(() ->
+                die("error: no repository found at " + cwd.toString())
+        );
+
+        var upstream = arguments.at(0).asString();
+        var remotes = repo.remotes();
+        var upstreamPullPath = remotes.contains(upstream) ?
+            Remote.toURI(repo.pullPath(upstream)) : URI.create(upstream);
+        var origin = "origin";
+        var originPushPath = Remote.toURI(repo.pushPath(origin));
+
+        var branches = new HashSet<String>();
+        if (arguments.contains("branches")) {
+            var requested = arguments.get("branches").asString().split(",");
+            for (var branch : requested) {
+                branches.add(branch.trim());
+            }
+        }
+
+        for (var branch : repo.remoteBranches(upstream)) {
+            var name = branch.name();
+            if (!branches.isEmpty() && !branches.contains(name)) {
+                System.out.println("Skipping branch " + name);
+                continue;
+            }
+            System.out.print("Syncing " + upstream + "/" + name + " to " + origin + "/" + name + "... ");
+            var fetchHead = repo.fetch(upstreamPullPath, branch.hash().hex());
+            repo.push(fetchHead, originPushPath, name);
+            System.out.println("done");
+        }
+    }
+}

--- a/cli/src/main/java/org/openjdk/skara/cli/GitSync.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitSync.java
@@ -159,6 +159,7 @@ public class GitSync {
                 continue;
             }
             System.out.print("Syncing " + upstream + "/" + name + " to " + origin + "/" + name + "... ");
+            System.out.flush();
             var fetchHead = repo.fetch(upstreamPullPath, branch.hash().hex());
             repo.push(fetchHead, originPushPath, name);
             System.out.println("done");

--- a/cli/src/main/java/org/openjdk/skara/cli/Remote.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/Remote.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.cli;
+
+import org.openjdk.skara.ssh.SSHConfig;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Files;
+
+class Remote {
+    public static URI toWebURI(String remotePath) throws IOException {
+        if (remotePath.startsWith("git+")) {
+            remotePath = remotePath.substring("git+".length());
+        }
+        if (remotePath.startsWith("http")) {
+            return URI.create(remotePath);
+        } else {
+            if (remotePath.startsWith("ssh://")) {
+                remotePath = remotePath.substring("ssh://".length()).replaceFirst("/", ":");
+            }
+            var indexOfColon = remotePath.indexOf(':');
+            var indexOfSlash = remotePath.indexOf('/');
+            if (indexOfColon != -1) {
+                if (indexOfSlash == -1 || indexOfColon < indexOfSlash) {
+                    var path = remotePath.contains("@") ? remotePath.split("@")[1] : remotePath;
+                    var name = path.split(":")[0];
+
+                    // Could be a Host in the ~/.ssh/config file
+                    var sshConfig = Path.of(System.getProperty("user.home"), ".ssh", "config");
+                    if (Files.exists(sshConfig)) {
+                        for (var host : SSHConfig.parse(sshConfig).hosts()) {
+                            if (host.name().equals(name)) {
+                                var hostName = host.hostName();
+                                if (hostName != null) {
+                                    return URI.create("https://" + hostName + "/" + path.split(":")[1]);
+                                }
+                            }
+                        }
+                    }
+
+                    // Otherwise is must be a domain
+                    return URI.create("https://" + path.replace(":", "/"));
+                }
+            }
+        }
+
+        throw new IOException("error: cannot find remote repository for " + remotePath);
+    }
+
+    public static URI toURI(String remotePath) throws IOException {
+        if (remotePath.startsWith("git+")) {
+            remotePath = remotePath.substring("git+".length());
+        }
+        if (remotePath.startsWith("http://") ||
+            remotePath.startsWith("https://") ||
+            remotePath.startsWith("ssh://") ||
+            remotePath.startsWith("file://") ||
+            remotePath.startsWith("git://")) {
+            return URI.create(remotePath);
+        }
+
+        var indexOfColon = remotePath.indexOf(':');
+        var indexOfSlash = remotePath.indexOf('/');
+        if (indexOfColon != -1) {
+            if (indexOfSlash == -1 || indexOfColon < indexOfSlash) {
+                var path = remotePath.contains("@") ? remotePath.split("@")[1] : remotePath;
+                var name = path.split(":")[0];
+
+                // Could be a Host in the ~/.ssh/config file
+                var sshConfig = Path.of(System.getProperty("user.home"), ".ssh", "config");
+                if (Files.exists(sshConfig)) {
+                    for (var host : SSHConfig.parse(sshConfig).hosts()) {
+                        if (host.name().equals(name)) {
+                            var hostName = host.hostName();
+                            if (hostName != null) {
+                                var username = host.user();
+                                if (username == null) {
+                                    username = remotePath.contains("@") ? remotePath.split("@")[0] : null;
+                                }
+                                var userPrefix = username == null ? "" : username + "@";
+                                return URI.create("ssh://" + userPrefix + hostName + "/" + path.split(":")[1]);
+                            }
+                        }
+                    }
+                }
+
+                // Otherwise is must be a domain
+                var userPrefix = remotePath.contains("@") ? remotePath.split("@")[0] + "@" : "";
+                return URI.create("ssh://" + userPrefix + path.replace(":", "/"));
+            }
+        }
+
+        throw new IOException("error: cannot construct proper URI for " + remotePath);
+    }
+}

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/TestRepository.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/TestRepository.java
@@ -224,4 +224,12 @@ class TestRepository implements ReadOnlyRepository {
     public boolean contains(Branch b, Hash h) throws IOException {
         return false;
     }
+
+    public List<Reference> remoteBranches(String remote) throws IOException {
+        return null;
+    }
+
+    public List<String> remotes() throws IOException {
+        return null;
+    }
 }

--- a/skara.gitconfig
+++ b/skara.gitconfig
@@ -31,3 +31,4 @@
         token = ! git skara token
         info = ! git skara info
         translate = ! git skara translate
+        sync = ! git skara sync

--- a/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
@@ -84,6 +84,8 @@ public interface ReadOnlyRepository {
     String pushPath(String remote) throws IOException;
     boolean isValidRevisionRange(String expression) throws IOException;
     Optional<String> upstreamFor(Branch branch) throws IOException;
+    List<Reference> remoteBranches(String remote) throws IOException;
+    List<String> remotes() throws IOException;
 
     static Optional<ReadOnlyRepository> get(Path p) throws IOException {
         return Repository.get(p).map(r -> r);

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Reference.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Reference.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.vcs;
+
+import java.util.Objects;
+
+public class Reference {
+    private final String name;
+    private final Hash hash;
+
+    public Reference(String name, Hash hash) {
+        this.name = name;
+        this.hash = hash;
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public Hash hash() {
+        return hash;
+    }
+
+    @Override
+    public String toString() {
+        return name + ": " + hash.hex();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof Reference)) {
+            return false;
+        }
+
+        var r = (Reference) o;
+        return Objects.equals(name, r.name) && Objects.equals(hash, r.hash);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, hash);
+    }
+}

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -1065,4 +1065,28 @@ public class GitRepository implements Repository {
 
         return false;
     }
+
+    @Override
+    public List<Reference> remoteBranches(String remote) throws IOException {
+        var refs = new ArrayList<Reference>();
+        try (var p = capture("git", "ls-remote", "--heads", "--refs", remote)) {
+            for (var line : await(p).stdout()) {
+                var parts = line.split("\t");
+                var name = parts[1].replace("refs/heads/", "");
+                refs.add(new Reference(name, new Hash(parts[0])));
+            }
+        }
+        return refs;
+    }
+
+    @Override
+    public List<String> remotes() throws IOException {
+        var remotes = new ArrayList<String>();
+        try (var p = capture("git", "remote")) {
+            for (var line : await(p).stdout()) {
+                remotes.add(line);
+            }
+        }
+        return remotes;
+    }
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -1092,4 +1092,38 @@ public class HgRepository implements Repository {
             return line.equals(b.name());
         }
     }
+
+    @Override
+    public List<Reference> remoteBranches(String remote) throws IOException {
+        var refs = new ArrayList<Reference>();
+
+        var ext = Files.createTempFile("ext", ".py");
+        copyResource(EXT_PY, ext);
+
+        try (var p = capture("hg", "--config", "extensions.ls-remote=" + ext, "ls-remote", remote)) {
+            var res = await(p);
+            for (var line : res.stdout()) {
+                var parts = line.split("\t");
+                refs.add(new Reference(parts[1], new Hash(parts[0])));
+            }
+        }
+        return refs;
+    }
+
+    @Override
+    public List<String> remotes() throws IOException {
+        var remotes = new ArrayList<String>();
+        try (var p = capture("hg", "paths")) {
+            for (var line : await(p).stdout()) {
+                var parts = line.split(" = ");
+                var name = parts[0];
+                if (name.endsWith("-push") || name.endsWith(":push")) {
+                    continue;
+                } else {
+                    remotes.add(name);
+                }
+            }
+        }
+        return remotes;
+    }
 }

--- a/vcs/src/main/resources/ext.py
+++ b/vcs/src/main/resources/ext.py
@@ -23,6 +23,8 @@ import mercurial
 import mercurial.patch
 import mercurial.mdiff
 import mercurial.util
+import mercurial.hg
+import mercurial.node
 import difflib
 import sys
 
@@ -288,3 +290,12 @@ def ls_tree(ui, repo, rev, **opts):
         write(nullHash)
         write('\t')
         writeln(filename)
+
+@command('ls-remote', [],  'hg ls-remote PATH')
+def ls_remote(ui, repo, path, **opts):
+    peer = mercurial.hg.peer(ui or repo, opts, ui.expandpath(path))
+    for branch, heads in peer.branchmap().iteritems():
+        for head in heads:
+            write(mercurial.node.hex(head))
+            write("\t")
+            writeln(branch)

--- a/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
@@ -1817,4 +1817,35 @@ public class RepositoryTests {
             assertEquals(1, repo.commits().asList().size());
         }
     }
+
+    @ParameterizedTest
+    @EnumSource(VCS.class)
+    void testRemotes(VCS vcs) throws IOException {
+        try (var dir = new TemporaryDirectory()) {
+            var repo = Repository.init(dir.path(), vcs);
+            assertEquals(List.of(), repo.remotes());
+            repo.addRemote("foobar", "https://foo/bar");
+            assertEquals(List.of("foobar"), repo.remotes());
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(VCS.class)
+    void testRemoteBranches(VCS vcs) throws IOException {
+        try (var dir = new TemporaryDirectory()) {
+            var upstream = Repository.init(dir.path().resolve("upstream"), vcs);
+            var readme = upstream.root().resolve("README");
+            Files.writeString(readme, "Hello\n");
+            upstream.add(readme);
+            var head = upstream.commit("Added README", "duke", "duke@openjdk.org");
+
+            var fork = Repository.init(dir.path().resolve("fork"), vcs);
+            fork.addRemote("upstream", "file://" + upstream.root());
+            var refs = fork.remoteBranches("upstream");
+            assertEquals(1, refs.size());
+            var ref = refs.get(0);
+            assertEquals(head, ref.hash());
+            assertEquals(upstream.defaultBranch().name(), ref.name());
+        }
+    }
 }


### PR DESCRIPTION
Hi all,

this commits adds the new `git sync` command which is useful for syncing a personal fork with its upstream repository. `git sync` supports both a remote and URL as a argument, for example:

```bash
$ git sync upstream
Syncing upstream/master with origin/master... done

$ git sync https://github.com/openjdk/skara
Syncing https://github.com/openjdk/skara/master with origin/master... done
```

The remote can also be configured in `.git/config` (or `~/.gitconfig`) as in:

```
[sync]
       remote = upstream
```

I also added two options, `--pull` and `--fetch`, that will pull and/or fetch the current branch. This is a shorthand for `git sync && git pull`. Since `git fork` sets the `sync.remote` in `.git/config` (local for the repository) a user now only has to write to fork an upstream repository, sync the branches and update their local copy:

```bash
$ git fork https://github.com/openjdk/skara
$ cd skara
$ git sync --pull
```

The syncing leaves no trace in the local repository, I'm only using `FETCH_HEAD` in the refspec when pushing to the personal fork.

## Testing
- [x] `sh gradlew test` passes on Linux x86_64
- [x] `sh gradlew reproduce` passes on Linux x86_64
- [x] Added two new unit tests
- [x] Manual testing of `git sync`

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**) **Note!** Review applies to 62268c27972ce202e4cb0b9a92ebc5078a61440b
 * Jorn Vernee ([jvernee](@JornVernee) - Committer)