### PR TITLE
124: The sponsor label should only be set on PRs that are ready for integration

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -492,7 +492,7 @@ class CheckRun {
             // Ensure that the ready for sponsor label is up to date
             newLabels.remove("sponsor");
             var readyHash = ReadyForSponsorTracker.latestReadyForSponsor(pr.repository().host().getCurrentUserDetails(), comments);
-            if (readyHash.isPresent()) {
+            if (readyHash.isPresent() && readyForIntegration) {
                 var acceptedHash = readyHash.get();
                 if (pr.getHeadHash().equals(acceptedHash)) {
                     newLabels.add("sponsor");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
@@ -72,21 +72,45 @@ public class SponsorCommand implements CommandHandler {
             var path = scratchPath.resolve("pr.sponsor").resolve(sanitizedUrl);
 
             var prInstance = new PullRequestInstance(path, pr);
-            var hash = prInstance.commit(censusInstance.namespace(), censusInstance.configuration().census().domain(),
+            var localHash = prInstance.commit(censusInstance.namespace(), censusInstance.configuration().census().domain(),
                                          comment.author().id());
-            var rebasedHash = prInstance.rebase(hash, reply);
-            if (rebasedHash.isPresent()) {
+            var rebaseMessage = new StringWriter();
+            var rebaseWriter = new PrintWriter(rebaseMessage);
+            var rebasedHash = prInstance.rebase(localHash, rebaseWriter);
+            if (rebasedHash.isEmpty()) {
+                return;
+            } else {
+                if (!rebasedHash.get().equals(localHash)) {
+                    localHash = rebasedHash.get();
+                }
+            }
+
+            var issues = prInstance.executeChecks(localHash, censusInstance);
+            if (!issues.getMessages().isEmpty()) {
+                reply.print("Your merge request cannot be fulfilled at this time, as ");
+                reply.println("your changes failed the final jcheck:");
+                issues.getMessages().stream()
+                      .map(line -> " * " + line)
+                      .forEach(reply::println);
+                return;
+            }
+
+            if (!localHash.equals(pr.getTargetHash())) {
+                reply.println(rebaseMessage.toString());
                 reply.println("Pushed as commit " + rebasedHash.get().hex() + ".");
                 prInstance.localRepo().push(rebasedHash.get(), pr.repository().getUrl(), pr.getTargetRef());
                 pr.setState(PullRequest.State.CLOSED);
                 pr.addLabel("integrated");
                 pr.removeLabel("sponsor");
                 pr.removeLabel("ready");
+            } else {
+                reply.print("Warning! This commit did not result in any changes! ");
+                reply.println("No push attempt will be made.");
             }
-        } catch (IOException e) {
+        } catch (Exception e) {
             log.throwing("SponsorCommand", "handle", e);
             reply.println("An error occurred during sponsored integration");
-            throw new UncheckedIOException(e);
+            throw new RuntimeException(e);
         }
     }
 


### PR DESCRIPTION
Hi all,

Please review this change that ensures that the `sponsor` label is removed from a PR if it transitions away from the `ready` state. Also run a final jcheck before pushing to enforce this.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-124](https://bugs.openjdk.java.net/browse/SKARA-124): Drop the "sponsor" label if a PR transitions away from the "ready" state


## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)