### PR TITLE
Add config option for git-sync --pull

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitSync.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitSync.java
@@ -155,7 +155,12 @@ public class GitSync {
             System.out.println("done");
         }
 
-        if (arguments.contains("pull")) {
+        var shouldPull = arguments.contains("pull");
+        if (!shouldPull) {
+            var lines = repo.config("sync.pull");
+            shouldPull = lines.size() == 1 && lines.get(0).toLowerCase().equals("always");
+        }
+        if (shouldPull) {
             int err = pull();
             if (err != 0) {
                 System.exit(err);


### PR DESCRIPTION
Hi all,

please review this small patch that enables configuring `git sync` to always pull the active branch (via the `sync.pull` configuration). If `sync.pull` is set to `always`, for example via `git config sync.pull always` then `git sync` will always try to pull the active branch after a successful sync.

Thanks,
Erik

## Testing
- [x] Manual testing of `git sync` with and without configuration setting
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)