### PR TITLE
198: git-pr should remember mapping between PR and local branch

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
@@ -786,6 +786,8 @@ public class GitPr {
             }
             System.out.println(pr.webUrl().toString());
             Files.deleteIfExists(file);
+
+            repo.config("pr." + currentBranch.name(), "id", pr.id().toString());
         } else if (action.equals("integrate") || action.equals("approve") || action.equals("test")) {
             var pr = getPullRequest(uri, repo, host, arguments.at(1));
 

--- a/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
@@ -786,8 +786,8 @@ public class GitPr {
             repo.config("pr." + currentBranch.name(), "id", pr.id().toString());
         } else if (action.equals("integrate") || action.equals("approve") || action.equals("test")) {
             String id = null;
-            if (arguments.at(0).isPresent()) {
-                id = arguments.at(0).asString();
+            if (arguments.at(1).isPresent()) {
+                id = arguments.at(1).asString();
             } else {
                 if (action.equals("approve")) {
                     exit("error: you must provide a pull request id");

--- a/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
@@ -170,12 +170,8 @@ public class GitPr {
         return targetRepo;
     }
 
-    private static PullRequest getPullRequest(URI uri, ReadOnlyRepository repo, Forge host, Argument prId) throws IOException {
-        if (!prId.isPresent()) {
-            exit("error: missing pull request identifier");
-        }
-
-        var pr = getHostedRepositoryFor(uri, repo, host).pullRequest(prId.asString());
+    private static PullRequest getPullRequest(URI uri, ReadOnlyRepository repo, Forge host, String prId) throws IOException {
+        var pr = getHostedRepositoryFor(uri, repo, host).pullRequest(prId);
         if (pr == null) {
             exit("error: could not fetch PR information");
         }
@@ -789,7 +785,26 @@ public class GitPr {
 
             repo.config("pr." + currentBranch.name(), "id", pr.id().toString());
         } else if (action.equals("integrate") || action.equals("approve") || action.equals("test")) {
-            var pr = getPullRequest(uri, repo, host, arguments.at(1));
+            String id = null;
+            if (arguments.at(0).isPresent()) {
+                id = arguments.at(0).asString();
+            } else {
+                if (action.equals("approve")) {
+                    exit("error: you must provide a pull request id");
+                } else {
+                    var currentBranch = repo.currentBranch();
+                    if (currentBranch.isPresent()) {
+                        var lines = repo.config("pr." + currentBranch.get().name() + ".id");
+                        if (lines.size() == 1) {
+                            id = lines.get(0);
+                        } else {
+                            exit("error: you must provide a pull request id");
+                        }
+                    }
+                }
+            }
+
+            var pr = getPullRequest(uri, repo, host, id);
 
             if (action.equals("integrate")) {
                 pr.addComment("/integrate");

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
@@ -64,6 +64,10 @@ public interface Repository extends ReadOnlyRepository {
     void pull(String remote) throws IOException;
     void pull(String remote, String refspec) throws IOException;
     void addremove() throws IOException;
+    void config(String section, String key, String value, boolean global) throws IOException;
+    default void config(String section, String key, String value) throws IOException {
+        config(section, key, value, false);
+    }
     Hash commit(String message,
                 String authorName,
                 String authorEmail) throws IOException;

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -1188,4 +1188,18 @@ public class GitRepository implements Repository {
             return Optional.empty();
         }
     }
+
+    @Override
+    public void config(String section, String key, String value, boolean global) throws IOException {
+        var cmd = new ArrayList<String>();
+        cmd.addAll(List.of("git", "config"));
+        if (global) {
+            cmd.add("--global");
+        }
+        cmd.add(section + "." + key);
+        cmd.add(value);
+        try (var p = capture(cmd)) {
+            await(p);
+        }
+    }
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -1212,4 +1212,20 @@ public class HgRepository implements Repository {
         }
         return Optional.empty();
     }
+
+    @Override
+    public void config(String section, String key, String value, boolean global) throws IOException {
+        var hgrc = global ?
+            Path.of(System.getProperty("user.home"), ".hgrc") :
+            root().resolve(".hg").resolve("hgrc");
+
+        var lines = List.of(
+            "[" + section + "]",
+            key + " = " + value
+        );
+        if (!Files.exists(hgrc)) {
+            Files.createFile(hgrc);
+        }
+        Files.write(hgrc, lines, StandardOpenOption.WRITE, StandardOpenOption.APPEND);
+    }
 }

--- a/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
@@ -1948,7 +1948,7 @@ public class RepositoryTests {
     @ParameterizedTest
     @EnumSource(VCS.class)
     void testDiffWithFileList(VCS vcs) throws IOException {
-        try (var dir = new TemporaryDirectory(false)) {
+        try (var dir = new TemporaryDirectory()) {
             var repo = Repository.init(dir.path(), vcs);
             var readme = repo.root().resolve("README");
             Files.writeString(readme, "Hello\n");
@@ -1992,6 +1992,17 @@ public class RepositoryTests {
 
             diff = repo.diff(first, second, List.of(Path.of("DOES_NOT_EXIST")));
             assertEquals(0, diff.patches().size());
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(VCS.class)
+    void testWritingConfigValue(VCS vcs) throws IOException {
+        try (var dir = new TemporaryDirectory(false)) {
+            var repo = Repository.init(dir.path(), vcs);
+            assertEquals(List.of(), repo.config("test.key"));
+            repo.config("test", "key", "value");
+            assertEquals(List.of("value"), repo.config("test.key"));
         }
     }
 }

--- a/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
@@ -1998,7 +1998,7 @@ public class RepositoryTests {
     @ParameterizedTest
     @EnumSource(VCS.class)
     void testWritingConfigValue(VCS vcs) throws IOException {
-        try (var dir = new TemporaryDirectory(false)) {
+        try (var dir = new TemporaryDirectory()) {
             var repo = Repository.init(dir.path(), vcs);
             assertEquals(List.of(), repo.config("test.key"));
             repo.config("test", "key", "value");


### PR DESCRIPTION
Hi all,

please review this patch that adds a mapping between pull requests and local
branches. This is done by adding a section per local branch to the
repositorie's local configuration file, for example:

```
[pr "skara-198"]
id = 310
```

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-198](https://bugs.openjdk.java.net/browse/SKARA-198): git-pr should remember mapping between PR and local branch


## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)