### PR TITLE
Post specific review comments before generic ones

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
@@ -279,15 +279,6 @@ class ArchiveWorkItem implements WorkItem {
             reviewArchive.addComment(comment);
         }
 
-        // Review comments
-        var reviews = pr.getReviews();
-        for (var review : reviews) {
-            if (ignoreComment(review.reviewer(), review.body().orElse(""))) {
-                continue;
-            }
-            reviewArchive.addReview(review);
-        }
-
         // File specific comments
         var reviewComments = pr.getReviewComments();
         for (var reviewComment : reviewComments) {
@@ -295,6 +286,15 @@ class ArchiveWorkItem implements WorkItem {
                 continue;
             }
             reviewArchive.addReviewComment(reviewComment);
+        }
+
+        // Review comments
+        var reviews = pr.getReviews();
+        for (var review : reviews) {
+            if (ignoreComment(review.reviewer(), review.body().orElse(""))) {
+                continue;
+            }
+            reviewArchive.addReview(review);
         }
 
         var newMails = reviewArchive.generatedEmails();


### PR DESCRIPTION
Hi all,

Please review this small change that improves the order in which mailing list messages are composed with regards to review comments.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)