### PR TITLE
git-pr: do not fetch pull requests twice

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
@@ -741,7 +741,7 @@ public class GitPr {
                 }
             }
 
-            for (var pr : remoteRepo.pullRequests()) {
+            for (var pr : prs) {
                 var prAuthor = pr.author().userName();
                 if (!filterAuthors.isEmpty() && !filterAuthors.contains(prAuthor)) {
                     continue;


### PR DESCRIPTION
Hi all,

please review this small patch that fixes an issue where `git-pr` would
unnecessarily download the metadata for all pull requests _twice_.

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)