### PR TITLE
Use headHash instead of targetRef when fetching PRs

### DIFF
--- a/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestWorkItem.java
+++ b/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestWorkItem.java
@@ -404,7 +404,7 @@ public class TestWorkItem implements WorkItem {
                             return new RuntimeException("Repository in " + localRepoDir + " has vanished");
                     });
                 }
-                fetchHead = localRepo.fetch(repository.url(), pr.targetRef());
+                fetchHead = localRepo.fetch(repository.url(), pr.headHash().hex());
                 localRepo.checkout(fetchHead, true);
                 job = ci.submit(localRepoDir, jobs, jobId);
             } catch (IOException e) {

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
@@ -38,7 +38,6 @@ class InMemoryPullRequest implements PullRequest {
     HostedRepository repository;
     Hash headHash;
     String id;
-    String targetRef;
     Map<String, Map<String, Check>> checks = new HashMap<>();
 
     @Override
@@ -92,7 +91,7 @@ class InMemoryPullRequest implements PullRequest {
 
     @Override
     public String targetRef() {
-        return targetRef;
+        return null;
     }
 
     @Override

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/TestWorkItemTests.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/TestWorkItemTests.java
@@ -504,7 +504,6 @@ class TestWorkItemTests {
             var pr = new InMemoryPullRequest();
             pr.repository = repo;
             pr.id = "17";
-            pr.targetRef = "master";
 
             var duke = new HostUser(0, "duke", "Duke");
             pr.author = duke;
@@ -613,11 +612,10 @@ class TestWorkItemTests {
             var pr = new InMemoryPullRequest();
             pr.repository = repo;
             pr.id = "17";
-            pr.targetRef = "master";
+            pr.headHash = head;
 
             var duke = new HostUser(0, "duke", "Duke");
             pr.author = duke;
-            pr.headHash = head;
 
             var now = ZonedDateTime.now();
             var comment = new Comment("0", "/test tier1", duke, now, now);
@@ -739,11 +737,10 @@ class TestWorkItemTests {
             var pr = new InMemoryPullRequest();
             pr.repository = repo;
             pr.id = "17";
-            pr.targetRef = "master";
+            pr.headHash = head;
 
             var duke = new HostUser(0, "duke", "Duke");
             pr.author = duke;
-            pr.headHash = head;
 
             var now = ZonedDateTime.now();
             var comment = new Comment("0", "/test tier1", duke, now, now);
@@ -828,11 +825,10 @@ class TestWorkItemTests {
             var pr = new InMemoryPullRequest();
             pr.repository = repo;
             pr.id = "17";
-            pr.targetRef = "master";
+            pr.headHash = head;
 
             var duke = new HostUser(0, "duke", "Duke");
             pr.author = duke;
-            pr.headHash = head;
 
             var now = ZonedDateTime.now();
             var comment = new Comment("0", "/test tier1", duke, now, now);


### PR DESCRIPTION
Hi all,

please review this pull request that ensures that the `tester` bot uses `pr.headHash()` instead of `pr.targetRef()` when fetching the changes for a PR (otherwise we just fetch `master` most of the time). I also removed the `targetRef` implementation for `InMemoryPullRequest` and updated the `TestWorkItem` tests to ensure that `TestWorkItem` does _not_ use `pr.targetRef()`.

Thanks,
Erik

## Testing
- [x] `make test` passes on Linux x64
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)