### PR TITLE
197: git-fork should use --dissociate with --reference-if-able

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitFork.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitFork.java
@@ -335,6 +335,7 @@ public class GitFork {
             var cloneArgs = new ArrayList<String>();
             if (reference != null) {
                 cloneArgs.add("--reference-if-able=" + reference);
+                cloneArgs.add("--dissociate");
             }
             if (depth != null) {
                 cloneArgs.add("--depth=" + depth);


### PR DESCRIPTION
Hi all,

please review this patch that ensures we use the `--dissociate` option to `git
clone` when someone is using `git fork --reference`. We need to use this flag
to ensure that the objects are only borrowed from the referenced repository to
reduce network transfer, we don't the borrow to continue after the clone.

Testing:
- [x] Manual testing of `git-pr fork --reference`

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-197](https://bugs.openjdk.java.net/browse/SKARA-197): git-fork should use --dissociate with --reference-if-able


## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)