### PR TITLE
Make instantiating forges from known hosts faster

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/ForgeFactory.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/ForgeFactory.java
@@ -37,6 +37,12 @@ public interface ForgeFactory {
     String name();
 
     /**
+     * A set of known hostnames that are instances of this forge.
+     * @return
+     */
+    Set<String> knownHosts();
+
+    /**
      * Instantiate an instance of this forge.
      * @return
      */

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubForgeFactory.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubForgeFactory.java
@@ -5,12 +5,18 @@ import org.openjdk.skara.host.Credential;
 import org.openjdk.skara.json.JSONObject;
 
 import java.net.URI;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 public class GitHubForgeFactory implements ForgeFactory {
     @Override
     public String name() {
         return "github";
+    }
+
+    @Override
+    public Set<String> knownHosts() {
+        return Set.of("github.com");
     }
 
     @Override

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabForgeFactory.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabForgeFactory.java
@@ -5,11 +5,17 @@ import org.openjdk.skara.host.Credential;
 import org.openjdk.skara.json.JSONObject;
 
 import java.net.URI;
+import java.util.Set;
 
 public class GitLabForgeFactory implements ForgeFactory {
     @Override
     public String name() {
         return "gitlab";
+    }
+
+    @Override
+    public Set<String> knownHosts() {
+        return Set.of("gitlab.com");
     }
 
     @Override

--- a/forge/src/test/java/org/openjdk/skara/forge/ForgeTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/ForgeTests.java
@@ -42,6 +42,11 @@ class ForgeTests {
                                        }
 
                                        @Override
+                                       public Set<String> knownHosts() {
+                                           return Set.of();
+                                       }
+
+                                       @Override
                                        public Forge create(URI uri, Credential credential, JSONObject configuration) {
                                            return null;
                                        }
@@ -50,6 +55,11 @@ class ForgeTests {
                                        @Override
                                        public String name() {
                                            return "other";
+                                       }
+
+                                       @Override
+                                       public Set<String> knownHosts() {
+                                           return Set.of();
                                        }
 
                                        @Override


### PR DESCRIPTION
Hi all,

please review this pull request that speeds things up a little when calling `Forge.from`. If the hostname of the provided URI exactly matches a known host for exactly one `ForgeFactory`, then I argue that it is safe to create a `Forge` from that factory and return it without calling `isValid()` first. In other words, I would be very surprised if we ever encounter an issue with returning a `GitHubForge` instance for URIs with a hostname of `github.com` (and vice-versa, a `GitLabForge` instance for URIs with a hostname of `gitlab.com`).

Thanks,
Erik

## Testing
- [x] `make test` on Linux x64
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)