### PR TITLE
Update to Gradle 6.0

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -26,7 +26,7 @@ plugins {
 }
 
 dependencies {
-    runtime subprojects.collect { owner.project(it.path) }
+    runtimeOnly subprojects.collect { owner.project(it.path) }
 }
 
 defaultTasks 'compileJava'

--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -47,7 +47,7 @@ dependencies {
 
 jar {
     manifest {
-        attributes("Implementation-Title": "org.openjdk.skara.cli", "Implementation-Version": version)
+        attributes("Implementation-Title": "org.openjdk.skara.cli", "Implementation-Version": archiveVersion)
     }
 }
 

--- a/deps.env
+++ b/deps.env
@@ -7,5 +7,5 @@ JDK_MACOS_X64_SHA256="52164a04db4d3fdfe128cfc7b868bc4dae52d969f03d53ae9d4239fe78
 JDK_WINDOWS_X64_URL="https://download.java.net/java/GA/jdk12/GPL/openjdk-12_windows-x64_bin.zip"
 JDK_WINDOWS_X64_SHA256="35a8d018f420fb05fe7c2aa9933122896ca50bd23dbd373e90d8e2f3897c4e92"
 
-GRADLE_URL="https://services.gradle.org/distributions/gradle-5.6.2-bin.zip"
-GRADLE_SHA256="32fce6628848f799b0ad3205ae8db67d0d828c10ffe62b748a7c0d9f4a5d9ee0"
+GRADLE_URL="https://services.gradle.org/distributions/gradle-6.0-bin.zip"
+GRADLE_SHA256="5a3578b9f0bb162f5e08cf119f447dfb8fa950cedebb4d2a977e912a11a74b91"


### PR DESCRIPTION
Hi all,

please review this patch that updates Gradle to version 6.0. I had to fix two minor deprecation warnings:
- `runtime` -> `runtimeOnly`
- `version` -> `archiveVersion`

Thanks,
Erik

## Testing
- [x] `sh gradlew test --warning-mode all`
- [x] `sh gradlew images --warning-mode all`
- [x] Various manual testing of different build targets
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)