### PR TITLE
165: Replace large webrev files with placeholders instead of dropping them

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
@@ -56,23 +56,42 @@ class WebrevStorage {
               .generate(base, head);
     }
 
-    private void push(Repository localStorage, Path webrevFolder, String identifier) throws IOException {
+    private String generatePlaceholder(PullRequest pr, Hash base, Hash head) {
+        return "This file was too large to be included in the published webrev, and has been replaced with " +
+                "this placeholder message. It is possible to generate the original content locally by " +
+                "following these instructions:\n\n" +
+                "  $ git fetch " + pr.repository().webUrl() + " " + pr.sourceRef() + "\n" +
+                "  $ git checkout " + head.hex() + "\n" +
+                "  $ git webrev -r " + base.hex() + "\n";
+    }
+
+    private void push(Repository localStorage, Path webrevFolder, String identifier, String placeholder) throws IOException {
         var batchIndex = new AtomicInteger();
         try (var files = Files.walk(webrevFolder)) {
+            // Replace large files (except the index) with placeholders
+            var largeFiles = files.filter(Files::isRegularFile)
+                    .filter(file -> {
+                        try {
+                            if (file.getFileName().toString().equals("index.html")) {
+                                return false;
+                            } else {
+                                return Files.size(file) >= 1000 * 1000;
+                            }
+                        } catch (IOException e) {
+                            return false;
+                        }
+                    })
+                    .collect(Collectors.toList());
+            largeFiles.forEach(file -> {
+                try {
+                    Files.writeString(file, placeholder);
+                } catch (IOException e) {
+                    throw new RuntimeException("Failed to replace large file with placeholder");
+                }
+            });
+
             // Try to push 1000 files at a time
             var batches = files.filter(Files::isRegularFile)
-                               .filter(file -> {
-                                   // Huge files are not that useful in a webrev - but make an exception for the index
-                                   try {
-                                       if (file.getFileName().toString().equals("index.html")) {
-                                           return true;
-                                       } else {
-                                           return Files.size(file) < 1000 * 1000;
-                                       }
-                                   } catch (IOException e) {
-                                       return false;
-                                   }
-                               })
                                .collect(Collectors.groupingBy(path -> {
                                    int curIndex = batchIndex.incrementAndGet();
                                    return Math.floorDiv(curIndex, 1000);
@@ -116,8 +135,9 @@ class WebrevStorage {
                 clearDirectory(outputFolder);
             }
             generate(pr, localRepository, outputFolder, base, head);
+            var placeholder = generatePlaceholder(pr, base, head);
             if (!localStorage.isClean()) {
-                push(localStorage, outputFolder, baseFolder.resolve(pr.id()).toString());
+                push(localStorage, outputFolder, baseFolder.resolve(pr.id()).toString(), placeholder);
             }
             return URIBuilder.base(baseUri).appendPath(relativeFolder.toString().replace('\\', '/')).build();
         } catch (IOException e) {

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
@@ -65,31 +65,45 @@ class WebrevStorage {
                 "  $ git webrev -r " + base.hex() + "\n";
     }
 
+    private void replaceContent(Path file, String placeholder) {
+        try {
+            if (file.getFileName().toString().endsWith(".html")) {
+                var existing = Files.readString(file);
+                var headerEnd = existing.indexOf("<pre>");
+                var footerStart = existing.lastIndexOf("</pre>");
+                if ((headerEnd > 0) && (footerStart > 0)) {
+                    var header = existing.substring(0, headerEnd + 5);
+                    var footer = existing.substring(footerStart);
+                    Files.writeString(file, header + placeholder + footer);
+                    return;
+                }
+            }
+            Files.writeString(file, placeholder);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to replace large file with placeholder");
+        }
+    }
+
+    private boolean shouldBeReplaced(Path file) {
+        try {
+            if (file.getFileName().toString().equals("index.html")) {
+                return false;
+            } else {
+                return Files.size(file) >= 1000 * 1000;
+            }
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
     private void push(Repository localStorage, Path webrevFolder, String identifier, String placeholder) throws IOException {
         var batchIndex = new AtomicInteger();
 
         // Replace large files (except the index) with placeholders
         try (var files = Files.walk(webrevFolder)) {
-            var largeFiles = files.filter(Files::isRegularFile)
-                                  .filter(file -> {
-                                      try {
-                                          if (file.getFileName().toString().equals("index.html")) {
-                                              return false;
-                                          } else {
-                                              return Files.size(file) >= 1000 * 1000;
-                                          }
-                                      } catch (IOException e) {
-                                          return false;
-                                      }
-                                  })
-                                  .collect(Collectors.toList());
-            largeFiles.forEach(file -> {
-                try {
-                    Files.writeString(file, placeholder);
-                } catch (IOException e) {
-                    throw new RuntimeException("Failed to replace large file with placeholder");
-                }
-            });
+            files.filter(Files::isRegularFile)
+                 .filter(this::shouldBeReplaced)
+                 .forEach(file -> replaceContent(file, placeholder));
         }
 
         // Try to push 1000 files at a time

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/WebrevStorageTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/WebrevStorageTests.java
@@ -77,4 +77,49 @@ class WebrevStorageTests {
             assertTrue(Files.exists(repoFolder.resolve("test/" + pr.id() + "/webrev.00/index.html")));
         }
     }
+
+    @Test
+    void dropLarge(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var archive = credentials.getHostedRepository();
+
+            // Populate the projects repository
+            var reviewFile = Path.of("reviewfile.txt");
+            var repoFolder = tempFolder.path().resolve("repo");
+            var localRepo = CheckableRepository.init(repoFolder, author.repositoryType(), reviewFile);
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, archive.url(), "webrev", true);
+
+            // Make a change with a corresponding PR
+            CheckableRepository.appendAndCommit(localRepo);
+            var large = "This line is about 30 bytes long\n".repeat(1000 * 100);
+            Files.writeString(repoFolder.resolve("large.txt"), large);
+            localRepo.add(repoFolder.resolve("large.txt"));
+            var editHash = localRepo.commit("Add large file", "duke", "duke@openjdk.org");
+
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(archive, "master", "edit", "This is a pull request");
+            pr.addLabel("rfr");
+            pr.setBody("This is now ready");
+
+            var from = EmailAddress.from("test", "test@test.mail");
+            var storage = new WebrevStorage(archive, "webrev", Path.of("test"),
+                                            URIBuilder.base("http://www.test.test/").build(), from);
+
+            var prFolder = tempFolder.path().resolve("pr");
+            var prRepo = Repository.materialize(prFolder, pr.repository().url(), "edit");
+            var scratchFolder = tempFolder.path().resolve("scratch");
+            var generator = storage.generator(pr, prRepo, scratchFolder);
+            generator.generate(masterHash, editHash, "00");
+
+            // Update the local repository and check that the webrev has been generated
+            Repository.materialize(repoFolder, archive.url(), "webrev");
+            assertTrue(Files.exists(repoFolder.resolve("test/" + pr.id() + "/webrev.00/index.html")));
+            assertTrue(Files.size(repoFolder.resolve("test/" + pr.id() + "/webrev.00/large.txt")) > 0);
+            assertTrue(Files.size(repoFolder.resolve("test/" + pr.id() + "/webrev.00/large.txt")) < 1000);
+        }
+    }
 }


### PR DESCRIPTION
Hi all,

Please review this change that replaces large files in published webrevs with a placeholder message, instead of just omitting them.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-165](https://bugs.openjdk.java.net/browse/SKARA-165): Replace large webrev files with placeholders instead of dropping them


## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)