### PR TITLE
Ensure that redirects are followed when verifying webrev links

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
@@ -150,6 +150,7 @@ class WebrevStorage {
         var uriBuilder = URIBuilder.base(uri);
         var client = HttpClient.newBuilder()
                                .connectTimeout(Duration.ofSeconds(30))
+                               .followRedirects(HttpClient.Redirect.NORMAL)
                                .build();
         while (Instant.now().isBefore(end)) {
             var uncachedUri = uriBuilder.setQuery(Map.of("nocache", UUID.randomUUID().toString())).build();

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/WebrevStorageTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/WebrevStorageTests.java
@@ -70,8 +70,9 @@ class WebrevStorageTests {
             var generator = storage.generator(pr, prRepo, scratchFolder);
             generator.generate(masterHash, editHash, "00");
 
-            // Check that the web link has been verified now
+            // Check that the web link has been verified now and followed the redirect
             assertTrue(webrevServer.isChecked());
+            assertTrue(webrevServer.isRedirectFollowed());
 
             // Update the local repository and check that the webrev has been generated
             Repository.materialize(repoFolder, archive.url(), "webrev");


### PR DESCRIPTION
Hi all,

Please review this change that ensures that webrev link verification follows redirects, to avoid false positives.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)