### PR TITLE
Add issue information to the PR summary

### DIFF
--- a/bot/src/main/java/org/openjdk/skara/bot/BotConfiguration.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotConfiguration.java
@@ -22,7 +22,7 @@
  */
 package org.openjdk.skara.bot;
 
-import org.openjdk.skara.host.HostedRepository;
+import org.openjdk.skara.host.*;
 import org.openjdk.skara.json.JSONObject;
 
 import java.nio.file.Path;
@@ -40,6 +40,13 @@ public interface BotConfiguration {
      * @return
      */
     HostedRepository repository(String name);
+
+    /**
+     * Configuration-specific name mapped to a IssueProject.
+     * @param name
+     * @return
+     */
+    IssueProject issueProject(String name);
 
     /**
      * Retrieves the ref name that optionally follows the configuration-specific repository name.

--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunnerConfiguration.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunnerConfiguration.java
@@ -149,6 +149,21 @@ public class BotRunnerConfiguration {
         return ret;
     }
 
+    private IssueProject parseIssueProjectEntry(String entry) throws ConfigurationError {
+        var hostSeparatorIndex = entry.indexOf('/');
+        if (hostSeparatorIndex >= 0) {
+            var hostName = entry.substring(0, hostSeparatorIndex);
+            var host = hosts.get(hostName);
+            if (!hosts.containsKey(hostName)) {
+                throw new ConfigurationError("Issue project entry " + entry + " uses undefined host '" + hostName + "'");
+            }
+            var issueProjectName = entry.substring(hostSeparatorIndex + 1);
+            return host.getIssueProject(issueProjectName);
+        } else {
+            throw new ConfigurationError("Malformed issue project entry");
+        }
+    }
+
     public static BotRunnerConfiguration parse(JSONObject config, Path cwd) throws ConfigurationError {
         return new BotRunnerConfiguration(config, cwd);
     }
@@ -182,6 +197,15 @@ public class BotRunnerConfiguration {
                     return entry.repository;
                 } catch (ConfigurationError configurationError) {
                     throw new RuntimeException("Couldn't find repository with name: " + name, configurationError);
+                }
+            }
+
+            @Override
+            public IssueProject issueProject(String name) {
+                try {
+                    return parseIssueProjectEntry(name);
+                } catch (ConfigurationError configurationError) {
+                    throw new RuntimeException("Couldn't find issue project with name: " + name, configurationError);
                 }
             }
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -254,14 +254,12 @@ class CheckRun {
 
     private String getStatusMessage(List<Review> reviews, PullRequestCheckIssueVisitor visitor) {
         var progressBody = new StringBuilder();
-        progressBody.append("Progress\n");
-        progressBody.append("--------\n");
+        progressBody.append("## Progress\n");
         progressBody.append(getChecksList(visitor));
 
         var issue = Issue.fromString(pr.getTitle());
         if (issueProject != null && issue.isPresent()) {
-            progressBody.append("\n\nIssue\n");
-            progressBody.append("--------\n");
+            progressBody.append("\n\n## Issue\n");
             var iss = issueProject.getIssue(issue.get().id());
             if (iss.isPresent()) {
                 progressBody.append("[");
@@ -279,8 +277,7 @@ class CheckRun {
         }
 
         getReviewersList(reviews).ifPresent(reviewers -> {
-            progressBody.append("\n\nApprovers\n");
-            progressBody.append("---------\n");
+            progressBody.append("\n\n## Approvers\n");
             progressBody.append(reviewers);
         });
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -24,6 +24,7 @@ package org.openjdk.skara.bots.pr;
 
 import org.openjdk.skara.host.*;
 import org.openjdk.skara.vcs.*;
+import org.openjdk.skara.vcs.openjdk.Issue;
 
 import java.io.IOException;
 import java.util.*;
@@ -41,6 +42,7 @@ class CheckRun {
     private final Set<String> labels;
     private final CensusInstance censusInstance;
     private final Map<String, String> blockingLabels;
+    private final IssueProject issueProject;
 
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots.pr");
     private final String progressMarker = "<!-- Anything below this marker will be automatically updated, please do not edit manually! -->";
@@ -50,7 +52,7 @@ class CheckRun {
 
     private CheckRun(CheckWorkItem workItem, PullRequest pr, PullRequestInstance prInstance, List<Comment> comments,
                      List<Review> allReviews, List<Review> activeReviews, Set<String> labels,
-                     CensusInstance censusInstance, Map<String, String> blockingLabels) {
+                     CensusInstance censusInstance, Map<String, String> blockingLabels, IssueProject issueProject) {
         this.workItem = workItem;
         this.pr = pr;
         this.prInstance = prInstance;
@@ -61,11 +63,13 @@ class CheckRun {
         this.newLabels = new HashSet<>(labels);
         this.censusInstance = censusInstance;
         this.blockingLabels = blockingLabels;
+        this.issueProject = issueProject;
     }
 
     static void execute(CheckWorkItem workItem, PullRequest pr, PullRequestInstance prInstance, List<Comment> comments,
-                        List<Review> allReviews, List<Review> activeReviews, Set<String> labels, CensusInstance censusInstance, Map<String, String> blockingLabels) {
-        var run = new CheckRun(workItem, pr, prInstance, comments, allReviews, activeReviews, labels, censusInstance, blockingLabels);
+                        List<Review> allReviews, List<Review> activeReviews, Set<String> labels, CensusInstance censusInstance, Map<String, String> blockingLabels,
+                        IssueProject issueProject) {
+        var run = new CheckRun(workItem, pr, prInstance, comments, allReviews, activeReviews, labels, censusInstance, blockingLabels, issueProject);
         run.checkStatus();
     }
 
@@ -248,12 +252,32 @@ class CheckRun {
         }
     }
 
-    private String getStatusMessage(List<Review> reviews, PullRequestCheckIssueVisitor visitor) throws IOException {
+    private String getStatusMessage(List<Review> reviews, PullRequestCheckIssueVisitor visitor) {
         var progressBody = new StringBuilder();
         progressBody.append("Progress\n");
         progressBody.append("--------\n");
-
         progressBody.append(getChecksList(visitor));
+
+        var issue = Issue.fromString(pr.getTitle());
+        if (issueProject != null && issue.isPresent()) {
+            progressBody.append("\n\nIssue\n");
+            progressBody.append("--------\n");
+            var iss = issueProject.getIssue(issue.get().id());
+            if (iss.isPresent()) {
+                progressBody.append("[");
+                progressBody.append(iss.get().getId());
+                progressBody.append("](");
+                progressBody.append(iss.get().getWebUrl());
+                progressBody.append("]: ");
+                progressBody.append(iss.get().getTitle());
+                progressBody.append("\n");
+            } else {
+                progressBody.append("⚠️ Failed to retrieve information on issue `");
+                progressBody.append(issue.get().toString());
+                progressBody.append("`.\n");
+            }
+        }
+
         getReviewersList(reviews).ifPresent(reviewers -> {
             progressBody.append("\n\nApprovers\n");
             progressBody.append("---------\n");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -40,15 +40,18 @@ class CheckWorkItem extends PullRequestWorkItem {
     private final HostedRepository censusRepo;
     private final String censusRef;
     private final Map<String, String> blockingLabels;
+    private final IssueProject issueProject;
 
     private final Pattern metadataComments = Pattern.compile("<!-- (?:(add|remove) contributor)|(?:summary: ')");
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots.pr");
 
-    CheckWorkItem(PullRequest pr, HostedRepository censusRepo, String censusRef, Map<String, String> blockingLabels, Consumer<RuntimeException> errorHandler) {
+    CheckWorkItem(PullRequest pr, HostedRepository censusRepo, String censusRef, Map<String, String> blockingLabels,
+                  Consumer<RuntimeException> errorHandler, IssueProject issueProject) {
         super(pr, errorHandler);
         this.censusRepo = censusRepo;
         this.censusRef = censusRef;
         this.blockingLabels = blockingLabels;
+        this.issueProject = issueProject;
     }
 
     private String encodeReviewer(HostUserDetails reviewer, CensusInstance censusInstance) {
@@ -153,7 +156,8 @@ class CheckWorkItem extends PullRequestWorkItem {
 
             try {
                 var prInstance = new PullRequestInstance(scratchPath.resolve("pr"), pr);
-                CheckRun.execute(this, pr, prInstance, comments, allReviews, activeReviews, labels, census, blockingLabels);
+                CheckRun.execute(this, pr, prInstance, comments, allReviews, activeReviews, labels, census,
+                                 blockingLabels, issueProject);
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
@@ -76,8 +76,11 @@ public class PullRequestBotFactory implements BotFactory {
                     labelPatterns.put(label.name(), patterns);
                 }
             }
+            var issueProject = repo.value().contains("issues") ?
+                    configuration.issueProject(repo.value().get("issues").asString()) :
+                    null;
             var bot = new PullRequestBot(configuration.repository(repo.name()), censusRepo, censusRef, labelPatterns,
-                                         external, blockers, readyLabels, readyComments);
+                                         external, blockers, readyLabels, readyComments, issueProject);
             ret.add(bot);
         }
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -780,4 +780,71 @@ class CheckTests {
             assertEquals(CheckStatus.SUCCESS, check.status());
         }
     }
+
+    @Test
+    void issueInSummary(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var reviewer = credentials.getHostedRepository();
+            var issues = credentials.getIssueProject();
+
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addAuthor(author.host().getCurrentUserDetails().id())
+                                           .addReviewer(reviewer.host().getCurrentUserDetails().id());
+            var checkBot = new PullRequestBot(author, censusBuilder.build(), "master", Map.of(), Map.of(),
+                                              Map.of(), Set.of(), Map.of(), issues);
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.getRepositoryType(), Path.of("appendable.txt"),
+                                                     Set.of("issues"));
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            localRepo.push(masterHash, author.getUrl(), "master", true);
+
+            var issue1 = issues.createIssue("My first issue", List.of("Hello"));
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.getUrl(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", issue1.getId() + ": This is a pull request");
+
+            // Check the status
+            TestBotRunner.runPeriodicItems(checkBot);
+
+            // The check should be successful
+            var checks = pr.getChecks(editHash);
+            assertEquals(1, checks.size());
+            var check = checks.get("jcheck");
+            assertEquals(CheckStatus.SUCCESS, check.status());
+
+            // And the body should contain the issue title
+            assertTrue(pr.getBody().contains("My first issue"));
+
+            // Change the issue
+            var issue2 = issues.createIssue("My second issue", List.of("Body"));
+            pr.setTitle(issue2.getId() + ": This is a pull request");
+
+            // Check the status again
+            TestBotRunner.runPeriodicItems(checkBot);
+
+            // The body should contain the updated issue title
+            assertFalse(pr.getBody().contains("My first issue"));
+            assertTrue(pr.getBody().contains("My second issue"));
+
+            // Now enter an invalid issue id
+            pr.setTitle("2384848: This is a pull request");
+
+            // Check the status again
+            TestBotRunner.runPeriodicItems(checkBot);
+            assertFalse(pr.getBody().contains("My first issue"));
+            assertFalse(pr.getBody().contains("My second issue"));
+            assertTrue(pr.getBody().contains("Failed to retrieve"));
+
+            // The check should still be successful though
+            checks = pr.getChecks(editHash);
+            assertEquals(1, checks.size());
+            check = checks.get("jcheck");
+            assertEquals(CheckStatus.SUCCESS, check.status());
+        }
+    }
 }

--- a/host/src/main/java/org/openjdk/skara/host/IssueProject.java
+++ b/host/src/main/java/org/openjdk/skara/host/IssueProject.java
@@ -23,12 +23,12 @@
 package org.openjdk.skara.host;
 
 import java.net.URI;
-import java.util.List;
+import java.util.*;
 
 public interface IssueProject {
     Host host();
     URI getWebUrl();
     Issue createIssue(String title, List<String> body);
-    Issue getIssue(String id);
+    Optional<Issue> getIssue(String id);
     List<Issue> getIssues();
 }

--- a/host/src/main/java/org/openjdk/skara/host/github/GitHubRepository.java
+++ b/host/src/main/java/org/openjdk/skara/host/github/GitHubRepository.java
@@ -78,7 +78,7 @@ public class GitHubRepository implements HostedRepository {
     }
 
     @Override
-    public Issue getIssue(String id) {
+    public Optional<Issue> getIssue(String id) {
         throw new RuntimeException("not implemented yet");
     }
 

--- a/host/src/main/java/org/openjdk/skara/host/gitlab/GitLabRepository.java
+++ b/host/src/main/java/org/openjdk/skara/host/gitlab/GitLabRepository.java
@@ -71,7 +71,7 @@ public class GitLabRepository implements HostedRepository {
     }
 
     @Override
-    public Issue getIssue(String id) {
+    public Optional<Issue> getIssue(String id) {
         throw new RuntimeException("not implemented yet");
     }
 

--- a/test/src/main/java/org/openjdk/skara/test/TestHost.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHost.java
@@ -164,6 +164,9 @@ public class TestHost implements Host {
 
     TestIssue getIssue(TestIssueProject issueProject, String id) {
         var original = data.issues.get(id);
+        if (original == null) {
+            return null;
+        }
         return TestIssue.createFrom(issueProject, original);
     }
 

--- a/test/src/main/java/org/openjdk/skara/test/TestIssueProject.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestIssueProject.java
@@ -53,8 +53,8 @@ public class TestIssueProject implements IssueProject {
     }
 
     @Override
-    public Issue getIssue(String id) {
-        return host.getIssue(this, id);
+    public Optional<Issue> getIssue(String id) {
+        return Optional.ofNullable(host.getIssue(this, id));
     }
 
     @Override


### PR DESCRIPTION
Hi all,

Please review this change that adds issue information to the PR summary, if it can be parsed from the PR title. It also tries to retrieve the title of the issue from the associated issue tracker.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**) **Note!** Review applies to d7dceeedc847c1a72ebedbec1d95c7925daf0d12