### PR TITLE
Add buildnum extraction support for OpenJFX tags

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/OpenJDKTag.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/OpenJDKTag.java
@@ -52,16 +52,19 @@ public class OpenJDKTag {
      * jdk7u40-b20 -> jdk7u40  7u40     u20     -b           29
      * hs24-b30    -> hs24     24               -b           30
      * hs23.6-b19  -> hs23.6   23.6     .6      -b           19
+     * 11.1+22     -> 11.1     11.1     .1      +            22
      */
 
     private final static String legacyOpenJDKVersionPattern = "(jdk([0-9]{1,2}(u[0-9]{1,3})?))";
     private final static String legacyHSVersionPattern = "((hs[0-9]{1,2}(\\.[0-9]{1,3})?))";
     private final static String legacyBuildPattern = "(-b)([0-9]{2,3})";
     private final static String OpenJDKVersionPattern = "(jdk-([0-9]+(\\.[0-9]){0,3}))(\\+)([0-9]+)";
+    private final static String OpenJFXVersionPattern = "((?:jdk-){0,1}([1-9](?:(?:[0-9]*)(\\.(?:0|[1-9][0-9]*)){0,3})))(?:(\\+)([0-9]+)|(-ga))";
 
     private final static List<Pattern> tagPatterns = List.of(Pattern.compile(legacyOpenJDKVersionPattern + legacyBuildPattern),
                                                              Pattern.compile(legacyHSVersionPattern + legacyBuildPattern),
-                                                             Pattern.compile(OpenJDKVersionPattern));
+                                                             Pattern.compile(OpenJDKVersionPattern),
+                                                             Pattern.compile(OpenJFXVersionPattern));
 
     /**
      * Attempts to create an OpenJDKTag instance from a general Tag.
@@ -106,6 +109,9 @@ public class OpenJDKTag {
      * @return
      */
     public int buildNum() {
+        if (buildNum == null) {
+            return 0;
+        }
         return Integer.parseInt(buildNum);
     }
 

--- a/vcs/src/test/java/org/openjdk/skara/vcs/openjdk/OpenJDKTagTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/openjdk/OpenJDKTagTests.java
@@ -22,10 +22,11 @@
  */
 package org.openjdk.skara.vcs.openjdk;
 
-import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.*;
-
 import org.openjdk.skara.vcs.Tag;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 class OpenJDKTagTests {
     @Test
@@ -91,5 +92,23 @@ class OpenJDKTagTests {
         var jdkTag = OpenJDKTag.create(tag).orElseThrow();
         assertEquals(0, jdkTag.buildNum());
         assertFalse(jdkTag.previous().isPresent());
+    }
+
+    @Test
+    void parseJfxTags() {
+        var tag = new Tag("12.1.3+14");
+        var jdkTag = OpenJDKTag.create(tag).orElseThrow();
+        assertEquals("12.1.3", jdkTag.version());
+        assertEquals(14, jdkTag.buildNum());
+        var previousTag = jdkTag.previous().orElseThrow();
+        assertEquals(13, previousTag.buildNum());
+    }
+
+    @Test
+    void parseJfxTagsGa() {
+        var tag = new Tag("12.1-ga");
+        var jdkTag = OpenJDKTag.create(tag).orElseThrow();
+        assertEquals("12.1", jdkTag.version());
+        assertEquals(0, jdkTag.buildNum());
     }
 }


### PR DESCRIPTION
Hi all,

Please review this minor change that enables parsing of the tag format used in the OpenJFX project.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Kevin Rushforth ([kcr](@kevinrushforth) - no project role)
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)