### PR TITLE
72: Retry jcheck if an exception occurs

### DIFF
--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -28,6 +28,7 @@ import org.openjdk.skara.test.*;
 import org.junit.jupiter.api.*;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.util.*;
 import java.util.regex.Pattern;
@@ -1041,6 +1042,59 @@ class CheckTests {
             assertEquals(1, checks.size());
             var check = checks.get("jcheck");
             assertEquals(CheckStatus.FAILURE, check.status());
+        }
+    }
+
+    @Test
+    void retryOnException(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var reviewer = credentials.getHostedRepository();
+
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addAuthor(author.forge().currentUser().id())
+                                           .addReviewer(reviewer.forge().currentUser().id());
+            var checkBot = new PullRequestBot(author, censusBuilder.build(), "master");
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Break the jcheck configuration
+            var confPath = tempFolder.path().resolve(".jcheck/conf");
+            var oldConf = Files.readString(confPath, StandardCharsets.UTF_8);
+            Files.writeString(confPath, "Hello there!", StandardCharsets.UTF_8);
+            localRepo.add(confPath);
+            var editHash = CheckableRepository.appendAndCommit(localRepo, "A change");
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit",
+                                                   "This is a pull request", true);
+
+            // Check the status - should throw every time
+            assertThrows(RuntimeException.class, () -> TestBotRunner.runPeriodicItems(checkBot));
+            assertThrows(RuntimeException.class, () -> TestBotRunner.runPeriodicItems(checkBot));
+            assertThrows(RuntimeException.class, () -> TestBotRunner.runPeriodicItems(checkBot));
+
+            // Verify that the check failed
+            var checks = pr.checks(editHash);
+            assertEquals(1, checks.size());
+            var check = checks.get("jcheck");
+            assertEquals(CheckStatus.FAILURE, check.status());
+
+            Files.writeString(confPath, oldConf, StandardCharsets.UTF_8);
+            localRepo.add(confPath);
+            editHash = CheckableRepository.appendAndCommit(localRepo, "Another change");
+            localRepo.push(editHash, author.url(), "edit");
+
+            TestBotRunner.runPeriodicItems(checkBot);
+
+            // Verify that the check now passes
+            checks = pr.checks(editHash);
+            assertEquals(1, checks.size());
+            check = checks.get("jcheck");
+            assertEquals(CheckStatus.SUCCESS, check.status());
         }
     }
 }


### PR DESCRIPTION
Hi all,

Please review this change that automatically reruns a jcheck that fails due to an exception, as this should only happen on transient errors such as external services being down.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-72](https://bugs.openjdk.java.net/browse/SKARA-72): If jcheck fails due to a server error, it can be tricky to rerun it


## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)