### PR TITLE
119: Support fetching Jira issues with only a partial id

### DIFF
--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -831,6 +831,25 @@ class CheckTests {
             assertFalse(pr.getBody().contains("My first issue"));
             assertTrue(pr.getBody().contains("My second issue"));
 
+            // Use an invalid issue key
+            var issueKey = issue1.getId().replace("TEST", "BADPROJECT");
+            pr.setTitle(issueKey + ": This is a pull request");
+
+            // Check the status again
+            TestBotRunner.runPeriodicItems(checkBot);
+            assertFalse(pr.getBody().contains("My first issue"));
+            assertFalse(pr.getBody().contains("My second issue"));
+            assertTrue(pr.getBody().contains("Failed to retrieve"));
+
+            // Now drop the issue key
+            issueKey = issue1.getId().replace("TEST-", "");
+            pr.setTitle(issueKey + ": This is a pull request");
+
+            // The body should now contain the updated issue title
+            TestBotRunner.runPeriodicItems(checkBot);
+            assertTrue(pr.getBody().contains("My first issue"));
+            assertFalse(pr.getBody().contains("My second issue"));
+
             // Now enter an invalid issue id
             pr.setTitle("2384848: This is a pull request");
 

--- a/host/src/main/java/org/openjdk/skara/host/jira/JiraProject.java
+++ b/host/src/main/java/org/openjdk/skara/host/jira/JiraProject.java
@@ -57,6 +57,9 @@ public class JiraProject implements IssueProject {
 
     @Override
     public Optional<Issue> getIssue(String id) {
+        if (id.indexOf('-') < 0) {
+            id = projectName.toUpperCase() + "-" + id;
+        }
         var issue = request.get("issue/" + id)
                            .onError(r -> r.statusCode() == 404 ? JSON.object().put("NOT_FOUND", true) : null)
                            .execute();

--- a/test/src/main/java/org/openjdk/skara/test/TestHost.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHost.java
@@ -161,7 +161,7 @@ public class TestHost implements Host {
     }
 
     TestIssue createIssue(TestIssueProject issueProject, String title, List<String> body) {
-        var id = String.valueOf(data.issues.size() + 1);
+        var id = issueProject.projectName().toUpperCase() + "-" + (data.issues.size() + 1);
         var issue = TestIssue.createNew(issueProject, id, title, body);
         data.issues.put(id ,issue);
         return issue;

--- a/test/src/main/java/org/openjdk/skara/test/TestIssueProject.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestIssueProject.java
@@ -32,6 +32,10 @@ public class TestIssueProject implements IssueProject {
     private final String projectName;
     private final TestHost host;
 
+    String projectName() {
+        return projectName;
+    }
+
     @Override
     public Host host() {
         return host;
@@ -54,6 +58,10 @@ public class TestIssueProject implements IssueProject {
 
     @Override
     public Optional<Issue> getIssue(String id) {
+        if (id.indexOf('-') < 0) {
+            id = projectName.toUpperCase() + "-" + id;
+        }
+
         return Optional.ofNullable(host.getIssue(this, id));
     }
 


### PR DESCRIPTION
Hi all,

Please review the following change that allows specifying Jira issues by number only, without a qualifying project name.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
⚠️ Failed to retrieve information on issue `119: Support fetching Jira issues with only a partial id`.


## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)