### PR TITLE
Make it possible to only allow PRs against a select set of target branches

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -70,7 +70,7 @@ class CheckRun {
         run.checkStatus();
     }
 
-    private boolean checkTargetBranch() {
+    private boolean isTargetBranchAllowed() {
         var matcher = workItem.bot.allowedTargetBranches().matcher(pr.targetRef());
         return matcher.matches();
     }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -124,7 +124,7 @@ class CheckRun {
     private List<String> botSpecificChecks() throws IOException {
         var ret = new ArrayList<String>();
 
-        if (!checkTargetBranch()) {
+        if (!isTargetBranchAllowed()) {
             var error = "The branch `" + pr.targetRef() + "` is not allowed as target branch. The allowed target branches are:\n" +
                     allowedTargetBranches().stream()
                     .map(name -> "   - " + name)

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -149,8 +149,7 @@ class CheckWorkItem extends PullRequestWorkItem {
 
             try {
                 var prInstance = new PullRequestInstance(scratchPath.resolve("pr"), pr, bot.ignoreStaleReviews());
-                CheckRun.execute(this, pr, prInstance, comments, allReviews, activeReviews, labels, census,
-                                 bot.blockingLabels(), bot.issueProject());
+                CheckRun.execute(this, pr, prInstance, comments, allReviews, activeReviews, labels, census);
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -44,6 +44,7 @@ class PullRequestBot implements Bot {
     private final Map<String, Pattern> readyComments;
     private final IssueProject issueProject;
     private final boolean ignoreStaleReviews;
+    private final Pattern allowedTargetBranches;
     private final ConcurrentMap<Hash, Boolean> currentLabels;
     private final PullRequestUpdateCache updateCache;
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots.pr");
@@ -51,7 +52,8 @@ class PullRequestBot implements Bot {
     PullRequestBot(HostedRepository repo, HostedRepository censusRepo, String censusRef,
                    Map<String, List<Pattern>> labelPatterns, Map<String, String> externalCommands,
                    Map<String, String> blockingLabels, Set<String> readyLabels,
-                   Map<String, Pattern> readyComments, IssueProject issueProject, boolean ignoreStaleReviews) {
+                   Map<String, Pattern> readyComments, IssueProject issueProject, boolean ignoreStaleReviews,
+                   Pattern allowedTargetBranches) {
         remoteRepo = repo;
         this.censusRepo = censusRepo;
         this.censusRef = censusRef;
@@ -62,6 +64,7 @@ class PullRequestBot implements Bot {
         this.issueProject = issueProject;
         this.readyComments = readyComments;
         this.ignoreStaleReviews = ignoreStaleReviews;
+        this.allowedTargetBranches = allowedTargetBranches;
 
         this.currentLabels = new ConcurrentHashMap<>();
         this.updateCache = new PullRequestUpdateCache();
@@ -172,5 +175,9 @@ class PullRequestBot implements Bot {
 
     boolean ignoreStaleReviews() {
         return ignoreStaleReviews;
+    }
+
+    Pattern allowedTargetBranches() {
+        return allowedTargetBranches;
     }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
@@ -39,6 +39,7 @@ public class PullRequestBotBuilder {
     private Map<String, Pattern> readyComments = Map.of();
     private IssueProject issueProject = null;
     private boolean ignoreStaleReviews = false;
+    private Pattern allowedTargetBranches = Pattern.compile(".*");
 
     PullRequestBotBuilder() {
     }
@@ -93,7 +94,13 @@ public class PullRequestBotBuilder {
         return this;
     }
 
+    public PullRequestBotBuilder allowedTargetBranches(String allowedTargetBranches) {
+        this.allowedTargetBranches = Pattern.compile(allowedTargetBranches);
+        return this;
+    }
+
     public PullRequestBot build() {
-        return new PullRequestBot(repo, censusRepo, censusRef, labelPatterns, externalCommands, blockingLabels, readyLabels, readyComments, issueProject, ignoreStaleReviews);
+        return new PullRequestBot(repo, censusRepo, censusRef, labelPatterns, externalCommands, blockingLabels,
+                                  readyLabels, readyComments, issueProject, ignoreStaleReviews, allowedTargetBranches);
     }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
@@ -66,8 +66,17 @@ public class PullRequestBotFactory implements BotFactory {
             var censusRepo = configuration.repository(repo.value().get("census").asString());
             var censusRef = configuration.repositoryRef(repo.value().get("census").asString());
 
-            var labelPatterns = new HashMap<String, List<Pattern>>();
+            var botBuilder = PullRequestBot.newBuilder()
+                                           .repo(configuration.repository(repo.name()))
+                                           .censusRepo(censusRepo)
+                                           .censusRef(censusRef)
+                                           .blockingLabels(blockers)
+                                           .readyLabels(readyLabels)
+                                           .readyComments(readyComments)
+                                           .externalCommands(external);
+
             if (repo.value().contains("labels")) {
+                var labelPatterns = new HashMap<String, List<Pattern>>();
                 for (var label : repo.value().get("labels").fields()) {
                     var patterns = label.value().stream()
                                         .map(JSONValue::asString)
@@ -75,24 +84,19 @@ public class PullRequestBotFactory implements BotFactory {
                                         .collect(Collectors.toList());
                     labelPatterns.put(label.name(), patterns);
                 }
+                botBuilder.labelPatterns(labelPatterns);
             }
-            var issueProject = repo.value().contains("issues") ?
-                    configuration.issueProject(repo.value().get("issues").asString()) :
-                    null;
-            var ignoreStaleReviews = repo.value().contains("ignorestale") && repo.value().get("ignorestale").asBoolean();
-            var bot = PullRequestBot.newBuilder()
-                                    .repo(configuration.repository(repo.name()))
-                                    .censusRepo(censusRepo)
-                                    .censusRef(censusRef)
-                                    .labelPatterns(labelPatterns)
-                                    .externalCommands(external)
-                                    .blockingLabels(blockers)
-                                    .readyLabels(readyLabels)
-                                    .readyComments(readyComments)
-                                    .issueProject(issueProject)
-                                    .ignoreStaleReviews(ignoreStaleReviews)
-                                    .build();
-            ret.add(bot);
+            if (repo.value().contains("issues")) {
+                botBuilder.issueProject(configuration.issueProject(repo.value().get("issues").asString()));
+            }
+            if (repo.value().contains("ignorestale")) {
+                botBuilder.ignoreStaleReviews(repo.value().get("ignorestale").asBoolean());
+            }
+            if (repo.value().contains("targetbranches")) {
+                botBuilder.allowedTargetBranches(repo.value().get("targetbranches").asString());
+            }
+
+            ret.add(botBuilder.build());
         }
 
         return ret;

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestInstance.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestInstance.java
@@ -226,4 +226,12 @@ class PullRequestInstance {
             }
         }
     }
+
+    List<Reference> remoteBranches() {
+        try {
+            return localRepo.remoteBranches(pr.repository().url().toString());
+        } catch (IOException e) {
+            return List.of();
+        }
+    }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -1184,4 +1184,60 @@ class CheckTests {
             assertTrue(pr.labels().contains("rfr"));
         }
     }
+
+    @Test
+    void targetBranchPattern(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var reviewer = credentials.getHostedRepository();
+
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addAuthor(author.forge().currentUser().id())
+                                           .addReviewer(reviewer.forge().currentUser().id());
+            var checkBot = PullRequestBot.newBuilder().repo(author).censusRepo(censusBuilder.build())
+                                         .allowedTargetBranches("^(?!master$).*")
+                                         .build();
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.url(), "notmaster", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit",
+                                                   "This is a pull request", true);
+
+            // Check the status
+            TestBotRunner.runPeriodicItems(checkBot);
+
+            // Verify that the check failed
+            var checks = pr.checks(editHash);
+            assertEquals(1, checks.size());
+            var check = checks.get("jcheck");
+            assertEquals(CheckStatus.FAILURE, check.status());
+            assertTrue(check.summary().orElseThrow().contains("The target branch of this PR does not match the allowed set of branches"));
+
+            var anotherPr = credentials.createPullRequest(author, "notmaster", "edit",
+                                                   "This is a pull request", true);
+
+            // Check the status
+            TestBotRunner.runPeriodicItems(checkBot);
+
+            // Approve it as another user
+            var approvalPr = reviewer.pullRequest(anotherPr.id());
+            approvalPr.addReview(Review.Verdict.APPROVED, "Approved");
+            TestBotRunner.runPeriodicItems(checkBot);
+
+            // Verify that the check passed
+            checks = anotherPr.checks(editHash);
+            assertEquals(1, checks.size());
+            check = checks.get("jcheck");
+            assertEquals(CheckStatus.SUCCESS, check.status());
+        }
+    }
+
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -1219,7 +1219,8 @@ class CheckTests {
             assertEquals(1, checks.size());
             var check = checks.get("jcheck");
             assertEquals(CheckStatus.FAILURE, check.status());
-            assertTrue(check.summary().orElseThrow().contains("The target branch of this PR does not match the allowed set of branches"));
+            assertTrue(check.summary().orElseThrow().contains("The branch `master` is not allowed as target branch"));
+            assertTrue(check.summary().orElseThrow().contains("notmaster"));
 
             var anotherPr = credentials.createPullRequest(author, "notmaster", "edit",
                                                    "This is a pull request", true);


### PR DESCRIPTION
Hi all,

Please review this change that makes it possible to only allow PRs to target a select set of branches.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**) **Note!** Review applies to 7b261d73abbb0367ddc413e52e6f110da4facb43