### PR TITLE
137: Watchdog test can fail to terminate

### DIFF
--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
@@ -177,7 +177,6 @@ public class BotRunner {
             }
             try {
                 Thread.sleep(1);
-                watchdog();
             } catch (InterruptedException e) {
                 log.warning("Exception during queue drain");
                 log.throwing("BotRunner", "drain", e);
@@ -259,7 +258,10 @@ public class BotRunner {
     }
 
     public void run() {
-        log.info("Starting BotRunner execution, will run forever.");
+        run(Duration.ofDays(10 * 365));
+    }
+
+    public void run(Duration timeout) {
         log.info("Periodic task interval: " + config.scheduledExecutionPeriod());
         log.info("Concurrency: " + config.concurrency());
 
@@ -280,7 +282,7 @@ public class BotRunner {
                                      config.scheduledExecutionPeriod().toMillis(), TimeUnit.MILLISECONDS);
 
         try {
-            executor.awaitTermination(Long.MAX_VALUE, TimeUnit.DAYS);
+            executor.awaitTermination(timeout.toMillis(), TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }

--- a/bot/src/test/java/org/openjdk/skara/bot/BotRunnerTests.java
+++ b/bot/src/test/java/org/openjdk/skara/bot/BotRunnerTests.java
@@ -276,7 +276,6 @@ class BotRunnerTests {
     }
 
     @Test
-    @DisabledOnOs(OS.WINDOWS)
     void watchdogTrigger() throws TimeoutException {
         var countdownLatch = new CountDownLatch(1);
         var item = new TestBlockedWorkItem(countdownLatch);

--- a/bot/src/test/java/org/openjdk/skara/bot/BotRunnerTests.java
+++ b/bot/src/test/java/org/openjdk/skara/bot/BotRunnerTests.java
@@ -281,7 +281,7 @@ class BotRunnerTests {
         var countdownLatch = new CountDownLatch(1);
         var item = new TestBlockedWorkItem(countdownLatch);
         var bot = new TestBot(item);
-        var runner = new BotRunner(config("{ \"runner\": { \"watchdog\": \"PT0.01S\" } }"), List.of(bot));
+        var runner = new BotRunner(config("{ \"runner\": { \"watchdog\": \"PT0.01S\", \"interval\": \"PT0.001S\" } }"), List.of(bot));
 
         var errors = new ArrayList<String>();
         var log = Logger.getLogger("org.openjdk.skara.bot");
@@ -302,7 +302,7 @@ class BotRunnerTests {
             }
         });
 
-        assertThrows(TimeoutException.class, () -> runner.runOnce(Duration.ofMillis(100)));
+        runner.run(Duration.ofMillis(100));
         assertTrue(errors.size() > 0);
         assertTrue(errors.size() <= 10);
         countdownLatch.countDown();

--- a/bot/src/test/java/org/openjdk/skara/bot/BotRunnerTests.java
+++ b/bot/src/test/java/org/openjdk/skara/bot/BotRunnerTests.java
@@ -303,7 +303,7 @@ class BotRunnerTests {
 
         runner.run(Duration.ofMillis(100));
         assertTrue(errors.size() > 0);
-        assertTrue(errors.size() <= 10);
+        assertTrue(errors.size() <= 100);
         countdownLatch.countDown();
     }
 }


### PR DESCRIPTION
Hi all,

Please review this change that fixes a problem with the BotRunnerTests.watchdogTrigger test.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-137](https://bugs.openjdk.java.net/browse/SKARA-137): Watchdog test can fail to terminate


## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)