### PR TITLE
Add "binary" jcheck check

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
@@ -207,4 +207,9 @@ class PullRequestCheckIssueVisitor implements IssueVisitor {
     public void visit(BlacklistIssue issue) {
         log.fine("ignored: blacklisted commit");
     }
+
+    @Override
+    public void visit(BinaryIssue issue) {
+        log.fine("ignored: binary file");
+    }
 }

--- a/cli/src/main/java/org/openjdk/skara/cli/JCheckCLIVisitor.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/JCheckCLIVisitor.java
@@ -228,4 +228,8 @@ class JCheckCLIVisitor implements IssueVisitor {
     public void visit(BlacklistIssue i) {
         println(i, "commit is blacklisted");
     }
+
+    public void visit(BinaryIssue i) {
+        println(i, "adds binary file: " + i.path().toString());
+    }
 }

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/BinaryCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/BinaryCheck.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.jcheck;
+
+import org.openjdk.skara.vcs.Commit;
+import org.openjdk.skara.vcs.openjdk.CommitMessage;
+
+import java.util.Iterator;
+import java.util.ArrayList;
+import java.util.logging.Logger;
+
+public class BinaryCheck extends CommitCheck {
+    private final Logger log = Logger.getLogger("org.openjdk.skara.jcheck.binary");
+
+    @Override
+    Iterator<Issue> check(Commit commit, CommitMessage message, JCheckConfiguration conf) {
+        var metadata = CommitIssue.metadata(commit, message, conf, this);
+
+        var issues = new ArrayList<Issue>();
+        for (var diff : commit.parentDiffs()) {
+            for (var patch : diff.patches()) {
+                if (patch.isBinary() &&
+                    (patch.status().isAdded() || patch.status().isCopied())) {
+                    issues.add(new BinaryIssue(patch.target().path().get(), metadata));
+                }
+            }
+        }
+
+        return issues.iterator();
+    }
+
+    @Override
+    public String name() {
+        return "binary";
+    }
+
+    @Override
+    public String description() {
+        return "Files should not be binary";
+    }
+}

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/BinaryIssue.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/BinaryIssue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,24 +22,22 @@
  */
 package org.openjdk.skara.jcheck;
 
-public interface IssueVisitor {
-    void visit(TagIssue issue);
-    void visit(BranchIssue issue);
-    void visit(DuplicateIssuesIssue issue);
-    void visit(SelfReviewIssue issue);
-    void visit(TooFewReviewersIssue issue);
-    void visit(InvalidReviewersIssue issue);
-    void visit(MergeMessageIssue issue);
-    void visit(HgTagCommitIssue issue);
-    void visit(CommitterIssue issue);
-    void visit(CommitterNameIssue issue);
-    void visit(CommitterEmailIssue issue);
-    void visit(AuthorNameIssue issue);
-    void visit(AuthorEmailIssue issue);
-    void visit(WhitespaceIssue issue);
-    void visit(MessageIssue issue);
-    void visit(IssuesIssue issue);
-    void visit(ExecutableIssue issue);
-    void visit(BlacklistIssue issue);
-    void visit(BinaryIssue issue);
+import java.nio.file.Path;
+
+public class BinaryIssue extends CommitIssue {
+    private final Path path;
+
+    BinaryIssue(Path path, CommitIssue.Metadata metadata) {
+        super(metadata);
+        this.path = path;
+    }
+
+    public Path path() {
+        return path;
+    }
+
+    @Override
+    public void accept(IssueVisitor v) {
+        v.visit(this);
+    }
 }

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/BinaryCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/BinaryCheckTests.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.jcheck;
+
+import org.openjdk.skara.vcs.*;
+import org.openjdk.skara.vcs.openjdk.CommitMessage;
+import org.openjdk.skara.vcs.openjdk.CommitMessageParsers;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.nio.file.Path;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ArrayList;
+import java.time.ZonedDateTime;
+import java.io.IOException;
+
+class BinaryCheckTests {
+    private static final Hash NULL_HASH = new Hash("0".repeat(40));
+    private static final JCheckConfiguration conf = JCheckConfiguration.parse(List.of(
+        "[general]",
+        "project = test",
+        "[checks]",
+        "error = binary"
+    ));
+
+    private static List<Diff> textualParentDiffs(String filename, String mode) {
+        var hunk = new Hunk(new Range(1, 0), List.of(),
+                            new Range(1, 1), List.of("An additional line"));
+        var patch = new TextualPatch(Path.of(filename), FileType.fromOctal("100644"), NULL_HASH,
+                                     Path.of(filename), FileType.fromOctal(mode), NULL_HASH,
+                                     Status.from('M'), List.of(hunk));
+        var diff = new Diff(NULL_HASH, NULL_HASH, List.of(patch));
+        return List.of(diff);
+    }
+
+    private static Commit commit(List<Diff> parentDiffs) {
+        var author = new Author("foo", "foo@host.org");
+        var hash = new Hash("0123456789012345678901234567890123456789");
+        var parents = List.of(hash, hash);
+        var message = List.of("A commit");
+        var date = ZonedDateTime.now();
+        var metadata = new CommitMetadata(hash, parents, author, author, date, message);
+        return new Commit(metadata, parentDiffs);
+    }
+
+    private List<Issue> toList(Iterator<Issue> i) {
+        var list = new ArrayList<Issue>();
+        while (i.hasNext()) {
+            list.add(i.next());
+        }
+        return list;
+    }
+
+    private static CommitMessage message(Commit c) {
+        return CommitMessageParsers.v1.parse(c);
+    }
+
+    @Test
+    void regularFileShouldPass() throws IOException {
+        var commit = commit(textualParentDiffs("README", "100644"));
+        var message = message(commit);
+        var check = new BinaryCheck();
+        var issues = toList(check.check(commit, message, conf));
+        assertEquals(0, issues.size());
+    }
+
+    @Test
+    void binaryFileShouldFail() throws IOException {
+        var hunk = BinaryHunk.ofLiteral(8, List.of("asdfasdf8"));
+        var patch = new BinaryPatch(null, null, null,
+                                    Path.of("file.bin"), FileType.fromOctal("100644"), NULL_HASH,
+                                    Status.from('A'), List.of(hunk));
+        var diff = new Diff(NULL_HASH, NULL_HASH, List.of(patch));
+        var commit = commit(List.of(diff));
+        var message = message(commit);
+        var check = new BinaryCheck();
+        var issues = toList(check.check(commit, message, conf));
+        assertEquals(1, issues.size());
+        assertTrue(issues.get(0) instanceof BinaryIssue);
+        var issue = (BinaryIssue) issues.get(0);
+        assertEquals(Path.of("file.bin"), issue.path());
+        assertEquals(commit, issue.commit());
+        assertEquals(message, issue.message());
+        assertEquals(check, issue.check());
+        assertEquals(Severity.ERROR, issue.severity());
+    }
+}

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/JCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/JCheckTests.java
@@ -222,6 +222,11 @@ class JCheckTests {
             issues.add(e);
         }
 
+        @Override
+        public void visit(BinaryIssue e) {
+            issues.add(e);
+        }
+
         Set<Issue> issues() {
             return issues;
         }


### PR DESCRIPTION
Hi all,

this patch adds a new jcheck check called "binary" that checks for binary files.

## Testing
- `sh gradlew test` passes on Linux x86_64
- Added two new unit tests

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)