### PR TITLE
116: Changes link in email notification is wrong for GitLab

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
@@ -64,7 +64,7 @@ class ArchiveMessages {
                 infoSeparator + "\n\n" +
                 "Commits:\n" +
                 commitMessages + "\n\n" +
-                "Changes: " + prInstance.changeUrl() + "\n" +
+                "Changes: " + prInstance.pr().getChangeUrl() + "\n" +
                 " Webrev: " + webrev.toString() + "\n" +
                 issueString +
                 "  Stats: " + prInstance.stats(prInstance.baseHash(), prInstance.headHash()) + "\n" +
@@ -80,7 +80,7 @@ class ArchiveMessages {
                 infoSeparator + "\n\n" +
                 "Commits:\n" +
                 commitMessages + "\n\n" +
-                "Changes: " + prInstance.changeUrl() + "\n" +
+                "Changes: " + prInstance.pr().getChangeUrl() + "\n" +
                 " Webrev: " + fullWebrev.toString() + "\n" +
                 issueString +
                 "  Stats: " + prInstance.stats(prInstance.baseHash(), prInstance.headHash()) + "\n" +
@@ -96,8 +96,8 @@ class ArchiveMessages {
                 "Added commits:\n" +
                 newCommitMessages + "\n\n" +
                 "Changes:\n" +
-                "  - all: " + prInstance.pr().getWebUrl() + "/files\n" +
-                "  - new: " + prInstance.changeUrl(lastHead, prInstance.headHash()) + "\n\n" +
+                "  - all: " + prInstance.pr().getChangeUrl() + "\n" +
+                "  - new: " + prInstance.pr().getChangeUrl(lastHead) + "\n\n" +
                 "Webrevs:\n" +
                 " - full: " + fullWebrev.toString() + "\n" +
                 " - incr: " + incrementalWebrev.toString() + "\n\n" +

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/PullRequestInstance.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/PullRequestInstance.java
@@ -75,14 +75,6 @@ class PullRequestInstance {
         return pr.getWebUrl() + ".diff";
     }
 
-    String changeUrl() {
-        return pr.getWebUrl() + "/files";
-    }
-
-    String changeUrl(Hash base, Hash head) {
-        return pr.getWebUrl() + "/files/" + base.abbreviate() + ".." + head.abbreviate();
-    }
-
     String fetchCommand() {
         var repoUrl = pr.repository().getWebUrl();
         return "git fetch " + repoUrl + " " + pr.getSourceRef() + ":pull/" + pr.getId();

--- a/host/src/main/java/org/openjdk/skara/host/PullRequest.java
+++ b/host/src/main/java/org/openjdk/skara/host/PullRequest.java
@@ -24,6 +24,7 @@ package org.openjdk.skara.host;
 
 import org.openjdk.skara.vcs.Hash;
 
+import java.net.URI;
 import java.util.*;
 
 public interface PullRequest extends Issue {
@@ -88,7 +89,6 @@ public interface PullRequest extends Issue {
      */
     Hash getTargetHash();
 
-
     /**
      * List of completed checks on the given hash.
      * @return
@@ -106,4 +106,14 @@ public interface PullRequest extends Issue {
      * @param check
      */
     void updateCheck(Check check);
+
+    /**
+     * Returns a link that will lead to the list of changes done in the request.
+     */
+    URI getChangeUrl();
+
+    /**
+     * Returns a link that will lead to the list of changes with the specified base.
+     */
+    URI getChangeUrl(Hash base);
 }

--- a/host/src/main/java/org/openjdk/skara/host/github/GitHubPullRequest.java
+++ b/host/src/main/java/org/openjdk/skara/host/github/GitHubPullRequest.java
@@ -23,7 +23,7 @@
 package org.openjdk.skara.host.github;
 
 import org.openjdk.skara.host.*;
-import org.openjdk.skara.host.network.RestRequest;
+import org.openjdk.skara.host.network.*;
 import org.openjdk.skara.json.*;
 import org.openjdk.skara.vcs.Hash;
 
@@ -387,6 +387,16 @@ public class GitHubPullRequest implements PullRequest {
         check.metadata().ifPresent(metadata -> completedQuery.put("external_id", metadata));
 
         request.post("check-runs").body(completedQuery).execute();
+    }
+
+    @Override
+    public URI getChangeUrl() {
+        return URIBuilder.base(getWebUrl()).appendPath("/files").build();
+    }
+
+    @Override
+    public URI getChangeUrl(Hash base) {
+        return URIBuilder.base(getWebUrl()).appendPath("/files/" + base.abbreviate() + ".." + getHeadHash().abbreviate()).build();
     }
 
     @Override

--- a/host/src/main/java/org/openjdk/skara/host/gitlab/GitLabMergeRequest.java
+++ b/host/src/main/java/org/openjdk/skara/host/gitlab/GitLabMergeRequest.java
@@ -506,6 +506,18 @@ public class GitLabMergeRequest implements PullRequest {
         updateCheckComment(Optional.of(previous), check);
     }
 
+    @Override
+    public URI getChangeUrl() {
+        return URIBuilder.base(getWebUrl()).appendPath("/diffs").build();
+    }
+
+    @Override
+    public URI getChangeUrl(Hash base) {
+        return URIBuilder.base(getWebUrl()).appendPath("/diffs")
+                         .setQuery(Map.of("start_sha", base.hex()))
+                         .build();
+    }
+
 
     @Override
     public void setState(State state) {

--- a/host/src/main/java/org/openjdk/skara/host/network/URIBuilder.java
+++ b/host/src/main/java/org/openjdk/skara/host/network/URIBuilder.java
@@ -55,7 +55,7 @@ public class URIBuilder {
             var uriString = uri.toString();
             scheme = uri.getScheme();
             host = uri.getHost();
-            var pathStart = uriString.indexOf(host) + host.length();
+            var pathStart = host != null ? uriString.indexOf(host) + host.length() : scheme.length() + 3;
             if (uri.getPort() != -1) {
                 pathStart += Integer.toString(uri.getPort()).length() + 1;
             }

--- a/host/src/test/java/org/openjdk/skara/host/network/URIBuilderTests.java
+++ b/host/src/test/java/org/openjdk/skara/host/network/URIBuilderTests.java
@@ -26,8 +26,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class URIBuilderTests {
-
+class URIBuilderTests {
     private final String validHost = "http://www.test.com";
 
     @Test
@@ -46,8 +45,6 @@ public class URIBuilderTests {
     void appendPathSimple() {
         var a = URIBuilder.base(validHost).setPath("/a").build();
         var aPlusB = URIBuilder.base(a).appendPath("/b").build();
-
-        var x = new URIBuilderException();
 
         assertEquals("/a", a.getPath());
         assertEquals("/a/b", aPlusB.getPath());
@@ -69,5 +66,11 @@ public class URIBuilderTests {
     void invalidAppendPath() {
         assertThrows(URIBuilderException.class,
                 () -> URIBuilder.base(validHost).appendPath("\\c").build());
+    }
+
+    @Test
+    void noHost() {
+        var a = URIBuilder.base("file:///a/b/c").build();
+        assertEquals("/a/b/c", a.getPath());
     }
 }

--- a/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
@@ -23,6 +23,7 @@
 package org.openjdk.skara.test;
 
 import org.openjdk.skara.host.*;
+import org.openjdk.skara.host.network.URIBuilder;
 import org.openjdk.skara.vcs.Hash;
 
 import java.io.*;
@@ -171,6 +172,16 @@ public class TestPullRequest extends TestIssue implements PullRequest {
         data.checks.remove(existing);
         data.checks.add(updated);
         data.lastUpdate = ZonedDateTime.now();
+    }
+
+    @Override
+    public URI getChangeUrl() {
+        return URIBuilder.base(getWebUrl()).appendPath("/files").build();
+    }
+
+    @Override
+    public URI getChangeUrl(Hash base) {
+        return URIBuilder.base(getWebUrl()).appendPath("/files/" + base.abbreviate()).build();
     }
 
     @Override


### PR DESCRIPTION
Hi all,

Please review this change that implements proper changes links in notifications for GitLab.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-116](https://bugs.openjdk.java.net/browse/SKARA-116): Changes link in email notification is wrong for GitLab


## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)