### PR TITLE
218: Enforce check on approval of CSRs

### DIFF
--- a/bots/cli/build.gradle
+++ b/bots/cli/build.gradle
@@ -37,6 +37,7 @@ module {
 
 dependencies {
     implementation project(':bots:pr')
+    implementation project(':bots:csr')
     implementation project(':bots:hgbridge')
     implementation project(':bots:forward')
     implementation project(':bots:notify')

--- a/bots/csr/build.gradle
+++ b/bots/csr/build.gradle
@@ -20,42 +20,25 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-rootProject.name = 'skara'
 
-include 'args'
-include 'bot'
-include 'ci'
-include 'cli'
-include 'census'
-include 'email'
-include 'encoding'
-include 'host'
-include 'ini'
-include 'jcheck'
-include 'json'
-include 'mailinglist'
-include 'process'
-include 'proxy'
-include 'storage'
-include 'ssh'
-include 'test'
-include 'vcs'
-include 'webrev'
-include 'network'
-include 'forge'
-include 'issuetracker'
-include 'version'
+module {
+    name = 'org.openjdk.skara.bots.csr'
+    test {
+        requires 'org.junit.jupiter.api'
+        requires 'org.openjdk.skara.test'
+        opens 'org.openjdk.skara.bots.csr' to 'org.junit.platform.commons'
+    }
+}
 
-include 'bots:bridgekeeper'
-include 'bots:cli'
-include 'bots:csr'
-include 'bots:forward'
-include 'bots:hgbridge'
-include 'bots:merge'
-include 'bots:mirror'
-include 'bots:mlbridge'
-include 'bots:notify'
-include 'bots:pr'
-include 'bots:submit'
-include 'bots:tester'
-include 'bots:topological'
+dependencies {
+    implementation project(':host')
+    implementation project(':bot')
+    implementation project(':forge')
+    implementation project(':issuetracker')
+    implementation project(':census')
+    implementation project(':ci')
+    implementation project(':json')
+    implementation project(':vcs')
+
+    testImplementation project(':test')
+}

--- a/bots/csr/src/main/java/module-info.java
+++ b/bots/csr/src/main/java/module-info.java
@@ -20,42 +20,12 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-rootProject.name = 'skara'
+module org.openjdk.skara.bots.csr {
+    requires org.openjdk.skara.bot;
+    requires org.openjdk.skara.vcs;
+    requires org.openjdk.skara.forge;
+    requires org.openjdk.skara.issuetracker;
+    requires java.logging;
 
-include 'args'
-include 'bot'
-include 'ci'
-include 'cli'
-include 'census'
-include 'email'
-include 'encoding'
-include 'host'
-include 'ini'
-include 'jcheck'
-include 'json'
-include 'mailinglist'
-include 'process'
-include 'proxy'
-include 'storage'
-include 'ssh'
-include 'test'
-include 'vcs'
-include 'webrev'
-include 'network'
-include 'forge'
-include 'issuetracker'
-include 'version'
-
-include 'bots:bridgekeeper'
-include 'bots:cli'
-include 'bots:csr'
-include 'bots:forward'
-include 'bots:hgbridge'
-include 'bots:merge'
-include 'bots:mirror'
-include 'bots:mlbridge'
-include 'bots:notify'
-include 'bots:pr'
-include 'bots:submit'
-include 'bots:tester'
-include 'bots:topological'
+    provides org.openjdk.skara.bot.BotFactory with org.openjdk.skara.bots.csr.CSRBotFactory;
+}

--- a/bots/csr/src/main/java/org/openjdk/skara/bots/csr/CSRBot.java
+++ b/bots/csr/src/main/java/org/openjdk/skara/bots/csr/CSRBot.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.csr;
+
+import org.openjdk.skara.bot.*;
+import org.openjdk.skara.forge.HostedRepository;
+import org.openjdk.skara.forge.PullRequest;
+import org.openjdk.skara.issuetracker.IssueProject;
+import org.openjdk.skara.issuetracker.Issue;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.logging.Logger;
+
+class CSRBot implements Bot, WorkItem {
+    private final static String CSR_LABEL = "csr";
+    private final Logger log = Logger.getLogger("org.openjdk.skara.bots");;
+    private final HostedRepository repo;
+    private final IssueProject project;
+
+    CSRBot(HostedRepository repo, IssueProject project) {
+        this.repo = repo;
+        this.project = project;
+    }
+
+    @Override
+    public boolean concurrentWith(WorkItem other) {
+        if (!(other instanceof CSRBot)) {
+            return false;
+        }
+
+        return !repo.webUrl().equals(((CSRBot) other).repo.webUrl());
+    }
+
+    private String describe(PullRequest pr) {
+        return repo.name() + "#" + pr.id();
+    }
+
+    @Override
+    public void run(Path scratchPath) {
+        for (var pr : repo.pullRequests()) {
+            log.info("Checking CSR label for " + describe(pr) + "...");
+            if (pr.labels().contains(CSR_LABEL)) {
+                var issue = org.openjdk.skara.vcs.openjdk.Issue.fromString(pr.title());
+                if (issue.isEmpty()) {
+                    log.info("No issue found in title for " + describe(pr));
+                    continue;
+                }
+                var jbsIssue = project.issue(issue.get().id());
+                if (jbsIssue.isEmpty()) {
+                    log.info("No issue found in JBS for " + describe(pr));
+                    continue;
+                }
+
+                for (var link : jbsIssue.get().links()) {
+                    var relationship = link.relationship();
+                    if (relationship.isPresent() && relationship.get().equals("csr for")) {
+                        var csr = link.issue().orElseThrow(
+                                () -> new IllegalStateException("Link with title 'csr for' does not contain issue")
+                        );
+                        var resolution = csr.properties().get("resolution").get("name").asString();
+                        log.info("Found CSR for " + describe(pr));
+                        if (csr.state() == Issue.State.CLOSED && resolution.equals("Approved")) {
+                            log.info("CSR closed and approved for " + repo.name() + "#" + pr.id() + ", removing csr label");
+                            pr.removeLabel(CSR_LABEL);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "CSRBot@(" + repo.name() + ")";
+    }
+
+    @Override
+    public List<WorkItem> getPeriodicItems() {
+        return List.of(this);
+    }
+}

--- a/bots/csr/src/main/java/org/openjdk/skara/bots/csr/CSRBotFactory.java
+++ b/bots/csr/src/main/java/org/openjdk/skara/bots/csr/CSRBotFactory.java
@@ -20,42 +20,34 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-rootProject.name = 'skara'
+package org.openjdk.skara.bots.csr;
 
-include 'args'
-include 'bot'
-include 'ci'
-include 'cli'
-include 'census'
-include 'email'
-include 'encoding'
-include 'host'
-include 'ini'
-include 'jcheck'
-include 'json'
-include 'mailinglist'
-include 'process'
-include 'proxy'
-include 'storage'
-include 'ssh'
-include 'test'
-include 'vcs'
-include 'webrev'
-include 'network'
-include 'forge'
-include 'issuetracker'
-include 'version'
+import org.openjdk.skara.bot.*;
 
-include 'bots:bridgekeeper'
-include 'bots:cli'
-include 'bots:csr'
-include 'bots:forward'
-include 'bots:hgbridge'
-include 'bots:merge'
-include 'bots:mirror'
-include 'bots:mlbridge'
-include 'bots:notify'
-include 'bots:pr'
-include 'bots:submit'
-include 'bots:tester'
-include 'bots:topological'
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+
+public class CSRBotFactory implements BotFactory {
+    private final Logger log = Logger.getLogger("org.openjdk.skara.bots");;
+
+    @Override
+    public String name() {
+        return "csr";
+    }
+
+    @Override
+    public List<Bot> create(BotConfiguration configuration) {
+        var ret = new ArrayList<Bot>();
+        var specific = configuration.specific();
+
+        for (var project : specific.get("projects").asArray()) {
+            var repo = configuration.repository(project.get("repository").asString());
+            var issues = configuration.issueProject(project.get("issues").asString());
+            log.info("Setting up csr bot for " + repo.name());
+            ret.add(new CSRBot(repo, issues));
+        }
+
+        return ret;
+    }
+}

--- a/bots/csr/src/test/java/org/openjdk/skara/bots/csr/CSRBotTests.java
+++ b/bots/csr/src/test/java/org/openjdk/skara/bots/csr/CSRBotTests.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.csr;
+
+import org.openjdk.skara.issuetracker.Link;
+import org.openjdk.skara.issuetracker.Issue;
+import org.openjdk.skara.test.*;
+import org.openjdk.skara.json.JSON;
+
+import org.junit.jupiter.api.*;
+
+import java.io.IOException;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CSRBotTests {
+    @Test
+    void removeLabelForApprovedCSR(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var repo = credentials.getHostedRepository();
+            var issues = credentials.getIssueProject();
+            var issue = issues.createIssue("This is an issue", List.of(), Map.of());
+
+            var csr = issues.createIssue("This is an approved CSR", List.of(), Map.of("resolution",
+                                                                                      JSON.object().put("name", "Approved")));
+            csr.setState(Issue.State.CLOSED);
+            issue.addLink(Link.create(csr, "csr for").build());
+
+            var bot = new CSRBot(repo, issues);
+
+            // Populate the projects repository
+            var localRepoFolder = tempFolder.path().resolve("localrepo");
+            var localRepo = CheckableRepository.init(localRepoFolder, repo.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, repo.url(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, repo.url(), "edit", true);
+            var pr = credentials.createPullRequest(repo, "master", "edit", issue.id() + ": This is an issue");
+
+            // Add CSR label
+            pr.addLabel("csr");
+
+            // Run bot
+            TestBotRunner.runPeriodicItems(bot);
+
+            // The bot should have removed the CSR label
+            assertFalse(pr.labels().contains("csr"));
+        }
+    }
+
+    @Test
+    void keepLabelForNoIssue(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var repo = credentials.getHostedRepository();
+            var issues = credentials.getIssueProject();
+            var bot = new CSRBot(repo, issues);
+
+            // Populate the projects repository
+            var localRepoFolder = tempFolder.path().resolve("localrepo");
+            var localRepo = CheckableRepository.init(localRepoFolder, repo.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, repo.url(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, repo.url(), "edit", true);
+            var pr = credentials.createPullRequest(repo, "master", "edit", "This is an issue");
+
+            // Add CSR label
+            pr.addLabel("csr");
+
+            // Run bot
+            TestBotRunner.runPeriodicItems(bot);
+
+            // The bot should have kept the CSR label
+            assertTrue(pr.labels().contains("csr"));
+        }
+    }
+
+    @Test
+    void keepLabelForNoJBS(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var repo = credentials.getHostedRepository();
+            var issues = credentials.getIssueProject();
+            var bot = new CSRBot(repo, issues);
+
+            // Populate the projects repository
+            var localRepoFolder = tempFolder.path().resolve("localrepo");
+            var localRepo = CheckableRepository.init(localRepoFolder, repo.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, repo.url(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, repo.url(), "edit", true);
+            var pr = credentials.createPullRequest(repo, "master", "edit", "123: This is an issue");
+
+            // Add CSR label
+            pr.addLabel("csr");
+
+            // Run bot
+            TestBotRunner.runPeriodicItems(bot);
+
+            // The bot should have kept the CSR label
+            assertTrue(pr.labels().contains("csr"));
+        }
+    }
+
+    @Test
+    void keepLabelForNotApprovedCSR(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var repo = credentials.getHostedRepository();
+            var issues = credentials.getIssueProject();
+            var issue = issues.createIssue("This is an issue", List.of(), Map.of());
+
+            var csr = issues.createIssue("This is an approved CSR", List.of(), Map.of("resolution",
+                                                                                      JSON.object().put("name", "Unresolved")));
+            csr.setState(Issue.State.OPEN);
+            issue.addLink(Link.create(csr, "csr for").build());
+
+            var bot = new CSRBot(repo, issues);
+
+            // Populate the projects repository
+            var localRepoFolder = tempFolder.path().resolve("localrepo");
+            var localRepo = CheckableRepository.init(localRepoFolder, repo.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, repo.url(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, repo.url(), "edit", true);
+            var pr = credentials.createPullRequest(repo, "master", "edit", issue.id() + ": This is an issue");
+
+            // Add CSR label
+            pr.addLabel("csr");
+
+            // Run bot
+            TestBotRunner.runPeriodicItems(bot);
+
+            // The bot should have removed the CSR label
+            assertTrue(pr.labels().contains("csr"));
+        }
+    }
+}

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CSRCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CSRCommand.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.pr;
+
+import org.openjdk.skara.forge.PullRequest;
+import org.openjdk.skara.issuetracker.Comment;
+import org.openjdk.skara.issuetracker.Issue;
+
+import java.io.PrintWriter;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class CSRCommand implements CommandHandler {
+    private static final String CSR_LABEL = "csr";
+
+    private static void showHelp(PrintWriter writer) {
+        writer.println("usage: `/csr [unneeded]`, requires that the issue the pull request links to an approved [CSR](https://wiki.openjdk.java.net/display/csr/Main) request.");
+    }
+
+    private static void csrReply(PrintWriter writer) {
+        writer.println("has indicated that a " +
+                      "[compatability and specification](https://wiki.openjdk.java.net/display/csr/Main) (CSR) request " +
+                      "is needed for this pull request.");
+    }
+
+    private static void jbsReply(PullRequest pr, PrintWriter writer) {
+        writer.println("@" + pr.author().userName() + " this pull request must refer to an issue in " +
+                      "[JBS](https://bugs.openjdk.java.net) to be able to link it to a CSR request. To refer this pull request to " +
+                      "an issue in JBS, please use the `/solves` command in a comment in this pull request.");
+    }
+
+    private static void linkReply(PullRequest pr, Issue issue, PrintWriter writer) {
+        writer.println("@" + pr.author().userName() + " please create a CSR request and add link to it in " +
+                      "[" + issue.id() + "](" + issue.webUrl() + "). This pull request cannot be integrated until " +
+                      "the CSR request is approved.");
+    }
+
+    @Override
+    public void handle(PullRequestBot bot, PullRequest pr, CensusInstance censusInstance, Path scratchPath, String args, Comment comment, List<Comment> allComments, PrintWriter reply) {
+        if (!ProjectPermissions.mayReview(censusInstance, comment.author())) {
+            reply.println("only [Reviewers](https://openjdk.java.net/bylaws#reviewer) are allowed require a CSR.");
+            return;
+        }
+
+        var labels = pr.labels();
+
+        if (args.trim().toLowerCase().equals("unneeded")) {
+            if (labels.contains(CSR_LABEL)) {
+                pr.removeLabel(CSR_LABEL);
+            }
+            reply.println("determined that a [CSR](https://wiki.openjdk.java.net/display/csr/Main) request " +
+                          "is no longer needed for this pull request.");
+            return;
+        } else if (!args.isEmpty()) {
+            showHelp(reply);
+            return;
+        }
+
+        if (labels.contains(CSR_LABEL)) {
+            reply.println("an approved [CSR](https://wiki.openjdk.java.net/display/csr/Main) request " +
+                          "is already required for this pull request.");
+            return;
+        }
+
+        var issueProject = bot.issueProject();
+        var issue = org.openjdk.skara.vcs.openjdk.Issue.fromString(pr.title());
+        if (issue.isEmpty()) {
+            csrReply(reply);
+            jbsReply(pr, reply);
+            pr.addLabel(CSR_LABEL);
+            return;
+        }
+
+        var jbsIssue = issueProject.issue(issue.get().id());
+        if (jbsIssue.isEmpty()) {
+            csrReply(reply);
+            jbsReply(pr, reply);
+            pr.addLabel(CSR_LABEL);
+            return;
+
+        }
+        Issue csr = null;
+        for (var link : jbsIssue.get().links()) {
+            var relationship = link.relationship();
+            if (relationship.isPresent() && relationship.get().equals("csr for")) {
+                csr = link.issue().orElseThrow(
+                        () -> new IllegalStateException("Link with title 'csr for' does not contain issue")
+                );
+            }
+        }
+
+        if (csr == null && !labels.contains(CSR_LABEL)) {
+            csrReply(reply);
+            linkReply(pr, jbsIssue.get(), reply);
+            pr.addLabel(CSR_LABEL);
+            return;
+        }
+
+        var resolution = csr.properties().get("resolution").get("name").asString();
+        if (csr.state() == Issue.State.CLOSED && resolution.equals("Approved")) {
+            reply.println("the issue for this pull request, (" + jbsIssue.get().id() + ")[" + jbsIssue.get().webUrl() + "], already has " +
+                          "an approved CSR request: (" + csr.id() + ")[" + csr.webUrl() + "]");
+        } else {
+            reply.println("this pull request will not be integrated until the [CSR](https://wiki.openjdk.java.net/display/csr/Main) " +
+                          "request " + "(" + csr.id() + ")[" + csr.webUrl() + "]" + " for issue " +
+                          "(" + jbsIssue.get().id() + ")[" + jbsIssue.get().webUrl() + "] has been approved.");
+            pr.addLabel(CSR_LABEL);
+        }
+    }
+
+    @Override
+    public String description() {
+        return "require a compatability and specification request (CSR) for this pull request";
+    }
+}
+

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CSRCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CSRCommand.java
@@ -40,7 +40,7 @@ public class CSRCommand implements CommandHandler {
 
     private static void csrReply(PrintWriter writer) {
         writer.println("has indicated that a " +
-                      "[compatability and specification](https://wiki.openjdk.java.net/display/csr/Main) (CSR) request " +
+                      "[compatibility and specification](https://wiki.openjdk.java.net/display/csr/Main) (CSR) request " +
                       "is needed for this pull request.");
     }
 
@@ -131,7 +131,6 @@ public class CSRCommand implements CommandHandler {
 
     @Override
     public String description() {
-        return "require a compatability and specification request (CSR) for this pull request";
+        return "require a compatibility and specification request (CSR) for this pull request";
     }
 }
-

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandWorkItem.java
@@ -46,7 +46,8 @@ public class CommandWorkItem extends PullRequestWorkItem {
             "contributor", new ContributorCommand(),
             "summary", new SummaryCommand(),
             "solves", new SolvesCommand(),
-            "reviewers", new ReviewersCommand()
+            "reviewers", new ReviewersCommand(),
+            "csr", new CSRCommand()
     );
 
     static class HelpCommand implements CommandHandler {
@@ -94,6 +95,7 @@ public class CommandWorkItem extends PullRequestWorkItem {
     }
 
     private void processCommand(PullRequest pr, CensusInstance censusInstance, Path scratchPath, String command, Comment comment, List<Comment> allComments) {
+        System.out.println("processing command " + command);
         var writer = new StringWriter();
         var printer = new PrintWriter(writer);
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandWorkItem.java
@@ -95,7 +95,6 @@ public class CommandWorkItem extends PullRequestWorkItem {
     }
 
     private void processCommand(PullRequest pr, CensusInstance censusInstance, Path scratchPath, String command, Comment comment, List<Comment> allComments) {
-        System.out.println("processing command " + command);
         var writer = new StringWriter();
         var printer = new PrintWriter(writer);
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CSRTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CSRTests.java
@@ -1,0 +1,381 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.pr;
+
+import org.openjdk.skara.forge.Review;
+import org.openjdk.skara.issuetracker.Comment;
+import org.openjdk.skara.issuetracker.Link;
+import org.openjdk.skara.issuetracker.Issue;
+import org.openjdk.skara.test.*;
+import org.openjdk.skara.vcs.Repository;
+import org.openjdk.skara.json.JSON;
+
+import org.junit.jupiter.api.*;
+
+import java.io.IOException;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.openjdk.skara.bots.pr.PullRequestAsserts.assertLastCommentContains;
+
+class CSRTests {
+    @Test
+    void simple(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var reviewer = credentials.getHostedRepository();
+            var bot = credentials.getHostedRepository();
+            var issues = credentials.getIssueProject();
+            var issue = issues.createIssue("This is an issue", List.of(), Map.of());
+
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addReviewer(reviewer.forge().currentUser().id())
+                                           .addCommitter(author.forge().currentUser().id());
+            var prBot = PullRequestBot.newBuilder().repo(bot).issueProject(issues).censusRepo(censusBuilder.build()).build();
+
+            // Populate the projects repository
+            var localRepoFolder = tempFolder.path().resolve("localrepo");
+            var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", issue.id() + ": This is an issue");
+
+            // Require CSR
+            var prAsReviewer = reviewer.pullRequest(pr.id());
+            prAsReviewer.addComment("/csr");
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // The bot should reply with a message that a CSR is needed
+            assertLastCommentContains(pr, "has indicated that a " +
+                                          "[compatability and specification](https://wiki.openjdk.java.net/display/csr/Main) (CSR) request " +
+                                          "is needed for this pull request.");
+            assertTrue(pr.labels().contains("csr"));
+
+
+            // No longer require CSR
+            prAsReviewer.addComment("/csr unneeded");
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // The bot should reply with a message that a CSR is no longer needed
+            assertLastCommentContains(pr, "determined that a [CSR](https://wiki.openjdk.java.net/display/csr/Main) request " +
+                                          "is no longer needed for this pull request.");
+            assertFalse(pr.labels().contains("csr"));
+        }
+    }
+
+    @Test
+    void alreadyApprovedCSR(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var reviewer = credentials.getHostedRepository();
+            var bot = credentials.getHostedRepository();
+            var issues = credentials.getIssueProject();
+            var issue = issues.createIssue("This is an issue", List.of(), Map.of());
+
+            var csr = issues.createIssue("This is an approved CSR", List.of(), Map.of("resolution",
+                                                                                      JSON.object().put("name", "Approved")));
+            csr.setState(Issue.State.CLOSED);
+            issue.addLink(Link.create(csr, "csr for").build());
+
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addReviewer(reviewer.forge().currentUser().id())
+                                           .addCommitter(author.forge().currentUser().id());
+            var prBot = PullRequestBot.newBuilder().repo(bot).issueProject(issues).censusRepo(censusBuilder.build()).build();
+
+            // Populate the projects repository
+            var localRepoFolder = tempFolder.path().resolve("localrepo");
+            var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", issue.id() + ": This is an issue");
+
+            // Require CSR
+            var prAsReviewer = reviewer.pullRequest(pr.id());
+            prAsReviewer.addComment("/csr");
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // The bot should reply with a message that the CSR is already aproved
+            assertLastCommentContains(pr, "the issue for this pull request");
+            assertLastCommentContains(pr, "already has an approved CSR request");
+            assertFalse(pr.labels().contains("csr"));
+        }
+    }
+
+    @Test
+    void testMissingIssue(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var reviewer = credentials.getHostedRepository();
+            var bot = credentials.getHostedRepository();
+            var issues = credentials.getIssueProject();
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addReviewer(reviewer.forge().currentUser().id())
+                                           .addCommitter(author.forge().currentUser().id());
+            var prBot = PullRequestBot.newBuilder().repo(bot).issueProject(issues).censusRepo(censusBuilder.build()).build();
+
+            // Populate the projects repository
+            var localRepoFolder = tempFolder.path().resolve("localrepo");
+            var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "Just a patch");
+
+            // Require CSR
+            var prAsReviewer = reviewer.pullRequest(pr.id());
+            prAsReviewer.addComment("/csr");
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // The bot should reply with a message that the CSR is already aproved
+            assertLastCommentContains(pr, "has indicated that a " +
+                                          "[compatability and specification](https://wiki.openjdk.java.net/display/csr/Main) " +
+                                          "(CSR) request is needed for this pull request.");
+            assertLastCommentContains(pr, "this pull request must refer to an issue in [JBS]");
+            assertLastCommentContains(pr, "to be able to link it to a CSR request. To refer this pull request to an issue in JBS");
+            assertTrue(pr.labels().contains("csr"));
+        }
+    }
+
+    @Test
+    void requireCSRAsCommitter(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var reviewer = credentials.getHostedRepository();
+            var bot = credentials.getHostedRepository();
+            var issues = credentials.getIssueProject();
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addReviewer(reviewer.forge().currentUser().id())
+                                           .addCommitter(author.forge().currentUser().id());
+            var prBot = PullRequestBot.newBuilder().repo(bot).issueProject(issues).censusRepo(censusBuilder.build()).build();
+
+            // Populate the projects repository
+            var localRepoFolder = tempFolder.path().resolve("localrepo");
+            var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "Just a patch");
+
+            // Require CSR as committer
+            pr.addComment("/csr");
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // The bot should reply with a message that only reviewers can require a CSR
+            assertLastCommentContains(pr, "only [Reviewers](https://openjdk.java.net/bylaws#reviewer) are allowed require a CSR.");
+            assertFalse(pr.labels().contains("csr"));
+        }
+    }
+
+    @Test
+    void showHelpMessageOnUnexpectedArg(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var reviewer = credentials.getHostedRepository();
+            var bot = credentials.getHostedRepository();
+            var issues = credentials.getIssueProject();
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addReviewer(reviewer.forge().currentUser().id())
+                                           .addCommitter(author.forge().currentUser().id());
+            var prBot = PullRequestBot.newBuilder().repo(bot).issueProject(issues).censusRepo(censusBuilder.build()).build();
+
+            // Populate the projects repository
+            var localRepoFolder = tempFolder.path().resolve("localrepo");
+            var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "Just a patch");
+
+            // Require CSR with bad argument
+            var prAsReviewer = reviewer.pullRequest(pr.id());
+            prAsReviewer.addComment("/csr foobar");
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // Show help
+            assertLastCommentContains(pr, "usage: `/csr [unneeded]`, requires that the issue the pull request links " +
+                                          "to an approved [CSR](https://wiki.openjdk.java.net/display/csr/Main) request.");
+            assertFalse(pr.labels().contains("csr"));
+        }
+    }
+
+    @Test
+    void nonExistingJBSIssue(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var reviewer = credentials.getHostedRepository();
+            var bot = credentials.getHostedRepository();
+            var issues = credentials.getIssueProject();
+
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addReviewer(reviewer.forge().currentUser().id())
+                                           .addCommitter(author.forge().currentUser().id());
+            var prBot = PullRequestBot.newBuilder().repo(bot).issueProject(issues).censusRepo(censusBuilder.build()).build();
+
+            // Populate the projects repository
+            var localRepoFolder = tempFolder.path().resolve("localrepo");
+            var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "123: This is an issue");
+
+            // Require CSR
+            var prAsReviewer = reviewer.pullRequest(pr.id());
+            prAsReviewer.addComment("/csr");
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // The bot should reply with a message that the PR must refer to an issue in JBS
+            assertLastCommentContains(pr, "has indicated that a " +
+                                          "[compatability and specification](https://wiki.openjdk.java.net/display/csr/Main) " +
+                                          "(CSR) request is needed for this pull request.");
+            assertLastCommentContains(pr, "this pull request must refer to an issue in [JBS]");
+            assertLastCommentContains(pr, "to be able to link it to a CSR request. To refer this pull request to an issue in JBS");
+            assertTrue(pr.labels().contains("csr"));
+        }
+    }
+
+    @Test
+    void csrRequestWhenCSRIsAlreadyRequested(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var reviewer = credentials.getHostedRepository();
+            var bot = credentials.getHostedRepository();
+            var issues = credentials.getIssueProject();
+            var issue = issues.createIssue("This is an issue", List.of(), Map.of());
+
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addReviewer(reviewer.forge().currentUser().id())
+                                           .addCommitter(author.forge().currentUser().id());
+            var prBot = PullRequestBot.newBuilder().repo(bot).issueProject(issues).censusRepo(censusBuilder.build()).build();
+
+            // Populate the projects repository
+            var localRepoFolder = tempFolder.path().resolve("localrepo");
+            var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", issue.id() + ": This is an issue");
+
+            // Require CSR
+            var prAsReviewer = reviewer.pullRequest(pr.id());
+            prAsReviewer.addComment("/csr");
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // The bot should reply with a message that a CSR is needed
+            assertLastCommentContains(pr, "has indicated that a " +
+                                          "[compatability and specification](https://wiki.openjdk.java.net/display/csr/Main) (CSR) request " +
+                                          "is needed for this pull request.");
+            assertTrue(pr.labels().contains("csr"));
+
+            // Require a CSR again
+            prAsReviewer.addComment("/csr");
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // The bot should reply with a message that a CSR is already required
+            assertLastCommentContains(pr, "an approved [CSR]");
+            assertLastCommentContains(pr, "request is already required for this pull request.");
+            assertTrue(pr.labels().contains("csr"));
+        }
+    }
+
+    @Test
+    void notYetApprovedCSR(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var reviewer = credentials.getHostedRepository();
+            var bot = credentials.getHostedRepository();
+            var issues = credentials.getIssueProject();
+            var issue = issues.createIssue("This is an issue", List.of(), Map.of());
+
+            var csr = issues.createIssue("This is an approved CSR", List.of(), Map.of("resolution",
+                                                                                      JSON.object().put("name", "Unresolved")));
+            csr.setState(Issue.State.OPEN);
+            issue.addLink(Link.create(csr, "csr for").build());
+
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addReviewer(reviewer.forge().currentUser().id())
+                                           .addCommitter(author.forge().currentUser().id());
+            var prBot = PullRequestBot.newBuilder().repo(bot).issueProject(issues).censusRepo(censusBuilder.build()).build();
+
+            // Populate the projects repository
+            var localRepoFolder = tempFolder.path().resolve("localrepo");
+            var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", issue.id() + ": This is an issue");
+
+            // Require CSR
+            var prAsReviewer = reviewer.pullRequest(pr.id());
+            prAsReviewer.addComment("/csr");
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // The bot should reply with a message that the PR will not be integrated until the CSR is approved
+            assertLastCommentContains(pr, "this pull request will not be integrated until the [CSR]");
+            assertLastCommentContains(pr, "for issue ");
+            assertLastCommentContains(pr, "has been approved.");
+        }
+    }
+}

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CSRTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CSRTests.java
@@ -73,7 +73,7 @@ class CSRTests {
 
             // The bot should reply with a message that a CSR is needed
             assertLastCommentContains(pr, "has indicated that a " +
-                                          "[compatability and specification](https://wiki.openjdk.java.net/display/csr/Main) (CSR) request " +
+                                          "[compatibility and specification](https://wiki.openjdk.java.net/display/csr/Main) (CSR) request " +
                                           "is needed for this pull request.");
             assertTrue(pr.labels().contains("csr"));
 
@@ -165,7 +165,7 @@ class CSRTests {
 
             // The bot should reply with a message that the CSR is already aproved
             assertLastCommentContains(pr, "has indicated that a " +
-                                          "[compatability and specification](https://wiki.openjdk.java.net/display/csr/Main) " +
+                                          "[compatibility and specification](https://wiki.openjdk.java.net/display/csr/Main) " +
                                           "(CSR) request is needed for this pull request.");
             assertLastCommentContains(pr, "this pull request must refer to an issue in [JBS]");
             assertLastCommentContains(pr, "to be able to link it to a CSR request. To refer this pull request to an issue in JBS");
@@ -278,7 +278,7 @@ class CSRTests {
 
             // The bot should reply with a message that the PR must refer to an issue in JBS
             assertLastCommentContains(pr, "has indicated that a " +
-                                          "[compatability and specification](https://wiki.openjdk.java.net/display/csr/Main) " +
+                                          "[compatibility and specification](https://wiki.openjdk.java.net/display/csr/Main) " +
                                           "(CSR) request is needed for this pull request.");
             assertLastCommentContains(pr, "this pull request must refer to an issue in [JBS]");
             assertLastCommentContains(pr, "to be able to link it to a CSR request. To refer this pull request to an issue in JBS");
@@ -320,7 +320,7 @@ class CSRTests {
 
             // The bot should reply with a message that a CSR is needed
             assertLastCommentContains(pr, "has indicated that a " +
-                                          "[compatability and specification](https://wiki.openjdk.java.net/display/csr/Main) (CSR) request " +
+                                          "[compatibility and specification](https://wiki.openjdk.java.net/display/csr/Main) (CSR) request " +
                                           "is needed for this pull request.");
             assertTrue(pr.labels().contains("csr"));
 


### PR DESCRIPTION
Hi all,

please review this patch that adds a CSR bot. The CSR bot allows a reviewer to
issue the command `/csr` in a pull request comment. Once issued, the PR cannot
be integrated until the CSR for the issue associated with the PR is in state
"Closed" and "Approved". A reviewer can cancel this requirement by issuing the
command `/csr unneeded` in a pull request comment.

Testing:
- Added a bunch of new unit tests for the `/csr` command and the CSR bot
- `sh gradlew test` passes on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-218](https://bugs.openjdk.java.net/browse/SKARA-218): Enforce check on approval of CSRs


## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**) **Note!** Review applies to 76d62dd89d1dfdea764e59751f99cb8ab2235840