### PR TITLE
Fix gradlew on Cygwin

### DIFF
--- a/gradlew
+++ b/gradlew
@@ -154,7 +154,11 @@ if [ ! -d "${GRADLE_DIR}" ]; then
     fi
     checksum ${GRADLE_FILENAME} ${GRADLE_SHA256}
     echo "Extracting Gradle..."
-    "${JAVA_LAUNCHER}" "${DIR}"/Unzip.java "${GRADLE_FILENAME}" "${GRADLE_DIR}"
+    if [ "${OS}" = "Linux" -o "${OS}" = "Darwin" ]; then
+        "${JAVA_LAUNCHER}" "${DIR}"/Unzip.java "${GRADLE_FILENAME}" "${GRADLE_DIR}"
+    else
+        extract_zip "${GRADLE_FILENAME}" "${GRADLE_DIR}"
+    fi
 fi
 
 GRADLE_LAUNCHER=$(find "${GRADLE_DIR}" | grep '.*/bin/gradle$')


### PR DESCRIPTION
Hi all,

this small patch fixes the Skara build on Cygwin _if_ `gradlew` is used instead of `gradlew.bat`. There is no reason for `Unzip.java` in the Cygwin case since the Windows JDK is itself a ZIP archive, so we need a native `unzip` to pack up the Windows JDK. Therefore we might as well use the native `unzip` when unpacking Gradle as well.

## Testing
- `sh gradlew` works in Cygwin on Windows

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)