### PR TITLE
203: git-pr: add flag --jcheck to run jcheck as part of git-pr create

### DIFF
--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/JCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/JCheck.java
@@ -181,7 +181,7 @@ public class JCheck {
         }
 
         @Override
-        public void close() throws Exception {
+        public void close() throws IOException {
             if (resource != null) {
                 resource.close();
             }


### PR DESCRIPTION
Hi all,

please review this patch that adds the flag `--jcheck` to `git-pr create`. As
the name suggests, adding the flag `--jcheck` to `git-pr create` will cause
`git-pr create` to run jcheck on the commits that will be part of the pull
request. Since not all messages are relevant for commits that are to be part of
a pull request (i.e. commit message errors do not matter) I added a new flag to
jcheck `--pull-request` to filter out those.

I also had to some slight refactoring to `GitJCheck.java` to allow it to be
called from other Java code.

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-203](https://bugs.openjdk.java.net/browse/SKARA-203): git-pr: add flag --jcheck to run jcheck as part of git-pr create


## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)