### PR TITLE
200: git-info should show link to review

### DIFF
--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/JCheckConfiguration.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/JCheckConfiguration.java
@@ -141,11 +141,17 @@ public class JCheckConfiguration {
         return new JCheckConfiguration(ini);
     }
 
-    public static JCheckConfiguration from(Repository r, Hash h, Path p) throws IOException {
+    public static JCheckConfiguration from(ReadOnlyRepository r, Hash h, Path p) throws IOException {
         return parse(r.lines(p, h).orElse(Collections.emptyList()));
     }
 
-    public static JCheckConfiguration from(Repository r, Hash h) throws IOException {
+    public static JCheckConfiguration from(ReadOnlyRepository r, Hash h) throws IOException {
         return from(r, h, Path.of(".jcheck", "conf"));
+    }
+
+    public static JCheckConfiguration from(ReadOnlyRepository r) throws IOException {
+        var master = r.resolve("master")
+                      .orElseThrow(() -> new IOException("Cannot resolve 'master' branch"));
+        return from(r, master, Path.of(".jcheck", "conf"));
     }
 }


### PR DESCRIPTION
Hi all,

please review this patch that adds the flag `--review` to `git-info`. This
allows a user to show the link to the pull request for a given commit, for
example in the Skara repository:

```bash
$ git info --review --no-decoration 914cbefe88a059db12e9e55ac6a3168c75a005fd
https://git.openjdk.java.net/skara/pull/322
```

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-200](https://bugs.openjdk.java.net/browse/SKARA-200): git-info should show link to review


## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)