### PR TITLE
206: Add proper escaping for replacement pattern

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/TextToMarkdown.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/TextToMarkdown.java
@@ -22,7 +22,7 @@
  */
 package org.openjdk.skara.bots.mlbridge;
 
-import java.util.regex.Pattern;
+import java.util.regex.*;
 
 public class TextToMarkdown {
     private static final Pattern punctuationPattern = Pattern.compile("([!\"#$%&'()*+,\\-./:;<=?@\\[\\]^_`{|}~])", Pattern.MULTILINE);
@@ -34,7 +34,7 @@ public class TextToMarkdown {
 
     private static String escapePunctuation(String text) {
         var punctuationMatcher = punctuationPattern.matcher(text);
-        return punctuationMatcher.replaceAll(mr -> "\\\\" + mr.group(1));
+        return punctuationMatcher.replaceAll(mr -> "\\\\" + Matcher.quoteReplacement(mr.group(1)));
     }
 
     private static String escapeIndention(String text) {

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/TextToMarkdownTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/TextToMarkdownTests.java
@@ -43,4 +43,9 @@ class TextToMarkdownTests {
     void preserveQuoting() {
         assertEquals("> quoted", TextToMarkdown.escapeFormatting("> quoted"));
     }
+
+    @Test
+    void escapedPattern() {
+        assertEquals("1\\$2", TextToMarkdown.escapeFormatting("1$2"));
+    }
 }


### PR DESCRIPTION
Hi all,

Please review this fix that adds proper escaping for replacement patterns in the `TextToMarkdown.escapeFormatting` function. Previously it was possible for exceptions to be thrown on certain input containing regex control characters.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-206](https://bugs.openjdk.java.net/browse/SKARA-206): Improper quoting of regex replacement pattern


## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)