### PR TITLE
Update to JDK 13.0.1

### DIFF
--- a/bots/cli/build.gradle
+++ b/bots/cli/build.gradle
@@ -80,8 +80,8 @@ images {
         options = ["--module-path", "plugins"]
         bundles = ['zip', 'tar.gz']
         jdk {
-            url = 'https://download.java.net/java/GA/jdk12/GPL/openjdk-12_linux-x64_bin.tar.gz'
-            sha256 = 'b43bc15f4934f6d321170419f2c24451486bc848a2179af5e49d10721438dd56'
+            url = 'https://download.java.net/java/GA/jdk13.0.1/cec27d702aa74d5a8630c65ae61e4305/9/GPL/openjdk-13.0.1_linux-x64_bin.tar.gz'
+            sha256 = '2e01716546395694d3fad54c9b36d1cd46c5894c06f72d156772efbcf4b41335'
         }
     }
 }

--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -76,8 +76,8 @@ images {
         launchers = ext.launchers
         bundles = ['zip', 'tar.gz']
         jdk {
-            url = 'https://download.java.net/java/GA/jdk12/GPL/openjdk-12_windows-x64_bin.zip'
-            sha256 = '35a8d018f420fb05fe7c2aa9933122896ca50bd23dbd373e90d8e2f3897c4e92'
+            url = 'https://download.java.net/java/GA/jdk13.0.1/cec27d702aa74d5a8630c65ae61e4305/9/GPL/openjdk-13.0.1_windows-x64_bin.zip'
+            sha256 = '438a6920f1851b1eeb6f09f05d9f91c4423c6586f7a1a7ccbb19df76ea5901ee'
         }
     }
 
@@ -87,8 +87,8 @@ images {
         man = 'cli/resources/man'
         bundles = ['zip', 'tar.gz']
         jdk {
-            url = 'https://download.java.net/java/GA/jdk12/GPL/openjdk-12_linux-x64_bin.tar.gz'
-            sha256 = 'b43bc15f4934f6d321170419f2c24451486bc848a2179af5e49d10721438dd56'
+            url = 'https://download.java.net/java/GA/jdk13.0.1/cec27d702aa74d5a8630c65ae61e4305/9/GPL/openjdk-13.0.1_linux-x64_bin.tar.gz'
+            sha256 = '2e01716546395694d3fad54c9b36d1cd46c5894c06f72d156772efbcf4b41335'
         }
     }
 
@@ -98,8 +98,8 @@ images {
         man = 'cli/resources/man'
         bundles = ['zip', 'tar.gz']
         jdk {
-            url = 'https://download.java.net/java/GA/jdk12/GPL/openjdk-12_osx-x64_bin.tar.gz'
-            sha256 = '52164a04db4d3fdfe128cfc7b868bc4dae52d969f03d53ae9d4239fe783e1a3a'
+            url = 'https://download.java.net/java/GA/jdk13.0.1/cec27d702aa74d5a8630c65ae61e4305/9/GPL/openjdk-13.0.1_osx-x64_bin.tar.gz'
+            sha256 = '593c5c9dc0978db21b06d6219dc8584b76a59c79d57e6ec1b28ad0d848a7713f'
         }
     }
 

--- a/deps.env
+++ b/deps.env
@@ -1,11 +1,11 @@
-JDK_LINUX_X64_URL="https://download.java.net/java/GA/jdk12/GPL/openjdk-12_linux-x64_bin.tar.gz"
-JDK_LINUX_X64_SHA256="b43bc15f4934f6d321170419f2c24451486bc848a2179af5e49d10721438dd56"
+JDK_LINUX_X64_URL="https://download.java.net/java/GA/jdk13.0.1/cec27d702aa74d5a8630c65ae61e4305/9/GPL/openjdk-13.0.1_linux-x64_bin.tar.gz"
+JDK_LINUX_X64_SHA256="2e01716546395694d3fad54c9b36d1cd46c5894c06f72d156772efbcf4b41335"
 
-JDK_MACOS_X64_URL="https://download.java.net/java/GA/jdk12/GPL/openjdk-12_osx-x64_bin.tar.gz"
-JDK_MACOS_X64_SHA256="52164a04db4d3fdfe128cfc7b868bc4dae52d969f03d53ae9d4239fe783e1a3a"
+JDK_MACOS_X64_URL="https://download.java.net/java/GA/jdk13.0.1/cec27d702aa74d5a8630c65ae61e4305/9/GPL/openjdk-13.0.1_osx-x64_bin.tar.gz"
+JDK_MACOS_X64_SHA256="593c5c9dc0978db21b06d6219dc8584b76a59c79d57e6ec1b28ad0d848a7713f"
 
-JDK_WINDOWS_X64_URL="https://download.java.net/java/GA/jdk12/GPL/openjdk-12_windows-x64_bin.zip"
-JDK_WINDOWS_X64_SHA256="35a8d018f420fb05fe7c2aa9933122896ca50bd23dbd373e90d8e2f3897c4e92"
+JDK_WINDOWS_X64_URL="https://download.java.net/java/GA/jdk13.0.1/cec27d702aa74d5a8630c65ae61e4305/9/GPL/openjdk-13.0.1_windows-x64_bin.zip"
+JDK_WINDOWS_X64_SHA256="438a6920f1851b1eeb6f09f05d9f91c4423c6586f7a1a7ccbb19df76ea5901ee"
 
 GRADLE_URL="https://services.gradle.org/distributions/gradle-6.0-bin.zip"
 GRADLE_SHA256="5a3578b9f0bb162f5e08cf119f447dfb8fa950cedebb4d2a977e912a11a74b91"


### PR DESCRIPTION
Hi all,

please review this small patch that updates to JDK 13.0.1 :tada: 

Thanks,
Erik

## Testing
- [x] `sh gradlew images` passes
- [x] `sh gradlew test` passes on Linux x64
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)