### PR TITLE
244: Legacy reviewers jcheck configuration does not reset default

### DIFF
--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/ReviewersConfiguration.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/ReviewersConfiguration.java
@@ -86,6 +86,13 @@ public class ReviewersConfiguration {
         var contributors = s.get("contributors", DEFAULT.contributors());
 
         if (s.contains("minimum")) {
+            // Reset defaults to 0
+            lead = 0;
+            reviewers = 0;
+            committers = 0;
+            authors = 0;
+            contributors = 0;
+
             var minimum = s.get("minimum").asInt();
             if (s.contains("role")) {
                 var role = s.get("role").asString();

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/ReviewersCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/ReviewersCheckTests.java
@@ -383,4 +383,36 @@ class ReviewersCheckTests {
         assertEquals(Severity.ERROR, issue.severity());
         assertEquals(check, issue.check());
     }
+
+    @Test
+    void legacyConfigurationShouldAcceptCommitterRole() throws IOException {
+        var commit = commit(List.of("foo"));
+        var check = new ReviewersCheck(census(), utils);
+        var legacyConf = new ArrayList<>(CONFIGURATION);
+        legacyConf.add("minimum = 1");
+        legacyConf.add("role = committer");
+
+        var issues = toList(check.check(commit, message(commit), JCheckConfiguration.parse(legacyConf)));
+        assertEquals(0, issues.size());
+
+        commit = commit(List.of("bar"));
+        issues = toList(check.check(commit, message(commit), JCheckConfiguration.parse(legacyConf)));
+        assertEquals(0, issues.size());
+
+        commit = commit(List.of("baz"));
+        issues = toList(check.check(commit, message(commit), JCheckConfiguration.parse(legacyConf)));
+        assertEquals(0, issues.size());
+
+        commit = commit(List.of("qux"));
+        issues = toList(check.check(commit, message(commit), JCheckConfiguration.parse(legacyConf)));
+        assertEquals(1, issues.size());
+        assertTrue(issues.get(0) instanceof TooFewReviewersIssue);
+        var issue = (TooFewReviewersIssue) issues.get(0);
+        assertEquals(0, issue.numActual());
+        assertEquals(1, issue.numRequired());
+        assertEquals("committer", issue.role());
+        assertEquals(commit, issue.commit());
+        assertEquals(Severity.ERROR, issue.severity());
+        assertEquals(check, issue.check());
+    }
 }


### PR DESCRIPTION
Hi all,

please review this patch that fixes an issue with the parsing of the older
format of the "reviewers" jcheck configuration. The problem is that the defaults
weren't reset when parsing the older format, so if a repository has a
`.jcheck/conf` containing the following

```
[checks "reviewer"]
minimum = 1
role = committer
```

then the outcome would be the that jcheck would require 1 Reviewer and 1
Committer (since the default is 1 Reviewer).

The fix is to reset the defaults to zero when parsing the older format.

Thanks,
Erik

## Testing
- [x] Added a new unit test for the above scenario
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-244](https://bugs.openjdk.java.net/browse/SKARA-244): Legacy reviewers jcheck configuration does not reset default


## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)