### PR TITLE
Make it possible to cancel a Check

### DIFF
--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -847,4 +847,51 @@ class CheckTests {
             assertEquals(CheckStatus.SUCCESS, check.status());
         }
     }
+
+    @Test
+    void cancelCheck(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.getRepositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            localRepo.push(masterHash, author.getUrl(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.getUrl(), "refs/heads/edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
+
+            // Verify no checks exists
+            var checks = pr.getChecks(editHash);
+            assertEquals(0, checks.size());
+
+            // Create a check that is running
+            var original = CheckBuilder.create("jcheck", editHash)
+                                       .title("jcheck title")
+                                       .summary("jcheck summary")
+                                       .build();
+            pr.createCheck(original);
+
+            // Verify check is created
+            checks = pr.getChecks(editHash);
+            assertEquals(1, checks.size());
+            var retrieved = checks.get("jcheck");
+            assertEquals("jcheck title", retrieved.title().get());
+            assertEquals("jcheck summary", retrieved.summary().get());
+            assertEquals(CheckStatus.IN_PROGRESS, retrieved.status());
+
+            // Cancel the check
+            var cancelled = CheckBuilder.from(retrieved).cancel().build();
+            pr.updateCheck(cancelled);
+            checks = pr.getChecks(editHash);
+            assertEquals(1, checks.size());
+            retrieved = checks.get("jcheck");
+            assertEquals("jcheck title", retrieved.title().get());
+            assertEquals("jcheck summary", retrieved.summary().get());
+            assertEquals(CheckStatus.CANCELLED, retrieved.status());
+        }
+    }
 }

--- a/host/src/main/java/org/openjdk/skara/host/CheckBuilder.java
+++ b/host/src/main/java/org/openjdk/skara/host/CheckBuilder.java
@@ -97,6 +97,18 @@ public class CheckBuilder {
         return this;
     }
 
+    public CheckBuilder cancel() {
+        status = CheckStatus.CANCELLED;
+        completedAt = ZonedDateTime.now();
+        return this;
+    }
+
+    public CheckBuilder cancel(ZonedDateTime completedAt) {
+        status = CheckStatus.CANCELLED;
+        this.completedAt = completedAt;
+        return this;
+    }
+
     public CheckBuilder startedAt(ZonedDateTime startedAt) {
         this.startedAt = startedAt;
         return this;

--- a/host/src/main/java/org/openjdk/skara/host/CheckStatus.java
+++ b/host/src/main/java/org/openjdk/skara/host/CheckStatus.java
@@ -25,5 +25,6 @@ package org.openjdk.skara.host;
 public enum CheckStatus {
     IN_PROGRESS,
     SUCCESS,
-    FAILURE
+    FAILURE,
+    CANCELLED
 }

--- a/host/src/main/java/org/openjdk/skara/host/github/GitHubPullRequest.java
+++ b/host/src/main/java/org/openjdk/skara/host/github/GitHubPullRequest.java
@@ -292,8 +292,21 @@ public class GitHubPullRequest implements PullRequest {
 
                             var completed = c.get("status").asString().equals("completed");
                             if (completed) {
-                                checkBuilder.complete(c.get("conclusion").asString().equals("success"),
-                                        ZonedDateTime.parse(c.get("completed_at").asString()));
+                                var conclusion = c.get("conclusion").asString();
+                                var completedAt = ZonedDateTime.parse(c.get("completed_at").asString());
+                                switch (conclusion) {
+                                    case "cancelled":
+                                        checkBuilder.cancel(completedAt);
+                                        break;
+                                    case "success":
+                                        checkBuilder.complete(true, completedAt);
+                                        break;
+                                    case "failure":
+                                        checkBuilder.complete(false, completedAt);
+                                        break;
+                                    default:
+                                        throw new IllegalStateException("Unexpected conclusion: " + conclusion);
+                                }
                             }
                             if (c.contains("external_id")) {
                                 checkBuilder.metadata(c.get("external_id").asString());
@@ -314,22 +327,21 @@ public class GitHubPullRequest implements PullRequest {
 
     @Override
     public void createCheck(Check check) {
-        var checkQuery = JSON.object();
-        checkQuery.put("name", check.name());
-        checkQuery.put("head_branch", json.get("head").get("ref").asString());
-        checkQuery.put("head_sha", check.hash().hex());
-        checkQuery.put("started_at", check.startedAt().format(DateTimeFormatter.ISO_INSTANT));
-        checkQuery.put("status", "in_progress");
-        check.metadata().ifPresent(metadata -> checkQuery.put("external_id", metadata));
-
-        request.post("check-runs").body(checkQuery).execute();
+        // update and create are currenly identical operations, both do an HTTP
+        // POST to the /repos/:owner/:repo/check-runs endpoint. There is an additional
+        // endpoint explicitly for updating check-runs, but that is not currently used.
+        updateCheck(check);
     }
 
     @Override
     public void updateCheck(Check check) {
-        JSONObject outputQuery = null;
+        var completedQuery = JSON.object();
+        completedQuery.put("name", check.name());
+        completedQuery.put("head_branch", json.get("head").get("ref"));
+        completedQuery.put("head_sha", check.hash().hex());
+
         if (check.title().isPresent() && check.summary().isPresent()) {
-            outputQuery = JSON.object();
+            var outputQuery = JSON.object();
             outputQuery.put("title", check.title().get());
             outputQuery.put("summary", check.summary().get());
 
@@ -359,25 +371,20 @@ public class GitHubPullRequest implements PullRequest {
             }
 
             outputQuery.put("annotations", annotations);
+            completedQuery.put("output", outputQuery);
         }
 
-        var completedQuery = JSON.object();
-        completedQuery.put("name", check.name());
-        completedQuery.put("head_branch", json.get("head").get("ref"));
-        completedQuery.put("head_sha", check.hash().hex());
-        completedQuery.put("status", "completed");
-        completedQuery.put("started_at", check.startedAt().format(DateTimeFormatter.ISO_INSTANT));
-        check.metadata().ifPresent(metadata -> completedQuery.put("external_id", metadata));
-
-        if (check.status() != CheckStatus.IN_PROGRESS) {
-            completedQuery.put("conclusion", check.status() == CheckStatus.SUCCESS ? "success" : "failure");
+        if (check.status() == CheckStatus.IN_PROGRESS) {
+            completedQuery.put("status", "in_progress");
+        } else {
+            completedQuery.put("status", "completed");
+            completedQuery.put("conclusion", check.status().name().toLowerCase());
             completedQuery.put("completed_at", check.completedAt().orElse(ZonedDateTime.now(ZoneOffset.UTC))
                     .format(DateTimeFormatter.ISO_INSTANT));
         }
 
-        if (outputQuery != null) {
-            completedQuery.put("output", outputQuery);
-        }
+        completedQuery.put("started_at", check.startedAt().format(DateTimeFormatter.ISO_INSTANT));
+        check.metadata().ifPresent(metadata -> completedQuery.put("external_id", metadata));
 
         request.post("check-runs").body(completedQuery).execute();
     }

--- a/host/src/main/java/org/openjdk/skara/host/gitlab/GitLabMergeRequest.java
+++ b/host/src/main/java/org/openjdk/skara/host/gitlab/GitLabMergeRequest.java
@@ -440,7 +440,7 @@ public class GitLabMergeRequest implements PullRequest {
                 body = ":warning: The merge request check **" + check.name() + "** identified the following issues:";
                 break;
             case CANCELLED:
-                body = ":x: The merge request check **" + check.name() + "** has been cancelled";
+                body = ":x: The merge request check **" + check.name() + "** has been cancelled.";
                 break;
             default:
                 throw new RuntimeException("Unknown check status");

--- a/host/src/main/java/org/openjdk/skara/host/gitlab/GitLabMergeRequest.java
+++ b/host/src/main/java/org/openjdk/skara/host/gitlab/GitLabMergeRequest.java
@@ -364,41 +364,59 @@ public class GitLabMergeRequest implements PullRequest {
                         entry -> {
                             var checkBuilder = CheckBuilder.create(entry.getValue().group(1), hash);
                             checkBuilder.startedAt(entry.getKey().createdAt());
-                            if (!entry.getValue().group(2).equals("RUNNING")) {
-                                checkBuilder.complete(entry.getValue().group(2).equals("SUCCESS"), entry.getKey().updatedAt());
+                            var status = entry.getValue().group(2);
+                            var completedAt = entry.getKey().updatedAt();
+                            switch (status) {
+                                case "RUNNING":
+                                    // do nothing
+                                    break;
+                                case "SUCCESS":
+                                    checkBuilder.complete(true, completedAt);
+                                    break;
+                                case "FAILURE":
+                                    checkBuilder.complete(false, completedAt);
+                                    break;
+                                case "CANCELLED":
+                                    checkBuilder.cancel(completedAt);
+                                    break;
+                                default:
+                                    throw new IllegalStateException("Unknown status: " + status);
                             }
                             if (!entry.getValue().group(3).equals("NONE")) {
                                 checkBuilder.metadata(new String(Base64.getDecoder().decode(entry.getValue().group(3)), StandardCharsets.UTF_8));
                             }
                             var checkBodyMatcher = checkBodyPattern.matcher(entry.getKey().body());
                             if (checkBodyMatcher.find()) {
-                                checkBuilder.title(checkBodyMatcher.group(1));
+                                // escapeMarkdown adds an additional space before the newline
+                                var title = checkBodyMatcher.group(1);
+                                var nonEscapedTitle = title.substring(0, title.length() - 2);
+                                checkBuilder.title(nonEscapedTitle);
                                 checkBuilder.summary(checkBodyMatcher.group(2));
                             }
                             return checkBuilder.build();
                         }));
     }
 
-    @Override
-    public void createCheck(Check check) {
-        log.info("Looking for previous status check comment");
-
-        var previous = getStatusCheckComment(check.name());
-        var body = ":hourglass_flowing_sand: The merge request check **" + check.name() + "** is currently running...";
-        var metadata = "NONE";
-        if (check.metadata().isPresent()) {
-            metadata = Base64.getEncoder().encodeToString(check.metadata().get().getBytes(StandardCharsets.UTF_8));
+    private String statusFor(Check check) {
+        switch (check.status()) {
+            case IN_PROGRESS:
+                return "RUNNING";
+            case SUCCESS:
+                return "SUCCESS";
+            case FAILURE:
+                return "FAILURE";
+            case CANCELLED:
+                return "CANCELLED";
+            default:
+                throw new RuntimeException("Unknown check status");
         }
-        var message = String.format(checkMarker, check.name()) + "\n" +
-                String.format(checkResultMarker,
-                        check.name(),
-                        "RUNNING",
-                        check.hash(),
-                        metadata
-                        ) + "\n" + encodeMarkdown(body);
+    }
 
-        previous.ifPresentOrElse(p -> updateComment(p.id(), message),
-                () -> addComment(message));
+    private String metadataFor(Check check) {
+        if (check.metadata().isPresent()) {
+            return Base64.getEncoder().encodeToString(check.metadata().get().getBytes(StandardCharsets.UTF_8));
+        }
+        return "NONE";
     }
 
     private String linkToDiff(String path, Hash hash, int line) {
@@ -408,70 +426,86 @@ public class GitLabMergeRequest implements PullRequest {
                          .build() + "#L" + Integer.toString(line) + ")";
     }
 
+    private String bodyFor(Check check) {
+        var status = check.status();
+        String body;
+        switch (status) {
+            case IN_PROGRESS:
+                body = ":hourglass_flowing_sand: The merge request check **" + check.name() + "** is currently running...";
+                break;
+            case SUCCESS:
+                body = ":tada: The merge request check **" + check.name() + "** completed successfully!";
+                break;
+            case FAILURE:
+                body = ":warning: The merge request check **" + check.name() + "** identified the following issues:";
+                break;
+            case CANCELLED:
+                body = ":x: The merge request check **" + check.name() + "** has been cancelled";
+                break;
+            default:
+                throw new RuntimeException("Unknown check status");
+        }
+
+        if ( check.title().isPresent() && check.summary().isPresent()) {
+            body += encodeMarkdown("\n" + "##### " + check.title().get() + "\n" + check.summary().get());
+
+            for (var annotation : check.annotations()) {
+                var annotationString = "  - ";
+                switch (annotation.level()) {
+                    case NOTICE:
+                        annotationString += "Notice: ";
+                        break;
+                    case WARNING:
+                        annotationString += "Warning: ";
+                        break;
+                    case FAILURE:
+                        annotationString += "Failure: ";
+                        break;
+                }
+                annotationString += linkToDiff(annotation.path(), check.hash(), annotation.startLine());
+                annotationString += "\n    - " + annotation.message().lines().collect(Collectors.joining("\n    - "));
+
+                body += "\n" + annotationString;
+            }
+        }
+
+        return body;
+    }
+
+    private void updateCheckComment(Optional<Comment> previous, Check check) {
+        var status = statusFor(check);
+        var metadata = metadataFor(check);
+        var markers = String.format(checkMarker, check.name()) + "\n" +
+                      String.format(checkResultMarker,
+                                    check.name(),
+                                    status,
+                                    check.hash(),
+                                    metadata);
+
+        var body = bodyFor(check);
+        var message = markers + "\n" + body;
+        previous.ifPresentOrElse(
+                p  -> updateComment(p.id(), message),
+                () -> addComment(message));
+    }
+
+    @Override
+    public void createCheck(Check check) {
+        log.info("Looking for previous status check comment");
+
+        var previous = getStatusCheckComment(check.name());
+        updateCheckComment(previous, check);
+    }
+
     @Override
     public void updateCheck(Check check) {
         log.info("Looking for previous status check comment");
 
         var previous = getStatusCheckComment(check.name())
                 .orElseGet(() -> addComment("Progress deleted?"));
-
-        String status;
-        switch (check.status()) {
-            case IN_PROGRESS:
-                status = "RUNNING";
-                break;
-            case SUCCESS:
-                status = "SUCCESS";
-                break;
-            case FAILURE:
-                status = "FAILURE";
-                break;
-            default:
-                throw new RuntimeException("Unknown check status");
-        }
-
-        var metadata = "NONE";
-        if (check.metadata().isPresent()) {
-            metadata = Base64.getEncoder().encodeToString(check.metadata().get().getBytes(StandardCharsets.UTF_8));
-        }
-        var markers = String.format(checkMarker, check.name()) + "\n" + String.format(checkResultMarker, check.name(),
-                status, check.hash(), metadata);
-
-        String body;
-        if (check.status() == CheckStatus.SUCCESS) {
-            body = ":tada: The merge request check **" + check.name() + "** completed successfully!";
-        } else {
-            if (check.status() == CheckStatus.IN_PROGRESS) {
-                body = ":hourglass_flowing_sand: The merge request check **" + check.name() + "** is currently running...";
-            } else {
-                body = ":warning: The merge request check **" + check.name() + "** identified the following issues:";
-            }
-            if (check.title().isPresent() && check.summary().isPresent()) {
-                body += encodeMarkdown("\n" + "##### " + check.title().get() + "\n" + check.summary().get());
-
-                for (var annotation : check.annotations()) {
-                    var annotationString = "  - ";
-                    switch (annotation.level()) {
-                        case NOTICE:
-                            annotationString += "Notice: ";
-                            break;
-                        case WARNING:
-                            annotationString += "Warning: ";
-                            break;
-                        case FAILURE:
-                            annotationString += "Failure: ";
-                            break;
-                    }
-                    annotationString += linkToDiff(annotation.path(), check.hash(), annotation.startLine());
-                    annotationString += "\n    - " + annotation.message().lines().collect(Collectors.joining("\n    - "));
-
-                    body += "\n" + annotationString;
-                }
-            }
-        }
-
-        updateComment(previous.id(), markers + "\n" + body);
+        updateCheckComment(Optional.of(previous), check);
     }
+
 
     @Override
     public void setState(State state) {


### PR DESCRIPTION
Hi all,

this patch became a bit larger than I initially thought. I added a new `CheckState` - `CANCELLED` and a new method to `CheckBuider` - `cancel()`. However to fully support this I needed to quite a bit of refactoring in both `GitHubPullRequest` and `GitLabMergeRequest` so that `createCheck` allows checks with all kinds of states to be created.

## Testing
- [x] `sh gradlew test` passes on Linux x86_64
- [x] Added one new unit test
- [x] `sh gradlew test` with credentials mostly passes against both GitHub and GitLab (there are a few known failures)

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**) **Note!** Review applies to ed66f45c4d5671275e0ed7a5f2e591ae958dece7