### PR TITLE
Allow unsafe features when importing

### DIFF
--- a/bots.dockerfile
+++ b/bots.dockerfile
@@ -23,7 +23,7 @@ FROM oraclelinux:7.5 as prerequisites-runtime
 
 WORKDIR /bots-build
 
-ARG GIT_VERSION=2.19.1
+ARG GIT_VERSION=2.19.3
 ARG MERCURIAL_VERSION=4.7.2
 
 ENV LANG en_US.UTF-8
@@ -37,7 +37,7 @@ RUN curl -sSO https://www.mercurial-scm.org/release/mercurial-${MERCURIAL_VERSIO
     cd mercurial-${MERCURIAL_VERSION} && \
     python setup.py install --force --prefix=/bots/hg
 RUN curl -sSO https://mirrors.edge.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.xz && \
-    echo "345056aa9b8084280b1b9fe1374d232dec05a34e8849028a20bfdb56e920dbb5  git-2.19.1.tar.xz" | sha256sum --check - && \
+    echo "0457f33eedd3f5e9fb9c2ea30bf455ed9915230e3800c632ff07e00ac2466ace git-${GIT_VERSION}.tar.xz" | sha256sum --check - && \
     tar xvfJ git-${GIT_VERSION}.tar.xz && \
     cd git-${GIT_VERSION} && \
     make configure && \

--- a/test.dockerfile
+++ b/test.dockerfile
@@ -23,7 +23,7 @@ FROM oraclelinux:7.6 as prerequisites-runtime
 
 WORKDIR /bots-build
 
-ARG GIT_VERSION=2.19.1
+ARG GIT_VERSION=2.19.3
 ARG MERCURIAL_VERSION=4.7.2
 
 ENV LANG en_US.UTF-8
@@ -37,7 +37,7 @@ RUN curl -sSO https://www.mercurial-scm.org/release/mercurial-${MERCURIAL_VERSIO
     cd mercurial-${MERCURIAL_VERSION} && \
     python setup.py install --force --prefix=/bots/hg
 RUN curl -sSO https://mirrors.edge.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.xz && \
-    echo "345056aa9b8084280b1b9fe1374d232dec05a34e8849028a20bfdb56e920dbb5  git-2.19.1.tar.xz" | sha256sum --check - && \
+    echo "0457f33eedd3f5e9fb9c2ea30bf455ed9915230e3800c632ff07e00ac2466ace git-${GIT_VERSION}.tar.xz" | sha256sum --check - && \
     tar xvfJ git-${GIT_VERSION}.tar.xz && \
     cd git-${GIT_VERSION} && \
     make configure && \

--- a/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/convert/HgToGitConverter.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/convert/HgToGitConverter.java
@@ -599,7 +599,7 @@ public class HgToGitConverter implements Converter {
     }
 
     private ProcessInfo fastImport(ReadOnlyRepository repo) throws IOException {
-        var command = List.of("git", "fast-import");
+        var command = List.of("git", "fast-import", "--allow-unsafe-features");
         var pb = new ProcessBuilder(command);
         pb.directory(repo.root().toFile());
 


### PR DESCRIPTION
Hi all,

Please review this change that adds a new required flag for running git fast-import, required after the latest git security fixes.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)