### PR TITLE
Save references to materialized branches locally

### DIFF
--- a/bots/hgbridge/src/main/java/org/openjdk/skara/bots/hgbridge/ExporterConfig.java
+++ b/bots/hgbridge/src/main/java/org/openjdk/skara/bots/hgbridge/ExporterConfig.java
@@ -169,7 +169,7 @@ class ExporterConfig {
 
     public Converter resolve(Path scratchPath) throws IOException {
         var localRepo = Repository.materialize(scratchPath, configurationRepo.url(),
-                                               configurationRef + ":hgbridge_config_" + configurationRepo.name());
+                                               "+" + configurationRef + ":hgbridge_config_" + configurationRepo.name());
 
         var replacements = parseMap(localRepo.root(), replacementsFile,
                                     field -> new Hash(field.name()),

--- a/bots/hgbridge/src/main/java/org/openjdk/skara/bots/hgbridge/ExporterConfig.java
+++ b/bots/hgbridge/src/main/java/org/openjdk/skara/bots/hgbridge/ExporterConfig.java
@@ -168,7 +168,8 @@ class ExporterConfig {
     }
 
     public Converter resolve(Path scratchPath) throws IOException {
-        var localRepo = Repository.materialize(scratchPath, configurationRepo.url(), configurationRef);
+        var localRepo = Repository.materialize(scratchPath, configurationRepo.url(),
+                                               configurationRef + ":hgbridge_config_" + configurationRepo.name());
 
         var replacements = parseMap(localRepo.root(), replacementsFile,
                                     field -> new Hash(field.name()),

--- a/bots/hgbridge/src/main/java/org/openjdk/skara/bots/hgbridge/JBridgeBot.java
+++ b/bots/hgbridge/src/main/java/org/openjdk/skara/bots/hgbridge/JBridgeBot.java
@@ -63,7 +63,8 @@ public class JBridgeBot implements Bot, WorkItem {
     }
 
     private void pushMarks(Path markSource, String destName, Path markScratchPath) throws IOException {
-        var marksRepo = Repository.materialize(markScratchPath, exporterConfig.marksRepo().url(), exporterConfig.marksRef());
+        var marksRepo = Repository.materialize(markScratchPath, exporterConfig.marksRepo().url(),
+                                               "+" + exporterConfig.marksRef() + ":hgbridge_marks");
 
         // We should never change existing marks
         var markDest = markScratchPath.resolve(destName);

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
@@ -112,7 +112,8 @@ class ArchiveWorkItem implements WorkItem {
 
     private Repository materializeArchive(Path scratchPath) {
         try {
-            return Repository.materialize(scratchPath, bot.archiveRepo().url(), pr.targetRef());
+            return Repository.materialize(scratchPath, bot.archiveRepo().url(),
+                                          "+" + bot.archiveRef() + ":mlbridge_archive");
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/CensusInstance.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/CensusInstance.java
@@ -49,7 +49,7 @@ class CensusInstance {
 
     private static Repository initialize(HostedRepository repo, String ref, Path folder) {
         try {
-            return Repository.materialize(folder, repo.url(), ref);
+            return Repository.materialize(folder, repo.url(), "+" + ref + ":" + "mlbridge_census_" + repo.name());
         } catch (IOException e) {
             throw new RuntimeException("Failed to retrieve census to " + folder, e);
         }

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBot.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBot.java
@@ -36,6 +36,7 @@ public class MailingListBridgeBot implements Bot {
     private final EmailAddress emailAddress;
     private final HostedRepository codeRepo;
     private final HostedRepository archiveRepo;
+    private final String archiveRef;
     private final HostedRepository censusRepo;
     private final String censusRef;
     private final EmailAddress listAddress;
@@ -51,7 +52,7 @@ public class MailingListBridgeBot implements Bot {
     private final PullRequestUpdateCache updateCache;
     private final Duration sendInterval;
 
-    MailingListBridgeBot(EmailAddress from, HostedRepository repo, HostedRepository archive,
+    MailingListBridgeBot(EmailAddress from, HostedRepository repo, HostedRepository archive, String archiveRef,
                          HostedRepository censusRepo, String censusRef, EmailAddress list,
                          Set<String> ignoredUsers, Set<Pattern> ignoredComments, URI listArchive, String smtpServer,
                          HostedRepository webrevStorageRepository, String webrevStorageRef,
@@ -61,6 +62,7 @@ public class MailingListBridgeBot implements Bot {
         emailAddress = from;
         codeRepo = repo;
         archiveRepo = archive;
+        this.archiveRef = archiveRef;
         this.censusRepo = censusRepo;
         this.censusRef = censusRef;
         listAddress = list;
@@ -85,6 +87,10 @@ public class MailingListBridgeBot implements Bot {
 
     HostedRepository archiveRepo() {
         return archiveRepo;
+    }
+
+    String archiveRef() {
+        return archiveRef;
     }
 
     HostedRepository censusRepo() {

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotFactory.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotFactory.java
@@ -63,6 +63,7 @@ public class MailingListBridgeBotFactory implements BotFactory {
         var webrevWeb = specific.get("webrevs").get("web").asString();
 
         var archiveRepo = configuration.repository(specific.get("archive").asString());
+        var archiveRef = configuration.repositoryRef(specific.get("archive").asString());
         var issueTracker = URIBuilder.base(specific.get("issues").asString()).build();
 
         var allListNames = new HashSet<EmailAddress>();
@@ -88,7 +89,7 @@ public class MailingListBridgeBotFactory implements BotFactory {
 
             var list = EmailAddress.parse(repoConfig.get("list").asString());
             var folder = repoConfig.contains("folder") ? repoConfig.get("folder").asString() : configuration.repositoryName(repo);
-            var bot = new MailingListBridgeBot(from, configuration.repository(repo), archiveRepo,
+            var bot = new MailingListBridgeBot(from, configuration.repository(repo), archiveRepo, archiveRef,
                                                censusRepo, censusRef,
                                                list, ignoredUsers, ignoredComments, listArchive, listSmtp,
                                                webrevRepo, webrevRef, Path.of(folder),

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/PullRequestInstance.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/PullRequestInstance.java
@@ -50,7 +50,8 @@ class PullRequestInstance {
         // Materialize the PR's target ref
         try {
             var repository = pr.repository();
-            localRepo = Repository.materialize(localRepoPath, repository.url(), pr.targetRef());
+            localRepo = Repository.materialize(localRepoPath, repository.url(),
+                                               "+" + pr.targetRef() + ":mlbridge_prinstance_" + repository.name());
             targetHash = localRepo.fetch(repository.url(), pr.targetRef());
             headHash = localRepo.fetch(repository.url(), pr.headHash().hex());
             baseHash = localRepo.mergeBase(targetHash, headHash);

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
@@ -107,7 +107,8 @@ class WebrevStorage {
 
     URI createAndArchive(PullRequestInstance prInstance, Path scratchPath, Hash base, Hash head, String identifier) {
         try {
-            var localStorage = Repository.materialize(scratchPath, storage.url(), storageRef);
+            var localStorage = Repository.materialize(scratchPath, storage.url(),
+                                                      "+" + storageRef + ":mlbridge_webrevs");
             var relativeFolder = baseFolder.resolve(String.format("%s/webrev.%s", prInstance.id(), identifier));
             var outputFolder = scratchPath.resolve(relativeFolder);
             // If a previous operation was interrupted there may be content here already - overwrite if so

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBotTests.java
@@ -64,7 +64,8 @@ class MailingListArchiveReaderBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mlBot = new MailingListBridgeBot(from, author, archive, censusBuilder.build(), "master",
+            var mlBot = new MailingListBridgeBot(from, author, archive, "master",
+                                                 censusBuilder.build(), "master",
                                                  listAddress,
                                                  Set.of(ignored.forge().currentUser().userName()),
                                                  Set.of(),
@@ -133,7 +134,8 @@ class MailingListArchiveReaderBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mlBot = new MailingListBridgeBot(from, author, archive, censusBuilder.build(), "master",
+            var mlBot = new MailingListBridgeBot(from, author, archive, "master",
+                                                 censusBuilder.build(), "master",
                                                  listAddress,
                                                  Set.of(ignored.forge().currentUser().userName()),
                                                  Set.of(),

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -112,7 +112,8 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mlBot = new MailingListBridgeBot(from, author, archive, censusBuilder.build(), "master", listAddress,
+            var mlBot = new MailingListBridgeBot(from, author, archive, "master",
+                                                 censusBuilder.build(), "master", listAddress,
                                                  Set.of(ignored.forge().currentUser().userName()),
                                                  Set.of(),
                                                  listServer.getArchive(), listServer.getSMTP(),
@@ -269,7 +270,8 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mlBot = new MailingListBridgeBot(from, author, archive, censusBuilder.build(), "master", listAddress,
+            var mlBot = new MailingListBridgeBot(from, author, archive, "master",
+                                                 censusBuilder.build(), "master", listAddress,
                                                  Set.of(ignored.forge().currentUser().userName()),
                                                  Set.of(),
                                                  listServer.getArchive(), listServer.getSMTP(),
@@ -357,7 +359,8 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mlBot = new MailingListBridgeBot(from, author, archive, censusBuilder.build(), "master",
+            var mlBot = new MailingListBridgeBot(from, author, archive, "master",
+                                                 censusBuilder.build(), "master",
                                                  listAddress, Set.of(), Set.of(),
                                                  listServer.getArchive(),
                                                  listServer.getSMTP(),
@@ -445,7 +448,8 @@ class MailingListBridgeBotTests {
                                            .addReviewer(reviewer.forge().currentUser().id())
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mlBot = new MailingListBridgeBot(from, author, archive, censusBuilder.build(), "master",
+            var mlBot = new MailingListBridgeBot(from, author, archive, "master",
+                                                 censusBuilder.build(), "master",
                                                  listAddress, Set.of(), Set.of(),
                                                  listServer.getArchive(),
                                                  listServer.getSMTP(),
@@ -566,7 +570,8 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mlBot = new MailingListBridgeBot(from, author, archive, censusBuilder.build(), "master",
+            var mlBot = new MailingListBridgeBot(from, author, archive, "master",
+                                                 censusBuilder.build(), "master",
                                                  listAddress, Set.of(), Set.of(),
                                                  listServer.getArchive(),
                                                  listServer.getSMTP(),
@@ -617,7 +622,8 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mlBot = new MailingListBridgeBot(from, author, archive, censusBuilder.build(), "master",
+            var mlBot = new MailingListBridgeBot(from, author, archive, "master",
+                                                 censusBuilder.build(), "master",
                                                  listAddress, Set.of(), Set.of(),
                                                  listServer.getArchive(),
                                                  listServer.getSMTP(),
@@ -687,7 +693,8 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mlBot = new MailingListBridgeBot(from, author, archive, censusBuilder.build(), "master",
+            var mlBot = new MailingListBridgeBot(from, author, archive, "master",
+                                                 censusBuilder.build(), "master",
                                                  listAddress, Set.of(), Set.of(),
                                                  listServer.getArchive(), listServer.getSMTP(),
                                                  archive, "webrev", Path.of("test"),
@@ -746,7 +753,8 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mlBot = new MailingListBridgeBot(from, author, archive, censusBuilder.build(), "master",
+            var mlBot = new MailingListBridgeBot(from, author, archive, "master",
+                                                 censusBuilder.build(), "master",
                                                  listAddress, Set.of(), Set.of(),
                                                  listServer.getArchive(), listServer.getSMTP(),
                                                  archive, "webrev", Path.of("test"),
@@ -867,7 +875,8 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var sender = EmailAddress.from("test", "test@test.mail");
-            var mlBot = new MailingListBridgeBot(sender, author, archive, censusBuilder.build(), "master",
+            var mlBot = new MailingListBridgeBot(sender, author, archive, "master",
+                                                 censusBuilder.build(), "master",
                                                  listAddress, Set.of(), Set.of(),
                                                  listServer.getArchive(), listServer.getSMTP(),
                                                  archive, "webrev", Path.of("test"),
@@ -958,7 +967,8 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mlBot = new MailingListBridgeBot(from, author, archive, censusBuilder.build(), "master",
+            var mlBot = new MailingListBridgeBot(from, author, archive, "master",
+                                                 censusBuilder.build(), "master",
                                                  listAddress,
                                                  Set.of(ignored.forge().currentUser().userName()),
                                                  Set.of(),
@@ -1033,7 +1043,8 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addReviewer(reviewer.forge().currentUser().id())
                                            .addAuthor(author.forge().currentUser().id());
-            var mlBot = new MailingListBridgeBot(from, author, archive, censusBuilder.build(), "master",
+            var mlBot = new MailingListBridgeBot(from, author, archive, "master",
+                                                 censusBuilder.build(), "master",
                                                  listAddress, Set.of(), Set.of(),
                                                  listServer.getArchive(), listServer.getSMTP(),
                                                  archive, "webrev", Path.of("test"),
@@ -1115,7 +1126,8 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mlBot = new MailingListBridgeBot(from, author, archive, censusBuilder.build(), "master",
+            var mlBot = new MailingListBridgeBot(from, author, archive, "master",
+                                                 censusBuilder.build(), "master",
                                                  listAddress,
                                                  Set.of(ignored.forge().currentUser().userName()),
                                                  Set.of(Pattern.compile("ignore this comment", Pattern.MULTILINE | Pattern.DOTALL)),

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CensusInstance.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CensusInstance.java
@@ -49,7 +49,7 @@ class CensusInstance {
 
     private static Repository initialize(HostedRepository repo, String ref, Path folder) {
         try {
-            return Repository.materialize(folder, repo.url(), ref);
+            return Repository.materialize(folder, repo.url(), "+" + ref + ":pr_census_" + repo.name());
         } catch (IOException e) {
             throw new RuntimeException("Failed to retrieve census to " + folder, e);
         }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestInstance.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestInstance.java
@@ -47,7 +47,8 @@ class PullRequestInstance {
         var repository = pr.repository();
 
         // Materialize the PR's target ref
-        localRepo = Repository.materialize(localRepoPath, repository.url(), pr.targetRef());
+        localRepo = Repository.materialize(localRepoPath, repository.url(),
+                                           "+" + pr.targetRef() + ":pr_prinstance_" + repository.name());
         targetHash = localRepo.fetch(repository.url(), pr.targetRef());
         headHash = localRepo.fetch(repository.url(), pr.headHash().hex());
         baseHash = localRepo.mergeBase(targetHash, headHash);

--- a/bots/submit/src/main/java/org/openjdk/skara/bots/submit/SubmitBotWorkItem.java
+++ b/bots/submit/src/main/java/org/openjdk/skara/bots/submit/SubmitBotWorkItem.java
@@ -84,7 +84,8 @@ public class SubmitBotWorkItem implements WorkItem {
 
         // Materialize the PR's target ref
         try {
-            var localRepo = Repository.materialize(prFolder, pr.repository().url(), pr.targetRef());
+            var localRepo = Repository.materialize(prFolder, pr.repository().url(),
+                                                   "+" + pr.targetRef() + ":submit_" + pr.repository().name());
             var headHash = localRepo.fetch(pr.repository().url(), pr.headHash().hex());
 
             var checkBuilder = CheckBuilder.create(executor.checkName(), headHash);

--- a/storage/src/main/java/org/openjdk/skara/storage/HostedRepositoryStorage.java
+++ b/storage/src/main/java/org/openjdk/skara/storage/HostedRepositoryStorage.java
@@ -57,7 +57,7 @@ class HostedRepositoryStorage<T> implements Storage<T> {
         try {
             Repository localRepository;
             try {
-                localRepository = Repository.materialize(localStorage, repository.url(), ref);
+                localRepository = Repository.materialize(localStorage, repository.url(), "+" + ref + ":storage");
             } catch (IOException e) {
                 // The remote ref may not yet exist
                 localRepository = Repository.init(localStorage, repository.repositoryType());


### PR DESCRIPTION
Hi all,

Please review this change that ensure that when bots use `Repository.materialize`, they always save a named reference to what was fetched. This ensures that subsequent fetches will present these existing refs, and avoid re-fetching commits that already exist locally.

It also fixes a potential bug where the mlbridge archive reader could have fetched from an incorrect branch.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)