### PR TITLE
Make build incremental

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,29 +91,27 @@ configure(subprojects.findAll() { it.name != 'bots' }) {
     }
 }
 
-task jar {
-    subprojects.findAll() { it.name != 'bots' }.each { dependsOn "${it.path}:jar" }
+task test {
+    subprojects.findAll() { !it.getTasksByName('test', false).isEmpty() }.each { dependsOn "${it.path}:test" }
 }
 
-task test {
-    subprojects.findAll() { it.name != 'bots' }.each { dependsOn "${it.path}:test" }
+task clean {
+    subprojects.findAll() { !it.getTasksByName('clean', false).isEmpty() }.each { dependsOn "${it.path}:clean" }
 }
 
 reproduce {
     dockerfile = 'test.dockerfile'
 }
 
-task deleteBuildDir(type: Delete) {
-    delete project.buildDir
-}
-
 task local(type: Copy) {
+    doFirst {
+        delete project.buildDir
+    }
     def os = System.getProperty('os.name').toLowerCase()
     def osName = os.startsWith('win') ? 'Windows' :
         os.startsWith('mac') ? 'Macos' : 'Linux'
 
     dependsOn ':cli:image' + osName
-    dependsOn deleteBuildDir
     from zipTree(file(project.rootDir.toString() +
                       '/cli/build/distributions/cli' +
                       '-' + project.version + '-' +

--- a/buildSrc/images/src/main/java/org/openjdk/skara/gradle/images/DownloadJDKTask.java
+++ b/buildSrc/images/src/main/java/org/openjdk/skara/gradle/images/DownloadJDKTask.java
@@ -26,6 +26,9 @@ package org.openjdk.skara.gradle.images;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.provider.Property;
 
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -42,20 +45,29 @@ import java.io.File;
 import java.util.Comparator;
 
 public class DownloadJDKTask extends DefaultTask {
-    private String url;
-    private String sha256;
-    private Path toDir;
+    private final Property<String> url;
+    private final Property<String> sha256;
+    private final Property<Path> toDir;
 
-    void setUrl(String url) {
-        this.url = url;
+    public DownloadJDKTask() {
+        url = getProject().getObjects().property(String.class);
+        sha256 = getProject().getObjects().property(String.class);
+        toDir = getProject().getObjects().property(Path.class);
     }
 
-    void setSha256(String sha256) {
-        this.sha256 = sha256;
+    @Input
+    Property<String> getUrl() {
+        return url;
     }
 
-    void setToDir(Path toDir) {
-        this.toDir = toDir;
+    @Input
+    Property<String> getSha256() {
+        return sha256;
+    }
+
+    @OutputDirectory
+    Property<Path> getToDir() {
+        return toDir;
     }
 
     private static String checksum(Path file) throws IOException {
@@ -101,10 +113,10 @@ public class DownloadJDKTask extends DefaultTask {
 
     @TaskAction
     void download() throws IOException, InterruptedException {
-        var uri = URI.create(url);
+        var uri = URI.create(url.get());
         var filename = Path.of(uri.getPath()).getFileName().toString();
-        var file = toDir.resolve(filename).toAbsolutePath();
-        var dist = toDir.resolve(filename.replace(".zip", "").replace(".tar.gz", ""));
+        var file = toDir.get().resolve(filename).toAbsolutePath();
+        var dist = toDir.get().resolve(filename.replace(".zip", "").replace(".tar.gz", ""));
 
         if (Files.exists(dist) && Files.isDirectory(dist)) {
             return;
@@ -112,7 +124,7 @@ public class DownloadJDKTask extends DefaultTask {
 
         if (Files.exists(file)) {
             var sum = checksum(file);
-            if (sum.equals(sha256)) {
+            if (sum.equals(sha256.get())) {
                 unpack(file, dist);
                 return;
             } else {
@@ -120,8 +132,8 @@ public class DownloadJDKTask extends DefaultTask {
             }
         }
 
-        if (!Files.exists(toDir)) {
-            Files.createDirectories(toDir);
+        if (!Files.exists(toDir.get())) {
+            Files.createDirectories(toDir.get());
         }
 
         var client = HttpClient.newHttpClient();
@@ -131,11 +143,11 @@ public class DownloadJDKTask extends DefaultTask {
 
         var res = client.send(req, BodyHandlers.ofFile(file));
         if (res.statusCode() >= 300) {
-            throw new GradleException("could not download " + url + ", got " + res.statusCode());
+            throw new GradleException("could not download " + url.get() + ", got " + res.statusCode());
         }
 
         var sum = checksum(file);
-        if (!sum.equals(sha256)) {
+        if (!sum.equals(sha256.get())) {
             throw new GradleException("checksums do not match, actual: " + sum + ", expected: " + sha256);
         }
 

--- a/buildSrc/images/src/main/java/org/openjdk/skara/gradle/images/LaunchersTask.java
+++ b/buildSrc/images/src/main/java/org/openjdk/skara/gradle/images/LaunchersTask.java
@@ -35,27 +35,32 @@ import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Comparator;
 
 public class LaunchersTask extends DefaultTask {
-    private Path toDir;
-    private String os;
+    private Property<Path> toDir;
+    private Property<String> os;
     private MapProperty<String, String> launchers;
     private ListProperty<String> options;
 
     @Inject
     public LaunchersTask(ObjectFactory factory) {
-        this.launchers = factory.mapProperty(String.class, String.class);
+        toDir = factory.property(Path.class);
+        os = factory.property(String.class);
+        launchers = factory.mapProperty(String.class, String.class);
         options = factory.listProperty(String.class);
     }
 
-    void setOptions(ListProperty<String> options) {
-        this.options.set(options);
+    @Input
+    ListProperty<String> getOptions() {
+        return options;
     }
 
-    void setToDir(Path toDir) {
-        this.toDir = toDir;
+    @OutputDirectory
+    Property<Path> getToDir() {
+        return toDir;
     }
 
-    void setOS(String os) {
-        this.os = os;
+    @Input
+    Property<String> getOS() {
+        return os;
     }
 
     @Input
@@ -72,7 +77,7 @@ public class LaunchersTask extends DefaultTask {
 
     @TaskAction
     void generate() throws IOException {
-        var dest = toDir.resolve(os);
+        var dest = toDir.get().resolve(os.get());
         if (Files.isDirectory(dest)) {
             clearDirectory(dest);
         }


### PR DESCRIPTION
Hi all,

this larger patch adds proper `@Input` and `@OutputDirectory` annotations to our Gradle plugins. The result is that the build is fully incremental :tada:.

## Testing
- `sh gradlew images` works
- `sh gradlew test` passes on Linux x86_64
- Manual testing of CLI binaries

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)