### PR TITLE
Ensure Python 3 compatibility for the hg extension

### DIFF
--- a/vcs/src/main/resources/ext.py
+++ b/vcs/src/main/resources/ext.py
@@ -49,11 +49,14 @@ def ratio(a, b, threshold):
     return ratio
 
 def write(s):
-    sys.stdout.buffer.write(s)
+    if sys.version_info >= (3, 0):
+        sys.stdout.buffer.write(s)
+    else:
+        sys.stdout.write(s)
 
 def writeln(s):
     write(s)
-    sys.stdout.buffer.write(b'\n')
+    write(b'\n')
 
 def _match_exact(root, cwd, files, badfn=None):
     """

--- a/vcs/src/main/resources/ext.py
+++ b/vcs/src/main/resources/ext.py
@@ -58,6 +58,9 @@ def writeln(s):
     write(s)
     write(b'\n')
 
+def int_to_str(i):
+    return str(i).encode('ascii')
+
 def _match_exact(root, cwd, files, badfn=None):
     """
     Wrapper for mercurial.match.exact that ignores some arguments based on the used version
@@ -89,7 +92,7 @@ def _diff_git_raw(repo, ctx1, ctx2, modified, added, removed, showPatch):
                 writeln(b':000000 ' + mode(fctx) + b' ' + nullHash + b' ' + nullHash + b' A\t' + fctx.path())
             else:
                 parent = fctx.p1()
-                score = str(int(ratio(parent.data(), fctx.data(), 0.5) * 100)).encode('utf-8')
+                score = int_to_str(int(ratio(parent.data(), fctx.data(), 0.5) * 100))
                 old_path, _ = fctx.renamed()
 
                 if old_path in removed:
@@ -220,19 +223,19 @@ def log_git(ui, repo, revs=None, **opts):
 def __dump_metadata(ctx):
         writeln(b'#@!_-=&')
         writeln(ctx.hex())
-        writeln(str(ctx.rev()).encode('utf-8'))
+        writeln(int_to_str(ctx.rev()))
         writeln(ctx.branch())
 
         parents = ctx.parents()
         writeln(b' '.join([p.hex() for p in parents]))
-        writeln(b' '.join([str(p.rev()).encode('utf-8') for p in parents]))
+        writeln(b' '.join([int_to_str(p.rev()) for p in parents]))
 
         writeln(ctx.user())
         date = datestr(ctx.date(), format=b'%Y-%m-%d %H:%M:%S%z')
         writeln(date)
 
         description = ctx.description()
-        writeln(str(len(description)).encode('utf-8'))
+        writeln(int_to_str(len(description)))
         write(description)
 
 def __dump(repo, start, end):
@@ -243,9 +246,9 @@ def __dump(repo, start, end):
         parents = ctx.parents()
 
         modified, added, removed = repo.status(parents[0], ctx)[:3]
-        writeln(str(len(modified)).encode('utf-8'))
-        writeln(str(len(added)).encode('utf-8'))
-        writeln(str(len(removed)).encode('utf-8'))
+        writeln(int_to_str(len(modified)))
+        writeln(int_to_str(len(added)))
+        writeln(int_to_str(len(removed)))
 
         for filename in added + modified:
             fctx = ctx.filectx(filename)
@@ -254,7 +257,7 @@ def __dump(repo, start, end):
             writeln(b' '.join(fctx.flags()))
 
             content = fctx.data()
-            writeln(str(len(content)).encode('utf-8'))
+            writeln(int_to_str(len(content)))
             write(content)
 
         for filename in removed:

--- a/vcs/src/main/resources/ext.py
+++ b/vcs/src/main/resources/ext.py
@@ -29,7 +29,7 @@ import difflib
 import sys
 
 # space separated version list
-testedwith = '4.9.2 5.0.2'
+testedwith = '4.9.2 5.0.2 5.2.1'
 
 def mode(fctx):
     flags = fctx.flags()
@@ -62,7 +62,7 @@ def _match_exact(root, cwd, files, badfn=None):
     """
     Wrapper for mercurial.match.exact that ignores some arguments based on the used version
     """
-    if mercurial.util.version().startswith("5"):
+    if mercurial.util.version().startswith(b"5"):
         return mercurial.match.exact(files, badfn)
     else:
         return mercurial.match.exact(root, cwd, files, badfn)
@@ -151,7 +151,7 @@ else:
     revsingle = mercurial.cmdutil.revsingle
     revrange = mercurial.cmdutil.revrange
 
-@command('diff-git-raw', [('', 'patch', False, '')], 'hg diff-git-raw rev1 [rev2]')
+@command(b'diff-git-raw', [(b'', b'patch', False, b'')], b'hg diff-git-raw rev1 [rev2]')
 def diff_git_raw(ui, repo, rev1, rev2=None, **opts):
     ctx1 = revsingle(repo, rev1)
 
@@ -165,16 +165,16 @@ def diff_git_raw(ui, repo, rev1, rev2=None, **opts):
     modified, added, removed = [set(l) for l in status[:3]]
     _diff_git_raw(repo, ctx1, ctx2, modified, added, removed, opts['patch'])
 
-@command('log-git', [('', 'reverse', False, ''), ('l', 'limit', -1, '')],  'hg log-git <revisions>')
+@command(b'log-git', [(b'', b'reverse', False, b''), (b'l', b'limit', -1, b'')],  b'hg log-git <revisions>')
 def log_git(ui, repo, revs=None, **opts):
     if len(repo) == 0:
         return
 
     if revs == None:
         if opts['reverse']:
-            revs = '0:tip'
+            revs = b'0:tip'
         else:
-            revs = 'tip:0'
+            revs = b'tip:0'
 
     limit = opts['limit']
     i = 0
@@ -227,7 +227,7 @@ def __dump_metadata(ctx):
         writeln(' '.join([str(p.rev()) for p in parents]))
 
         writeln(ctx.user())
-        date = datestr(ctx.date(), format='%Y-%m-%d %H:%M:%S%z')
+        date = datestr(ctx.date(), format=b'%Y-%m-%d %H:%M:%S%z')
         writeln(date)
 
         description = encode(ctx.description())
@@ -235,7 +235,7 @@ def __dump_metadata(ctx):
         write(description)
 
 def __dump(repo, start, end):
-    for rev in xrange(start, end):
+    for rev in range(start, end):
         ctx = revsingle(repo, rev)
 
         __dump_metadata(ctx)
@@ -264,11 +264,11 @@ def pretxnclose(ui, repo, **kwargs):
     end = revsingle(repo, kwargs['node_last'])
     __dump(repo, start.rev(), end.rev() + 1)
 
-@command('dump', [],  'hg dump')
+@command(b'dump', [], b'hg dump')
 def dump(ui, repo, **opts):
     __dump(repo, 0, len(repo))
 
-@command('metadata', [],  'hg metadata')
+@command(b'metadata', [], b'hg metadata')
 def dump(ui, repo, revs=None, **opts):
     if revs == None:
         revs = "0:tip"
@@ -277,7 +277,7 @@ def dump(ui, repo, revs=None, **opts):
         ctx = repo[r]
         __dump_metadata(ctx)
 
-@command('ls-tree', [],  'hg ls-tree')
+@command(b'ls-tree', [], b'hg ls-tree')
 def ls_tree(ui, repo, rev, **opts):
     nullHash = '0' * 40
     ctx = revsingle(repo, rev)
@@ -291,7 +291,7 @@ def ls_tree(ui, repo, rev, **opts):
         write('\t')
         writeln(filename)
 
-@command('ls-remote', [],  'hg ls-remote PATH')
+@command(b'ls-remote', [], b'hg ls-remote PATH')
 def ls_remote(ui, repo, path, **opts):
     peer = mercurial.hg.peer(ui or repo, opts, ui.expandpath(path))
     for branch, heads in peer.branchmap().iteritems():


### PR DESCRIPTION
Hi all,

Please review this change that makes Skara's internally used Mercurial extension work with Python 3, while also retaining Python 2 compatibility. The Mercurial distribution on MacOS (through homebrew) recently switched to using Python 3, so this change will make the CI for Mac pass again.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)