### PR TITLE
Fix number of context lines between coalesced hunks

### DIFF
--- a/webrev/src/main/java/org/openjdk/skara/webrev/HunkCoalescer.java
+++ b/webrev/src/main/java/org/openjdk/skara/webrev/HunkCoalescer.java
@@ -258,6 +258,12 @@ class HunkCoalescer {
                     ? Math.min(destAfterContextEnd, nextNonEmptyTargetHunkStart)
                     : Math.max(destAfterContextEnd, nextNonEmptyTargetHunkStart);
         }
+
+        if (nextNonEmptySourceHunk != null || nextNonEmptyTargetHunk != null) {
+            sourceAfterContextEnd += numContextLines;
+            destAfterContextEnd += numContextLines;
+        }
+
         var destAfterContextCount = destAfterContextEnd - destAfterContextStart;
 
         var afterContextCount = Math.min(sourceAfterContextCount, destAfterContextCount);


### PR DESCRIPTION
Hi all,

this patch fixes a smal issue with the `HunkCoalescer`. If two hunks are more than 2 * number-of-context-lines apart then we correctly calculate that they should be coalesced, but we don't include the correct number of context lines. We only include number-of-context-lines (.e.g. 5), not up to the maximum which is 2 * number-of-context-lines (e.g. 10). This small patch fixes this problem.

Thanks to @lkorinth for reporting this bug!

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)