### PR TITLE
235: git-webrev can't handle empty files

### DIFF
--- a/webrev/src/main/java/org/openjdk/skara/webrev/AddedPatchView.java
+++ b/webrev/src/main/java/org/openjdk/skara/webrev/AddedPatchView.java
@@ -91,28 +91,29 @@ class AddedPatchView implements View {
             fw.write(ViewUtils.pathWithUnixSeps(textualPatch.target().path().get()));
             fw.write("\n");
 
-            assert textualPatch.hunks().size() == 1;
+            var hunks = textualPatch.hunks();
+            if (hunks.size() == 1) {
+                var hunk = hunks.get(0);
 
-            var hunk = textualPatch.hunks().get(0);
+                assert hunk.source().range().start() == 0;
+                assert hunk.source().range().count() == 0;
+                assert hunk.source().lines().size() == 0;
 
-            assert hunk.source().range().start() == 0;
-            assert hunk.source().range().count() == 0;
-            assert hunk.source().lines().size() == 0;
+                fw.write("@@ -");
+                fw.write(String.valueOf(hunk.source().range().start()));
+                fw.write(",");
+                fw.write(String.valueOf(hunk.source().range().count()));
+                fw.write(" +");
+                fw.write(String.valueOf(hunk.target().range().start()));
+                fw.write(",");
+                fw.write(String.valueOf(hunk.target().range().count()));
+                fw.write(" @@\n");
 
-            fw.write("@@ -");
-            fw.write(String.valueOf(hunk.source().range().start()));
-            fw.write(",");
-            fw.write(String.valueOf(hunk.source().range().count()));
-            fw.write(" +");
-            fw.write(String.valueOf(hunk.target().range().start()));
-            fw.write(",");
-            fw.write(String.valueOf(hunk.target().range().count()));
-            fw.write(" @@\n");
-
-            for (var line : hunk.target().lines()) {
-                fw.write("+");
-                fw.write(line);
-                fw.write("\n");
+                for (var line : hunk.target().lines()) {
+                    fw.write("+");
+                    fw.write(line);
+                    fw.write("\n");
+                }
             }
         }
     }

--- a/webrev/src/main/java/org/openjdk/skara/webrev/RemovedPatchView.java
+++ b/webrev/src/main/java/org/openjdk/skara/webrev/RemovedPatchView.java
@@ -91,28 +91,29 @@ class RemovedPatchView implements View {
             fw.write("+++ /dev/null");
             fw.write("\n");
 
-            assert textualPatch.hunks().size() == 1;
+            var hunks = textualPatch.hunks();
+            if (hunks.size() == 1) {
+                var hunk = hunks.get(0);
 
-            var hunk = textualPatch.hunks().get(0);
+                assert hunk.target().range().start() == 0;
+                assert hunk.target().range().count() == 0;
+                assert hunk.target().lines().size() == 0;
 
-            assert hunk.target().range().start() == 0;
-            assert hunk.target().range().count() == 0;
-            assert hunk.target().lines().size() == 0;
+                fw.write("@@ -");
+                fw.write(String.valueOf(hunk.source().range().start()));
+                fw.write(",");
+                fw.write(String.valueOf(hunk.source().range().count()));
+                fw.write(" +");
+                fw.write(String.valueOf(hunk.target().range().start()));
+                fw.write(",");
+                fw.write(String.valueOf(hunk.target().range().count()));
+                fw.write(" @@\n");
 
-            fw.write("@@ -");
-            fw.write(String.valueOf(hunk.source().range().start()));
-            fw.write(",");
-            fw.write(String.valueOf(hunk.source().range().count()));
-            fw.write(" +");
-            fw.write(String.valueOf(hunk.target().range().start()));
-            fw.write(",");
-            fw.write(String.valueOf(hunk.target().range().count()));
-            fw.write(" @@\n");
-
-            for (var line : hunk.source().lines()) {
-                fw.write("-");
-                fw.write(line);
-                fw.write("\n");
+                for (var line : hunk.source().lines()) {
+                    fw.write("-");
+                    fw.write(line);
+                    fw.write("\n");
+                }
             }
         }
     }


### PR DESCRIPTION
Hi all,

please review this patch that makes `git-webrev` work with empty files (either
added or removed). The addition or removal of an empty file can't unfortunately
be represented using the unified diff output format (one needs "extended
headers" like `git`), but we can still make the HTML view work.

Thanks,
Erik

## Testing
- [x] Manual testing of `git-webrev` on repositories with empty files
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-235](https://bugs.openjdk.java.net/browse/SKARA-235): git-webrev can't handle empty files


## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)