### PR TITLE
151: Encode single dot characters in the SMTP client

### DIFF
--- a/email/src/main/java/org/openjdk/skara/email/SMTP.java
+++ b/email/src/main/java/org/openjdk/skara/email/SMTP.java
@@ -28,18 +28,19 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.format.DateTimeFormatter;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * Limited SMTP client implementation - only compatibility requirement (currently) is the OpenJDK
  * mailing list servers.
  */
 public class SMTP {
-    private static Pattern initReply = Pattern.compile("220 .*");
+    private static Pattern initReply = Pattern.compile("^220 .*");
     private static Pattern ehloReply = Pattern.compile("^250 .*");
     private static Pattern mailReply = Pattern.compile("^250 .*");
     private static Pattern rcptReply = Pattern.compile("^250 .*");
-    private static Pattern dataReply = Pattern.compile("354 Enter.*");
-    private static Pattern doneReply = Pattern.compile("250 .*");
+    private static Pattern dataReply = Pattern.compile("^354 .*");
+    private static Pattern doneReply = Pattern.compile("^250 .*");
 
     public static void send(String server, EmailAddress recipient, Email email) throws IOException {
         send(server, recipient, email, Duration.ofMinutes(30));
@@ -74,7 +75,10 @@ public class SMTP {
             session.sendCommand("Subject: " + MimeText.encode(email.subject()));
             session.sendCommand("Content-type: text/plain; charset=utf-8");
             session.sendCommand("");
-            session.sendCommand(email.body());
+            var escapedBody = email.body().lines()
+                                   .map(line -> line.startsWith(".") ? "." + line : line)
+                                   .collect(Collectors.joining("\n"));
+            session.sendCommand(escapedBody);
             session.sendCommand(".", doneReply);
             session.sendCommand("QUIT");
         }

--- a/email/src/test/java/org/openjdk/skara/email/SMTPTests.java
+++ b/email/src/test/java/org/openjdk/skara/email/SMTPTests.java
@@ -22,24 +22,19 @@
  */
 package org.openjdk.skara.email;
 
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 import org.openjdk.skara.test.SMTPServer;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.*;
 
 import java.io.IOException;
 import java.time.Duration;
-import java.util.logging.Logger;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class SMTPTests {
-    private final static Logger log = Logger.getLogger("org.openjdk.skara.email");;
-
     @Test
     void simple() throws IOException {
-        log.info("Hello");
         try (var server = new SMTPServer()) {
             var sender = EmailAddress.from("Test", "test@test.email");
             var recipient = EmailAddress.from("Dest", "dest@dest.email");
@@ -53,7 +48,6 @@ class SMTPTests {
 
     @Test
     void withHeader() throws IOException {
-        log.info("Hello");
         try (var server = new SMTPServer()) {
             var sender = EmailAddress.from("Test", "test@test.email");
             var author = EmailAddress.from("Auth", "auth@test.email");
@@ -73,7 +67,6 @@ class SMTPTests {
     @Test
     @DisabledOnOs(OS.WINDOWS)
     void encoded() throws IOException {
-        log.info("Hello");
         try (var server = new SMTPServer()) {
             var sender = EmailAddress.from("Señor Dévèlöper", "test@test.email");
             var recipient = EmailAddress.from("Dêst", "dest@dest.email");
@@ -90,13 +83,25 @@ class SMTPTests {
 
     @Test
     void timeout() throws IOException {
-        log.info("Hello");
         try (var server = new SMTPServer()) {
             var sender = EmailAddress.from("Test", "test@test.email");
             var recipient = EmailAddress.from("Dest", "dest@dest.email");
             var sentMail = Email.create(sender, "Subject", "Body").recipient(recipient).build();
 
             assertThrows(RuntimeException.class, () -> SMTP.send(server.address(), recipient, sentMail, Duration.ZERO));
+        }
+    }
+
+    @Test
+    void withDot() throws IOException {
+        try (var server = new SMTPServer()) {
+            var sender = EmailAddress.from("Test", "test@test.email");
+            var recipient = EmailAddress.from("Dest", "dest@dest.email");
+            var sentMail = Email.create(sender, "Subject", "Body\n.\nMore text").recipient(recipient).build();
+
+            SMTP.send(server.address(), recipient, sentMail);
+            var email = server.receive(Duration.ofSeconds(10));
+            assertEquals(sentMail, email);
         }
     }
 }

--- a/test/src/main/java/org/openjdk/skara/test/SMTPServer.java
+++ b/test/src/main/java/org/openjdk/skara/test/SMTPServer.java
@@ -71,6 +71,9 @@ public class SMTPServer implements AutoCloseable {
                         inHeader = false;
                     }
                 }
+                if (line.startsWith(".")) {
+                    line = line.substring(1);
+                }
                 mailBody.append(line);
                 mailBody.append("\n");
             }


### PR DESCRIPTION
Hi all,

Please review this change that ensures that lines containing a single dot are properly escaped in the SMTP client.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-151](https://bugs.openjdk.java.net/browse/SKARA-151): Encode single dot characters in the SMTP client


## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)