### PR TITLE
210: git-pr: add BRANCH column to git-pr list

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
@@ -92,7 +92,7 @@ class ArchiveMessages {
 
     private static String fetchCommand(PullRequest pr) {
         var repoUrl = pr.repository().webUrl();
-        return "git fetch " + repoUrl + " " + pr.sourceRef() + ":pull/" + pr.id();
+        return "git fetch " + repoUrl + " " + pr.fetchRef() + ":pull/" + pr.id();
     }
 
     static String composeConversation(PullRequest pr, Hash base, Hash head) {

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
@@ -60,7 +60,7 @@ class WebrevStorage {
         return "This file was too large to be included in the published webrev, and has been replaced with " +
                 "this placeholder message. It is possible to generate the original content locally by " +
                 "following these instructions:\n\n" +
-                "  $ git fetch " + pr.repository().webUrl() + " " + pr.sourceRef() + "\n" +
+                "  $ git fetch " + pr.repository().webUrl() + " " + pr.fetchRef() + "\n" +
                 "  $ git checkout " + head.hex() + "\n" +
                 "  $ git webrev -r " + base.hex() + "\n";
     }

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
@@ -85,7 +85,17 @@ class InMemoryPullRequest implements PullRequest {
     }
 
     @Override
+    public String fetchRef() {
+        return null;
+    }
+
+    @Override
     public String sourceRef() {
+        return null;
+    }
+
+    @Override
+    public HostedRepository sourceRepository() {
         return null;
     }
 

--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
@@ -73,10 +73,22 @@ public interface PullRequest extends Issue {
     Hash headHash();
 
     /**
+     * Returns the name of the ref used for fetching the pull request.
+     * @return
+     */
+    String fetchRef();
+
+    /**
      * Returns the name of the ref the request is created from.
      * @return
      */
     String sourceRef();
+
+    /**
+     * Returns the repository the request is created from.
+     * @return
+     */
+    HostedRepository sourceRepository();
 
     /**
      * Returns the name of the ref the request is intended to be merged into.

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -216,8 +216,18 @@ public class GitHubPullRequest implements PullRequest {
     }
 
     @Override
-    public String sourceRef() {
+    public String fetchRef() {
         return "pull/" + id() + "/head";
+    }
+
+    @Override
+    public String sourceRef() {
+        return json.get("head").get("ref").asString();
+    }
+
+    @Override
+    public HostedRepository sourceRepository() {
+        return new GitHubRepository(host, json.get("head").get("repo").get("full_name").asString());
     }
 
     @Override

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -256,8 +256,19 @@ public class GitLabMergeRequest implements PullRequest {
     }
 
     @Override
-    public String sourceRef() {
+    public String fetchRef() {
         return "merge-requests/" + id() + "/head";
+    }
+
+    @Override
+    public String sourceRef() {
+        return json.get("source_branch").asString();
+    }
+
+    @Override
+    public HostedRepository sourceRepository() {
+        return new GitLabRepository((GitLabHost) repository.forge(),
+                                    json.get("head").get("source_project_id").asString());
     }
 
     @Override

--- a/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
@@ -134,8 +134,18 @@ public class TestPullRequest extends TestIssue implements PullRequest {
     }
 
     @Override
+    public String fetchRef() {
+        return sourceRef;
+    }
+
+    @Override
     public String sourceRef() {
         return sourceRef;
+    }
+
+    @Override
+    public HostedRepository sourceRepository() {
+        return repository;
     }
 
     @Override


### PR DESCRIPTION
Hi all,

please review this patch that adds the "BRANCH" column to the `git pr list`
output. The branch column will list the local branches in a repository that
corresponds to a pull request.

@rwestberg I had to make a few changes to `PullRequest`:

- renamed `sourceRef` to `fetchRef`
- added `sourceRef` which now really means the reference in the source
  repository :smiley:
- added `sourceRepository` for getting the source repository for a pull request

I did the rename of `sourceRef` to `fetchRef` first, so I shouldn't have missed
updating any places where it was used.

Thanks,
Erik

## Testing
- [x] `make test` on Linux x64
- [x] Manual testing of `git pr list` on Linux x64
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-210](https://bugs.openjdk.java.net/browse/SKARA-210): git-pr: add BRANCH column to git-pr list


## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)