### PR TITLE
214: Improve the message given when a change can be integrated

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -358,13 +358,20 @@ class CheckRun {
         var message = new StringBuilder();
         message.append("@");
         message.append(pr.author().userName());
-        message.append(" This change can now be integrated. The commit message will be:\n");
+        message.append(" This change now passes all automated pre-integration checks. When the change also ");
+        message.append("fulfills all [project specific requirements](https://github.com/");
+        message.append(pr.repository().name());
+        message.append("/blob/");
+        message.append(pr.targetRef());
+        message.append("CONTRIBUTING.md), type `/integrate` in a new comment to proceed. After integration, ");
+        message.append("the commit message will be:\n");
         message.append("```\n");
         message.append(commitMessage);
         message.append("\n```\n");
 
         message.append("- If you would like to add a summary, use the `/summary` command.\n");
-        message.append("- To list additional contributors, use the `/contributor` command.\n");
+        message.append("- To credit additional contributors, use the `/contributor` command.\n");
+        message.append("- To add additional solved issues, use the `/solves` command.\n");
 
         var divergingCommits = prInstance.divergingCommits();
         if (divergingCommits.size() > 0) {
@@ -379,15 +386,10 @@ class CheckRun {
             }
             message.append("pushed to the `");
             message.append(pr.targetRef());
-            message.append("` branch:\n");
-            var commitList = divergingCommits.stream()
-                    .map(commit -> " * " + commit.hash().hex() + ": " + commit.message().get(0))
-                    .collect(Collectors.joining("\n"));
-            message.append(commitList);
-            message.append("\n\n");
+            message.append("` branch. ");
             if (rebasePossible) {
-                message.append("Since there are no conflicts, your changes will automatically be rebased on top of the ");
-                message.append("above commits when integrating. If you prefer to do this manually, please merge `");
+                message.append("Since there are no conflicts, your changes will automatically be rebased on top of ");
+                message.append("these commits when integrating. If you prefer to do this manually, please merge `");
                 message.append(pr.targetRef());
                 message.append("` into your branch first.\n");
             } else {
@@ -420,7 +422,7 @@ class CheckRun {
             }
             if (rebasePossible) {
                 message.append("\n\n");
-                message.append("- To flag this PR as ready for integration with the above commit message, type ");
+                message.append("➡️ To flag this PR as ready for integration with the above commit message, type ");
                 message.append("`/integrate` in a new comment. (Afterwards, your sponsor types ");
                 message.append("`/sponsor` in a new comment to perform the integration).\n");
             }
@@ -428,7 +430,7 @@ class CheckRun {
             if (divergingCommits.size() > 0) {
                 message.append("\n");
             }
-            message.append("- To integrate this PR with the above commit message, type ");
+            message.append("➡️ To integrate this PR with the above commit message, type ");
             message.append("`/integrate` in a new comment.\n");
         }
         message.append(mergeReadyMarker);

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -598,7 +598,7 @@ class CheckTests {
 
             // The bot should no longer detect a conflict
             updated = pr.comments().stream()
-                        .filter(comment -> comment.body().contains("change can now be integrated"))
+                        .filter(comment -> comment.body().contains("change now passes all automated"))
                         .count();
             assertEquals(1, updated);
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ContributorTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ContributorTests.java
@@ -106,7 +106,7 @@ class ContributorTests {
             assertEquals("Co-authored-by: Test Person <test@test.test>", creditLine);
 
             var pushed = pr.comments().stream()
-                           .filter(comment -> comment.body().contains("change can now be integrated"))
+                           .filter(comment -> comment.body().contains("change now passes all automated"))
                            .count();
             assertEquals(1, pushed);
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrateTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrateTests.java
@@ -343,7 +343,7 @@ class IntegrateTests {
 
             // The bot should reply with an instructional message (and only one)
             var pushed = pr.comments().stream()
-                           .filter(comment -> comment.body().contains("change can now be integrated"))
+                           .filter(comment -> comment.body().contains("change now passes all automated"))
                            .filter(comment -> comment.body().contains("Reviewed-by: integrationreviewer3"))
                            .count();
             assertEquals(1, pushed);
@@ -370,7 +370,7 @@ class IntegrateTests {
 
             // The instructional message should have been updated
             pushed = pr.comments().stream()
-                       .filter(comment -> comment.body().contains("change can now be integrated"))
+                       .filter(comment -> comment.body().contains("change now passes all automated"))
                        .filter(comment -> comment.body().contains("Reviewed-by: integrationreviewer3"))
                        .count();
             assertEquals(1, pushed);
@@ -382,7 +382,7 @@ class IntegrateTests {
 
             // The instructional message should have been updated
             pushed = pr.comments().stream()
-                       .filter(comment -> comment.body().contains("change can now be integrated"))
+                       .filter(comment -> comment.body().contains("change now passes all automated"))
                        .filter(comment -> comment.body().contains("Reviewed-by: integrationreviewer3, integrationreviewer2"))
                        .count();
             assertEquals(1, pushed);

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/SolvesTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/SolvesTests.java
@@ -22,11 +22,12 @@
  */
 package org.openjdk.skara.bots.pr;
 
-import org.junit.jupiter.api.*;
 import org.openjdk.skara.forge.Review;
 import org.openjdk.skara.issuetracker.Comment;
 import org.openjdk.skara.test.*;
 import org.openjdk.skara.vcs.Repository;
+
+import org.junit.jupiter.api.*;
 
 import java.io.IOException;
 import java.util.*;
@@ -117,7 +118,7 @@ class SolvesTests {
 
             // The commit message preview should contain the additional issues
             var preview = pr.comments().stream()
-                            .filter(comment -> comment.body().contains("The commit message will be"))
+                            .filter(comment -> comment.body().contains("the commit message will be"))
                             .map(Comment::body)
                             .findFirst()
                             .orElseThrow();


### PR DESCRIPTION
Hi all,

This change adjusts the "this change is now ready to be integrated" message. After the change, it would look something like the below. Comments are welcome!

@rwestberg This change now passes all automated pre-integration checks. When the change also fulfills all [project specific requirements](https://github.com/openjdk/skara/blob/master/CONTRIBUTING.md), type `/integrate` in a new comment to proceed. After integration, the commit message will be:
```
No need for locking when using TestHostedRepository

Reviewed-by: ehelin
```
- If you would like to add a summary, use the `/summary` command.
- To credit additional contributors, use the `/contributor` command.
- To add additional solved issues, use the `/solves` command.

Since the source branch of this PR was last updated there have been 61 commits pushed to the `master` branch. As there are no conflicts, your changes will automatically be rebased on top of these commits when integrating. If you prefer to do this manually, please merge `master` into your branch first.

➡️ To integrate this PR with the above commit message, type `/integrate` in a new comment.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-214](https://bugs.openjdk.java.net/browse/SKARA-214): Improve the message given when a change can be integrated


## Approvers
 * Kevin Rushforth ([kcr](@kevinrushforth) - no project role) **Note!** Review applies to 91d414c35241d9b6f3e0b0642f52ee60b769ada4
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)