### PR TITLE
Correctly compare the os property when generating launch scripts

### DIFF
--- a/buildSrc/images/src/main/java/org/openjdk/skara/gradle/images/LaunchersTask.java
+++ b/buildSrc/images/src/main/java/org/openjdk/skara/gradle/images/LaunchersTask.java
@@ -87,7 +87,7 @@ public class LaunchersTask extends DefaultTask {
             var filename = entry.getKey();
             var clazz = entry.getValue();
 
-            if (os.equals("windows")) {
+            if (os.get().equals("windows")) {
                 var file = dest.resolve(filename + ".bat");
                 try (var w = Files.newBufferedWriter(file)) {
                     w.write("@echo off\r\n");


### PR DESCRIPTION
Previous code was comparing `Propterty<String>` to a `String` -> get the `String` from it first
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)