### PR TITLE
Escape potential unintentional markdown formatting when bridging mails

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/CommentPosterWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/CommentPosterWorkItem.java
@@ -70,7 +70,7 @@ public class CommentPosterWorkItem implements WorkItem {
                 "*Mailing list message from [" + email.author().fullName().orElse(email.author().localPart()) +
                 "](mailto:" + email.author().address() + ") on [" + email.sender().localPart() +
                 "](mailto:" + email.sender().address() + "):*\n\n" +
-                email.body();
+                TextToMarkdown.escapeFormatting(email.body());
         pr.addComment(body);
     }
 

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/TextToMarkdown.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/TextToMarkdown.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.mlbridge;
+
+import java.util.regex.Pattern;
+
+public class TextToMarkdown {
+    private static final Pattern punctuationPattern = Pattern.compile("([!\"#$%&'()*+,\\-./:;<=?@\\[\\]^_`{|}~])", Pattern.MULTILINE);
+    private static final Pattern indentedPattern = Pattern.compile("^ {4}", Pattern.MULTILINE);
+
+    private static String escapeBackslashes(String text) {
+        return text.replace("\\", "\\\\");
+    }
+
+    private static String escapePunctuation(String text) {
+        var punctuationMatcher = punctuationPattern.matcher(text);
+        return punctuationMatcher.replaceAll(mr -> "\\\\" + mr.group(1));
+    }
+
+    private static String escapeIndention(String text) {
+        var indentedMatcher = indentedPattern.matcher(text);
+        return indentedMatcher.replaceAll("&#32;   ");
+    }
+
+    static String escapeFormatting(String text) {
+        return escapeIndention(escapePunctuation(escapeBackslashes(text)));
+    }
+}

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/TextToMarkdownTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/TextToMarkdownTests.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.mlbridge;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TextToMarkdownTests {
+    @Test
+    void punctuation() {
+        assertEquals("1\\. Not a list", TextToMarkdown.escapeFormatting("1. Not a list"));
+        assertEquals("\\*not emphasized\\*", TextToMarkdown.escapeFormatting("*not emphasized*"));
+        assertEquals("\\\\n", TextToMarkdown.escapeFormatting("\\n"));
+    }
+
+    @Test
+    void indented() {
+        assertEquals("&#32;      hello", TextToMarkdown.escapeFormatting("       hello"));
+    }
+
+    @Test
+    void preserveQuouting() {
+        assertEquals("> quoted", TextToMarkdown.escapeFormatting("> quoted"));
+    }
+}

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/TextToMarkdownTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/TextToMarkdownTests.java
@@ -40,7 +40,7 @@ class TextToMarkdownTests {
     }
 
     @Test
-    void preserveQuouting() {
+    void preserveQuoting() {
         assertEquals("> quoted", TextToMarkdown.escapeFormatting("> quoted"));
     }
 }


### PR DESCRIPTION
Hi all,

Please review this change that ensures that text that could be interpreted as markdown formatting is properly escaped when posted as a bridged comment from an email to a PR.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)