### PR TITLE
Use https:// everywhere

### DIFF
--- a/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestCloserBot.java
+++ b/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestCloserBot.java
@@ -56,7 +56,7 @@ class PullRequestCloserBotWorkItem implements WorkItem {
                     "This repository is currently a read-only git mirror of the official Mercurial " +
                     "repository (located at https://hg.openjdk.java.net/). As such, we are not " +
                     "currently accepting pull requests here. If you would like to contribute to " +
-                    "the OpenJDK project, please see http://openjdk.java.net/contribute/ on how " +
+                    "the OpenJDK project, please see https://openjdk.java.net/contribute/ on how " +
                     "to proceed.\n\n" +
                     "This pull request will be automatically closed.";
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -402,13 +402,13 @@ class CheckRun {
             message.append("\n");
             var contributor = censusInstance.namespace().get(pr.author().id());
             if (contributor == null) {
-                message.append("As you are not a known OpenJDK [Author](http://openjdk.java.net/bylaws#author), ");
+                message.append("As you are not a known OpenJDK [Author](https://openjdk.java.net/bylaws#author), ");
             } else {
                 message.append("As you do not have Committer status in this project, ");
             }
 
-            message.append("an existing [Committer](http://openjdk.java.net/bylaws#committer) must agree to ");
-            message.append("[sponsor](http://openjdk.java.net/sponsor/) your change. ");
+            message.append("an existing [Committer](https://openjdk.java.net/bylaws#committer) must agree to ");
+            message.append("[sponsor](https://openjdk.java.net/sponsor/) your change. ");
             var candidates = reviews.stream()
                                     .filter(review -> ProjectPermissions.mayCommit(censusInstance, review.reviewer()))
                                     .map(review -> "@" + review.reviewer().userName())

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/RejectCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/RejectCommand.java
@@ -37,7 +37,7 @@ public class RejectCommand implements CommandHandler {
             return;
         }
         if (!ProjectPermissions.mayReview(censusInstance, comment.author())) {
-            reply.println("Only [Reviewers](http://openjdk.java.net/bylaws#reviewer) are allowed to reject changes.");
+            reply.println("Only [Reviewers](https://openjdk.java.net/bylaws#reviewer) are allowed to reject changes.");
             return;
         }
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
@@ -42,7 +42,7 @@ public class SponsorCommand implements CommandHandler {
             return;
         }
         if (!ProjectPermissions.mayCommit(censusInstance, comment.author())) {
-            reply.println("Only [Committers](http://openjdk.java.net/bylaws#committer) are allowed to sponsor changes.");
+            reply.println("Only [Committers](https://openjdk.java.net/bylaws#committer) are allowed to sponsor changes.");
             return;
         }
 


### PR DESCRIPTION
Hi all,

please review this small patch that ensures what we use `https://` links in all our Markdown generated by the bots.

Thanks,
Erik

## Testing
- [x] `make test` on Linux x64
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)