### PR TITLE
142: The new_line field of a GitLab review comment can be null

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/GitLabMergeRequest.java
@@ -160,11 +160,15 @@ public class GitLabMergeRequest implements PullRequest {
     }
 
     private ReviewComment parseReviewComment(String discussionId, ReviewComment parent, JSONObject note) {
+        var line = note.get("position").get("new_line").isNull() ?
+                note.get("position").get("old_line").asInt() :
+                note.get("position").get("new_line").asInt();
+
         var comment = new ReviewComment(parent,
                                         discussionId,
                                         new Hash(note.get("position").get("head_sha").asString()),
                                         note.get("position").get("new_path").asString(),
-                                        note.get("position").get("new_line").asInt(),
+                                        line,
                                         note.get("id").toString(),
                                         note.get("body").asString(),
                                         new HostUser(note.get("author").get("id").asInt(),


### PR DESCRIPTION
Hi all,

Please review this small change that avoids trying to parse a null value as an integer.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-142](https://bugs.openjdk.java.net/browse/SKARA-142): The new_line field of a GitLab review comment can be null


## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)