### PR TITLE
166: Update PR status in body with multiple issues if needed

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -44,7 +44,7 @@ class CheckWorkItem extends PullRequestWorkItem {
     private final Map<String, String> blockingLabels;
     private final IssueProject issueProject;
 
-    private final Pattern metadataComments = Pattern.compile("<!-- (?:(add|remove) contributor)|(?:summary: ')");
+    private final Pattern metadataComments = Pattern.compile("<!-- (?:(add|remove) contributor)|(?:summary: ')|(?:solves: ')");
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots.pr");
 
     CheckWorkItem(PullRequest pr, HostedRepository censusRepo, String censusRef, Map<String, String> blockingLabels,


### PR DESCRIPTION
Hi all,

Please review this change that ensures that the status in the PR body is correctly updated when the `/solves` command is used.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-166](https://bugs.openjdk.java.net/browse/SKARA-166): Add `/solves` command


## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)