### PR TITLE
127: Avoid sending consecutive emails too fast

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
@@ -235,7 +235,7 @@ class ArchiveWorkItem implements WorkItem {
                                                  jbs.toUpperCase());
         var reviewArchive = new ReviewArchive(bot.emailAddress(), prInstance, census, sentMails);
         var webrevPath = scratchPath.resolve("mlbridge-webrevs");
-        var listServer = MailingListServerFactory.createMailmanServer(bot.listArchive(), bot.smtpServer());
+        var listServer = MailingListServerFactory.createMailmanServer(bot.listArchive(), bot.smtpServer(), bot.sendInterval());
         var list = listServer.getList(bot.listAddress().address());
 
         // First post

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBot.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBot.java
@@ -28,6 +28,7 @@ import org.openjdk.skara.host.*;
 
 import java.net.URI;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.*;
 import java.util.regex.Pattern;
 
@@ -48,13 +49,15 @@ public class MailingListBridgeBot implements Bot {
     private final Map<String, String> headers;
     private final URI issueTracker;
     private final PullRequestUpdateCache updateCache;
+    private final Duration sendInterval;
 
     MailingListBridgeBot(EmailAddress from, HostedRepository repo, HostedRepository archive,
                          HostedRepository censusRepo, String censusRef, EmailAddress list,
                          Set<String> ignoredUsers, Set<Pattern> ignoredComments, URI listArchive, String smtpServer,
                          HostedRepository webrevStorageRepository, String webrevStorageRef,
                          Path webrevStorageBase, URI webrevStorageBaseUri, Set<String> readyLabels,
-                         Map<String, Pattern> readyComments, URI issueTracker, Map<String, String> headers) {
+                         Map<String, Pattern> readyComments, URI issueTracker, Map<String, String> headers,
+                         Duration sendInterval) {
         emailAddress = from;
         codeRepo = repo;
         archiveRepo = archive;
@@ -69,6 +72,7 @@ public class MailingListBridgeBot implements Bot {
         this.readyComments = readyComments;
         this.headers = headers;
         this.issueTracker = issueTracker;
+        this.sendInterval = sendInterval;
 
         this.webrevStorage = new WebrevStorage(webrevStorageRepository, webrevStorageRef, webrevStorageBase,
                                                webrevStorageBaseUri, from);
@@ -97,6 +101,10 @@ public class MailingListBridgeBot implements Bot {
 
     EmailAddress listAddress() {
         return listAddress;
+    }
+
+    Duration sendInterval() {
+        return sendInterval;
     }
 
     Set<String> ignoredUsers() {

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotFactory.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotFactory.java
@@ -30,6 +30,7 @@ import org.openjdk.skara.json.*;
 import org.openjdk.skara.mailinglist.MailingListServerFactory;
 
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.*;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -55,6 +56,7 @@ public class MailingListBridgeBotFactory implements BotFactory {
                                       .collect(Collectors.toSet());
         var listArchive = URIBuilder.base(specific.get("server").get("archive").asString()).build();
         var listSmtp = specific.get("server").get("smtp").asString();
+        var interval = specific.get("server").contains("interval") ? Duration.parse(specific.get("server").get("interval").asString()) : Duration.ofSeconds(1);
 
         var webrevRepo = configuration.repository(specific.get("webrevs").get("repository").asString());
         var webrevRef = configuration.repositoryRef(specific.get("webrevs").get("repository").asString());
@@ -91,14 +93,14 @@ public class MailingListBridgeBotFactory implements BotFactory {
                                                list, ignoredUsers, ignoredComments, listArchive, listSmtp,
                                                webrevRepo, webrevRef, Path.of(folder),
                                                URIBuilder.base(webrevWeb).build(), readyLabels, readyComments,
-                                               issueTracker, headers);
+                                               issueTracker, headers, interval);
             ret.add(bot);
 
             allListNames.add(list);
             allRepositories.add(configuration.repository(repo));
         }
 
-        var mailmanServer = MailingListServerFactory.createMailmanServer(listArchive, listSmtp);
+        var mailmanServer = MailingListServerFactory.createMailmanServer(listArchive, listSmtp, Duration.ZERO);
         var allLists = allListNames.stream()
                                    .map(name -> mailmanServer.getList(name.toString()))
                                    .collect(Collectors.toSet());

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBotTests.java
@@ -73,10 +73,11 @@ class MailingListArchiveReaderBotTests {
                                                  URIBuilder.base("http://www.test.test/").build(),
                                                  Set.of(), Map.of(),
                                                  URIBuilder.base("http://issues.test/browse/").build(),
-                                                 Map.of());
+                                                 Map.of(), Duration.ZERO);
 
             // The mailing list as well
-            var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP());
+            var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(),
+                                                                             Duration.ZERO);
             var mailmanList = mailmanServer.getList(listAddress.address());
             var readerBot = new MailingListArchiveReaderBot(from, Set.of(mailmanList), Set.of(archive));
 
@@ -138,10 +139,11 @@ class MailingListArchiveReaderBotTests {
                                                  URIBuilder.base("http://www.test.test/").build(),
                                                  Set.of(), Map.of(),
                                                  URIBuilder.base("http://issues.test/browse/").build(),
-                                                 Map.of());
+                                                 Map.of(), Duration.ZERO);
 
             // The mailing list as well
-            var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP());
+            var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(),
+                                                                             Duration.ZERO);
             var mailmanList = mailmanServer.getList(listAddress.address());
             var readerBot = new MailingListArchiveReaderBot(from, Set.of(mailmanList), Set.of(archive));
 

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -121,7 +121,8 @@ class MailingListBridgeBotTests {
                                                  Set.of("rfr"), Map.of(ignored.host().getCurrentUserDetails().userName(),
                                                                        Pattern.compile("ready")),
                                                  URIBuilder.base("http://issues.test/browse/").build(),
-                                                 Map.of("Extra1", "val1", "Extra2", "val2"));
+                                                 Map.of("Extra1", "val1", "Extra2", "val2"),
+                                                 Duration.ZERO);
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.getRepositoryType());
@@ -188,7 +189,7 @@ class MailingListBridgeBotTests {
 
             // The mailing list as well
             listServer.processIncoming();
-            var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP());
+            var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
             var mailmanList = mailmanServer.getList(listAddress.address());
             var conversations = mailmanList.conversations(Duration.ofDays(1));
             assertEquals(1, conversations.size());
@@ -276,7 +277,7 @@ class MailingListBridgeBotTests {
                                                  URIBuilder.base("http://www.test.test/").build(),
                                                  Set.of(), Map.of(),
                                                  URIBuilder.base("http://issues.test/browse/").build(),
-                                                 Map.of());
+                                                 Map.of(), Duration.ZERO);
 
             // Populate the projects repository
             var reviewFile = Path.of("reviewfile.txt");
@@ -315,7 +316,7 @@ class MailingListBridgeBotTests {
             assertFalse(archiveContains(archiveFolder.path(), "Don't mind me"));
 
             // The mailing list as well
-            var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP());
+            var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
             var mailmanList = mailmanServer.getList(listAddress.address());
             var conversations = mailmanList.conversations(Duration.ofDays(1));
             assertEquals(1, conversations.size());
@@ -364,7 +365,7 @@ class MailingListBridgeBotTests {
                                                  URIBuilder.base("http://www.test.test/").build(),
                                                  Set.of(), Map.of(),
                                                  URIBuilder.base("http://issues.test/browse/").build(),
-                                                 Map.of());
+                                                 Map.of(), Duration.ZERO);
 
             // Populate the projects repository
             var reviewFile = Path.of("reviewfile.txt");
@@ -397,7 +398,7 @@ class MailingListBridgeBotTests {
             assertEquals(2, archiveContainsCount(archiveFolder.path(), "^On.*wrote:"));
 
             // As well as the mailing list
-            var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP());
+            var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
             var mailmanList = mailmanServer.getList(listAddress.address());
             var conversations = mailmanList.conversations(Duration.ofDays(1));
             assertEquals(1, conversations.size());
@@ -452,7 +453,7 @@ class MailingListBridgeBotTests {
                                                  URIBuilder.base("http://www.test.test/").build(),
                                                  Set.of(), Map.of(),
                                                  URIBuilder.base("http://issues.test/browse/").build(),
-                                                 Map.of());
+                                                 Map.of(), Duration.ZERO);
 
             // Populate the projects repository
             var reviewFile = Path.of("reviewfile.txt");
@@ -506,7 +507,7 @@ class MailingListBridgeBotTests {
             assertTrue(archiveText.indexOf("Looks fine") > archiveText.indexOf("You are welcome"));
 
             // Check the mailing list
-            var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP());
+            var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
             var mailmanList = mailmanServer.getList(listAddress.address());
             var conversations = mailmanList.conversations(Duration.ofDays(1));
             assertEquals(1, conversations.size());
@@ -569,7 +570,7 @@ class MailingListBridgeBotTests {
                                                  URIBuilder.base("http://www.test.test/").build(),
                                                  Set.of(), Map.of(),
                                                  URIBuilder.base("http://issues.test/browse/").build(),
-                                                 Map.of());
+                                                 Map.of(), Duration.ZERO);
 
             // Populate the projects repository
             var reviewFile = Path.of("reviewfile.txt");
@@ -620,7 +621,7 @@ class MailingListBridgeBotTests {
                                                  URIBuilder.base("http://www.test.test/").build(),
                                                  Set.of(), Map.of(),
                                                  URIBuilder.base("http://issues.test/browse/").build(),
-                                                 Map.of());
+                                                 Map.of(), Duration.ZERO);
 
             // Populate the projects repository
             var reviewFile = Path.of("reviewfile.txt");
@@ -689,7 +690,7 @@ class MailingListBridgeBotTests {
                                                  URIBuilder.base("http://www.test.test/").build(),
                                                  Set.of(), Map.of(),
                                                  URIBuilder.base("http://issues.test/browse/").build(),
-                                                 Map.of());
+                                                 Map.of(), Duration.ZERO);
 
             // Populate the projects repository
             var reviewFile = Path.of("reviewfile.txt");
@@ -748,7 +749,7 @@ class MailingListBridgeBotTests {
                                                  URIBuilder.base("http://www.test.test/").build(),
                                                  Set.of(), Map.of(),
                                                  URIBuilder.base("http://issues.test/browse/").build(),
-                                                 Map.of());
+                                                 Map.of(), Duration.ZERO);
 
             // Populate the projects repository
             var reviewFile = Path.of("reviewfile.txt");
@@ -806,7 +807,7 @@ class MailingListBridgeBotTests {
             assertEquals(1, webrevComments.size());
 
             // Check that sender address is set properly
-            var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP());
+            var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
             var mailmanList = mailmanServer.getList(listAddress.address());
             var conversations = mailmanList.conversations(Duration.ofDays(1));
             assertEquals(1, conversations.size());
@@ -869,7 +870,7 @@ class MailingListBridgeBotTests {
                                                  URIBuilder.base("http://www.test.test/").build(),
                                                  Set.of(), Map.of(),
                                                  URIBuilder.base("http://issues.test/browse/").build(),
-                                                 Map.of());
+                                                 Map.of(), Duration.ZERO);
 
             // Populate the projects repository
             var reviewFile = Path.of("reviewfile.txt");
@@ -926,7 +927,7 @@ class MailingListBridgeBotTests {
             assertEquals(1, webrevComments.size());
 
             // Check that sender address is set properly
-            var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP());
+            var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
             var mailmanList = mailmanServer.getList(listAddress.address());
             var conversations = mailmanList.conversations(Duration.ofDays(1));
             assertEquals(1, conversations.size());
@@ -962,7 +963,7 @@ class MailingListBridgeBotTests {
                                                  URIBuilder.base("http://www.test.test/").build(),
                                                  Set.of(), Map.of(),
                                                  URIBuilder.base("http://issues.test/browse/").build(),
-                                                 Map.of());
+                                                 Map.of(), Duration.ZERO);
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.getRepositoryType());
@@ -1035,7 +1036,7 @@ class MailingListBridgeBotTests {
                                                  URIBuilder.base("http://www.test.test/").build(),
                                                  Set.of(), Map.of(),
                                                  URIBuilder.base("http://issues.test/browse/").build(),
-                                                 Map.of());
+                                                 Map.of(), Duration.ZERO);
 
             // Populate the projects repository
             var reviewFile = Path.of("reviewfile.txt");
@@ -1119,7 +1120,7 @@ class MailingListBridgeBotTests {
                                                  URIBuilder.base("http://www.test.test/").build(),
                                                  Set.of(), Map.of(),
                                                  URIBuilder.base("http://issues.test/browse/").build(),
-                                                 Map.of());
+                                                 Map.of(), Duration.ZERO);
 
             // Populate the projects repository
             var reviewFile = Path.of("reviewfile.txt");

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/JNotifyBotFactory.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/JNotifyBotFactory.java
@@ -31,6 +31,7 @@ import org.openjdk.skara.storage.StorageBuilder;
 import org.openjdk.skara.vcs.Tag;
 
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.*;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
@@ -79,7 +80,8 @@ public class JNotifyBotFactory implements BotFactory {
                 var smtp = email.get("smtp").asString();
                 var sender = EmailAddress.parse(email.get("sender").asString());
                 var archive = URIBuilder.base(email.get("archive").asString()).build();
-                var listServer = MailingListServerFactory.createMailmanServer(archive, smtp);
+                var interval = email.contains("interval") ? Duration.parse(email.get("interval").asString()) : Duration.ofSeconds(1);
+                var listServer = MailingListServerFactory.createMailmanServer(archive, smtp, interval);
 
                 for (var mailinglist : repo.value().get("mailinglists").asArray()) {
                     var recipient = mailinglist.get("recipient").asString();

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdaterTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdaterTests.java
@@ -178,7 +178,7 @@ class UpdaterTests {
             localRepo.pushAll(repo.getUrl());
 
             var listAddress = EmailAddress.parse(listServer.createList("test"));
-            var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP());
+            var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
             var mailmanList = mailmanServer.getList(listAddress.address());
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
@@ -229,7 +229,7 @@ class UpdaterTests {
             localRepo.pushAll(repo.getUrl());
 
             var listAddress = EmailAddress.parse(listServer.createList("test"));
-            var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP());
+            var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
             var mailmanList = mailmanServer.getList(listAddress.address());
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
@@ -282,7 +282,7 @@ class UpdaterTests {
             localRepo.pushAll(repo.getUrl());
 
             var listAddress = EmailAddress.parse(listServer.createList("test"));
-            var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP());
+            var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
             var mailmanList = mailmanServer.getList(listAddress.address());
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
@@ -331,7 +331,7 @@ class UpdaterTests {
             localRepo.pushAll(repo.getUrl());
 
             var listAddress = EmailAddress.parse(listServer.createList("test"));
-            var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP());
+            var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
             var mailmanList = mailmanServer.getList(listAddress.address());
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
@@ -403,7 +403,7 @@ class UpdaterTests {
             localRepo.pushAll(repo.getUrl());
 
             var listAddress = EmailAddress.parse(listServer.createList("test"));
-            var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP());
+            var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
             var mailmanList = mailmanServer.getList(listAddress.address());
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
@@ -481,7 +481,7 @@ class UpdaterTests {
             localRepo.pushAll(repo.getUrl());
 
             var listAddress = EmailAddress.parse(listServer.createList("test"));
-            var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP());
+            var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
             var mailmanList = mailmanServer.getList(listAddress.address());
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
@@ -568,7 +568,7 @@ class UpdaterTests {
             localRepo.pushAll(repo.getUrl());
 
             var listAddress = EmailAddress.parse(listServer.createList("test"));
-            var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP());
+            var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
             var mailmanList = mailmanServer.getList(listAddress.address());
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);

--- a/mailinglist/src/main/java/org/openjdk/skara/mailinglist/MailingListServerFactory.java
+++ b/mailinglist/src/main/java/org/openjdk/skara/mailinglist/MailingListServerFactory.java
@@ -27,11 +27,12 @@ import org.openjdk.skara.mailinglist.mboxfile.MboxFileListServer;
 
 import java.net.URI;
 import java.nio.file.Path;
+import java.time.Duration;
 
 public class MailingListServerFactory {
 
-    public static MailingListServer createMailmanServer(URI archive, String smtp) {
-        return new MailmanServer(archive, smtp);
+    public static MailingListServer createMailmanServer(URI archive, String smtp, Duration sendInterval) {
+        return new MailmanServer(archive, smtp, sendInterval);
     }
     public static MailingListServer createMboxFileServer(Path file) {
         return new MboxFileListServer(file);

--- a/mailinglist/src/test/java/org/openjdk/skara/mailinglist/MailmanTests.java
+++ b/mailinglist/src/test/java/org/openjdk/skara/mailinglist/MailmanTests.java
@@ -37,7 +37,8 @@ class MailmanTests {
     void simple() throws IOException {
         try (var testServer = new TestMailmanServer()) {
             var listAddress = testServer.createList("test");
-            var mailmanServer = MailingListServerFactory.createMailmanServer(testServer.getArchive(), testServer.getSMTP());
+            var mailmanServer = MailingListServerFactory.createMailmanServer(testServer.getArchive(), testServer.getSMTP(),
+                                                                             Duration.ZERO);
             var mailmanList = mailmanServer.getList(listAddress);
             var sender = EmailAddress.from("Test", "test@test.email");
             var mail = Email.create(sender, "Subject", "Body")
@@ -57,7 +58,8 @@ class MailmanTests {
     void replies() throws IOException {
         try (var testServer = new TestMailmanServer()) {
             var listAddress = testServer.createList("test");
-            var mailmanServer = MailingListServerFactory.createMailmanServer(testServer.getArchive(), testServer.getSMTP());
+            var mailmanServer = MailingListServerFactory.createMailmanServer(testServer.getArchive(), testServer.getSMTP(),
+                                                                             Duration.ZERO);
             var mailmanList = mailmanServer.getList(listAddress);
             var sender = EmailAddress.from("Test", "test@test.email");
             var sentParent = Email.create(sender, "Subject", "Body")
@@ -95,7 +97,8 @@ class MailmanTests {
     void cached() throws IOException {
         try (var testServer = new TestMailmanServer()) {
             var listAddress = testServer.createList("test");
-            var mailmanServer = MailingListServerFactory.createMailmanServer(testServer.getArchive(), testServer.getSMTP());
+            var mailmanServer = MailingListServerFactory.createMailmanServer(testServer.getArchive(), testServer.getSMTP(),
+                                                                             Duration.ZERO);
             var mailmanList = mailmanServer.getList(listAddress);
             var sender = EmailAddress.from("Test", "test@test.email");
             var mail = Email.create(sender, "Subject", "Body")
@@ -118,6 +121,34 @@ class MailmanTests {
                 assertEquals(mail, conversation.first());
                 assertTrue(testServer.lastResponseCached());
             }
+        }
+    }
+
+    @Test
+    void interval() throws IOException {
+        try (var testServer = new TestMailmanServer()) {
+            var listAddress = testServer.createList("test");
+            var mailmanServer = MailingListServerFactory.createMailmanServer(testServer.getArchive(), testServer.getSMTP(),
+                                                                             Duration.ofDays(1));
+            var mailmanList = mailmanServer.getList(listAddress);
+            var sender = EmailAddress.from("Test", "test@test.email");
+            var mail1 = Email.create(sender, "Subject 1", "Body 1")
+                            .recipient(EmailAddress.parse(listAddress))
+                            .build();
+            var mail2 = Email.create(sender, "Subject 2", "Body 2")
+                             .recipient(EmailAddress.parse(listAddress))
+                             .build();
+            new Thread(() -> {
+                mailmanList.post(mail1);
+                mailmanList.post(mail2);
+            }).start();
+            testServer.processIncoming();
+            assertThrows(RuntimeException.class, () -> testServer.processIncoming(Duration.ZERO));
+
+            var conversations = mailmanList.conversations(Duration.ofDays(1));
+            assertEquals(1, conversations.size());
+            var conversation = conversations.get(0);
+            assertEquals(mail1, conversation.first());
         }
     }
 }


### PR DESCRIPTION
Hi all,

Please review the following change that makes it possible to configure an interval between emails send to a mailing list.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-127](https://bugs.openjdk.java.net/browse/SKARA-127): Avoid sending consecutive emails too fast


## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)