### PR TITLE
245: CLI tools do not consider git's http.proxy configuration

### DIFF
--- a/proxy/src/main/java/org/openjdk/skara/proxy/HttpProxy.java
+++ b/proxy/src/main/java/org/openjdk/skara/proxy/HttpProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,25 +22,37 @@
  */
 package org.openjdk.skara.proxy;
 
+import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
 public class HttpProxy {
+    private static void setProxyHostAndPortBasedOn(URI uri) {
+        var scheme = uri.getScheme();
+        var port = String.valueOf(uri.getPort() == -1 ? 80 : uri.getPort());
+        if (System.getProperty(scheme + ".proxyHost") == null) {
+            System.setProperty(scheme + ".proxyHost", uri.getHost());
+            System.setProperty(scheme + ".proxyPort", port);
+        }
+    }
+
     public static void setup() {
+        var hasSetupProxy = false;
         for (var key : List.of("http_proxy", "https_proxy")) {
             var value = System.getenv(key);
             value = value == null ? System.getenv(key.toUpperCase()) : value;
             if (value != null) {
-                var protocol = key.split("_")[0];
                 try {
-                    var uri = new URI(value);
-                    if (System.getProperty(protocol + ".proxyHost") == null && uri.getHost() != null) {
-                        System.setProperty(protocol + ".proxyHost", uri.getHost());
-                        System.setProperty(protocol + ".proxyPort", String.valueOf(uri.getPort()));
+                    if (!value.startsWith("http://") && !value.startsWith("https://")) {
+                        var scheme = key.split("_")[0];
+                        value = scheme + "://" + value;
                     }
+                    var uri = new URI(value);
+                    setProxyHostAndPortBasedOn(uri);
                 } catch (URISyntaxException e) {
                     // pass
                 }
@@ -53,6 +65,36 @@ public class HttpProxy {
                               .map(s -> s.startsWith(".") ? "*" + s : s)
                               .collect(Collectors.toList());
             System.setProperty("http.nonProxyHosts", String.join("|", hosts));
+            hasSetupProxy = true;
+        }
+
+        if (!hasSetupProxy) {
+            try {
+                var pb = new ProcessBuilder("git", "config", "http.proxy");
+                pb.redirectOutput(ProcessBuilder.Redirect.PIPE);
+                pb.redirectError(ProcessBuilder.Redirect.DISCARD);
+                var p = pb.start();
+
+                var output = new String(p.getInputStream().readAllBytes(), StandardCharsets.UTF_8).trim();
+                var res = p.waitFor();
+                if (res == 0 && output != null && !output.isEmpty()) {
+                    if (output.startsWith("https://") || output.startsWith("http://")) {
+                        var uri = new URI(output);
+                        setProxyHostAndPortBasedOn(uri);
+                    } else {
+                        for (var scheme : List.of("http", "https")) {
+                            var uri = new URI(scheme + "://" + output);
+                            setProxyHostAndPortBasedOn(uri);
+                        }
+                    }
+                }
+            } catch (InterruptedException e) {
+                // pass
+            } catch (IOException e) {
+                // pass
+            } catch (URISyntaxException e) {
+                // pass
+            }
         }
     }
 }

--- a/proxy/src/main/java/org/openjdk/skara/proxy/HttpProxy.java
+++ b/proxy/src/main/java/org/openjdk/skara/proxy/HttpProxy.java
@@ -41,7 +41,34 @@ public class HttpProxy {
     }
 
     public static void setup() {
-        var hasSetupProxy = false;
+        try {
+            var pb = new ProcessBuilder("git", "config", "http.proxy");
+            pb.redirectOutput(ProcessBuilder.Redirect.PIPE);
+            pb.redirectError(ProcessBuilder.Redirect.DISCARD);
+            var p = pb.start();
+
+            var output = new String(p.getInputStream().readAllBytes(), StandardCharsets.UTF_8).trim();
+            var res = p.waitFor();
+            if (res == 0 && output != null && !output.isEmpty()) {
+                if (output.startsWith("https://") || output.startsWith("http://")) {
+                    var uri = new URI(output);
+                    setProxyHostAndPortBasedOn(uri);
+                } else {
+                    for (var scheme : List.of("http", "https")) {
+                        var uri = new URI(scheme + "://" + output);
+                        setProxyHostAndPortBasedOn(uri);
+                    }
+                }
+                return;
+            }
+        } catch (InterruptedException e) {
+            // pass
+        } catch (IOException e) {
+            // pass
+        } catch (URISyntaxException e) {
+            // pass
+        }
+
         for (var key : List.of("http_proxy", "https_proxy")) {
             var value = System.getenv(key);
             value = value == null ? System.getenv(key.toUpperCase()) : value;
@@ -65,36 +92,6 @@ public class HttpProxy {
                               .map(s -> s.startsWith(".") ? "*" + s : s)
                               .collect(Collectors.toList());
             System.setProperty("http.nonProxyHosts", String.join("|", hosts));
-            hasSetupProxy = true;
-        }
-
-        if (!hasSetupProxy) {
-            try {
-                var pb = new ProcessBuilder("git", "config", "http.proxy");
-                pb.redirectOutput(ProcessBuilder.Redirect.PIPE);
-                pb.redirectError(ProcessBuilder.Redirect.DISCARD);
-                var p = pb.start();
-
-                var output = new String(p.getInputStream().readAllBytes(), StandardCharsets.UTF_8).trim();
-                var res = p.waitFor();
-                if (res == 0 && output != null && !output.isEmpty()) {
-                    if (output.startsWith("https://") || output.startsWith("http://")) {
-                        var uri = new URI(output);
-                        setProxyHostAndPortBasedOn(uri);
-                    } else {
-                        for (var scheme : List.of("http", "https")) {
-                            var uri = new URI(scheme + "://" + output);
-                            setProxyHostAndPortBasedOn(uri);
-                        }
-                    }
-                }
-            } catch (InterruptedException e) {
-                // pass
-            } catch (IOException e) {
-                // pass
-            } catch (URISyntaxException e) {
-                // pass
-            }
         }
     }
 }


### PR DESCRIPTION
Hi all,

please review this patch that makes the CLI tools respect git's
[http.proxy](https://git-scm.com/docs/git-config#Documentation/git-config.txt-httpproxy)
setting. The behavior with this patch is if `http_proxy`, `https_proxy` and/or
`no_proxy` is *not* set, then we try to set the proxy based on git's
`http.proxy` config (i.e. `http_proxy` and friends have precedence).

Thanks,
Erik

## Testing
- [x] Manual testing of CLI tools behind http(s) proxy
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-245](https://bugs.openjdk.java.net/browse/SKARA-245): CLI tools do not consider git's http.proxy configuration


## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)