### PR TITLE
Minor test cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,7 @@ configure(subprojects.findAll() { it.name != 'bots' }) {
 
         testLogging {
             events "passed", "skipped", "failed"
+            exceptionFormat "full"
         }
     }
 

--- a/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
@@ -1765,7 +1765,7 @@ public class RepositoryTests {
     @ParameterizedTest
     @EnumSource(VCS.class)
     void testAbortMerge(VCS vcs) throws IOException {
-        try (var dir = new TemporaryDirectory(false)) {
+        try (var dir = new TemporaryDirectory()) {
             var r = Repository.init(dir.path(), vcs);
             assertTrue(r.isClean());
 


### PR DESCRIPTION
Hi all,

please review this small patch that properly cleans up a temporary directory from one test in `RepositoryTests` and also sets the `exceptionFormat` to `"full"` for all `test` targets (so that if a test fails we get full stacktraces).

Thanks,
Erik

## Testing
- `sh gradlew test` passes on Linux x64
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)