### PR TITLE
220: webrev version unknown message

### DIFF
--- a/bots/cli/build.gradle
+++ b/bots/cli/build.gradle
@@ -62,6 +62,7 @@ dependencies {
     implementation project(':process')
     implementation project(':args')
     implementation project(':proxy')
+    implementation project(':version')
 
     testImplementation project(':test')
 }

--- a/bots/cli/src/main/java/module-info.java
+++ b/bots/cli/src/main/java/module-info.java
@@ -31,6 +31,7 @@ module org.openjdk.skara.bots.cli {
     requires org.openjdk.skara.process;
     requires org.openjdk.skara.proxy;
     requires org.openjdk.skara.network;
+    requires org.openjdk.skara.version;
 
     requires java.sql;
 

--- a/bots/cli/src/main/java/org/openjdk/skara/bots/cli/BotLauncher.java
+++ b/bots/cli/src/main/java/org/openjdk/skara/bots/cli/BotLauncher.java
@@ -27,6 +27,7 @@ import org.openjdk.skara.bot.*;
 import org.openjdk.skara.network.URIBuilder;
 import org.openjdk.skara.json.*;
 import org.openjdk.skara.proxy.HttpProxy;
+import org.openjdk.skara.version.Version;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -123,6 +124,10 @@ public class BotLauncher {
                       .fullname("once")
                       .helptext("Instead of repeatedly executing periodical task, run each task exactly once")
                       .optional(),
+                Switch.shortcut("v")
+                      .fullname("version")
+                      .helptext("Show version")
+                      .optional(),
                 Switch.shortcut("l")
                       .fullname("list-bots")
                       .helptext("List all available bots and then exit")
@@ -141,6 +146,11 @@ public class BotLauncher {
             for (var botFactory : botFactories) {
                 System.out.println(" - " + botFactory.name() + " (" + botFactory.getClass().getModule() + ")");
             }
+            System.exit(0);
+        }
+
+        if (arguments.contains("version")) {
+            System.out.println(Version.fromManifest().orElse("unknown"));
             System.exit(0);
         }
 

--- a/bots/mlbridge/src/main/java/module-info.java
+++ b/bots/mlbridge/src/main/java/module-info.java
@@ -31,6 +31,7 @@ module org.openjdk.skara.bots.mlbridge {
     requires org.openjdk.skara.email;
     requires org.openjdk.skara.webrev;
     requires org.openjdk.skara.network;
+    requires org.openjdk.skara.version;
     requires java.logging;
     requires java.net.http;
 

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
@@ -27,6 +27,7 @@ import org.openjdk.skara.forge.*;
 import org.openjdk.skara.network.URIBuilder;
 import org.openjdk.skara.vcs.*;
 import org.openjdk.skara.webrev.Webrev;
+import org.openjdk.skara.version.Version;
 
 import java.io.*;
 import java.net.URI;
@@ -56,7 +57,9 @@ class WebrevStorage {
 
     private void generate(PullRequest pr, Repository localRepository, Path folder, Hash base, Hash head) throws IOException {
         Files.createDirectories(folder);
-        Webrev.repository(localRepository).output(folder)
+        Webrev.repository(localRepository)
+              .output(folder)
+              .version(Version.fromManifest().orElse("unknown"))
               .generate(base, head);
     }
 

--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -42,13 +42,7 @@ dependencies {
     implementation project(':issuetracker')
     implementation project(':proxy')
     implementation project(':ssh')
-}
-
-
-jar {
-    manifest {
-        attributes("Implementation-Title": "org.openjdk.skara.cli", "Implementation-Version": archiveVersion)
-    }
+    implementation project(':version')
 }
 
 images {

--- a/cli/src/main/java/module-info.java
+++ b/cli/src/main/java/module-info.java
@@ -31,6 +31,7 @@ module org.openjdk.skara.cli {
     requires org.openjdk.skara.forge;
     requires org.openjdk.skara.proxy;
     requires org.openjdk.skara.ssh;
+    requires org.openjdk.skara.version;
 
     requires java.net.http;
     requires java.logging;

--- a/cli/src/main/java/org/openjdk/skara/cli/GitDefpath.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitDefpath.java
@@ -28,6 +28,7 @@ import org.openjdk.skara.host.Credential;
 import org.openjdk.skara.vcs.*;
 import org.openjdk.skara.webrev.*;
 import org.openjdk.skara.proxy.HttpProxy;
+import org.openjdk.skara.version.Version;
 
 import java.io.*;
 import java.nio.file.*;

--- a/cli/src/main/java/org/openjdk/skara/cli/GitFork.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitFork.java
@@ -27,6 +27,7 @@ import org.openjdk.skara.forge.Forge;
 import org.openjdk.skara.host.*;
 import org.openjdk.skara.vcs.Repository;
 import org.openjdk.skara.proxy.HttpProxy;
+import org.openjdk.skara.version.Version;
 
 import java.io.*;
 import java.net.URI;

--- a/cli/src/main/java/org/openjdk/skara/cli/GitInfo.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitInfo.java
@@ -28,6 +28,7 @@ import org.openjdk.skara.issuetracker.IssueTracker;
 import org.openjdk.skara.jcheck.*;
 import org.openjdk.skara.vcs.openjdk.*;
 import org.openjdk.skara.proxy.HttpProxy;
+import org.openjdk.skara.version.Version;
 
 import java.io.IOException;
 import java.net.URI;

--- a/cli/src/main/java/org/openjdk/skara/cli/GitJCheck.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitJCheck.java
@@ -29,6 +29,7 @@ import org.openjdk.skara.json.JSON;
 import org.openjdk.skara.json.JSONValue;
 import org.openjdk.skara.vcs.*;
 import org.openjdk.skara.vcs.openjdk.CommitMessageParsers;
+import org.openjdk.skara.version.Version;
 
 import java.io.IOException;
 import java.net.*;

--- a/cli/src/main/java/org/openjdk/skara/cli/GitOpenJDKImport.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitOpenJDKImport.java
@@ -27,6 +27,7 @@ import org.openjdk.skara.json.*;
 import org.openjdk.skara.vcs.*;
 import org.openjdk.skara.vcs.openjdk.*;
 import org.openjdk.skara.vcs.openjdk.convert.*;
+import org.openjdk.skara.version.Version;
 
 import java.io.*;
 import java.nio.file.*;

--- a/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
@@ -31,6 +31,7 @@ import org.openjdk.skara.jcheck.JCheckConfiguration;
 import org.openjdk.skara.proxy.HttpProxy;
 import org.openjdk.skara.vcs.*;
 import org.openjdk.skara.vcs.openjdk.CommitMessageParsers;
+import org.openjdk.skara.version.Version;
 
 import java.io.IOException;
 import java.net.URI;

--- a/cli/src/main/java/org/openjdk/skara/cli/GitPublish.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitPublish.java
@@ -24,6 +24,7 @@ package org.openjdk.skara.cli;
 
 import org.openjdk.skara.args.*;
 import org.openjdk.skara.vcs.*;
+import org.openjdk.skara.version.Version;
 
 import java.io.*;
 import java.nio.file.*;

--- a/cli/src/main/java/org/openjdk/skara/cli/GitSync.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitSync.java
@@ -26,6 +26,7 @@ import org.openjdk.skara.args.*;
 import org.openjdk.skara.vcs.*;
 import org.openjdk.skara.forge.*;
 import org.openjdk.skara.proxy.HttpProxy;
+import org.openjdk.skara.version.Version;
 
 import java.io.*;
 import java.net.*;

--- a/cli/src/main/java/org/openjdk/skara/cli/GitToken.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitToken.java
@@ -23,6 +23,7 @@
 package org.openjdk.skara.cli;
 
 import org.openjdk.skara.args.*;
+import org.openjdk.skara.version.Version;
 
 import java.io.IOException;
 import java.net.URI;

--- a/cli/src/main/java/org/openjdk/skara/cli/GitTranslate.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitTranslate.java
@@ -24,6 +24,7 @@ package org.openjdk.skara.cli;
 
 import org.openjdk.skara.args.*;
 import org.openjdk.skara.vcs.ReadOnlyRepository;
+import org.openjdk.skara.version.Version;
 
 import java.io.IOException;
 import java.util.*;

--- a/cli/src/main/java/org/openjdk/skara/cli/GitVerifyImport.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitVerifyImport.java
@@ -24,6 +24,7 @@ package org.openjdk.skara.cli;
 
 import org.openjdk.skara.args.*;
 import org.openjdk.skara.vcs.*;
+import org.openjdk.skara.version.Version;
 
 import java.io.IOException;
 import java.nio.file.*;

--- a/cli/src/main/java/org/openjdk/skara/cli/GitWebrev.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitWebrev.java
@@ -26,6 +26,7 @@ import org.openjdk.skara.args.*;
 import org.openjdk.skara.proxy.HttpProxy;
 import org.openjdk.skara.vcs.*;
 import org.openjdk.skara.webrev.*;
+import org.openjdk.skara.version.Version;
 
 import java.io.*;
 import java.net.URI;

--- a/cli/src/main/java/org/openjdk/skara/cli/HgOpenJDKImport.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/HgOpenJDKImport.java
@@ -27,6 +27,7 @@ import org.openjdk.skara.json.*;
 import org.openjdk.skara.vcs.*;
 import org.openjdk.skara.vcs.openjdk.*;
 import org.openjdk.skara.vcs.openjdk.convert.*;
+import org.openjdk.skara.version.Version;
 
 import java.io.*;
 import java.nio.file.*;

--- a/settings.gradle
+++ b/settings.gradle
@@ -44,6 +44,7 @@ include 'webrev'
 include 'network'
 include 'forge'
 include 'issuetracker'
+include 'version'
 
 include 'bots:bridgekeeper'
 include 'bots:cli'

--- a/version/build.gradle
+++ b/version/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,29 +22,19 @@
  */
 
 module {
-    name = 'org.openjdk.skara.bots.mlbridge'
-    test {
-        requires 'org.junit.jupiter.api'
-        requires 'org.openjdk.skara.test'
-        opens 'org.openjdk.skara.bots.mlbridge' to 'org.junit.platform.commons'
+    name = 'org.openjdk.skara.version'
+}
+
+jar {
+    manifest {
+        attributes("Implementation-Title": "org.openjdk.skara.version", "Implementation-Version": archiveVersion)
     }
 }
 
-dependencies {
-    implementation project(':ci')
-    implementation project(':bot')
-    implementation project(':mailinglist')
-    implementation project(':host')
-    implementation project(':forge')
-    implementation project(':issuetracker')
-    implementation project(':network')
-    implementation project(':census')
-    implementation project(':vcs')
-    implementation project(':jcheck')
-    implementation project(':json')
-    implementation project(':email')
-    implementation project(':webrev')
-    implementation project(':version')
-
-    testImplementation project(':test')
+publishing {
+    publications {
+        version(MavenPublication) {
+            from components.java
+        }
+    }
 }

--- a/version/src/main/java/module-info.java
+++ b/version/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,31 +20,6 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-
-module {
-    name = 'org.openjdk.skara.bots.mlbridge'
-    test {
-        requires 'org.junit.jupiter.api'
-        requires 'org.openjdk.skara.test'
-        opens 'org.openjdk.skara.bots.mlbridge' to 'org.junit.platform.commons'
-    }
-}
-
-dependencies {
-    implementation project(':ci')
-    implementation project(':bot')
-    implementation project(':mailinglist')
-    implementation project(':host')
-    implementation project(':forge')
-    implementation project(':issuetracker')
-    implementation project(':network')
-    implementation project(':census')
-    implementation project(':vcs')
-    implementation project(':jcheck')
-    implementation project(':json')
-    implementation project(':email')
-    implementation project(':webrev')
-    implementation project(':version')
-
-    testImplementation project(':test')
+module org.openjdk.skara.version {
+    exports org.openjdk.skara.version;
 }

--- a/version/src/main/java/org/openjdk/skara/version/Version.java
+++ b/version/src/main/java/org/openjdk/skara/version/Version.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,15 +20,15 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package org.openjdk.skara.cli;
+package org.openjdk.skara.version;
 
 import java.io.IOException;
 import java.util.jar.Manifest;
 import java.util.Optional;
 
-class Version {
+public class Version {
     private static String version = null;
-    static Optional<String> fromManifest() {
+    public static Optional<String> fromManifest() {
         if (version == null) {
             try {
                 var resources = Version.class.getClassLoader().getResources("META-INF/MANIFEST.MF");


### PR DESCRIPTION
Hi all,

please review this patch that add proper versions to the automatically generated
webrevs. I also took the opportunity to add a `--version` flag to the bot
launcher.

Thanks,
Erik

## Testing
- [x] Manual testing of `skara-bots` and the CLI tools
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-220](https://bugs.openjdk.java.net/browse/SKARA-220): webrev version unknown message


## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)