### PR TITLE
Use inheritIO for git command to get output

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitPublish.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitPublish.java
@@ -40,7 +40,13 @@ public class GitPublish {
         };
     }
 
-    public static void main(String[] args) throws IOException {
+    private static int pushAndTrack(String remote, Branch b) throws IOException, InterruptedException {
+        var pb = new ProcessBuilder("git", "push", "--set-upstream", remote, b.name());
+        pb.inheritIO();
+        return pb.start().waitFor();
+    }
+
+    public static void main(String[] args) throws IOException, InterruptedException {
         var flags = List.of(
             Switch.shortcut("")
                   .fullname("verbose")
@@ -78,6 +84,7 @@ public class GitPublish {
         var cwd = Path.of("").toAbsolutePath();
         var repo = Repository.get(cwd).or(die("error: no repository found at " + cwd.toString())).get();
         var remote = arguments.at(0).orString("origin");
-        repo.push(repo.currentBranch(), remote, true);
+
+        System.exit(pushAndTrack(remote, repo.currentBranch()));
     }
 }


### PR DESCRIPTION
Hi all,

this small patch uses a `ProcessBuilder` for `git push --set-upstream` instead of the `Repository.push` function. This is done in order to have to the `git` process inherit the file descriptors from the `java` process, so that the output from `git` will be shown in the terminal.

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)