### PR TITLE
Add support for offline and local builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,14 +39,14 @@ external Git source code hosting providers are available:
 ## Building
 
 [JDK 12](http://jdk.java.net/12/) or later and [Gradle](https://gradle.org/)
-5.2.1 or later is required for building. To build the project on macOS or
-GNU/Linux, just run the following command from the source tree root:
+5.6.2 or later is required for building. To build the project on macOS or
+GNU/Linux x64, just run the following command from the source tree root:
 
 ```bash
 $ sh gradlew
 ```
 
-To build the project on Windows, run the following command from the source tree root:
+To build the project on Windows x64, run the following command from the source tree root:
 
 ```bat
 > gradlew
@@ -54,6 +54,42 @@ To build the project on Windows, run the following command from the source tree 
 
 The extracted jlinked image will end up in the `build` directory in the source
 tree root.
+
+### Other operating systems and CPU architectures
+
+If you want to build on an operating system other than GNU/Linux, macOS or
+Windows _or_ if you want to build on a CPU architecture other than x64, then
+ensure that you have JDK 12 or later installed locally. You can then run the
+following command from the source tree root:
+
+```bash
+$ sh gradlew
+```
+
+The extracted jlinked image will end up in the `build` directory in the source
+tree root.
+
+### Offline builds
+
+If you don't want the build to automatically download any depenendcies, then
+you must ensure that you have installed the following software locally:
+
+- JDK 12 or later
+- Gradle 5.6.2 or later
+
+To create a build then run the command
+
+```bash
+$ gradle offline
+```
+
+_Please note_ that the above command does _not_ make use of `gradlew` to avoid
+downloading Gradle.
+
+The extracted jlinked image will end up in the `build` directory in the source
+tree root.
+
+### Cross-linking
 
 It is also supported to cross-jlink jimages to GNU/Linux, macOS and/or Windows from
 any of the aforementioned operating systems. To build all applicable jimages

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ tree root.
 
 ### Offline builds
 
-If you don't want the build to automatically download any depenendcies, then
+If you don't want the build to automatically download any dependencies, then
 you must ensure that you have installed the following software locally:
 
 - JDK 12 or later

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ you must ensure that you have installed the following software locally:
 - JDK 12 or later
 - Gradle 5.6.2 or later
 
-To create a build then run the command
+To create a build then run the command:
 
 ```bash
 $ gradle offline

--- a/bots/cli/build.gradle
+++ b/bots/cli/build.gradle
@@ -64,7 +64,7 @@ dependencies {
 }
 
 images {
-    linux {
+    linux_x64 {
         modules = ['jdk.crypto.ec',
                    'org.openjdk.skara.bots.pr',
                    'org.openjdk.skara.bots.hgbridge',

--- a/build.gradle
+++ b/build.gradle
@@ -123,7 +123,7 @@ def getOS() {
 
 def getCPU() {
     def cpu = System.getProperty('os.arch').toLowerCase()
-    if (cpu.startsWith('amd64')) {
+    if (cpu.startsWith('amd64') || cpu.startsWith('x86_64') || cpu.startsWith('x64')) {
         return 'x64'
     }
     if (cpu.startsWith('x86') || cpu.startsWith('i386')) {

--- a/build.gradle
+++ b/build.gradle
@@ -104,19 +104,79 @@ reproduce {
     dockerfile = 'test.dockerfile'
 }
 
+def getOS() {
+    def os = System.getProperty('os.name').toLowerCase()
+    if (os.startsWith('linux')) {
+        return 'linux'
+    }
+    if (os.startsWith('mac')) {
+        return 'macos'
+    }
+    if (os.startsWith('win')) {
+        return 'windows'
+    }
+    if (os.startsWith('sunos')) {
+        return 'solaris'
+    }
+    throw new GradleException("Unexpected operating system: " + os)
+}
+
+def getCPU() {
+    def cpu = System.getProperty('os.arch').toLowerCase()
+    if (cpu.startsWith('amd64')) {
+        return 'x64'
+    }
+    if (cpu.startsWith('x86') || cpu.startsWith('i386')) {
+        return 'x86'
+    }
+    if (cpu.startsWith('sparc')) {
+        return 'sparc'
+    }
+    if (cpu.startsWith('ppc')) {
+        return 'ppc'
+    }
+    if (cpu.startsWith('arm')) {
+        return 'arm'
+    }
+    throw new GradleException("Unexpected operating system: " + cpu)
+}
+
 task local(type: Copy) {
     doFirst {
         delete project.buildDir
     }
-    def os = System.getProperty('os.name').toLowerCase()
-    def osName = os.startsWith('win') ? 'Windows' :
-        os.startsWith('mac') ? 'Macos' : 'Linux'
 
-    dependsOn ':cli:image' + osName
+    def os = getOS()
+    def cpu = getCPU()
+
+    if (os in ['linux', 'macos', 'windows'] && cpu == 'x64') {
+        def target = os.substring(0, 1).toUpperCase() + os.substring(1) +
+                     cpu.substring(0, 1).toUpperCase() + cpu.substring(1)
+        dependsOn ':cli:image' + target
+    } else {
+        dependsOn ':cli:imageLocal'
+    }
+
     from zipTree(file(project.rootDir.toString() +
                       '/cli/build/distributions/cli' +
                       '-' + project.version + '-' +
-		      osName.toLowerCase() + '.zip'))
+                      os + '-' + cpu + '.zip'))
+    into project.buildDir
+}
+
+task offline(type: Copy) {
+    doFirst {
+        delete project.buildDir
+    }
+
+    def os = getOS()
+    def cpu = getCPU()
+
+    dependsOn ':cli:imageLocal'
+    from zipTree(file(project.rootDir.toString() +
+                      '/cli/build/distributions/cli' +
+                      '-' + project.version + '-' +
+                      os + '-' + cpu + '.zip'))
     into project.buildDir
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -138,7 +138,10 @@ def getCPU() {
     if (cpu.startsWith('arm')) {
         return 'arm'
     }
-    throw new GradleException("Unexpected operating system: " + cpu)
+    if (cpu.startsWith('aarch64')) {
+        return 'aarch64';
+    }
+    throw new GradleException("Unexpected CPU: " + cpu)
 }
 
 task local(type: Copy) {

--- a/buildSrc/images/src/main/java/org/openjdk/skara/gradle/images/ImagesPlugin.java
+++ b/buildSrc/images/src/main/java/org/openjdk/skara/gradle/images/ImagesPlugin.java
@@ -29,9 +29,49 @@ import org.gradle.api.tasks.bundling.*;
 import org.gradle.api.artifacts.UnknownConfigurationException;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.io.File;
 
 public class ImagesPlugin implements Plugin<Project> {
+    private static String getOS() {
+        var p = System.getProperty("os.name").toLowerCase();
+        if (p.startsWith("win")) {
+            return "windows";
+        }
+        if (p.startsWith("mac")) {
+            return "macos";
+        }
+        if (p.startsWith("linux")) {
+            return "linux";
+        }
+        if (p.startsWith("sunos")) {
+            return "solaris";
+        }
+
+        throw new RuntimeException("Unknown operating system: " + System.getProperty("os.name"));
+    }
+
+    private static String getCPU() {
+        var p = System.getProperty("os.arch").toLowerCase();
+        if (p.startsWith("amd64")) {
+            return "x64";
+        }
+        if (p.startsWith("x86") || p.startsWith("i386")) {
+            return "x86";
+        }
+        if (p.startsWith("sparc")) {
+            return "sparc";
+        }
+        if (p.startsWith("ppc")) {
+            return "ppc";
+        }
+        if (p.startsWith("arm")) {
+            return "arm";
+        }
+
+        throw new RuntimeException("Unknown CPU: " + System.getProperty("os.arch"));
+    }
+
     @Override
     public void apply(Project project) {
         NamedDomainObjectContainer<ImageEnvironment> imageEnvironmentContainer =
@@ -49,15 +89,23 @@ public class ImagesPlugin implements Plugin<Project> {
 
         imageEnvironmentContainer.all(new Action<ImageEnvironment>() {
             public void execute(ImageEnvironment env) {
-                var name = env.getName();
-                var subName = name.substring(0, 1).toUpperCase() + name.substring(1);
+                var parts = env.getName().split("_");;
+                var isLocal = parts.length == 1 && parts[0].equals("local");
+                var os = isLocal ? getOS() : parts[0];
+                var cpu = isLocal ? getCPU() : parts[1];
+                var osAndCpuPascalCased =
+                    os.substring(0, 1).toUpperCase() + os.substring(1) +
+                    cpu.substring(0, 1).toUpperCase() + cpu.substring(1);
+                var subName = isLocal ? "Local" : osAndCpuPascalCased;
 
                 var downloadTaskName = "download" + subName + "JDK";
-                project.getTasks().register(downloadTaskName, DownloadJDKTask.class, (task) -> {
-                    task.getUrl().set(env.getUrl());
-                    task.getSha256().set(env.getSha256());
-                    task.getToDir().set(rootDir.resolve(".jdk"));
-                });
+                if (!isLocal) {
+                    project.getTasks().register(downloadTaskName, DownloadJDKTask.class, (task) -> {
+                        task.getUrl().set(env.getUrl());
+                        task.getSha256().set(env.getSha256());
+                        task.getToDir().set(rootDir.resolve(".jdk"));
+                    });
+                }
 
                 var linkTaskName = "link" + subName;
                 project.getTasks().register(linkTaskName, LinkTask.class, (task) -> {
@@ -75,10 +123,15 @@ public class ImagesPlugin implements Plugin<Project> {
                         // ignored
                     }
 
-                    task.dependsOn(projectPath + ":" + downloadTaskName);
+                    if (!isLocal) {
+                        task.dependsOn(projectPath + ":" + downloadTaskName);
+                        task.getUrl().set(env.getUrl());
+                    } else {
+                        task.getUrl().set("local");
+                    }
                     task.getToDir().set(buildDir.resolve("images"));
-                    task.getUrl().set(env.getUrl());
-                    task.getOS().set(name);
+                    task.getOS().set(os);
+                    task.getCPU().set(cpu);
                     task.getLaunchers().set(env.getLaunchers());
                     task.getModules().set(env.getModules());
                 });
@@ -88,7 +141,8 @@ public class ImagesPlugin implements Plugin<Project> {
                     task.getLaunchers().set(env.getLaunchers());
                     task.getOptions().set(env.getOptions());
                     task.getToDir().set(buildDir.resolve("launchers"));
-                    task.getOS().set(name);
+                    task.getOS().set(os);
+                    task.getCPU().set(cpu);
                 });
 
                 var zipTaskName = "bundleZip" + subName;
@@ -99,7 +153,7 @@ public class ImagesPlugin implements Plugin<Project> {
                     task.setPreserveFileTimestamps(false);
                     task.setReproducibleFileOrder(true);
                     task.getArchiveBaseName().set(project.getName());
-                    task.getArchiveClassifier().set(name);
+                    task.getArchiveClassifier().set(os + "-" + cpu);
                     task.getArchiveExtension().set("zip");
 
                     if (env.getMan().isPresent()) {
@@ -109,10 +163,11 @@ public class ImagesPlugin implements Plugin<Project> {
                         });
                     }
 
-                    task.from(buildDir.resolve("images").resolve(name), (s) -> {
+                    var subdir = os + "-" + cpu;
+                    task.from(buildDir.resolve("images").resolve(subdir), (s) -> {
                         s.into("image");
                     });
-                    task.from(buildDir.resolve("launchers").resolve(name), (s) -> {
+                    task.from(buildDir.resolve("launchers").resolve(subdir), (s) -> {
                         s.into("bin");
                     });
                 });
@@ -125,7 +180,7 @@ public class ImagesPlugin implements Plugin<Project> {
                     task.setPreserveFileTimestamps(false);
                     task.setReproducibleFileOrder(true);
                     task.getArchiveBaseName().set(project.getName());
-                    task.getArchiveClassifier().set(name);
+                    task.getArchiveClassifier().set(os + "-" + cpu);
                     task.getArchiveExtension().set("tar.gz");
                     task.setCompression(Compression.GZIP);
 
@@ -136,10 +191,11 @@ public class ImagesPlugin implements Plugin<Project> {
                         });
                     }
 
-                    task.from(buildDir.resolve("images").resolve(name), (s) -> {
+                    var subdir = os + "-" + cpu;
+                    task.from(buildDir.resolve("images").resolve(subdir), (s) -> {
                         s.into("image");
                     });
-                    task.from(buildDir.resolve("launchers").resolve(name), (s) -> {
+                    task.from(buildDir.resolve("launchers").resolve(subdir), (s) -> {
                         s.into("bin");
                     });
                 });

--- a/buildSrc/images/src/main/java/org/openjdk/skara/gradle/images/ImagesPlugin.java
+++ b/buildSrc/images/src/main/java/org/openjdk/skara/gradle/images/ImagesPlugin.java
@@ -53,7 +53,7 @@ public class ImagesPlugin implements Plugin<Project> {
 
     private static String getCPU() {
         var p = System.getProperty("os.arch").toLowerCase();
-        if (p.startsWith("amd64")) {
+        if (p.startsWith("amd64") || p.startsWith("x86_64") || p.startsWith("x64")) {
             return "x64";
         }
         if (p.startsWith("x86") || p.startsWith("i386")) {

--- a/buildSrc/images/src/main/java/org/openjdk/skara/gradle/images/ImagesPlugin.java
+++ b/buildSrc/images/src/main/java/org/openjdk/skara/gradle/images/ImagesPlugin.java
@@ -68,6 +68,9 @@ public class ImagesPlugin implements Plugin<Project> {
         if (p.startsWith("arm")) {
             return "arm";
         }
+        if (p.startsWith("aarch64")) {
+            return "aarch64";
+        }
 
         throw new RuntimeException("Unknown CPU: " + System.getProperty("os.arch"));
     }

--- a/buildSrc/images/src/main/java/org/openjdk/skara/gradle/images/LaunchersTask.java
+++ b/buildSrc/images/src/main/java/org/openjdk/skara/gradle/images/LaunchersTask.java
@@ -37,6 +37,7 @@ import java.util.Comparator;
 public class LaunchersTask extends DefaultTask {
     private Property<Path> toDir;
     private Property<String> os;
+    private Property<String> cpu;
     private MapProperty<String, String> launchers;
     private ListProperty<String> options;
 
@@ -44,6 +45,7 @@ public class LaunchersTask extends DefaultTask {
     public LaunchersTask(ObjectFactory factory) {
         toDir = factory.property(Path.class);
         os = factory.property(String.class);
+        cpu = factory.property(String.class);
         launchers = factory.mapProperty(String.class, String.class);
         options = factory.listProperty(String.class);
     }
@@ -64,6 +66,11 @@ public class LaunchersTask extends DefaultTask {
     }
 
     @Input
+    Property<String> getCPU() {
+        return cpu;
+    }
+
+    @Input
     MapProperty<String, String> getLaunchers() {
         return launchers;
     }
@@ -77,7 +84,7 @@ public class LaunchersTask extends DefaultTask {
 
     @TaskAction
     void generate() throws IOException {
-        var dest = toDir.get().resolve(os.get());
+        var dest = toDir.get().resolve(os.get() + "-" + cpu.get());
         if (Files.isDirectory(dest)) {
             clearDirectory(dest);
         }

--- a/buildSrc/images/src/main/java/org/openjdk/skara/gradle/images/LinkTask.java
+++ b/buildSrc/images/src/main/java/org/openjdk/skara/gradle/images/LinkTask.java
@@ -41,6 +41,7 @@ import java.util.stream.Collectors;
 
 public class LinkTask extends DefaultTask {
     private final Property<String> os;
+    private final Property<String> cpu;
     private final Property<String> url;
     private final Property<Path> toDir;
     private final MapProperty<String, String> launchers;
@@ -51,6 +52,7 @@ public class LinkTask extends DefaultTask {
     @Inject
     public LinkTask(ObjectFactory factory) {
         os = factory.property(String.class);
+        cpu = factory.property(String.class);
         url = factory.property(String.class);
         toDir = factory.property(Path.class);
         launchers = factory.mapProperty(String.class, String.class);
@@ -67,6 +69,11 @@ public class LinkTask extends DefaultTask {
     @Input
     Property<String> getOS() {
         return os;
+    }
+
+    @Input
+    Property<String> getCPU() {
+        return cpu;
     }
 
     @Input
@@ -117,9 +124,14 @@ public class LinkTask extends DefaultTask {
             modularJars.add(jar.getAsFile().toString());
         }
 
-        var filename = Path.of(URI.create(url.get()).getPath()).getFileName().toString();
-        var dirname = filename.replace(".zip", "").replace(".tar.gz", "");
-        var jdk = project.getRootDir().toPath().toAbsolutePath().resolve(".jdk").resolve(dirname);
+        Path jdk = null;
+        if (!url.get().equals("local")) {
+            var filename = Path.of(URI.create(url.get()).getPath()).getFileName().toString();
+            var dirname = filename.replace(".zip", "").replace(".tar.gz", "");
+            jdk = project.getRootDir().toPath().toAbsolutePath().resolve(".jdk").resolve(dirname);
+        } else {
+            jdk = Path.of(System.getProperty("java.home"));
+        }
         var dirs = Files.walk(jdk)
                         .filter(Files::isDirectory)
                         .filter(p -> p.getFileName().toString().equals("jmods"))
@@ -143,7 +155,7 @@ public class LinkTask extends DefaultTask {
         var allModules = new ArrayList<String>(uniqueModules);
 
         Files.createDirectories(toDir.get());
-        var dest = toDir.get().resolve(os.get());
+        var dest = toDir.get().resolve(os.get() + "-" + cpu.get());
         if (Files.exists(dest) && Files.isDirectory(dest)) {
             clearDirectory(dest);
         }
@@ -163,14 +175,14 @@ public class LinkTask extends DefaultTask {
         });
 
         var currentOS = System.getProperty("os.name").toLowerCase().substring(0, 3);
-        if (currentOS.equals(os.get().substring(0, 3))) {
+        if (os.get().equals("local") || currentOS.equals(os.get().substring(0, 3))) {
             var ext = currentOS.startsWith("win") ? ".exe" : "";
             var javaLaunchers = Files.walk(dest)
                                      .filter(Files::isExecutable)
                                      .filter(p -> p.getFileName().toString().equals("java" + ext))
                                      .collect(Collectors.toList());
             if (javaLaunchers.size() != 1) {
-                throw new GradleException("Multiple or no java launchers generated for " + os.get() + " image");
+                throw new GradleException("Multiple or no java launchers generated for " + os.get() + "-" + cpu.get() + " image");
             }
             var java = javaLaunchers.get(0);
             project.exec((spec) -> {

--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -71,7 +71,7 @@ images {
 
     ext.modules = ['jdk.crypto.ec']
 
-    windows {
+    windows_x64 {
         modules = ext.modules
         launchers = ext.launchers
         bundles = ['zip', 'tar.gz']
@@ -81,7 +81,7 @@ images {
         }
     }
 
-    linux {
+    linux_x64 {
         modules = ext.modules
         launchers = ext.launchers
         man = 'cli/resources/man'
@@ -92,7 +92,7 @@ images {
         }
     }
 
-    macos {
+    macos_x64 {
         modules = ext.modules
         launchers = ext.launchers
         man = 'cli/resources/man'
@@ -101,5 +101,12 @@ images {
             url = 'https://download.java.net/java/GA/jdk12/GPL/openjdk-12_osx-x64_bin.tar.gz'
             sha256 = '52164a04db4d3fdfe128cfc7b868bc4dae52d969f03d53ae9d4239fe783e1a3a'
         }
+    }
+
+    local {
+        modules = ext.modules
+        launchers = ext.launchers
+        man = 'cli/resources/man'
+        bundles = ['zip', 'tar.gz']
     }
 }

--- a/deps.env
+++ b/deps.env
@@ -1,11 +1,11 @@
-JDK_LINUX_URL="https://download.java.net/java/GA/jdk12/GPL/openjdk-12_linux-x64_bin.tar.gz"
-JDK_LINUX_SHA256="b43bc15f4934f6d321170419f2c24451486bc848a2179af5e49d10721438dd56"
+JDK_LINUX_X64_URL="https://download.java.net/java/GA/jdk12/GPL/openjdk-12_linux-x64_bin.tar.gz"
+JDK_LINUX_X64_SHA256="b43bc15f4934f6d321170419f2c24451486bc848a2179af5e49d10721438dd56"
 
-JDK_MACOS_URL="https://download.java.net/java/GA/jdk12/GPL/openjdk-12_osx-x64_bin.tar.gz"
-JDK_MACOS_SHA256="52164a04db4d3fdfe128cfc7b868bc4dae52d969f03d53ae9d4239fe783e1a3a"
+JDK_MACOS_X64_URL="https://download.java.net/java/GA/jdk12/GPL/openjdk-12_osx-x64_bin.tar.gz"
+JDK_MACOS_X64_SHA256="52164a04db4d3fdfe128cfc7b868bc4dae52d969f03d53ae9d4239fe783e1a3a"
 
-JDK_WINDOWS_URL="https://download.java.net/java/GA/jdk12/GPL/openjdk-12_windows-x64_bin.zip"
-JDK_WINDOWS_SHA256="35a8d018f420fb05fe7c2aa9933122896ca50bd23dbd373e90d8e2f3897c4e92"
+JDK_WINDOWS_X64_URL="https://download.java.net/java/GA/jdk12/GPL/openjdk-12_windows-x64_bin.zip"
+JDK_WINDOWS_X64_SHA256="35a8d018f420fb05fe7c2aa9933122896ca50bd23dbd373e90d8e2f3897c4e92"
 
 GRADLE_URL="https://services.gradle.org/distributions/gradle-5.6.2-bin.zip"
 GRADLE_SHA256="32fce6628848f799b0ad3205ae8db67d0d828c10ffe62b748a7c0d9f4a5d9ee0"

--- a/gradlew
+++ b/gradlew
@@ -81,67 +81,70 @@ extract_zip() {
 }
 
 DIR=$(dirname $0)
+ARCH=$(uname -m)
 OS=$(uname)
 
 . $(dirname "${0}")/deps.env
-case "${OS}" in
-    Linux )
-        JDK_URL="${JDK_LINUX_URL}"
-        JDK_SHA256="${JDK_LINUX_SHA256}"
-        ;;
-    Darwin )
-        JDK_URL="${JDK_MACOS_URL}"
-        JDK_SHA256="${JDK_MACOS_SHA256}"
-        ;;
-    CYGWIN_NT* )
-        JDK_URL="${JDK_WINDOWS_URL}"
-        JDK_SHA256="${JDK_WINDOWS_SHA256}"
-        ;;
-    *)
-        echo "error: unknown operating system ${OS}"
-        exit 1
-        ;;
-esac
-
-JDK_FILENAME="${DIR}/.jdk/$(basename ${JDK_URL})"
-if [ "${OS}" = "Linux" -o "${OS}" = "Darwin" ]; then
-    JDK_DIR="${DIR}/.jdk/$(basename -s '.tar.gz' ${JDK_URL})"
-else
-    JDK_DIR="${DIR}/.jdk/$(basename -s '.zip' ${JDK_URL})"
+if [ "${ARCH}" = "x86_64" ]; then
+    case "${OS}" in
+        Linux )
+            JDK_URL="${JDK_LINUX_X64_URL}"
+            JDK_SHA256="${JDK_LINUX_X64_SHA256}"
+            ;;
+        Darwin )
+            JDK_URL="${JDK_MACOS_X64_URL}"
+            JDK_SHA256="${JDK_MACOS_X64_SHA256}"
+            ;;
+        CYGWIN_NT* )
+            JDK_URL="${JDK_WINDOWS_X64_URL}"
+            JDK_SHA256="${JDK_WINDOWS_X64_SHA256}"
+            ;;
+    esac
 fi
 
-if [ ! -d "${JDK_DIR}" ]; then
-    mkdir -p ${DIR}/.jdk
-    if [ ! -f "${JDK_FILENAME}" ]; then
-        if [ -f "${JDK_URL}" ]; then
-            echo "Copying JDK..."
-            cp "${JDK_URL}" "${JDK_FILENAME}"
+if [ ! -z "${JDK_URL}" ]; then
+    JDK_FILENAME="${DIR}/.jdk/$(basename ${JDK_URL})"
+    if [ "${OS}" = "Linux" -o "${OS}" = "Darwin" ]; then
+        JDK_DIR="${DIR}/.jdk/$(basename -s '.tar.gz' ${JDK_URL})"
+    else
+        JDK_DIR="${DIR}/.jdk/$(basename -s '.zip' ${JDK_URL})"
+    fi
+
+    if [ ! -d "${JDK_DIR}" ]; then
+        mkdir -p ${DIR}/.jdk
+        if [ ! -f "${JDK_FILENAME}" ]; then
+            if [ -f "${JDK_URL}" ]; then
+                echo "Copying JDK..."
+                cp "${JDK_URL}" "${JDK_FILENAME}"
+            else
+                echo "Downloading JDK..."
+                download ${JDK_URL} "${JDK_FILENAME}"
+                checksum "${JDK_FILENAME}" ${JDK_SHA256}
+            fi
+        fi
+        echo "Extracting JDK..."
+        if [ "${OS}" = "Linux" -o "${OS}" = "Darwin" ]; then
+            extract_tar "${JDK_FILENAME}" "${JDK_DIR}"
         else
-            echo "Downloading JDK..."
-            download ${JDK_URL} "${JDK_FILENAME}"
-            checksum "${JDK_FILENAME}" ${JDK_SHA256}
+            extract_zip "${JDK_FILENAME}" "${JDK_DIR}"
         fi
     fi
-    echo "Extracting JDK..."
-    if [ "${OS}" = "Linux" -o "${OS}" = "Darwin" ]; then
-        extract_tar "${JDK_FILENAME}" "${JDK_DIR}"
+
+    if [ "${OS}" = "Darwin" ]; then
+        EXECUTABLE_FILTER='-perm +111'
+        LAUNCHER='java'
+    elif [ "${OS}" = "Linux" ]; then
+        EXECUTABLE_FILTER='-executable'
+        LAUNCHER='java'
     else
-        extract_zip "${JDK_FILENAME}" "${JDK_DIR}"
+        LAUNCHER='java.exe'
     fi
-fi
 
-if [ "${OS}" = "Darwin" ]; then
-    EXECUTABLE_FILTER='-perm +111'
-    LAUNCHER='java'
-elif [ "${OS}" = "Linux" ]; then
-    EXECUTABLE_FILTER='-executable'
-    LAUNCHER='java'
+    JAVA_LAUNCHER=$(find "${JDK_DIR}" -type f ${EXECUTABLE_FILTER} | grep ".*/bin/${LAUNCHER}$")
+    export JAVA_HOME="$(dirname $(dirname ${JAVA_LAUNCHER}))"
 else
-    LAUNCHER='java.exe'
+    JAVA_LAUNCHER="java"
 fi
-
-JAVA_LAUNCHER=$(find "${JDK_DIR}" -type f ${EXECUTABLE_FILTER} | grep ".*/bin/${LAUNCHER}$")
-export JAVA_HOME="$(dirname $(dirname ${JAVA_LAUNCHER}))"
 
 GRADLE_FILENAME="${DIR}/.gradle/$(basename ${GRADLE_URL})"
 GRADLE_DIR="${DIR}/.gradle/$(basename -s '.zip' ${GRADLE_URL})"
@@ -155,7 +158,11 @@ if [ ! -d "${GRADLE_DIR}" ]; then
     checksum ${GRADLE_FILENAME} ${GRADLE_SHA256}
     echo "Extracting Gradle..."
     if [ "${OS}" = "Linux" -o "${OS}" = "Darwin" ]; then
-        "${JAVA_LAUNCHER}" "${DIR}"/Unzip.java "${GRADLE_FILENAME}" "${GRADLE_DIR}"
+        if exists unzip; then
+            extract_zip "${GRADLE_FILENAME}" "${GRADLE_DIR}"
+        else
+            "${JAVA_LAUNCHER}" "${DIR}"/Unzip.java "${GRADLE_FILENAME}" "${GRADLE_DIR}"
+        fi
     else
         extract_zip "${GRADLE_FILENAME}" "${GRADLE_DIR}"
     fi

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -21,14 +21,14 @@ rem or visit www.oracle.com if you need additional information or have any
 rem questions.
 
 for /f "tokens=1,2 delims==" %%A in (deps.env) do (set %%A=%%~B)
-for /f %%i in ("%JDK_WINDOWS_URL%") do set JDK_WINDOWS_DIR=%%~ni
+for /f %%i in ("%JDK_WINDOWS_X64_URL%") do set JDK_WINDOWS_DIR=%%~ni
 for /f %%i in ("%GRADLE_URL%") do set GRADLE_DIR=%%~ni
 
 if exist %~dp0\.jdk\%JDK_WINDOWS_DIR% goto gradle
 
 echo Downloading JDK...
 mkdir %~dp0\.jdk\temp
-curl -L %JDK_WINDOWS_URL% -o %JDK_WINDOWS_DIR%.zip
+curl -L %JDK_WINDOWS_X64_URL% -o %JDK_WINDOWS_DIR%.zip
 move %JDK_WINDOWS_DIR%.zip %~dp0\.jdk\
 for /f "tokens=*" %%i in ('@certutil -hashfile %~dp0/.jdk/%JDK_WINDOWS_DIR%.zip sha256 ^| %WINDIR%\System32\find /v "hash of file" ^| %WINDIR%\System32\find /v "CertUtil"') do set SHA256JDK=%%i
 if "%SHA256JDK%" == "%JDK_WINDOWS_SHA256%" (goto extractJdk)

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -31,7 +31,7 @@ mkdir %~dp0\.jdk\temp
 curl -L %JDK_WINDOWS_X64_URL% -o %JDK_WINDOWS_DIR%.zip
 move %JDK_WINDOWS_DIR%.zip %~dp0\.jdk\
 for /f "tokens=*" %%i in ('@certutil -hashfile %~dp0/.jdk/%JDK_WINDOWS_DIR%.zip sha256 ^| %WINDIR%\System32\find /v "hash of file" ^| %WINDIR%\System32\find /v "CertUtil"') do set SHA256JDK=%%i
-if "%SHA256JDK%" == "%JDK_WINDOWS_SHA256%" (goto extractJdk)
+if "%SHA256JDK%" == "%JDK_WINDOWS_X64_SHA256%" (goto extractJdk)
 echo Invalid SHA256 for JDK detected (%SHA256JDK%)
 goto done
 


### PR DESCRIPTION
Hi all,

this patch adds much improved support for both _offline_ and _local_ builds. We are currently downloading both JDK and Gradle distributions for the most common platforms (GNU/Linux x64, macOS x64 and Windows x64), but this scheme does not scale to multiple other operating systems and/or CPU architectures. I have therefore extended the `images` plugin to support a `local` image which uses the JDK that is currently executing Gradle for producing the jlinked image.

I also added support for fully offline builds for those want to supply both a JDK and Gradle themselves and ensure that the build does not download anything.

Thanks,
Erik

## Testing
- Tested multiple variants of builds, including local, offline and default builds
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**) **Note!** Review applies to 66a6b56bbab2b8bd7d79f4c31e39c35a94850824