### PR TITLE
webrev: fix indentation of removed binary file view

### DIFF
--- a/webrev/src/main/java/org/openjdk/skara/webrev/RemovedFileView.java
+++ b/webrev/src/main/java/org/openjdk/skara/webrev/RemovedFileView.java
@@ -72,8 +72,7 @@ class RemovedFileView implements FileView {
             var rawView = new RawView(out, patch.source().path().get(), oldContent);
             rawView.render(w);
         } else {
-            w.write("------ ------ ------ ------ --- --- ");
-
+            w.write(" --- --- ");
             var patchView = new RemovedPatchView(out, patch.source().path().get(), patch.asBinaryPatch());
             patchView.render(w);
 


### PR DESCRIPTION
Hi all,

this small patch fixes an indentation issue with removed binary files in webrev's `index.html`.

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)