### PR TITLE
172: Moving a PR from draft state should trigger a new check

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -526,7 +526,8 @@ class CheckRun {
             }
 
             // Calculate current metadata to avoid unnecessary future checks
-            var metadata = workItem.getMetadata(pr.title(), updatedBody, pr.comments(), activeReviews, newLabels, censusInstance, pr.targetHash());
+            var metadata = workItem.getMetadata(pr.title(), updatedBody, pr.comments(), activeReviews, newLabels,
+                                                censusInstance, pr.targetHash(), pr.isDraft());
             checkBuilder.metadata(metadata);
         } catch (Exception e) {
             log.throwing("CommitChecker", "checkStatus", e);

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -73,7 +73,7 @@ class CheckWorkItem extends PullRequestWorkItem {
     }
 
     String getMetadata(String title, String body, List<Comment> comments, List<Review> reviews, Set<String> labels,
-                       CensusInstance censusInstance, Hash target) {
+                       CensusInstance censusInstance, Hash target, boolean isDraft) {
         try {
             var approverString = reviews.stream()
                                         .filter(review -> review.verdict() == Review.Verdict.APPROVED)
@@ -95,6 +95,7 @@ class CheckWorkItem extends PullRequestWorkItem {
             digest.update(commentString.getBytes(StandardCharsets.UTF_8));
             digest.update(labelString.getBytes(StandardCharsets.UTF_8));
             digest.update(target.hex().getBytes(StandardCharsets.UTF_8));
+            digest.update(isDraft ? (byte)0 : (byte)1);
 
             return Base64.getUrlEncoder().encodeToString(digest.digest());
         } catch (NoSuchAlgorithmException e) {
@@ -105,7 +106,7 @@ class CheckWorkItem extends PullRequestWorkItem {
     private boolean currentCheckValid(CensusInstance censusInstance, List<Comment> comments, List<Review> reviews, Set<String> labels) {
         var hash = pr.headHash();
         var targetHash = pr.targetHash();
-        var metadata = getMetadata(pr.title(), pr.body(), comments, reviews, labels, censusInstance, targetHash);
+        var metadata = getMetadata(pr.title(), pr.body(), comments, reviews, labels, censusInstance, targetHash, pr.isDraft());
         var currentChecks = pr.checks(hash);
 
         if (currentChecks.containsKey("jcheck")) {


### PR DESCRIPTION
Hi all,

Please review this small change that ensures that moving a PR from draft state triggers a new check.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-172](https://bugs.openjdk.java.net/browse/SKARA-172): Moving a PR from draft state should trigger a new check


## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)