### PR TITLE
Try a bit harder to generate incremental webrevs

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
@@ -114,7 +114,15 @@ class ArchiveMessages {
                             "The incremental views will show differences compared to the previous content of the PR.";
                 }
             } else {
-                return "The pull request has been updated with a new target base due to a merge or a rebase.";
+                try {
+                    localRepository.checkout(lastHead, true);
+                    localRepository.rebase(base, "duke", "duke@openjdk.org");
+                    var rebasedLastHead = localRepository.head();
+                    return "The pull request has been updated with a new target base due to a merge or a rebase. " +
+                            "The incremental webrev excludes the unrelated changes brought in by the merge/rebase.";
+                } catch (IOException e) {
+                    return "The pull request has been updated with a new target base due to a merge or a rebase.";
+                }
             }
         } catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
@@ -76,7 +76,7 @@ class ArchiveWorkItem implements WorkItem {
         try {
             localRepo.add(localRepo.root().resolve("."));
             var hash = localRepo.commit(message, bot.emailAddress().fullName().orElseThrow(), bot.emailAddress().address());
-            localRepo.push(hash, bot.archiveRepo().url(), "master");
+            localRepo.push(hash, bot.archiveRepo().url(), bot.archiveRef());
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }


### PR DESCRIPTION
Hi all,

Please review this change that makes the mailing list bridge bot try a little harder to generate an incremental webrev. If a pull request has been rebased or merged the latest changes from the target branch, it may be possible to exclude these and generate a clean incremental webrev. If so, we do that.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)