### PR TITLE
102: Setting summary does not update the preview message

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -41,7 +41,7 @@ class CheckWorkItem extends PullRequestWorkItem {
     private final String censusRef;
     private final Map<String, String> blockingLabels;
 
-    private final Pattern metadataComments = Pattern.compile("<!-- (add|remove) contributor");
+    private final Pattern metadataComments = Pattern.compile("<!-- (?:(add|remove) contributor)|(?:summary: ')");
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots.pr");
 
     CheckWorkItem(PullRequest pr, HostedRepository censusRepo, String censusRef, Map<String, String> blockingLabels, Consumer<RuntimeException> errorHandler) {

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/SummaryTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/SummaryTests.java
@@ -86,18 +86,19 @@ class SummaryTests {
             // The bot should reply with a success message
             assertLastCommentContains(pr,"Setting summary to");
 
-            // Now update it
-            pr.addComment("/summary Third time is surely the charm");
-            TestBotRunner.runPeriodicItems(prBot);
-
-            // The bot should reply with a success message
-            assertLastCommentContains(pr,"Updating existing summary");
-
             // Approve it as another user
             var approvalPr = integrator.getPullRequest(pr.getId());
             approvalPr.addReview(Review.Verdict.APPROVED, "Approved");
             TestBotRunner.runPeriodicItems(prBot);
             TestBotRunner.runPeriodicItems(prBot);
+
+            // Now update it
+            pr.addComment("/summary Third time is surely the charm");
+            TestBotRunner.runPeriodicItems(prBot);
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // The bot should reply with a success message
+            assertLastCommentContains(pr,"Updating existing summary");
 
             // The commit message preview should contain the final summary
             var summaryLine = pr.getComments().stream()


### PR DESCRIPTION
Hi all,

Please review this change that ensures that the commit preview message is updated when a summary is added or updated.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Kevin Rushforth ([kcr](@kevinrushforth) - no project role)
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)