### PR TITLE
The test mailman server should handle utf-8 encoded content

### DIFF
--- a/test/src/main/java/org/openjdk/skara/test/TestMailmanServer.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestMailmanServer.java
@@ -69,9 +69,10 @@ public class TestMailmanServer implements AutoCloseable {
                     }
                 }
 
-                exchange.sendResponseHeaders(200, response.length());
+                var responseBytes = response.getBytes(StandardCharsets.UTF_8);
+                exchange.sendResponseHeaders(200, responseBytes.length);
                 OutputStream outputStream = exchange.getResponseBody();
-                outputStream.write(response.getBytes());
+                outputStream.write(responseBytes);
                 outputStream.close();
             } catch (NoSuchAlgorithmException e) {
                 throw new RuntimeException(e);


### PR DESCRIPTION
Hi all,

Please review this small change that fixes a failing test case introduced by no longer mime encoding email bodies.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)