### PR TITLE
223: Make required re-reviewing configurable

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/AllowCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/AllowCommand.java
@@ -31,7 +31,7 @@ import java.util.List;
 
 public class AllowCommand implements CommandHandler {
     @Override
-    public void handle(PullRequest pr, CensusInstance censusInstance, Path scratchPath, String args, Comment comment, List<Comment> allComments, PrintWriter reply) {
+    public void handle(PullRequestBot bot, PullRequest pr, CensusInstance censusInstance, Path scratchPath, String args, Comment comment, List<Comment> allComments, PrintWriter reply) {
         var botUser = pr.repository().forge().currentUser();
         var vetoers = Veto.vetoers(botUser, allComments);
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -187,12 +187,6 @@ class CheckRun {
     }
 
     private void updateReadyForReview(PullRequestCheckIssueVisitor visitor, List<String> additionalErrors) {
-        // If there are no issues at all, the PR is already reviewed
-        if (visitor.getMessages().isEmpty() && additionalErrors.isEmpty()) {
-            pr.removeLabel("rfr");
-            return;
-        }
-
         // Additional errors are not allowed
         if (!additionalErrors.isEmpty()) {
             newLabels.remove("rfr");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandHandler.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandHandler.java
@@ -30,6 +30,6 @@ import java.nio.file.Path;
 import java.util.List;
 
 interface CommandHandler {
-    void handle(PullRequest pr, CensusInstance censusInstance, Path scratchPath, String args, Comment comment, List<Comment> allComments, PrintWriter reply);
+    void handle(PullRequestBot bot, PullRequest pr, CensusInstance censusInstance, Path scratchPath, String args, Comment comment, List<Comment> allComments, PrintWriter reply);
     String description();
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandWorkItem.java
@@ -34,10 +34,6 @@ import java.util.regex.*;
 import java.util.stream.*;
 
 public class CommandWorkItem extends PullRequestWorkItem {
-    private final HostedRepository censusRepo;
-    private final String censusRef;
-    private final Map<String, String> external;
-
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots.pr");
 
     private final String commandReplyMarker = "<!-- Jmerge command reply message (%s) -->";
@@ -56,7 +52,7 @@ public class CommandWorkItem extends PullRequestWorkItem {
         static private Map<String, String> external = null;
 
         @Override
-        public void handle(PullRequest pr, CensusInstance censusInstance, Path scratchPath, String args, Comment comment, List<Comment> allComments, PrintWriter reply) {
+        public void handle(PullRequestBot bot, PullRequest pr, CensusInstance censusInstance, Path scratchPath, String args, Comment comment, List<Comment> allComments, PrintWriter reply) {
             reply.println("Available commands:");
             Stream.concat(
                     commandHandlers.entrySet().stream()
@@ -72,15 +68,8 @@ public class CommandWorkItem extends PullRequestWorkItem {
         }
     }
 
-    CommandWorkItem(PullRequest pr, HostedRepository censusRepo, String censusRef, Map<String, String> external, Consumer<RuntimeException> errorHandler) {
-        super(pr, errorHandler);
-        this.censusRepo = censusRepo;
-        this.censusRef = censusRef;
-        this.external = external;
-
-        if (HelpCommand.external == null) {
-            HelpCommand.external = external;
-        }
+    CommandWorkItem(PullRequestBot bot, PullRequest pr, Consumer<RuntimeException> errorHandler) {
+        super(bot, pr, errorHandler);
     }
 
     private List<AbstractMap.SimpleEntry<String, Comment>> findCommandComments(List<Comment> comments) {
@@ -119,9 +108,9 @@ public class CommandWorkItem extends PullRequestWorkItem {
 
         var handler = commandHandlers.get(commandWord);
         if (handler != null) {
-            handler.handle(pr, censusInstance, scratchPath, commandArgs, comment, allComments, printer);
+            handler.handle(bot, pr, censusInstance, scratchPath, commandArgs, comment, allComments, printer);
         } else {
-            if (!external.containsKey(commandWord)) {
+            if (!bot.externalCommands().containsKey(commandWord)) {
                 printer.print("Unknown command `");
                 printer.print(command);
                 printer.println("` - for a list of valid commands use `/help`.");
@@ -150,7 +139,11 @@ public class CommandWorkItem extends PullRequestWorkItem {
             return;
         }
 
-        var census = CensusInstance.create(censusRepo, censusRef, scratchPath.resolve("census"), pr);
+        if (HelpCommand.external == null) {
+            HelpCommand.external = bot.externalCommands();
+        }
+
+        var census = CensusInstance.create(bot.censusRepo(), bot.censusRef(), scratchPath.resolve("census"), pr);
         for (var entry : unprocessedCommands) {
             processCommand(pr, census, scratchPath.resolve("pr"), entry.getKey(), entry.getValue(), comments);
         }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ContributorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ContributorCommand.java
@@ -35,7 +35,7 @@ public class ContributorCommand implements CommandHandler {
     private static final Pattern commandPattern = Pattern.compile("^(add|remove)\\s+(.*?\\s+<\\S+>)$");
 
     @Override
-    public void handle(PullRequest pr, CensusInstance censusInstance, Path scratchPath, String args, Comment comment, List<Comment> allComments, PrintWriter reply) {
+    public void handle(PullRequestBot bot, PullRequest pr, CensusInstance censusInstance, Path scratchPath, String args, Comment comment, List<Comment> allComments, PrintWriter reply) {
         if (!comment.author().equals(pr.author())) {
             reply.println("Only the author (@" + pr.author().userName() + ") is allowed to issue the `contributor` command.");
             return;

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
@@ -54,7 +54,7 @@ public class IntegrateCommand implements CommandHandler {
     }
 
     @Override
-    public void handle(PullRequest pr, CensusInstance censusInstance, Path scratchPath, String args, Comment comment, List<Comment> allComments, PrintWriter reply) {
+    public void handle(PullRequestBot bot, PullRequest pr, CensusInstance censusInstance, Path scratchPath, String args, Comment comment, List<Comment> allComments, PrintWriter reply) {
         if (!comment.author().equals(pr.author())) {
             reply.println("Only the author (@" + pr.author().userName() + ") is allowed to issue the `integrate` command.");
             return;
@@ -77,7 +77,7 @@ public class IntegrateCommand implements CommandHandler {
             var sanitizedUrl = URLEncoder.encode(pr.repository().webUrl().toString(), StandardCharsets.UTF_8);
             var path = scratchPath.resolve("pr.integrate").resolve(sanitizedUrl);
 
-            var prInstance = new PullRequestInstance(path, pr);
+            var prInstance = new PullRequestInstance(path, pr, bot.ignoreStaleReviews());
             var localHash = prInstance.commit(censusInstance.namespace(), censusInstance.configuration().census().domain(), null);
             var rebaseMessage = new StringWriter();
             var rebaseWriter = new PrintWriter(rebaseMessage);

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
@@ -23,24 +23,16 @@
 package org.openjdk.skara.bots.pr;
 
 import org.openjdk.skara.forge.PullRequest;
-import org.openjdk.skara.vcs.Hash;
 
 import java.io.*;
 import java.nio.file.Path;
 import java.util.*;
-import java.util.concurrent.ConcurrentMap;
 import java.util.function.Consumer;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class LabelerWorkItem extends PullRequestWorkItem {
-    private final Map<String, List<Pattern>> labelPatterns;
-    private final ConcurrentMap<Hash, Boolean> currentLabels;
-
-    LabelerWorkItem(PullRequest pr, Map<String, List<Pattern>> labelPatterns, ConcurrentMap<Hash, Boolean> currentLabels, Consumer<RuntimeException> errorHandler) {
-        super(pr, errorHandler);
-        this.labelPatterns = labelPatterns;
-        this.currentLabels = currentLabels;
+    LabelerWorkItem(PullRequestBot bot, PullRequest pr, Consumer<RuntimeException> errorHandler) {
+        super(bot, pr, errorHandler);
     }
 
     @Override
@@ -52,7 +44,7 @@ public class LabelerWorkItem extends PullRequestWorkItem {
         var labels = new HashSet<String>();
         var files = prInstance.changedFiles();
         for (var file : files) {
-            for (var label : labelPatterns.entrySet()) {
+            for (var label : bot.labelPatterns().entrySet()) {
                 for (var pattern : label.getValue()) {
                     var matcher = pattern.matcher(file.toString());
                     if (matcher.find()) {
@@ -67,14 +59,14 @@ public class LabelerWorkItem extends PullRequestWorkItem {
 
     @Override
     public void run(Path scratchPath) {
-        if (currentLabels.containsKey(pr.headHash())) {
+        if (bot.currentLabels().containsKey(pr.headHash())) {
             return;
         }
         try {
-            var prInstance = new PullRequestInstance(scratchPath.resolve("labeler"), pr);
+            var prInstance = new PullRequestInstance(scratchPath.resolve("labeler"), pr, bot.ignoreStaleReviews());
             var newLabels = getLabels(prInstance);
             var currentLabels = pr.labels().stream()
-                                  .filter(labelPatterns::containsKey)
+                                  .filter(key -> bot.labelPatterns().containsKey(key))
                                   .collect(Collectors.toSet());
 
             // Add all labels not already set
@@ -87,7 +79,7 @@ public class LabelerWorkItem extends PullRequestWorkItem {
                          .filter(label -> !newLabels.contains(label))
                          .forEach(pr::removeLabel);
 
-            this.currentLabels.put(pr.headHash(), Boolean.TRUE);
+            bot.currentLabels().put(pr.headHash(), Boolean.TRUE);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.pr;
+
+import org.openjdk.skara.forge.HostedRepository;
+import org.openjdk.skara.issuetracker.IssueProject;
+
+import java.util.*;
+import java.util.regex.Pattern;
+
+public class PullRequestBotBuilder {
+    private HostedRepository repo;
+    private HostedRepository censusRepo;
+    private String censusRef = "master";
+    private Map<String, List<Pattern>> labelPatterns = Map.of();
+    private Map<String, String> externalCommands = Map.of();
+    private Map<String, String> blockingLabels = Map.of();
+    private Set<String> readyLabels = Set.of();
+    private Map<String, Pattern> readyComments = Map.of();
+    private IssueProject issueProject = null;
+    private boolean ignoreStaleReviews = false;
+
+    PullRequestBotBuilder() {
+    }
+
+    public PullRequestBotBuilder repo(HostedRepository repo) {
+        this.repo = repo;
+        return this;
+    }
+
+    public PullRequestBotBuilder censusRepo(HostedRepository censusRepo) {
+        this.censusRepo = censusRepo;
+        return this;
+    }
+
+    public PullRequestBotBuilder censusRef(String censusRef) {
+        this.censusRef = censusRef;
+        return this;
+    }
+
+    public PullRequestBotBuilder labelPatterns(Map<String, List<Pattern>> labelPatterns) {
+        this.labelPatterns = labelPatterns;
+        return this;
+    }
+
+    public PullRequestBotBuilder externalCommands(Map<String, String> externalCommands) {
+        this.externalCommands = externalCommands;
+        return this;
+    }
+
+    public PullRequestBotBuilder blockingLabels(Map<String, String> blockingLabels) {
+        this.blockingLabels = blockingLabels;
+        return this;
+    }
+
+    public PullRequestBotBuilder readyLabels(Set<String> readyLabels) {
+        this.readyLabels = readyLabels;
+        return this;
+    }
+
+    public PullRequestBotBuilder readyComments(Map<String, Pattern> readyComments) {
+        this.readyComments = readyComments;
+        return this;
+    }
+
+    public PullRequestBotBuilder issueProject(IssueProject issueProject) {
+        this.issueProject = issueProject;
+        return this;
+    }
+
+    public PullRequestBotBuilder ignoreStaleReviews(boolean ignoreStaleReviews) {
+        this.ignoreStaleReviews = ignoreStaleReviews;
+        return this;
+    }
+
+    public PullRequestBot build() {
+        return new PullRequestBot(repo, censusRepo, censusRef, labelPatterns, externalCommands, blockingLabels, readyLabels, readyComments, issueProject, ignoreStaleReviews);
+    }
+}

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
@@ -79,7 +79,19 @@ public class PullRequestBotFactory implements BotFactory {
             var issueProject = repo.value().contains("issues") ?
                     configuration.issueProject(repo.value().get("issues").asString()) :
                     null;
-            var bot = PullRequestBot.newBuilder().repo(configuration.repository(repo.name())).censusRepo(censusRepo).censusRef(censusRef).labelPatterns(labelPatterns).externalCommands(external).blockingLabels(blockers).readyLabels(readyLabels).readyComments(readyComments).issueProject(issueProject).build();
+            var ignoreStaleReviews = repo.value().contains("ignorestale") && repo.value().get("ignorestale").asBoolean();
+            var bot = PullRequestBot.newBuilder()
+                                    .repo(configuration.repository(repo.name()))
+                                    .censusRepo(censusRepo)
+                                    .censusRef(censusRef)
+                                    .labelPatterns(labelPatterns)
+                                    .externalCommands(external)
+                                    .blockingLabels(blockers)
+                                    .readyLabels(readyLabels)
+                                    .readyComments(readyComments)
+                                    .issueProject(issueProject)
+                                    .ignoreStaleReviews(ignoreStaleReviews)
+                                    .build();
             ret.add(bot);
         }
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
@@ -79,8 +79,7 @@ public class PullRequestBotFactory implements BotFactory {
             var issueProject = repo.value().contains("issues") ?
                     configuration.issueProject(repo.value().get("issues").asString()) :
                     null;
-            var bot = new PullRequestBot(configuration.repository(repo.name()), censusRepo, censusRef, labelPatterns,
-                                         external, blockers, readyLabels, readyComments, issueProject);
+            var bot = PullRequestBot.newBuilder().repo(configuration.repository(repo.name())).censusRepo(censusRepo).censusRef(censusRef).labelPatterns(labelPatterns).externalCommands(external).blockingLabels(blockers).readyLabels(readyLabels).readyComments(readyComments).issueProject(issueProject).build();
             ret.add(bot);
         }
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestWorkItem.java
@@ -29,9 +29,11 @@ import java.util.function.Consumer;
 
 abstract class PullRequestWorkItem implements WorkItem {
     private final Consumer<RuntimeException> errorHandler;
+    final PullRequestBot bot;
     final PullRequest pr;
 
-    PullRequestWorkItem(PullRequest pr, Consumer<RuntimeException> errorHandler) {
+    PullRequestWorkItem(PullRequestBot bot, PullRequest pr, Consumer<RuntimeException> errorHandler) {
+        this.bot = bot;
         this.pr = pr;
         this.errorHandler = errorHandler;
     }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/RejectCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/RejectCommand.java
@@ -31,7 +31,7 @@ import java.util.List;
 
 public class RejectCommand implements CommandHandler {
     @Override
-    public void handle(PullRequest pr, CensusInstance censusInstance, Path scratchPath, String args, Comment comment, List<Comment> allComments, PrintWriter reply) {
+    public void handle(PullRequestBot bot, PullRequest pr, CensusInstance censusInstance, Path scratchPath, String args, Comment comment, List<Comment> allComments, PrintWriter reply) {
         if (pr.author().equals(comment.author())) {
             reply.println("You can't reject your own changes.");
             return;

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewersCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewersCommand.java
@@ -48,7 +48,7 @@ public class ReviewersCommand implements CommandHandler {
     }
 
     @Override
-    public void handle(PullRequest pr, CensusInstance censusInstance, Path scratchPath, String args, Comment comment, List<Comment> allComments, PrintWriter reply) {
+    public void handle(PullRequestBot bot, PullRequest pr, CensusInstance censusInstance, Path scratchPath, String args, Comment comment, List<Comment> allComments, PrintWriter reply) {
         if (!ProjectPermissions.mayReview(censusInstance, comment.author())) {
             reply.println("Only [Reviewers](https://openjdk.java.net/bylaws#reviewer) are allowed to change the number of required reviewers.");
             return;

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SolvesCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SolvesCommand.java
@@ -38,7 +38,7 @@ public class SolvesCommand implements CommandHandler {
     }
 
     @Override
-    public void handle(PullRequest pr, CensusInstance censusInstance, Path scratchPath, String args, Comment comment, List<Comment> allComments, PrintWriter reply) {
+    public void handle(PullRequestBot bot, PullRequest pr, CensusInstance censusInstance, Path scratchPath, String args, Comment comment, List<Comment> allComments, PrintWriter reply) {
         if (!comment.author().equals(pr.author())) {
             reply.println("Only the author (@" + pr.author().userName() + ") is allowed to issue the `solves` command.");
             return;

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
@@ -36,7 +36,7 @@ public class SponsorCommand implements CommandHandler {
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots.pr");
 
     @Override
-    public void handle(PullRequest pr, CensusInstance censusInstance, Path scratchPath, String args, Comment comment, List<Comment> allComments, PrintWriter reply) {
+    public void handle(PullRequestBot bot, PullRequest pr, CensusInstance censusInstance, Path scratchPath, String args, Comment comment, List<Comment> allComments, PrintWriter reply) {
         if (ProjectPermissions.mayCommit(censusInstance, pr.author())) {
             reply.println("This change does not need sponsoring - the author is allowed to integrate it.");
             return;
@@ -72,7 +72,7 @@ public class SponsorCommand implements CommandHandler {
             var sanitizedUrl = URLEncoder.encode(pr.repository().webUrl().toString(), StandardCharsets.UTF_8);
             var path = scratchPath.resolve("pr.sponsor").resolve(sanitizedUrl);
 
-            var prInstance = new PullRequestInstance(path, pr);
+            var prInstance = new PullRequestInstance(path, pr, bot.ignoreStaleReviews());
             var localHash = prInstance.commit(censusInstance.namespace(), censusInstance.configuration().census().domain(),
                                          comment.author().id());
             var rebaseMessage = new StringWriter();

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SummaryCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SummaryCommand.java
@@ -31,7 +31,7 @@ import java.util.List;
 
 public class SummaryCommand implements CommandHandler {
     @Override
-    public void handle(PullRequest pr, CensusInstance censusInstance, Path scratchPath, String args, Comment comment, List<Comment> allComments, PrintWriter reply) {
+    public void handle(PullRequestBot bot, PullRequest pr, CensusInstance censusInstance, Path scratchPath, String args, Comment comment, List<Comment> allComments, PrintWriter reply) {
         if (!comment.author().equals(pr.author())) {
             reply.println("Only the author (@" + pr.author().userName() + ") is allowed to issue the `summary` command.");
             return;

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -47,7 +47,7 @@ class CheckTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id())
                                            .addReviewer(reviewer.forge().currentUser().id());
-            var checkBot = new PullRequestBot(author, censusBuilder.build(), "master");
+            var checkBot = PullRequestBot.newBuilder().repo(author).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -85,8 +85,7 @@ class CheckTests {
             check = checks.get("jcheck");
             assertEquals(CheckStatus.SUCCESS, check.status());
 
-            // The PR should not be flagged as ready for review, at it is already reviewed
-            assertFalse(pr.labels().contains("rfr"));
+            // The PR should now be ready
             assertTrue(pr.labels().contains("ready"));
         }
     }
@@ -102,7 +101,7 @@ class CheckTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id())
                                            .addReviewer(reviewer.forge().currentUser().id());
-            var checkBot = new PullRequestBot(author, censusBuilder.build(), "master");
+            var checkBot = PullRequestBot.newBuilder().repo(author).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -153,8 +152,8 @@ class CheckTests {
             // Check the status again
             TestBotRunner.runPeriodicItems(checkBot);
 
-            // The PR should not be flagged as ready for review, at it is already reviewed
-            assertFalse(pr.labels().contains("rfr"));
+            // The PR should now be ready
+            assertTrue(pr.labels().contains("ready"));
 
             // The check should now be successful
             checks = pr.checks(editHash);
@@ -178,7 +177,7 @@ class CheckTests {
                                            .addReviewer(reviewer.forge().currentUser().id())
                                            .addReviewer(commenter.forge().currentUser().id());
 
-            var checkBot = new PullRequestBot(author, censusBuilder.build(), "master");
+            var checkBot = PullRequestBot.newBuilder().repo(author).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -257,7 +256,7 @@ class CheckTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addReviewer(author.forge().currentUser().id());
 
-            var checkBot = new PullRequestBot(author, censusBuilder.build(), "master");
+            var checkBot = PullRequestBot.newBuilder().repo(author).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -298,7 +297,7 @@ class CheckTests {
 
             var censusBuilder = credentials.getCensusBuilder()
                                            .addReviewer(reviewer.forge().currentUser().id());
-            var checkBot = new PullRequestBot(author, censusBuilder.build(), "master");
+            var checkBot = PullRequestBot.newBuilder().repo(author).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -350,7 +349,7 @@ class CheckTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id())
                                            .addReviewer(reviewer.forge().currentUser().id());
-            var checkBot = new PullRequestBot(author, censusBuilder.build(), "master");
+            var checkBot = PullRequestBot.newBuilder().repo(author).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -388,8 +387,8 @@ class CheckTests {
             check = checks.get("jcheck");
             assertEquals(CheckStatus.SUCCESS, check.status());
 
-            // The PR should not be flagged as ready for review, at it is already reviewed
-            assertFalse(pr.labels().contains("rfr"));
+            // The PR should now be ready
+            assertTrue(pr.labels().contains("rfr"));
             assertTrue(pr.labels().contains("ready"));
 
             var addedHash = CheckableRepository.appendAndCommit(localRepo, "trailing whitespace   ");
@@ -433,7 +432,7 @@ class CheckTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id())
                                            .addReviewer(reviewer.forge().currentUser().id());
-            var checkBot = new PullRequestBot(author, censusBuilder.build(), "master");
+            var checkBot = PullRequestBot.newBuilder().repo(author).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -495,7 +494,7 @@ class CheckTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addCommitter(author.forge().currentUser().id())
                                            .addReviewer(integrator.forge().currentUser().id());
-            var mergeBot = new PullRequestBot(integrator, censusBuilder.build(), "master");
+            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -546,7 +545,7 @@ class CheckTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addCommitter(author.forge().currentUser().id())
                                            .addReviewer(integrator.forge().currentUser().id());
-            var mergeBot = new PullRequestBot(integrator, censusBuilder.build(), "master");
+            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -617,8 +616,7 @@ class CheckTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id())
                                            .addReviewer(reviewer.forge().currentUser().id());
-            var checkBot = new PullRequestBot(author, censusBuilder.build(), "master", Map.of(), Map.of(),
-                                              Map.of("block", "Test Blocker"), Set.of(), Map.of());
+            var checkBot = PullRequestBot.newBuilder().repo(author).censusRepo(censusBuilder.build()).blockingLabels(Map.of("block", "Test Blocker")).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -666,8 +664,7 @@ class CheckTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id())
                                            .addReviewer(reviewer.forge().currentUser().id());
-            var checkBot = new PullRequestBot(author, censusBuilder.build(), "master", Map.of(), Map.of(),
-                                              Map.of(), Set.of("good-to-go"), Map.of());
+            var checkBot = PullRequestBot.newBuilder().repo(author).censusRepo(censusBuilder.build()).readyLabels(Set.of("good-to-go")).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -708,8 +705,7 @@ class CheckTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id())
                                            .addReviewer(reviewer.forge().currentUser().id());
-            var checkBot = new PullRequestBot(author, censusBuilder.build(), "master", Map.of(), Map.of(),
-                                              Map.of(), Set.of(), Map.of(reviewer.forge().currentUser().userName(), Pattern.compile("proceed")));
+            var checkBot = PullRequestBot.newBuilder().repo(author).censusRepo(censusBuilder.build()).readyComments(Map.of(reviewer.forge().currentUser().userName(), Pattern.compile("proceed"))).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -751,8 +747,7 @@ class CheckTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id())
                                            .addReviewer(reviewer.forge().currentUser().id());
-            var checkBot = new PullRequestBot(author, censusBuilder.build(), "master", Map.of(), Map.of(),
-                                              Map.of(), Set.of(), Map.of());
+            var checkBot = PullRequestBot.newBuilder().repo(author).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(), Path.of("appendable.txt"),
@@ -799,8 +794,7 @@ class CheckTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id())
                                            .addReviewer(reviewer.forge().currentUser().id());
-            var checkBot = new PullRequestBot(author, censusBuilder.build(), "master", Map.of(), Map.of(),
-                                              Map.of(), Set.of(), Map.of(), issues);
+            var checkBot = PullRequestBot.newBuilder().repo(author).censusRepo(censusBuilder.build()).issueProject(issues).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(), Path.of("appendable.txt"),
@@ -931,7 +925,7 @@ class CheckTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id())
                                            .addReviewer(reviewer.forge().currentUser().id());
-            var checkBot = new PullRequestBot(author, censusBuilder.build(), "master");
+            var checkBot = PullRequestBot.newBuilder().repo(author).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -982,7 +976,7 @@ class CheckTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id())
                                            .addReviewer(reviewer.forge().currentUser().id());
-            var checkBot = new PullRequestBot(author, censusBuilder.build(), "master");
+            var checkBot = PullRequestBot.newBuilder().repo(author).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -1020,7 +1014,7 @@ class CheckTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id())
                                            .addReviewer(reviewer.forge().currentUser().id());
-            var checkBot = new PullRequestBot(author, censusBuilder.build(), "master");
+            var checkBot = PullRequestBot.newBuilder().repo(author).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -1055,7 +1049,7 @@ class CheckTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id())
                                            .addReviewer(reviewer.forge().currentUser().id());
-            var checkBot = new PullRequestBot(author, censusBuilder.build(), "master");
+            var checkBot = PullRequestBot.newBuilder().repo(author).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -1108,7 +1102,7 @@ class CheckTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id())
                                            .addReviewer(reviewer.forge().currentUser().id());
-            var checkBot = new PullRequestBot(author, censusBuilder.build(), "master");
+            var checkBot = PullRequestBot.newBuilder().repo(author).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -1129,6 +1123,65 @@ class CheckTests {
             assertEquals(1, checks.size());
             var check = checks.get("jcheck");
             assertEquals(CheckStatus.FAILURE, check.status());
+        }
+    }
+
+    @Test
+    void ignoreStale(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+
+            var author = credentials.getHostedRepository();
+            var reviewer = credentials.getHostedRepository();
+
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addAuthor(author.forge().currentUser().id())
+                                           .addReviewer(reviewer.forge().currentUser().id());
+            var checkBot = PullRequestBot.newBuilder().repo(author).censusRepo(censusBuilder.build()).ignoreStaleReviews(true).build();
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo, "A line with");
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
+
+            // Check the status
+            TestBotRunner.runPeriodicItems(checkBot);
+
+            // Approve it as another user
+            var approvalPr = reviewer.pullRequest(pr.id());
+            approvalPr.addReview(Review.Verdict.APPROVED, "Approved");
+
+            // Check the status
+            TestBotRunner.runPeriodicItems(checkBot);
+
+            // The PR should be flagged as ready
+            assertTrue(pr.labels().contains("ready"));
+
+            // Add another commit
+            editHash = CheckableRepository.replaceAndCommit(localRepo, "Another line");
+            localRepo.push(editHash, author.url(), "edit", true);
+
+            // Make sure that the push registered
+            var lastHeadHash = pr.headHash();
+            var refreshCount = 0;
+            do {
+                pr = author.pullRequest(pr.id());
+                if (refreshCount++ > 100) {
+                    fail("The PR did not update after the new push");
+                }
+            } while (pr.headHash().equals(lastHeadHash));
+
+            // Check the status again
+            TestBotRunner.runPeriodicItems(checkBot);
+
+            // The PR should no longer be ready, as the review is stale
+            assertFalse(pr.labels().contains("ready"));
+            assertTrue(pr.labels().contains("rfr"));
         }
     }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CommandTests.java
@@ -41,7 +41,7 @@ class CommandTests {
 
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
-            var mergeBot = new PullRequestBot(integrator, censusBuilder.build(), "master");
+            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -76,7 +76,7 @@ class CommandTests {
 
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
-            var mergeBot = new PullRequestBot(integrator, censusBuilder.build(), "master");
+            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ContributorTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ContributorTests.java
@@ -44,7 +44,7 @@ class ContributorTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addReviewer(integrator.forge().currentUser().id())
                                            .addCommitter(author.forge().currentUser().id());
-            var prBot = new PullRequestBot(integrator, censusBuilder.build(), "master");
+            var prBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepoFolder = tempFolder.path().resolve("localrepo");
@@ -157,7 +157,7 @@ class ContributorTests {
 
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
-            var mergeBot = new PullRequestBot(integrator, censusBuilder.build(), "master");
+            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrateTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrateTests.java
@@ -51,7 +51,7 @@ class IntegrateTests {
                                            .addCommitter(author.forge().currentUser().id())
                                            .addReviewer(integrator.forge().currentUser().id())
                                            .addReviewer(reviewer.forge().currentUser().id());
-            var mergeBot = new PullRequestBot(integrator, censusBuilder.build(), "master");
+            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -112,7 +112,7 @@ class IntegrateTests {
                                            .addCommitter(author.forge().currentUser().id())
                                            .addCommitter(committer.forge().currentUser().id())
                                            .addReviewer(integrator.forge().currentUser().id());
-            var mergeBot = new PullRequestBot(integrator, censusBuilder.build(), "master");
+            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -159,7 +159,7 @@ class IntegrateTests {
             var integrator = credentials.getHostedRepository();
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
-            var mergeBot = new PullRequestBot(integrator, censusBuilder.build(), "master");
+            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -194,7 +194,7 @@ class IntegrateTests {
             var integrator = credentials.getHostedRepository();
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
-            var mergeBot = new PullRequestBot(integrator, censusBuilder.build(), "master");
+            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository - but without any checks enabled
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(), Path.of("appendable.txt"),
@@ -236,7 +236,7 @@ class IntegrateTests {
             var integrator = credentials.getHostedRepository();
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
-            var mergeBot = new PullRequestBot(integrator, censusBuilder.build(), "master");
+            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -271,7 +271,7 @@ class IntegrateTests {
             var integrator = credentials.getHostedRepository();
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
-            var mergeBot = new PullRequestBot(integrator, censusBuilder.build(), "master");
+            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -319,7 +319,7 @@ class IntegrateTests {
                                            .addAuthor(author.forge().currentUser().id())
                                            .addReviewer(reviewer.forge().currentUser().id())
                                            .addReviewer(integrator.forge().currentUser().id());
-            var mergeBot = new PullRequestBot(integrator, censusBuilder.build(), "master");
+            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -399,7 +399,7 @@ class IntegrateTests {
 
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
-            var mergeBot = new PullRequestBot(integrator, censusBuilder.build(), "master");
+            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -436,7 +436,7 @@ class IntegrateTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addCommitter(author.forge().currentUser().id())
                                            .addReviewer(integrator.forge().currentUser().id());
-            var mergeBot = new PullRequestBot(integrator, censusBuilder.build(), "master");
+            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -492,7 +492,7 @@ class IntegrateTests {
                                            .addCommitter(author.forge().currentUser().id())
                                            .addReviewer(integrator.forge().currentUser().id());
             var censusRepo = censusBuilder.build();
-            var mergeBot = new PullRequestBot(integrator, censusRepo, "master");
+            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusRepo).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -548,7 +548,7 @@ class IntegrateTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addCommitter(author.forge().currentUser().id())
                                            .addReviewer(integrator.forge().currentUser().id());
-            var mergeBot = new PullRequestBot(integrator, censusBuilder.build(), "master");
+            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelerTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelerTests.java
@@ -46,7 +46,7 @@ class LabelerTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id())
                                            .addReviewer(reviewer.forge().currentUser().id());
-            var labelBot = new PullRequestBot(author, censusBuilder.build(), "master", labelPatterns, Map.of(), Map.of(), Set.of(), Map.of());
+            var labelBot = PullRequestBot.newBuilder().repo(author).censusRepo(censusBuilder.build()).labelPatterns(labelPatterns).build();
 
             // Populate the projects repository
             var localRepoFolder = tempFolder.path();

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
@@ -50,7 +50,7 @@ class MergeTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addCommitter(author.forge().currentUser().id())
                                            .addReviewer(integrator.forge().currentUser().id());
-            var mergeBot = new PullRequestBot(integrator, censusBuilder.build(), "master");
+            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepoFolder = tempFolder.path().resolve("localrepo");
@@ -132,7 +132,7 @@ class MergeTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addCommitter(author.forge().currentUser().id())
                                            .addReviewer(integrator.forge().currentUser().id());
-            var mergeBot = new PullRequestBot(integrator, censusBuilder.build(), "master");
+            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepoFolder = tempFolder.path().resolve("localrepo");
@@ -224,7 +224,7 @@ class MergeTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addCommitter(author.forge().currentUser().id())
                                            .addReviewer(integrator.forge().currentUser().id());
-            var mergeBot = new PullRequestBot(integrator, censusBuilder.build(), "master");
+            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepoFolder = tempFolder.path().resolve("localrepo");
@@ -279,7 +279,7 @@ class MergeTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addCommitter(author.forge().currentUser().id())
                                            .addReviewer(integrator.forge().currentUser().id());
-            var mergeBot = new PullRequestBot(integrator, censusBuilder.build(), "master");
+            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepoFolder = tempFolder.path().resolve("localrepo");
@@ -337,7 +337,7 @@ class MergeTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addCommitter(author.forge().currentUser().id())
                                            .addReviewer(integrator.forge().currentUser().id());
-            var mergeBot = new PullRequestBot(integrator, censusBuilder.build(), "master");
+            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepoFolder = tempFolder.path().resolve("localrepo");
@@ -395,7 +395,7 @@ class MergeTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addCommitter(author.forge().currentUser().id())
                                            .addReviewer(integrator.forge().currentUser().id());
-            var mergeBot = new PullRequestBot(integrator, censusBuilder.build(), "master");
+            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepoFolder = tempFolder.path().resolve("localrepo");
@@ -458,7 +458,7 @@ class MergeTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id())
                                            .addReviewer(integrator.forge().currentUser().id());
-            var mergeBot = new PullRequestBot(integrator, censusBuilder.build(), "master");
+            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepoFolder = tempFolder.path().resolve("localrepo");
@@ -516,7 +516,7 @@ class MergeTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addCommitter(author.forge().currentUser().id())
                                            .addReviewer(integrator.forge().currentUser().id());
-            var mergeBot = new PullRequestBot(integrator, censusBuilder.build(), "master");
+            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepoFolder = tempFolder.path().resolve("localrepo");

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ReviewersTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ReviewersTests.java
@@ -44,7 +44,7 @@ public class ReviewersTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addReviewer(integrator.forge().currentUser().id())
                                            .addCommitter(author.forge().currentUser().id());
-            var prBot = new PullRequestBot(bot, censusBuilder.build(), "master");
+            var prBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepoFolder = tempFolder.path().resolve("localrepo");
@@ -147,7 +147,7 @@ public class ReviewersTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addReviewer(integrator.forge().currentUser().id())
                                            .addCommitter(author.forge().currentUser().id());
-            var prBot = new PullRequestBot(bot, censusBuilder.build(), "master");
+            var prBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepoFolder = tempFolder.path().resolve("localrepo");
@@ -202,7 +202,7 @@ public class ReviewersTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addReviewer(integrator.forge().currentUser().id())
                                            .addAuthor(author.forge().currentUser().id());
-            var prBot = new PullRequestBot(bot, censusBuilder.build(), "master");
+            var prBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepoFolder = tempFolder.path().resolve("localrepo");

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ReviewersTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ReviewersTests.java
@@ -44,7 +44,7 @@ public class ReviewersTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addReviewer(integrator.forge().currentUser().id())
                                            .addCommitter(author.forge().currentUser().id());
-            var prBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
+            var prBot = PullRequestBot.newBuilder().repo(bot).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepoFolder = tempFolder.path().resolve("localrepo");
@@ -147,7 +147,7 @@ public class ReviewersTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addReviewer(integrator.forge().currentUser().id())
                                            .addCommitter(author.forge().currentUser().id());
-            var prBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
+            var prBot = PullRequestBot.newBuilder().repo(bot).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepoFolder = tempFolder.path().resolve("localrepo");
@@ -202,7 +202,7 @@ public class ReviewersTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addReviewer(integrator.forge().currentUser().id())
                                            .addAuthor(author.forge().currentUser().id());
-            var prBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
+            var prBot = PullRequestBot.newBuilder().repo(bot).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepoFolder = tempFolder.path().resolve("localrepo");

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/SolvesTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/SolvesTests.java
@@ -46,7 +46,7 @@ class SolvesTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addReviewer(integrator.forge().currentUser().id())
                                            .addCommitter(author.forge().currentUser().id());
-            var prBot = new PullRequestBot(integrator, censusBuilder.build(), "master");
+            var prBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepoFolder = tempFolder.path().resolve("localrepo");
@@ -160,7 +160,7 @@ class SolvesTests {
 
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
-            var mergeBot = new PullRequestBot(integrator, censusBuilder.build(), "master");
+            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -195,7 +195,7 @@ class SolvesTests {
 
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
-            var prBot = new PullRequestBot(integrator, censusBuilder.build(), "master");
+            var prBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -240,8 +240,7 @@ class SolvesTests {
 
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
-            var prBot = new PullRequestBot(integrator, censusBuilder.build(), "master",
-                                           Map.of(), Map.of(), Map.of(), Set.of(), Map.of(), issues);
+            var prBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).issueProject(issues).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/SponsorTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/SponsorTests.java
@@ -47,7 +47,7 @@ class SponsorTests {
             if (isAuthor) {
                 censusBuilder.addAuthor(author.forge().currentUser().id());
             }
-            var mergeBot = new PullRequestBot(integrator, censusBuilder.build(), "master");
+            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -135,7 +135,7 @@ class SponsorTests {
 
             var censusBuilder = credentials.getCensusBuilder()
                                            .addCommitter(author.forge().currentUser().id());
-            var mergeBot = new PullRequestBot(integrator, censusBuilder.build(), "master");
+            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -169,7 +169,7 @@ class SponsorTests {
 
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
-            var mergeBot = new PullRequestBot(integrator, censusBuilder.build(), "master");
+            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -205,7 +205,7 @@ class SponsorTests {
 
             var censusBuilder = credentials.getCensusBuilder()
                                            .addReviewer(reviewer.forge().currentUser().id());
-            var mergeBot = new PullRequestBot(integrator, censusBuilder.build(), "master");
+            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -241,7 +241,7 @@ class SponsorTests {
 
             var censusBuilder = credentials.getCensusBuilder()
                                            .addReviewer(reviewer.forge().currentUser().id());
-            var mergeBot = new PullRequestBot(integrator, censusBuilder.build(), "master");
+            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -333,7 +333,7 @@ class SponsorTests {
                                            .addAuthor(author.forge().currentUser().id())
                                            .addReviewer(integrator.forge().currentUser().id())
                                            .addReviewer(reviewer.forge().currentUser().id());
-            var mergeBot = new PullRequestBot(integrator, censusBuilder.build(), "master");
+            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -397,7 +397,7 @@ class SponsorTests {
 
             var censusBuilder = credentials.getCensusBuilder()
                                            .addReviewer(reviewer.forge().currentUser().id());
-            var mergeBot = new PullRequestBot(integrator, censusBuilder.build(), "master");
+            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -477,7 +477,7 @@ class SponsorTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addReviewer(reviewer.forge().currentUser().id())
                                            .addAuthor(author.forge().currentUser().id());
-            var mergeBot = new PullRequestBot(integrator, censusBuilder.build(), "master");
+            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/SummaryTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/SummaryTests.java
@@ -44,7 +44,7 @@ class SummaryTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addReviewer(integrator.forge().currentUser().id())
                                            .addCommitter(author.forge().currentUser().id());
-            var prBot = new PullRequestBot(integrator, censusBuilder.build(), "master");
+            var prBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepoFolder = tempFolder.path().resolve("localrepo");
@@ -143,7 +143,7 @@ class SummaryTests {
 
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
-            var mergeBot = new PullRequestBot(integrator, censusBuilder.build(), "master");
+            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/VetoTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/VetoTests.java
@@ -94,7 +94,7 @@ class VetoTests {
 
             var censusBuilder = credentials.getCensusBuilder()
                                            .addCommitter(author.forge().currentUser().id());
-            var prBot = new PullRequestBot(integrator, censusBuilder.build(), "master");
+            var prBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -131,7 +131,7 @@ class VetoTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addCommitter(author.forge().currentUser().id())
                                            .addCommitter(vetoer.forge().currentUser().id());
-            var prBot = new PullRequestBot(integrator, censusBuilder.build(), "master");
+            var prBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -170,7 +170,7 @@ class VetoTests {
                                            .addCommitter(author.forge().currentUser().id())
                                            .addReviewer(vetoer.forge().currentUser().id());
 
-            var prBot = new PullRequestBot(integrator, censusBuilder.build(), "master");
+            var prBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -240,7 +240,7 @@ class VetoTests {
                                            .addAuthor(author.forge().currentUser().id())
                                            .addReviewer(vetoer.forge().currentUser().id());
 
-            var prBot = new PullRequestBot(integrator, censusBuilder.build(), "master");
+            var prBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());


### PR DESCRIPTION
Hi all,

Please review this change that makes it possible to configure (per project) if additional commits to a pull request renders previous reviews invalid or not. It also tweaks the behavior of the `rfr` label slightly - instead of dropping it when a PR is reviewed and receives the `ready` label, is will remain for as long the PR is eligible for further reviews. This should reduce the number of label transitions when this feature is enabled.

The change also contains a bit of refactoring to make it easier to add more project specific configuration in the future.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-223](https://bugs.openjdk.java.net/browse/SKARA-223): Make required re-reviewing configurable


## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**) **Note!** Review applies to 9f819abd6ebdadc7feb7dfb785005abc37389392