### PR TITLE
Add command git-publish

### DIFF
--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -63,7 +63,8 @@ images {
         'git-translate': 'org.openjdk.skara.cli/org.openjdk.skara.cli.GitTranslate',
         'git-skara': 'org.openjdk.skara.cli/org.openjdk.skara.cli.GitSkara',
         'hg-openjdk-import': 'org.openjdk.skara.cli/org.openjdk.skara.cli.HgOpenJDKImport',
-        'git-sync': 'org.openjdk.skara.cli/org.openjdk.skara.cli.GitSync'
+        'git-sync': 'org.openjdk.skara.cli/org.openjdk.skara.cli.GitSync',
+        'git-publish': 'org.openjdk.skara.cli/org.openjdk.skara.cli.GitPublish'
     ]
 
     ext.modules = ['jdk.crypto.ec']

--- a/cli/src/main/java/org/openjdk/skara/cli/GitPublish.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitPublish.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.cli;
+
+import org.openjdk.skara.args.*;
+import org.openjdk.skara.vcs.*;
+
+import java.io.*;
+import java.nio.file.*;
+import java.util.*;
+import java.util.function.Supplier;
+import java.util.logging.Level;
+
+public class GitPublish {
+    private static <T> Supplier<T> die(String fmt, Object... args) {
+        return () -> {
+            System.err.println(String.format(fmt, args));
+            System.exit(1);
+            return null;
+        };
+    }
+
+    public static void main(String[] args) throws IOException {
+        var flags = List.of(
+            Switch.shortcut("")
+                  .fullname("verbose")
+                  .helptext("Turn on verbose output")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("debug")
+                  .helptext("Turn on debugging output")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("version")
+                  .helptext("Print the version of this tool")
+                  .optional());
+
+        var inputs = List.of(
+            Input.position(0)
+                 .describe("ORIGIN")
+                 .singular()
+                 .optional()
+        );
+
+        var parser = new ArgumentParser("git-publish", flags, inputs);
+        var arguments = parser.parse(args);
+
+        if (arguments.contains("version")) {
+            System.out.println("git-publish version: " + Version.fromManifest().orElse("unknown"));
+            System.exit(0);
+        }
+
+        if (arguments.contains("verbose") || arguments.contains("debug")) {
+            var level = arguments.contains("debug") ? Level.FINER : Level.FINE;
+            Logging.setup(level);
+        }
+
+        var cwd = Path.of("").toAbsolutePath();
+        var repo = Repository.get(cwd).or(die("error: no repository found at " + cwd.toString())).get();
+        var remote = arguments.at(0).orString("origin");
+        repo.push(repo.currentBranch(), remote, true);
+    }
+}


### PR DESCRIPTION
Hi all,

this patch adds the command `git-publish` which is handy shortcut for pushing the current branch to the a remote (by default `origin`). I essentially grew tired of typing `git push -u origin <current-branch>` and don't want to set `git config --global push.default current` since then I don't get an upstream set.

## Testing
- Manual testing (pushed the branch for this PR with the tool)

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)