### PR TITLE
204: git-sync: must fetch before --fast-forward

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitSync.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitSync.java
@@ -241,6 +241,7 @@ public class GitSync {
             if (!remotes.contains(to)) {
                 die("error: --fast-forward can only be used when --to is the name of a remote");
             }
+            repo.fetchRemote(to);
 
             var remoteBranchNames = new HashSet<String>();
             for (var branch : remoteBranches) {

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
@@ -44,6 +44,7 @@ public interface Repository extends ReadOnlyRepository {
     }
     Hash fetch(URI uri, String refspec) throws IOException;
     void fetchAll() throws IOException;
+    void fetchRemote(String remote) throws IOException;
     void pushAll(URI uri) throws IOException;
     void push(Hash hash, URI uri, String ref, boolean force) throws IOException;
     void push(Branch branch, String remote, boolean setUpstream) throws IOException;

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -343,6 +343,13 @@ public class GitRepository implements Repository {
         }
     }
 
+    @Override
+    public void fetchRemote(String remote) throws IOException {
+        try (var p = capture("git", "fetch", "--recurse-submodules=on-demand", "--tags", "--prune", "--prune-tags", remote)) {
+            await(p);
+        }
+    }
+
     private void checkout(String ref, boolean force) throws IOException {
         var cmd = new ArrayList<String>();
         cmd.addAll(List.of("git", "-c", "advice.detachedHead=false", "checkout", "--recurse-submodules"));

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -335,6 +335,10 @@ public class HgRepository implements Repository {
 
     @Override
     public Hash fetch(URI uri, String refspec) throws IOException {
+        return fetch(uri != null ? uri.toString() : null, refspec);
+    }
+
+    private Hash fetch(String from, String refspec) throws IOException {
         var oldHeads = new HashSet<Hash>(heads());
 
         var cmd = new ArrayList<String>();
@@ -344,8 +348,8 @@ public class HgRepository implements Repository {
             cmd.add("--rev");
             cmd.add(refspec);
         }
-        if (uri != null) {
-            cmd.add(uri.toString());
+        if (from != null) {
+            cmd.add(from);
         }
         try (var p = capture(cmd)) {
             await(p);
@@ -381,6 +385,11 @@ public class HgRepository implements Repository {
         for (var uri : pullPaths) {
             fetch(uri, null);
         }
+    }
+
+    @Override
+    public void fetchRemote(String remote) throws IOException {
+        fetch(remote, null);
     }
 
     @Override


### PR DESCRIPTION
Hi all,

please review this patch that ensures `git sync --fast-forward` fetches the
changes from the `to` remote _before_ trying to do "fast forward" merges. This
is needed because doing a push to a remote ref does not cause that ref to be
updated.

Thanks,
Erik

## Testing
- [x] Manual testing of `git sync --fast-foward`
- [x] Added a new unit test
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-204](https://bugs.openjdk.java.net/browse/SKARA-204): git-sync: must fetch before --fast-forward


## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)