### PR TITLE
208: git-publish: off-by-one error when parsing --quiet

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitPublish.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitPublish.java
@@ -116,7 +116,7 @@ public class GitPublish {
         var isQuiet = arguments.contains("quiet");
         if (!isQuiet) {
             var lines = repo.config("publish.quiet");
-            isQuiet = lines.size() == 0 && lines.get(0).toLowerCase().equals("true");
+            isQuiet = lines.size() == 1 && lines.get(0).toLowerCase().equals("true");
         }
         var err = pushAndTrack(remote, repo.currentBranch().get(), isQuiet);
         if (err != 0) {


### PR DESCRIPTION
Hi all,

please review this tiny patch that fixes an (embarrassing) off-by-one indexing error in `GitPublish.java`.

Thanks,
Erik

## Testing
- [x] Manual testing of `git-publish`
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-208](https://bugs.openjdk.java.net/browse/SKARA-208): git-publish: off-by-one error when parsing --quiet


## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)