### PR TITLE
Add config option sync.branches and make git-sync less chatty

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitSync.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitSync.java
@@ -160,12 +160,22 @@ public class GitSync {
             for (var branch : requested) {
                 branches.add(branch.trim());
             }
+        } else {
+            var lines = repo.config("sync.branches");
+            if (lines.size() == 1) {
+                var requested = lines.get(0).split(",");
+                for (var branch : requested) {
+                    branches.add(branch.trim());
+                }
+            }
         }
 
         for (var branch : repo.remoteBranches(upstream)) {
             var name = branch.name();
             if (!branches.isEmpty() && !branches.contains(name)) {
-                System.out.println("Skipping branch " + name);
+                if (arguments.contains("verbose") || arguments.contains("debug")) {
+                    System.out.println("Skipping branch " + name);
+                }
                 continue;
             }
             System.out.print("Syncing " + upstream + "/" + name + " to " + origin + "/" + name + "... ");


### PR DESCRIPTION
Hi all,

please review this small pull request that adds the configuration option `sync.branches`. Setting `sync.branches` means I don't have to provide `--branches` to `git-sync` every time for repositories where I know I always want to sync only a subset of the remote branches.

I also moved the printing of "Skipping branch foo..." behind the `--verbose` (or `--debug`) switch, since `git-sync` became quite chatty otherwise for upstream repositories with lots of branches.

Thanks,
Erik

## Testing
- [x] Manual testing of `git-sync`
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)