### PR TITLE
Update messages when a reviewer isn't a project member

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
@@ -319,7 +319,7 @@ class ReviewArchive {
         } else if (censusInstance.project().isAuthor(contributor.username(), version)) {
             return "Author";
         }
-        return "none";
+        return "no project role";
     }
 
     void addReview(Review review) {
@@ -356,7 +356,7 @@ class ReviewArchive {
         }
 
         var userName = contributor != null ? contributor.username() : review.reviewer().userName() + "@" + censusInstance.namespace().name();
-        var userRole = contributor != null ? projectRole(contributor) : "no project role";
+        var userRole = contributor != null ? projectRole(contributor) : "no OpenJDK username";
         var replyBody = ArchiveMessages.reviewVerdictBody(review.body().orElse(""), review.verdict(), userName, userRole);
 
         addReplyCommon(parent, review.reviewer(), subject, replyBody, id);


### PR DESCRIPTION
Hi all,

Please review this small change that updates the role message for reviewers that are either not project members or not OpenJDK authors.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)