### PR TITLE
Batch add tags in the notifier bot

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/JNotifyBot.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/JNotifyBot.java
@@ -113,7 +113,7 @@ class JNotifyBot implements Bot, WorkItem {
         if (tags.size() == newTags.size()) {
             if (tags.size() > 0) {
                 log.warning("No previous tag history found - ignoring all current tags");
-                tags.forEach(history::addTag);
+                history.addTags(tags);
             }
             return;
         }
@@ -142,7 +142,7 @@ class JNotifyBot implements Bot, WorkItem {
             }
 
             // Update the history first - if there is a problem here we don't want to send out multiple updates
-            history.addTag(tag.tag());
+            history.addTags(List.of(tag.tag()));
 
             Collections.reverse(commits);
             for (var updater : updaters) {

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/UpdateHistory.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/UpdateHistory.java
@@ -44,11 +44,11 @@ class UpdateHistory {
                       .collect(Collectors.toSet());
     }
 
-    private String serializeBranches(ResolvedBranch added, Set<ResolvedBranch> existing) {
+    private String serializeBranches(Collection<ResolvedBranch> added, Set<ResolvedBranch> existing) {
         var updatedBranches = existing.stream()
-                .collect(Collectors.toMap(ResolvedBranch::branch,
-                                          ResolvedBranch::hash));
-        updatedBranches.put(added.branch(), added.hash());
+                                      .collect(Collectors.toMap(ResolvedBranch::branch,
+                                                                ResolvedBranch::hash));
+        added.forEach(a -> updatedBranches.put(a.branch(), a.hash()));
         return updatedBranches.entrySet().stream()
                               .map(entry -> entry.getKey().toString() + " " + entry.getValue().toString())
                               .sorted()
@@ -61,9 +61,9 @@ class UpdateHistory {
                       .collect(Collectors.toSet());
     }
 
-    private String serializeTags(Tag added, Set<Tag> existing) {
+    private String serializeTags(Collection<Tag> added, Set<Tag> existing) {
         return Stream.concat(existing.stream(),
-                             Stream.of(added))
+                             added.stream())
                      .map(Tag::toString)
                      .sorted()
                      .collect(Collectors.joining("\n"));
@@ -97,12 +97,12 @@ class UpdateHistory {
         return new UpdateHistory(tagStorageBuilder, tagLocation, branchStorageBuilder, branchLocation);
     }
 
-    void addTag(Tag tag) {
-        tagStorage.put(tag);
+    void addTags(Collection<Tag> addedTags) {
+        tagStorage.put(addedTags);
         var newTags = currentTags();
 
-        if (tags != null) {
-            for (var existingTag : tags) {
+        if (addedTags != null) {
+            for (var existingTag : addedTags) {
                 if (!newTags.contains(existingTag)) {
                     throw new RuntimeException("Tag '" + existingTag + "' has been removed");
                 }

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdateHistoryTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdateHistoryTests.java
@@ -22,19 +22,19 @@
  */
 package org.openjdk.skara.bots.notify;
 
-import org.junit.jupiter.api.*;
-
 import org.openjdk.skara.host.HostedRepository;
 import org.openjdk.skara.storage.StorageBuilder;
-import org.openjdk.skara.test.*;
-import org.openjdk.skara.vcs.*;
+import org.openjdk.skara.test.HostCredentials;
 import org.openjdk.skara.vcs.Tag;
+import org.openjdk.skara.vcs.*;
+
+import org.junit.jupiter.api.*;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class UpdateHistoryTests {
     private String resetHostedRepository(HostedRepository repository) throws IOException {
@@ -64,8 +64,7 @@ class UpdateHistoryTests {
             var ref = resetHostedRepository(repository);
             var history = createHistory(repository, ref);
 
-            history.addTag(new Tag("1"));
-            history.addTag(new Tag("2"));
+            history.addTags(List.of(new Tag("1"), new Tag("2")));
 
             assertTrue(history.hasTag(new Tag("1")));
             assertTrue(history.hasTag(new Tag("2")));
@@ -106,8 +105,7 @@ class UpdateHistoryTests {
             var ref = resetHostedRepository(repository);
             var history = createHistory(repository, ref);
 
-            history.addTag(new Tag("1"));
-            history.addTag(new Tag("2"));
+            history.addTags(List.of(new Tag("1"), new Tag("2")));
 
             assertTrue(history.hasTag(new Tag("1")));
             assertTrue(history.hasTag(new Tag("2")));
@@ -124,8 +122,8 @@ class UpdateHistoryTests {
             assertFalse(history2.hasTag(new Tag("3")));
             assertFalse(history2.hasTag(new Tag("4")));
 
-            history1.addTag(new Tag("3"));
-            history2.addTag(new Tag("4"));
+            history1.addTags(Set.of(new Tag("3")));
+            history2.addTags(Set.of(new Tag("4")));
 
             assertTrue(history1.hasTag(new Tag("3")));
             assertFalse(history1.hasTag(new Tag("4")));

--- a/storage/src/main/java/org/openjdk/skara/storage/FileStorage.java
+++ b/storage/src/main/java/org/openjdk/skara/storage/FileStorage.java
@@ -52,8 +52,8 @@ class FileStorage<T> implements Storage<T> {
     }
 
     @Override
-    public void put(T item) {
-        var updated = serializer.serialize(item, current());
+    public void put(Collection<T> items) {
+        var updated = serializer.serialize(items, current());
         if (current.equals(updated)) {
             return;
         }

--- a/storage/src/main/java/org/openjdk/skara/storage/HostedRepositoryStorage.java
+++ b/storage/src/main/java/org/openjdk/skara/storage/HostedRepositoryStorage.java
@@ -27,7 +27,7 @@ import org.openjdk.skara.vcs.*;
 
 import java.io.*;
 import java.nio.file.*;
-import java.util.Set;
+import java.util.*;
 
 class HostedRepositoryStorage<T> implements Storage<T> {
     private final HostedRepository hostedRepository;
@@ -80,14 +80,14 @@ class HostedRepositoryStorage<T> implements Storage<T> {
     }
 
     @Override
-    public void put(T item) {
+    public void put(Collection<T> items) {
         int retryCount = 0;
         IOException lastException = null;
         Hash lastRemoteHash = null;
 
         while (retryCount < 10) {
             // Update our local storage
-            repositoryStorage.put(item);
+            repositoryStorage.put(items);
             var updated = repositoryStorage.current();
             if (current.equals(updated)) {
                 return;

--- a/storage/src/main/java/org/openjdk/skara/storage/RepositoryStorage.java
+++ b/storage/src/main/java/org/openjdk/skara/storage/RepositoryStorage.java
@@ -25,7 +25,7 @@ package org.openjdk.skara.storage;
 import org.openjdk.skara.vcs.Repository;
 
 import java.io.*;
-import java.util.Set;
+import java.util.*;
 
 class RepositoryStorage<T> implements Storage<T> {
     private final Repository repository;
@@ -66,8 +66,8 @@ class RepositoryStorage<T> implements Storage<T> {
     }
 
     @Override
-    public void put(T item) {
-        fileStorage.put(item);
+    public void put(Collection<T> items) {
+        fileStorage.put(items);
         var updated = current();
         if (current.equals(updated)) {
             return;

--- a/storage/src/main/java/org/openjdk/skara/storage/Storage.java
+++ b/storage/src/main/java/org/openjdk/skara/storage/Storage.java
@@ -22,7 +22,7 @@
  */
 package org.openjdk.skara.storage;
 
-import java.util.Set;
+import java.util.*;
 
 public interface Storage<T> {
     /**
@@ -33,10 +33,14 @@ public interface Storage<T> {
     Set<T> current();
 
     /**
-     * Add a new item or update an existing one. Flushes to permanent storage if needed. The
+     * Add new items and/or update existing ones. Flushes to permanent storage if needed. The
      * Storage instance may not be used concurrently, but the backing storage may have been updated
      * concurrently from a different instance. In that case the put operation will be retried.
      * @param item
      */
-    void put(T item);
+    void put(Collection<T> item);
+
+    default void put(T item) {
+        put(List.of(item));
+    }
 }

--- a/storage/src/main/java/org/openjdk/skara/storage/StorageSerializer.java
+++ b/storage/src/main/java/org/openjdk/skara/storage/StorageSerializer.java
@@ -22,8 +22,8 @@
  */
 package org.openjdk.skara.storage;
 
-import java.util.Set;
+import java.util.*;
 
 public interface StorageSerializer<T> {
-    String serialize(T added, Set<T> existing);
+    String serialize(Collection<T> added, Set<T> existing);
 }

--- a/storage/src/test/java/org/openjdk/skara/storage/FileStorageTests.java
+++ b/storage/src/test/java/org/openjdk/skara/storage/FileStorageTests.java
@@ -33,12 +33,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class FileStorageTests {
     private FileStorage<String> stringStorage(Path fileName) {
-        return new FileStorage<String>(fileName, (added, cur) -> Stream.concat(cur.stream(), Stream.of(added))
-                                                                       .sorted()
-                                                                       .collect(Collectors.joining(";")),
-                                       cur -> Arrays.stream(cur.split(";"))
-                                                    .filter(str -> !str.isEmpty())
-                                                    .collect(Collectors.toSet()));
+        return new FileStorage<>(fileName, (added, cur) -> Stream.concat(cur.stream(), added.stream())
+                                                                 .sorted()
+                                                                 .collect(Collectors.joining(";")),
+                                 cur -> Arrays.stream(cur.split(";"))
+                                              .filter(str -> !str.isEmpty())
+                                              .collect(Collectors.toSet()));
     }
 
     @Test
@@ -49,6 +49,18 @@ class FileStorageTests {
         assertEquals(Set.of(), storage.current());
         storage.put("hello there");
         assertEquals(Set.of("hello there"), storage.current());
+
+        Files.delete(tmpFile);
+    }
+
+    @Test
+    void multiple() throws IOException {
+        var tmpFile = Files.createTempFile("filestorage", ".txt");
+        var storage = stringStorage(tmpFile);
+
+        assertEquals(Set.of(), storage.current());
+        storage.put(List.of("hello", "there"));
+        assertEquals(Set.of("hello", "there"), storage.current());
 
         Files.delete(tmpFile);
     }


### PR DESCRIPTION
Hi all,

Please review this change that allows adding multiple tags in one run when starting to run the notifier for the new repository. Previously, for a repository with many tags, a separate commit would be generated for each.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
Progress
--------
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

Approvers
---------
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)