### PR TITLE
92: GitRepository::currentBranch fails when on a detached HEAD

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
@@ -519,7 +519,11 @@ public class GitPr {
 
                 System.exit(0);
             }
-            var currentBranch = repo.currentBranch();
+            var currentBranch = repo.currentBranch().orElseGet(() -> {
+                    System.err.println("error: the repository is in a detached HEAD state");
+                    System.exit(1);
+                    return null;
+            });
             if (currentBranch.equals(repo.defaultBranch())) {
                 System.err.println("error: you should not create pull requests from the 'master' branch");
                 System.err.println("");

--- a/cli/src/main/java/org/openjdk/skara/cli/GitPublish.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitPublish.java
@@ -85,6 +85,11 @@ public class GitPublish {
         var repo = Repository.get(cwd).or(die("error: no repository found at " + cwd.toString())).get();
         var remote = arguments.at(0).orString("origin");
 
-        System.exit(pushAndTrack(remote, repo.currentBranch()));
+        var currentBranch = repo.currentBranch();
+        if (currentBranch.isEmpty()) {
+            System.err.println("error: the repository is in a detached HEAD state");
+            System.exit(1);
+        }
+        System.exit(pushAndTrack(remote, repo.currentBranch().get()));
     }
 }

--- a/cli/src/main/java/org/openjdk/skara/cli/GitWebrev.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitWebrev.java
@@ -206,15 +206,18 @@ public class GitWebrev {
         }
         if (issue == null) {
             var pattern = Pattern.compile("(?:(JDK|CODETOOLS|JMC)-)?([0-9]+).*");
-            var branch = repo.currentBranch().name().toUpperCase();
-            var m = pattern.matcher(branch);
-            if (m.matches()) {
-                var project = m.group(1);
-                if (project == null) {
-                    project = "JDK";
+            var currentBranch = repo.currentBranch();
+            if (currentBranch.isPresent()) {
+                var branchName = currentBranch.get().name().toUpperCase();
+                var m = pattern.matcher(branchName);
+                if (m.matches()) {
+                    var project = m.group(1);
+                    if (project == null) {
+                        project = "JDK";
+                    }
+                    var id = m.group(2);
+                    issue = "https://bugs.openjdk.java.net/browse/" + project + "-" + id;
                 }
-                var id = m.group(2);
-                issue = "https://bugs.openjdk.java.net/browse/" + project + "-" + id;
             }
         }
 

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/TestRepository.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/TestRepository.java
@@ -36,8 +36,8 @@ class TestRepository implements ReadOnlyRepository {
     private Tag defaultTag = null;
     private List<Tag> tags = new ArrayList<Tag>();
 
-    public Branch currentBranch() throws IOException {
-        return currentBranch;
+    public Optional<Branch> currentBranch() throws IOException {
+        return Optional.empty();
     }
 
     void setCurrentBranch(Branch branch) {

--- a/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
@@ -30,7 +30,7 @@ import java.util.*;
 
 public interface ReadOnlyRepository {
     Hash head() throws IOException;
-    Branch currentBranch() throws IOException;
+    Optional<Branch> currentBranch() throws IOException;
     Optional<Bookmark> currentBookmark() throws IOException;
     Branch defaultBranch() throws IOException;
     List<Branch> branches() throws IOException;

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -661,13 +661,13 @@ public class GitRepository implements Repository {
     }
 
     @Override
-    public Branch currentBranch() throws IOException {
+    public Optional<Branch> currentBranch() throws IOException {
         try (var p = capture("git", "symbolic-ref", "--short", "HEAD")) {
-            var res = await(p);
-            if (res.stdout().size() != 1) {
-                throw new IOException("Unexpected output\n" + res);
+            var res = p.await();
+            if (res.status() == 0 && res.stdout().size() == 1) {
+                return Optional.of(new Branch(res.stdout().get(0)));
             }
-            return new Branch(res.stdout().get(0));
+            return Optional.empty();
         }
     }
 

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -599,21 +599,23 @@ public class HgRepository implements Repository {
 
     @Override
     public void rebase(Hash hash, String committerName, String committerEmail) throws IOException {
-        var current = currentBranch().name();
+        var current = currentBranch().orElseThrow(() ->
+                new IOException("No current branch to rebase upon")
+        );
         try (var p = capture("hg", "--config", "extensions.rebase=",
-                             "rebase", "--dest", hash.hex(), "--base", current)) {
+                             "rebase", "--dest", hash.hex(), "--base", current.name())) {
             await(p);
         }
     }
 
     @Override
-    public Branch currentBranch() throws IOException {
+    public Optional<Branch> currentBranch() throws IOException {
         try (var p = capture("hg", "branch")) {
             var res = await(p);
             if (res.stdout().size() != 1) {
-                throw new IllegalStateException("No current branch\n" + res);
+                return Optional.empty();
             }
-            return new Branch(res.stdout().get(0));
+            return Optional.of(new Branch(res.stdout().get(0)));
         }
     }
 

--- a/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
@@ -156,7 +156,7 @@ public class RepositoryTests {
     void testCurrentBranchOnEmptyRepository(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
             var r = Repository.init(dir.path(), vcs);
-            assertEquals(r.defaultBranch(), r.currentBranch());
+            assertEquals(r.defaultBranch(), r.currentBranch().get());
         }
     }
 


### PR DESCRIPTION
Hi all,

please review this pull request that makes `git webrev` work when the repository is in a "detached HEAD" state (i.e. there is no active branch). The main part of the change is making `ReadOnlyRepository::currentBranch` return `Optional<Branch>` instead of `Branch`.

Thanks,
Erik

## Testing
- [x] `make test` on Linux x64
- [x] Manually running `git webrev` on a repository with a detached HEAD
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-92](https://bugs.openjdk.java.net/browse/SKARA-92): GitRepository::currentBranch fails when on a detached HEAD


## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)