### PR TITLE
Add "Required" title to jcheck-check only if it fails

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -171,6 +171,7 @@ class CheckRun {
         if (visitor.isReadyForReview() && additionalErrors.isEmpty()) {
             checkBuilder.complete(true);
         } else {
+            checkBuilder.title("Required");
             var summary = Stream.concat(visitor.getMessages().stream(), additionalErrors.stream())
                                 .sorted()
                                 .map(m -> "- " + m)
@@ -448,7 +449,6 @@ class CheckRun {
 
     private void checkStatus() {
         var checkBuilder = CheckBuilder.create("jcheck", pr.headHash());
-        checkBuilder.title("Required");
         var censusDomain = censusInstance.configuration().census().domain();
         Exception checkException = null;
 


### PR DESCRIPTION
Hi all,

please review this small patch that only sets the title `"Required"` for the jcheck-check if jcheck fails.

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)