### PR TITLE
Add ReadOnlyRepository.annotate(Tag t) method

### DIFF
--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/TestRepository.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/TestRepository.java
@@ -239,4 +239,8 @@ class TestRepository implements ReadOnlyRepository {
     public List<Submodule> submodules() throws IOException {
         return null;
     }
+
+    public Optional<Tag.Annotated> annotate(Tag tag) throws IOException {
+        return null;
+    }
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
@@ -95,4 +95,6 @@ public interface ReadOnlyRepository {
     static boolean exists(Path p) throws IOException {
         return Repository.exists(p);
     }
+
+    Optional<Tag.Annotated> annotate(Tag tag) throws IOException;
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Tag.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Tag.java
@@ -24,8 +24,73 @@ package org.openjdk.skara.vcs;
 
 import java.util.Objects;
 import java.util.Optional;
+import java.time.ZonedDateTime;
 
 public class Tag {
+    public static class Annotated {
+        private final String name;
+        private final Hash target;
+        private final Author author;
+        private final ZonedDateTime date;
+        private final String message;
+
+        public Annotated(String name, Hash target, Author author, ZonedDateTime date, String message) {
+            this.name = name;
+            this.target = target;
+            this.author = author;
+            this.date = date;
+            this.message = message;
+        }
+
+        public String name() {
+            return name;
+        }
+
+        public Hash target() {
+            return target;
+        }
+
+        public Author author() {
+            return author;
+        }
+
+        public ZonedDateTime date() {
+            return date;
+        }
+
+        public String message() {
+            return message;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (other == this) {
+                return true;
+            }
+
+            if (!(other instanceof Annotated)) {
+                return false;
+            }
+
+            var o = (Annotated) other;
+            return Objects.equals(name, o.name) &&
+                   Objects.equals(target, o.target) &&
+                   Objects.equals(author, o.author) &&
+                   Objects.equals(date, o.date) &&
+                   Objects.equals(message, o.message);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(name, target, author, date, message);
+        }
+
+        @Override
+        public String toString() {
+            return name + " -> " + target.hex();
+        }
+    }
+
     private final String name;
 
     public Tag(String name) {

--- a/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.file.*;
 import java.nio.file.attribute.*;
+import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -1892,6 +1893,55 @@ public class RepositoryTests {
             assertEquals(Path.of("sub"), module.path());
             assertEquals(head, module.hash());
             assertEquals(pullPath, module.pullPath());
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(VCS.class)
+    void testAnnotateTag(VCS vcs) throws IOException {
+        try (var dir = new TemporaryDirectory()) {
+            var repo = Repository.init(dir.path(), vcs);
+            var readme = repo.root().resolve("README");
+            var now = ZonedDateTime.now();
+            Files.writeString(readme, "Hello\n");
+            repo.add(readme);
+            var head = repo.commit("Added README", "duke", "duke@openjdk.org");
+            var tag = repo.tag(head, "1.0", "Added tag 1.0 for HEAD\n", "duke", "duke@openjdk.org");
+            var annotated = repo.annotate(tag).get();
+
+            assertEquals("1.0", annotated.name());
+            assertEquals(head, annotated.target());
+            assertEquals(new Author("duke", "duke@openjdk.org"), annotated.author());
+            assertEquals(now.getYear(), annotated.date().getYear());
+            assertEquals(now.getMonth(), annotated.date().getMonth());
+            assertEquals(now.getDayOfYear(), annotated.date().getDayOfYear());
+            assertEquals(now.getHour(), annotated.date().getHour());
+            assertEquals(now.getOffset(), annotated.date().getOffset());
+            assertEquals("Added tag 1.0 for HEAD\n", annotated.message());
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(VCS.class)
+    void testAnnotateTagOnMissingTag(VCS vcs) throws IOException {
+        try (var dir = new TemporaryDirectory()) {
+            var repo = Repository.init(dir.path(), vcs);
+            var readme = repo.root().resolve("README");
+            var now = ZonedDateTime.now();
+            Files.writeString(readme, "Hello\n");
+            repo.add(readme);
+            var head = repo.commit("Added README", "duke", "duke@openjdk.org");
+
+            assertEquals(Optional.empty(), repo.annotate(new Tag("unknown")));
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(VCS.class)
+    void testAnnotateTagOnEmptyRepo(VCS vcs) throws IOException {
+        try (var dir = new TemporaryDirectory()) {
+            var repo = Repository.init(dir.path(), vcs);
+            assertEquals(Optional.empty(), repo.annotate(new Tag("unknown")));
         }
     }
 }


### PR DESCRIPTION
Hi all,

please review this patch that adds the `ReadOnlyRepository.annotate(Tag t)` method that can be used to get more information for annotated tags (git) or just tags (hg).

Thanks,
Erik

## Testing
- `make test` passes
- Added three new unit tests
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)