### PR TITLE
Propagate issue properties when creating backports

### DIFF
--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
@@ -25,6 +25,7 @@ package org.openjdk.skara.bots.tester;
 import org.openjdk.skara.forge.*;
 import org.openjdk.skara.host.*;
 import org.openjdk.skara.issuetracker.*;
+import org.openjdk.skara.json.JSONValue;
 import org.openjdk.skara.vcs.*;
 
 import java.util.*;
@@ -244,32 +245,17 @@ class InMemoryPullRequest implements PullRequest {
     }
 
     @Override
-    public List<String> fixVersions() {
+    public Map<String, JSONValue> properties() {
         return null;
     }
 
     @Override
-    public void addFixVersion(String fixVersion) {
+    public void setProperty(String name, JSONValue value) {
 
     }
 
     @Override
-    public void removeFixVersion(String fixVersion) {
-
-    }
-
-    @Override
-    public Map<String, String> properties() {
-        return null;
-    }
-
-    @Override
-    public void setProperty(String name, String value) {
-
-    }
-
-    @Override
-    public void removePropery(String name) {
+    public void removeProperty(String name) {
 
     }
 

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -524,32 +524,17 @@ public class GitHubPullRequest implements PullRequest {
     }
 
     @Override
-    public List<String> fixVersions() {
+    public Map<String, JSONValue> properties() {
         throw new RuntimeException("not implemented yet");
     }
 
     @Override
-    public void addFixVersion(String fixVersion) {
+    public void setProperty(String name, JSONValue value) {
         throw new RuntimeException("not implemented yet");
     }
 
     @Override
-    public void removeFixVersion(String fixVersion) {
-        throw new RuntimeException("not implemented yet");
-    }
-
-    @Override
-    public Map<String, String> properties() {
-        throw new RuntimeException("not implemented yet");
-    }
-
-    @Override
-    public void setProperty(String name, String value) {
-        throw new RuntimeException("not implemented yet");
-    }
-
-    @Override
-    public void removePropery(String name) {
+    public void removeProperty(String name) {
         throw new RuntimeException("not implemented yet");
     }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -653,32 +653,17 @@ public class GitLabMergeRequest implements PullRequest {
     }
 
     @Override
-    public List<String> fixVersions() {
+    public Map<String, JSONValue> properties() {
         throw new RuntimeException("not implemented yet");
     }
 
     @Override
-    public void addFixVersion(String fixVersion) {
+    public void setProperty(String name,JSONValue value) {
         throw new RuntimeException("not implemented yet");
     }
 
     @Override
-    public void removeFixVersion(String fixVersion) {
-        throw new RuntimeException("not implemented yet");
-    }
-
-    @Override
-    public Map<String, String> properties() {
-        throw new RuntimeException("not implemented yet");
-    }
-
-    @Override
-    public void setProperty(String name, String value) {
-        throw new RuntimeException("not implemented yet");
-    }
-
-    @Override
-    public void removePropery(String name) {
+    public void removeProperty(String name) {
         throw new RuntimeException("not implemented yet");
     }
 }

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/Issue.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/Issue.java
@@ -23,6 +23,7 @@
 package org.openjdk.skara.issuetracker;
 
 import org.openjdk.skara.host.HostUser;
+import org.openjdk.skara.json.JSONValue;
 
 import java.net.URI;
 import java.time.ZonedDateTime;
@@ -154,15 +155,9 @@ public interface Issue {
 
     void removeLink(Link link);
 
-    List<String> fixVersions();
+    Map<String, JSONValue> properties();
 
-    void addFixVersion(String fixVersion);
+    void setProperty(String name, JSONValue value);
 
-    void removeFixVersion(String fixVersion);
-
-    Map<String, String> properties();
-
-    void setProperty(String name, String value);
-
-    void removePropery(String name);
+    void removeProperty(String name);
 }

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/IssueProject.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/IssueProject.java
@@ -22,13 +22,15 @@
  */
 package org.openjdk.skara.issuetracker;
 
+import org.openjdk.skara.json.JSONValue;
+
 import java.net.URI;
 import java.util.*;
 
 public interface IssueProject {
     IssueTracker issueTracker();
     URI webUrl();
-    Issue createIssue(String title, List<String> body, Map<String, String> properties);
+    Issue createIssue(String title, List<String> body, Map<String, JSONValue> properties);
     Optional<Issue> issue(String id);
     List<Issue> issues();
 }

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraIssue.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraIssue.java
@@ -442,47 +442,30 @@ public class JiraIssue implements Issue {
     }
 
     @Override
-    public List<String> fixVersions() {
-        return json.get("fields").get("fixVersions").stream()
-                   .map(obj -> obj.get("id").asString())
-                   .map(id -> jiraProject.fixVersionNameFromId(id).orElseThrow())
-                   .collect(Collectors.toList());
-    }
+    public Map<String, JSONValue> properties() {
+        var ret = new HashMap<String, JSONValue>();
 
-    @Override
-    public void addFixVersion(String fixVersion) {
-        var query = JSON.object()
-                        .put("update", JSON.object()
-                                           .put("fixVersions", JSON.array().add(JSON.object()
-                                                                                    .put("add", JSON.object()
-                                                                                                    .put("id", jiraProject.fixVersionIdFromName(fixVersion).orElseThrow())))));
-        request.put("").body(query).execute();
-    }
-
-    @Override
-    public void removeFixVersion(String fixVersion) {
-        var query = JSON.object()
-                        .put("update", JSON.object()
-                                           .put("fixVersions", JSON.array().add(JSON.object()
-                                                                                    .put("remove", JSON.object()
-                                                                                                    .put("id", jiraProject.fixVersionIdFromName(fixVersion).orElseThrow())))));
-        request.put("").body(query).execute();
-    }
-
-    @Override
-    public Map<String, String> properties() {
-        var ret = new HashMap<String, String>();
-        ret.put("type", json.get("fields").get("issuetype").get("name").asString());
+        for (var field : json.get("fields").asObject().fields()) {
+            var value = field.value();
+            var decoded = jiraProject.decodeProperty(field.name(), value);
+            decoded.ifPresent(jsonValue -> ret.put(field.name(), jsonValue));
+        }
         return ret;
     }
 
     @Override
-    public void setProperty(String name, String value) {
-
+    public void setProperty(String name, JSONValue value) {
+        var encoded = jiraProject.encodeProperty(name, value);
+        if (encoded.isEmpty()) {
+            log.warning("Ignoring unknown property: " + name);
+            return;
+        }
+        var query = JSON.object().put("fields", JSON.object().put(name, encoded.get()));
+        request.put("").body(query).execute();
     }
 
     @Override
-    public void removePropery(String name) {
+    public void removeProperty(String name) {
 
     }
 }

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraProject.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraProject.java
@@ -37,8 +37,6 @@ public class JiraProject implements IssueProject {
     private final RestRequest request;
 
     private JSONObject projectMetadataCache = null;
-    private Map<String, String> versionNameToId = null;
-    private Map<String, String> versionIdToName = null;
     private List<JiraLinkType> linkTypes = null;
 
     private final Logger log = Logger.getLogger("org.openjdk.skara.issuetracker.jira");
@@ -72,25 +70,12 @@ public class JiraProject implements IssueProject {
         return ret;
     }
 
-    private void populateVersionsIfNeeded() {
-        if (versionIdToName != null) {
-            return;
+    private Map<String, String> versions() {
+        var ret = new HashMap<String, String>();
+        for (var type : project().get("versions").asArray()) {
+            ret.put(type.get("name").asString(), type.get("id").asString());
         }
-
-        versionNameToId = project().get("versions").stream()
-                                   .collect(Collectors.toMap(v -> v.get("name").asString(), v -> v.get("id").asString()));
-        versionIdToName = project().get("versions").stream()
-                                   .collect(Collectors.toMap(v -> v.get("id").asString(), v -> v.get("name").asString()));
-    }
-
-    Optional<String> fixVersionNameFromId(String id) {
-        populateVersionsIfNeeded();
-        return Optional.ofNullable(versionIdToName.getOrDefault(id, null));
-    }
-
-    Optional<String> fixVersionIdFromName(String name) {
-        populateVersionsIfNeeded();
-        return Optional.ofNullable(versionNameToId.getOrDefault(name, null));
+        return ret;
     }
 
     private void populateLinkTypesIfNeeded() {
@@ -134,6 +119,66 @@ public class JiraProject implements IssueProject {
         return jiraHost;
     }
 
+    private static final Set<String> knownProperties = Set.of("issuetype", "fixVersions", "versions", "priority", "components");
+
+    boolean isAllowedProperty(String name) {
+        if (knownProperties.contains(name)) {
+            return true;
+        }
+        return name.startsWith("customfield_");
+    }
+
+    Optional<JSONValue> decodeProperty(String name, JSONValue value) {
+        if (!isAllowedProperty(name)) {
+            return Optional.empty();
+        }
+        if (value.isNull()) {
+            return Optional.empty();
+        }
+
+        // Transform known fields to a better representation
+        switch (name) {
+            case "fixVersions": // fall-through
+            case "versions": // fall-through
+            case "components":
+                return Optional.of(new JSONArray(value.stream()
+                                                      .map(obj -> obj.get("name"))
+                                                      .collect(Collectors.toList())));
+            case "issuetype":
+                return Optional.of(JSON.of(value.get("name").asString()));
+            case "priority":
+                return Optional.of(JSON.of(value.get("id").asString()));
+            default:
+                return Optional.of(value);
+        }
+    }
+
+    Optional<JSONValue> encodeProperty(String name, JSONValue value) {
+        if (!isAllowedProperty(name)) {
+            return Optional.empty();
+        }
+
+        switch (name) {
+            case "fixVersions": // fall-through
+            case "versions":
+                return Optional.of(new JSONArray(value.stream()
+                                                      .map(JSONValue::asString)
+                                                      .map(s -> JSON.object().put("id", versions().get(s)))
+                                                      .collect(Collectors.toList())));
+            case "components":
+                return Optional.of(new JSONArray(value.stream()
+                                                      .map(JSONValue::asString)
+                                                      .map(s -> JSON.object().put("id", components().get(s)))
+                                                      .collect(Collectors.toList())));
+            case "issuetype":
+                return Optional.of(JSON.object().put("id", issueTypes().get(value.asString())));
+            case "priority":
+                return Optional.of(JSON.object().put("id", value.asString()));
+            default:
+                return Optional.of(value);
+        }
+    }
+
     @Override
     public IssueTracker issueTracker() {
         return jiraHost;
@@ -144,36 +189,45 @@ public class JiraProject implements IssueProject {
         return URIBuilder.base(jiraHost.getUri()).setPath("/projects/" + projectName).build();
     }
 
+    private boolean isInitialField(String name, JSONValue value) {
+        if (name.equals("project") || name.equals("summary") || name.equals("description") || name.equals("components")) {
+            return true;
+        }
+        return false;
+    }
+
     @Override
-    public Issue createIssue(String title, List<String> body, Map<String, String> properties) {
+    public Issue createIssue(String title, List<String> body, Map<String, JSONValue> properties) {
         var query = JSON.object();
-        var fields = JSON.object()
-                         .put("project", JSON.object()
-                                             .put("id", projectId()))
-                         .put("components", JSON.array()
-                                                .add(JSON.object().put("id", defaultComponent())))
-                         .put("summary", title)
-                         .put("description", String.join("\n", body));
 
-        var fixupFields = JSON.object();
+        var finalProperties = new HashMap<String, JSONValue>(properties);
+
+        // Always override certain fields
+        finalProperties.put("project", JSON.object().put("id", projectId()));
+        finalProperties.put("summary", JSON.of(title));
+        finalProperties.put("description", JSON.of(String.join("\n", body)));
+
+        // Encode optional properties as fields
         for (var property : properties.entrySet()) {
-            switch (property.getKey()) {
-                case "type":
-                    if (!property.getValue().equals("Backport")) {
-                        fields.put("issuetype", JSON.object().put("id", issueTypes().get(property.getValue())));
-                    } else {
-                        fixupFields.put("issuetype", JSON.object().put("id", issueTypes().get(property.getValue())));
-                    }
-                    break;
-                default:
-                    log.warning("Unknown issue property: " + property.getKey());
-                    break;
+            var encoded = encodeProperty(property.getKey(), property.getValue());
+            if (encoded.isEmpty()) {
+                continue;
             }
+            finalProperties.put(property.getKey(), encoded.get());
         }
 
-        if (!fields.contains("issuetype")) {
-            fields.put("issuetype", JSON.object().put("id", defaultIssueType()));
-        }
+        // Provide default values for required fields if not present
+        finalProperties.putIfAbsent("components", JSON.array().add(JSON.object().put("id", defaultComponent())));
+
+        // Filter out the fields that can be set at creation time
+        var fields = JSON.object();
+        finalProperties.entrySet().stream()
+                       .filter(entry -> isInitialField(entry.getKey(), entry.getValue()))
+                       .forEach(entry -> fields.put(entry.getKey(), entry.getValue()));
+
+        // Certain types can only be set after creation, so always start with the default value
+        fields.put("issuetype", JSON.object().put("id", defaultIssueType()));
+
         query.put("fields", fields);
         jiraHost.securityLevel().ifPresent(securityLevel -> fields.put("security", JSON.object()
                                                                                        .put("id", securityLevel)));
@@ -181,16 +235,22 @@ public class JiraProject implements IssueProject {
                           .body(query)
                           .execute();
 
-        // Workaround - some fields cannot be set immediately
-        if (properties.containsKey("type") && properties.get("type").equals("Backport")) {
+        // Apply fields that have to be set later (if any)
+        var editFields = JSON.object();
+        finalProperties.entrySet().stream()
+                       .filter(entry -> !isInitialField(entry.getKey(), entry.getValue()))
+                       .forEach(entry -> editFields.put(entry.getKey(), entry.getValue()));
+
+        if (editFields.fields().size() > 0) {
             var id = data.get("key").asString();
             if (id.indexOf('-') < 0) {
                 id = projectName.toUpperCase() + "-" + id;
             }
-            var updateQuery = JSON.object().put("fields", fixupFields);
+            var updateQuery = JSON.object().put("fields", editFields);
             request.put("issue/" + id)
                    .body(updateQuery)
                    .execute();
+
         }
 
         return issue(data.get("key").asString()).orElseThrow();

--- a/issuetracker/src/test/java/org/openjdk/skara/issuetracker/IssueTrackerTests.java
+++ b/issuetracker/src/test/java/org/openjdk/skara/issuetracker/IssueTrackerTests.java
@@ -66,7 +66,8 @@ class IssueTrackerTests {
             issue.setProperty("fixVersions", JSON.array().add("3.0"));
             var updated = project.issue(issue.id()).orElseThrow();
             assertEquals(List.of("another"), updated.labels());
-            assertEquals(List.of(JSON.array().add("3.0")), updated.properties().get("fixVersions"));
+            assertEquals(1, updated.properties().get("fixVersions").asArray().size());
+            assertEquals("3.0", updated.properties().get("fixVersions").get(0).asString());
             assertEquals(List.of(project.issueTracker().currentUser()), updated.assignees());
             assertEquals(1, updated.comments().size());
             assertEquals("Updated title", updated.title());

--- a/issuetracker/src/test/java/org/openjdk/skara/issuetracker/IssueTrackerTests.java
+++ b/issuetracker/src/test/java/org/openjdk/skara/issuetracker/IssueTrackerTests.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.skara.issuetracker;
 
+import org.openjdk.skara.json.JSON;
 import org.openjdk.skara.test.HostCredentials;
 
 import org.junit.jupiter.api.*;
@@ -60,12 +61,12 @@ class IssueTrackerTests {
             issue.addLabel("another");
             issue.removeLabel("label");
             issue.setAssignees(List.of(project.issueTracker().currentUser()));
-            issue.addFixVersion("1.0");
-            issue.addFixVersion("2.0");
-            issue.removeFixVersion("1.0");
+            issue.setProperty("fixVersions", JSON.array().add("1.0"));
+            issue.setProperty("fixVersions", JSON.array().add("1.0").add("2.0"));
+            issue.setProperty("fixVersions", JSON.array().add("3.0"));
             var updated = project.issue(issue.id()).orElseThrow();
             assertEquals(List.of("another"), updated.labels());
-            assertEquals(List.of("2.0"), updated.fixVersions());
+            assertEquals(List.of(JSON.array().add("3.0")), updated.properties().get("fixVersions"));
             assertEquals(List.of(project.issueTracker().currentUser()), updated.assignees());
             assertEquals(1, updated.comments().size());
             assertEquals("Updated title", updated.title());

--- a/test/src/main/java/org/openjdk/skara/test/IssueData.java
+++ b/test/src/main/java/org/openjdk/skara/test/IssueData.java
@@ -24,6 +24,7 @@ package org.openjdk.skara.test;
 
 import org.openjdk.skara.host.HostUser;
 import org.openjdk.skara.issuetracker.*;
+import org.openjdk.skara.json.JSONValue;
 
 import java.time.ZonedDateTime;
 import java.util.*;
@@ -36,8 +37,7 @@ class IssueData {
     final Set<String> labels = new HashSet<>();
     final List<HostUser> assignees = new ArrayList<>();
     final List<Link> links = new ArrayList<>();
-    final Set<String> fixVersions = new HashSet<>();
-    final Map<String, String> properties = new HashMap<>();
+    final Map<String, JSONValue> properties = new HashMap<>();
     ZonedDateTime created = ZonedDateTime.now();
     ZonedDateTime lastUpdate = created;
 }

--- a/test/src/main/java/org/openjdk/skara/test/TestHost.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHost.java
@@ -25,6 +25,7 @@ package org.openjdk.skara.test;
 import org.openjdk.skara.forge.*;
 import org.openjdk.skara.host.*;
 import org.openjdk.skara.issuetracker.*;
+import org.openjdk.skara.json.JSONValue;
 import org.openjdk.skara.vcs.*;
 
 import java.io.*;
@@ -162,7 +163,7 @@ public class TestHost implements Forge, IssueTracker {
                                 .collect(Collectors.toList());
     }
 
-    TestIssue createIssue(TestIssueProject issueProject, String title, List<String> body, Map<String, String> properties) {
+    TestIssue createIssue(TestIssueProject issueProject, String title, List<String> body, Map<String, JSONValue> properties) {
         var id = issueProject.projectName().toUpperCase() + "-" + (data.issues.size() + 1);
         var issue = TestIssue.createNew(issueProject, id, title, body, properties);
         data.issues.put(id ,issue);

--- a/test/src/main/java/org/openjdk/skara/test/TestIssue.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestIssue.java
@@ -24,6 +24,7 @@ package org.openjdk.skara.test;
 
 import org.openjdk.skara.host.HostUser;
 import org.openjdk.skara.issuetracker.*;
+import org.openjdk.skara.json.JSONValue;
 import org.openjdk.skara.network.URIBuilder;
 
 import java.net.URI;
@@ -45,7 +46,7 @@ public class TestIssue implements Issue {
         this.data = data;
     }
 
-    static TestIssue createNew(TestIssueProject issueProject, String id, String title, List<String> body, Map<String, String> properties) {
+    static TestIssue createNew(TestIssueProject issueProject, String id, String title, List<String> body, Map<String, JSONValue> properties) {
         var data = new IssueData();
         data.title = title;
         data.body = String.join("\n", body);
@@ -227,35 +228,18 @@ public class TestIssue implements Issue {
     }
 
     @Override
-    public List<String> fixVersions() {
-        return new ArrayList<>(data.fixVersions);
-    }
-
-    @Override
-    public void addFixVersion(String fixVersion) {
-        data.fixVersions.add(fixVersion);
-        data.lastUpdate = ZonedDateTime.now();
-    }
-
-    @Override
-    public void removeFixVersion(String fixVersion) {
-        data.fixVersions.remove(fixVersion);
-        data.lastUpdate = ZonedDateTime.now();
-    }
-
-    @Override
-    public Map<String, String> properties() {
+    public Map<String, JSONValue> properties() {
         return data.properties;
     }
 
     @Override
-    public void setProperty(String name, String value) {
+    public void setProperty(String name, JSONValue value) {
         data.properties.put(name, value);
         data.lastUpdate = ZonedDateTime.now();
     }
 
     @Override
-    public void removePropery(String name) {
+    public void removeProperty(String name) {
         data.properties.remove(name);
         data.lastUpdate = ZonedDateTime.now();
     }

--- a/test/src/main/java/org/openjdk/skara/test/TestIssueProject.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestIssueProject.java
@@ -23,6 +23,7 @@
 package org.openjdk.skara.test;
 
 import org.openjdk.skara.issuetracker.*;
+import org.openjdk.skara.json.JSONValue;
 import org.openjdk.skara.network.URIBuilder;
 
 import java.net.URI;
@@ -52,7 +53,7 @@ public class TestIssueProject implements IssueProject {
     }
 
     @Override
-    public Issue createIssue(String title, List<String> body, Map<String, String> properties) {
+    public Issue createIssue(String title, List<String> body, Map<String, JSONValue> properties) {
         return host.createIssue(this, title, body, properties);
     }
 


### PR DESCRIPTION
Hi all,

Please review this change that ensures that certain properties are propagated when creating backport issues.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)