### PR TITLE
193: git-pr: add flag --publish

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitPublish.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitPublish.java
@@ -90,6 +90,9 @@ public class GitPublish {
             System.err.println("error: the repository is in a detached HEAD state");
             System.exit(1);
         }
-        System.exit(pushAndTrack(remote, repo.currentBranch().get()));
+        var err = pushAndTrack(remote, repo.currentBranch().get());
+        if (err != 0) {
+            System.exit(err);
+        }
     }
 }


### PR DESCRIPTION
Hi all,

please review this patch that adds the flag `--publish` to `git-pr create`
(also configurable). When `--publish` is set then `git-pr` will call
`git-publish --quiet` if the branch is not yet pushed to the remote. This
avoids having to type `git publish && git pr create` when creating pull
requests from the command-line.

Note that I had to update `git-publish` a bit to fully support the `--quiet`
flag.

Thanks,
Erik

- [x] Manual testing of `git-pr create --publish`
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-193](https://bugs.openjdk.java.net/browse/SKARA-193): git-pr: add flag --publish


## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)