### PR TITLE
Add Host::isMemberOf

### DIFF
--- a/host/src/main/java/org/openjdk/skara/host/Host.java
+++ b/host/src/main/java/org/openjdk/skara/host/Host.java
@@ -31,7 +31,7 @@ public interface Host {
     HostUserDetails getUserDetails(String username);
     HostUserDetails getCurrentUserDetails();
     boolean supportsReviewBody();
-    boolean isMemberOf(long groupId, HostUserDetails user);
+    boolean isMemberOf(String groupId, HostUserDetails user);
 
     static Host from(URI uri, PersonalAccessToken pat) {
         return HostFactory.createFromURI(uri, pat);

--- a/host/src/main/java/org/openjdk/skara/host/github/GitHubHost.java
+++ b/host/src/main/java/org/openjdk/skara/host/github/GitHubHost.java
@@ -201,11 +201,17 @@ public class GitHubHost implements Host {
     }
 
     @Override
-    public boolean isMemberOf(long groupId, HostUserDetails user) {
+    public boolean isMemberOf(String groupId, HostUserDetails user) {
+        long gid = 0L;
+        try {
+            gid = Long.parseLong(groupId);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Group id is not a number: " + groupId);
+        }
         var username = URLEncoder.encode(user.userName(), StandardCharsets.UTF_8);
         var orgs = request.get("users/" + username + "/orgs").execute().asArray();
         for (var org : orgs) {
-            if (org.get("id").asLong() == groupId) {
+            if (org.get("id").asLong() == gid) {
                 return true;
             }
         }

--- a/host/src/main/java/org/openjdk/skara/host/github/GitHubHost.java
+++ b/host/src/main/java/org/openjdk/skara/host/github/GitHubHost.java
@@ -199,4 +199,17 @@ public class GitHubHost implements Host {
     public boolean supportsReviewBody() {
         return true;
     }
+
+    @Override
+    public boolean isMemberOf(long groupId, HostUserDetails user) {
+        var username = URLEncoder.encode(user.userName(), StandardCharsets.UTF_8);
+        var orgs = request.get("users/" + username + "/orgs").execute().asArray();
+        for (var org : orgs) {
+            if (org.get("id").asLong() == groupId) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/host/src/main/java/org/openjdk/skara/host/gitlab/GitLabHost.java
+++ b/host/src/main/java/org/openjdk/skara/host/gitlab/GitLabHost.java
@@ -142,4 +142,13 @@ public class GitLabHost implements Host {
             throw new RuntimeException("Project does not seem to be a fork");
         }
     }
+
+    @Override
+    public boolean isMemberOf(long groupId, HostUserDetails user) {
+        var details = request.get("groups/" + groupId + "/members/" + user.id())
+                             .onError(r -> JSON.of())
+                             .execute()
+                             .asObject();
+        return !details.isNull();
+    }
 }

--- a/host/src/main/java/org/openjdk/skara/host/gitlab/GitLabHost.java
+++ b/host/src/main/java/org/openjdk/skara/host/gitlab/GitLabHost.java
@@ -144,8 +144,14 @@ public class GitLabHost implements Host {
     }
 
     @Override
-    public boolean isMemberOf(long groupId, HostUserDetails user) {
-        var details = request.get("groups/" + groupId + "/members/" + user.id())
+    public boolean isMemberOf(String groupId, HostUserDetails user) {
+        long gid = 0L;
+        try {
+            gid = Long.parseLong(groupId);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Group id is not a number: " + groupId);
+        }
+        var details = request.get("groups/" + gid + "/members/" + user.id())
                              .onError(r -> JSON.of())
                              .execute()
                              .asObject();

--- a/host/src/test/java/org/openjdk/skara/host/HostTests.java
+++ b/host/src/test/java/org/openjdk/skara/host/HostTests.java
@@ -35,7 +35,7 @@ public class HostTests {
     public void isMemberOfNegativeTests(TestInfo info) throws IOException {
         try (var credentials = new HostCredentials(info)) {
             var host = credentials.getHostedRepository().host();
-            var madeUpGroupIdThatCannotContainTestMember = 1234567890L;
+            var madeUpGroupIdThatCannotContainTestMember = "1234567890";
             assertFalse(host.isMemberOf(madeUpGroupIdThatCannotContainTestMember, host.getCurrentUserDetails()));
         }
     }

--- a/host/src/test/java/org/openjdk/skara/host/HostTests.java
+++ b/host/src/test/java/org/openjdk/skara/host/HostTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,22 +22,21 @@
  */
 package org.openjdk.skara.host;
 
-import java.net.URI;
+import java.io.IOException;
 
-public interface Host {
-    boolean isValid();
-    HostedRepository getRepository(String name);
-    IssueProject getIssueProject(String name);
-    HostUserDetails getUserDetails(String username);
-    HostUserDetails getCurrentUserDetails();
-    boolean supportsReviewBody();
-    boolean isMemberOf(long groupId, HostUserDetails user);
+import org.openjdk.skara.test.HostCredentials;
 
-    static Host from(URI uri, PersonalAccessToken pat) {
-        return HostFactory.createFromURI(uri, pat);
-    }
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
-    static Host from(URI uri) {
-        return HostFactory.createFromURI(uri, null);
+public class HostTests {
+    @Test
+    public void isMemberOfNegativeTests(TestInfo info) throws IOException {
+        try (var credentials = new HostCredentials(info)) {
+            var host = credentials.getHostedRepository().host();
+            var madeUpGroupIdThatCannotContainTestMember = 1234567890L;
+            assertFalse(host.isMemberOf(madeUpGroupIdThatCannotContainTestMember, host.getCurrentUserDetails()));
+        }
     }
 }

--- a/test/src/main/java/org/openjdk/skara/test/TestHost.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHost.java
@@ -130,7 +130,7 @@ public class TestHost implements Host {
     }
 
     @Override
-    public boolean isMemberOf(long groupId, HostUserDetails user) {
+    public boolean isMemberOf(String groupId, HostUserDetails user) {
         return false;
     }
 

--- a/test/src/main/java/org/openjdk/skara/test/TestHost.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHost.java
@@ -129,6 +129,11 @@ public class TestHost implements Host {
         return true;
     }
 
+    @Override
+    public boolean isMemberOf(long groupId, HostUserDetails user) {
+        return false;
+    }
+
     void close() {
         if (currentUser == 0) {
             data.folders.forEach(TemporaryDirectory::close);


### PR DESCRIPTION
Hi all,

this patch adds a new method `Host::isMemberOf` that can be used to query a host (e.g. GitHub or Gitlab) if a specific user is a member of a particular group. I couldn't come up with a positive test for the method, since it is really hard to rely on a test user being a member of a particular group, but I could at least write a negative test.

## Testing
- [x] `sh gradlew test` passes on Linux x86_64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)