### PR TITLE
Add submodule and subrepo support

### DIFF
--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/TestRepository.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/TestRepository.java
@@ -232,4 +232,11 @@ class TestRepository implements ReadOnlyRepository {
     public List<String> remotes() throws IOException {
         return null;
     }
+
+    public void addSubmodule(String pullPath, Path path) throws IOException {
+    }
+
+    public List<Submodule> submodules() throws IOException {
+        return null;
+    }
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
@@ -86,6 +86,7 @@ public interface ReadOnlyRepository {
     Optional<String> upstreamFor(Branch branch) throws IOException;
     List<Reference> remoteBranches(String remote) throws IOException;
     List<String> remotes() throws IOException;
+    List<Submodule> submodules() throws IOException;
 
     static Optional<ReadOnlyRepository> get(Path p) throws IOException {
         return Repository.get(p).map(r -> r);

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
@@ -107,6 +107,7 @@ public interface Repository extends ReadOnlyRepository {
     default void setPaths(String remote, String pullPath) throws IOException {
         setPaths(remote, pullPath, null);
     }
+    void addSubmodule(String pullPath, Path path) throws IOException;
 
     default void push(Hash hash, URI uri, String ref) throws IOException {
         push(hash, uri, ref, false);

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Submodule.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Submodule.java
@@ -1,0 +1,54 @@
+package org.openjdk.skara.vcs;
+
+import java.nio.file.Path;
+import java.util.Objects;
+
+public class Submodule {
+    private final Hash hash;
+    private final Path path;
+    private final String pullPath;
+
+    public Submodule(Hash hash, Path path, String pullPath) {
+        this.hash = hash;
+        this.path = path;
+        this.pullPath = pullPath;
+    }
+
+    public Hash hash() {
+        return hash;
+    }
+
+    public Path path() {
+        return path;
+    }
+
+    public String pullPath() {
+        return pullPath;
+    }
+
+    @Override
+    public String toString() {
+        return pullPath + " " + hash + " " + path;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(hash, path, pullPath);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof Submodule)) {
+            return false;
+        }
+
+        var o = (Submodule) other;
+        return Objects.equals(hash, o.hash) &&
+               Objects.equals(path, o.path) &&
+               Objects.equals(pullPath, o.pullPath);
+    }
+}

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -1129,7 +1129,7 @@ public class HgRepository implements Repository {
 
     @Override
     public void addSubmodule(String pullPath, Path path) throws IOException {
-        var uri = Files.exists(Path.of(pullPath)) ? "file://" + pullPath : pullPath;
+        var uri = Files.exists(Path.of(pullPath)) ? Path.of(pullPath).toUri().toString() : pullPath;
         HgRepository.clone(URI.create(uri), root().resolve(path).toAbsolutePath(), false);
         var hgSub = root().resolve(".hgsub");
         Files.writeString(hgSub, path.toString() + " = " + pullPath + "\n",

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -1126,4 +1126,48 @@ public class HgRepository implements Repository {
         }
         return remotes;
     }
+
+    @Override
+    public void addSubmodule(String pullPath, Path path) throws IOException {
+        var uri = Files.exists(Path.of(pullPath)) ? "file://" + pullPath : pullPath;
+        HgRepository.clone(URI.create(uri), root().resolve(path).toAbsolutePath(), false);
+        var hgSub = root().resolve(".hgsub");
+        Files.writeString(hgSub, path.toString() + " = " + pullPath + "\n",
+                          StandardOpenOption.WRITE, StandardOpenOption.APPEND, StandardOpenOption.CREATE);
+        add(List.of(hgSub));
+    }
+
+    @Override
+    public List<Submodule> submodules() throws IOException {
+        var hgSub = root().resolve(".hgsub");
+        var hgSubState = root().resolve(".hgsubstate");
+        if (!(Files.exists(hgSub) && Files.exists(hgSubState))) {
+            return List.of();
+        }
+
+        var urls = new HashMap<String, String>();
+        for (var line : Files.readAllLines(hgSub)) {
+            var parts = line.split("=");
+            var path = parts[0].trim();
+            var url = parts[1].trim();
+            urls.put(path, url);
+        }
+
+        var hashes = new HashMap<String, String>();
+        for (var line : Files.readAllLines(hgSubState)) {
+            var parts = line.split(" ");
+            var hash = parts[0];
+            var path = parts[1];
+            hashes.put(path, hash);
+        }
+
+        var modules = new ArrayList<Submodule>();
+        for (var path : urls.keySet()) {
+            var url = urls.get(path);
+            var hash = hashes.get(path);
+            modules.add(new Submodule(new Hash(hash), Path.of(path), url));
+        }
+
+        return modules;
+    }
 }

--- a/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
@@ -1848,4 +1848,50 @@ public class RepositoryTests {
             assertEquals(upstream.defaultBranch().name(), ref.name());
         }
     }
+
+    @ParameterizedTest
+    @EnumSource(VCS.class)
+    void testSubmodulesOnEmptyRepo(VCS vcs) throws IOException {
+        try (var dir = new TemporaryDirectory()) {
+            var repo = Repository.init(dir.path(), vcs);
+            assertEquals(List.of(), repo.submodules());
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(VCS.class)
+    void testSubmodulesOnRepoWithNoSubmodules(VCS vcs) throws IOException {
+        try (var dir = new TemporaryDirectory()) {
+            var repo = Repository.init(dir.path().resolve("repo"), vcs);
+            var readme = repo.root().resolve("README");
+            Files.writeString(readme, "Hello\n");
+            repo.add(readme);
+            repo.commit("Added README", "duke", "duke@openjdk.org");
+            assertEquals(List.of(), repo.submodules());
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(VCS.class)
+    void testSubmodulesOnRepoWithSubmodule(VCS vcs) throws IOException {
+        try (var dir = new TemporaryDirectory()) {
+            var submodule = Repository.init(dir.path().resolve("submodule"), vcs);
+            var readme = submodule.root().resolve("README");
+            Files.writeString(readme, "Hello\n");
+            submodule.add(readme);
+            var head = submodule.commit("Added README", "duke", "duke@openjdk.org");
+
+            var repo = Repository.init(dir.path().resolve("repo"), vcs);
+            var pullPath = submodule.root().toAbsolutePath().toString();
+            repo.addSubmodule(pullPath, Path.of("sub"));
+            repo.commit("Added submodule", "duke", "duke@openjdk.org");
+
+            var submodules = repo.submodules();
+            assertEquals(1, submodules.size());
+            var module = submodules.get(0);
+            assertEquals(Path.of("sub"), module.path());
+            assertEquals(head, module.hash());
+            assertEquals(pullPath, module.pullPath());
+        }
+    }
 }


### PR DESCRIPTION
Hi all,

this patch adds initial submodule and subrepo support to `GitRepository` and `HgRepository` and also adds a few unit tests.

Thanks,
Erik

## Testing
- `sh gradlew test` passes on Linux x64
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**) **Note!** Review applies to 3506616c3f0213a47dd7fd74cd6c330569a90d03