### PR TITLE
176: git-pr should promote usage of git-publish

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
@@ -542,7 +542,7 @@ public class GitPr {
                 System.err.println("A remote branch must be present at " + remotePullPath + " to create a pull request");
                 System.err.println("To create a remote branch and push the commits for your local branch, run:");
                 System.err.println("");
-                System.err.println("    git push --set-upstream " + remote + " " + currentBranch.name());
+                System.err.println("    git publish");
                 System.err.println("");
                 System.err.println("If you created the remote branch from another client, you must update this repository.");
                 System.err.println("To update remote information for this repository, run:");


### PR DESCRIPTION
Hi all,

pleaser review this small pull request that promotes usage of `git publish`
instead of `git push --set-upstream`.

Testing:
- [x] Tested live while demoing features

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-176](https://bugs.openjdk.java.net/browse/SKARA-176): git-pr should promote usage of git-publish


## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)