### PR TITLE
git-sync --fetch is a no-op

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitSync.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitSync.java
@@ -38,12 +38,6 @@ public class GitSync {
         return new IOException("will never reach here");
     }
 
-    private static int fetch() throws IOException, InterruptedException {
-        var pb = new ProcessBuilder("git", "fetch");
-        pb.inheritIO();
-        return pb.start().waitFor();
-    }
-
     private static int pull() throws IOException, InterruptedException {
         var pb = new ProcessBuilder("git", "pull");
         pb.inheritIO();
@@ -70,10 +64,6 @@ public class GitSync {
             Switch.shortcut("")
                   .fullname("pull")
                   .helptext("Pull current branch from origin after successful sync")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("fetch")
-                  .helptext("Fetch current branch from origin after successful sync")
                   .optional(),
             Switch.shortcut("m")
                   .fullname("mercurial")
@@ -165,11 +155,6 @@ public class GitSync {
             System.out.println("done");
         }
 
-        if (arguments.contains("fetch")) {
-            int err = fetch();
-            if (err != 0) {
-                System.exit(err);
-            }
         }
 
         if (arguments.contains("pull")) {

--- a/cli/src/main/java/org/openjdk/skara/cli/GitSync.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitSync.java
@@ -155,8 +155,6 @@ public class GitSync {
             System.out.println("done");
         }
 
-        }
-
         if (arguments.contains("pull")) {
             int err = pull();
             if (err != 0) {


### PR DESCRIPTION
Hi all,

please review this smallp patch that just removes the `--fetch` option from `git-sync`. The option is not needed since `git-sync` always implicitly does a fetch, so there is no point in providing this flag.

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)