### PR TITLE
241: Gradle version plugin should allow a version.txt file

### DIFF
--- a/buildSrc/version/src/main/java/org/openjdk/skara/gradle/version/VersionPlugin.java
+++ b/buildSrc/version/src/main/java/org/openjdk/skara/gradle/version/VersionPlugin.java
@@ -27,8 +27,11 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.GradleException;
 
+import java.nio.file.Files;
 import java.nio.charset.StandardCharsets;
 import java.io.IOException;
+
+import static java.util.stream.Collectors.toList;
 
 public class VersionPlugin implements Plugin<Project> {
     public void apply(Project project) {
@@ -47,7 +50,18 @@ public class VersionPlugin implements Plugin<Project> {
                 }
                 project.setProperty("version", desc);
             } else {
-                project.setProperty("version", "unknown");
+                var root = project.getRootProject().getRootDir().toPath();
+                var versionTxt = root.resolve("version.txt");
+                if (Files.exists(versionTxt)) {
+                    var lines = Files.lines(versionTxt).collect(toList());
+                    if (!lines.isEmpty()) {
+                        project.setProperty("version", lines.get(0));
+                    } else {
+                        project.setProperty("version", "unknown");
+                    }
+                } else {
+                    project.setProperty("version", "unknown");
+                }
             }
         } catch (InterruptedException e) {
             throw new GradleException("'git rev-parse' was interrupted", e);


### PR DESCRIPTION
Hi all,

please review this small patch that makes the `VersionPlugin` look for a
`version.txt` in the root directory of the repository _if_ the `.git` directory
is missing. This is useful to be able to build Skara with a proper version from
e.g. a source tarball.

Thanks,
Erik

## Testing
- [x] Manual testing in directory without `.git` present
- [x] Manual testing in directory with `.git` present
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-241](https://bugs.openjdk.java.net/browse/SKARA-241): Gradle version plugin should allow a version.txt file


## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)