### PR TITLE
153: Check if origin remote exists before trying to get the pullPath

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitWebrev.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitWebrev.java
@@ -156,15 +156,17 @@ public class GitWebrev {
         if (upstream == null) {
             try {
                 var remote = isMercurial ? "default" : "origin";
-                var pullPath = repo.pullPath(remote);
-                var uri = new URI(pullPath);
-                var host = uri.getHost();
-                var path = uri.getPath();
-                if (host != null && path != null) {
-                    if (host.equals("github.com") && path.startsWith("/openjdk/")) {
-                        upstream = "https://github.com" + path;
-                    } else if (host.equals("openjdk.java.net")) {
-                        upstream = "https://openjdk.java.net" + path;
+                if (repo.remotes().contains(remote)) {
+                    var pullPath = repo.pullPath(remote);
+                    var uri = new URI(pullPath);
+                    var host = uri.getHost();
+                    var path = uri.getPath();
+                    if (host != null && path != null) {
+                        if (host.equals("github.com") && path.startsWith("/openjdk/")) {
+                            upstream = "https://github.com" + path;
+                        } else if (host.equals("openjdk.java.net")) {
+                            upstream = "https://openjdk.java.net" + path;
+                        }
                     }
                 }
             } catch (URISyntaxException e) {


### PR DESCRIPTION
Trying to create a webrev in a Git repo that does not have a remote named "origin" causes the following exception:
```
Exception in thread "main" java.io.IOException: No pull path found for remote origin
        at org.openjdk.skara.vcs/org.openjdk.skara.vcs.git.GitRepository.pullPath(GitRepository.java:934)
        at org.openjdk.skara.cli/org.openjdk.skara.cli.GitWebrev.generate(GitWebrev.java:159)
        at org.openjdk.skara.args/org.openjdk.skara.args.Command.main(Command.java:54)
        at org.openjdk.skara.args/org.openjdk.skara.args.MultiCommandParser.lambda$parse$2(MultiCommandParser.java:64)
        at org.openjdk.skara.cli/org.openjdk.skara.cli.GitWebrev.main(GitWebrev.java:306)
        at org.openjdk.skara.cli/org.openjdk.skara.cli.GitSkara.main(GitSkara.java:127)
```

It seems that the pullPath is only used to generate a title for the webrev. So, it would be good to check whether the remote exists first, to avoid an exception, and rely on the fallback behaviour of using the filename as a title instead.

## Testing
* Running `.\gradlew test` locally
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-153](https://bugs.openjdk.java.net/browse/SKARA-153): 'git webrev generate' fails on Git repos without a remote named 'origin'


## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)