### PR TITLE
Add support for adding extra headers to mails sent to mailing lists

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
@@ -309,6 +309,7 @@ class ArchiveWorkItem implements WorkItem {
                                                                    newMail::headerValue));
             var filteredEmail = Email.from(newMail)
                                      .replaceHeaders(filteredHeaders)
+                                     .headers(bot.headers())
                                      .build();
             list.post(filteredEmail);
         }

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBot.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBot.java
@@ -45,6 +45,7 @@ public class MailingListBridgeBot implements Bot {
     private final WebrevStorage webrevStorage;
     private final Set<String> readyLabels;
     private final Map<String, Pattern> readyComments;
+    private final Map<String, String> headers;
     private final PullRequestUpdateCache updateCache;
 
     MailingListBridgeBot(EmailAddress from, HostedRepository repo, HostedRepository archive,
@@ -52,7 +53,7 @@ public class MailingListBridgeBot implements Bot {
                          Set<String> ignoredUsers, Set<Pattern> ignoredComments, URI listArchive, String smtpServer,
                          HostedRepository webrevStorageRepository, String webrevStorageRef,
                          Path webrevStorageBase, URI webrevStorageBaseUri, Set<String> readyLabels,
-                         Map<String, Pattern> readyComments) {
+                         Map<String, Pattern> readyComments, Map<String, String> headers) {
         emailAddress = from;
         codeRepo = repo;
         archiveRepo = archive;
@@ -65,6 +66,7 @@ public class MailingListBridgeBot implements Bot {
         this.smtpServer = smtpServer;
         this.readyLabels = readyLabels;
         this.readyComments = readyComments;
+        this.headers = headers;
 
         this.webrevStorage = new WebrevStorage(webrevStorageRepository, webrevStorageRef, webrevStorageBase,
                                                webrevStorageBaseUri, from);
@@ -121,6 +123,10 @@ public class MailingListBridgeBot implements Bot {
 
     Map<String, Pattern> readyComments() {
         return readyComments;
+    }
+
+    Map<String, String> headers() {
+        return headers;
     }
 
     @Override

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotFactory.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotFactory.java
@@ -78,13 +78,19 @@ public class MailingListBridgeBotFactory implements BotFactory {
             var censusRepo = configuration.repository(repoConfig.get("census").asString());
             var censusRef = configuration.repositoryRef(repoConfig.get("census").asString());
 
+            Map<String, String> headers = repoConfig.contains("headers") ?
+                    repoConfig.get("headers").fields().stream()
+                              .collect(Collectors.toMap(JSONObject.Field::name, field -> field.value().asString())) :
+                    Map.of();
+
             var list = EmailAddress.parse(repoConfig.get("list").asString());
             var folder = repoConfig.contains("folder") ? repoConfig.get("folder").asString() : configuration.repositoryName(repo);
             var bot = new MailingListBridgeBot(from, configuration.repository(repo), archiveRepo,
                                                censusRepo, censusRef,
                                                list, ignoredUsers, ignoredComments, listArchive, listSmtp,
                                                webrevRepo, webrevRef, Path.of(folder),
-                                               URIBuilder.base(webrevWeb).build(), readyLabels, readyComments);
+                                               URIBuilder.base(webrevWeb).build(), readyLabels, readyComments,
+                                               headers);
             ret.add(bot);
 
             allListNames.add(list);

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBotTests.java
@@ -71,7 +71,7 @@ class MailingListArchiveReaderBotTests {
                                                  listServer.getArchive(), listServer.getSMTP(),
                                                  archive, "webrev", Path.of("test"),
                                                  URIBuilder.base("http://www.test.test/").build(),
-                                                 Set.of(), Map.of());
+                                                 Set.of(), Map.of(), Map.of());
 
             // The mailing list as well
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP());
@@ -134,7 +134,7 @@ class MailingListArchiveReaderBotTests {
                                                  listServer.getArchive(), listServer.getSMTP(),
                                                  archive, "webrev", Path.of("test"),
                                                  URIBuilder.base("http://www.test.test/").build(),
-                                                 Set.of(), Map.of());
+                                                 Set.of(), Map.of(), Map.of());
 
             // The mailing list as well
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP());

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -111,7 +111,8 @@ class MailingListBridgeBotTests {
                                                  archive, "webrev", Path.of("test"),
                                                  URIBuilder.base("http://www.test.test/").build(),
                                                  Set.of("rfr"), Map.of(ignored.host().getCurrentUserDetails().userName(),
-                                                                       Pattern.compile("ready")));
+                                                                       Pattern.compile("ready")),
+                                                 Map.of("Extra1", "val1", "Extra2", "val2"));
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.getRepositoryType());
@@ -185,6 +186,8 @@ class MailingListBridgeBotTests {
             assertEquals(pr.getAuthor().fullName(), mail.author().fullName().orElseThrow());
             assertEquals(noreplyAddress(archive), mail.author().address());
             assertEquals(from, mail.sender());
+            assertEquals("val1", mail.headerValue("Extra1"));
+            assertEquals("val2", mail.headerValue("Extra2"));
 
             // And there should be a webrev
             Repository.materialize(webrevFolder.path(), archive.getUrl(), "webrev");
@@ -260,7 +263,7 @@ class MailingListBridgeBotTests {
                                                  listServer.getArchive(), listServer.getSMTP(),
                                                  archive, "webrev", Path.of("test"),
                                                  URIBuilder.base("http://www.test.test/").build(),
-                                                 Set.of(), Map.of());
+                                                 Set.of(), Map.of(), Map.of());
 
             // Populate the projects repository
             var reviewFile = Path.of("reviewfile.txt");
@@ -346,7 +349,7 @@ class MailingListBridgeBotTests {
                                                  listServer.getSMTP(),
                                                  archive, "webrev", Path.of("test"),
                                                  URIBuilder.base("http://www.test.test/").build(),
-                                                 Set.of(), Map.of());
+                                                 Set.of(), Map.of(), Map.of());
 
             // Populate the projects repository
             var reviewFile = Path.of("reviewfile.txt");
@@ -427,7 +430,7 @@ class MailingListBridgeBotTests {
                                                  listServer.getSMTP(),
                                                  archive, "webrev", Path.of("test"),
                                                  URIBuilder.base("http://www.test.test/").build(),
-                                                 Set.of(), Map.of());
+                                                 Set.of(), Map.of(), Map.of());
 
             // Populate the projects repository
             var reviewFile = Path.of("reviewfile.txt");
@@ -535,7 +538,7 @@ class MailingListBridgeBotTests {
                                                  listServer.getSMTP(),
                                                  archive, "webrev", Path.of("test"),
                                                  URIBuilder.base("http://www.test.test/").build(),
-                                                 Set.of(), Map.of());
+                                                 Set.of(), Map.of(), Map.of());
 
             // Populate the projects repository
             var reviewFile = Path.of("reviewfile.txt");
@@ -584,7 +587,7 @@ class MailingListBridgeBotTests {
                                                  listServer.getSMTP(),
                                                  archive, "webrev", Path.of("test"),
                                                  URIBuilder.base("http://www.test.test/").build(),
-                                                 Set.of(), Map.of());
+                                                 Set.of(), Map.of(), Map.of());
 
             // Populate the projects repository
             var reviewFile = Path.of("reviewfile.txt");
@@ -651,7 +654,7 @@ class MailingListBridgeBotTests {
                                                  listServer.getArchive(), listServer.getSMTP(),
                                                  archive, "webrev", Path.of("test"),
                                                  URIBuilder.base("http://www.test.test/").build(),
-                                                 Set.of(), Map.of());
+                                                 Set.of(), Map.of(), Map.of());
 
             // Populate the projects repository
             var reviewFile = Path.of("reviewfile.txt");
@@ -708,7 +711,7 @@ class MailingListBridgeBotTests {
                                                  listServer.getArchive(), listServer.getSMTP(),
                                                  archive, "webrev", Path.of("test"),
                                                  URIBuilder.base("http://www.test.test/").build(),
-                                                 Set.of(), Map.of());
+                                                 Set.of(), Map.of(), Map.of());
 
             // Populate the projects repository
             var reviewFile = Path.of("reviewfile.txt");
@@ -827,7 +830,7 @@ class MailingListBridgeBotTests {
                                                  listServer.getArchive(), listServer.getSMTP(),
                                                  archive, "webrev", Path.of("test"),
                                                  URIBuilder.base("http://www.test.test/").build(),
-                                                 Set.of(), Map.of());
+                                                 Set.of(), Map.of(), Map.of());
 
             // Populate the projects repository
             var reviewFile = Path.of("reviewfile.txt");
@@ -918,7 +921,7 @@ class MailingListBridgeBotTests {
                                                  listServer.getArchive(), listServer.getSMTP(),
                                                  archive, "webrev", Path.of("test"),
                                                  URIBuilder.base("http://www.test.test/").build(),
-                                                 Set.of(), Map.of());
+                                                 Set.of(), Map.of(), Map.of());
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.getRepositoryType());
@@ -989,7 +992,7 @@ class MailingListBridgeBotTests {
                                                  listServer.getArchive(), listServer.getSMTP(),
                                                  archive, "webrev", Path.of("test"),
                                                  URIBuilder.base("http://www.test.test/").build(),
-                                                 Set.of(), Map.of());
+                                                 Set.of(), Map.of(), Map.of());
 
             // Populate the projects repository
             var reviewFile = Path.of("reviewfile.txt");
@@ -1071,7 +1074,7 @@ class MailingListBridgeBotTests {
                                                  listServer.getArchive(), listServer.getSMTP(),
                                                  archive, "webrev", Path.of("test"),
                                                  URIBuilder.base("http://www.test.test/").build(),
-                                                 Set.of(), Map.of());
+                                                 Set.of(), Map.of(), Map.of());
 
             // Populate the projects repository
             var reviewFile = Path.of("reviewfile.txt");

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -355,7 +355,7 @@ class MailingListBridgeBotTests {
                                                  archive, "webrev", Path.of("test"),
                                                  URIBuilder.base("http://www.test.test/").build(),
                                                  Set.of(), Map.of(),
-                                                 URIBuilder.base("http://issues.test/browse/").build()
+                                                 URIBuilder.base("http://issues.test/browse/").build(),
                                                  Map.of());
 
             // Populate the projects repository
@@ -438,7 +438,7 @@ class MailingListBridgeBotTests {
                                                  archive, "webrev", Path.of("test"),
                                                  URIBuilder.base("http://www.test.test/").build(),
                                                  Set.of(), Map.of(),
-                                                 URIBuilder.base("http://issues.test/browse/").build()
+                                                 URIBuilder.base("http://issues.test/browse/").build(),
                                                  Map.of());
 
             // Populate the projects repository
@@ -548,7 +548,7 @@ class MailingListBridgeBotTests {
                                                  archive, "webrev", Path.of("test"),
                                                  URIBuilder.base("http://www.test.test/").build(),
                                                  Set.of(), Map.of(),
-                                                 URIBuilder.base("http://issues.test/browse/").build()
+                                                 URIBuilder.base("http://issues.test/browse/").build(),
                                                  Map.of());
 
             // Populate the projects repository
@@ -599,7 +599,7 @@ class MailingListBridgeBotTests {
                                                  archive, "webrev", Path.of("test"),
                                                  URIBuilder.base("http://www.test.test/").build(),
                                                  Set.of(), Map.of(),
-                                                 URIBuilder.base("http://issues.test/browse/").build()
+                                                 URIBuilder.base("http://issues.test/browse/").build(),
                                                  Map.of());
 
             // Populate the projects repository
@@ -668,7 +668,7 @@ class MailingListBridgeBotTests {
                                                  archive, "webrev", Path.of("test"),
                                                  URIBuilder.base("http://www.test.test/").build(),
                                                  Set.of(), Map.of(),
-                                                 URIBuilder.base("http://issues.test/browse/").build()
+                                                 URIBuilder.base("http://issues.test/browse/").build(),
                                                  Map.of());
 
             // Populate the projects repository
@@ -727,7 +727,7 @@ class MailingListBridgeBotTests {
                                                  archive, "webrev", Path.of("test"),
                                                  URIBuilder.base("http://www.test.test/").build(),
                                                  Set.of(), Map.of(),
-                                                 URIBuilder.base("http://issues.test/browse/").build()
+                                                 URIBuilder.base("http://issues.test/browse/").build(),
                                                  Map.of());
 
             // Populate the projects repository
@@ -848,7 +848,7 @@ class MailingListBridgeBotTests {
                                                  archive, "webrev", Path.of("test"),
                                                  URIBuilder.base("http://www.test.test/").build(),
                                                  Set.of(), Map.of(),
-                                                 URIBuilder.base("http://issues.test/browse/").build()
+                                                 URIBuilder.base("http://issues.test/browse/").build(),
                                                  Map.of());
 
             // Populate the projects repository
@@ -941,7 +941,7 @@ class MailingListBridgeBotTests {
                                                  archive, "webrev", Path.of("test"),
                                                  URIBuilder.base("http://www.test.test/").build(),
                                                  Set.of(), Map.of(),
-                                                 URIBuilder.base("http://issues.test/browse/").build()
+                                                 URIBuilder.base("http://issues.test/browse/").build(),
                                                  Map.of());
 
             // Populate the projects repository
@@ -1014,7 +1014,7 @@ class MailingListBridgeBotTests {
                                                  archive, "webrev", Path.of("test"),
                                                  URIBuilder.base("http://www.test.test/").build(),
                                                  Set.of(), Map.of(),
-                                                 URIBuilder.base("http://issues.test/browse/").build()
+                                                 URIBuilder.base("http://issues.test/browse/").build(),
                                                  Map.of());
 
             // Populate the projects repository
@@ -1098,7 +1098,7 @@ class MailingListBridgeBotTests {
                                                  archive, "webrev", Path.of("test"),
                                                  URIBuilder.base("http://www.test.test/").build(),
                                                  Set.of(), Map.of(),
-                                                 URIBuilder.base("http://issues.test/browse/").build()
+                                                 URIBuilder.base("http://issues.test/browse/").build(),
                                                  Map.of());
 
             // Populate the projects repository


### PR DESCRIPTION
Hi all,

Please review this change that allows adding extra headers to mails that are sent to mailing lists. This can be used to add authentication headers.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**) **Note!** Review applies to 7fcd00bc622f1af2de738484e42cfc3447eaba5a