### PR TITLE
Do not send tag-related updates when in PR_ONLY mode

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/MailingListUpdater.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/MailingListUpdater.java
@@ -217,6 +217,9 @@ public class MailingListUpdater implements UpdateConsumer {
 
     @Override
     public void handleTagCommits(HostedRepository repository, List<Commit> commits, OpenJDKTag tag) {
+        if (mode == Mode.PR_ONLY) {
+            return;
+        }
         var writer = new StringWriter();
         var printer = new PrintWriter(writer);
 

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdaterTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdaterTests.java
@@ -577,7 +577,10 @@ class UpdaterTests {
             var sender = EmailAddress.from("duke", "duke@duke.duke");
             var updater = new MailingListUpdater(mailmanList, listAddress, sender, null, false, MailingListUpdater.Mode.ALL,
                                                  Map.of("extra1", "value1", "extra2", "value2"));
-            var notifyBot = new JNotifyBot(repo, storageFolder, Pattern.compile("master"), tagStorage, branchStorage, List.of(updater));
+            var prOnlyUpdater = new MailingListUpdater(mailmanList, listAddress, sender, null, false,
+                                                       MailingListUpdater.Mode.PR_ONLY, Map.of());
+            var notifyBot = new JNotifyBot(repo, storageFolder, Pattern.compile("master"), tagStorage, branchStorage,
+                                           List.of(updater, prOnlyUpdater));
 
             // No mail should be sent on the first run as there is no history
             TestBotRunner.runPeriodicItems(notifyBot);


### PR DESCRIPTION
Hi all,

Please review this minor change that avoids sending tag-related notification emails for notifiers configured to PR_ONLY.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)