### PR TITLE
146: git-webrev: Add support for file list argument

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitWebrev.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitWebrev.java
@@ -36,6 +36,7 @@ import java.net.http.HttpResponse;
 import java.nio.file.*;
 import java.util.*;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 public class GitWebrev {
     private static void clearDirectory(Path directory) {
@@ -134,7 +135,13 @@ public class GitWebrev {
                   .helptext("Print the version of this tool")
                   .optional());
 
-        var parser = new ArgumentParser("git webrev", flags);
+        var inputs = List.of(
+            Input.position(0)
+                 .describe("FILE")
+                 .singular()
+                 .optional());
+
+        var parser = new ArgumentParser("git webrev", flags, inputs);
         var arguments = parser.parse(args);
 
         var version = Version.fromManifest().orElse("unknown");
@@ -246,6 +253,11 @@ public class GitWebrev {
             clearDirectory(output);
         }
 
+        List<Path> files = List.of();
+        if (arguments.at(0).isPresent()) {
+            var path = arguments.at(0).via(Path::of);
+            files = Files.readAllLines(path).stream().map(Path::of).collect(Collectors.toList());
+        }
         Webrev.repository(repo)
               .output(output)
               .title(title)
@@ -253,6 +265,7 @@ public class GitWebrev {
               .username(username)
               .issue(issue)
               .version(version)
+              .files(files)
               .generate(rev);
     }
 

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/TestRepository.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/TestRepository.java
@@ -189,7 +189,15 @@ class TestRepository implements ReadOnlyRepository {
         return null;
     }
 
+    public Diff diff(Hash base, Hash head, List<Path> files) throws IOException {
+        return null;
+    }
+
     public Diff diff(Hash head) throws IOException {
+        return null;
+    }
+
+    public Diff diff(Hash head, List<Path> files) throws IOException {
         return null;
     }
 

--- a/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
@@ -77,7 +77,9 @@ public interface ReadOnlyRepository {
     void dump(FileEntry entry, Path to) throws IOException;
     List<StatusEntry> status(Hash from, Hash to) throws IOException;
     Diff diff(Hash base, Hash head) throws IOException;
+    Diff diff(Hash base, Hash head, List<Path> files) throws IOException;
     Diff diff(Hash head) throws IOException;
+    Diff diff(Hash head, List<Path> files) throws IOException;
     List<String> config(String key) throws IOException;
     Repository copyTo(Path destination) throws IOException;
     String pullPath(String remote) throws IOException;

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -819,11 +819,21 @@ public class GitRepository implements Repository {
 
     @Override
     public Diff diff(Hash from) throws IOException {
-        return diff(from, null);
+        return diff(from, List.of());
+    }
+
+    @Override
+    public Diff diff(Hash from, List<Path> files) throws IOException {
+        return diff(from, null, files);
     }
 
     @Override
     public Diff diff(Hash from, Hash to) throws IOException {
+        return diff(from, to, List.of());
+    }
+
+    @Override
+    public Diff diff(Hash from, Hash to, List<Path> files) throws IOException {
         var cmd = new ArrayList<>(List.of("git", "diff", "--patch",
                                                          "--find-renames=99%",
                                                          "--find-copies=99%",
@@ -836,6 +846,13 @@ public class GitRepository implements Repository {
                                                          from.hex()));
         if (to != null) {
             cmd.add(to.hex());
+        }
+
+        if (files != null && !files.isEmpty()) {
+            cmd.add("--");
+            for (var file : files) {
+                cmd.add(file.toString());
+            }
         }
 
         var p = start(cmd);

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -736,11 +736,21 @@ public class HgRepository implements Repository {
 
     @Override
     public Diff diff(Hash from) throws IOException {
-        return diff(from, null);
+        return diff(from, List.of());
+    }
+
+    @Override
+    public Diff diff(Hash from, List<Path> files) throws IOException {
+        return diff(from, null, files);
     }
 
     @Override
     public Diff diff(Hash from, Hash to) throws IOException {
+        return diff(from, to, List.of());
+    }
+
+    @Override
+    public Diff diff(Hash from, Hash to, List<Path> files) throws IOException {
         var ext = Files.createTempFile("ext", ".py");
         copyResource(EXT_PY, ext);
 
@@ -748,6 +758,11 @@ public class HgRepository implements Repository {
                                                 "diff-git-raw", "--patch", from.hex()));
         if (to != null) {
             cmd.add(to.hex());
+        }
+
+        if (files != null) {
+            var filenames = files.stream().map(Path::toString).collect(Collectors.toList());
+            cmd.add("--files=" + String.join(",", filenames));
         }
 
         var p = start(cmd);

--- a/vcs/src/main/resources/ext.py
+++ b/vcs/src/main/resources/ext.py
@@ -169,8 +169,8 @@ def diff_git_raw(ui, repo, rev1, rev2=None, *files, **opts):
     modified, added, removed = [set(l) for l in status[:3]]
 
     files = opts['files']
-    if files != '':
-        wanted = set(files.split(','))
+    if files != b'':
+        wanted = set(files.split(b','))
         modified = modified & wanted
         added = added & wanted
         removed = removed & wanted

--- a/vcs/src/main/resources/ext.py
+++ b/vcs/src/main/resources/ext.py
@@ -155,8 +155,8 @@ else:
     revsingle = mercurial.cmdutil.revsingle
     revrange = mercurial.cmdutil.revrange
 
-@command(b'diff-git-raw', [(b'', b'patch', False, b'')], b'hg diff-git-raw rev1 [rev2]')
-def diff_git_raw(ui, repo, rev1, rev2=None, **opts):
+@command(b'diff-git-raw', [(b'', b'patch', False, b''), (b'', b'files', b'', b'')], b'hg diff-git-raw rev1 [rev2]')
+def diff_git_raw(ui, repo, rev1, rev2=None, *files, **opts):
     ctx1 = revsingle(repo, rev1)
 
     if rev2 != None:
@@ -167,6 +167,14 @@ def diff_git_raw(ui, repo, rev1, rev2=None, **opts):
         status = repo.status(ctx1)
 
     modified, added, removed = [set(l) for l in status[:3]]
+
+    files = opts['files']
+    if files != '':
+        wanted = set(files.split(','))
+        modified = modified & wanted
+        added = added & wanted
+        removed = removed & wanted
+
     _diff_git_raw(repo, ctx1, ctx2, modified, added, removed, opts['patch'])
 
 @command(b'log-git', [(b'', b'reverse', False, b''), (b'l', b'limit', -1, b'')],  b'hg log-git <revisions>')

--- a/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
@@ -1944,4 +1944,54 @@ public class RepositoryTests {
             assertEquals(Optional.empty(), repo.annotate(new Tag("unknown")));
         }
     }
+
+    @ParameterizedTest
+    @EnumSource(VCS.class)
+    void testDiffWithFileList(VCS vcs) throws IOException {
+        try (var dir = new TemporaryDirectory(false)) {
+            var repo = Repository.init(dir.path(), vcs);
+            var readme = repo.root().resolve("README");
+            Files.writeString(readme, "Hello\n");
+            repo.add(readme);
+
+            var contribute = repo.root().resolve("CONTRIBUTE");
+            Files.writeString(contribute, "1. Make changes\n");
+            repo.add(contribute);
+
+            var first = repo.commit("Added README and CONTRIBUTE", "duke", "duke@openjdk.org");
+            Files.writeString(readme, "World\n", WRITE, APPEND);
+            Files.writeString(contribute, "2. Run git commit", WRITE, APPEND);
+
+            var diff = repo.diff(first, List.of(Path.of("README")));
+            assertEquals(1, diff.added());
+            assertEquals(0, diff.modified());
+            assertEquals(0, diff.removed());
+            var patches = diff.patches();
+            assertEquals(1, patches.size());
+            var patch = patches.get(0);
+            assertTrue(patch.isTextual());
+            assertTrue(patch.status().isModified());
+            assertEquals(Path.of("README"), patch.source().path().get());
+            assertEquals(Path.of("README"), patch.target().path().get());
+
+            repo.add(readme);
+            repo.add(contribute);
+            var second = repo.commit("Updates to both README and CONTRIBUTE", "duke", "duke@openjdk.org");
+
+            diff = repo.diff(first, second, List.of(Path.of("CONTRIBUTE")));
+            assertEquals(1, diff.added());
+            assertEquals(0, diff.modified());
+            assertEquals(0, diff.removed());
+            patches = diff.patches();
+            assertEquals(1, patches.size());
+            patch = patches.get(0);
+            assertTrue(patch.isTextual());
+            assertTrue(patch.status().isModified());
+            assertEquals(Path.of("CONTRIBUTE"), patch.source().path().get());
+            assertEquals(Path.of("CONTRIBUTE"), patch.target().path().get());
+
+            diff = repo.diff(first, second, List.of(Path.of("DOES_NOT_EXIST")));
+            assertEquals(0, diff.patches().size());
+        }
+    }
 }


### PR DESCRIPTION
Hi all,

please review this pull request that add support for an input argument to `git-webrev`. The argument is a file that itself contains a list of files to include in the webrev. This input file also specifies the order in which the files should appear in the webrev's index.html file.

The main part of the patch is adding support for a list of paths to `ReadOnlyRepository.diff`.

One part of the bug that is not addressed yet is the support for specifying `-` as the input file, `git-webrev` should then read the list of file names (separated by `\n`) from stdin. I plan to address this in a follow-up patch since I wanted to keep this patch as small as possible.

Thanks,
Erik

## Testing
- [x] Added a new unit test
- [x] Manual testing of `git-webrev` with input file
- [x] `make test` passes on Linux x64
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-146](https://bugs.openjdk.java.net/browse/SKARA-146): git-webrev: Add support for file list argument


## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**) **Note!** Review applies to e0c3162fd5e8bc596d6632d14d8087537b93506a