### PR TITLE
Email body should not be mime encoded

### DIFF
--- a/email/src/main/java/org/openjdk/skara/email/Email.java
+++ b/email/src/main/java/org/openjdk/skara/email/Email.java
@@ -111,10 +111,11 @@ public class Email {
                                              .filter(entry -> !entry.getKey().equalsIgnoreCase("From"))
                                              .filter(entry -> !entry.getKey().equalsIgnoreCase("Sender"))
                                              .filter(entry -> !entry.getKey().equalsIgnoreCase("To"))
+                                             .filter(entry -> !entry.getKey().equalsIgnoreCase("Content-type"))
                                              .collect(Collectors.toMap(Map.Entry::getKey,
                                                                        entry -> MimeText.decode(entry.getValue())));
 
-        return new Email(id, date, recipients, author, sender, subject, MimeText.decode(message.body), filteredHeaders);
+        return new Email(id, date, recipients, author, sender, subject, message.body, filteredHeaders);
     }
 
     public static EmailBuilder create(EmailAddress author, String subject, String body) {

--- a/email/src/main/java/org/openjdk/skara/email/SMTP.java
+++ b/email/src/main/java/org/openjdk/skara/email/SMTP.java
@@ -24,6 +24,7 @@ package org.openjdk.skara.email;
 
 import java.io.*;
 import java.net.Socket;
+import java.nio.charset.StandardCharsets;
 import java.time.format.DateTimeFormatter;
 import java.util.regex.Pattern;
 
@@ -47,8 +48,8 @@ public class SMTP {
             port = Integer.parseInt(parts[1]);
         }
         try (var socket = new Socket(server, port);
-             var out = new OutputStreamWriter(socket.getOutputStream());
-             var in = new InputStreamReader(socket.getInputStream())) {
+             var out = new OutputStreamWriter(socket.getOutputStream(), StandardCharsets.UTF_8);
+             var in = new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8)) {
 
             var session = new SMTPSession(in, out);
 
@@ -66,8 +67,9 @@ public class SMTP {
                 session.sendCommand(header + ": " + MimeText.encode(email.headerValue(header)));
             }
             session.sendCommand("Subject: " + MimeText.encode(email.subject()));
+            session.sendCommand("Content-type: text/plain; charset=utf-8");
             session.sendCommand("");
-            session.sendCommand(MimeText.encode(email.body()));
+            session.sendCommand(email.body());
             session.sendCommand(".", doneReply);
             session.sendCommand("QUIT");
         }

--- a/mailinglist/src/main/java/org/openjdk/skara/mailinglist/Mbox.java
+++ b/mailinglist/src/main/java/org/openjdk/skara/mailinglist/Mbox.java
@@ -129,7 +129,7 @@ public class Mbox {
         mboxMail.println("Message-Id: " + mail.id());
         mail.headers().forEach(header -> mboxMail.println(header + ": " + MimeText.encode(mail.headerValue(header))));
         mboxMail.println();
-        mboxMail.println(encodeFromStrings(MimeText.encode(mail.body())));
+        mboxMail.println(encodeFromStrings(mail.body()));
 
         return mboxString.toString();
     }

--- a/mailinglist/src/main/java/org/openjdk/skara/mailinglist/mboxfile/MboxFileList.java
+++ b/mailinglist/src/main/java/org/openjdk/skara/mailinglist/mboxfile/MboxFileList.java
@@ -55,10 +55,10 @@ public class MboxFileList implements MailingList {
             }
         }
         try {
-            Files.writeString(file, mboxMail, StandardCharsets.US_ASCII, StandardOpenOption.APPEND);
+            Files.writeString(file, mboxMail, StandardCharsets.UTF_8, StandardOpenOption.APPEND);
         } catch (IOException e) {
             try {
-                Files.writeString(file, mboxMail, StandardCharsets.US_ASCII, StandardOpenOption.CREATE_NEW);
+                Files.writeString(file, mboxMail, StandardCharsets.UTF_8, StandardOpenOption.CREATE_NEW);
             } catch (IOException e1) {
                 throw new UncheckedIOException(e);
             }
@@ -68,7 +68,7 @@ public class MboxFileList implements MailingList {
     private void postReply(Email mail) {
         var mboxMail = Mbox.fromMail(mail);
         try {
-            Files.writeString(file, mboxMail, StandardCharsets.US_ASCII, StandardOpenOption.APPEND);
+            Files.writeString(file, mboxMail, StandardCharsets.UTF_8, StandardOpenOption.APPEND);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -87,7 +87,7 @@ public class MboxFileList implements MailingList {
     public List<Conversation> conversations(Duration maxAge) {
         String mbox;
         try {
-            mbox = Files.readString(file, StandardCharsets.US_ASCII);
+            mbox = Files.readString(file, StandardCharsets.UTF_8);
         } catch (IOException e) {
             log.info("Failed to open mbox file");
             log.throwing("MboxFileList", "conversations", e);


### PR DESCRIPTION
Hi all,

Please review this change that reverts the previously introduced mime encoding of email bodies. This encoding should only be applied to email headers. For the body, a content-type header should be used.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**) **Note!** Review applies to 642a41a53e830281648438d1d8989ef07f02eb85