### PR TITLE
Add Makefile wrapper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,56 @@
+# Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+
+BUILD=build
+prefix=$(HOME)/.local
+bindir=$(prefix)/bin
+sharedir=$(prefix)/share
+mandir=$(prefix)/man
+
+LAUNCHERS=$(addprefix $(bindir)/,$(notdir $(wildcard $(BUILD)/bin/git-*)))
+MANPAGES=$(addprefix $(mandir)/man1/,$(notdir $(wildcard $(BUILD)/bin/man/man1/*)))
+
+all:
+	@sh gradlew
+
+check:
+	@sh gradlew test
+
+test:
+	@sh gradlew test
+
+install: all $(LAUNCHERS) $(MANPAGES) $(sharedir)/skara
+
+$(mandir)/man1/%: $(BUILD)/bin/man/man1/%
+	@mkdir -p $(mandir)/man1
+	@cp $< $@
+
+$(sharedir)/skara: $(BUILD)/image
+	@mkdir -p $(sharedir)
+	@rm -rf $@
+	@cp -r $< $@
+
+$(bindir)/%: $(BUILD)/bin/%
+	@mkdir -p $(bindir)
+	@sed 's~export JAVA_HOME=.*$$~export JAVA_HOME\=$(sharedir)\/skara~' < $< > $@
+	@chmod 755 $@
+
+.PHONY: all check install test

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ test:
 	@sh gradlew test
 
 install: all $(LAUNCHERS) $(MANPAGES) $(sharedir)/skara
+	@echo "Successfully installed to $(prefix)"
 
 $(mandir)/man1/%: $(BUILD)/bin/man/man1/%
 	@mkdir -p $(mandir)/man1

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,11 @@ test:
 install: all $(LAUNCHERS) $(MANPAGES) $(sharedir)/skara
 	@echo "Successfully installed to $(prefix)"
 
+uninstall:
+	@rm -rf $(sharedir)/skara
+	@rm $(LAUNCHERS)
+	@rm $(MANPAGES)
+
 $(mandir)/man1/%: $(BUILD)/bin/man/man1/%
 	@mkdir -p $(mandir)/man1
 	@cp $< $@
@@ -54,4 +59,4 @@ $(bindir)/%: $(BUILD)/bin/%
 	@sed 's~export JAVA_HOME=.*$$~export JAVA_HOME\=$(sharedir)\/skara~' < $< > $@
 	@chmod 755 $@
 
-.PHONY: all check install test
+.PHONY: all check install test uninstall


### PR DESCRIPTION
Hi all,

this patch adds a Makefile "wrapper" around `gradlew`. This allows the Skara CLI tooling to be installed using the (for Linux/macOS users) familiar commands:

```bash
$ make
$ make install
```

The user can also give a prefix to `make install`, as in `make prefix=/usr install`. The Makefile variables have the same names as for git upstream. One benefit of installing the Skara CLI tooling this way is that the man pages are available via `--help` to various Skara CLI commands.

Please note that this is in _no_ way meant to replace the existing Gradle based build system, this is only a thin wrapper for convenience.

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**) **Note!** Review applies to c34d755acee1ded4c011dd858ca519c4f5ddbbcc