### PR TITLE
238: Add link to upstream repository to generated webrevs

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
@@ -66,6 +66,7 @@ class WebrevStorage {
         var builder = Webrev.repository(localRepository)
                             .output(folder)
                             .version(Version.fromManifest().orElse("unknown"))
+                            .upstream(pr.repository().webUrl().toString())
                             .username(fullName);
 
         var issue = Issue.fromString(pr.title());


### PR DESCRIPTION
Hi all,

please review this small patch that adds a link to the upstream repository in
automatically generated webrevs.

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-238](https://bugs.openjdk.java.net/browse/SKARA-238): Add link to upstream repository to generated webrevs


## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)