### PR TITLE
215: Verify webrev links before considering publication successful

### DIFF
--- a/bots/mlbridge/src/main/java/module-info.java
+++ b/bots/mlbridge/src/main/java/module-info.java
@@ -32,6 +32,7 @@ module org.openjdk.skara.bots.mlbridge {
     requires org.openjdk.skara.webrev;
     requires org.openjdk.skara.network;
     requires java.logging;
+    requires java.net.http;
 
     provides org.openjdk.skara.bot.BotFactory with org.openjdk.skara.bots.mlbridge.MailingListBridgeBotFactory;
 }

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBotTests.java
@@ -56,7 +56,8 @@ class MailingListArchiveReaderBotTests {
     void simpleArchive(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
              var tempFolder = new TemporaryDirectory();
-             var listServer = new TestMailmanServer()) {
+             var listServer = new TestMailmanServer();
+             var webrevServer = new TestWebrevServer()) {
             var author = credentials.getHostedRepository();
             var archive = credentials.getHostedRepository();
             var ignored = credentials.getHostedRepository();
@@ -71,7 +72,7 @@ class MailingListArchiveReaderBotTests {
                                                  Set.of(),
                                                  listServer.getArchive(), listServer.getSMTP(),
                                                  archive, "webrev", Path.of("test"),
-                                                 URIBuilder.base("http://www.test.test/").build(),
+                                                 webrevServer.uri(),
                                                  Set.of(), Map.of(),
                                                  URIBuilder.base("http://issues.test/browse/").build(),
                                                  Map.of(), Duration.ZERO);
@@ -126,7 +127,8 @@ class MailingListArchiveReaderBotTests {
     void rememberBridged(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
              var tempFolder = new TemporaryDirectory();
-             var listServer = new TestMailmanServer()) {
+             var listServer = new TestMailmanServer();
+             var webrevServer = new TestWebrevServer()) {
             var author = credentials.getHostedRepository();
             var archive = credentials.getHostedRepository();
             var ignored = credentials.getHostedRepository();
@@ -141,7 +143,7 @@ class MailingListArchiveReaderBotTests {
                                                  Set.of(),
                                                  listServer.getArchive(), listServer.getSMTP(),
                                                  archive, "webrev", Path.of("test"),
-                                                 URIBuilder.base("http://www.test.test/").build(),
+                                                 webrevServer.uri(),
                                                  Set.of(), Map.of(),
                                                  URIBuilder.base("http://issues.test/browse/").build(),
                                                  Map.of(), Duration.ZERO);

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -104,7 +104,8 @@ class MailingListBridgeBotTests {
              var tempFolder = new TemporaryDirectory();
              var archiveFolder = new TemporaryDirectory();
              var webrevFolder = new TemporaryDirectory();
-             var listServer = new TestMailmanServer()) {
+             var listServer = new TestMailmanServer();
+             var webrevServer = new TestWebrevServer()) {
             var author = credentials.getHostedRepository();
             var archive = credentials.getHostedRepository();
             var ignored = credentials.getHostedRepository();
@@ -118,7 +119,7 @@ class MailingListBridgeBotTests {
                                                  Set.of(),
                                                  listServer.getArchive(), listServer.getSMTP(),
                                                  archive, "webrev", Path.of("test"),
-                                                 URIBuilder.base("http://www.test.test/").build(),
+                                                 webrevServer.uri(),
                                                  Set.of("rfr"), Map.of(ignored.forge().currentUser().userName(),
                                                                        Pattern.compile("ready")),
                                                  URIBuilder.base("http://issues.test/browse/").build(),
@@ -180,7 +181,7 @@ class MailingListBridgeBotTests {
             assertTrue(archiveContains(archiveFolder.path(), "Patch:"));
             assertTrue(archiveContains(archiveFolder.path(), "Changes:"));
             assertTrue(archiveContains(archiveFolder.path(), "Webrev:"));
-            assertTrue(archiveContains(archiveFolder.path(), "http://www.test.test/"));
+            assertTrue(archiveContains(archiveFolder.path(), webrevServer.uri().toString()));
             assertTrue(archiveContains(archiveFolder.path(), "webrev.00"));
             assertTrue(archiveContains(archiveFolder.path(), "Issue:"));
             assertTrue(archiveContains(archiveFolder.path(), "http://issues.test/browse/TSTPRJ-1234"));
@@ -262,7 +263,8 @@ class MailingListBridgeBotTests {
         try (var credentials = new HostCredentials(testInfo);
              var tempFolder = new TemporaryDirectory();
              var archiveFolder = new TemporaryDirectory();
-             var listServer = new TestMailmanServer()) {
+             var listServer = new TestMailmanServer();
+             var webrevServer = new TestWebrevServer()) {
             var author = credentials.getHostedRepository();
             var archive = credentials.getHostedRepository();
             var ignored = credentials.getHostedRepository();
@@ -276,7 +278,7 @@ class MailingListBridgeBotTests {
                                                  Set.of(),
                                                  listServer.getArchive(), listServer.getSMTP(),
                                                  archive, "webrev", Path.of("test"),
-                                                 URIBuilder.base("http://www.test.test/").build(),
+                                                 webrevServer.uri(),
                                                  Set.of(), Map.of(),
                                                  URIBuilder.base("http://issues.test/browse/").build(),
                                                  Map.of(), Duration.ZERO);
@@ -352,7 +354,8 @@ class MailingListBridgeBotTests {
         try (var credentials = new HostCredentials(testInfo);
              var tempFolder = new TemporaryDirectory();
              var archiveFolder = new TemporaryDirectory();
-             var listServer = new TestMailmanServer()) {
+             var listServer = new TestMailmanServer();
+             var webrevServer = new TestWebrevServer()) {
             var author = credentials.getHostedRepository();
             var archive = credentials.getHostedRepository();
             var listAddress = EmailAddress.parse(listServer.createList("test"));
@@ -365,7 +368,7 @@ class MailingListBridgeBotTests {
                                                  listServer.getArchive(),
                                                  listServer.getSMTP(),
                                                  archive, "webrev", Path.of("test"),
-                                                 URIBuilder.base("http://www.test.test/").build(),
+                                                 webrevServer.uri(),
                                                  Set.of(), Map.of(),
                                                  URIBuilder.base("http://issues.test/browse/").build(),
                                                  Map.of(), Duration.ZERO);
@@ -439,7 +442,8 @@ class MailingListBridgeBotTests {
         try (var credentials = new HostCredentials(testInfo);
              var tempFolder = new TemporaryDirectory();
              var archiveFolder = new TemporaryDirectory();
-             var listServer = new TestMailmanServer()) {
+             var listServer = new TestMailmanServer();
+             var webrevServer = new TestWebrevServer()) {
             var author = credentials.getHostedRepository();
             var reviewer = credentials.getHostedRepository();
             var archive = credentials.getHostedRepository();
@@ -454,7 +458,7 @@ class MailingListBridgeBotTests {
                                                  listServer.getArchive(),
                                                  listServer.getSMTP(),
                                                  archive, "webrev", Path.of("test"),
-                                                 URIBuilder.base("http://www.test.test/").build(),
+                                                 webrevServer.uri(),
                                                  Set.of(), Map.of(),
                                                  URIBuilder.base("http://issues.test/browse/").build(),
                                                  Map.of(), Duration.ZERO);
@@ -563,7 +567,8 @@ class MailingListBridgeBotTests {
         try (var credentials = new HostCredentials(testInfo);
              var tempFolder = new TemporaryDirectory();
              var archiveFolder = new TemporaryDirectory();
-             var listServer = new TestMailmanServer()) {
+             var listServer = new TestMailmanServer();
+             var webrevServer = new TestWebrevServer()) {
             var author = credentials.getHostedRepository();
             var reviewer = credentials.getHostedRepository();
             var archive = credentials.getHostedRepository();
@@ -577,7 +582,7 @@ class MailingListBridgeBotTests {
                                                  listServer.getArchive(),
                                                  listServer.getSMTP(),
                                                  archive, "webrev", Path.of("test"),
-                                                 URIBuilder.base("http://www.test.test/").build(),
+                                                 webrevServer.uri(),
                                                  Set.of(), Map.of(),
                                                  URIBuilder.base("http://issues.test/browse/").build(),
                                                  Map.of(), Duration.ZERO);
@@ -620,7 +625,8 @@ class MailingListBridgeBotTests {
         try (var credentials = new HostCredentials(testInfo);
              var tempFolder = new TemporaryDirectory();
              var archiveFolder = new TemporaryDirectory();
-             var listServer = new TestMailmanServer()) {
+             var listServer = new TestMailmanServer();
+             var webrevServer = new TestWebrevServer()) {
             var author = credentials.getHostedRepository();
             var archive = credentials.getHostedRepository();
             var listAddress = EmailAddress.parse(listServer.createList("test"));
@@ -633,7 +639,7 @@ class MailingListBridgeBotTests {
                                                  listServer.getArchive(),
                                                  listServer.getSMTP(),
                                                  archive, "webrev", Path.of("test"),
-                                                 URIBuilder.base("http://www.test.test/").build(),
+                                                 webrevServer.uri(),
                                                  Set.of(), Map.of(),
                                                  URIBuilder.base("http://issues.test/browse/").build(),
                                                  Map.of(), Duration.ZERO);
@@ -672,7 +678,8 @@ class MailingListBridgeBotTests {
         try (var credentials = new HostCredentials(testInfo);
              var tempFolder = new TemporaryDirectory();
              var archiveFolder = new TemporaryDirectory();
-             var listServer = new TestMailmanServer()) {
+             var listServer = new TestMailmanServer();
+             var webrevServer = new TestWebrevServer()) {
             var author = credentials.getHostedRepository();
             var archive = credentials.getHostedRepository();
             var listAddress = EmailAddress.parse(listServer.createList("test"));
@@ -685,7 +692,7 @@ class MailingListBridgeBotTests {
                                                  listServer.getArchive(),
                                                  listServer.getSMTP(),
                                                  archive, "webrev", Path.of("test"),
-                                                 URIBuilder.base("http://www.test.test/").build(),
+                                                 webrevServer.uri(),
                                                  Set.of(), Map.of(),
                                                  URIBuilder.base("http://issues.test/browse/").build(),
                                                  Map.of(), Duration.ZERO);
@@ -743,7 +750,8 @@ class MailingListBridgeBotTests {
         try (var credentials = new HostCredentials(testInfo);
              var tempFolder = new TemporaryDirectory();
              var archiveFolder = new TemporaryDirectory();
-             var listServer = new TestMailmanServer()) {
+             var listServer = new TestMailmanServer();
+             var webrevServer = new TestWebrevServer()) {
             var author = credentials.getHostedRepository();
             var archive = credentials.getHostedRepository();
             var listAddress = EmailAddress.parse(listServer.createList("test"));
@@ -755,7 +763,7 @@ class MailingListBridgeBotTests {
                                                  listAddress, Set.of(), Set.of(),
                                                  listServer.getArchive(), listServer.getSMTP(),
                                                  archive, "webrev", Path.of("test"),
-                                                 URIBuilder.base("http://www.test.test/").build(),
+                                                 webrevServer.uri(),
                                                  Set.of(), Map.of(),
                                                  URIBuilder.base("http://issues.test/browse/").build(),
                                                  Map.of(), Duration.ZERO);
@@ -802,7 +810,8 @@ class MailingListBridgeBotTests {
         try (var credentials = new HostCredentials(testInfo);
              var tempFolder = new TemporaryDirectory();
              var archiveFolder = new TemporaryDirectory();
-             var listServer = new TestMailmanServer()) {
+             var listServer = new TestMailmanServer();
+             var webrevServer = new TestWebrevServer()) {
             var author = credentials.getHostedRepository();
             var archive = credentials.getHostedRepository();
             var commenter = credentials.getHostedRepository();
@@ -815,7 +824,7 @@ class MailingListBridgeBotTests {
                                                  listAddress, Set.of(), Set.of(),
                                                  listServer.getArchive(), listServer.getSMTP(),
                                                  archive, "webrev", Path.of("test"),
-                                                 URIBuilder.base("http://www.test.test/").build(),
+                                                 webrevServer.uri(),
                                                  Set.of(), Map.of(),
                                                  URIBuilder.base("http://issues.test/browse/").build(),
                                                  Map.of(), Duration.ZERO);
@@ -925,7 +934,8 @@ class MailingListBridgeBotTests {
         try (var credentials = new HostCredentials(testInfo);
              var tempFolder = new TemporaryDirectory();
              var archiveFolder = new TemporaryDirectory();
-             var listServer = new TestMailmanServer()) {
+             var listServer = new TestMailmanServer();
+             var webrevServer = new TestWebrevServer()) {
             var author = credentials.getHostedRepository();
             var archive = credentials.getHostedRepository();
             var listAddress = EmailAddress.parse(listServer.createList("test"));
@@ -937,7 +947,7 @@ class MailingListBridgeBotTests {
                                                  listAddress, Set.of(), Set.of(),
                                                  listServer.getArchive(), listServer.getSMTP(),
                                                  archive, "webrev", Path.of("test"),
-                                                 URIBuilder.base("http://www.test.test/").build(),
+                                                 webrevServer.uri(),
                                                  Set.of(), Map.of(),
                                                  URIBuilder.base("http://issues.test/browse/").build(),
                                                  Map.of(), Duration.ZERO);
@@ -1015,7 +1025,8 @@ class MailingListBridgeBotTests {
         try (var credentials = new HostCredentials(testInfo);
              var tempFolder = new TemporaryDirectory();
              var archiveFolder = new TemporaryDirectory();
-             var listServer = new TestMailmanServer()) {
+             var listServer = new TestMailmanServer();
+             var webrevServer = new TestWebrevServer()) {
             var author = credentials.getHostedRepository();
             var archive = credentials.getHostedRepository();
             var listAddress = EmailAddress.parse(listServer.createList("test"));
@@ -1027,7 +1038,7 @@ class MailingListBridgeBotTests {
                                                  listAddress, Set.of(), Set.of(),
                                                  listServer.getArchive(), listServer.getSMTP(),
                                                  archive, "webrev", Path.of("test"),
-                                                 URIBuilder.base("http://www.test.test/").build(),
+                                                 webrevServer.uri(),
                                                  Set.of(), Map.of(),
                                                  URIBuilder.base("http://issues.test/browse/").build(),
                                                  Map.of(), Duration.ZERO);
@@ -1098,7 +1109,8 @@ class MailingListBridgeBotTests {
              var tempFolder = new TemporaryDirectory();
              var archiveFolder = new TemporaryDirectory();
              var webrevFolder = new TemporaryDirectory();
-             var listServer = new TestMailmanServer()) {
+             var listServer = new TestMailmanServer();
+             var webrevServer = new TestWebrevServer()) {
             var author = credentials.getHostedRepository();
             var archive = credentials.getHostedRepository();
             var ignored = credentials.getHostedRepository();
@@ -1113,7 +1125,7 @@ class MailingListBridgeBotTests {
                                                  Set.of(),
                                                  listServer.getArchive(), listServer.getSMTP(),
                                                  archive, "webrev", Path.of("test"),
-                                                 URIBuilder.base("http://www.test.test/").build(),
+                                                 webrevServer.uri(),
                                                  Set.of(), Map.of(),
                                                  URIBuilder.base("http://issues.test/browse/").build(),
                                                  Map.of(), Duration.ZERO);
@@ -1173,7 +1185,8 @@ class MailingListBridgeBotTests {
         try (var credentials = new HostCredentials(testInfo);
              var tempFolder = new TemporaryDirectory();
              var archiveFolder = new TemporaryDirectory();
-             var listServer = new TestMailmanServer()) {
+             var listServer = new TestMailmanServer();
+             var webrevServer = new TestWebrevServer()) {
             var author = credentials.getHostedRepository();
             var archive = credentials.getHostedRepository();
             var reviewer = credentials.getHostedRepository();
@@ -1187,7 +1200,7 @@ class MailingListBridgeBotTests {
                                                  listAddress, Set.of(), Set.of(),
                                                  listServer.getArchive(), listServer.getSMTP(),
                                                  archive, "webrev", Path.of("test"),
-                                                 URIBuilder.base("http://www.test.test/").build(),
+                                                 webrevServer.uri(),
                                                  Set.of(), Map.of(),
                                                  URIBuilder.base("http://issues.test/browse/").build(),
                                                  Map.of(), Duration.ZERO);
@@ -1257,7 +1270,8 @@ class MailingListBridgeBotTests {
         try (var credentials = new HostCredentials(testInfo);
              var tempFolder = new TemporaryDirectory();
              var archiveFolder = new TemporaryDirectory();
-             var listServer = new TestMailmanServer()) {
+             var listServer = new TestMailmanServer();
+             var webrevServer = new TestWebrevServer()) {
             var author = credentials.getHostedRepository();
             var ignored = credentials.getHostedRepository();
             var archive = credentials.getHostedRepository();
@@ -1272,7 +1286,7 @@ class MailingListBridgeBotTests {
                                                  Set.of(Pattern.compile("ignore this comment", Pattern.MULTILINE | Pattern.DOTALL)),
                                                  listServer.getArchive(), listServer.getSMTP(),
                                                  archive, "webrev", Path.of("test"),
-                                                 URIBuilder.base("http://www.test.test/").build(),
+                                                 webrevServer.uri(),
                                                  Set.of(), Map.of(),
                                                  URIBuilder.base("http://issues.test/browse/").build(),
                                                  Map.of(), Duration.ZERO);

--- a/test/src/main/java/org/openjdk/skara/test/TestWebrevServer.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestWebrevServer.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.test;
+
+import com.sun.net.httpserver.*;
+import org.openjdk.skara.network.URIBuilder;
+
+import java.io.*;
+import java.net.*;
+import java.nio.charset.StandardCharsets;
+
+public class TestWebrevServer implements AutoCloseable {
+    private final HttpServer httpServer;
+    private boolean checked = false;
+
+    private class Handler implements HttpHandler {
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            var response = "ok!";
+            var responseBytes = response.getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, responseBytes.length);
+            OutputStream outputStream = exchange.getResponseBody();
+            outputStream.write(responseBytes);
+            outputStream.close();
+            checked = true;
+        }
+    }
+
+    public TestWebrevServer() throws IOException {
+        InetSocketAddress address = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
+        httpServer = HttpServer.create(address, 0);
+        httpServer.createContext("/webrevs", new Handler());
+        httpServer.setExecutor(null);
+        httpServer.start();
+    }
+
+    public URI uri() {
+        return URIBuilder.base("http://" + httpServer.getAddress().getHostString() + ":" +  httpServer.getAddress().getPort() + "/webrevs/").build();
+    }
+
+    public boolean isChecked() {
+        return checked;
+    }
+
+    @Override
+    public void close() throws IOException {
+        httpServer.stop(0);
+    }
+}


### PR DESCRIPTION
Hi all,

Please review this change which ensures that webrev links can be successfully reached before returning from the publication step. 

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-215](https://bugs.openjdk.java.net/browse/SKARA-215): Verify webrev links before considering publication successful


## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)