### PR TITLE
177: Filter markdown escapes when sending plaintext emails

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MarkdownToText.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MarkdownToText.java
@@ -22,12 +22,14 @@
  */
 package org.openjdk.skara.bots.mlbridge;
 
-import java.util.regex.Pattern;
+import java.util.regex.*;
 
 public class MarkdownToText {
     private static final Pattern emojiPattern = Pattern.compile("(:([0-9a-z_+-]+):)");
     private static final Pattern suggestionPattern = Pattern.compile("^```suggestion$", Pattern.MULTILINE);
     private static final Pattern codePattern = Pattern.compile("^```(?:\\w+)?\\R?", Pattern.MULTILINE);
+    private static final Pattern escapesPattern = Pattern.compile("\\\\([!\"#$%&'()*+,\\-./:;<=?@\\[\\]^_`{|}~])", Pattern.MULTILINE);
+    private static final Pattern entitiesPattern = Pattern.compile("&#32;", Pattern.MULTILINE);
 
     private static String removeEmojis(String markdown) {
         var emojiMatcher = emojiPattern.matcher(markdown);
@@ -44,7 +46,17 @@ public class MarkdownToText {
         return codeMatcher.replaceAll("");
     }
 
+    static String removeEscapes(String markdown) {
+        var escapesMatcher = escapesPattern.matcher(markdown);
+        return escapesMatcher.replaceAll(mr -> Matcher.quoteReplacement(mr.group(1)));
+    }
+
+    static String removeEntities(String markdown) {
+        var entitiesMatcher = entitiesPattern.matcher(markdown);
+        return entitiesMatcher.replaceAll(" ");
+    }
+
     static String removeFormatting(String markdown) {
-        return removeCode(removeSuggestions(removeEmojis(markdown))).strip();
+        return removeEscapes(removeEntities(removeCode(removeSuggestions(removeEmojis(markdown))))).strip();
     }
 }

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MarkdownToTextTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MarkdownToTextTests.java
@@ -55,4 +55,14 @@ class MarkdownToTextTests {
     void suggestion() {
         assertEquals("Suggestion:\n\nJust some text", MarkdownToText.removeFormatting("```suggestion\nJust some text\n```"));
     }
+
+    @Test
+    void escapes() {
+        assertEquals("Special chars: #$%&'()*+\\!", MarkdownToText.removeFormatting("Special chars: \\#\\$\\%\\&\\'\\(\\)\\*\\+\\\\!"));
+    }
+
+    @Test
+    void entities() {
+        assertEquals("space is here", MarkdownToText.removeFormatting("space&#32;is here"));
+    }
 }


### PR DESCRIPTION
Hi all,

Please review this change that extends the markdown to text filtering to handle the escapes that can be inserted by the text to markdown filter.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-177](https://bugs.openjdk.java.net/browse/SKARA-177): Filter markdown escapes when sending plaintext emails


## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)