### PR TITLE
Add support for building on AArch64

### DIFF
--- a/bots/cli/build.gradle
+++ b/bots/cli/build.gradle
@@ -80,8 +80,8 @@ images {
         options = ["--module-path", "plugins"]
         bundles = ['zip', 'tar.gz']
         jdk {
-            url = 'https://download.java.net/java/GA/jdk12/GPL/openjdk-12_linux-x64_bin.tar.gz'
-            sha256 = 'b43bc15f4934f6d321170419f2c24451486bc848a2179af5e49d10721438dd56'
+            url = project.jdkUrl
+            sha256 = project.jdkSha256
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,59 @@
  * questions.
  */
 
+buildscript {
+    def deps = [:]
+    file('deps.env').readLines().each() {
+        def (key, value) = it.tokenize('=')
+        if (key != null && value != null) {
+            deps[key] = value.replaceAll(/^\"|\"$/, '')
+        }
+    }
+
+    ext {
+        def os = System.getProperty('os.name').toLowerCase()
+        osName = os.startsWith('win') ? 'Windows' :
+            os.startsWith('mac') ? 'Macos' : 'Linux'
+
+        def jdks = [
+            'Windows': [
+                'amd64': [
+                    url: deps['JDK_WINDOWS_URL'],
+                    sha256: deps['JDK_WINDOWS_SHA256']
+                ],
+            ],
+            'Linux': [
+                'amd64': [
+                    url: deps['JDK_LINUX_X86_64_URL'],
+                    sha256: deps['JDK_LINUX_X86_64_SHA256']
+                ],
+                'aarch64': [
+                    url: deps['JDK_LINUX_AARCH64_URL'],
+                    sha256: deps['JDK_LINUX_AARCH64_SHA256']
+                ],
+            ],
+            'Macos': [
+                'amd64': [
+                    url: deps['JDK_MACOS_URL'],
+                    sha256: deps['JDK_MACOS_SHA256']
+                ],
+            ],
+        ]
+
+        if (osName in jdks) {
+            def arch = System.getProperty('os.arch')
+            if (arch in jdks[osName]) {
+                jdkUrl = jdks[osName][arch].url
+                jdkSha256 = jdks[osName][arch].sha256
+            } else {
+                throw new GradleException("Unsupported architecture: ${arch}")
+            }
+        } else {
+            throw new GradleException("Unsupported OS: ${os}")
+        }
+    }
+}
+
 plugins {
     id 'org.openjdk.skara.gradle.proxy'
     id 'org.openjdk.skara.gradle.version'
@@ -108,11 +161,8 @@ task local(type: Copy) {
     doFirst {
         delete project.buildDir
     }
-    def os = System.getProperty('os.name').toLowerCase()
-    def osName = os.startsWith('win') ? 'Windows' :
-        os.startsWith('mac') ? 'Macos' : 'Linux'
 
-    dependsOn ':cli:image' + osName
+    dependsOn ':cli:image' + project.osName
     from zipTree(file(project.rootDir.toString() +
                       '/cli/build/distributions/cli' +
                       '-' + project.version + '-' +

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ buildscript {
                 ],
             ],
             'Macos': [
-                'amd64': [
+                'x86_64': [
                     url: deps['JDK_MACOS_URL'],
                     sha256: deps['JDK_MACOS_SHA256']
                 ],

--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -76,8 +76,8 @@ images {
         launchers = ext.launchers
         bundles = ['zip', 'tar.gz']
         jdk {
-            url = 'https://download.java.net/java/GA/jdk12/GPL/openjdk-12_windows-x64_bin.zip'
-            sha256 = '35a8d018f420fb05fe7c2aa9933122896ca50bd23dbd373e90d8e2f3897c4e92'
+            url = project.jdkUrl
+            sha256 = project.jdkSha256
         }
     }
 
@@ -87,8 +87,8 @@ images {
         man = 'cli/resources/man'
         bundles = ['zip', 'tar.gz']
         jdk {
-            url = 'https://download.java.net/java/GA/jdk12/GPL/openjdk-12_linux-x64_bin.tar.gz'
-            sha256 = 'b43bc15f4934f6d321170419f2c24451486bc848a2179af5e49d10721438dd56'
+            url = project.jdkUrl
+            sha256 = project.jdkSha256
         }
     }
 
@@ -98,8 +98,8 @@ images {
         man = 'cli/resources/man'
         bundles = ['zip', 'tar.gz']
         jdk {
-            url = 'https://download.java.net/java/GA/jdk12/GPL/openjdk-12_osx-x64_bin.tar.gz'
-            sha256 = '52164a04db4d3fdfe128cfc7b868bc4dae52d969f03d53ae9d4239fe783e1a3a'
+            url = project.jdkUrl
+            sha256 = project.jdkSha256
         }
     }
 }

--- a/deps.env
+++ b/deps.env
@@ -1,5 +1,8 @@
-JDK_LINUX_URL="https://download.java.net/java/GA/jdk12/GPL/openjdk-12_linux-x64_bin.tar.gz"
-JDK_LINUX_SHA256="b43bc15f4934f6d321170419f2c24451486bc848a2179af5e49d10721438dd56"
+JDK_LINUX_X86_64_URL="https://download.java.net/java/GA/jdk12/GPL/openjdk-12_linux-x64_bin.tar.gz"
+JDK_LINUX_X86_64_SHA256="b43bc15f4934f6d321170419f2c24451486bc848a2179af5e49d10721438dd56"
+
+JDK_LINUX_AARCH64_URL="https://github.com/AdoptOpenJDK/openjdk12-binaries/releases/download/jdk-12.0.2%2B10/OpenJDK12U-jdk_aarch64_linux_hotspot_12.0.2_10.tar.gz"
+JDK_LINUX_AARCH64_SHA256="855f046afc5a5230ad6da45a5c811194267acd1748f16b648bfe5710703fe8c6"
 
 JDK_MACOS_URL="https://download.java.net/java/GA/jdk12/GPL/openjdk-12_osx-x64_bin.tar.gz"
 JDK_MACOS_SHA256="52164a04db4d3fdfe128cfc7b868bc4dae52d969f03d53ae9d4239fe783e1a3a"

--- a/gradlew
+++ b/gradlew
@@ -82,12 +82,25 @@ extract_zip() {
 
 DIR=$(dirname $0)
 OS=$(uname)
+ARCH=$(uname -m)
 
 . $(dirname "${0}")/deps.env
 case "${OS}" in
     Linux )
-        JDK_URL="${JDK_LINUX_URL}"
-        JDK_SHA256="${JDK_LINUX_SHA256}"
+        case "${ARCH}" in
+            x86_64 )
+                JDK_URL="${JDK_LINUX_X86_64_URL}"
+                JDK_SHA256="${JDK_LINUX_X86_64_SHA256}"
+                ;;
+            aarch64 )
+                JDK_URL="${JDK_LINUX_AARCH64_URL}"
+                JDK_SHA256="${JDK_LINUX_AARCH64_SHA256}"
+                ;;
+            *)
+                echo "error: unsupported Linux architecture ${ARCH}"
+                exit 1
+                ;;
+        esac
         ;;
     Darwin )
         JDK_URL="${JDK_MACOS_URL}"


### PR DESCRIPTION
I'm working with OpenJDK on Arm machines so I want to be able to run
`git webrev' etc. there. At the moment we can't build the Skara tools on
AArch64 due to an implicit assumption that Linux means X86. I tried to
refactor the build scripts support multiple architectures on Linux. Only
X86 and AArch64 for now but should be trivial to add others.

Using the AdoptOpenJDK AArch64 binary build as there are no prebuilt
binaries for AArch64 on java.net.

Currently there are several Gradle sub-projects that use the image
plugin to build Java images, and each specifies the URL and SHA265 of
the binary JDK to use. Changed the top-level Gradle script to parse
deps.env and select the JDK source based on the OS and architecture
system properties. This gets rid of the duplicated URLs but now each
image { .. } block has a redundant section like the following for each
OS:

        jdk {
            url = project.jdkUrl
            sha256 = project.jdkSha256
        }

So maybe the plugin should be tweaked to move this up into the image {}
block itself?
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed