### PR TITLE
Make it possible to fetch the state of an issue

### DIFF
--- a/bots/bridgekeeper/src/test/java/org/openjdk/skara/bots/bridgekeeper/PullRequestCloserBotTests.java
+++ b/bots/bridgekeeper/src/test/java/org/openjdk/skara/bots/bridgekeeper/PullRequestCloserBotTests.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.*;
 import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.openjdk.skara.issuetracker.Issue.State.*;
 
 class PullRequestCloserBotTests {
     @Test
@@ -48,6 +49,7 @@ class PullRequestCloserBotTests {
             var editHash = CheckableRepository.appendAndCommit(localRepo);
             localRepo.push(editHash, author.url(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
+            assertEquals(OPEN, pr.state());
 
             // Let the bot see it
             TestBotRunner.runPeriodicItems(bot);
@@ -55,6 +57,9 @@ class PullRequestCloserBotTests {
             // There should now be no open PRs
             var prs = author.pullRequests();
             assertEquals(0, prs.size());
+
+            var updatedPr = author.pullRequest(pr.id());
+            assertEquals(CLOSED, updatedPr.state());
         }
     }
 

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdaterTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdaterTests.java
@@ -43,6 +43,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.openjdk.skara.issuetracker.Issue.State.*;
 
 class UpdaterTests {
     private List<Path> findJsonFiles(Path folder, String partialName) throws IOException {
@@ -1206,6 +1207,7 @@ class UpdaterTests {
             // The fixVersion should not have been updated
             var updatedIssue = issueProject.issue(issue.id()).orElseThrow();
             assertEquals(Set.of("13.0.1"), fixVersions(updatedIssue));
+            assertEquals(OPEN, updatedIssue.state());
 
             // There should be a link
             var links = updatedIssue.links();
@@ -1215,6 +1217,7 @@ class UpdaterTests {
 
             // The backport issue should have a correct fixVersion
             assertEquals(Set.of("12.0.2"), fixVersions(backport));
+            assertEquals(RESOLVED, backport.state());
 
             // Custom properties should also propagate
             assertEquals("1", backport.properties().get("priority").asString());

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
@@ -164,6 +164,11 @@ class InMemoryPullRequest implements PullRequest {
     }
 
     @Override
+    public State state() {
+        return null;
+    }
+
+    @Override
     public Map<String, Check> checks(Hash hash) {
         return checks.get(hash.hex());
     }

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -311,6 +311,14 @@ public class GitHubPullRequest implements PullRequest {
     }
 
     @Override
+    public State state() {
+        if (json.get("state").asString().equals("open")) {
+            return State.OPEN;
+        }
+        return State.CLOSED;
+    }
+
+    @Override
     public Map<String, Check> checks(Hash hash) {
         var checks = request.get("commits/" + hash.hex() + "/check-runs").execute();
 

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -361,6 +361,14 @@ public class GitLabMergeRequest implements PullRequest {
         return ZonedDateTime.parse(json.get("updated_at").asString());
     }
 
+    @Override
+    public State state() {
+        if (json.get("state").asString().equals("open")) {
+            return State.OPEN;
+        }
+        return State.CLOSED;
+    }
+
     private final String checkMarker = "<!-- Merge request status check message (%s) -->";
     private final String checkResultMarker = "<!-- Merge request status check result (%s) (%s) (%s) (%s) -->";
     private final String checkResultPattern = "<!-- Merge request status check result \\(([-\\w]+)\\) \\((\\w+)\\) \\(%s\\) \\((\\S+)\\) -->";

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/Issue.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/Issue.java
@@ -110,6 +110,12 @@ public interface Issue {
     }
 
     /**
+     * Returns the current state.
+     * @return
+     */
+    State state();
+
+    /**
      * Set the state.
      * @param state Desired state
      */

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraIssue.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraIssue.java
@@ -177,6 +177,18 @@ public class JiraIssue implements Issue {
         return ZonedDateTime.parse(json.get("fields").get("updated").asString(), dateFormat);
     }
 
+    @Override
+    public State state() {
+        switch (json.get("fields").get("status").get("name").asString()) {
+            case "Closed":
+                return State.CLOSED;
+            case "Resolved":
+                return State.RESOLVED;
+            default:
+                return State.OPEN;
+        }
+    }
+
     private Map<String, String> availableTransitions() {
         var transitions = request.get("/transitions").execute();
         return transitions.get("transitions").stream()

--- a/test/src/main/java/org/openjdk/skara/test/TestHost.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHost.java
@@ -159,7 +159,7 @@ public class TestHost implements Forge, IssueTracker {
         return data.pullRequests.entrySet().stream()
                                 .sorted(Comparator.comparing(Map.Entry::getKey))
                                 .map(pr -> getPullRequest(repository, pr.getKey()))
-                                .filter(TestPullRequest::isOpen)
+                                .filter(pr -> pr.state().equals(Issue.State.OPEN))
                                 .collect(Collectors.toList());
     }
 
@@ -182,7 +182,7 @@ public class TestHost implements Forge, IssueTracker {
         return data.issues.entrySet().stream()
                           .sorted(Comparator.comparing(Map.Entry::getKey))
                           .map(issue -> getIssue(issueProject, issue.getKey()))
-                          .filter(TestIssue::isOpen)
+                          .filter(i -> i.state().equals(Issue.State.OPEN))
                           .collect(Collectors.toList());
     }
 }

--- a/test/src/main/java/org/openjdk/skara/test/TestIssue.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestIssue.java
@@ -139,13 +139,14 @@ public class TestIssue implements Issue {
     }
 
     @Override
+    public State state() {
+        return data.state;
+    }
+
+    @Override
     public void setState(State state) {
         data.state = state;
         data.lastUpdate = ZonedDateTime.now();
-    }
-
-    boolean isOpen() {
-        return data.state.equals(Issue.State.OPEN);
     }
 
     @Override


### PR DESCRIPTION
Hi all,

Please review this change that adds a method that returns the state of an issue, to complement the current possibility of just setting it.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)