### PR TITLE
130: Integrating outdated PRs shows an empty error message

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
@@ -82,6 +82,7 @@ public class IntegrateCommand implements CommandHandler {
             var rebaseWriter = new PrintWriter(rebaseMessage);
             var rebasedHash = prInstance.rebase(localHash, rebaseWriter);
             if (rebasedHash.isEmpty()) {
+                reply.println(rebaseMessage.toString());
                 return;
             } else {
                 if (!rebasedHash.get().equals(localHash)) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestInstance.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestInstance.java
@@ -166,8 +166,9 @@ class PullRequestInstance {
                 return Optional.of(hash);
             } catch (IOException e) {
                 reply.println();
-                reply.print("It was not possible to rebase your changes automatically. ");
-                reply.println("Please rebase your branch manually and try again.");
+                reply.print("It was not possible to rebase your changes automatically. Please merge `");
+                reply.print(pr.getTargetRef());
+                reply.println("` into your branch and try again.");
                 try {
                     localRepo.checkout(commitHash, true);
                 } catch (IOException e2) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
@@ -78,6 +78,7 @@ public class SponsorCommand implements CommandHandler {
             var rebaseWriter = new PrintWriter(rebaseMessage);
             var rebasedHash = prInstance.rebase(localHash, rebaseWriter);
             if (rebasedHash.isEmpty()) {
+                reply.println(rebaseMessage.toString());
                 return;
             } else {
                 if (!rebasedHash.get().equals(localHash)) {

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/SponsorTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/SponsorTests.java
@@ -466,4 +466,70 @@ class SponsorTests {
         }
     }
 
+    @Test
+    void cannotRebase(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var integrator = credentials.getHostedRepository();
+            var reviewer = credentials.getHostedRepository();
+
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addReviewer(reviewer.host().getCurrentUserDetails().id())
+                                           .addAuthor(author.host().getCurrentUserDetails().id());
+            var mergeBot = new PullRequestBot(integrator, censusBuilder.build(), "master");
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.getRepositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, author.getUrl(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.getUrl(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
+
+            // Approve it as another user
+            var approvalPr = reviewer.getPullRequest(pr.getId());
+            approvalPr.addReview(Review.Verdict.APPROVED, "Approved");
+
+            // Let the bot see it
+            TestBotRunner.runPeriodicItems(mergeBot);
+
+            // Issue a merge command without being a Committer
+            pr.addComment("/integrate");
+            TestBotRunner.runPeriodicItems(mergeBot);
+
+            // The bot should reply that a sponsor is required
+            var sponsor = pr.getComments().stream()
+                            .filter(comment -> comment.body().contains("sponsor"))
+                            .filter(comment -> comment.body().contains("your change"))
+                            .count();
+            assertEquals(1, sponsor);
+
+            // The bot should not have pushed the commit
+            var notPushed = pr.getComments().stream()
+                              .filter(comment -> comment.body().contains("Pushed as commit"))
+                              .count();
+            assertEquals(0, notPushed);
+
+            // Push something conflicting to master
+            localRepo.checkout(masterHash, true);
+            var conflictingHash = CheckableRepository.appendAndCommit(localRepo, "This looks like a conflict");
+            localRepo.push(conflictingHash, author.getUrl(), "master");
+
+            // Reviewer now agrees to sponsor
+            var reviewerPr = reviewer.getPullRequest(pr.getId());
+            reviewerPr.addComment("/sponsor");
+            TestBotRunner.runPeriodicItems(mergeBot);
+
+            // The bot should reply with an error message
+            var error = pr.getComments().stream()
+                          .filter(comment -> comment.body().contains("It was not possible to rebase your changes automatically."))
+                          .filter(comment -> comment.body().contains("Please merge `master`"))
+                          .count();
+            assertEquals(1, error);
+        }
+    }
 }


### PR DESCRIPTION
Hi all,

Please review this change that ensures that an attempt to integrate an outdated PR shows a proper error message instead of just an empty comment.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-130](https://bugs.openjdk.java.net/browse/SKARA-130): Integrating outdated PRs show an empty error message


## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)