### PR TITLE
Proper mime encoding of high ascii strings

### DIFF
--- a/email/src/main/java/org/openjdk/skara/email/MimeText.java
+++ b/email/src/main/java/org/openjdk/skara/email/MimeText.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.email;
+
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.regex.Pattern;
+
+public class MimeText {
+    private final static Pattern encodePattern = Pattern.compile("([^\\x00-\\x7f]+)");
+    private final static Pattern decodePattern = Pattern.compile("=\\?([A-Za-z0-9_.-]+)\\?([bBqQ])\\?(.*?)\\?=");
+    private final static Pattern decodeQuotedPrintablePattern = Pattern.compile("=([0-9A-F]{2})");
+
+    public static String encode(String raw) {
+        var quoteMatcher = encodePattern.matcher(raw);
+        return quoteMatcher.replaceAll(mo -> "=?utf-8?b?" + Base64.getEncoder().encodeToString(String.valueOf(mo.group(1)).getBytes(StandardCharsets.UTF_8)) + "?=");
+    }
+
+    public static String decode(String encoded) {
+        var quotedMatcher = decodePattern.matcher(encoded);
+        return quotedMatcher.replaceAll(mo -> {
+            try {
+                if (mo.group(2).toUpperCase().equals("B")) {
+                    return new String(Base64.getDecoder().decode(mo.group(3)), mo.group(1));
+                } else {
+                    var quotedPrintableMatcher = decodeQuotedPrintablePattern.matcher(mo.group(3));
+                    return quotedPrintableMatcher.replaceAll(qmo -> {
+                        var byteValue = new byte[1];
+                        byteValue[0] = (byte)Integer.parseInt(qmo.group(1), 16);
+                        try {
+                            return new String(byteValue, mo.group(1));
+                        } catch (UnsupportedEncodingException e) {
+                            throw new RuntimeException(e);
+                        }
+                    });
+                }
+            } catch (UnsupportedEncodingException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+}

--- a/email/src/main/java/org/openjdk/skara/email/SMTP.java
+++ b/email/src/main/java/org/openjdk/skara/email/SMTP.java
@@ -57,17 +57,17 @@ public class SMTP {
             session.sendCommand("MAIL FROM:" + email.sender().address(), mailReply);
             session.sendCommand("RCPT TO:<" + recipient.address() + ">", rcptReply);
             session.sendCommand("DATA", dataReply);
-            session.sendCommand("From: " + email.author());
+            session.sendCommand("From: " + MimeText.encode(email.author().toString()));
             session.sendCommand("Message-Id: " + email.id());
             session.sendCommand("Date: " + email.date().format(DateTimeFormatter.RFC_1123_DATE_TIME));
-            session.sendCommand("Sender: " + email.sender());
-            session.sendCommand("To: " + recipient);
+            session.sendCommand("Sender: " + MimeText.encode(email.sender().toString()));
+            session.sendCommand("To: " + MimeText.encode(recipient.toString()));
             for (var header : email.headers()) {
-                session.sendCommand(header + ": " + email.headerValue(header));
+                session.sendCommand(header + ": " + MimeText.encode(email.headerValue(header)));
             }
-            session.sendCommand("Subject: " + email.subject());
+            session.sendCommand("Subject: " + MimeText.encode(email.subject()));
             session.sendCommand("");
-            session.sendCommand(email.body());
+            session.sendCommand(MimeText.encode(email.body()));
             session.sendCommand(".", doneReply);
             session.sendCommand("QUIT");
         }

--- a/email/src/test/java/org/openjdk/skara/email/EmailTests.java
+++ b/email/src/test/java/org/openjdk/skara/email/EmailTests.java
@@ -112,4 +112,24 @@ class EmailTests {
         assertEquals("The body", mail.body());
     }
 
+    @Test
+    void parseEncoded() {
+        var mail = Email.parse("Message-Id: <a@b.c>\n" +
+                                       "Date: Wed, 27 Mar 2019 14:31:00 +0100\n" +
+                                       "Subject: hello\n" +
+                                       "From: r.b at c.d (r =?iso-8859-1?Q?b=E4?=)\n" +
+                                       "To: C <c@c.c>, <d@d.c>\n" +
+                                       "\n" +
+                                       "The body"
+        );
+
+        assertEquals(EmailAddress.from("a@b.c"), mail.id());
+        assertEquals("hello", mail.subject());
+        assertEquals(EmailAddress.from("r bä", "r.b@c.d"), mail.author());
+        assertEquals(EmailAddress.from("r bä", "r.b@c.d"), mail.sender());
+        assertEquals(List.of(EmailAddress.from("C", "c@c.c"),
+                             EmailAddress.from("d@d.c")),
+                     mail.recipients());
+        assertEquals("The body", mail.body());
+    }
 }

--- a/email/src/test/java/org/openjdk/skara/email/MimeTextTests.java
+++ b/email/src/test/java/org/openjdk/skara/email/MimeTextTests.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.email;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MimeTextTests {
+    @Test
+    void encode() {
+        assertEquals("=?utf-8?b?w6XDpMO2?=", MimeText.encode("åäö"));
+    }
+
+    @Test
+    void decode() {
+        assertEquals("åäö", MimeText.decode("=?utf-8?b?w6XDpMO2?="));
+    }
+
+    @Test
+    void decodeIsoQ() {
+        assertEquals("Bä", MimeText.decode("=?iso-8859-1?Q?B=E4?="));
+    }
+}

--- a/email/src/test/java/org/openjdk/skara/email/SMTPTests.java
+++ b/email/src/test/java/org/openjdk/skara/email/SMTPTests.java
@@ -67,4 +67,21 @@ class SMTPTests {
             assertEquals(sentMail, email);
         }
     }
+
+    @Test
+    void encoded() throws IOException {
+        log.info("Hello");
+        try (var server = new SMTPServer()) {
+            var sender = EmailAddress.from("Señor Dévèlöper", "test@test.email");
+            var recipient = EmailAddress.from("Dêst", "dest@dest.email");
+            var sentMail = Email.create(sender, "Sübject", "Bödÿ")
+                                .recipient(recipient)
+                                .header("Something", "Öthè®")
+                                .build();
+
+            SMTP.send(server.address(), recipient, sentMail);
+            var email = server.receive(Duration.ofSeconds(10));
+            assertEquals(sentMail, email);
+        }
+    }
 }


### PR DESCRIPTION
Hi all,

Please review this change that ensures that all high ascii strings that are sent in emails are properly mime encoded. Before, this was only done when writing mbox archives.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)