### PR TITLE
174: git-webrev should support taking file list via STDIN

### DIFF
--- a/args/src/main/java/org/openjdk/skara/args/ArgumentParser.java
+++ b/args/src/main/java/org/openjdk/skara/args/ArgumentParser.java
@@ -181,7 +181,7 @@ public class ArgumentParser {
                     }
                     seen.add(flag);
                 }
-            } else if (arg.startsWith("-")) {
+            } else if (arg.startsWith("-") && !arg.equals("-")) {
                 var name = arg.substring(1);
                 var flag = lookupShortcut(name);
                 if (flag.isSwitch()) {

--- a/cli/src/main/java/org/openjdk/skara/cli/GitWebrev.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitWebrev.java
@@ -256,8 +256,14 @@ public class GitWebrev {
         List<Path> files = List.of();
         if (arguments.at(0).isPresent()) {
             var path = arguments.at(0).via(Path::of);
-            files = Files.readAllLines(path).stream().map(Path::of).collect(Collectors.toList());
+            if (path.equals(Path.of("-"))) {
+                var reader = new BufferedReader(new InputStreamReader(System.in));
+                files = reader.lines().map(Path::of).collect(Collectors.toList());
+            } else {
+                files = Files.readAllLines(path).stream().map(Path::of).collect(Collectors.toList());
+            }
         }
+
         Webrev.repository(repo)
               .output(output)
               .title(title)


### PR DESCRIPTION
Hi all,

please review this small patch that adds support for `git-webrev` to take the list of files that should be included via STDIN.

Thanks,
Erik

## Testing
- [x] Manual testing of `git-webrev` and passing files to include via STDIN
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-174](https://bugs.openjdk.java.net/browse/SKARA-174): git-webrev should support taking file list via STDIN


## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)