### PR TITLE
134: BotRunnerConfiguration cannot parse hosts

### DIFF
--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunnerConfiguration.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunnerConfiguration.java
@@ -56,11 +56,11 @@ public class BotRunnerConfiguration {
     private Map<String, Forge> parseRepositoryHosts(JSONObject config, Path cwd) throws ConfigurationError {
         Map<String, Forge> ret = new HashMap<>();
 
-        if (!config.contains("hosts")) {
+        if (!config.contains("forges")) {
             return ret;
         }
 
-        for (var entry : config.get("hosts").fields()) {
+        for (var entry : config.get("forges").fields()) {
             if (entry.value().contains("gitlab")) {
                 var gitlab = entry.value().get("gitlab");
                 var uri = URIBuilder.base(gitlab.get("url").asString()).build();
@@ -101,11 +101,11 @@ public class BotRunnerConfiguration {
     private Map<String, IssueTracker> parseIssueHosts(JSONObject config, Path cwd) throws ConfigurationError {
         Map<String, IssueTracker> ret = new HashMap<>();
 
-        if (!config.contains("hosts")) {
+        if (!config.contains("issuetrackers")) {
             return ret;
         }
 
-        for (var entry : config.get("hosts").fields()) {
+        for (var entry : config.get("issuetrackers").fields()) {
             if (entry.value().contains("jira")) {
                 var jira = entry.value().get("jira");
                 var uri = URIBuilder.base(jira.get("url").asString()).build();


### PR DESCRIPTION
Hi all,

this patch fixes a bug that was introduced after the `host` module split. We must separate the different kinds of hosts in the bot configuration file, otherwise the `BotRunnerConfiguration` can't do sanity checking on the configuration.

Thanks,
Erik

## Testing
- [x] `sh gradlew test` passes
- [x] `sh gradlew images` passes
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-134](https://bugs.openjdk.java.net/browse/SKARA-134): BotRunnerConfiguration cannot parse hosts


## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)