### PR TITLE
Handle redirects manually

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
@@ -150,20 +150,27 @@ class WebrevStorage {
         var uriBuilder = URIBuilder.base(uri);
         var client = HttpClient.newBuilder()
                                .connectTimeout(Duration.ofSeconds(30))
-                               .followRedirects(HttpClient.Redirect.NORMAL)
                                .build();
         while (Instant.now().isBefore(end)) {
             var uncachedUri = uriBuilder.setQuery(Map.of("nocache", UUID.randomUUID().toString())).build();
+            log.fine("Validating webrev URL: " + uncachedUri);
             var request = HttpRequest.newBuilder(uncachedUri)
                                      .timeout(Duration.ofSeconds(30))
                                      .GET()
                                      .build();
             try {
                 var response = client.send(request, HttpResponse.BodyHandlers.ofString());
-                if (response.statusCode() < 400) {
+                if (response.statusCode() < 300) {
                     log.info(response.statusCode() + " when checking " + uncachedUri + " - success!");
-                    // Success!
                     return;
+                }
+                if (response.statusCode() < 400) {
+                    var newLocation = response.headers().firstValue("location");
+                    if (newLocation.isPresent()) {
+                        log.info("Webrev url redirection: " + newLocation.get());
+                        uriBuilder = URIBuilder.base(newLocation.get());
+                        continue;
+                    }
                 }
                 log.info(response.statusCode() + " when checking " + uncachedUri + " - waiting...");
                 Thread.sleep(Duration.ofSeconds(10).toMillis());

--- a/test/src/main/java/org/openjdk/skara/test/TestWebrevServer.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestWebrevServer.java
@@ -41,7 +41,7 @@ public class TestWebrevServer implements AutoCloseable {
             var response = "ok!";
             var responseBytes = response.getBytes(StandardCharsets.UTF_8);
             if (!exchange.getRequestURI().toString().contains("final=true")) {
-                exchange.getResponseHeaders().add("Location", exchange.getRequestURI().toString() + "&final=true");
+                exchange.getResponseHeaders().add("Location", uri() + "&final=true");
                 exchange.sendResponseHeaders(302, responseBytes.length);
             } else {
                 redirectFollowed = true;


### PR DESCRIPTION
Hi all,

Please review this change that updates the webrev link verifier to handle redirects manually. Requesting the HttpClient to follow redirects automatically doesn't actually work in our case, not quite sure why. But we can work around it in the meantime.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)