### PR TITLE
git-pr: no need to check forge validity

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
@@ -330,7 +330,7 @@ public class GitPr {
         var forge = credentials == null ?
             Forge.from(forgeURI) :
             Forge.from(forgeURI, new Credential(credentials.username(), credentials.password()));
-        if (forge.isEmpty() || !forge.get().isValid()) {
+        if (forge.isEmpty()) {
             if (!shouldUseToken) {
                 if (arguments.contains("verbose")) {
                     System.err.println("");


### PR DESCRIPTION
Hi all,

please review this small patch that removes an superfluous call to
`Forge.isValid` in `git-pr`. `Forge.from` already ensures that the returned
`Forge` is valid, so there is no need for `git-pr` to repeat this check.

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)