### PR TITLE
178: Test bot misses transition from RUNNING to COMPLETE

### DIFF
--- a/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestBot.java
+++ b/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestBot.java
@@ -33,6 +33,16 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 public class TestBot implements Bot {
+    private static class Observation {
+        Job.State nextToLast;
+        Job.State last;
+
+        Observation(Job.State nextToLast, Job.State last) {
+            this.nextToLast = nextToLast;
+            this.last = last;
+        }
+    }
+
     private final ContinuousIntegration ci;
     private final String approversGroupId;
     private final List<String> availableJobs;
@@ -41,7 +51,7 @@ public class TestBot implements Bot {
     private final Path storage;
     private final HostedRepository repo;
     private final PullRequestUpdateCache cache;
-    private final Map<String, Job.State> states;
+    private final Map<String, Observation> states;
 
     TestBot(ContinuousIntegration ci,
             String approversGroupId,
@@ -85,12 +95,18 @@ public class TestBot implements Bot {
                         for (var job : jobs) {
                             if (!states.containsKey(job.id())) {
                                 shouldUpdate = true;
+                                states.put(job.id(), new Observation(job.state(), job.state()));
                             } else {
-                                if (!states.get(job.id()).equals(Job.State.COMPLETED)) {
+                                var observed = states.get(job.id());
+
+                                if (!observed.last.equals(Job.State.COMPLETED) ||
+                                    !observed.nextToLast.equals(Job.State.COMPLETED)) {
                                     shouldUpdate = true;
                                 }
+
+                                observed.nextToLast = observed.last;
+                                observed.last = job.state();
                             }
-                            states.put(job.id(), job.state());
                         }
                         if (shouldUpdate) {
                             ret.add(new TestWorkItem(ci,


### PR DESCRIPTION
Hi all,

please review this pull request that ensures that the test bot will execute a
`TestWorkItem` when jobs are doing the final transition from `RUNNING` to
`COMPLETE`. This is done by having the `TestBot` observe the two last states,
not just the last state. By observing the last two states, the `TestBot` can
witness the final transition from `RUNNING` to `COMPLETE`.

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-178](https://bugs.openjdk.java.net/browse/SKARA-178): Test bot misses transition from RUNNING to COMPLETE


## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)