### PR TITLE
git-fork: add --sync option

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitFork.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitFork.java
@@ -144,7 +144,7 @@ public class GitFork {
                   .optional(),
             Switch.shortcut("")
                   .fullname("sync")
-                  .helptext("Sync with the upstream repository after succesful fork")
+                  .helptext("Sync with the upstream repository after successful fork")
                   .optional(),
             Switch.shortcut("")
                   .fullname("verbose")

--- a/cli/src/main/java/org/openjdk/skara/cli/GitFork.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitFork.java
@@ -99,7 +99,7 @@ public class GitFork {
         }
     }
 
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) throws IOException, InterruptedException {
         var flags = List.of(
             Option.shortcut("u")
                   .fullname("username")
@@ -141,6 +141,10 @@ public class GitFork {
             Switch.shortcut("")
                   .fullname("https")
                   .helptext("Use the https:// protocol when cloning")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("sync")
+                  .helptext("Sync with the upstream repository after succesful fork")
                   .optional(),
             Switch.shortcut("")
                   .fullname("verbose")
@@ -262,6 +266,11 @@ public class GitFork {
             var config = gitConfig("fork.no-remote");
             noRemote = config != null && config.toLowerCase().equals("true");
         }
+        boolean shouldSync = arguments.contains("sync");
+        if (!shouldSync) {
+            var config = gitConfig("fork.sync");
+            shouldSync = config != null && config.toLowerCase().equals("true");
+        }
         if (noClone || !arguments.at(0).isPresent()) {
             if (!arguments.at(0).isPresent()) {
                 var cwd = Path.of("").toAbsolutePath();
@@ -280,11 +289,15 @@ public class GitFork {
                     }
                     repo.addRemote("fork", forkURL);
                     System.out.println("done");
+
+                    if (shouldSync) {
+                        GitSync.sync(repo, new String[]{"--from", "origin", "--to", "fork"});
+                    }
                 }
             }
         } else {
             var reference = arguments.get("reference").orString(() -> gitConfig("fork.reference"));
-            if (reference.startsWith("~" + File.separator)) {
+            if (reference != null && reference.startsWith("~" + File.separator)) {
                 reference = System.getProperty("user.home") + reference.substring(1);
             }
             var depth = arguments.get("depth").orString(() -> gitConfig("fork.depth"));
@@ -339,6 +352,10 @@ public class GitFork {
                 repo.addRemote("upstream", upstreamUrl);
 
                 System.out.println("done");
+
+                if (shouldSync) {
+                    GitSync.sync(repo, new String[]{"--from", "upstream", "--to", "origin", "--pull"});
+                }
             }
         }
     }


### PR DESCRIPTION
Hi all,

please review this patch that adds the `--sync` option to `git-fork`. Setting
`--sync` (either via command-line or configuration file) makes `git-fork` sync
the fork with the upstream repository as a last step. This ensures that the
local clone of the fork on the user's machine is fully up to date with
upstream.

Note that I hade to shuffle some code around in `git-sync` to allow for this,
since `git-fork` simply just calls `git-sync` to implement this feaure.

Thanks,
Erik

- [x] Manual testing of `git-fork`
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**) **Note!** Review applies to e234fb973dafe60586290db3b5358d4907467ae5