### PR TITLE
243: Merge bot should support merging with certain frequency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,9 @@ clean:
 images:
 	@sh gradlew images
 
+bots:
+	@sh gradlew :bots:cli:images
+
 install: all $(LAUNCHERS) $(MANPAGES) $(sharedir)/skara
 	@echo "Successfully installed to $(prefix)"
 
@@ -65,4 +68,4 @@ $(bindir)/%: $(BUILD)/bin/%
 	@sed 's~export JAVA_HOME=.*$$~export JAVA_HOME\=$(sharedir)\/skara~' < $< > $@
 	@chmod 755 $@
 
-.PHONY: all check clean images install test uninstall
+.PHONY: all bots check clean images install test uninstall

--- a/bots/merge/src/main/java/org/openjdk/skara/bots/merge/Clock.java
+++ b/bots/merge/src/main/java/org/openjdk/skara/bots/merge/Clock.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.merge;
+
+import java.time.ZonedDateTime;
+
+interface Clock {
+    ZonedDateTime now();
+}

--- a/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
+++ b/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,8 +32,11 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Files;
 import java.net.URLEncoder;
-import java.util.List;
-import java.util.ArrayList;
+import java.time.DayOfWeek;
+import java.time.Month;
+import java.time.temporal.WeekFields;
+import java.time.ZonedDateTime;
+import java.util.*;
 import java.util.logging.Logger;
 
 class MergeBot implements Bot, WorkItem {
@@ -44,23 +47,153 @@ class MergeBot implements Bot, WorkItem {
     private final HostedRepository fork;
     private final List<Spec> specs;
 
+    private final Clock clock;
+
+    private final Map<String, Set<Integer>> hourly = new HashMap<>();
+    private final Map<String, Set<Integer>> daily = new HashMap<>();
+    private final Map<String, Set<Integer>> weekly = new HashMap<>();
+    private final Map<String, Set<Month>> monthly = new HashMap<>();
+    private final Map<String, Set<Integer>> yearly = new HashMap<>();
+
     MergeBot(Path storage, HostedRepository target, HostedRepository fork,
              List<Spec> specs) {
+        this(storage, target, fork, specs, new Clock() {
+            public ZonedDateTime now() {
+                return ZonedDateTime.now();
+            }
+        });
+    }
+
+    MergeBot(Path storage, HostedRepository target, HostedRepository fork,
+             List<Spec> specs, Clock clock) {
         this.storage = storage;
         this.target = target;
         this.fork = fork;
         this.specs = specs;
+        this.clock = clock;
     }
 
     final static class Spec {
+        final static class Frequency {
+            static enum Interval {
+                HOURLY,
+                DAILY,
+                WEEKLY,
+                MONTHLY,
+                YEARLY;
+
+                boolean isHourly() {
+                    return this.equals(HOURLY);
+                }
+
+                boolean isDaily() {
+                    return this.equals(DAILY);
+                }
+
+                boolean isWeekly() {
+                    return this.equals(WEEKLY);
+                }
+
+                boolean isMonthly() {
+                    return this.equals(MONTHLY);
+                }
+
+                boolean isYearly() {
+                    return this.equals(YEARLY);
+                }
+            }
+
+            private final Interval interval;
+            private final DayOfWeek weekday;
+            private final Month month;
+            private final int day;
+            private final int hour;
+            private final int minute;
+
+            private Frequency(Interval interval, DayOfWeek weekday, Month month, int day, int hour, int minute) {
+                this.interval = interval;
+                this.weekday = weekday;
+                this.month = month;
+                this.day = day;
+                this.hour = hour;
+                this.minute = minute;
+            }
+
+            static Frequency hourly(int minute) {
+                return new Frequency(Interval.HOURLY, null, null, -1, -1, minute);
+            }
+
+            static Frequency daily(int hour) {
+                return new Frequency(Interval.DAILY, null, null, -1, hour, -1);
+            }
+
+            static Frequency weekly(DayOfWeek weekday, int hour) {
+                return new Frequency(Interval.WEEKLY, weekday, null, -1, hour, -1);
+            }
+
+            static Frequency monthly(int day, int hour) {
+                return new Frequency(Interval.MONTHLY, null, null, day, hour, -1);
+            }
+
+            static Frequency yearly(Month month, int day, int hour) {
+                return new Frequency(Interval.YEARLY, null, month, day, hour, -1);
+            }
+
+            boolean isHourly() {
+                return interval.isHourly();
+            }
+
+            boolean isDaily() {
+                return interval.isDaily();
+            }
+
+            boolean isWeekly() {
+                return interval.isWeekly();
+            }
+
+            boolean isMonthly() {
+                return interval.isMonthly();
+            }
+
+            boolean isYearly() {
+                return interval.isYearly();
+            }
+
+            DayOfWeek weekday() {
+                return weekday;
+            }
+
+            Month month() {
+                return month;
+            }
+
+            int day() {
+                return day;
+            }
+
+            int hour() {
+                return hour;
+            }
+
+            int minute() {
+                return minute;
+            }
+        }
+
         private final HostedRepository fromRepo;
         private final Branch fromBranch;
         private final Branch toBranch;
+        private final Frequency frequency;
 
         Spec(HostedRepository fromRepo, Branch fromBranch, Branch toBranch) {
+            this(fromRepo, fromBranch, toBranch, null);
+        }
+
+        Spec(HostedRepository fromRepo, Branch fromBranch, Branch toBranch, Frequency frequency) {
             this.fromRepo = fromRepo;
             this.fromBranch = fromBranch;
             this.toBranch = toBranch;
+            this.frequency = frequency;
         }
 
         HostedRepository fromRepo() {
@@ -73,6 +206,10 @@ class MergeBot implements Bot, WorkItem {
 
         Branch toBranch() {
             return toBranch;
+        }
+
+        Optional<Frequency> frequency() {
+            return Optional.ofNullable(frequency);
         }
     }
 
@@ -126,7 +263,7 @@ class MergeBot implements Bot, WorkItem {
                 repo.checkout(toBranch, false);
 
                 // Check if merge conflict pull request is present
-                var isMergeConflictPRPresent = false;
+                var shouldMerge = true;
                 var title = "Cannot automatically merge " + fromRepo.name() + ":" + fromBranch.name() + " to " + toBranch.name();
                 var marker = "<!-- MERGE CONFLICTS -->";
                 for (var pr : prs) {
@@ -141,13 +278,85 @@ class MergeBot implements Bot, WorkItem {
                             pr.setState(PullRequest.State.CLOSED);
                         } else {
                             log.info("Outstanding unresolved merge already present");
-                            isMergeConflictPRPresent = true;
+                            shouldMerge = false;
                         }
                         break;
                     }
                 }
 
-                if (isMergeConflictPRPresent) {
+                if (spec.frequency().isPresent()) {
+                    var now = clock.now();
+                    var desc = toBranch.name() + "->" + fromRepo.name() + ":" + fromBranch.name();
+                    var freq = spec.frequency().get();
+                    if (freq.isHourly()) {
+                        if (!hourly.containsKey(desc)) {
+                            hourly.put(desc, new HashSet<Integer>());
+                        }
+                        var minute = now.getMinute();
+                        var hour = now.getHour();
+                        if (freq.minute() == minute && !hourly.get(desc).contains(hour)) {
+                            hourly.get(desc).add(hour);
+                        } else {
+                            shouldMerge = false;
+                        }
+                    } else if (freq.isDaily()) {
+                        if (!daily.containsKey(desc)) {
+                            daily.put(desc, new HashSet<Integer>());
+                        }
+                        var hour = now.getHour();
+                        var day = now.getDayOfYear();
+                        if (freq.hour() == hour && !daily.get(desc).contains(day)) {
+                            daily.get(desc).add(day);
+                        } else {
+                            shouldMerge = false;
+                        }
+                    } else if (freq.isWeekly()) {
+                        if (!weekly.containsKey(desc)) {
+                            weekly.put(desc, new HashSet<Integer>());
+                        }
+                        var weekOfYear = now.get(WeekFields.ISO.weekOfYear());
+                        var weekday = now.getDayOfWeek();
+                        var hour = now.getHour();
+                        if (freq.weekday().equals(weekday) &&
+                            freq.hour() == hour &&
+                            !weekly.get(desc).contains(weekOfYear)) {
+                            weekly.get(desc).add(weekOfYear);
+                        } else {
+                            shouldMerge = false;
+                        }
+                    } else if (freq.isMonthly()) {
+                        if (!monthly.containsKey(desc)) {
+                            monthly.put(desc, new HashSet<Month>());
+                        }
+                        var day = now.getDayOfMonth();
+                        var hour = now.getHour();
+                        var month = now.getMonth();
+                        if (freq.day() == day && freq.hour() == hour &&
+                            !monthly.get(desc).contains(month)) {
+                            monthly.get(desc).add(month);
+                        } else {
+                            shouldMerge = false;
+                        }
+                    } else if (freq.isYearly()) {
+                        if (!yearly.containsKey(desc)) {
+                            yearly.put(desc, new HashSet<Integer>());
+                        }
+                        var month = now.getMonth();
+                        var day = now.getDayOfMonth();
+                        var hour = now.getHour();
+                        var year = now.getYear();
+                        if (freq.month().equals(month) &&
+                            freq.day() == day &&
+                            freq.hour() == hour &&
+                            !yearly.get(desc).contains(year)) {
+                            yearly.get(desc).add(year);
+                        } else {
+                            shouldMerge = false;
+                        }
+                    }
+                }
+
+                if (!shouldMerge) {
                     continue;
                 }
 

--- a/bots/merge/src/test/java/org/openjdk/skara/bots/merge/MergeBotTests.java
+++ b/bots/merge/src/test/java/org/openjdk/skara/bots/merge/MergeBotTests.java
@@ -34,7 +34,10 @@ import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
 import java.util.*;
 import java.util.stream.Collectors;
+import java.time.DayOfWeek;
+import java.time.Month;
 import java.time.ZonedDateTime;
+import java.time.ZoneId;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -431,6 +434,628 @@ class MergeBotTests {
             pullRequests = toHostedRepo.pullRequests();
             assertEquals(1, pullRequests.size());
             assertEquals("Cannot automatically merge test:master to master", pr.title());
+        }
+    }
+
+    final static class TestClock implements Clock {
+        ZonedDateTime now;
+
+        TestClock() {
+            this(null);
+        }
+
+        TestClock(ZonedDateTime now) {
+            this.now = now;
+        }
+
+        @Override
+        public ZonedDateTime now() {
+            return now;
+        }
+    }
+
+    @Test
+    void testMergeHourly(TestInfo testInfo) throws IOException {
+        try (var temp = new TemporaryDirectory(false)) {
+            var host = TestHost.createNew(List.of(new HostUser(0, "duke", "J. Duke")));
+
+            var fromDir = temp.path().resolve("from.git");
+            var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
+            var fromHostedRepo = new TestHostedRepository(host, "test", fromLocalRepo);
+
+            var toDir = temp.path().resolve("to.git");
+            var toLocalRepo = Repository.init(toDir, VCS.GIT);
+            var toGitConfig = toDir.resolve(".git").resolve("config");
+            Files.write(toGitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
+                        StandardOpenOption.APPEND);
+            var toHostedRepo = new TestHostedRepository(host, "test-mirror", toLocalRepo);
+
+            var forkDir = temp.path().resolve("fork.git");
+            var forkLocalRepo = Repository.init(forkDir, VCS.GIT);
+            var forkGitConfig = forkDir.resolve(".git").resolve("config");
+            Files.write(forkGitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
+                        StandardOpenOption.APPEND);
+            var toFork = new TestHostedRepository(host, "test-mirror-fork", forkLocalRepo);
+
+            var now = ZonedDateTime.now();
+            var fromFileA = fromDir.resolve("a.txt");
+            Files.writeString(fromFileA, "Hello A\n");
+            fromLocalRepo.add(fromFileA);
+            var fromHashA = fromLocalRepo.commit("Adding a.txt", "duke", "duke@openjdk.org", now);
+            var fromCommits = fromLocalRepo.commits().asList();
+            assertEquals(1, fromCommits.size());
+            assertEquals(fromHashA, fromCommits.get(0).hash());
+
+            var toFileA = toDir.resolve("a.txt");
+            Files.writeString(toFileA, "Hello A\n");
+            toLocalRepo.add(toFileA);
+            var toHashA = toLocalRepo.commit("Adding a.txt", "duke", "duke@openjdk.org", now);
+            var toCommits = toLocalRepo.commits().asList();
+            assertEquals(1, toCommits.size());
+            assertEquals(toHashA, toCommits.get(0).hash());
+            assertEquals(fromHashA, toHashA);
+
+            var fromFileB = fromDir.resolve("b.txt");
+            Files.writeString(fromFileB, "Hello B\n");
+            fromLocalRepo.add(fromFileB);
+            var fromHashB = fromLocalRepo.commit("Adding b.txt", "duke", "duke@openjdk.org");
+
+            var toFileC = toDir.resolve("c.txt");
+            Files.writeString(toFileC, "Hello C\n");
+            toLocalRepo.add(toFileC);
+            var toHashC = toLocalRepo.commit("Adding c.txt", "duke", "duke@openjdk.org");
+
+            var storage = temp.path().resolve("storage");
+            var master = new Branch("master");
+
+            // Merge only at most once during the first minute every hour
+            var freq = MergeBot.Spec.Frequency.hourly(1);
+            var specs = List.of(new MergeBot.Spec(fromHostedRepo, master, master, freq));
+
+            var clock = new TestClock(ZonedDateTime.of(2020, 1, 23, 15, 0, 0, 0, ZoneId.of("GMT+1")));
+            var bot = new MergeBot(storage, toHostedRepo, toFork, specs, clock);
+
+            TestBotRunner.runPeriodicItems(bot);
+
+            // Ensure nothing has been merged
+            toCommits = toLocalRepo.commits().asList();
+            assertEquals(2, toCommits.size());
+            assertEquals(toHashC, toCommits.get(0).hash());
+            assertEquals(toHashA, toCommits.get(1).hash());
+
+            // Set the clock to the first minute of the hour
+            clock.now = ZonedDateTime.of(2020, 1, 23, 15, 1, 0, 0, ZoneId.of("GMT+1"));
+            TestBotRunner.runPeriodicItems(bot);
+
+            // Should have merged
+            toCommits = toLocalRepo.commits().asList();
+            assertEquals(4, toCommits.size());
+            var hashes = toCommits.stream().map(Commit::hash).collect(Collectors.toSet());
+            assertTrue(hashes.contains(toHashA));
+            assertTrue(hashes.contains(fromHashB));
+            assertTrue(hashes.contains(toHashC));
+
+            var known = Set.of(toHashA, fromHashB, toHashC);
+            var merge = toCommits.stream().filter(c -> !known.contains(c.hash())).findAny().get();
+            assertTrue(merge.isMerge());
+            assertEquals(List.of("Merge"), merge.message());
+            assertEquals("duke", merge.author().name());
+            assertEquals("duke@openjdk.org", merge.author().email());
+
+            assertEquals(0, toHostedRepo.pullRequests().size());
+
+            var fromFileD = fromDir.resolve("d.txt");
+            Files.writeString(fromFileD, "Hello D\n");
+            fromLocalRepo.add(fromFileD);
+            var fromHashD = fromLocalRepo.commit("Adding d.txt", "duke", "duke@openjdk.org");
+
+            // Since the time hasn't changed it should not merge again
+            TestBotRunner.runPeriodicItems(bot);
+            toCommits = toLocalRepo.commits().asList();
+            assertEquals(4, toCommits.size());
+
+            // Move the minutes forward, the bot should not merge
+            clock.now = ZonedDateTime.of(2020, 1, 23, 15, 45, 0, 0, ZoneId.of("GMT+1"));
+            TestBotRunner.runPeriodicItems(bot);
+            toCommits = toLocalRepo.commits().asList();
+            assertEquals(4, toCommits.size());
+
+            // Move the clock forward one hour, the bot should merge
+            clock.now = ZonedDateTime.of(2020, 1, 23, 16, 1, 0, 0, ZoneId.of("GMT+1"));
+            TestBotRunner.runPeriodicItems(bot);
+
+            toCommits = toLocalRepo.commits().asList();
+            assertEquals(6, toCommits.size());
+        }
+    }
+
+    @Test
+    void testMergeDaily(TestInfo testInfo) throws IOException {
+        try (var temp = new TemporaryDirectory(false)) {
+            var host = TestHost.createNew(List.of(new HostUser(0, "duke", "J. Duke")));
+
+            var fromDir = temp.path().resolve("from.git");
+            var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
+            var fromHostedRepo = new TestHostedRepository(host, "test", fromLocalRepo);
+
+            var toDir = temp.path().resolve("to.git");
+            var toLocalRepo = Repository.init(toDir, VCS.GIT);
+            var toGitConfig = toDir.resolve(".git").resolve("config");
+            Files.write(toGitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
+                        StandardOpenOption.APPEND);
+            var toHostedRepo = new TestHostedRepository(host, "test-mirror", toLocalRepo);
+
+            var forkDir = temp.path().resolve("fork.git");
+            var forkLocalRepo = Repository.init(forkDir, VCS.GIT);
+            var forkGitConfig = forkDir.resolve(".git").resolve("config");
+            Files.write(forkGitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
+                        StandardOpenOption.APPEND);
+            var toFork = new TestHostedRepository(host, "test-mirror-fork", forkLocalRepo);
+
+            var now = ZonedDateTime.now();
+            var fromFileA = fromDir.resolve("a.txt");
+            Files.writeString(fromFileA, "Hello A\n");
+            fromLocalRepo.add(fromFileA);
+            var fromHashA = fromLocalRepo.commit("Adding a.txt", "duke", "duke@openjdk.org", now);
+            var fromCommits = fromLocalRepo.commits().asList();
+            assertEquals(1, fromCommits.size());
+            assertEquals(fromHashA, fromCommits.get(0).hash());
+
+            var toFileA = toDir.resolve("a.txt");
+            Files.writeString(toFileA, "Hello A\n");
+            toLocalRepo.add(toFileA);
+            var toHashA = toLocalRepo.commit("Adding a.txt", "duke", "duke@openjdk.org", now);
+            var toCommits = toLocalRepo.commits().asList();
+            assertEquals(1, toCommits.size());
+            assertEquals(toHashA, toCommits.get(0).hash());
+            assertEquals(fromHashA, toHashA);
+
+            var fromFileB = fromDir.resolve("b.txt");
+            Files.writeString(fromFileB, "Hello B\n");
+            fromLocalRepo.add(fromFileB);
+            var fromHashB = fromLocalRepo.commit("Adding b.txt", "duke", "duke@openjdk.org");
+
+            var toFileC = toDir.resolve("c.txt");
+            Files.writeString(toFileC, "Hello C\n");
+            toLocalRepo.add(toFileC);
+            var toHashC = toLocalRepo.commit("Adding c.txt", "duke", "duke@openjdk.org");
+
+            var storage = temp.path().resolve("storage");
+            var master = new Branch("master");
+
+            // Merge only at most once during the third hour every day
+            var freq = MergeBot.Spec.Frequency.daily(3);
+            var specs = List.of(new MergeBot.Spec(fromHostedRepo, master, master, freq));
+
+            var clock = new TestClock(ZonedDateTime.of(2020, 1, 23, 2, 45, 0, 0, ZoneId.of("GMT+1")));
+            var bot = new MergeBot(storage, toHostedRepo, toFork, specs, clock);
+
+            TestBotRunner.runPeriodicItems(bot);
+
+            // Ensure nothing has been merged
+            toCommits = toLocalRepo.commits().asList();
+            assertEquals(2, toCommits.size());
+            assertEquals(toHashC, toCommits.get(0).hash());
+            assertEquals(toHashA, toCommits.get(1).hash());
+
+            // Set the clock to the third hour of the day (minutes should not matter)
+            clock.now = ZonedDateTime.of(2020, 1, 23, 3, 37, 0, 0, ZoneId.of("GMT+1"));
+            TestBotRunner.runPeriodicItems(bot);
+
+            // Should have merged
+            toCommits = toLocalRepo.commits().asList();
+            assertEquals(4, toCommits.size());
+            var hashes = toCommits.stream().map(Commit::hash).collect(Collectors.toSet());
+            assertTrue(hashes.contains(toHashA));
+            assertTrue(hashes.contains(fromHashB));
+            assertTrue(hashes.contains(toHashC));
+
+            var known = Set.of(toHashA, fromHashB, toHashC);
+            var merge = toCommits.stream().filter(c -> !known.contains(c.hash())).findAny().get();
+            assertTrue(merge.isMerge());
+            assertEquals(List.of("Merge"), merge.message());
+            assertEquals("duke", merge.author().name());
+            assertEquals("duke@openjdk.org", merge.author().email());
+
+            assertEquals(0, toHostedRepo.pullRequests().size());
+
+            var fromFileD = fromDir.resolve("d.txt");
+            Files.writeString(fromFileD, "Hello D\n");
+            fromLocalRepo.add(fromFileD);
+            var fromHashD = fromLocalRepo.commit("Adding d.txt", "duke", "duke@openjdk.org");
+
+            // Since the time hasn't changed it should not merge
+            TestBotRunner.runPeriodicItems(bot);
+            toCommits = toLocalRepo.commits().asList();
+            assertEquals(4, toCommits.size());
+
+            // Move the minutes forward, the bot should not merge
+            clock.now = ZonedDateTime.of(2020, 1, 23, 3, 45, 0, 0, ZoneId.of("GMT+1"));
+            TestBotRunner.runPeriodicItems(bot);
+            toCommits = toLocalRepo.commits().asList();
+            assertEquals(4, toCommits.size());
+
+            // Move the hours forward, the bot should not merge
+            clock.now = ZonedDateTime.of(2020, 1, 23, 17, 45, 0, 0, ZoneId.of("GMT+1"));
+            TestBotRunner.runPeriodicItems(bot);
+            toCommits = toLocalRepo.commits().asList();
+            assertEquals(4, toCommits.size());
+
+            // Move the clock forward one day, the bot should merge
+            clock.now = ZonedDateTime.of(2020, 1, 24, 3, 55, 0, 0, ZoneId.of("GMT+1"));
+            TestBotRunner.runPeriodicItems(bot);
+
+            toCommits = toLocalRepo.commits().asList();
+            assertEquals(6, toCommits.size());
+        }
+    }
+
+    @Test
+    void testMergeWeekly(TestInfo testInfo) throws IOException {
+        try (var temp = new TemporaryDirectory(false)) {
+            var host = TestHost.createNew(List.of(new HostUser(0, "duke", "J. Duke")));
+
+            var fromDir = temp.path().resolve("from.git");
+            var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
+            var fromHostedRepo = new TestHostedRepository(host, "test", fromLocalRepo);
+
+            var toDir = temp.path().resolve("to.git");
+            var toLocalRepo = Repository.init(toDir, VCS.GIT);
+            var toGitConfig = toDir.resolve(".git").resolve("config");
+            Files.write(toGitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
+                        StandardOpenOption.APPEND);
+            var toHostedRepo = new TestHostedRepository(host, "test-mirror", toLocalRepo);
+
+            var forkDir = temp.path().resolve("fork.git");
+            var forkLocalRepo = Repository.init(forkDir, VCS.GIT);
+            var forkGitConfig = forkDir.resolve(".git").resolve("config");
+            Files.write(forkGitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
+                        StandardOpenOption.APPEND);
+            var toFork = new TestHostedRepository(host, "test-mirror-fork", forkLocalRepo);
+
+            var now = ZonedDateTime.now();
+            var fromFileA = fromDir.resolve("a.txt");
+            Files.writeString(fromFileA, "Hello A\n");
+            fromLocalRepo.add(fromFileA);
+            var fromHashA = fromLocalRepo.commit("Adding a.txt", "duke", "duke@openjdk.org", now);
+            var fromCommits = fromLocalRepo.commits().asList();
+            assertEquals(1, fromCommits.size());
+            assertEquals(fromHashA, fromCommits.get(0).hash());
+
+            var toFileA = toDir.resolve("a.txt");
+            Files.writeString(toFileA, "Hello A\n");
+            toLocalRepo.add(toFileA);
+            var toHashA = toLocalRepo.commit("Adding a.txt", "duke", "duke@openjdk.org", now);
+            var toCommits = toLocalRepo.commits().asList();
+            assertEquals(1, toCommits.size());
+            assertEquals(toHashA, toCommits.get(0).hash());
+            assertEquals(fromHashA, toHashA);
+
+            var fromFileB = fromDir.resolve("b.txt");
+            Files.writeString(fromFileB, "Hello B\n");
+            fromLocalRepo.add(fromFileB);
+            var fromHashB = fromLocalRepo.commit("Adding b.txt", "duke", "duke@openjdk.org");
+
+            var toFileC = toDir.resolve("c.txt");
+            Files.writeString(toFileC, "Hello C\n");
+            toLocalRepo.add(toFileC);
+            var toHashC = toLocalRepo.commit("Adding c.txt", "duke", "duke@openjdk.org");
+
+            var storage = temp.path().resolve("storage");
+            var master = new Branch("master");
+
+            // Merge only at most once per week on Friday's at 12:00
+            var freq = MergeBot.Spec.Frequency.weekly(DayOfWeek.FRIDAY, 12);
+            var specs = List.of(new MergeBot.Spec(fromHostedRepo, master, master, freq));
+
+            var clock = new TestClock(ZonedDateTime.of(2020, 1, 24, 11, 45, 0, 0, ZoneId.of("GMT+1")));
+            var bot = new MergeBot(storage, toHostedRepo, toFork, specs, clock);
+
+            TestBotRunner.runPeriodicItems(bot);
+
+            // Ensure nothing has been merged
+            toCommits = toLocalRepo.commits().asList();
+            assertEquals(2, toCommits.size());
+            assertEquals(toHashC, toCommits.get(0).hash());
+            assertEquals(toHashA, toCommits.get(1).hash());
+
+            // Set the clock to the 12th hour of the day (minutes should not matter)
+            clock.now = ZonedDateTime.of(2020, 1, 24, 12, 37, 0, 0, ZoneId.of("GMT+1"));
+            TestBotRunner.runPeriodicItems(bot);
+
+            // Should have merged
+            toCommits = toLocalRepo.commits().asList();
+            assertEquals(4, toCommits.size());
+            var hashes = toCommits.stream().map(Commit::hash).collect(Collectors.toSet());
+            assertTrue(hashes.contains(toHashA));
+            assertTrue(hashes.contains(fromHashB));
+            assertTrue(hashes.contains(toHashC));
+
+            var known = Set.of(toHashA, fromHashB, toHashC);
+            var merge = toCommits.stream().filter(c -> !known.contains(c.hash())).findAny().get();
+            assertTrue(merge.isMerge());
+            assertEquals(List.of("Merge"), merge.message());
+            assertEquals("duke", merge.author().name());
+            assertEquals("duke@openjdk.org", merge.author().email());
+
+            assertEquals(0, toHostedRepo.pullRequests().size());
+
+            var fromFileD = fromDir.resolve("d.txt");
+            Files.writeString(fromFileD, "Hello D\n");
+            fromLocalRepo.add(fromFileD);
+            var fromHashD = fromLocalRepo.commit("Adding d.txt", "duke", "duke@openjdk.org");
+
+            // Since the time hasn't changed it should not merge
+            TestBotRunner.runPeriodicItems(bot);
+            toCommits = toLocalRepo.commits().asList();
+            assertEquals(4, toCommits.size());
+
+            // Move the hours forward, the bot should not merge
+            clock.now = ZonedDateTime.of(2020, 1, 24, 13, 45, 0, 0, ZoneId.of("GMT+1"));
+            TestBotRunner.runPeriodicItems(bot);
+            toCommits = toLocalRepo.commits().asList();
+            assertEquals(4, toCommits.size());
+
+            // Move the days forward, the bot should not merge
+            clock.now = ZonedDateTime.of(2020, 1, 25, 13, 45, 0, 0, ZoneId.of("GMT+1"));
+            TestBotRunner.runPeriodicItems(bot);
+            toCommits = toLocalRepo.commits().asList();
+            assertEquals(4, toCommits.size());
+
+            // Move the clock forward one week, the bot should merge
+            clock.now = ZonedDateTime.of(2020, 1, 31, 12, 29, 0, 0, ZoneId.of("GMT+1"));
+            TestBotRunner.runPeriodicItems(bot);
+
+            toCommits = toLocalRepo.commits().asList();
+            assertEquals(6, toCommits.size());
+        }
+    }
+
+    @Test
+    void testMergeMonthly(TestInfo testInfo) throws IOException {
+        try (var temp = new TemporaryDirectory(false)) {
+            var host = TestHost.createNew(List.of(new HostUser(0, "duke", "J. Duke")));
+
+            var fromDir = temp.path().resolve("from.git");
+            var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
+            var fromHostedRepo = new TestHostedRepository(host, "test", fromLocalRepo);
+
+            var toDir = temp.path().resolve("to.git");
+            var toLocalRepo = Repository.init(toDir, VCS.GIT);
+            var toGitConfig = toDir.resolve(".git").resolve("config");
+            Files.write(toGitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
+                        StandardOpenOption.APPEND);
+            var toHostedRepo = new TestHostedRepository(host, "test-mirror", toLocalRepo);
+
+            var forkDir = temp.path().resolve("fork.git");
+            var forkLocalRepo = Repository.init(forkDir, VCS.GIT);
+            var forkGitConfig = forkDir.resolve(".git").resolve("config");
+            Files.write(forkGitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
+                        StandardOpenOption.APPEND);
+            var toFork = new TestHostedRepository(host, "test-mirror-fork", forkLocalRepo);
+
+            var now = ZonedDateTime.now();
+            var fromFileA = fromDir.resolve("a.txt");
+            Files.writeString(fromFileA, "Hello A\n");
+            fromLocalRepo.add(fromFileA);
+            var fromHashA = fromLocalRepo.commit("Adding a.txt", "duke", "duke@openjdk.org", now);
+            var fromCommits = fromLocalRepo.commits().asList();
+            assertEquals(1, fromCommits.size());
+            assertEquals(fromHashA, fromCommits.get(0).hash());
+
+            var toFileA = toDir.resolve("a.txt");
+            Files.writeString(toFileA, "Hello A\n");
+            toLocalRepo.add(toFileA);
+            var toHashA = toLocalRepo.commit("Adding a.txt", "duke", "duke@openjdk.org", now);
+            var toCommits = toLocalRepo.commits().asList();
+            assertEquals(1, toCommits.size());
+            assertEquals(toHashA, toCommits.get(0).hash());
+            assertEquals(fromHashA, toHashA);
+
+            var fromFileB = fromDir.resolve("b.txt");
+            Files.writeString(fromFileB, "Hello B\n");
+            fromLocalRepo.add(fromFileB);
+            var fromHashB = fromLocalRepo.commit("Adding b.txt", "duke", "duke@openjdk.org");
+
+            var toFileC = toDir.resolve("c.txt");
+            Files.writeString(toFileC, "Hello C\n");
+            toLocalRepo.add(toFileC);
+            var toHashC = toLocalRepo.commit("Adding c.txt", "duke", "duke@openjdk.org");
+
+            var storage = temp.path().resolve("storage");
+            var master = new Branch("master");
+
+            // Merge only at most once per month on the 17th day at at 11:00
+            var freq = MergeBot.Spec.Frequency.monthly(17, 11);
+            var specs = List.of(new MergeBot.Spec(fromHostedRepo, master, master, freq));
+
+            var clock = new TestClock(ZonedDateTime.of(2020, 1, 16, 11, 0, 0, 0, ZoneId.of("GMT+1")));
+            var bot = new MergeBot(storage, toHostedRepo, toFork, specs, clock);
+
+            TestBotRunner.runPeriodicItems(bot);
+
+            // Ensure nothing has been merged
+            toCommits = toLocalRepo.commits().asList();
+            assertEquals(2, toCommits.size());
+            assertEquals(toHashC, toCommits.get(0).hash());
+            assertEquals(toHashA, toCommits.get(1).hash());
+
+            // Set the clock to the 17th day and at hour 11 (minutes should not matter)
+            clock.now = ZonedDateTime.of(2020, 1, 17, 11, 37, 0, 0, ZoneId.of("GMT+1"));
+            TestBotRunner.runPeriodicItems(bot);
+
+            // Should have merged
+            toCommits = toLocalRepo.commits().asList();
+            assertEquals(4, toCommits.size());
+            var hashes = toCommits.stream().map(Commit::hash).collect(Collectors.toSet());
+            assertTrue(hashes.contains(toHashA));
+            assertTrue(hashes.contains(fromHashB));
+            assertTrue(hashes.contains(toHashC));
+
+            var known = Set.of(toHashA, fromHashB, toHashC);
+            var merge = toCommits.stream().filter(c -> !known.contains(c.hash())).findAny().get();
+            assertTrue(merge.isMerge());
+            assertEquals(List.of("Merge"), merge.message());
+            assertEquals("duke", merge.author().name());
+            assertEquals("duke@openjdk.org", merge.author().email());
+
+            assertEquals(0, toHostedRepo.pullRequests().size());
+
+            var fromFileD = fromDir.resolve("d.txt");
+            Files.writeString(fromFileD, "Hello D\n");
+            fromLocalRepo.add(fromFileD);
+            var fromHashD = fromLocalRepo.commit("Adding d.txt", "duke", "duke@openjdk.org");
+
+            // Since the time hasn't changed it should not merge
+            TestBotRunner.runPeriodicItems(bot);
+            toCommits = toLocalRepo.commits().asList();
+            assertEquals(4, toCommits.size());
+
+            // Move the hours forward, the bot should not merge
+            clock.now = ZonedDateTime.of(2020, 1, 17, 12, 45, 0, 0, ZoneId.of("GMT+1"));
+            TestBotRunner.runPeriodicItems(bot);
+            toCommits = toLocalRepo.commits().asList();
+            assertEquals(4, toCommits.size());
+
+            // Move the days forward, the bot should not merge
+            clock.now = ZonedDateTime.of(2020, 1, 18, 11, 0, 0, 0, ZoneId.of("GMT+1"));
+            TestBotRunner.runPeriodicItems(bot);
+            toCommits = toLocalRepo.commits().asList();
+            assertEquals(4, toCommits.size());
+
+            // Move the clock forward one month, the bot should merge
+            clock.now = ZonedDateTime.of(2020, 2, 17, 11, 55, 0, 0, ZoneId.of("GMT+1"));
+            TestBotRunner.runPeriodicItems(bot);
+
+            toCommits = toLocalRepo.commits().asList();
+            assertEquals(6, toCommits.size());
+        }
+    }
+
+    @Test
+    void testMergeYearly(TestInfo testInfo) throws IOException {
+        try (var temp = new TemporaryDirectory(false)) {
+            var host = TestHost.createNew(List.of(new HostUser(0, "duke", "J. Duke")));
+
+            var fromDir = temp.path().resolve("from.git");
+            var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
+            var fromHostedRepo = new TestHostedRepository(host, "test", fromLocalRepo);
+
+            var toDir = temp.path().resolve("to.git");
+            var toLocalRepo = Repository.init(toDir, VCS.GIT);
+            var toGitConfig = toDir.resolve(".git").resolve("config");
+            Files.write(toGitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
+                        StandardOpenOption.APPEND);
+            var toHostedRepo = new TestHostedRepository(host, "test-mirror", toLocalRepo);
+
+            var forkDir = temp.path().resolve("fork.git");
+            var forkLocalRepo = Repository.init(forkDir, VCS.GIT);
+            var forkGitConfig = forkDir.resolve(".git").resolve("config");
+            Files.write(forkGitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
+                        StandardOpenOption.APPEND);
+            var toFork = new TestHostedRepository(host, "test-mirror-fork", forkLocalRepo);
+
+            var now = ZonedDateTime.now();
+            var fromFileA = fromDir.resolve("a.txt");
+            Files.writeString(fromFileA, "Hello A\n");
+            fromLocalRepo.add(fromFileA);
+            var fromHashA = fromLocalRepo.commit("Adding a.txt", "duke", "duke@openjdk.org", now);
+            var fromCommits = fromLocalRepo.commits().asList();
+            assertEquals(1, fromCommits.size());
+            assertEquals(fromHashA, fromCommits.get(0).hash());
+
+            var toFileA = toDir.resolve("a.txt");
+            Files.writeString(toFileA, "Hello A\n");
+            toLocalRepo.add(toFileA);
+            var toHashA = toLocalRepo.commit("Adding a.txt", "duke", "duke@openjdk.org", now);
+            var toCommits = toLocalRepo.commits().asList();
+            assertEquals(1, toCommits.size());
+            assertEquals(toHashA, toCommits.get(0).hash());
+            assertEquals(fromHashA, toHashA);
+
+            var fromFileB = fromDir.resolve("b.txt");
+            Files.writeString(fromFileB, "Hello B\n");
+            fromLocalRepo.add(fromFileB);
+            var fromHashB = fromLocalRepo.commit("Adding b.txt", "duke", "duke@openjdk.org");
+
+            var toFileC = toDir.resolve("c.txt");
+            Files.writeString(toFileC, "Hello C\n");
+            toLocalRepo.add(toFileC);
+            var toHashC = toLocalRepo.commit("Adding c.txt", "duke", "duke@openjdk.org");
+
+            var storage = temp.path().resolve("storage");
+            var master = new Branch("master");
+
+            // Merge only at most once per year on the 29th day of May at at 07:00
+            var freq = MergeBot.Spec.Frequency.yearly(Month.MAY, 29, 07);
+            var specs = List.of(new MergeBot.Spec(fromHostedRepo, master, master, freq));
+
+            var clock = new TestClock(ZonedDateTime.of(2020, 5, 27, 11, 0, 0, 0, ZoneId.of("GMT+1")));
+            var bot = new MergeBot(storage, toHostedRepo, toFork, specs, clock);
+
+            TestBotRunner.runPeriodicItems(bot);
+
+            // Ensure nothing has been merged
+            toCommits = toLocalRepo.commits().asList();
+            assertEquals(2, toCommits.size());
+            assertEquals(toHashC, toCommits.get(0).hash());
+            assertEquals(toHashA, toCommits.get(1).hash());
+
+            // Set the clock to the 29th of May and at hour 11 (minutes should not matter)
+            clock.now = ZonedDateTime.of(2020, 5, 29, 7, 37, 0, 0, ZoneId.of("GMT+1"));
+            TestBotRunner.runPeriodicItems(bot);
+
+            // Should have merged
+            toCommits = toLocalRepo.commits().asList();
+            assertEquals(4, toCommits.size());
+            var hashes = toCommits.stream().map(Commit::hash).collect(Collectors.toSet());
+            assertTrue(hashes.contains(toHashA));
+            assertTrue(hashes.contains(fromHashB));
+            assertTrue(hashes.contains(toHashC));
+
+            var known = Set.of(toHashA, fromHashB, toHashC);
+            var merge = toCommits.stream().filter(c -> !known.contains(c.hash())).findAny().get();
+            assertTrue(merge.isMerge());
+            assertEquals(List.of("Merge"), merge.message());
+            assertEquals("duke", merge.author().name());
+            assertEquals("duke@openjdk.org", merge.author().email());
+
+            assertEquals(0, toHostedRepo.pullRequests().size());
+
+            var fromFileD = fromDir.resolve("d.txt");
+            Files.writeString(fromFileD, "Hello D\n");
+            fromLocalRepo.add(fromFileD);
+            var fromHashD = fromLocalRepo.commit("Adding d.txt", "duke", "duke@openjdk.org");
+
+            // Since the time hasn't changed it should not merge again
+            TestBotRunner.runPeriodicItems(bot);
+            toCommits = toLocalRepo.commits().asList();
+            assertEquals(4, toCommits.size());
+
+            // Move the hours forward, the bot should not merge
+            clock.now = ZonedDateTime.of(2020, 5, 29, 8, 45, 0, 0, ZoneId.of("GMT+1"));
+            TestBotRunner.runPeriodicItems(bot);
+            toCommits = toLocalRepo.commits().asList();
+            assertEquals(4, toCommits.size());
+
+            // Move the days forward, the bot should not merge
+            clock.now = ZonedDateTime.of(2020, 5, 30, 11, 0, 0, 0, ZoneId.of("GMT+1"));
+            TestBotRunner.runPeriodicItems(bot);
+            toCommits = toLocalRepo.commits().asList();
+            assertEquals(4, toCommits.size());
+
+            // Move the months forward, the bot should not merge
+            clock.now = ZonedDateTime.of(2020, 7, 29, 7, 0, 0, 0, ZoneId.of("GMT+1"));
+            TestBotRunner.runPeriodicItems(bot);
+            toCommits = toLocalRepo.commits().asList();
+            assertEquals(4, toCommits.size());
+
+            // Move the clock forward one year, the bot should merge
+            clock.now = ZonedDateTime.of(2021, 5, 29, 7, 55, 0, 0, ZoneId.of("GMT+1"));
+            TestBotRunner.runPeriodicItems(bot);
+
+            toCommits = toLocalRepo.commits().asList();
+            assertEquals(6, toCommits.size());
         }
     }
 }


### PR DESCRIPTION
Hi all,

please review this patch that enables the merge bot to periodically sync
branches with a certain frequency. This is implemented by extending the
configuration for a merge specification:

```
"merge": {
    "target": "github:openjdk/panama",
    "specs": [
        {
	    "from": "github:openjdk/jdk:master",
	    "to": "master",
	    "frequency": {
	        "interval": "weekly",
		"weekday": "Friday",
		"hour": "11"
	    }
	}
    ]
}
```

The above configuration would merge the `master` branch from the
[jdk](https://github.com/openjdk/jdk) repository to the `master` branch in the
[panama](https://github.com/openjdk/panama) repository every Friday at 11:00.
The merge will only be done once, i.e. it won't be retried until the next Friday
if the merge fails (and result in a merge conflict PR).

There is one limitation with the patch and that is that the merge bot only
"remember" previous merges in memory. This is problematic if we redeploy the
merge bot during 11:00 - 11:59 on a Friday and the merge already has occurred,
the merge bot will then do a second merge. This is known limitation and one I
think we can live with, I don't foresee it to become a problem in practice.

Thanks,
Erik

## Testing
- [x] Added a bunch of new unit tests
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-243](https://bugs.openjdk.java.net/browse/SKARA-243): Merge bot should support merging with certain frequency


## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)