### PR TITLE
123: Set the commit author as sender of commit notification emails

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/JNotifyBotFactory.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/JNotifyBotFactory.java
@@ -78,9 +78,6 @@ public class JNotifyBotFactory implements BotFactory {
                 var email = specific.get("email").asObject();
                 var smtp = email.get("smtp").asString();
                 var archive = URIBuilder.base(email.get("archive").asString()).build();
-                var senderName = email.get("name").asString();
-                var senderMail = email.get("address").asString();
-                var sender = EmailAddress.from(senderName, senderMail);
                 var listServer = MailingListServerFactory.createMailmanServer(archive, smtp);
 
                 for (var mailinglist : repo.value().get("mailinglists").asArray()) {
@@ -105,7 +102,7 @@ public class JNotifyBotFactory implements BotFactory {
                             mailinglist.get("headers").fields().stream()
                                        .collect(Collectors.toMap(JSONObject.Field::name, field -> field.value().asString())) :
                             Map.of();
-
+                    var sender = mailinglist.contains("sender") ? EmailAddress.parse(mailinglist.get("sender").asString()) : null;
                     updaters.add(new MailingListUpdater(listServer.getList(recipient), recipientAddress, sender,
                                                         includeBranchNames, mode, headers));
                 }


### PR DESCRIPTION
Hi all,

Please review this change that uses the commit author (of the last commit, in case of several) as the email author when sending a commit notification email. This can be overridden on a per-list basis if wanted.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-123](https://bugs.openjdk.java.net/browse/SKARA-123): Set the commit author as sender of commit notification emails


## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)