### PR TITLE
Use tag annotation if present when sending notifications

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/JNotifyBot.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/JNotifyBot.java
@@ -171,11 +171,6 @@ class JNotifyBot implements Bot, WorkItem {
                                 .map(Optional::get)
                                 .sorted(Comparator.comparingInt(OpenJDKTag::buildNum))
                                 .collect(Collectors.toList());
-
-        var newNonJdkTags = newTags.stream()
-                                   .filter(tag -> OpenJDKTag.create(tag).isEmpty())
-                                   .collect(Collectors.toList());
-
         for (var tag : newJdkTags) {
             // Update the history first - if there is a problem here we don't want to send out multiple updates
             history.addTags(List.of(tag.tag()));
@@ -205,6 +200,9 @@ class JNotifyBot implements Bot, WorkItem {
             }
         }
 
+        var newNonJdkTags = newTags.stream()
+                                   .filter(tag -> OpenJDKTag.create(tag).isEmpty())
+                                   .collect(Collectors.toList());
         for (var tag : newNonJdkTags) {
             // Update the history first - if there is a problem here we don't want to send out multiple updates
             history.addTags(List.of(tag));

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/JNotifyBot.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/JNotifyBot.java
@@ -35,7 +35,7 @@ import java.nio.file.*;
 import java.util.*;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
+import java.util.stream.*;
 
 class JNotifyBot implements Bot, WorkItem {
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots");;
@@ -166,33 +166,48 @@ class JNotifyBot implements Bot, WorkItem {
                              .map(Optional::get)
                              .collect(Collectors.toSet());
         var newJdkTags = newTags.stream()
-                             .map(OpenJDKTag::create)
-                             .filter(Optional::isPresent)
-                             .map(Optional::get)
-                             .sorted(Comparator.comparingInt(OpenJDKTag::buildNum))
-                             .collect(Collectors.toList());
+                                .map(OpenJDKTag::create)
+                                .filter(Optional::isPresent)
+                                .map(Optional::get)
+                                .sorted(Comparator.comparingInt(OpenJDKTag::buildNum))
+                                .map(OpenJDKTag::tag);
+        var newNonJdkTags = newTags.stream()
+                                   .filter(tag -> OpenJDKTag.create(tag).isEmpty());
 
-        for (var tag : newJdkTags) {
+        var sortedNewTags = Stream.concat(newJdkTags, newNonJdkTags).collect(Collectors.toList());
+        for (var tag : sortedNewTags) {
             // Update the history first - if there is a problem here we don't want to send out multiple updates
-            history.addTags(List.of(tag.tag()));
+            history.addTags(List.of(tag));
 
             var commits = new ArrayList<Commit>();
-            var previous = existingPrevious(tag, allJdkTags);
-            if (previous.isEmpty()) {
-                var commit = localRepo.lookup(tag.tag());
+
+            // Try to determine which commits are new since the last build
+            var openjdkTag = OpenJDKTag.create(tag);
+            if (openjdkTag.isPresent()) {
+                var previous = existingPrevious(openjdkTag.get(), allJdkTags);
+                if (previous.isPresent()) {
+                    commits.addAll(localRepo.commits(previous.get().tag() + ".." + tag).asList());
+                }
+            }
+
+            // If none are found, just include the commit that was tagged
+            if (commits.isEmpty()) {
+                var commit = localRepo.lookup(tag);
                 if (commit.isEmpty()) {
                     throw new RuntimeException("Failed to lookup tag '" + tag.toString() + "'");
                 } else {
                     commits.add(commit.get());
-                    log.warning("No previous tag found for '" + tag.tag() + "'");
                 }
-            } else {
-                commits.addAll(localRepo.commits(previous.get().tag() + ".." + tag.tag()).asList());
             }
 
             Collections.reverse(commits);
+            var annotation = localRepo.annotate(tag);
             for (var updater : updaters) {
-                updater.handleTagCommits(repository, commits, tag);
+                if (annotation.isPresent()) {
+                    updater.handleAnnotatedTagCommits(repository, commits, tag, annotation.get());
+                } else {
+                    updater.handleTagCommits(repository, commits, tag);
+                }
             }
         }
     }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/JsonUpdater.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/JsonUpdater.java
@@ -86,12 +86,8 @@ public class JsonUpdater implements UpdateConsumer {
     }
 
     @Override
-    public void handleTagCommits(HostedRepository repository, List<Commit> commits, Tag tag) {
-        var openjdkTag = OpenJDKTag.create(tag);
-        if (openjdkTag.isEmpty()) {
-            return;
-        }
-        var build = String.format("b%02d", openjdkTag.get().buildNum());
+    public void handleOpenJDKTagCommits(HostedRepository repository, List<Commit> commits, OpenJDKTag tag, Tag.Annotated annotation) {
+        var build = String.format("b%02d", tag.buildNum());
         try (var writer = new JsonUpdateWriter(path, repository.name())) {
             var issues = new ArrayList<Issue>();
             for (var commit : commits) {
@@ -104,12 +100,10 @@ public class JsonUpdater implements UpdateConsumer {
     }
 
     @Override
-    public void handleAnnotatedTagCommits(HostedRepository repository, List<Commit> commits, Tag tag, Tag.Annotated annotation) {
-        handleTagCommits(repository, commits, tag);
+    public void handleTagCommit(HostedRepository repository, Commit commit, Tag tag, Tag.Annotated annotation) {
     }
 
     @Override
     public void handleNewBranch(HostedRepository repository, List<Commit> commits, Branch parent, Branch branch) {
-
     }
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/JsonUpdater.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/JsonUpdater.java
@@ -86,8 +86,12 @@ public class JsonUpdater implements UpdateConsumer {
     }
 
     @Override
-    public void handleTagCommits(HostedRepository repository, List<Commit> commits, OpenJDKTag tag) {
-        var build = String.format("b%02d", tag.buildNum());
+    public void handleTagCommits(HostedRepository repository, List<Commit> commits, Tag tag) {
+        var openjdkTag = OpenJDKTag.create(tag);
+        if (openjdkTag.isEmpty()) {
+            return;
+        }
+        var build = String.format("b%02d", openjdkTag.get().buildNum());
         try (var writer = new JsonUpdateWriter(path, repository.name())) {
             var issues = new ArrayList<Issue>();
             for (var commit : commits) {
@@ -97,6 +101,11 @@ public class JsonUpdater implements UpdateConsumer {
             var json = issuesToChanges(repository, issues, build);
             writer.write(json);
         }
+    }
+
+    @Override
+    public void handleAnnotatedTagCommits(HostedRepository repository, List<Commit> commits, Tag tag, Tag.Annotated annotation) {
+        handleTagCommits(repository, commits, tag);
     }
 
     @Override

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/MailingListUpdater.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/MailingListUpdater.java
@@ -332,11 +332,11 @@ public class MailingListUpdater implements UpdateConsumer {
         }
 
         var subject = newBranchSubject(repository, commits, parent, branch);
-        var lastCommit = commits.get(commits.size() - 1);
+        var finalAuthor = commits.size() > 0 ? commitToAuthor(commits.get(commits.size() - 1)) : sender;
 
         var email = Email.create(subject, writer.toString())
                          .sender(sender)
-                         .author(commitToAuthor(lastCommit))
+                         .author(finalAuthor)
                          .recipient(recipient)
                          .headers(headers)
                          .build();

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/MailingListUpdater.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/MailingListUpdater.java
@@ -32,9 +32,9 @@ import java.io.*;
 import java.time.Duration;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
+import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import java.util.logging.Logger;
 
 public class MailingListUpdater implements UpdateConsumer {
     private final MailingList list;
@@ -101,15 +101,38 @@ public class MailingListUpdater implements UpdateConsumer {
         return writer.toString();
     }
 
-    private EmailAddress commitsToAuthor(List<Commit> commits) {
-        var commit = commits.get(commits.size() - 1);
-        var commitAddress = EmailAddress.from(commit.committer().name(), commit.committer().email());
+    private String tagAnnotationToText(HostedRepository repository, Tag.Annotated annotation) {
+        var writer = new StringWriter();
+        var printer = new PrintWriter(writer);
+
+        printer.println("Changeset: " + annotation.target().abbreviate());
+        printer.println("Author:    " + annotation.author().name() + " <" + annotation.author().email() + ">");
+        printer.println("Date:      " + annotation.date().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss +0000")));
+        printer.println("URL:       " + repository.webUrl(annotation.target()));
+        printer.println();
+        printer.print(String.join("\n", annotation.message()));
+
+        return writer.toString();
+    }
+
+    private EmailAddress filteredAuthor(EmailAddress commitAddress) {
+        if (author != null) {
+            return author;
+        }
         var allowedAuthorMatcher = allowedAuthorDomains.matcher(commitAddress.domain());
         if (!allowedAuthorMatcher.matches()) {
             return sender;
         } else {
             return commitAddress;
         }
+    }
+
+    private EmailAddress commitToAuthor(Commit commit) {
+        return filteredAuthor(EmailAddress.from(commit.committer().name(), commit.committer().email()));
+    }
+
+    private EmailAddress annotationToAuthor(Tag.Annotated annotation) {
+        return filteredAuthor(EmailAddress.from(annotation.author().name(), annotation.author().email()));
     }
 
     private String commitsToSubject(HostedRepository repository, List<Commit> commits, Branch branch) {
@@ -131,12 +154,12 @@ public class MailingListUpdater implements UpdateConsumer {
         return subject.toString();
     }
 
-    private String tagToSubject(HostedRepository repository, Hash hash, OpenJDKTag tag) {
+    private String tagToSubject(HostedRepository repository, Hash hash, Tag tag) {
         return repository.repositoryType().shortName() +
                 ": " +
                 repository.name() +
                 ": Added tag " +
-                tag.tag() +
+                tag +
                 " for changeset " +
                 hash.abbreviate();
     }
@@ -170,11 +193,11 @@ public class MailingListUpdater implements UpdateConsumer {
                 continue;
             }
             var rfr = rfrCandidates.get(0);
-            var finalAuthor = author != null ? author : commitsToAuthor(commits);
+
             var body = commitToText(repository, commit);
             var email = Email.reply(rfr, "Re: [Integrated] " + rfr.subject(), body)
                              .sender(sender)
-                             .author(finalAuthor)
+                             .author(commitToAuthor(commit))
                              .recipient(recipient)
                              .headers(headers)
                              .build();
@@ -197,10 +220,11 @@ public class MailingListUpdater implements UpdateConsumer {
         }
 
         var subject = commitsToSubject(repository, commits, branch);
-        var finalAuthor = author != null ? author : commitsToAuthor(commits);
+        var lastCommit = commits.get(commits.size() - 1);
+        var commitAddress = filteredAuthor(EmailAddress.from(lastCommit.committer().name(), lastCommit.committer().email()));
         var email = Email.create(subject, writer.toString())
                          .sender(sender)
-                         .author(finalAuthor)
+                         .author(commitAddress)
                          .recipient(recipient)
                          .headers(headers)
                          .build();
@@ -224,34 +248,49 @@ public class MailingListUpdater implements UpdateConsumer {
     }
 
     @Override
-    public void handleTagCommits(HostedRepository repository, List<Commit> commits, OpenJDKTag tag) {
+    public void handleAnnotatedTagCommits(HostedRepository repository, List<Commit> commits, Tag tag, Tag.Annotated annotation) {
         if (mode == Mode.PR_ONLY) {
             return;
         }
         var writer = new StringWriter();
         var printer = new PrintWriter(writer);
 
-        printer.println("The following commits are included in " + tag.tag());
-        printer.println("========================================================");
-        for (var commit : commits) {
-            printer.print(commit.hash().abbreviate());
-            if (commit.message().size() > 0) {
-                printer.print(": " + commit.message().get(0));
+        if (annotation != null) {
+            printer.println(tagAnnotationToText(repository, annotation));
+        }
+
+        var openjdkTag = OpenJDKTag.create(tag);
+        if (openjdkTag.isPresent()) {
+            printer.println("The following commits are included in " + tag);
+            printer.println("========================================================");
+            for (var commit : commits) {
+                printer.print(commit.hash().abbreviate());
+                if (commit.message().size() > 0) {
+                    printer.print(": " + commit.message().get(0));
+                }
+                printer.println();
             }
-            printer.println();
         }
 
         var tagCommit = commits.get(commits.size() - 1);
         var subject = tagToSubject(repository, tagCommit.hash(), tag);
-        var finalAuthor = author != null ? author : commitsToAuthor(commits);
         var email = Email.create(subject, writer.toString())
                          .sender(sender)
-                         .author(finalAuthor)
                          .recipient(recipient)
-                         .headers(headers)
-                         .build();
+                         .headers(headers);
 
-        list.post(email);
+        if (annotation != null) {
+            email.author(annotationToAuthor(annotation));
+        } else {
+            email.author(commitToAuthor(tagCommit));
+        }
+
+        list.post(email.build());
+    }
+
+    @Override
+    public void handleTagCommits(HostedRepository repository, List<Commit> commits, Tag tag) {
+        handleAnnotatedTagCommits(repository, commits, tag, null);
     }
 
     private String newBranchSubject(HostedRepository repository, List<Commit> commits, Branch parent, Branch branch) {
@@ -293,10 +332,11 @@ public class MailingListUpdater implements UpdateConsumer {
         }
 
         var subject = newBranchSubject(repository, commits, parent, branch);
-        var finalAuthor = author != null ? author : commits.size() > 0 ? commitsToAuthor(commits) : sender;
+        var lastCommit = commits.get(commits.size() - 1);
+
         var email = Email.create(subject, writer.toString())
                          .sender(sender)
-                         .author(finalAuthor)
+                         .author(commitToAuthor(lastCommit))
                          .recipient(recipient)
                          .headers(headers)
                          .build();

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/UpdateConsumer.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/UpdateConsumer.java
@@ -24,12 +24,12 @@ package org.openjdk.skara.bots.notify;
 
 import org.openjdk.skara.forge.HostedRepository;
 import org.openjdk.skara.vcs.*;
-import org.openjdk.skara.vcs.openjdk.OpenJDKTag;
 
 import java.util.List;
 
 public interface UpdateConsumer {
     void handleCommits(HostedRepository repository, List<Commit> commits, Branch branch);
-    void handleTagCommits(HostedRepository repository, List<Commit> commits, OpenJDKTag tag);
+    void handleTagCommits(HostedRepository repository, List<Commit> commits, Tag tag);
+    void handleAnnotatedTagCommits(HostedRepository repository, List<Commit> commits, Tag tag, Tag.Annotated annotation);
     void handleNewBranch(HostedRepository repository, List<Commit> commits, Branch parent, Branch branch);
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/UpdateConsumer.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/UpdateConsumer.java
@@ -24,12 +24,20 @@ package org.openjdk.skara.bots.notify;
 
 import org.openjdk.skara.forge.HostedRepository;
 import org.openjdk.skara.vcs.*;
+import org.openjdk.skara.vcs.openjdk.OpenJDKTag;
 
 import java.util.List;
 
 public interface UpdateConsumer {
     void handleCommits(HostedRepository repository, List<Commit> commits, Branch branch);
-    void handleTagCommits(HostedRepository repository, List<Commit> commits, Tag tag);
-    void handleAnnotatedTagCommits(HostedRepository repository, List<Commit> commits, Tag tag, Tag.Annotated annotation);
+    void handleOpenJDKTagCommits(HostedRepository repository, List<Commit> commits, OpenJDKTag tag, Tag.Annotated annotated);
+    void handleTagCommit(HostedRepository repository, Commit commit, Tag tag, Tag.Annotated annotation);
     void handleNewBranch(HostedRepository repository, List<Commit> commits, Branch parent, Branch branch);
+
+    default void handleOpenJDKTagCommits(HostedRepository repository, List<Commit> commits, OpenJDKTag tag) {
+        handleOpenJDKTagCommits(repository, commits, tag, null);
+    }
+    default void handleTagCommit(HostedRepository repository, Commit commit, Tag tag) {
+        handleTagCommit(repository, commit, tag, null);
+    }
 }

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdaterTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdaterTests.java
@@ -566,7 +566,7 @@ class UpdaterTests {
             var localRepo = CheckableRepository.init(localRepoFolder, repo.repositoryType());
             credentials.commitLock(localRepo);
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.tag(masterHash, "jdk-12+1", "Added tag 1", "Duke", "duke@openjdk.java.net");
+            localRepo.tag(masterHash, "jdk-12+1", "Added tag 1", "Duke Tagger", "tagger@openjdk.java.net");
             localRepo.pushAll(repo.url());
 
             var listAddress = EmailAddress.parse(listServer.createList("test"));
@@ -591,23 +591,24 @@ class UpdaterTests {
 
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", "23456789: More fixes");
             localRepo.fetch(repo.url(), "history:history");
-            localRepo.tag(editHash, "jdk-12+2", "Added tag 2", "Duke", "duke@openjdk.java.net");
+            localRepo.tag(editHash, "jdk-12+2", "Added tag 2", "Duke Tagger", "tagger@openjdk.java.net");
             CheckableRepository.appendAndCommit(localRepo, "Another line 1", "34567890: Even more fixes");
             CheckableRepository.appendAndCommit(localRepo, "Another line 2", "45678901: Yet even more fixes");
             var editHash2 = CheckableRepository.appendAndCommit(localRepo, "Another line 3", "56789012: Still even more fixes");
-            localRepo.tag(editHash2, "jdk-12+4", "Added tag 3", "Duke", "duke@openjdk.java.net");
+            localRepo.tag(editHash2, "jdk-12+4", "Added tag 3", "Duke Tagger", "tagger@openjdk.java.net");
             CheckableRepository.appendAndCommit(localRepo, "Another line 4", "67890123: Brand new fixes");
             var editHash3 = CheckableRepository.appendAndCommit(localRepo, "Another line 5", "78901234: More brand new fixes");
-            localRepo.tag(editHash3, "jdk-13+0", "Added tag 4", "Duke", "duke@openjdk.java.net");
+            localRepo.tag(editHash3, "jdk-13+0", "Added tag 4", "Duke Tagger", "tagger@openjdk.java.net");
             localRepo.pushAll(repo.url());
 
             TestBotRunner.runPeriodicItems(notifyBot);
             listServer.processIncoming();
             listServer.processIncoming();
             listServer.processIncoming();
+            listServer.processIncoming();
 
             var conversations = mailmanList.conversations(Duration.ofDays(1));
-            assertEquals(3, conversations.size());
+            assertEquals(4, conversations.size());
 
             for (var conversation : conversations) {
                 var email = conversation.first();
@@ -618,6 +619,7 @@ class UpdaterTests {
                     assertFalse(email.body().contains("56789012: Still even more fixes"));
                     assertFalse(email.body().contains("67890123: Brand new fixes"));
                     assertFalse(email.body().contains("78901234: More brand new fixes"));
+                    assertEquals(EmailAddress.from("Duke Tagger", "tagger@openjdk.java.net"), email.author());
                 } else if (email.subject().equals("git: test: Added tag jdk-12+4 for changeset " + editHash2.abbreviate())) {
                     assertFalse(email.body().contains("23456789: More fixes"));
                     assertTrue(email.body().contains("34567890: Even more fixes"));
@@ -625,6 +627,7 @@ class UpdaterTests {
                     assertTrue(email.body().contains("56789012: Still even more fixes"));
                     assertFalse(email.body().contains("67890123: Brand new fixes"));
                     assertFalse(email.body().contains("78901234: More brand new fixes"));
+                    assertEquals(EmailAddress.from("Duke Tagger", "tagger@openjdk.java.net"), email.author());
                 } else if (email.subject().equals("git: test: Added tag jdk-13+0 for changeset " + editHash3.abbreviate())) {
                     assertFalse(email.body().contains("23456789: More fixes"));
                     assertFalse(email.body().contains("34567890: Even more fixes"));
@@ -632,13 +635,15 @@ class UpdaterTests {
                     assertFalse(email.body().contains("56789012: Still even more fixes"));
                     assertFalse(email.body().contains("67890123: Brand new fixes"));
                     assertTrue(email.body().contains("78901234: More brand new fixes"));
-                } else if (email.subject().equals("git: test: 4 new changesets")) {
+                    assertEquals(EmailAddress.from("Duke Tagger", "tagger@openjdk.java.net"), email.author());
+                } else if (email.subject().equals("git: test: 6 new changesets")) {
                     assertTrue(email.body().contains("23456789: More fixes"));
                     assertTrue(email.body().contains("34567890: Even more fixes"));
                     assertTrue(email.body().contains("45678901: Yet even more fixes"));
                     assertTrue(email.body().contains("56789012: Still even more fixes"));
                     assertTrue(email.body().contains("67890123: Brand new fixes"));
                     assertTrue(email.body().contains("78901234: More brand new fixes"));
+                    assertEquals(EmailAddress.from("testauthor", "ta@none.none"), email.author());
                 } else {
                     fail("Mismatched subject: " + email.subject());
                 }


### PR DESCRIPTION
Hi all,

Please review this change that updates the notifier to include the tag annotation if it is present when creating a new tag notification email. Also ensure that notifications are sent even if a tag does not conform to the OpenJDK tag parser format.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**) **Note!** Review applies to fe09eede152c673f917315708b385ecb873e259b