### PR TITLE
80: Allow valid bug ID format to be configurable

### DIFF
--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/ChecksConfiguration.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/ChecksConfiguration.java
@@ -35,7 +35,8 @@ public class ChecksConfiguration {
                                 WhitespaceConfiguration.DEFAULT,
                                 ReviewersConfiguration.DEFAULT,
                                 MergeConfiguration.DEFAULT,
-                                CommitterConfiguration.DEFAULT);
+                                CommitterConfiguration.DEFAULT,
+                                IssuesConfiguration.DEFAULT);
 
     private final List<String> error;
     private final List<String> warning;
@@ -43,19 +44,22 @@ public class ChecksConfiguration {
     private final ReviewersConfiguration reviewers;
     private final MergeConfiguration merge;
     private final CommitterConfiguration committer;
+    private final IssuesConfiguration issues;
 
     ChecksConfiguration(List<String> error,
                         List<String> warning,
                         WhitespaceConfiguration whitespace,
                         ReviewersConfiguration reviewers,
                         MergeConfiguration merge,
-                        CommitterConfiguration committer) {
+                        CommitterConfiguration committer,
+                        IssuesConfiguration issues) {
         this.error = error;
         this.warning = warning;
         this.whitespace = whitespace;
         this.reviewers = reviewers;
         this.merge = merge;
         this.committer = committer;
+        this.issues = issues;
     }
 
     public List<String> error() {
@@ -100,6 +104,10 @@ public class ChecksConfiguration {
         return committer;
     }
 
+    public IssuesConfiguration issues() {
+        return issues;
+    }
+
     static String name() {
         return "checks";
     }
@@ -116,7 +124,8 @@ public class ChecksConfiguration {
         var reviewers = ReviewersConfiguration.parse(s.subsection(ReviewersConfiguration.name()));
         var merge = MergeConfiguration.parse(s.subsection(MergeConfiguration.name()));
         var committer = CommitterConfiguration.parse(s.subsection(CommitterConfiguration.name()));
+        var issues = IssuesConfiguration.parse(s.subsection(IssuesConfiguration.name()));
 
-        return new ChecksConfiguration(error, warning, whitespace, reviewers, merge, committer);
+        return new ChecksConfiguration(error, warning, whitespace, reviewers, merge, committer, issues);
     }
 }

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/IssuesCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/IssuesCheck.java
@@ -45,7 +45,7 @@ public class IssuesCheck extends CommitCheck {
 
         var metadata = CommitIssue.metadata(commit, message, conf, this);
         if (commit.message().isEmpty() || message.issues().isEmpty()) {
-            log.finer("isuse: no reference to a JBS issue");
+            log.finer("issue: no reference to a JBS issue");
             return iterator(new IssuesIssue(metadata));
         }
 

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/IssuesCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/IssuesCheck.java
@@ -27,6 +27,7 @@ import org.openjdk.skara.vcs.openjdk.CommitMessage;
 
 import java.util.Iterator;
 import java.util.logging.Logger;
+import java.util.regex.Pattern;
 
 public class IssuesCheck extends CommitCheck {
     private final Logger log = Logger.getLogger("org.openjdk.skara.jcheck.issues");
@@ -42,10 +43,17 @@ public class IssuesCheck extends CommitCheck {
             return iterator();
         }
 
+        var metadata = CommitIssue.metadata(commit, message, conf, this);
         if (commit.message().isEmpty() || message.issues().isEmpty()) {
-            var metadata = CommitIssue.metadata(commit, message, conf, this);
             log.finer("isuse: no reference to a JBS issue");
             return iterator(new IssuesIssue(metadata));
+        }
+
+        var pattern = Pattern.compile(conf.checks().issues().pattern());
+        for (var issue : message.issues()) {
+            if (!pattern.matcher(issue.toString()).matches()) {
+                return iterator(new IssuesIssue(metadata));
+            }
         }
 
         return iterator();

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/IssuesConfiguration.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/IssuesConfiguration.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.jcheck;
+
+import org.openjdk.skara.ini.Section;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class IssuesConfiguration {
+    static final IssuesConfiguration DEFAULT =
+        new IssuesConfiguration("^(([A-Z][A-Z0-9]+-)?[0-9]+): (\\S.*)$");
+
+    private final String pattern;
+
+    IssuesConfiguration(String pattern) {
+        this.pattern = pattern;
+    }
+
+    public String pattern() {
+        return pattern;
+    }
+
+    static String name() {
+        return "issues";
+    }
+
+    static IssuesConfiguration parse(Section s) {
+        if (s == null) {
+            return DEFAULT;
+        }
+
+        var pattern = s.get("pattern", DEFAULT.pattern());
+        return new IssuesConfiguration(pattern);
+    }
+}

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/JCheckConfiguration.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/JCheckConfiguration.java
@@ -125,6 +125,9 @@ public class JCheckConfiguration {
         config.add("[checks \"committer\"]");
         config.add("role=contributor");
 
+        config.add("[checks \"issues\"]");
+        config.add("pattern=^([124-8][0-9]{6}): (\\S.*)$");
+
         return INI.parse(config);
     }
 

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/IssuesCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/IssuesCheckTests.java
@@ -41,6 +41,7 @@ import java.io.IOException;
 class IssuesCheckTests {
     private final Utilities utils = new Utilities();
 
+    // Default issue pattern: optional prefix followed by 1 or more digits
     private static final List<String> CONFIGURATION = List.of(
         "[general]",
         "project = test",
@@ -48,10 +49,34 @@ class IssuesCheckTests {
         "error = issues"
     );
 
+    // Issue pattern with a required prefix
+    private static final List<String> CONFIGURATION2 = List.of(
+        "[general]",
+        "project = test",
+        "[checks]",
+        "error = issues",
+        "[checks \"issues\"]",
+        "pattern = ^(PROJ-[1-9][0-9]+): (\\S.*)$"
+    );
+
+    // Default issue pattern for legacy conf: 7 digit starting with [124-8]
+    private static final List<String> CONFIGURATION3 = List.of(
+        "project=jdk",
+        "bugids=dup"
+    );
+
     private static JCheckConfiguration conf() {
         return JCheckConfiguration.parse(CONFIGURATION);
     }
 
+
+    private static JCheckConfiguration conf2() {
+        return JCheckConfiguration.parse(CONFIGURATION2);
+    }
+
+    private static JCheckConfiguration conf3() {
+        return JCheckConfiguration.parse(CONFIGURATION3);
+    }
     private static Commit commit(List<String> message) {
         var author = new Author("foo", "foo@host.org");
         var hash = new Hash("0123456789012345678901234567890123456789");
@@ -91,7 +116,7 @@ class IssuesCheckTests {
 
     @Test
     void singleIssueReferenceShouldPass() {
-        var commit = commit(List.of("0123457: A bug"));
+        var commit = commit(List.of("1234570: A bug"));
         var check = new IssuesCheck(utils);
         var issues = toList(check.check(commit, message(commit), conf()));
         assertEquals(0, issues.size());
@@ -99,10 +124,222 @@ class IssuesCheckTests {
 
     @Test
     void multipleIssueReferencesShouldPass() {
-        var commit = commit(List.of("0123457: A bug", "12345678: Another bug"));
+        var commit = commit(List.of("1234570: A bug", "1234567: Another bug"));
         var message = message(commit);
         var check = new IssuesCheck(utils);
         var issues = toList(check.check(commit, message, conf()));
         assertEquals(0, issues.size());
     }
+
+    @Test
+    void issueWithLeadingZeroShouldPass() {
+        var commit = commit(List.of("0123456: A bug"));
+        var message = message(commit);
+        var check = new IssuesCheck(utils);
+        var issues = toList(check.check(commit, message, conf()));
+
+        assertEquals(0, issues.size());
+    }
+
+    @Test
+    void issueWithTooFewDigitsShouldPass() {
+        var commit = commit(List.of("123456: A bug"));
+        var message = message(commit);
+        var check = new IssuesCheck(utils);
+        var issues = toList(check.check(commit, message, conf()));
+
+        assertEquals(0, issues.size());
+    }
+
+    @Test
+    void issueWithTooManyDigitsShouldPass() {
+        var commit = commit(List.of("12345678: A bug"));
+        var message = message(commit);
+        var check = new IssuesCheck(utils);
+        var issues = toList(check.check(commit, message, conf()));
+
+        assertEquals(0, issues.size());
+    }
+
+    @Test
+    void issueWithPrefixShouldPass() {
+        var commit = commit(List.of("JDK-7654321: A bug"));
+        var message = message(commit);
+        var check = new IssuesCheck(utils);
+        var issues = toList(check.check(commit, message, conf()));
+
+        assertEquals(0, issues.size());
+    }
+
+    @Test
+    void issueWithPrefixConf2ShouldPass() {
+        var commit = commit(List.of("PROJ-1234567: A bug"));
+        var message = message(commit);
+        var check = new IssuesCheck(utils);
+        var issues = toList(check.check(commit, message, conf2()));
+
+        assertEquals(0, issues.size());
+    }
+
+    @Test
+    void issueWithoutPrefixConf2ShouldFail() {
+        var commit = commit(List.of("1234567: A bug"));
+        var message = message(commit);
+        var check = new IssuesCheck(utils);
+        var issues = toList(check.check(commit, message, conf2()));
+
+        assertEquals(1, issues.size());
+        assertTrue(issues.get(0) instanceof IssuesIssue);
+        var issue = (IssuesIssue) issues.get(0);
+        assertEquals(commit, issue.commit());
+        assertEquals(message, issue.message());
+        assertEquals(Severity.ERROR, issue.severity());
+        assertEquals(check.getClass(), issue.check().getClass());
+    }
+
+    @Test
+    void issueWithBadPrefixConf2ShouldFail() {
+        var commit = commit(List.of("JDK-1234567: A bug"));
+        var message = message(commit);
+        var check = new IssuesCheck(utils);
+        var issues = toList(check.check(commit, message, conf2()));
+
+        assertEquals(1, issues.size());
+        assertTrue(issues.get(0) instanceof IssuesIssue);
+        var issue = (IssuesIssue) issues.get(0);
+        assertEquals(commit, issue.commit());
+        assertEquals(message, issue.message());
+        assertEquals(Severity.ERROR, issue.severity());
+        assertEquals(check.getClass(), issue.check().getClass());
+    }
+
+    @Test
+    void singleIssueReferenceConf3ShouldPass() {
+        var commit = commit(List.of("1234570: A bug"));
+        var check = new IssuesCheck(utils);
+        var issues = toList(check.check(commit, message(commit), conf3()));
+        assertEquals(0, issues.size());
+    }
+
+    @Test
+    void multipleIssueReferencesConf3ShouldPass() {
+        var commit = commit(List.of("1234570: A bug", "1234567: Another bug"));
+        var message = message(commit);
+        var check = new IssuesCheck(utils);
+        var issues = toList(check.check(commit, message, conf3()));
+        assertEquals(0, issues.size());
+    }
+
+    @Test
+    void issueWithLeadingZeroConf3ShouldFail() {
+        var commit = commit(List.of("0123456: A bug"));
+        var message = message(commit);
+        var check = new IssuesCheck(utils);
+        var issues = toList(check.check(commit, message, conf3()));
+
+        assertEquals(1, issues.size());
+        assertTrue(issues.get(0) instanceof IssuesIssue);
+        var issue = (IssuesIssue) issues.get(0);
+        assertEquals(commit, issue.commit());
+        assertEquals(message, issue.message());
+        assertEquals(Severity.ERROR, issue.severity());
+        assertEquals(check.getClass(), issue.check().getClass());
+    }
+
+    @Test
+    void issueWithLeadingNineConf3ShouldFail() {
+        var commit = commit(List.of("9876543: A bug"));
+        var message = message(commit);
+        var check = new IssuesCheck(utils);
+        var issues = toList(check.check(commit, message, conf3()));
+
+        assertEquals(1, issues.size());
+        assertTrue(issues.get(0) instanceof IssuesIssue);
+        var issue = (IssuesIssue) issues.get(0);
+        assertEquals(commit, issue.commit());
+        assertEquals(message, issue.message());
+        assertEquals(Severity.ERROR, issue.severity());
+        assertEquals(check.getClass(), issue.check().getClass());
+    }
+
+    @Test
+    void issueWithTooFewDigitsConf3ShouldFail() {
+        var commit = commit(List.of("123456: A bug"));
+        var message = message(commit);
+        var check = new IssuesCheck(utils);
+        var issues = toList(check.check(commit, message, conf3()));
+
+        assertEquals(1, issues.size());
+        assertTrue(issues.get(0) instanceof IssuesIssue);
+        var issue = (IssuesIssue) issues.get(0);
+        assertEquals(commit, issue.commit());
+        assertEquals(message, issue.message());
+        assertEquals(Severity.ERROR, issue.severity());
+        assertEquals(check.getClass(), issue.check().getClass());
+    }
+
+    @Test
+    void issueWithTooManyDigitsConf3ShouldFail() {
+        var commit = commit(List.of("12345678: A bug"));
+        var message = message(commit);
+        var check = new IssuesCheck(utils);
+        var issues = toList(check.check(commit, message, conf3()));
+
+        assertEquals(1, issues.size());
+        assertTrue(issues.get(0) instanceof IssuesIssue);
+        var issue = (IssuesIssue) issues.get(0);
+        assertEquals(commit, issue.commit());
+        assertEquals(message, issue.message());
+        assertEquals(Severity.ERROR, issue.severity());
+        assertEquals(check.getClass(), issue.check().getClass());
+    }
+
+    @Test
+    void issueWithPrefixConf3ShouldFail() {
+        var commit = commit(List.of("JDK-7654321: A bug"));
+        var message = message(commit);
+        var check = new IssuesCheck(utils);
+        var issues = toList(check.check(commit, message, conf3()));
+
+        assertEquals(1, issues.size());
+        assertTrue(issues.get(0) instanceof IssuesIssue);
+        var issue = (IssuesIssue) issues.get(0);
+        assertEquals(commit, issue.commit());
+        assertEquals(message, issue.message());
+        assertEquals(Severity.ERROR, issue.severity());
+        assertEquals(check.getClass(), issue.check().getClass());
+    }
+
+    @Test
+    void multipleIssueReferencesFirstBadConf3ShouldFail() {
+        var commit = commit(List.of("12345: A bug", "1234567: Another bug"));
+        var message = message(commit);
+        var check = new IssuesCheck(utils);
+        var issues = toList(check.check(commit, message, conf3()));
+
+        assertEquals(1, issues.size());
+        assertTrue(issues.get(0) instanceof IssuesIssue);
+        var issue = (IssuesIssue) issues.get(0);
+        assertEquals(commit, issue.commit());
+        assertEquals(message, issue.message());
+        assertEquals(Severity.ERROR, issue.severity());
+        assertEquals(check.getClass(), issue.check().getClass());
+    }
+
+    @Test
+    void multipleIssueReferencesLastBadConf3ShouldFail() {
+        var commit = commit(List.of("1234567: A bug", "012: Another bug"));
+        var message = message(commit);
+        var check = new IssuesCheck(utils);
+        var issues = toList(check.check(commit, message, conf3()));
+
+        assertEquals(1, issues.size());
+        assertTrue(issues.get(0) instanceof IssuesIssue);
+        var issue = (IssuesIssue) issues.get(0);
+        assertEquals(commit, issue.commit());
+        assertEquals(message, issue.message());
+        assertEquals(Severity.ERROR, issue.severity());
+        assertEquals(check.getClass(), issue.check().getClass());
+    }
+
 }


### PR DESCRIPTION
JBS issue: https://bugs.openjdk.java.net/browse/SKARA-80

This provides a configuration option to define the pattern for a valid issue ID as follows. This starts with the idea @edvbld mentioned in PR #99, although I felt it was cleaner to leave the default issue format as is, and use the more restrictive pattern for the "legacy" jdk conf file.

The syntax of the new pattern is:

```
[checks "issues"]
pattern=<PATTERN_STRING>
```

The default pattern is:

```
[checks "issues"]
pattern=^(([A-Z][A-Z0-9]+-)?[0-9]+): (\S.*)$
```

For legacy JDK `.jcheck/conf` files, the pattern is as follows to match the issue ID rules in `jcheck.py`:

```
[checks "issues"]
pattern=^([124-8][0-9]{6}): (\S.*)$
```
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**) **Note!** Review applies to a12ec8ee97b871f7ef91a0a4412d7c5be8da9bdc