### PR TITLE
WIP: 108: Command line tools fon't run with Cygwin git

### DIFF
--- a/skara.sh
+++ b/skara.sh
@@ -24,7 +24,14 @@
 DIR=$(dirname "${0}")
 OS=$(uname)
 
-if [ "${OS}" = "Linux" -o "${OS}" = "Darwin" ]; then
+case "${OS}" in
+    Linux) USEBAT=0 ;;
+    Darwin) USEBAT=0 ;;
+    CYGWIN*) USEBAT=0 ;;
+    *) USEBAT=1 ;;
+esac
+
+if [ ${USEBAT} -eq 0 ]; then
     if [ ! -x "${DIR}/bin/bin/git-skara" ]; then
         echo "Compiling ..."
         (cd "${DIR}" && sh gradlew)
@@ -42,7 +49,7 @@ if [ -d "${DIR}/build" ]; then
     mv "${DIR}/build" "${DIR}/bin"
 fi
 
-if [ "${OS}" = "Linux" -o "${OS}" = "Darwin" ]; then
+if [ ${USEBAT} -eq 0 ]; then
     exec "${DIR}/bin/bin/git-skara" "${@}"
 else
     exec "${DIR}/bin/bin/git-skara.bat" "${@}"

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -715,6 +715,8 @@ public class GitRepository implements Repository {
     }
 
     private String treeEntry(Path path, Hash hash) throws IOException {
+        // CYGWIN: map `\` to `/`
+        // FIXME: only do this if using Cygwin git
         try (var p = Process.capture("git", "ls-tree", hash.hex(), path.toString().replace("\\", "/"))
                             .workdir(root())
                             .execute()) {


### PR DESCRIPTION
https://bugs.openjdk.java.net/browse/SKARA-108

This is a very preliminary "proof of concept" patch that allows `git jcheck` to work with git from Cygwin. It is incomplete, and is missing the necessary checks to allow it to continue working with native Windows git.

@edvbld @rwestberg - I submitted it this early to get your high-level feedback on whether this support is something that you have thought about already; if not, I'd like your feedback on the approach.

The idea would be to check whether we are are using a Cygwin version of git (this should be trivial), and if so, do the conversion between the `Path` strings and the input/output to the `git` command in all of the necessary places in `GitRepository` (that should be the only class that needs to be modified).
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/170/head:pull/170`
`$ git checkout pull/170`
