### PR TITLE
135: Cannot report more than 50 check errors on GitHub

### DIFF
--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -1008,4 +1008,39 @@ class CheckTests {
             assertFalse(pr.labels().contains("ready"));
         }
     }
+
+    @Test
+    void excessiveFailures(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var reviewer = credentials.getHostedRepository();
+
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addAuthor(author.forge().currentUser().id())
+                                           .addReviewer(reviewer.forge().currentUser().id());
+            var checkBot = new PullRequestBot(author, censusBuilder.build(), "master");
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Make a change with a corresponding PR containing more errors than at least GitHub can handle in a check
+            var badContent = "\tline   \n".repeat(200);
+            var editHash = CheckableRepository.appendAndCommit(localRepo, badContent);
+            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit",
+                                                   "This is a pull request", true);
+
+            // Check the status
+            TestBotRunner.runPeriodicItems(checkBot);
+
+            // Verify that the check failed
+            var checks = pr.checks(editHash);
+            assertEquals(1, checks.size());
+            var check = checks.get("jcheck");
+            assertEquals(CheckStatus.FAILURE, check.status());
+        }
+    }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/GitHubPullRequest.java
@@ -347,7 +347,7 @@ public class GitHubPullRequest implements PullRequest {
             outputQuery.put("summary", check.summary().get());
 
             var annotations = JSON.array();
-            for (var annotation : check.annotations()) {
+            for (var annotation : check.annotations().subList(0, Math.min(check.annotations().size(), 50))) {
                 var annotationQuery = JSON.object();
                 annotationQuery.put("path", annotation.path());
                 annotationQuery.put("start_line", annotation.startLine());


### PR DESCRIPTION
Hi all,

Please review this change that ensures that we don't exceed the maximum number of allowed check annotations on GitHub.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-135](https://bugs.openjdk.java.net/browse/SKARA-135): Cannot report more than 50 check errors on GitHub


## Approvers
 * Kevin Rushforth ([kcr](@kevinrushforth) - no project role)
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)