### PR TITLE
205: git-pr: allow configurable default action

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
@@ -366,7 +366,7 @@ public class GitPr {
             Input.position(0)
                  .describe("list|fetch|show|checkout|apply|integrate|approve|create|close|update|test")
                  .singular()
-                 .required(),
+                 .optional(),
             Input.position(1)
                  .describe("ID")
                  .singular()
@@ -419,7 +419,14 @@ public class GitPr {
         }
         var host = forge.get();
 
-        var action = arguments.at(0).asString();
+        var action = arguments.at(0).isPresent() ? arguments.at(0).asString() : null;
+        if (action == null) {
+            var lines = repo.config("pr.default");
+            if (lines.size() == 1) {
+                action = lines.get(0);
+            }
+        }
+
         if (!shouldUseToken &&
             !List.of("list", "fetch", "show", "checkout", "apply").contains(action)) {
             System.err.println("error: --no-token can only be used with read-only operations");


### PR DESCRIPTION
Hi all,

please review this small patch that makes the default action of `git pr`
configurable.

Thanks,
Erik

## Testing
- [x] Manual testing of `git pr` with and without a default action
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-205](https://bugs.openjdk.java.net/browse/SKARA-205): git-pr: allow configurable default action


## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)