### PR TITLE
Treat Jira 4xx errors different from 5xx

### DIFF
--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraProject.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraProject.java
@@ -116,8 +116,11 @@ public class JiraProject implements IssueProject {
         }
         var issueRequest = request.restrict("issue/" + id);
         var issue = issueRequest.get("")
-                           .onError(r -> r.statusCode() == 404 ? JSON.object().put("NOT_FOUND", true) : null)
+                           .onError(r -> r.statusCode() < 500 ? JSON.object().put("NOT_FOUND", true) : null)
                            .execute();
+        if (issue == null) {
+            throw new RuntimeException("Server error when trying to fetch issue " + id);
+        }
         if (!issue.contains("NOT_FOUND")) {
             return Optional.of(new JiraIssue(this, issueRequest, issue));
         } else {


### PR DESCRIPTION
Hi all,

Please review this small change that considers all 4xx errors returned from Jira as permanent (issue not found) errors, while 5xx errors may go away if the operation is retried.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)