### PR TITLE
Run Windows CI using cmd

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,4 @@ jobs:
     - uses: actions/checkout@v1
     - name: Build and test
       run: gradlew.bat test --info --stacktrace
+      shell: cmd


### PR DESCRIPTION
Hi all,

Please review this change that ensures that gradlew.bat is run using cmd when using GitHub actions on Windows.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)