### PR TITLE
129: Do not send RFR mails for PRs in Draft stage

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -194,6 +194,12 @@ class CheckRun {
             return;
         }
 
+        // Draft requests are not for review
+        if (pr.isDraft()) {
+            newLabels.remove("rfr");
+            return;
+        }
+
         // Check if the visitor found any issues that should be resolved before reviewing
         if (visitor.isReadyForReview()) {
             newLabels.add("rfr");

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -970,4 +970,42 @@ class CheckTests {
             assertEquals(CheckStatus.SUCCESS, check.status());
         }
     }
+
+    @Test
+    void draft(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var reviewer = credentials.getHostedRepository();
+
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addAuthor(author.host().getCurrentUserDetails().id())
+                                           .addReviewer(reviewer.host().getCurrentUserDetails().id());
+            var checkBot = new PullRequestBot(author, censusBuilder.build(), "master");
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.getRepositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            localRepo.push(masterHash, author.getUrl(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.getUrl(), "refs/heads/edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit",
+                                                   "This is a pull request", true);
+
+            // Check the status
+            TestBotRunner.runPeriodicItems(checkBot);
+
+            // Verify that the check succeeded
+            var checks = pr.getChecks(editHash);
+            assertEquals(1, checks.size());
+            var check = checks.get("jcheck");
+            assertEquals(CheckStatus.SUCCESS, check.status());
+
+            // The PR should still not be ready for review as it is a draft
+            assertFalse(pr.getLabels().contains("rfr"));
+            assertFalse(pr.getLabels().contains("ready"));
+        }
+    }
 }

--- a/host/src/main/java/org/openjdk/skara/host/HostedRepository.java
+++ b/host/src/main/java/org/openjdk/skara/host/HostedRepository.java
@@ -34,7 +34,8 @@ public interface HostedRepository extends IssueProject {
                                   String targetRef,
                                   String sourceRef,
                                   String title,
-                                  List<String> body);
+                                  List<String> body,
+                                  boolean draft);
     PullRequest getPullRequest(String id);
     List<PullRequest> getPullRequests();
     List<PullRequest> findPullRequestsWithComment(String author, String body);
@@ -50,4 +51,12 @@ public interface HostedRepository extends IssueProject {
     HostedRepository fork();
     long getId();
     Hash getBranchHash(String ref);
+
+    default PullRequest createPullRequest(HostedRepository target,
+                                          String targetRef,
+                                          String sourceRef,
+                                          String title,
+                                          List<String> body) {
+        return createPullRequest(target, targetRef, sourceRef, title, body, false);
+    }
 }

--- a/host/src/main/java/org/openjdk/skara/host/PullRequest.java
+++ b/host/src/main/java/org/openjdk/skara/host/PullRequest.java
@@ -116,4 +116,10 @@ public interface PullRequest extends Issue {
      * Returns a link that will lead to the list of changes with the specified base.
      */
     URI getChangeUrl(Hash base);
+
+    /**
+     * Returns true if the request is in draft mode.
+     * @return
+     */
+    boolean isDraft();
 }

--- a/host/src/main/java/org/openjdk/skara/host/github/GitHubPullRequest.java
+++ b/host/src/main/java/org/openjdk/skara/host/github/GitHubPullRequest.java
@@ -400,6 +400,11 @@ public class GitHubPullRequest implements PullRequest {
     }
 
     @Override
+    public boolean isDraft() {
+        return json.get("draft").asBoolean();
+    }
+
+    @Override
     public void setState(State state) {
         request.patch("pulls/" + json.get("number").toString())
                .body("state", state == State.CLOSED ? "closed" : "open")

--- a/host/src/main/java/org/openjdk/skara/host/gitlab/GitLabMergeRequest.java
+++ b/host/src/main/java/org/openjdk/skara/host/gitlab/GitLabMergeRequest.java
@@ -518,6 +518,11 @@ public class GitLabMergeRequest implements PullRequest {
                          .build();
     }
 
+    @Override
+    public boolean isDraft() {
+        return json.get("work_in_progress").asBoolean();
+    }
+
 
     @Override
     public void setState(State state) {

--- a/host/src/main/java/org/openjdk/skara/host/gitlab/GitLabRepository.java
+++ b/host/src/main/java/org/openjdk/skara/host/gitlab/GitLabRepository.java
@@ -94,7 +94,8 @@ public class GitLabRepository implements HostedRepository {
                                          String targetRef,
                                          String sourceRef,
                                          String title,
-                                         List<String> body) {
+                                         List<String> body,
+                                         boolean draft) {
         if (!(target instanceof GitLabRepository)) {
             throw new IllegalArgumentException("target must be a GitLab repository");
         }
@@ -102,7 +103,7 @@ public class GitLabRepository implements HostedRepository {
         var pr = request.post("merge_requests")
                         .body("source_branch", sourceRef)
                         .body("target_branch", targetRef)
-                        .body("title", title)
+                        .body("title", draft ? "WIP: " : "" + title)
                         .body("description", String.join("\n", body))
                         .body("target_project_id", Long.toString(target.getId()))
                         .execute();

--- a/test/src/main/java/org/openjdk/skara/test/HostCredentials.java
+++ b/test/src/main/java/org/openjdk/skara/test/HostCredentials.java
@@ -281,10 +281,14 @@ public class HostCredentials implements AutoCloseable {
         return credentials.getIssueProject(host);
     }
 
-    public PullRequest createPullRequest(HostedRepository hostedRepository, String targetRef, String sourceRef, String title) {
-        var pr = hostedRepository.createPullRequest(hostedRepository, targetRef, sourceRef, title, List.of());
+    public PullRequest createPullRequest(HostedRepository hostedRepository, String targetRef, String sourceRef, String title, boolean draft) {
+        var pr = hostedRepository.createPullRequest(hostedRepository, targetRef, sourceRef, title, List.of(), draft);
         pullRequestsToBeClosed.add(pr);
         return pr;
+    }
+
+    public PullRequest createPullRequest(HostedRepository hostedRepository, String targetRef, String sourceRef, String title) {
+        return createPullRequest(hostedRepository, targetRef, sourceRef, title, false);
     }
 
     public CensusBuilder getCensusBuilder() {

--- a/test/src/main/java/org/openjdk/skara/test/PullRequestData.java
+++ b/test/src/main/java/org/openjdk/skara/test/PullRequestData.java
@@ -32,4 +32,5 @@ class PullRequestData extends IssueData {
     final List<ReviewComment> reviewComments = new ArrayList<>();
     final Set<Check> checks = new HashSet<>();
     final List<Review> reviews = new ArrayList<>();
+    boolean draft;
 }

--- a/test/src/main/java/org/openjdk/skara/test/TestHost.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHost.java
@@ -140,9 +140,9 @@ public class TestHost implements Host {
         }
     }
 
-    TestPullRequest createPullRequest(TestHostedRepository repository, String targetRef, String sourceRef, String title, List<String> body) {
+    TestPullRequest createPullRequest(TestHostedRepository repository, String targetRef, String sourceRef, String title, List<String> body, boolean draft) {
         var id = String.valueOf(data.pullRequests.size() + 1);
-        var pr = TestPullRequest.createNew(repository, id, targetRef, sourceRef, title, body);
+        var pr = TestPullRequest.createNew(repository, id, targetRef, sourceRef, title, body, draft);
         data.pullRequests.put(id, pr);
         return pr;
     }

--- a/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
@@ -58,8 +58,8 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
     }
 
     @Override
-    public PullRequest createPullRequest(HostedRepository target, String targetRef, String sourceRef, String title, List<String> body) {
-        return host.createPullRequest(this, targetRef, sourceRef, title, body);
+    public PullRequest createPullRequest(HostedRepository target, String targetRef, String sourceRef, String title, List<String> body, boolean draft) {
+        return host.createPullRequest(this, targetRef, sourceRef, title, body, draft);
     }
 
     @Override

--- a/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
@@ -57,10 +57,11 @@ public class TestPullRequest extends TestIssue implements PullRequest {
         }
     }
 
-    static TestPullRequest createNew(TestHostedRepository repository, String id, String targetRef, String sourceRef, String title, List<String> body) {
+    static TestPullRequest createNew(TestHostedRepository repository, String id, String targetRef, String sourceRef, String title, List<String> body, boolean draft) {
         var data = new PullRequestData();
         data.title = title;
         data.body = String.join("\n", body);
+        data.draft = draft;
         var pr = new TestPullRequest(repository, id, repository.host().getCurrentUserDetails(), repository.host().getCurrentUserDetails(), targetRef, sourceRef, data);
         return pr;
     }
@@ -182,6 +183,11 @@ public class TestPullRequest extends TestIssue implements PullRequest {
     @Override
     public URI getChangeUrl(Hash base) {
         return URIBuilder.base(getWebUrl()).appendPath("/files/" + base.abbreviate()).build();
+    }
+
+    @Override
+    public boolean isDraft() {
+        return data.draft;
     }
 
     @Override


### PR DESCRIPTION
Hi all,

Please review this change that adds support for creating pull requests in draft stage for GitHub and GitLab, as well as querying if this property is set. Finally, this is used to determine if a pull request is ready for review or not.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-129](https://bugs.openjdk.java.net/browse/SKARA-129): Do not send RFR mails for PRs in Draft stage


## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)