### PR TITLE
Fix NPE in GitLabHost::isMemberOf

### DIFF
--- a/host/src/main/java/org/openjdk/skara/host/gitlab/GitLabHost.java
+++ b/host/src/main/java/org/openjdk/skara/host/gitlab/GitLabHost.java
@@ -153,8 +153,7 @@ public class GitLabHost implements Host {
         }
         var details = request.get("groups/" + gid + "/members/" + user.id())
                              .onError(r -> JSON.of())
-                             .execute()
-                             .asObject();
+                             .execute();
         return !details.isNull();
     }
 }


### PR DESCRIPTION
Hi all,

this small patch fixes an (embarrasing) NPE in `GitLabHost::isMemberOf`. Calling `.asObject()` will result in `details` being `null` in the `onError` is executed (since `JSON.of()` produces `JSONNull` whose `asObject` returns `null`). The fix is simply to not call `.asObject()`.

## Testing
- [x] `sh gradlew test` passes on Linux x86_64
- [x] `HostTests` passes `sh gradlew test` with credentials

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)