### PR TITLE
207: Retry failed mlbridge comment post operations

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBot.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBot.java
@@ -49,6 +49,10 @@ public class MailingListArchiveReaderBot implements Bot {
         this.repositories = repositories;
     }
 
+    private synchronized void invalidate(List<Email> messages) {
+        messages.forEach(m -> parsedEmailIds.remove(m.id()));
+    }
+
     synchronized void inspect(Conversation conversation) {
         // Is this a new conversation?
         if (!parsedConversations.containsKey(conversation.first().id())) {
@@ -111,7 +115,7 @@ public class MailingListArchiveReaderBot implements Bot {
             return;
         }
 
-        var workItem = new CommentPosterWorkItem(pr, bridgeCandidates);
+        var workItem = new CommentPosterWorkItem(pr, bridgeCandidates, e -> invalidate(bridgeCandidates));
         commentQueue.add(workItem);
     }
 


### PR DESCRIPTION
Hi all,

Please review this change that ensures that failed mlbridge comment post operations are retried. It also ensures that unique post operations can run concurrently (and thus will not be dropped in case the scheduler is saturated).

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-207](https://bugs.openjdk.java.net/browse/SKARA-207): Retry failed mlbridge comment post operations


## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)