### PR TITLE
Add --recurse-submodules=on-demand to git fetch commands

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -330,7 +330,7 @@ public class GitRepository implements Repository {
 
     @Override
     public Hash fetch(URI uri, String refspec) throws IOException {
-        try (var p = capture("git", "fetch", "--tags", uri.toString(), refspec)) {
+        try (var p = capture("git", "fetch", "--recurse-submodules=on-demand", "--tags", uri.toString(), refspec)) {
             await(p);
             return resolve("FETCH_HEAD").get();
         }
@@ -338,7 +338,7 @@ public class GitRepository implements Repository {
 
     @Override
     public void fetchAll() throws IOException {
-        try (var p = capture("git", "fetch", "--tags", "--prune", "--prune-tags", "--all")) {
+        try (var p = capture("git", "fetch", "--recurse-submodules=on-demand", "--tags", "--prune", "--prune-tags", "--all")) {
             await(p);
         }
     }


### PR DESCRIPTION
Hi all,

please review this small patch that adds `--recurse-submodules=on-demand` to the `git fetch` commands in `GitRepository`. Adding `--recurse-submodules` means blobs for submodules will automatically fetched _if necessary_ (when a submodule has been updated in the parent repo). If no submodules are present then no additional action will be taken.

Thanks,
Erik

## Testing
- `make test` passes on Linux x64
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)