### PR TITLE
Support the "neutral" check conclusion

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -317,6 +317,8 @@ public class GitHubPullRequest implements PullRequest {
                                         checkBuilder.complete(true, completedAt);
                                         break;
                                     case "failure":
+                                        // fallthrough
+                                    case "neutral":
                                         checkBuilder.complete(false, completedAt);
                                         break;
                                     default:
@@ -342,7 +344,7 @@ public class GitHubPullRequest implements PullRequest {
 
     @Override
     public void createCheck(Check check) {
-        // update and create are currenly identical operations, both do an HTTP
+        // update and create are currently identical operations, both do an HTTP
         // POST to the /repos/:owner/:repo/check-runs endpoint. There is an additional
         // endpoint explicitly for updating check-runs, but that is not currently used.
         updateCheck(check);


### PR DESCRIPTION
Hi all,

Please review this minor change that adds support for the "neutral" check conclusion that can be returned by the GitHub check API.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**) **Note!** Review applies to fe87b6319a4229cba2fb63c2b21e093b730e53b9