### PR TITLE
212: Retry notifications for updaters that can check current state

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/IssueUpdater.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/IssueUpdater.java
@@ -32,7 +32,7 @@ import org.openjdk.skara.vcs.openjdk.*;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Path;
-import java.util.List;
+import java.util.*;
 import java.util.logging.Logger;
 
 public class IssueUpdater implements RepositoryUpdateConsumer, PullRequestUpdateConsumer {
@@ -61,14 +61,21 @@ public class IssueUpdater implements RepositoryUpdateConsumer, PullRequestUpdate
             var commitNotification = CommitFormatters.toTextBrief(repository, commit);
             var commitMessage = CommitMessageParsers.v1.parse(commit);
             for (var commitIssue : commitMessage.issues()) {
-                var issue = issueProject.issue(commitIssue.id());
-                if (issue.isEmpty()) {
+                var optionalIssue = issueProject.issue(commitIssue.id());
+                if (optionalIssue.isEmpty()) {
                     log.severe("Cannot update issue " + commitIssue.id() + " with commit " + commit.hash().abbreviate()
                                        + " - issue not found in issue project");
                     continue;
                 }
-                issue.get().addComment(commitNotification);
-                issue.get().setState(Issue.State.RESOLVED);
+                var issue = optionalIssue.get();
+                var existingComments = issue.comments();
+                var alreadyPostedComment = existingComments.stream()
+                                                           .filter(comment -> comment.author().equals(issueProject.issueTracker().currentUser()))
+                                                           .anyMatch(comment -> comment.body().contains(commit.hash().abbreviate()));
+                if (!alreadyPostedComment) {
+                    issue.addComment(commitNotification);
+                }
+                issue.setState(Issue.State.RESOLVED);
 
                 if (commitLink) {
                     var linkBuilder = Link.create(repository.webUrl(commit.hash()), "Commit")
@@ -77,23 +84,26 @@ public class IssueUpdater implements RepositoryUpdateConsumer, PullRequestUpdate
                         linkBuilder.iconTitle("Commit");
                         linkBuilder.iconUrl(commitIcon);
                     }
-                    issue.get().addLink(linkBuilder.build());
+                    issue.addLink(linkBuilder.build());
                 }
 
                 if (setFixVersion) {
-                    if (fixVersion == null) {
+                    var requestedVersion = fixVersion;
+                    if (requestedVersion == null) {
                         try {
                             var conf = localRepository.lines(Path.of(".jcheck/conf"), commit.hash());
                             if (conf.isPresent()) {
                                 var parsed = JCheckConfiguration.parse(conf.get());
                                 var version = parsed.general().version();
-                                version.ifPresent(v -> issue.get().addFixVersion(v));
+                                requestedVersion = version.orElse(null);
                             }
                         } catch (IOException e) {
                             throw new RuntimeException(e);
                         }
-                    } else {
-                        issue.get().addFixVersion(fixVersion);
+                    }
+
+                    if (requestedVersion != null) {
+                        issue.addFixVersion(requestedVersion);
                     }
                 }
             }
@@ -101,18 +111,23 @@ public class IssueUpdater implements RepositoryUpdateConsumer, PullRequestUpdate
     }
 
     @Override
-    public void handleOpenJDKTagCommits(HostedRepository repository, Repository loclRepository, List<Commit> commits, OpenJDKTag tag, Tag.Annotated annotated) {
+    public void handleOpenJDKTagCommits(HostedRepository repository, Repository localRepository, List<Commit> commits, OpenJDKTag tag, Tag.Annotated annotated) {
 
     }
 
     @Override
-    public void handleTagCommit(HostedRepository repository, Repository loclRepository, Commit commit, Tag tag, Tag.Annotated annotation) {
+    public void handleTagCommit(HostedRepository repository, Repository localRepository, Commit commit, Tag tag, Tag.Annotated annotation) {
 
     }
 
     @Override
-    public void handleNewBranch(HostedRepository repository, Repository loclRepository, List<Commit> commits, Branch parent, Branch branch) {
+    public void handleNewBranch(HostedRepository repository, Repository localRepository, List<Commit> commits, Branch parent, Branch branch) {
 
+    }
+
+    @Override
+    public boolean idempotent() {
+        return true;
     }
 
     @Override

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/IssueUpdater.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/IssueUpdater.java
@@ -69,9 +69,10 @@ public class IssueUpdater implements RepositoryUpdateConsumer, PullRequestUpdate
                 }
                 var issue = optionalIssue.get();
                 var existingComments = issue.comments();
+                var hashUrl = repository.webUrl(commit.hash()).toString();
                 var alreadyPostedComment = existingComments.stream()
                                                            .filter(comment -> comment.author().equals(issueProject.issueTracker().currentUser()))
-                                                           .anyMatch(comment -> comment.body().contains(commit.hash().abbreviate()));
+                                                           .anyMatch(comment -> comment.body().contains(hashUrl));
                 if (!alreadyPostedComment) {
                     issue.addComment(commitNotification);
                 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/IssueUpdater.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/IssueUpdater.java
@@ -127,7 +127,7 @@ public class IssueUpdater implements RepositoryUpdateConsumer, PullRequestUpdate
     }
 
     @Override
-    public boolean idempotent() {
+    public boolean isIdempotent() {
         return true;
     }
 

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/JsonUpdater.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/JsonUpdater.java
@@ -106,4 +106,9 @@ public class JsonUpdater implements RepositoryUpdateConsumer {
     @Override
     public void handleNewBranch(HostedRepository repository, Repository localRepository, List<Commit> commits, Branch parent, Branch branch) {
     }
+
+    @Override
+    public boolean idempotent() {
+        return false;
+    }
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/JsonUpdater.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/JsonUpdater.java
@@ -108,7 +108,7 @@ public class JsonUpdater implements RepositoryUpdateConsumer {
     }
 
     @Override
-    public boolean idempotent() {
+    public boolean isIdempotent() {
         return false;
     }
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/MailingListUpdater.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/MailingListUpdater.java
@@ -325,4 +325,9 @@ public class MailingListUpdater implements RepositoryUpdateConsumer {
                          .build();
         list.post(email);
     }
+
+    @Override
+    public boolean idempotent() {
+        return false;
+    }
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/MailingListUpdater.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/MailingListUpdater.java
@@ -327,7 +327,7 @@ public class MailingListUpdater implements RepositoryUpdateConsumer {
     }
 
     @Override
-    public boolean idempotent() {
+    public boolean isIdempotent() {
         return false;
     }
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/PullRequestUpdateConsumer.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/PullRequestUpdateConsumer.java
@@ -28,5 +28,4 @@ import org.openjdk.skara.vcs.openjdk.Issue;
 public interface PullRequestUpdateConsumer {
     void handleNewIssue(PullRequest pr, Issue issue);
     void handleRemovedIssue(PullRequest pr, Issue issue);
-    boolean idempotent();
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/PullRequestUpdateConsumer.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/PullRequestUpdateConsumer.java
@@ -28,4 +28,5 @@ import org.openjdk.skara.vcs.openjdk.Issue;
 public interface PullRequestUpdateConsumer {
     void handleNewIssue(PullRequest pr, Issue issue);
     void handleRemovedIssue(PullRequest pr, Issue issue);
+    boolean idempotent();
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryUpdateConsumer.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryUpdateConsumer.java
@@ -33,7 +33,7 @@ public interface RepositoryUpdateConsumer {
     void handleOpenJDKTagCommits(HostedRepository repository, Repository localRepository, List<Commit> commits, OpenJDKTag tag, Tag.Annotated annotated);
     void handleTagCommit(HostedRepository repository, Repository localRepository, Commit commit, Tag tag, Tag.Annotated annotation);
     void handleNewBranch(HostedRepository repository, Repository localRepository, List<Commit> commits, Branch parent, Branch branch);
-    boolean idempotent();
+    boolean isIdempotent();
 
     default void handleOpenJDKTagCommits(HostedRepository repository, Repository localRepository, List<Commit> commits, OpenJDKTag tag) {
         handleOpenJDKTagCommits(repository, localRepository, commits, tag, null);

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryUpdateConsumer.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryUpdateConsumer.java
@@ -33,6 +33,7 @@ public interface RepositoryUpdateConsumer {
     void handleOpenJDKTagCommits(HostedRepository repository, Repository localRepository, List<Commit> commits, OpenJDKTag tag, Tag.Annotated annotated);
     void handleTagCommit(HostedRepository repository, Repository localRepository, Commit commit, Tag tag, Tag.Annotated annotation);
     void handleNewBranch(HostedRepository repository, Repository localRepository, List<Commit> commits, Branch parent, Branch branch);
+    boolean idempotent();
 
     default void handleOpenJDKTagCommits(HostedRepository repository, Repository localRepository, List<Commit> commits, OpenJDKTag tag) {
         handleOpenJDKTagCommits(repository, localRepository, commits, tag, null);

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryWorkItem.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryWorkItem.java
@@ -55,7 +55,7 @@ public class RepositoryWorkItem implements WorkItem {
         this.updaters = updaters;
     }
 
-    private void handleNewRef(Repository localRepo, Reference ref, Collection<Reference> allRefs) {
+    private void handleNewRef(Repository localRepo, Reference ref, Collection<Reference> allRefs, boolean idempotent) {
         // Figure out the best parent ref
         var candidates = new HashSet<>(allRefs);
         candidates.remove(ref);
@@ -79,14 +79,20 @@ public class RepositoryWorkItem implements WorkItem {
                                                " detected (" + bestParent.getValue().size() + ") - skipping notifications");
         }
         for (var updater : updaters) {
+            if (updater.idempotent() != idempotent) {
+                continue;
+            }
             var branch = new Branch(ref.name());
             var parent = new Branch(bestParent.getKey().name());
             updater.handleNewBranch(repository, localRepo, bestParent.getValue(), parent, branch);
         }
     }
 
-    private void handleUpdatedRef(Repository localRepo, Reference ref, List<Commit> commits) {
+    private void handleUpdatedRef(Repository localRepo, Reference ref, List<Commit> commits, boolean idempotent) {
         for (var updater : updaters) {
+            if (updater.idempotent() != idempotent) {
+                continue;
+            }
             var branch = new Branch(ref.name());
             updater.handleCommits(repository, localRepo, commits, branch);
         }
@@ -97,20 +103,24 @@ public class RepositoryWorkItem implements WorkItem {
         var lastHash = history.branchHash(branch);
         if (lastHash.isEmpty()) {
             log.warning("No previous history found for branch '" + branch + "' - resetting mark");
+            handleNewRef(localRepo, ref, allRefs, true);
             history.setBranchHash(branch, ref.hash());
-            handleNewRef(localRepo, ref, allRefs);
+            handleNewRef(localRepo, ref, allRefs, false);
         } else {
             var commits = localRepo.commits(lastHash.get() + ".." + ref.hash()).asList();
             if (commits.size() == 0) {
                 return;
             }
-            history.setBranchHash(branch, ref.hash());
             if (commits.size() > 1000) {
+                history.setBranchHash(branch, ref.hash());
                 throw new RuntimeException("Excessive amount of new commits on branch " + branch.name() +
                                                    " detected (" + commits.size() + ") - skipping notifications");
             }
+
             Collections.reverse(commits);
-            handleUpdatedRef(localRepo, ref, commits);
+            handleUpdatedRef(localRepo, ref, commits, true);
+            history.setBranchHash(branch, ref.hash());
+            handleUpdatedRef(localRepo, ref, commits, false);
         }
     }
 
@@ -160,9 +170,6 @@ public class RepositoryWorkItem implements WorkItem {
                                 .sorted(Comparator.comparingInt(OpenJDKTag::buildNum))
                                 .collect(Collectors.toList());
         for (var tag : newJdkTags) {
-            // Update the history first - if there is a problem here we don't want to send out multiple updates
-            history.addTags(List.of(tag.tag()));
-
             var commits = new ArrayList<Commit>();
 
             // Try to determine which commits are new since the last build
@@ -183,27 +190,44 @@ public class RepositoryWorkItem implements WorkItem {
 
             Collections.reverse(commits);
             var annotation = localRepo.annotate(tag.tag());
-            for (var updater : updaters) {
-                updater.handleOpenJDKTagCommits(repository, localRepo, commits, tag, annotation.orElse(null));
-            }
+
+            // Run all notifiers that can be safely re-run
+            updaters.stream()
+                    .filter(RepositoryUpdateConsumer::idempotent)
+                    .forEach(updater -> updater.handleOpenJDKTagCommits(repository, localRepo, commits, tag, annotation.orElse(null)));
+
+            // Now update the history
+            history.addTags(List.of(tag.tag()));
+
+            // Finally run all one-shot notifiers
+            updaters.stream()
+                    .filter(updater -> !updater.idempotent())
+                    .forEach(updater -> updater.handleOpenJDKTagCommits(repository, localRepo, commits, tag, annotation.orElse(null)));
         }
 
         var newNonJdkTags = newTags.stream()
                                    .filter(tag -> OpenJDKTag.create(tag).isEmpty())
                                    .collect(Collectors.toList());
         for (var tag : newNonJdkTags) {
-            // Update the history first - if there is a problem here we don't want to send out multiple updates
-            history.addTags(List.of(tag));
-
             var commit = localRepo.lookup(tag);
             if (commit.isEmpty()) {
                 throw new RuntimeException("Failed to lookup tag '" + tag.toString() + "'");
             }
 
             var annotation = localRepo.annotate(tag);
-            for (var updater : updaters) {
-                updater.handleTagCommit(repository, localRepo, commit.get(), tag, annotation.orElse(null));
-            }
+
+            // Run all notifiers that can be safely re-run
+            updaters.stream()
+                    .filter(RepositoryUpdateConsumer::idempotent)
+                    .forEach(updater -> updater.handleTagCommit(repository, localRepo, commit.get(), tag, annotation.orElse(null)));
+
+            // Now update the history
+            history.addTags(List.of(tag));
+
+            // Finally run all one-shot notifiers
+            updaters.stream()
+                    .filter(updater -> !updater.idempotent())
+                    .forEach(updater -> updater.handleTagCommit(repository, localRepo, commit.get(), tag, annotation.orElse(null)));
         }
     }
 

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryWorkItem.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryWorkItem.java
@@ -55,7 +55,7 @@ public class RepositoryWorkItem implements WorkItem {
         this.updaters = updaters;
     }
 
-    private void handleNewRef(Repository localRepo, Reference ref, Collection<Reference> allRefs, boolean idempotent) {
+    private void handleNewRef(Repository localRepo, Reference ref, Collection<Reference> allRefs, boolean runOnlyIdempotent) {
         // Figure out the best parent ref
         var candidates = new HashSet<>(allRefs);
         candidates.remove(ref);
@@ -79,7 +79,7 @@ public class RepositoryWorkItem implements WorkItem {
                                                " detected (" + bestParent.getValue().size() + ") - skipping notifications");
         }
         for (var updater : updaters) {
-            if (updater.idempotent() != idempotent) {
+            if (updater.idempotent() != runOnlyIdempotent) {
                 continue;
             }
             var branch = new Branch(ref.name());
@@ -88,9 +88,9 @@ public class RepositoryWorkItem implements WorkItem {
         }
     }
 
-    private void handleUpdatedRef(Repository localRepo, Reference ref, List<Commit> commits, boolean idempotent) {
+    private void handleUpdatedRef(Repository localRepo, Reference ref, List<Commit> commits, boolean runOnlyIdempotent) {
         for (var updater : updaters) {
-            if (updater.idempotent() != idempotent) {
+            if (updater.idempotent() != runOnlyIdempotent) {
                 continue;
             }
             var branch = new Branch(ref.name());

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryWorkItem.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryWorkItem.java
@@ -79,7 +79,7 @@ public class RepositoryWorkItem implements WorkItem {
                                                " detected (" + bestParent.getValue().size() + ") - skipping notifications");
         }
         for (var updater : updaters) {
-            if (updater.idempotent() != runOnlyIdempotent) {
+            if (updater.isIdempotent() != runOnlyIdempotent) {
                 continue;
             }
             var branch = new Branch(ref.name());
@@ -90,7 +90,7 @@ public class RepositoryWorkItem implements WorkItem {
 
     private void handleUpdatedRef(Repository localRepo, Reference ref, List<Commit> commits, boolean runOnlyIdempotent) {
         for (var updater : updaters) {
-            if (updater.idempotent() != runOnlyIdempotent) {
+            if (updater.isIdempotent() != runOnlyIdempotent) {
                 continue;
             }
             var branch = new Branch(ref.name());
@@ -193,7 +193,7 @@ public class RepositoryWorkItem implements WorkItem {
 
             // Run all notifiers that can be safely re-run
             updaters.stream()
-                    .filter(RepositoryUpdateConsumer::idempotent)
+                    .filter(RepositoryUpdateConsumer::isIdempotent)
                     .forEach(updater -> updater.handleOpenJDKTagCommits(repository, localRepo, commits, tag, annotation.orElse(null)));
 
             // Now update the history
@@ -201,7 +201,7 @@ public class RepositoryWorkItem implements WorkItem {
 
             // Finally run all one-shot notifiers
             updaters.stream()
-                    .filter(updater -> !updater.idempotent())
+                    .filter(updater -> !updater.isIdempotent())
                     .forEach(updater -> updater.handleOpenJDKTagCommits(repository, localRepo, commits, tag, annotation.orElse(null)));
         }
 
@@ -218,7 +218,7 @@ public class RepositoryWorkItem implements WorkItem {
 
             // Run all notifiers that can be safely re-run
             updaters.stream()
-                    .filter(RepositoryUpdateConsumer::idempotent)
+                    .filter(RepositoryUpdateConsumer::isIdempotent)
                     .forEach(updater -> updater.handleTagCommit(repository, localRepo, commit.get(), tag, annotation.orElse(null)));
 
             // Now update the history
@@ -226,7 +226,7 @@ public class RepositoryWorkItem implements WorkItem {
 
             // Finally run all one-shot notifiers
             updaters.stream()
-                    .filter(updater -> !updater.idempotent())
+                    .filter(updater -> !updater.isIdempotent())
                     .forEach(updater -> updater.handleTagCommit(repository, localRepo, commit.get(), tag, annotation.orElse(null)));
         }
     }

--- a/test/src/main/java/org/openjdk/skara/test/TestIssue.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestIssue.java
@@ -187,6 +187,7 @@ public class TestIssue implements Issue {
 
     @Override
     public void addLink(Link link) {
+        removeLink(link.uri());
         data.links.add(link);
         data.lastUpdate = ZonedDateTime.now();
     }


### PR DESCRIPTION
Hi all,

Please review this change that enables issue notifications to be retried in case transient server errors occur, but will not send out duplicate email notifications.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-212](https://bugs.openjdk.java.net/browse/SKARA-212): Retry notifications for updaters that can check current state


## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)