### PR TITLE
git-sync: add --fast-forward option

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitSync.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitSync.java
@@ -47,6 +47,20 @@ public class GitSync {
         return pb.start().waitFor();
     }
 
+    private static int mergeFastForward(Repository repo, String ref) throws IOException, InterruptedException {
+        var pb = new ProcessBuilder("git", "merge", "--ff-only", "--quiet", ref);
+        pb.directory(repo.root().toFile());
+        pb.inheritIO();
+        return pb.start().waitFor();
+    }
+
+    private static int moveBranch(Repository repo, Branch branch, Hash to) throws IOException, InterruptedException {
+        var pb = new ProcessBuilder("git", "branch", "--force", branch.name(), to.hex());
+        pb.directory(repo.root().toFile());
+        pb.inheritIO();
+        return pb.start().waitFor();
+    }
+
     static void sync(Repository repo, String[] args) throws IOException, InterruptedException {
         var flags = List.of(
             Option.shortcut("")
@@ -67,6 +81,10 @@ public class GitSync {
             Switch.shortcut("")
                   .fullname("pull")
                   .helptext("Pull current branch from origin after successful sync")
+                  .optional(),
+            Switch.shortcut("ff")
+                  .fullname("fast-forward")
+                  .helptext("Fast forward all local branches where possible")
                   .optional(),
             Switch.shortcut("m")
                   .fullname("mercurial")
@@ -180,7 +198,8 @@ public class GitSync {
             }
         }
 
-        for (var branch : repo.remoteBranches(from)) {
+        var remoteBranches = repo.remoteBranches(from);
+        for (var branch : remoteBranches) {
             var name = branch.name();
             if (!branches.isEmpty() && !branches.contains(name)) {
                 if (arguments.contains("verbose") || arguments.contains("debug")) {
@@ -198,12 +217,54 @@ public class GitSync {
         var shouldPull = arguments.contains("pull");
         if (!shouldPull) {
             var lines = repo.config("sync.pull");
-            shouldPull = lines.size() == 1 && lines.get(0).toLowerCase().equals("always");
+            shouldPull = lines.size() == 1 && lines.get(0).toLowerCase().equals("true");
         }
         if (shouldPull) {
-            int err = pull(repo);
-            if (err != 0) {
-                System.exit(err);
+            var currentBranch = repo.currentBranch();
+            if (currentBranch.isPresent()) {
+                var upstreamBranch = repo.upstreamFor(currentBranch.get());
+                if (upstreamBranch.isPresent()) {
+                    int err = pull(repo);
+                    if (err != 0) {
+                        System.exit(err);
+                    }
+                }
+            }
+        }
+
+        var shouldFastForward = arguments.contains("fast-forward");
+        if (!shouldFastForward) {
+            var lines = repo.config("sync.fast-forward");
+            shouldFastForward = lines.size() == 1 && lines.get(0).toLowerCase().equals("true");
+        }
+        if (shouldFastForward) {
+            if (!remotes.contains(to)) {
+                die("error: --fast-forward can only be used when --to is the name of a remote");
+            }
+
+            var remoteBranchNames = new HashSet<String>();
+            for (var branch : remoteBranches) {
+                remoteBranchNames.add(to + "/" + branch.name());
+            }
+
+            var currentBranch = repo.currentBranch();
+            var localBranches = repo.branches();
+            for (var branch : localBranches) {
+                var upstreamBranch = repo.upstreamFor(branch);
+                if (upstreamBranch.isPresent() && remoteBranchNames.contains(upstreamBranch.get())) {
+                    var localHash = repo.resolve(branch);
+                    var upstreamHash = repo.resolve(upstreamBranch.get());
+                    if (localHash.isPresent() && upstreamHash.isPresent() &&
+                        !upstreamHash.equals(localHash) &&
+                        repo.isAncestor(localHash.get(), upstreamHash.get())) {
+                        var err = currentBranch.isPresent() && branch.equals(currentBranch.get()) ?
+                            mergeFastForward(repo, upstreamBranch.get()) :
+                            moveBranch(repo, branch, upstreamHash.get());
+                        if (err != 0) {
+                            System.exit(1);
+                        }
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Hi all,

please review this patch that adds the `--fast-forward` option to `git-sync`.
Setting the option `--fast-forward` will cause `git-sync` to fast-forward all
local branches where possible. Since it is mostly common that developer's do
not make change to branches in their personal forks that are also present in
the upstream repository, the effect is that all local branches that map to
upstream branches (via the personal fork) will be updated locally.

Thanks,
Erik

- Manual testing of `git-sync` on Linux x64
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)