### PR TITLE
219: Missing slash before CONTRIBUTING link in /integrate message

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -363,7 +363,7 @@ class CheckRun {
         message.append(pr.repository().name());
         message.append("/blob/");
         message.append(pr.targetRef());
-        message.append("CONTRIBUTING.md), type `/integrate` in a new comment to proceed. After integration, ");
+        message.append("/CONTRIBUTING.md), type `/integrate` in a new comment to proceed. After integration, ");
         message.append("the commit message will be:\n");
         message.append("```\n");
         message.append(commitMessage);


### PR DESCRIPTION
Hi all,

please review this small patch that fixes a typo with the URL to the
`COTNRIBUTING.md` file in the new "ready for integration" message.

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-219](https://bugs.openjdk.java.net/browse/SKARA-219): Missing slash before CONTRIBUTING link in /integrate message


## Approvers
 * Kevin Rushforth ([kcr](@kevinrushforth) - no project role)
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)