### PR TITLE
git-sync should use APIs to find upstream

### DIFF
--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunnerConfiguration.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunnerConfiguration.java
@@ -154,7 +154,9 @@ public class BotRunnerConfiguration {
                 throw new ConfigurationError("Repository " + entry.name() + " uses undefined host '" + hostName + "'");
             }
             var host = repositoryHosts.get(hostName);
-            var repo = host.repository(entry.value().get("repository").asString());
+            var repo = host.repository(entry.value().get("repository").asString()).orElseThrow(() ->
+                    new ConfigurationError("Repository " + entry.value().get("repository").asString() + " is not available at " + hostName)
+            );
             ret.put(entry.name(), repo);
         }
 
@@ -181,7 +183,9 @@ public class BotRunnerConfiguration {
                 throw new ConfigurationError("Repository entry " + entry + " uses undefined host '" + hostName + "'");
             }
             var repositoryName = entry.substring(hostSeparatorIndex + 1);
-            ret.repository = host.repository(repositoryName);
+            ret.repository = host.repository(repositoryName).orElseThrow(() ->
+                    new ConfigurationError("Repository " + repositoryName + " is not available at " + hostName)
+            );
         } else {
             if (!repositories.containsKey(entry)) {
                 throw new ConfigurationError("Repository " + entry + " is not defined!");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -137,7 +137,9 @@ class CheckRun {
                 var sourceBranch = mergeSourceBranch();
                 if (sourceBranch.isPresent() && sourceRepo.isPresent()) {
                     try {
-                        var mergeSourceRepo = pr.repository().forge().repository(sourceRepo.get()).get();
+                        var mergeSourceRepo = pr.repository().forge().repository(sourceRepo.get()).orElseThrow(() ->
+                                new RuntimeException("Could not find repository " + sourceRepo.get())
+                        );
                         try {
                             var sourceHash = prInstance.localRepo().fetch(mergeSourceRepo.url(), sourceBranch.get());
                             if (!prInstance.localRepo().isAncestor(commits.get(1).hash(), sourceHash)) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -137,7 +137,7 @@ class CheckRun {
                 var sourceBranch = mergeSourceBranch();
                 if (sourceBranch.isPresent() && sourceRepo.isPresent()) {
                     try {
-                        var mergeSourceRepo = pr.repository().forge().repository(sourceRepo.get());
+                        var mergeSourceRepo = pr.repository().forge().repository(sourceRepo.get()).get();
                         try {
                             var sourceHash = prInstance.localRepo().fetch(mergeSourceRepo.url(), sourceBranch.get());
                             if (!prInstance.localRepo().isAncestor(commits.get(1).hash(), sourceHash)) {

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHost.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHost.java
@@ -37,8 +37,8 @@ class InMemoryHost implements Forge {
     }
 
     @Override
-    public HostedRepository repository(String name) {
-        return null;
+    public Optional<HostedRepository> repository(String name) {
+        return Optional.empty();
     }
 
     @Override

--- a/cli/src/main/java/org/openjdk/skara/cli/GitFork.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitFork.java
@@ -157,7 +157,10 @@ public class GitFork {
             path = path.substring(1);
         }
 
-        var fork = host.get().repository(path).fork();
+        var hostedRepo = host.get().repository(path).orElseThrow(() ->
+                new IOException("Could not find repository at " + uri.toString())
+        );
+        var fork = hostedRepo.fork();
 
         if (token == null) {
             GitCredentials.approve(credentials);

--- a/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
@@ -108,7 +108,9 @@ public class GitPr {
         if (host.isEmpty() || !host.get().isValid()) {
             exit("error: failed to connect to host " + uri);
         }
-        var remoteRepo = host.get().repository(projectName(uri));
+        var remoteRepo = host.get().repository(projectName(uri)).orElseThrow(() ->
+                new IOException("Could not find repository at: " + uri.toString())
+        );
         var parentRepo = remoteRepo.parent();
         var targetRepo = parentRepo.isPresent() ? parentRepo.get() : remoteRepo;
         return targetRepo;
@@ -418,7 +420,9 @@ public class GitPr {
                     System.exit(1);
                 }
 
-                var remoteRepo = host.get().repository(projectName(uri));
+                var remoteRepo = host.get().repository(projectName(uri)).orElseThrow(() ->
+                        new IOException("Could not find repository at " + uri.toString())
+                );
                 if (token == null) {
                     GitCredentials.approve(credentials);
                 }
@@ -575,7 +579,9 @@ public class GitPr {
                 System.exit(1);
             }
 
-            var remoteRepo = host.get().repository(projectName(uri));
+            var remoteRepo = host.get().repository(projectName(uri)).orElseThrow(() ->
+                    new IOException("Could not find repository at " + uri.toString())
+            );
             if (token == null) {
                 GitCredentials.approve(credentials);
             }

--- a/cli/src/main/java/org/openjdk/skara/cli/GitSync.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitSync.java
@@ -24,9 +24,11 @@ package org.openjdk.skara.cli;
 
 import org.openjdk.skara.args.*;
 import org.openjdk.skara.vcs.*;
+import org.openjdk.skara.forge.*;
+import org.openjdk.skara.proxy.HttpProxy;
 
 import java.io.*;
-import java.net.URI;
+import java.net.*;
 import java.nio.file.*;
 import java.util.*;
 import java.util.logging.*;
@@ -101,6 +103,8 @@ public class GitSync {
                 die("error: no repository found at " + cwd.toString())
         );
 
+        HttpProxy.setup();
+
         var remotes = repo.remotes();
 
         String upstream = null;
@@ -111,8 +115,24 @@ public class GitSync {
             if (lines.size() == 1 && remotes.contains(lines.get(0))) {
                 upstream = lines.get(0);
             } else {
-                die("No remote provided to fetch from, please set the --from flag");
+                if (remotes.contains("origin")) {
+                    var originPullPath = repo.pullPath("origin");
+                    try {
+                        var uri = Remote.toWebURI(originPullPath);
+                        upstream = Forge.from(URI.create(uri.getScheme() + "://" + uri.getHost()))
+                                        .flatMap(f -> f.repository(uri.getPath().substring(1)))
+                                        .flatMap(r -> r.parent())
+                                        .map(p -> p.webUrl().toString())
+                                        .orElse(null);
+                    } catch (IllegalArgumentException e) {
+                        upstream = null;
+                    }
+                }
             }
+        }
+
+        if (upstream == null) {
+            die("Could not find upstream repository, please specify one with --from");
         }
         var upstreamPullPath = remotes.contains(upstream) ?
             Remote.toURI(repo.pullPath(upstream)) : URI.create(upstream);

--- a/cli/src/main/java/org/openjdk/skara/cli/Remote.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/Remote.java
@@ -34,6 +34,9 @@ class Remote {
         if (remotePath.startsWith("git+")) {
             remotePath = remotePath.substring("git+".length());
         }
+        if (remotePath.endsWith(".git")) {
+            remotePath = remotePath.substring(0, remotePath.length() - ".git".length());
+        }
         if (remotePath.startsWith("http")) {
             return URI.create(remotePath);
         } else {

--- a/forge/src/main/java/org/openjdk/skara/forge/Forge.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/Forge.java
@@ -30,7 +30,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 public interface Forge extends Host {
-    HostedRepository repository(String name);
+    Optional<HostedRepository> repository(String name);
     boolean supportsReviewBody();
 
     static Forge from(String name, URI uri, Credential credential, JSONObject configuration) {

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubHost.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubHost.java
@@ -30,7 +30,7 @@ import org.openjdk.skara.network.*;
 import java.io.IOException;
 import java.net.*;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
+import java.util.*;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
@@ -169,8 +169,12 @@ public class GitHubHost implements Forge {
     }
 
     @Override
-    public HostedRepository repository(String name) {
-        return new GitHubRepository(this, name);
+    public Optional<HostedRepository> repository(String name) {
+        try {
+            return Optional.of(new GitHubRepository(this, name));
+        } catch (Throwable t) {
+            return Optional.empty();
+        }
     }
 
     @Override

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -190,7 +190,7 @@ public class GitHubRepository implements HostedRepository {
     @Override
     public HostedRepository fork() {
         var response = request.post("forks").execute();
-        return gitHubHost.repository(response.get("full_name").asString());
+        return gitHubHost.repository(response.get("full_name").asString()).orElseThrow(RuntimeException::new);
     }
 
     @Override

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabHost.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabHost.java
@@ -102,8 +102,12 @@ public class GitLabHost implements Forge {
     }
 
     @Override
-    public HostedRepository repository(String name) {
-        return new GitLabRepository(this, name);
+    public Optional<HostedRepository> repository(String name) {
+        try {
+            return Optional.of(new GitLabRepository(this, name));
+        } catch (Throwable t) {
+            return Optional.empty();
+        }
     }
 
     private HostUser parseUserDetails(JSONObject details) {

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -235,7 +235,7 @@ public class GitLabRepository implements HostedRepository {
                 e.printStackTrace();
             }
         }
-        return gitLabHost.repository(forkedRepoName);
+        return gitLabHost.repository(forkedRepoName).orElseThrow(RuntimeException::new);
     }
 
     @Override

--- a/test/src/main/java/org/openjdk/skara/test/CensusBuilder.java
+++ b/test/src/main/java/org/openjdk/skara/test/CensusBuilder.java
@@ -208,7 +208,7 @@ public class CensusBuilder {
     public HostedRepository build() {
         try {
             var host = TestHost.createNew(List.of(new HostUser(1, "cu", "Census User")));
-            var repository = host.repository("census");
+            var repository = host.repository("census").get();
             var folder = Files.createTempDirectory("censusbuilder");
             var localRepository = Repository.init(folder, VCS.GIT);
 

--- a/test/src/main/java/org/openjdk/skara/test/CensusBuilder.java
+++ b/test/src/main/java/org/openjdk/skara/test/CensusBuilder.java
@@ -208,7 +208,7 @@ public class CensusBuilder {
     public HostedRepository build() {
         try {
             var host = TestHost.createNew(List.of(new HostUser(1, "cu", "Census User")));
-            var repository = host.repository("census").get();
+            var repository = host.repository("census").orElseThrow();
             var folder = Files.createTempDirectory("censusbuilder");
             var localRepository = Repository.init(folder, VCS.GIT);
 

--- a/test/src/main/java/org/openjdk/skara/test/HostCredentials.java
+++ b/test/src/main/java/org/openjdk/skara/test/HostCredentials.java
@@ -91,7 +91,7 @@ public class HostCredentials implements AutoCloseable {
 
         @Override
         public HostedRepository getHostedRepository(Forge host) {
-            return host.repository(config.get("project").asString());
+            return host.repository(config.get("project").asString()).get();
         }
 
         @Override
@@ -128,7 +128,7 @@ public class HostCredentials implements AutoCloseable {
 
         @Override
         public HostedRepository getHostedRepository(Forge host) {
-            return host.repository(config.get("project").asString());
+            return host.repository(config.get("project").asString()).get();
         }
 
         @Override
@@ -165,7 +165,7 @@ public class HostCredentials implements AutoCloseable {
 
         @Override
         public HostedRepository getHostedRepository(Forge host) {
-            return host.repository(config.get("project").asString());
+            return host.repository(config.get("project").asString()).get();
         }
 
         @Override
@@ -209,7 +209,7 @@ public class HostCredentials implements AutoCloseable {
 
         @Override
         public HostedRepository getHostedRepository(Forge host) {
-            return host.repository("test");
+            return host.repository("test").get();
         }
 
         @Override

--- a/test/src/main/java/org/openjdk/skara/test/HostCredentials.java
+++ b/test/src/main/java/org/openjdk/skara/test/HostCredentials.java
@@ -91,7 +91,7 @@ public class HostCredentials implements AutoCloseable {
 
         @Override
         public HostedRepository getHostedRepository(Forge host) {
-            return host.repository(config.get("project").asString()).get();
+            return host.repository(config.get("project").asString()).orElseThrow();
         }
 
         @Override
@@ -128,7 +128,7 @@ public class HostCredentials implements AutoCloseable {
 
         @Override
         public HostedRepository getHostedRepository(Forge host) {
-            return host.repository(config.get("project").asString()).get();
+            return host.repository(config.get("project").asString()).orElseThrow();
         }
 
         @Override
@@ -165,7 +165,7 @@ public class HostCredentials implements AutoCloseable {
 
         @Override
         public HostedRepository getHostedRepository(Forge host) {
-            return host.repository(config.get("project").asString()).get();
+            return host.repository(config.get("project").asString()).orElseThrow();
         }
 
         @Override
@@ -209,7 +209,7 @@ public class HostCredentials implements AutoCloseable {
 
         @Override
         public HostedRepository getHostedRepository(Forge host) {
-            return host.repository("test").get();
+            return host.repository("test").orElseThrow();
         }
 
         @Override

--- a/test/src/main/java/org/openjdk/skara/test/TestHost.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHost.java
@@ -85,7 +85,7 @@ public class TestHost implements Forge, IssueTracker {
     }
 
     @Override
-    public HostedRepository repository(String name) {
+    public Optional<HostedRepository> repository(String name) {
         Repository localRepository;
         if (data.repositories.containsKey(name)) {
             localRepository = data.repositories.get(name);
@@ -96,7 +96,7 @@ public class TestHost implements Forge, IssueTracker {
             localRepository = createLocalRepository();
             data.repositories.put(name, localRepository);
         }
-        return new TestHostedRepository(this, name, localRepository);
+        return Optional.of(new TestHostedRepository(this, name, localRepository));
     }
 
     @Override


### PR DESCRIPTION
Hi all,

this patch changes `git-sync` to to use the `Forge` APIs for finding the upstream repository for a personal fork (in case the `upstream` remote is missing). The big part of this change is making `Forge.repository` return `Optional<HostedRepository>` instead of `HostedRepository` (because a forge may not have the requested repository). Robin, what do you think about these changes?

Thanks,
Erik

## Testing
- [x] Manual testing of `git sync`, both with and without an `upstream` remote
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**) **Note!** Review applies to 20e4e200121b9fdd6962caf910962f60fd13a71b