### PR TITLE
231: The merge bot cannot create merge conflict PRs

### DIFF
--- a/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBotFactory.java
+++ b/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBotFactory.java
@@ -55,10 +55,11 @@ public class MergeBotFactory implements BotFactory {
 
             var toRepo = configuration.repository(repo.get("to").asString());
             var toBranch = new Branch(configuration.repositoryRef(repo.get("to").asString()));
+            var toFork = configuration.repository(repo.get("fork").asString());
 
             log.info("Setting up merging from " + fromRepo.name() + ":" + fromBranch.name() +
                      " to " + toRepo.name() + ":" + toBranch.name());
-            bots.add(new MergeBot(storage, fromRepo, fromBranch, toRepo, toBranch));
+            bots.add(new MergeBot(storage, fromRepo, fromBranch, toRepo, toBranch, toFork));
         }
         return bots;
     }

--- a/bots/merge/src/test/java/org/openjdk/skara/bots/merge/MergeBotTests.java
+++ b/bots/merge/src/test/java/org/openjdk/skara/bots/merge/MergeBotTests.java
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class MergeBotTests {
     @Test
     void mergeMasterBranch(TestInfo testInfo) throws IOException {
-        try (var temp = new TemporaryDirectory()) {
+        try (var temp = new TemporaryDirectory(false)) {
             var host = TestHost.createNew(List.of(new HostUser(0, "duke", "J. Duke")));
 
             var fromDir = temp.path().resolve("from.git");
@@ -50,10 +50,17 @@ class MergeBotTests {
 
             var toDir = temp.path().resolve("to.git");
             var toLocalRepo = Repository.init(toDir, VCS.GIT);
-            var gitConfig = toDir.resolve(".git").resolve("config");
-            Files.write(gitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
+            var toGitConfig = toDir.resolve(".git").resolve("config");
+            Files.write(toGitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
                         StandardOpenOption.APPEND);
             var toHostedRepo = new TestHostedRepository(host, "test-mirror", toLocalRepo);
+
+            var forkDir = temp.path().resolve("fork.git");
+            var forkLocalRepo = Repository.init(forkDir, VCS.GIT);
+            var forkGitConfig = forkDir.resolve(".git").resolve("config");
+            Files.write(forkGitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
+                        StandardOpenOption.APPEND);
+            var toFork = new TestHostedRepository(host, "test-mirror-fork", forkLocalRepo);
 
             var now = ZonedDateTime.now();
             var fromFileA = fromDir.resolve("a.txt");
@@ -85,7 +92,7 @@ class MergeBotTests {
 
             var storage = temp.path().resolve("storage");
             var master = new Branch("master");
-            var bot = new MergeBot(storage, fromHostedRepo, master, toHostedRepo, master);
+            var bot = new MergeBot(storage, fromHostedRepo, master, toHostedRepo, master, toFork);
             TestBotRunner.runPeriodicItems(bot);
 
             toCommits = toLocalRepo.commits().asList();
@@ -108,7 +115,7 @@ class MergeBotTests {
 
     @Test
     void failingMergeTest(TestInfo testInfo) throws IOException {
-        try (var temp = new TemporaryDirectory()) {
+        try (var temp = new TemporaryDirectory(false)) {
             var host = TestHost.createNew(List.of(new HostUser(0, "duke", "J. Duke")));
 
             var fromDir = temp.path().resolve("from.git");
@@ -117,10 +124,17 @@ class MergeBotTests {
 
             var toDir = temp.path().resolve("to.git");
             var toLocalRepo = Repository.init(toDir, VCS.GIT);
-            var gitConfig = toDir.resolve(".git").resolve("config");
-            Files.write(gitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
+            var toGitConfig = toDir.resolve(".git").resolve("config");
+            Files.write(toGitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
                         StandardOpenOption.APPEND);
             var toHostedRepo = new TestHostedRepository(host, "test-mirror", toLocalRepo);
+
+            var forkDir = temp.path().resolve("fork.git");
+            var forkLocalRepo = Repository.init(forkDir, VCS.GIT);
+            var forkGitConfig = forkDir.resolve(".git").resolve("config");
+            Files.write(forkGitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
+                        StandardOpenOption.APPEND);
+            var toFork = new TestHostedRepository(host, "test-mirror-fork", forkLocalRepo);
 
             var now = ZonedDateTime.now();
             var fromFileA = fromDir.resolve("a.txt");
@@ -152,7 +166,7 @@ class MergeBotTests {
 
             var storage = temp.path().resolve("storage");
             var master = new Branch("master");
-            var bot = new MergeBot(storage, fromHostedRepo, master, toHostedRepo, master);
+            var bot = new MergeBot(storage, fromHostedRepo, master, toHostedRepo, master, toFork);
             TestBotRunner.runPeriodicItems(bot);
 
             toCommits = toLocalRepo.commits().asList();
@@ -170,7 +184,7 @@ class MergeBotTests {
 
     @Test
     void failingMergeShouldResultInOnlyOnePR(TestInfo testInfo) throws IOException {
-        try (var temp = new TemporaryDirectory()) {
+        try (var temp = new TemporaryDirectory(false)) {
             var host = TestHost.createNew(List.of(new HostUser(0, "duke", "J. Duke")));
 
             var fromDir = temp.path().resolve("from.git");
@@ -179,10 +193,17 @@ class MergeBotTests {
 
             var toDir = temp.path().resolve("to.git");
             var toLocalRepo = Repository.init(toDir, VCS.GIT);
-            var gitConfig = toDir.resolve(".git").resolve("config");
-            Files.write(gitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
+            var toGitConfig = toDir.resolve(".git").resolve("config");
+            Files.write(toGitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
                         StandardOpenOption.APPEND);
             var toHostedRepo = new TestHostedRepository(host, "test-mirror", toLocalRepo);
+
+            var forkDir = temp.path().resolve("fork.git");
+            var forkLocalRepo = Repository.init(forkDir, VCS.GIT);
+            var forkGitConfig = forkDir.resolve(".git").resolve("config");
+            Files.write(forkGitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
+                        StandardOpenOption.APPEND);
+            var toFork = new TestHostedRepository(host, "test-mirror-fork", forkLocalRepo);
 
             var now = ZonedDateTime.now();
             var fromFileA = fromDir.resolve("a.txt");
@@ -214,7 +235,7 @@ class MergeBotTests {
 
             var storage = temp.path().resolve("storage");
             var master = new Branch("master");
-            var bot = new MergeBot(storage, fromHostedRepo, master, toHostedRepo, master);
+            var bot = new MergeBot(storage, fromHostedRepo, master, toHostedRepo, master, toFork);
             TestBotRunner.runPeriodicItems(bot);
             TestBotRunner.runPeriodicItems(bot);
 
@@ -242,10 +263,17 @@ class MergeBotTests {
 
             var toDir = temp.path().resolve("to.git");
             var toLocalRepo = Repository.init(toDir, VCS.GIT);
-            var gitConfig = toDir.resolve(".git").resolve("config");
-            Files.write(gitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
+            var toGitConfig = toDir.resolve(".git").resolve("config");
+            Files.write(toGitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
                         StandardOpenOption.APPEND);
             var toHostedRepo = new TestHostedRepository(host, "test-mirror", toLocalRepo);
+
+            var forkDir = temp.path().resolve("fork.git");
+            var forkLocalRepo = Repository.init(forkDir, VCS.GIT);
+            var forkGitConfig = forkDir.resolve(".git").resolve("config");
+            Files.write(forkGitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
+                        StandardOpenOption.APPEND);
+            var toFork = new TestHostedRepository(host, "test-mirror-fork", forkLocalRepo);
 
             var now = ZonedDateTime.now();
             var fromFileA = fromDir.resolve("a.txt");
@@ -277,7 +305,7 @@ class MergeBotTests {
 
             var storage = temp.path().resolve("storage");
             var master = new Branch("master");
-            var bot = new MergeBot(storage, fromHostedRepo, master, toHostedRepo, master);
+            var bot = new MergeBot(storage, fromHostedRepo, master, toHostedRepo, master, toFork);
             TestBotRunner.runPeriodicItems(bot);
             TestBotRunner.runPeriodicItems(bot);
 
@@ -316,10 +344,17 @@ class MergeBotTests {
 
             var toDir = temp.path().resolve("to.git");
             var toLocalRepo = Repository.init(toDir, VCS.GIT);
-            var gitConfig = toDir.resolve(".git").resolve("config");
-            Files.write(gitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
+            var toGitConfig = toDir.resolve(".git").resolve("config");
+            Files.write(toGitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
                         StandardOpenOption.APPEND);
             var toHostedRepo = new TestHostedRepository(host, "test-mirror", toLocalRepo);
+
+            var forkDir = temp.path().resolve("fork.git");
+            var forkLocalRepo = Repository.init(forkDir, VCS.GIT);
+            var forkGitConfig = forkDir.resolve(".git").resolve("config");
+            Files.write(forkGitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
+                        StandardOpenOption.APPEND);
+            var toFork = new TestHostedRepository(host, "test-mirror-fork", forkLocalRepo);
 
             var now = ZonedDateTime.now();
             var fromFileA = fromDir.resolve("a.txt");
@@ -351,7 +386,7 @@ class MergeBotTests {
 
             var storage = temp.path().resolve("storage");
             var master = new Branch("master");
-            var bot = new MergeBot(storage, fromHostedRepo, master, toHostedRepo, master);
+            var bot = new MergeBot(storage, fromHostedRepo, master, toHostedRepo, master, toFork);
             TestBotRunner.runPeriodicItems(bot);
             TestBotRunner.runPeriodicItems(bot);
 

--- a/test/src/main/java/org/openjdk/skara/test/TestHost.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHost.java
@@ -143,9 +143,9 @@ public class TestHost implements Forge, IssueTracker {
         }
     }
 
-    TestPullRequest createPullRequest(TestHostedRepository repository, String targetRef, String sourceRef, String title, List<String> body, boolean draft) {
+    TestPullRequest createPullRequest(TestHostedRepository targetRepository, TestHostedRepository sourceRepository, String targetRef, String sourceRef, String title, List<String> body, boolean draft) {
         var id = String.valueOf(data.pullRequests.size() + 1);
-        var pr = TestPullRequest.createNew(repository, id, targetRef, sourceRef, title, body, draft);
+        var pr = TestPullRequest.createNew(targetRepository, sourceRepository, id, targetRef, sourceRef, title, body, draft);
         data.pullRequests.put(id, pr);
         return pr;
     }

--- a/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
@@ -59,7 +59,7 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
 
     @Override
     public PullRequest createPullRequest(HostedRepository target, String targetRef, String sourceRef, String title, List<String> body, boolean draft) {
-        return host.createPullRequest(this, targetRef, sourceRef, title, body, draft);
+        return host.createPullRequest((TestHostedRepository) target, this, targetRef, sourceRef, title, body, draft);
     }
 
     @Override

--- a/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
@@ -36,22 +36,24 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class TestPullRequest extends TestIssue implements PullRequest {
-    private final TestHostedRepository repository;
+    private final TestHostedRepository targetRepository;
+    private final TestHostedRepository sourceRepository;
     private final String targetRef;
     private final String sourceRef;
     private final PullRequestData data;
 
-    private TestPullRequest(TestHostedRepository repository, String id, HostUser author, HostUser user, String targetRef, String sourceRef, PullRequestData data) {
-        super(repository, id, author, user, data);
-        this.repository = repository;
+    private TestPullRequest(TestHostedRepository targetRepository, TestHostedRepository sourceRepository, String id, HostUser author, HostUser user, String targetRef, String sourceRef, PullRequestData data) {
+        super(targetRepository, id, author, user, data);
+        this.targetRepository = targetRepository;
+        this.sourceRepository = sourceRepository;
         this.targetRef = targetRef;
         this.sourceRef = sourceRef;
         this.data = data;
 
         try {
-            var headHash = repository.localRepository().resolve(sourceRef).orElseThrow();
-            if (!headHash.equals(data.headHash)) {
-                data.headHash = headHash;
+            var headHash = sourceRepository.localRepository().resolve(sourceRef);
+            if (headHash.isPresent() && !headHash.get().equals(data.headHash)) {
+                data.headHash = headHash.get();
                 data.lastUpdate = ZonedDateTime.now();
             }
         } catch (IOException e) {
@@ -59,23 +61,23 @@ public class TestPullRequest extends TestIssue implements PullRequest {
         }
     }
 
-    static TestPullRequest createNew(TestHostedRepository repository, String id, String targetRef, String sourceRef, String title, List<String> body, boolean draft) {
+    static TestPullRequest createNew(TestHostedRepository targetRepository, TestHostedRepository sourceRepository, String id, String targetRef, String sourceRef, String title, List<String> body, boolean draft) {
         var data = new PullRequestData();
         data.title = title;
         data.body = String.join("\n", body);
         data.draft = draft;
-        var pr = new TestPullRequest(repository, id, repository.forge().currentUser(), repository.forge().currentUser(), targetRef, sourceRef, data);
+        var pr = new TestPullRequest(targetRepository, sourceRepository, id, targetRepository.forge().currentUser(), targetRepository.forge().currentUser(), targetRef, sourceRef, data);
         return pr;
     }
 
     static TestPullRequest createFrom(TestHostedRepository repository, TestPullRequest other) {
-        var pr = new TestPullRequest(repository, other.id, other.author, repository.forge().currentUser(), other.targetRef, other.sourceRef, other.data);
+        var pr = new TestPullRequest(repository, other.sourceRepository, other.id, other.author, repository.forge().currentUser(), other.targetRef, other.sourceRef, other.data);
         return pr;
     }
 
     @Override
     public HostedRepository repository() {
-        return repository;
+        return targetRepository;
     }
 
     @Override
@@ -91,8 +93,8 @@ public class TestPullRequest extends TestIssue implements PullRequest {
     @Override
     public void addReview(Review.Verdict verdict, String body) {
         try {
-            var review = new Review(ZonedDateTime.now(), repository.forge().currentUser(),
-                                    verdict, repository.localRepository().resolve(sourceRef).orElseThrow(),
+            var review = new Review(ZonedDateTime.now(), targetRepository.forge().currentUser(),
+                                    verdict, targetRepository.localRepository().resolve(sourceRef).orElseThrow(),
                                     data.reviews.size(),
                                     body);
 
@@ -145,7 +147,7 @@ public class TestPullRequest extends TestIssue implements PullRequest {
 
     @Override
     public HostedRepository sourceRepository() {
-        return repository;
+        return sourceRepository;
     }
 
     @Override
@@ -155,7 +157,7 @@ public class TestPullRequest extends TestIssue implements PullRequest {
 
     @Override
     public Hash targetHash() {
-        return repository.branchHash(targetRef);
+        return targetRepository.branchHash(targetRef);
     }
 
     @Override
@@ -205,7 +207,7 @@ public class TestPullRequest extends TestIssue implements PullRequest {
     @Override
     public URI webUrl() {
         try {
-            return new URI(repository.url().toString() + "/pr/" + id());
+            return new URI(targetRepository.url().toString() + "/pr/" + id());
         } catch (URISyntaxException e) {
             throw new RuntimeException(e);
         }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
@@ -98,6 +98,7 @@ public interface Repository extends ReadOnlyRepository {
                String committerEmail) throws IOException;
     Tag tag(Hash hash, String tagName, String message, String authorName, String authorEmail) throws IOException;
     Branch branch(Hash hash, String branchName) throws IOException;
+    void prune(Branch branch, String remote) throws IOException;
     void delete(Branch b) throws IOException;
     void rebase(Hash hash, String committerName, String committerEmail) throws IOException;
     void merge(Hash hash) throws IOException;

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -627,6 +627,16 @@ public class GitRepository implements Repository {
     }
 
     @Override
+    public void prune(Branch branch, String remote) throws IOException {
+        try (var p = capture("git", "push", "--delete", remote, branch.name())) {
+            await(p);
+        }
+        try (var p = capture("git", "branch", "--delete", "--force", branch.name())) {
+            await(p);
+        }
+    }
+
+    @Override
     public Hash mergeBase(Hash first, Hash second) throws IOException {
         try (var p = capture("git", "merge-base", first.hex(), second.hex())) {
             var res = await(p);

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -590,6 +590,16 @@ public class HgRepository implements Repository {
     }
 
     @Override
+    public void prune(Branch branch, String remote) throws IOException {
+        try (var p = capture("hg", "bookmark", "--delete", branch.name())) {
+            await(p);
+        }
+        try (var p = capture("hg", "push", "--bookmark", branch.name(), remote)) {
+            await(p);
+        }
+    }
+
+    @Override
     public Hash mergeBase(Hash first, Hash second) throws IOException {
         var revset = "ancestor(" + first.hex() + ", " + second.hex() + ")";
         try (var p = capture("hg", "log", "--rev=" + revset, "--template={node}\n")) {


### PR DESCRIPTION
Hi all,

please review this patch that fixes the merge bot. The merge bot is able to
automatically merge commits from a branch in one repository to a branch in
another repository. When the merge bot encounters a merge conflict it is
supposed to open a PR describing the conflict.

This didn't work because I forgot to include a personal fork for the bot when
writing the code the first time around. This patch fixes and makes the merge bot
aware of a personal fork it can use for creating PRs.

I also had to update `TestPullRequest` a little bit to make it work with pull
requests _between_ two different `TestHostedRepository` instances.

Finally I also added the new method `Repository.prune`. It isn't currently used
(besides by the unit test), but I used it at one point in time during this
rewrite of the merge bot and I have a feeling we might need it again soon, so I
decided to let it stay and be part of the patch.

Thanks,
Erik

## Testing
- [x] `make test` on Linux x64 (includes unit tests for the merge bot)
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-231](https://bugs.openjdk.java.net/browse/SKARA-231): The merge bot cannot create merge conflict PRs


## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)