### PR TITLE
Add clean and images targets to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,12 @@ check:
 test:
 	@sh gradlew test
 
+clean:
+	@sh gradlew clean
+
+images:
+	@sh gradlew images
+
 install: all $(LAUNCHERS) $(MANPAGES) $(sharedir)/skara
 	@echo "Successfully installed to $(prefix)"
 
@@ -59,4 +65,4 @@ $(bindir)/%: $(BUILD)/bin/%
 	@sed 's~export JAVA_HOME=.*$$~export JAVA_HOME\=$(sharedir)\/skara~' < $< > $@
 	@chmod 755 $@
 
-.PHONY: all check install test uninstall
+.PHONY: all check clean images install test uninstall


### PR DESCRIPTION
Hi,

this patch adds two new "wrapper" targets `images` and `clean` for the Makefile.

Thanks,
Erik

## Testing
- `make images` works
- `make clean` works
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)