### PR TITLE
169: If there are no changes after squashing, jcheck should fail

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
@@ -91,7 +91,8 @@ public class IntegrateCommand implements CommandHandler {
                 }
             }
 
-            var issues = prInstance.executeChecks(localHash, censusInstance);
+            var issues = prInstance.createVisitor(localHash, censusInstance);
+            prInstance.executeChecks(localHash, censusInstance, issues);
             if (!issues.getMessages().isEmpty()) {
                 reply.print("Your merge request cannot be fulfilled at this time, as ");
                 reply.println("your changes failed the final jcheck:");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestInstance.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestInstance.java
@@ -95,6 +95,10 @@ class PullRequestInstance {
     private Hash commitSquashed(List<Review> activeReviews, Namespace namespace, String censusDomain, String sponsorId) throws IOException {
         localRepo.checkout(baseHash, true);
         localRepo.squash(headHash);
+        if (localRepo.isClean()) {
+            // There are no changes remaining after squashing
+            return baseHash;
+        }
 
         Author committer;
         Author author;
@@ -201,16 +205,17 @@ class PullRequestInstance {
         return ret;
     }
 
-    PullRequestCheckIssueVisitor executeChecks(Hash localHash, CensusInstance censusInstance) throws Exception {
+    PullRequestCheckIssueVisitor createVisitor(Hash localHash, CensusInstance censusInstance) throws IOException {
         var checks = JCheck.checks(localRepo(), censusInstance.census(), localHash);
-        var visitor = new PullRequestCheckIssueVisitor(checks);
+        return new PullRequestCheckIssueVisitor(checks);
+    }
+
+    void executeChecks(Hash localHash, CensusInstance censusInstance, PullRequestCheckIssueVisitor visitor) throws Exception {
         try (var issues = JCheck.check(localRepo(), censusInstance.census(), CommitMessageParsers.v1, "HEAD~1..HEAD",
                                        localHash, new HashMap<>(), new HashSet<>())) {
             for (var issue : issues) {
                 issue.accept(visitor);
             }
         }
-
-        return visitor;
     }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
@@ -87,7 +87,8 @@ public class SponsorCommand implements CommandHandler {
                 }
             }
 
-            var issues = prInstance.executeChecks(localHash, censusInstance);
+            var issues = prInstance.createVisitor(localHash, censusInstance);
+            prInstance.executeChecks(localHash, censusInstance, issues);
             if (!issues.getMessages().isEmpty()) {
                 reply.print("Your merge request cannot be fulfilled at this time, as ");
                 reply.println("your changes failed the final jcheck:");

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -1097,4 +1097,38 @@ class CheckTests {
             assertEquals(CheckStatus.SUCCESS, check.status());
         }
     }
+
+    @Test
+    void noCommit(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var reviewer = credentials.getHostedRepository();
+
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addAuthor(author.forge().currentUser().id())
+                                           .addReviewer(reviewer.forge().currentUser().id());
+            var checkBot = new PullRequestBot(author, censusBuilder.build(), "master");
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.url(), "master");
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
+
+            // Check the status
+            TestBotRunner.runPeriodicItems(checkBot);
+
+            // Verify that the check failed
+            var checks = pr.checks(editHash);
+            assertEquals(1, checks.size());
+            var check = checks.get("jcheck");
+            assertEquals(CheckStatus.FAILURE, check.status());
+        }
+    }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrateTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrateTests.java
@@ -30,6 +30,7 @@ import org.openjdk.skara.vcs.Repository;
 import org.junit.jupiter.api.*;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -482,14 +483,16 @@ class IntegrateTests {
     @Test
     void retryOnFailure(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
-             var tempFolder = new TemporaryDirectory()) {
+             var tempFolder = new TemporaryDirectory();
+             var censusFolder = new TemporaryDirectory()) {
 
             var author = credentials.getHostedRepository();
             var integrator = credentials.getHostedRepository();
             var censusBuilder = credentials.getCensusBuilder()
                                            .addCommitter(author.forge().currentUser().id())
                                            .addReviewer(integrator.forge().currentUser().id());
-            var mergeBot = new PullRequestBot(integrator, censusBuilder.build(), "master");
+            var censusRepo = censusBuilder.build();
+            var mergeBot = new PullRequestBot(integrator, censusRepo, "master");
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -509,15 +512,20 @@ class IntegrateTests {
             // Let the bot check it
             TestBotRunner.runPeriodicItems(mergeBot);
 
-            // Pre-push to cause a failure
-            localRepo.push(editHash, author.url(), "master");
+            // Break the census to cause an exception
+            var localCensus = Repository.materialize(censusFolder.path(), censusRepo.url(), "+master:current_census");
+            var currentCensusHash = localCensus.resolve("current_census").orElseThrow();
+            Files.writeString(censusFolder.path().resolve("contributors.xml"), "This is not xml", StandardCharsets.UTF_8);
+            localCensus.add(censusFolder.path().resolve("contributors.xml"));
+            var badCensusHash = localCensus.commit("Bad census update", "duke", "duke@openjdk.org");
+            localCensus.push(badCensusHash, censusRepo.url(), "master", true);
 
             // Attempt a merge (without triggering another check)
             pr.addComment("/integrate");
             assertThrows(RuntimeException.class, () -> TestBotRunner.runPeriodicItems(mergeBot, wi -> wi instanceof CheckWorkItem));
 
-            // Restore the master branch
-            localRepo.push(masterHash, author.url(), "master", true);
+            // Restore the census
+            localCensus.push(currentCensusHash, censusRepo.url(), "master", true);
 
             // The bot should now retry
             TestBotRunner.runPeriodicItems(mergeBot, wi -> wi instanceof CheckWorkItem);


### PR DESCRIPTION
Hi all,

Please review this change that ensures that if the contents of a PR are identical to the base after squashing, jcheck will fail (as there's nothing to integrate). Previously, this caused an exception.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-169](https://bugs.openjdk.java.net/browse/SKARA-169): Fail check on empty squash merges


## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**) **Note!** Review applies to afb5d7b6f723e30ccfba66b62dac3152ade92dcd