### PR TITLE
Use the domain specified in the census when creating from addresses for non-authors

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
@@ -26,7 +26,9 @@ class ReviewArchive {
         var contributor = censusInstance.namespace().get(originalAuthor.id());
         if (contributor == null) {
             return EmailAddress.from(originalAuthor.fullName(),
-                                     originalAuthor.id() + "+" + originalAuthor.userName() + "@users.noreply." + censusInstance.namespace().name());
+                                     censusInstance.namespace().name() + "+" +
+                                             originalAuthor.id() + "+" + originalAuthor.userName() + "@" +
+                                             censusInstance.configuration().census().domain());
         } else {
             return EmailAddress.from(contributor.fullName().orElse(originalAuthor.fullName()),
                                      contributor.username() + "@" + censusInstance.configuration().census().domain());

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -93,9 +93,9 @@ class MailingListBridgeBotTests {
     }
 
     private String noreplyAddress(HostedRepository repository) {
-        return repository.host().getCurrentUserDetails().id() + "+" +
+        return "test+" + repository.host().getCurrentUserDetails().id() + "+" +
                 repository.host().getCurrentUserDetails().userName() +
-                "@users.noreply.test";
+                "@openjdk.java.net";
     }
 
     @Test


### PR DESCRIPTION
Hi all,

Please review this small change that adjusts the from address for emails sent on behalf of non-authors to use the census domain, as it can otherwise be rejected by mail servers.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)