### PR TITLE
117: Add support for custom headers in notifier emails

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/JNotifyBotFactory.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/JNotifyBotFactory.java
@@ -25,6 +25,7 @@ package org.openjdk.skara.bots.notify;
 import org.openjdk.skara.bot.*;
 import org.openjdk.skara.email.EmailAddress;
 import org.openjdk.skara.host.network.URIBuilder;
+import org.openjdk.skara.json.JSONObject;
 import org.openjdk.skara.mailinglist.MailingListServerFactory;
 import org.openjdk.skara.storage.StorageBuilder;
 import org.openjdk.skara.vcs.Tag;
@@ -33,6 +34,7 @@ import java.nio.file.Path;
 import java.util.*;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 public class JNotifyBotFactory implements BotFactory {
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots");;
@@ -99,7 +101,13 @@ public class JNotifyBotFactory implements BotFactory {
                         }
                     }
 
-                    updaters.add(new MailingListUpdater(listServer.getList(recipient), recipientAddress, sender, includeBranchNames, mode));
+                    Map<String, String> headers = mailinglist.contains("headers") ?
+                            mailinglist.get("headers").fields().stream()
+                                       .collect(Collectors.toMap(JSONObject.Field::name, field -> field.value().asString())) :
+                            Map.of();
+
+                    updaters.add(new MailingListUpdater(listServer.getList(recipient), recipientAddress, sender,
+                                                        includeBranchNames, mode, headers));
                 }
             }
 

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/MailingListUpdater.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/MailingListUpdater.java
@@ -42,6 +42,7 @@ public class MailingListUpdater implements UpdateConsumer {
     private final EmailAddress sender;
     private final boolean includeBranch;
     private final Mode mode;
+    private final Map<String, String> headers;
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots.notify");
 
     enum Mode {
@@ -50,12 +51,14 @@ public class MailingListUpdater implements UpdateConsumer {
         PR_ONLY
     }
 
-    MailingListUpdater(MailingList list, EmailAddress recipient, EmailAddress sender, boolean includeBranch, Mode mode) {
+    MailingListUpdater(MailingList list, EmailAddress recipient, EmailAddress sender, boolean includeBranch, Mode mode,
+                       Map<String, String> headers) {
         this.list = list;
         this.recipient = recipient;
         this.sender = sender;
         this.includeBranch = includeBranch;
         this.mode = mode;
+        this.headers = headers;
     }
 
     private String patchToText(Patch patch) {
@@ -146,6 +149,7 @@ public class MailingListUpdater implements UpdateConsumer {
             var email = Email.reply(rfr, "Re: [Integrated] " + rfr.subject(), body)
                              .author(sender)
                              .recipient(recipient)
+                             .headers(headers)
                              .build();
             list.post(email);
         }
@@ -168,6 +172,7 @@ public class MailingListUpdater implements UpdateConsumer {
         var subject = commitsToSubject(repository, commits, branch);
         var email = Email.create(sender, subject, writer.toString())
                          .recipient(recipient)
+                         .headers(headers)
                          .build();
 
         list.post(email);

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdaterTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdaterTests.java
@@ -185,7 +185,8 @@ class UpdaterTests {
             var storageFolder = tempFolder.path().resolve("storage");
 
             var sender = EmailAddress.from("duke", "duke@duke.duke");
-            var updater = new MailingListUpdater(mailmanList, listAddress, sender, false, MailingListUpdater.Mode.ALL);
+            var updater = new MailingListUpdater(mailmanList, listAddress, sender, false, MailingListUpdater.Mode.ALL,
+                                                 Map.of("extra1", "value1", "extra2", "value2"));
             var notifyBot = new JNotifyBot(repo, storageFolder, Pattern.compile("master"), tagStorage, branchStorage, List.of(updater));
 
             // No mail should be sent on the first run as there is no history
@@ -207,6 +208,10 @@ class UpdaterTests {
             assertTrue(email.body().contains("23456789: More fixes"));
             assertFalse(email.body().contains("Committer"));
             assertFalse(email.body().contains(masterHash.abbreviate()));
+            assertTrue(email.hasHeader("extra1"));
+            assertEquals("value1", email.headerValue("extra1"));
+            assertTrue(email.hasHeader("extra2"));
+            assertEquals("value2", email.headerValue("extra2"));
         }
     }
 
@@ -230,7 +235,8 @@ class UpdaterTests {
             var storageFolder = tempFolder.path().resolve("storage");
 
             var sender = EmailAddress.from("duke", "duke@duke.duke");
-            var updater = new MailingListUpdater(mailmanList, listAddress, sender, false, MailingListUpdater.Mode.ALL);
+            var updater = new MailingListUpdater(mailmanList, listAddress, sender, false,
+                                                 MailingListUpdater.Mode.ALL, Map.of());
             var notifyBot = new JNotifyBot(repo, storageFolder, Pattern.compile("master"), tagStorage, branchStorage, List.of(updater));
 
             // No mail should be sent on the first run as there is no history
@@ -279,7 +285,8 @@ class UpdaterTests {
             var storageFolder = tempFolder.path().resolve("storage");
 
             var sender = EmailAddress.from("duke", "duke@duke.duke");
-            var updater = new MailingListUpdater(mailmanList, listAddress, sender, false, MailingListUpdater.Mode.ALL);
+            var updater = new MailingListUpdater(mailmanList, listAddress, sender, false,
+                                                 MailingListUpdater.Mode.ALL, Map.of());
             var notifyBot = new JNotifyBot(repo, storageFolder, Pattern.compile("master"), tagStorage, branchStorage, List.of(updater));
 
             // No mail should be sent on the first run as there is no history
@@ -326,7 +333,8 @@ class UpdaterTests {
             var storageFolder = tempFolder.path().resolve("storage");
 
             var sender = EmailAddress.from("duke", "duke@duke.duke");
-            var updater = new MailingListUpdater(mailmanList, listAddress, sender, true, MailingListUpdater.Mode.ALL);
+            var updater = new MailingListUpdater(mailmanList, listAddress, sender, true,
+                                                 MailingListUpdater.Mode.ALL, Map.of());
             var notifyBot = new JNotifyBot(repo, storageFolder, Pattern.compile("master|another"), tagStorage, branchStorage, List.of(updater));
 
             // No mail should be sent on the first run as there is no history
@@ -395,7 +403,8 @@ class UpdaterTests {
             var storageFolder = tempFolder.path().resolve("storage");
 
             var sender = EmailAddress.from("duke", "duke@duke.duke");
-            var updater = new MailingListUpdater(mailmanList, listAddress, sender, false, MailingListUpdater.Mode.PR_ONLY);
+            var updater = new MailingListUpdater(mailmanList, listAddress, sender, false,
+                                                 MailingListUpdater.Mode.PR_ONLY, Map.of("extra1", "value1"));
             var notifyBot = new JNotifyBot(repo, storageFolder, Pattern.compile("master"), tagStorage, branchStorage, List.of(updater));
 
             // No mail should be sent on the first run as there is no history
@@ -440,6 +449,8 @@ class UpdaterTests {
             assertTrue(email.body().contains("23456789: More fixes"));
             assertFalse(email.body().contains("Committer"));
             assertFalse(email.body().contains(masterHash.abbreviate()));
+            assertTrue(email.hasHeader("extra1"));
+            assertEquals("value1", email.headerValue("extra1"));
 
             // Now push the other one without a matching PR - PR_ONLY will not generate a mail
             localRepo.push(otherHash, repo.getUrl(), "master");
@@ -468,7 +479,8 @@ class UpdaterTests {
             var storageFolder = tempFolder.path().resolve("storage");
 
             var sender = EmailAddress.from("duke", "duke@duke.duke");
-            var updater = new MailingListUpdater(mailmanList, listAddress, sender, false, MailingListUpdater.Mode.PR);
+            var updater = new MailingListUpdater(mailmanList, listAddress, sender, false,
+                                                 MailingListUpdater.Mode.PR, Map.of());
             var notifyBot = new JNotifyBot(repo, storageFolder, Pattern.compile("master"), tagStorage, branchStorage, List.of(updater));
 
             // No mail should be sent on the first run as there is no history


### PR DESCRIPTION
Hi all,

Please review this change that adds support for setting custom headers in emails sent by the notifier.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-117](https://bugs.openjdk.java.net/browse/SKARA-117): Add custom email header configuration to notifier


## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)