### PR TITLE
Proper separating of collapsed reply ids

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
@@ -266,7 +266,7 @@ class ReviewArchive {
             generated.remove(parentEmail);
             generatedIds.remove(getStableMessageId(parentEmail.id()));
 
-            var collapsed = parentEmail.hasHeader("PR-Collapsed-IDs") ? parentEmail.headerValue("PR-Collapsed-IDs") : "";
+            var collapsed = parentEmail.hasHeader("PR-Collapsed-IDs") ? parentEmail.headerValue("PR-Collapsed-IDs") + " " : "";
             collapsed += getStableMessageId(parentEmail.id());
 
             var reply = ArchiveMessages.composeCombinedReply(parentEmail, body, prInstance);

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -376,9 +376,11 @@ class MailingListBridgeBotTests {
             listServer.processIncoming();
             listServer.processIncoming();
 
-            // Make two file specific comments
+            // Make several file specific comments
             var first = pr.addReviewComment(masterHash, editHash, reviewFile.toString(), 2, "Review comment");
             pr.addReviewComment(masterHash, editHash, reviewFile.toString(), 2, "Another review comment");
+            pr.addReviewComment(masterHash, editHash, reviewFile.toString(), 2, "Further review comment");
+            pr.addReviewComment(masterHash, editHash, reviewFile.toString(), 2, "Final review comment");
             TestBotRunner.runPeriodicItems(mlBot);
             listServer.processIncoming();
 
@@ -414,6 +416,9 @@ class MailingListBridgeBotTests {
             // The archive should contain a new entry
             Repository.materialize(archiveFolder.path(), archive.getUrl(), "master");
             assertEquals(3, archiveContainsCount(archiveFolder.path(), "^On.*wrote:"));
+
+            // The combined review comments should only appear unquoted once
+            assertEquals(1, archiveContainsCount(archiveFolder.path(), "^Another review comment"));
         }
     }
 


### PR DESCRIPTION
Hi all,

Please review this change that fixes a problem when more than two replies have been collapsed into a single mail.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)