### PR TITLE
Add bridgekeeper bot to bot cli image

### DIFF
--- a/bots/cli/build.gradle
+++ b/bots/cli/build.gradle
@@ -78,7 +78,8 @@ images {
                    'org.openjdk.skara.bots.submit',
                    'org.openjdk.skara.bots.tester',
                    'org.openjdk.skara.bots.topological',
-                   'org.openjdk.skara.bots.forward']
+                   'org.openjdk.skara.bots.forward',
+                   'org.openjdk.skara.bots.bridgekeeper']
         launchers = ['skara-bots': 'org.openjdk.skara.bots.cli/org.openjdk.skara.bots.cli.BotLauncher']
         options = ["--module-path", "plugins"]
         bundles = ['zip', 'tar.gz']


### PR DESCRIPTION
Hi all,

Please review this minor change that adds the bridgekeeper to the bot cli image.

Best regard,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)