### PR TITLE
Replace ContinuousIntegration.query with ContinuousIntegration.jobsFor

### DIFF
--- a/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestBot.java
+++ b/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestBot.java
@@ -78,11 +78,8 @@ public class TestBot implements Bot {
                                          pr));
             } else {
                 // is there a job running for this PR?
-                var colon = "%3A";
-                var asterisk = "%2A";
-                var id = host + "-" + repoId  + "-"+ pr.id() + "-" + asterisk;
                 try {
-                    var jobs = ci.query("id" + colon + id);
+                    var jobs = ci.jobsFor(pr);
                     if (!jobs.isEmpty()) {
                         var shouldUpdate = false;
                         for (var job : jobs) {

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryContinuousIntegration.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryContinuousIntegration.java
@@ -25,6 +25,7 @@ package org.openjdk.skara.bots.tester;
 import org.openjdk.skara.ci.ContinuousIntegration;
 import org.openjdk.skara.ci.Job;
 import org.openjdk.skara.host.HostUser;
+import org.openjdk.skara.forge.PullRequest;
 
 import java.io.*;
 import java.nio.file.*;
@@ -93,7 +94,7 @@ class InMemoryContinuousIntegration implements ContinuousIntegration {
     }
 
     @Override
-    public List<Job> query(String query) throws IOException {
+    public List<Job> jobsFor(PullRequest pr) throws IOException {
         return List.of();
     }
 }

--- a/ci/build.gradle
+++ b/ci/build.gradle
@@ -33,4 +33,6 @@ module {
 dependencies {
     implementation project(':host')
     implementation project(':json')
+    implementation project(':forge')
+    implementation project(':issuetracker')
 }

--- a/ci/src/main/java/module-info.java
+++ b/ci/src/main/java/module-info.java
@@ -23,6 +23,7 @@
 module org.openjdk.skara.ci {
     requires org.openjdk.skara.host;
     requires org.openjdk.skara.json;
+    requires org.openjdk.skara.forge;
 
     uses org.openjdk.skara.ci.ContinuousIntegrationFactory;
     exports org.openjdk.skara.ci;

--- a/ci/src/main/java/org/openjdk/skara/ci/ContinuousIntegration.java
+++ b/ci/src/main/java/org/openjdk/skara/ci/ContinuousIntegration.java
@@ -25,6 +25,7 @@ package org.openjdk.skara.ci;
 import org.openjdk.skara.host.Host;
 import org.openjdk.skara.json.JSONObject;
 import org.openjdk.skara.json.JSON;
+import org.openjdk.skara.forge.PullRequest;
 
 import java.io.IOException;
 import java.net.URI;
@@ -34,7 +35,7 @@ import java.util.*;
 public interface ContinuousIntegration extends Host {
     Job submit(Path source, List<String> jobs, String id) throws IOException;
     Job job(String id) throws IOException;
-    List<Job> query(String query) throws IOException;
+    List<Job> jobsFor(PullRequest pr) throws IOException;
     void cancel(String id) throws IOException;
 
     static Optional<ContinuousIntegration> from(URI uri, JSONObject configuration) {


### PR DESCRIPTION
Hi all,

please review this small pull request that narrows the scope of `ContinuousIntegration.query(String s)` to what is really is used for - `ContinuousIntegration.jobsFor(PullRequest pr)`.

Thanks,
Erik

## Testing
- [x] `make test` on Linux x64
- [x] `make images`
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)