### PR TITLE
247: Support atomic pushes in with /integrate command

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -402,9 +402,12 @@ class CheckRun {
             message.append("` branch. ");
             if (rebasePossible) {
                 message.append("Since there are no conflicts, your changes will automatically be rebased on top of ");
-                message.append("these commits when integrating. If you prefer to do this manually, please merge `");
+                message.append("these commits when integrating. If you prefer to avoid automatic rebasing, please merge `");
                 message.append(pr.targetRef());
-                message.append("` into your branch first.\n");
+                message.append("` into your branch, and then specify the current head hash when integrating, like this: ");
+                message.append("`/integrate ");
+                message.append(prInstance.targetHash());
+                message.append("`.\n");
             } else {
                 message.append("Your changes cannot be rebased automatically without conflicts, so you will need to ");
                 message.append("merge `");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
@@ -24,6 +24,7 @@ package org.openjdk.skara.bots.pr;
 
 import org.openjdk.skara.forge.*;
 import org.openjdk.skara.issuetracker.Comment;
+import org.openjdk.skara.vcs.Hash;
 
 import java.io.*;
 import java.net.URLEncoder;
@@ -79,7 +80,19 @@ public class IntegrateCommand implements CommandHandler {
 
             var prInstance = new PullRequestInstance(path, pr, bot.ignoreStaleReviews());
             var localHash = prInstance.commit(censusInstance.namespace(), censusInstance.configuration().census().domain(), null);
+
+            // Validate the target hash if requested
             var rebaseMessage = new StringWriter();
+            if (!args.isBlank()) {
+                var wantedHash = new Hash(args);
+                if (!prInstance.targetHash().equals(wantedHash)) {
+                    reply.print("The head of the target branch is no longer at the requested hash " + wantedHash);
+                    reply.println(" - it has moved to " + prInstance.targetHash() + ". Aborting integration.");
+                    return;
+                }
+            };
+
+            // Now rebase onto the target hash
             var rebaseWriter = new PrintWriter(rebaseMessage);
             var rebasedHash = prInstance.rebase(localHash, rebaseWriter);
             if (rebasedHash.isEmpty()) {
@@ -108,6 +121,9 @@ public class IntegrateCommand implements CommandHandler {
                 if (!ProjectPermissions.mayCommit(censusInstance, pr.author())) {
                     reply.println(ReadyForSponsorTracker.addIntegrationMarker(pr.headHash()));
                     reply.println("Your change (at version " + pr.headHash() + ") is now ready to be sponsored by a Committer.");
+                    if (!args.isBlank()) {
+                        reply.println("Note that your sponsor will make the final decision on which target hash to integrate on.");
+                    }
                     pr.addLabel("sponsor");
                     return;
                 }
@@ -121,11 +137,12 @@ public class IntegrateCommand implements CommandHandler {
             // Rebase and push it!
             if (!localHash.equals(pr.targetHash())) {
                 reply.println(rebaseMessage.toString());
-                reply.println("Pushed as commit " + rebasedHash.get().hex() + ".");
-                prInstance.localRepo().push(rebasedHash.get(), pr.repository().url(), pr.targetRef());
+                reply.println("Pushed as commit " + localHash.hex() + ".");
+                prInstance.localRepo().push(localHash, pr.repository().url(), pr.targetRef());
                 pr.setState(PullRequest.State.CLOSED);
                 pr.addLabel("integrated");
                 pr.removeLabel("ready");
+                pr.removeLabel("rfr");
             } else {
                 reply.print("Warning! Your commit did not result in any changes! ");
                 reply.println("No push attempt will be made.");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
@@ -122,7 +122,7 @@ public class IntegrateCommand implements CommandHandler {
                     reply.println(ReadyForSponsorTracker.addIntegrationMarker(pr.headHash()));
                     reply.println("Your change (at version " + pr.headHash() + ") is now ready to be sponsored by a Committer.");
                     if (!args.isBlank()) {
-                        reply.println("Note that your sponsor will make the final decision on which target hash to integrate on.");
+                        reply.println("Note that your sponsor will make the final decision on which target hash to integrate onto.");
                     }
                     pr.addLabel("sponsor");
                     return;

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestInstance.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestInstance.java
@@ -196,11 +196,15 @@ class PullRequestInstance {
     }
 
     Repository localRepo() {
-        return this.localRepo;
+        return localRepo;
     }
 
     Hash baseHash() {
-        return this.baseHash;
+        return baseHash;
+    }
+
+    Hash targetHash() {
+        return targetHash;
     }
 
     Set<Path> changedFiles() throws IOException {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
@@ -24,6 +24,7 @@ package org.openjdk.skara.bots.pr;
 
 import org.openjdk.skara.forge.PullRequest;
 import org.openjdk.skara.issuetracker.Comment;
+import org.openjdk.skara.vcs.Hash;
 
 import java.io.*;
 import java.net.URLEncoder;
@@ -75,7 +76,19 @@ public class SponsorCommand implements CommandHandler {
             var prInstance = new PullRequestInstance(path, pr, bot.ignoreStaleReviews());
             var localHash = prInstance.commit(censusInstance.namespace(), censusInstance.configuration().census().domain(),
                                          comment.author().id());
+
+            // Validate the target hash if requested
             var rebaseMessage = new StringWriter();
+            if (!args.isBlank()) {
+                var wantedHash = new Hash(args);
+                if (!prInstance.targetHash().equals(wantedHash)) {
+                    reply.print("The head of the target branch is no longer at the requested hash " + wantedHash);
+                    reply.println(" - it has moved to " + prInstance.targetHash() + ". Aborting integration.");
+                    return;
+                }
+            }
+
+            // Now rebase onto the target hash
             var rebaseWriter = new PrintWriter(rebaseMessage);
             var rebasedHash = prInstance.rebase(localHash, rebaseWriter);
             if (rebasedHash.isEmpty()) {
@@ -101,12 +114,13 @@ public class SponsorCommand implements CommandHandler {
 
             if (!localHash.equals(pr.targetHash())) {
                 reply.println(rebaseMessage.toString());
-                reply.println("Pushed as commit " + rebasedHash.get().hex() + ".");
-                prInstance.localRepo().push(rebasedHash.get(), pr.repository().url(), pr.targetRef());
+                reply.println("Pushed as commit " + localHash.hex() + ".");
+                prInstance.localRepo().push(localHash, pr.repository().url(), pr.targetRef());
                 pr.setState(PullRequest.State.CLOSED);
                 pr.addLabel("integrated");
                 pr.removeLabel("sponsor");
                 pr.removeLabel("ready");
+                pr.removeLabel("rfr");
             } else {
                 reply.print("Warning! This commit did not result in any changes! ");
                 reply.println("No push attempt will be made.");

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrateTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrateTests.java
@@ -36,6 +36,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.openjdk.skara.bots.pr.PullRequestAsserts.assertLastCommentContains;
 
 class IntegrateTests {
     @Test
@@ -580,6 +581,62 @@ class IntegrateTests {
                           .filter(comment -> comment.body().contains("Please merge `master`"))
                           .count();
             assertEquals(1, error);
+        }
+    }
+
+    @Test
+    void noAutoRebase(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory();
+             var pushedFolder = new TemporaryDirectory()) {
+
+            var author = credentials.getHostedRepository();
+            var integrator = credentials.getHostedRepository();
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addCommitter(author.forge().currentUser().id())
+                                           .addReviewer(integrator.forge().currentUser().id());
+            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
+
+            // Approve it as another user
+            var approvalPr = integrator.pullRequest(pr.id());
+            approvalPr.addReview(Review.Verdict.APPROVED, "Approved");
+
+            // Push something unrelated to master
+            localRepo.checkout(masterHash, true);
+            var unrelated = localRepo.root().resolve("unrelated.txt");
+            Files.writeString(unrelated, "Hello");
+            localRepo.add(unrelated);
+            var unrelatedHash = localRepo.commit("Unrelated", "X", "x@y.z");
+            localRepo.push(unrelatedHash, author.url(), "master");
+
+            // Attempt a merge
+            pr.addComment("/integrate " + masterHash);
+            TestBotRunner.runPeriodicItems(mergeBot);
+
+            // The bot should reply with an error message
+            assertLastCommentContains(pr, "the target branch is no longer at the requested hash");
+
+            // Now use the correct target hash
+            pr.addComment("/integrate " + unrelatedHash);
+            TestBotRunner.runPeriodicItems(mergeBot);
+
+            // The bot should reply with an ok message
+            assertLastCommentContains(pr, "Pushed as commit");
+
+            // The change should now be present on the master branch
+            var pushedRepo = Repository.materialize(pushedFolder.path(), author.url(), "master");
+            assertTrue(CheckableRepository.hasBeenEdited(pushedRepo));
         }
     }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/SponsorTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/SponsorTests.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.openjdk.skara.bots.pr.PullRequestAsserts.assertLastCommentContains;
 
 class SponsorTests {
     private void runSponsortest(TestInfo testInfo, boolean isAuthor) throws IOException {
@@ -380,6 +381,85 @@ class SponsorTests {
                            .filter(comment -> comment.body().contains("commit was automatically rebased without conflicts"))
                            .count();
             assertEquals(1, pushed);
+
+            // The change should now be present on the master branch
+            var pushedRepo = Repository.materialize(pushedFolder.path(), author.url(), "master");
+            assertTrue(CheckableRepository.hasBeenEdited(pushedRepo));
+        }
+    }
+
+    @Test
+    void noAutoRebase(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory();
+             var pushedFolder = new TemporaryDirectory()) {
+
+            var author = credentials.getHostedRepository();
+            var integrator = credentials.getHostedRepository();
+            var reviewer = credentials.getHostedRepository();
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addAuthor(author.forge().currentUser().id())
+                                           .addReviewer(integrator.forge().currentUser().id())
+                                           .addReviewer(reviewer.forge().currentUser().id());
+            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
+
+            // Approve it as another user
+            var approvalPr = integrator.pullRequest(pr.id());
+            approvalPr.addReview(Review.Verdict.APPROVED, "Approved");
+
+            // Push something unrelated to master
+            localRepo.checkout(masterHash, true);
+            var unrelated = localRepo.root().resolve("unrelated.txt");
+            Files.writeString(unrelated, "Hello");
+            localRepo.add(unrelated);
+            var unrelatedHash = localRepo.commit("Unrelated", "X", "x@y.z");
+            localRepo.push(unrelatedHash, author.url(), "master");
+
+            // Issue a merge command without being a Committer
+            pr.addComment("/integrate " + masterHash);
+            TestBotRunner.runPeriodicItems(mergeBot);
+
+            // The bot should reply with an error message
+            assertLastCommentContains(pr, "the target branch is no longer at the requested hash");
+
+            // Now choose the actual hash
+            pr.addComment("/integrate " + unrelatedHash);
+            TestBotRunner.runPeriodicItems(mergeBot);
+
+            // The bot should reply that a sponsor is required
+            assertLastCommentContains(pr, "your sponsor will make the final decision on which target hash");
+
+            // Push more unrelated things
+            Files.writeString(unrelated, "Hello again");
+            localRepo.add(unrelated);
+            var unrelatedHash2 = localRepo.commit("Unrelated 2", "X", "x@y.z");
+            localRepo.push(unrelatedHash2, author.url(), "master");
+
+            // Reviewer now agrees to sponsor
+            var reviewerPr = reviewer.pullRequest(pr.id());
+            reviewerPr.addComment("/sponsor " + unrelatedHash);
+            TestBotRunner.runPeriodicItems(mergeBot);
+
+            // The bot should reply with an error message
+            assertLastCommentContains(pr, "head of the target branch is no longer at the requested hash");
+
+            // Use the current hash
+            reviewerPr.addComment("/sponsor " + unrelatedHash2);
+            TestBotRunner.runPeriodicItems(mergeBot);
+
+            // The bot should reply with an ok message
+            assertLastCommentContains(pr, "Pushed as commit");
 
             // The change should now be present on the master branch
             var pushedRepo = Repository.materialize(pushedFolder.path(), author.url(), "master");


### PR DESCRIPTION
Hi all,

Please review this change that allows pushing without automatic rebasing.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-247](https://bugs.openjdk.java.net/browse/SKARA-247): Support atomic pushes in with /integrate command


## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**) **Note!** Review applies to 7497ada979f17fa63e2643ed2e4cf93ee54db6a1