### PR TITLE
182: Implement a cooldown period when bridging pull request comments to mailing lists

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveItem.java
@@ -15,6 +15,7 @@ import java.util.stream.Collectors;
 class ArchiveItem {
     private final String id;
     private final ZonedDateTime created;
+    private final ZonedDateTime updated;
     private final HostUser author;
     private final Map<String, String> extraHeaders;
     private final ArchiveItem parent;
@@ -23,9 +24,10 @@ class ArchiveItem {
     private final Supplier<String> body;
     private final Supplier<String> footer;
 
-    private ArchiveItem(ArchiveItem parent, String id, ZonedDateTime created, HostUser author, Map<String, String> extraHeaders, Supplier<String> subject, Supplier<String> header, Supplier<String> body, Supplier<String> footer) {
+    private ArchiveItem(ArchiveItem parent, String id, ZonedDateTime created, ZonedDateTime updated, HostUser author, Map<String, String> extraHeaders, Supplier<String> subject, Supplier<String> header, Supplier<String> body, Supplier<String> footer) {
         this.id = id;
         this.created = created;
+        this.updated = updated;
         this.author = author;
         this.extraHeaders = extraHeaders;
         this.parent = parent;
@@ -36,7 +38,7 @@ class ArchiveItem {
     }
 
     static ArchiveItem from(PullRequest pr, Repository localRepo, URI issueTracker, String issuePrefix, WebrevStorage.WebrevGenerator webrevGenerator, WebrevNotification webrevNotification, Hash base, Hash head) {
-        return new ArchiveItem(null, "fc", pr.createdAt(), pr.author(), Map.of("PR-Head-Hash", head.hex(), "PR-Base-Hash", base.hex()),
+        return new ArchiveItem(null, "fc", pr.createdAt(), pr.updatedAt(), pr.author(), Map.of("PR-Head-Hash", head.hex(), "PR-Base-Hash", base.hex()),
                                () -> "RFR: " + pr.title(),
                                () -> "",
                                () -> ArchiveMessages.composeConversation(pr, base, head),
@@ -48,7 +50,7 @@ class ArchiveItem {
     }
 
     static ArchiveItem from(PullRequest pr, Repository localRepo, WebrevStorage.WebrevGenerator webrevGenerator, WebrevNotification webrevNotification, Hash lastBase, Hash lastHead, Hash base, Hash head, int index, ArchiveItem parent) {
-        return new ArchiveItem(parent,"ha" + head.hex(), ZonedDateTime.now(), pr.author(), Map.of("PR-Head-Hash", head.hex(), "PR-Base-Hash", base.hex()),
+        return new ArchiveItem(parent,"ha" + head.hex(), ZonedDateTime.now(), ZonedDateTime.now(), pr.author(), Map.of("PR-Head-Hash", head.hex(), "PR-Base-Hash", base.hex()),
                                () -> String.format("Re: [Rev %02d] RFR: %s", index, pr.title()),
                                () -> "",
                                () -> ArchiveMessages.composeRevision(pr, localRepo, base, head, lastBase, lastHead),
@@ -77,7 +79,7 @@ class ArchiveItem {
     }
 
     static ArchiveItem from(PullRequest pr, Comment comment, HostUserToEmailAuthor hostUserToEmailAuthor, ArchiveItem parent) {
-        return new ArchiveItem(parent, "pc" + comment.id(), comment.createdAt(), comment.author(), Map.of(),
+        return new ArchiveItem(parent, "pc" + comment.id(), comment.createdAt(), comment.updatedAt(), comment.author(), Map.of(),
                                () -> ArchiveMessages.composeReplySubject(parent.subject()),
                                () -> ArchiveMessages.composeReplyHeader(parent.createdAt(), hostUserToEmailAuthor.author(parent.author)),
                                () -> ArchiveMessages.composeComment(comment),
@@ -85,7 +87,7 @@ class ArchiveItem {
     }
 
     static ArchiveItem from(PullRequest pr, Review review, HostUserToEmailAuthor hostUserToEmailAuthor, HostUserToUserName hostUserToUserName, HostUserToRole hostUserToRole, ArchiveItem parent) {
-        return new ArchiveItem(parent, "rv" + review.id(), review.createdAt(), review.reviewer(), Map.of(),
+        return new ArchiveItem(parent, "rv" + review.id(), review.createdAt(), review.createdAt(), review.reviewer(), Map.of(),
                                () -> ArchiveMessages.composeReplySubject(parent.subject()),
                                () -> ArchiveMessages.composeReplyHeader(parent.createdAt(), hostUserToEmailAuthor.author(parent.author())),
                                () -> ArchiveMessages.composeReview(pr, review, hostUserToUserName, hostUserToRole),
@@ -93,7 +95,7 @@ class ArchiveItem {
     }
 
     static ArchiveItem from(PullRequest pr, ReviewComment reviewComment, HostUserToEmailAuthor hostUserToEmailAuthor, ArchiveItem parent) {
-        return new ArchiveItem(parent, "rc" + reviewComment.id(), reviewComment.createdAt(), reviewComment.author(), Map.of(),
+        return new ArchiveItem(parent, "rc" + reviewComment.id(), reviewComment.createdAt(), reviewComment.updatedAt(), reviewComment.author(), Map.of(),
                                () -> ArchiveMessages.composeReplySubject(parent.subject()),
                                () -> ArchiveMessages.composeReplyHeader(parent.createdAt(), hostUserToEmailAuthor.author(parent.author())),
                                () -> ArchiveMessages.composeReviewComment(pr, reviewComment) ,
@@ -168,6 +170,10 @@ class ArchiveItem {
 
     ZonedDateTime createdAt() {
         return created;
+    }
+
+    ZonedDateTime updatedAt() {
+        return updated;
     }
 
     HostUser author() {

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
@@ -24,7 +24,7 @@ package org.openjdk.skara.bots.mlbridge;
 
 import org.openjdk.skara.bot.WorkItem;
 import org.openjdk.skara.email.*;
-import org.openjdk.skara.forge.PullRequest;
+import org.openjdk.skara.forge.*;
 import org.openjdk.skara.host.HostUser;
 import org.openjdk.skara.issuetracker.Comment;
 import org.openjdk.skara.mailinglist.*;
@@ -33,12 +33,12 @@ import org.openjdk.skara.vcs.Repository;
 import java.io.*;
 import java.net.URI;
 import java.nio.file.Path;
-import java.time.Duration;
+import java.time.*;
 import java.util.*;
 import java.util.function.*;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
+import java.util.stream.*;
 
 class ArchiveWorkItem implements WorkItem {
     private final PullRequest pr;
@@ -80,34 +80,6 @@ class ArchiveWorkItem implements WorkItem {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
-    }
-
-    private static final Pattern replyToPattern = Pattern.compile("^\\s*@([-A-Za-z0-9]+)");
-
-    private Optional<Comment> getParentPost(Comment post, List<Comment> all) {
-        var matcher = replyToPattern.matcher(post.body());
-        if (matcher.find()) {
-            var replyToName = matcher.group(1);
-            var replyToNamePattern = Pattern.compile("^" + replyToName + "$");
-
-            var postIterator = all.listIterator();
-            while (postIterator.hasNext()) {
-                var cur = postIterator.next();
-                if (cur == post) {
-                    break;
-                }
-            }
-
-            while (postIterator.hasPrevious()) {
-                var cur = postIterator.previous();
-                var userMatcher = replyToNamePattern.matcher(cur.author().userName());
-                if (userMatcher.matches()) {
-                    return Optional.of(cur);
-                }
-            }
-        }
-
-        return Optional.empty();
     }
 
     private Repository materializeArchive(Path scratchPath) {
@@ -312,7 +284,7 @@ class ArchiveWorkItem implements WorkItem {
             }
 
             var webrevGenerator = bot.webrevStorage().generator(pr, localRepo, webrevPath);
-            var newMails = archiver.generateNewEmails(sentMails, localRepo, bot.issueTracker(), jbs.toUpperCase(), webrevGenerator,
+            var newMails = archiver.generateNewEmails(sentMails, bot.cooldown(), localRepo, bot.issueTracker(), jbs.toUpperCase(), webrevGenerator,
                                                       (index, full, inc) -> updateWebrevComment(comments, index, full, inc),
                                                       user -> getAuthorAddress(census, user),
                                                       user -> getAuthorUserName(census, user),

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBot.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBot.java
@@ -51,6 +51,7 @@ public class MailingListBridgeBot implements Bot {
     private final URI issueTracker;
     private final PullRequestUpdateCache updateCache;
     private final Duration sendInterval;
+    private final Duration cooldown;
 
     MailingListBridgeBot(EmailAddress from, HostedRepository repo, HostedRepository archive, String archiveRef,
                          HostedRepository censusRepo, String censusRef, EmailAddress list,
@@ -58,7 +59,7 @@ public class MailingListBridgeBot implements Bot {
                          HostedRepository webrevStorageRepository, String webrevStorageRef,
                          Path webrevStorageBase, URI webrevStorageBaseUri, Set<String> readyLabels,
                          Map<String, Pattern> readyComments, URI issueTracker, Map<String, String> headers,
-                         Duration sendInterval) {
+                         Duration sendInterval, Duration cooldown) {
         emailAddress = from;
         codeRepo = repo;
         archiveRepo = archive;
@@ -75,6 +76,7 @@ public class MailingListBridgeBot implements Bot {
         this.headers = headers;
         this.issueTracker = issueTracker;
         this.sendInterval = sendInterval;
+        this.cooldown = cooldown;
 
         this.webrevStorage = new WebrevStorage(webrevStorageRepository, webrevStorageRef, webrevStorageBase,
                                                webrevStorageBaseUri, from);
@@ -115,6 +117,10 @@ public class MailingListBridgeBot implements Bot {
 
     Duration sendInterval() {
         return sendInterval;
+    }
+
+    Duration cooldown() {
+        return cooldown;
     }
 
     Set<String> ignoredUsers() {

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBot.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBot.java
@@ -81,6 +81,10 @@ public class MailingListBridgeBot implements Bot {
         this.updateCache = new PullRequestUpdateCache();
     }
 
+    static MailingListBridgeBotBuilder newBuilder() {
+        return new MailingListBridgeBotBuilder();
+    }
+
     HostedRepository codeRepo() {
         return codeRepo;
     }

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotBuilder.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotBuilder.java
@@ -52,6 +52,7 @@ public class MailingListBridgeBotBuilder {
     private URI issueTracker;
     private Map<String, String> headers = Map.of();
     private Duration sendInterval = Duration.ZERO;
+    private Duration cooldown = Duration.ZERO;
 
     MailingListBridgeBotBuilder() {
     }
@@ -156,7 +157,15 @@ public class MailingListBridgeBotBuilder {
         return this;
     }
 
+    public MailingListBridgeBotBuilder cooldown(Duration cooldown) {
+        this.cooldown = cooldown;
+        return this;
+    }
+
     public MailingListBridgeBot build() {
-        return new MailingListBridgeBot(from, repo, archive, archiveRef, censusRepo, censusRef, list, ignoredUsers, ignoredComments, listArchive, smtpServer, webrevStorageRepository, webrevStorageRef, webrevStorageBase, webrevStorageBaseUri, readyLabels, readyComments, issueTracker, headers, sendInterval);
+        return new MailingListBridgeBot(from, repo, archive, archiveRef, censusRepo, censusRef, list,
+                                        ignoredUsers, ignoredComments, listArchive, smtpServer,
+                                        webrevStorageRepository, webrevStorageRef, webrevStorageBase, webrevStorageBaseUri,
+                                        readyLabels, readyComments, issueTracker, headers, sendInterval, cooldown);
     }
 }

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotBuilder.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotBuilder.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.mlbridge;
+
+import org.openjdk.skara.email.EmailAddress;
+import org.openjdk.skara.forge.HostedRepository;
+
+import java.net.URI;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.*;
+import java.util.regex.Pattern;
+
+public class MailingListBridgeBotBuilder {
+    private EmailAddress from;
+    private HostedRepository repo;
+    private HostedRepository archive;
+    private String archiveRef = "master";
+    private HostedRepository censusRepo;
+    private String censusRef = "master";
+    private EmailAddress list;
+    private Set<String> ignoredUsers = Set.of();
+    private Set<Pattern> ignoredComments = Set.of();
+    private URI listArchive;
+    private String smtpServer;
+    private HostedRepository webrevStorageRepository;
+    private String webrevStorageRef;
+    private Path webrevStorageBase;
+    private URI webrevStorageBaseUri;
+    private Set<String> readyLabels = Set.of();
+    private Map<String, Pattern> readyComments = Map.of();
+    private URI issueTracker;
+    private Map<String, String> headers = Map.of();
+    private Duration sendInterval = Duration.ZERO;
+
+    MailingListBridgeBotBuilder() {
+    }
+
+    public MailingListBridgeBotBuilder from(EmailAddress from) {
+        this.from = from;
+        return this;
+    }
+
+    public MailingListBridgeBotBuilder repo(HostedRepository repo) {
+        this.repo = repo;
+        return this;
+    }
+
+    public MailingListBridgeBotBuilder archive(HostedRepository archive) {
+        this.archive = archive;
+        return this;
+    }
+
+    public MailingListBridgeBotBuilder archiveRef(String archiveRef) {
+        this.archiveRef = archiveRef;
+        return this;
+    }
+
+    public MailingListBridgeBotBuilder censusRepo(HostedRepository censusRepo) {
+        this.censusRepo = censusRepo;
+        return this;
+    }
+
+    public MailingListBridgeBotBuilder censusRef(String censusRef) {
+        this.censusRef = censusRef;
+        return this;
+    }
+
+    public MailingListBridgeBotBuilder list(EmailAddress list) {
+        this.list = list;
+        return this;
+    }
+
+    public MailingListBridgeBotBuilder ignoredUsers(Set<String> ignoredUsers) {
+        this.ignoredUsers = ignoredUsers;
+        return this;
+    }
+
+    public MailingListBridgeBotBuilder ignoredComments(Set<Pattern> ignoredComments) {
+        this.ignoredComments = ignoredComments;
+        return this;
+    }
+
+    public MailingListBridgeBotBuilder listArchive(URI listArchive) {
+        this.listArchive = listArchive;
+        return this;
+    }
+
+    public MailingListBridgeBotBuilder smtpServer(String smtpServer) {
+        this.smtpServer = smtpServer;
+        return this;
+    }
+
+    public MailingListBridgeBotBuilder webrevStorageRepository(HostedRepository webrevStorageRepository) {
+        this.webrevStorageRepository = webrevStorageRepository;
+        return this;
+    }
+
+    public MailingListBridgeBotBuilder webrevStorageRef(String webrevStorageRef) {
+        this.webrevStorageRef = webrevStorageRef;
+        return this;
+    }
+
+    public MailingListBridgeBotBuilder webrevStorageBase(Path webrevStorageBase) {
+        this.webrevStorageBase = webrevStorageBase;
+        return this;
+    }
+
+    public MailingListBridgeBotBuilder webrevStorageBaseUri(URI webrevStorageBaseUri) {
+        this.webrevStorageBaseUri = webrevStorageBaseUri;
+        return this;
+    }
+
+    public MailingListBridgeBotBuilder readyLabels(Set<String> readyLabels) {
+        this.readyLabels = readyLabels;
+        return this;
+    }
+
+    public MailingListBridgeBotBuilder readyComments(Map<String, Pattern> readyComments) {
+        this.readyComments = readyComments;
+        return this;
+    }
+
+    public MailingListBridgeBotBuilder issueTracker(URI issueTracker) {
+        this.issueTracker = issueTracker;
+        return this;
+    }
+
+    public MailingListBridgeBotBuilder headers(Map<String, String> headers) {
+        this.headers = headers;
+        return this;
+    }
+
+    public MailingListBridgeBotBuilder sendInterval(Duration sendInterval) {
+        this.sendInterval = sendInterval;
+        return this;
+    }
+
+    public MailingListBridgeBot build() {
+        return new MailingListBridgeBot(from, repo, archive, archiveRef, censusRepo, censusRef, list, ignoredUsers, ignoredComments, listArchive, smtpServer, webrevStorageRepository, webrevStorageRef, webrevStorageBase, webrevStorageBaseUri, readyLabels, readyComments, issueTracker, headers, sendInterval);
+    }
+}

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotFactory.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotFactory.java
@@ -76,6 +76,7 @@ public class MailingListBridgeBotFactory implements BotFactory {
                 .map(JSONValue::asObject)
                 .collect(Collectors.toMap(obj -> obj.get("user").asString(),
                                           obj -> Pattern.compile(obj.get("pattern").asString())));
+        var cooldown = specific.contains("cooldown") ? Duration.parse(specific.get("cooldown").asString()) : Duration.ofMinutes(1);
 
         for (var repoConfig : specific.get("repositories").asArray()) {
             var repo = repoConfig.get("repository").asString();
@@ -109,6 +110,7 @@ public class MailingListBridgeBotFactory implements BotFactory {
                                           .issueTracker(issueTracker)
                                           .headers(headers)
                                           .sendInterval(interval)
+                                          .cooldown(cooldown)
                                           .build();
             ret.add(bot);
 

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotFactory.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotFactory.java
@@ -89,12 +89,27 @@ public class MailingListBridgeBotFactory implements BotFactory {
 
             var list = EmailAddress.parse(repoConfig.get("list").asString());
             var folder = repoConfig.contains("folder") ? repoConfig.get("folder").asString() : configuration.repositoryName(repo);
-            var bot = new MailingListBridgeBot(from, configuration.repository(repo), archiveRepo, archiveRef,
-                                               censusRepo, censusRef,
-                                               list, ignoredUsers, ignoredComments, listArchive, listSmtp,
-                                               webrevRepo, webrevRef, Path.of(folder),
-                                               URIBuilder.base(webrevWeb).build(), readyLabels, readyComments,
-                                               issueTracker, headers, interval);
+            var bot = MailingListBridgeBot.newBuilder().from(from)
+                                          .repo(configuration.repository(repo))
+                                          .archive(archiveRepo)
+                                          .archiveRef(archiveRef)
+                                          .censusRepo(censusRepo)
+                                          .censusRef(censusRef)
+                                          .list(list)
+                                          .ignoredUsers(ignoredUsers)
+                                          .ignoredComments(ignoredComments)
+                                          .listArchive(listArchive)
+                                          .smtpServer(listSmtp)
+                                          .webrevStorageRepository(webrevRepo)
+                                          .webrevStorageRef(webrevRef)
+                                          .webrevStorageBase(Path.of(folder))
+                                          .webrevStorageBaseUri(URIBuilder.base(webrevWeb).build())
+                                          .readyLabels(readyLabels)
+                                          .readyComments(readyComments)
+                                          .issueTracker(issueTracker)
+                                          .headers(headers)
+                                          .sendInterval(interval)
+                                          .build();
             ret.add(bot);
 
             allListNames.add(list);

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBotTests.java
@@ -67,17 +67,21 @@ class MailingListArchiveReaderBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mlBot = new MailingListBridgeBot(from, author, archive, "master",
-                                                 censusBuilder.build(), "master",
-                                                 listAddress,
-                                                 Set.of(ignored.forge().currentUser().userName()),
-                                                 Set.of(),
-                                                 listServer.getArchive(), listServer.getSMTP(),
-                                                 archive, "webrev", Path.of("test"),
-                                                 webrevServer.uri(),
-                                                 Set.of(), Map.of(),
-                                                 URIBuilder.base("http://issues.test/browse/").build(),
-                                                 Map.of(), Duration.ZERO);
+            var mlBot = MailingListBridgeBot.newBuilder()
+                                            .from(from)
+                                            .repo(author)
+                                            .archive(archive)
+                                            .censusRepo(censusBuilder.build())
+                                            .list(listAddress)
+                                            .ignoredUsers(Set.of(ignored.forge().currentUser().userName()))
+                                            .listArchive(listServer.getArchive())
+                                            .smtpServer(listServer.getSMTP())
+                                            .webrevStorageRepository(archive)
+                                            .webrevStorageRef("webrev")
+                                            .webrevStorageBase(Path.of("test"))
+                                            .webrevStorageBaseUri(webrevServer.uri())
+                                            .issueTracker(URIBuilder.base("http://issues.test/browse/").build())
+                                            .build();
 
             // The mailing list as well
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(),
@@ -138,17 +142,21 @@ class MailingListArchiveReaderBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mlBot = new MailingListBridgeBot(from, author, archive, "master",
-                                                 censusBuilder.build(), "master",
-                                                 listAddress,
-                                                 Set.of(ignored.forge().currentUser().userName()),
-                                                 Set.of(),
-                                                 listServer.getArchive(), listServer.getSMTP(),
-                                                 archive, "webrev", Path.of("test"),
-                                                 webrevServer.uri(),
-                                                 Set.of(), Map.of(),
-                                                 URIBuilder.base("http://issues.test/browse/").build(),
-                                                 Map.of(), Duration.ZERO);
+            var mlBot = MailingListBridgeBot.newBuilder()
+                                            .from(from)
+                                            .repo(author)
+                                            .archive(archive)
+                                            .censusRepo(censusBuilder.build())
+                                            .list(listAddress)
+                                            .ignoredUsers(Set.of(ignored.forge().currentUser().userName()))
+                                            .listArchive(listServer.getArchive())
+                                            .smtpServer(listServer.getSMTP())
+                                            .webrevStorageRepository(archive)
+                                            .webrevStorageRef("webrev")
+                                            .webrevStorageBase(Path.of("test"))
+                                            .webrevStorageBaseUri(webrevServer.uri())
+                                            .issueTracker(URIBuilder.base("http://issues.test/browse/").build())
+                                            .build();
 
             // The mailing list as well
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(),
@@ -210,17 +218,21 @@ class MailingListArchiveReaderBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mlBot = new MailingListBridgeBot(from, author, archive, "master",
-                                                 censusBuilder.build(), "master",
-                                                 listAddress,
-                                                 Set.of(ignored.forge().currentUser().userName()),
-                                                 Set.of(),
-                                                 listServer.getArchive(), listServer.getSMTP(),
-                                                 archive, "webrev", Path.of("test"),
-                                                 webrevServer.uri(),
-                                                 Set.of(), Map.of(),
-                                                 URIBuilder.base("http://issues.test/browse/").build(),
-                                                 Map.of(), Duration.ZERO);
+            var mlBot = MailingListBridgeBot.newBuilder()
+                                            .from(from)
+                                            .repo(author)
+                                            .archive(archive)
+                                            .censusRepo(censusBuilder.build())
+                                            .list(listAddress)
+                                            .ignoredUsers(Set.of(ignored.forge().currentUser().userName()))
+                                            .listArchive(listServer.getArchive())
+                                            .smtpServer(listServer.getSMTP())
+                                            .webrevStorageRepository(archive)
+                                            .webrevStorageRef("webrev")
+                                            .webrevStorageBase(Path.of("test"))
+                                            .webrevStorageBaseUri(webrevServer.uri())
+                                            .issueTracker(URIBuilder.base("http://issues.test/browse/").build())
+                                            .build();
 
             // The mailing list as well
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(),

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -1457,4 +1457,69 @@ class MailingListBridgeBotTests {
             assertEquals(1, archiveContainsCount(archiveFolder.path(), "^> Marked as reviewed"));
         }
     }
+
+    @Test
+    void cooldown(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory();
+             var archiveFolder = new TemporaryDirectory();
+             var listServer = new TestMailmanServer();
+             var webrevServer = new TestWebrevServer()) {
+            var bot = credentials.getHostedRepository();
+            var author = credentials.getHostedRepository();
+            var archive = credentials.getHostedRepository();
+            var listAddress = EmailAddress.parse(listServer.createList("test"));
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addAuthor(author.forge().currentUser().id());
+            var from = EmailAddress.from("test", "test@test.mail");
+            var mlBotBuilder = MailingListBridgeBot.newBuilder()
+                                                   .from(from)
+                                                   .repo(bot)
+                                                   .ignoredUsers(Set.of(bot.forge().currentUser().userName()))
+                                                   .archive(archive)
+                                                   .censusRepo(censusBuilder.build())
+                                                   .list(listAddress)
+                                                   .listArchive(listServer.getArchive())
+                                                   .smtpServer(listServer.getSMTP())
+                                                   .webrevStorageRepository(archive)
+                                                   .webrevStorageRef("webrev")
+                                                   .webrevStorageBase(Path.of("test"))
+                                                   .webrevStorageBaseUri(webrevServer.uri())
+                                                   .issueTracker(URIBuilder.base("http://issues.test/browse/").build());
+
+            // Populate the projects repository
+            var reviewFile = Path.of("reviewfile.txt");
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(), reviewFile);
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, archive.url(), "webrev", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo, "Line 1\nLine 2\nLine 3\nLine 4");
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(archive, "master", "edit", "This is a pull request");
+            pr.setBody("This is now ready");
+
+            var mlBot = mlBotBuilder.build();
+            var mlBotWithCooldown = mlBotBuilder.cooldown(Duration.ofDays(1)).build();
+
+            TestBotRunner.runPeriodicItems(mlBot);
+            listServer.processIncoming();
+
+            // Make a comment
+            pr.addComment("Looks good");
+
+            // Bot with cooldown configured should not bridge the comment
+            TestBotRunner.runPeriodicItems(mlBotWithCooldown);
+            assertThrows(RuntimeException.class, () -> listServer.processIncoming(Duration.ofMillis(1)));
+
+            // But without, it should
+            TestBotRunner.runPeriodicItems(mlBot);
+            listServer.processIncoming();
+
+            // Check the archive
+            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            assertTrue(archiveContains(archiveFolder.path(), "Looks good"));
+        }
+    }
 }

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -113,18 +113,26 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mlBot = new MailingListBridgeBot(from, author, archive, "master",
-                                                 censusBuilder.build(), "master", listAddress,
-                                                 Set.of(ignored.forge().currentUser().userName()),
-                                                 Set.of(),
-                                                 listServer.getArchive(), listServer.getSMTP(),
-                                                 archive, "webrev", Path.of("test"),
-                                                 webrevServer.uri(),
-                                                 Set.of("rfr"), Map.of(ignored.forge().currentUser().userName(),
-                                                                       Pattern.compile("ready")),
-                                                 URIBuilder.base("http://issues.test/browse/").build(),
-                                                 Map.of("Extra1", "val1", "Extra2", "val2"),
-                                                 Duration.ZERO);
+            var mlBot = MailingListBridgeBot.newBuilder()
+                                            .from(from)
+                                            .repo(author)
+                                            .archive(archive)
+                                            .censusRepo(censusBuilder.build())
+                                            .list(listAddress)
+                                            .ignoredUsers(Set.of(ignored.forge().currentUser().userName()))
+                                            .ignoredComments(Set.of())
+                                            .listArchive(listServer.getArchive())
+                                            .smtpServer(listServer.getSMTP())
+                                            .webrevStorageRepository(archive)
+                                            .webrevStorageRef("webrev")
+                                            .webrevStorageBase(Path.of("test"))
+                                            .webrevStorageBaseUri(webrevServer.uri())
+                                            .readyLabels(Set.of("rfr"))
+                                            .readyComments(Map.of(ignored.forge().currentUser().userName(), Pattern.compile("ready")))
+                                            .issueTracker(URIBuilder.base("http://issues.test/browse/").build())
+                                            .headers(Map.of("Extra1", "val1", "Extra2", "val2"))
+                                            .sendInterval(Duration.ZERO)
+                                            .build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -272,16 +280,21 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mlBot = new MailingListBridgeBot(from, author, archive, "master",
-                                                 censusBuilder.build(), "master", listAddress,
-                                                 Set.of(ignored.forge().currentUser().userName()),
-                                                 Set.of(),
-                                                 listServer.getArchive(), listServer.getSMTP(),
-                                                 archive, "webrev", Path.of("test"),
-                                                 webrevServer.uri(),
-                                                 Set.of(), Map.of(),
-                                                 URIBuilder.base("http://issues.test/browse/").build(),
-                                                 Map.of(), Duration.ZERO);
+            var mlBot = MailingListBridgeBot.newBuilder()
+                                            .from(from)
+                                            .repo(author)
+                                            .archive(archive)
+                                            .censusRepo(censusBuilder.build())
+                                            .list(listAddress)
+                                            .ignoredUsers(Set.of(ignored.forge().currentUser().userName()))
+                                            .listArchive(listServer.getArchive())
+                                            .smtpServer(listServer.getSMTP())
+                                            .webrevStorageRepository(archive)
+                                            .webrevStorageRef("webrev")
+                                            .webrevStorageBase(Path.of("test"))
+                                            .webrevStorageBaseUri(webrevServer.uri())
+                                            .issueTracker(URIBuilder.base("http://issues.test/browse/").build())
+                                            .build();
 
             // Populate the projects repository
             var reviewFile = Path.of("reviewfile.txt");
@@ -362,16 +375,20 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mlBot = new MailingListBridgeBot(from, author, archive, "master",
-                                                 censusBuilder.build(), "master",
-                                                 listAddress, Set.of(), Set.of(),
-                                                 listServer.getArchive(),
-                                                 listServer.getSMTP(),
-                                                 archive, "webrev", Path.of("test"),
-                                                 webrevServer.uri(),
-                                                 Set.of(), Map.of(),
-                                                 URIBuilder.base("http://issues.test/browse/").build(),
-                                                 Map.of(), Duration.ZERO);
+            var mlBot = MailingListBridgeBot.newBuilder()
+                                            .from(from)
+                                            .repo(author)
+                                            .archive(archive)
+                                            .censusRepo(censusBuilder.build())
+                                            .list(listAddress)
+                                            .listArchive(listServer.getArchive())
+                                            .smtpServer(listServer.getSMTP())
+                                            .webrevStorageRepository(archive)
+                                            .webrevStorageRef("webrev")
+                                            .webrevStorageBase(Path.of("test"))
+                                            .webrevStorageBaseUri(webrevServer.uri())
+                                            .issueTracker(URIBuilder.base("http://issues.test/browse/").build())
+                                            .build();
 
             // Populate the projects repository
             var reviewFile = Path.of("reviewfile.txt");
@@ -452,16 +469,20 @@ class MailingListBridgeBotTests {
                                            .addReviewer(reviewer.forge().currentUser().id())
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mlBot = new MailingListBridgeBot(from, author, archive, "master",
-                                                 censusBuilder.build(), "master",
-                                                 listAddress, Set.of(), Set.of(),
-                                                 listServer.getArchive(),
-                                                 listServer.getSMTP(),
-                                                 archive, "webrev", Path.of("test"),
-                                                 webrevServer.uri(),
-                                                 Set.of(), Map.of(),
-                                                 URIBuilder.base("http://issues.test/browse/").build(),
-                                                 Map.of(), Duration.ZERO);
+            var mlBot = MailingListBridgeBot.newBuilder()
+                                            .from(from)
+                                            .repo(author)
+                                            .archive(archive)
+                                            .censusRepo(censusBuilder.build())
+                                            .list(listAddress)
+                                            .listArchive(listServer.getArchive())
+                                            .smtpServer(listServer.getSMTP())
+                                            .webrevStorageRepository(archive)
+                                            .webrevStorageRef("webrev")
+                                            .webrevStorageBase(Path.of("test"))
+                                            .webrevStorageBaseUri(webrevServer.uri())
+                                            .issueTracker(URIBuilder.base("http://issues.test/browse/").build())
+                                            .build();
 
             // Populate the projects repository
             var reviewFile = Path.of("reviewfile.txt");
@@ -577,15 +598,20 @@ class MailingListBridgeBotTests {
                                            .addReviewer(reviewer.forge().currentUser().id())
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mlBot = new MailingListBridgeBot(from, author, archive, "master", censusBuilder.build(), "master",
-                                                 listAddress, Set.of(), Set.of(),
-                                                 listServer.getArchive(),
-                                                 listServer.getSMTP(),
-                                                 archive, "webrev", Path.of("test"),
-                                                 webrevServer.uri(),
-                                                 Set.of(), Map.of(),
-                                                 URIBuilder.base("http://issues.test/browse/").build(),
-                                                 Map.of(), Duration.ZERO);
+            var mlBot = MailingListBridgeBot.newBuilder()
+                                            .from(from)
+                                            .repo(author)
+                                            .archive(archive)
+                                            .censusRepo(censusBuilder.build())
+                                            .list(listAddress)
+                                            .listArchive(listServer.getArchive())
+                                            .smtpServer(listServer.getSMTP())
+                                            .webrevStorageRepository(archive)
+                                            .webrevStorageRef("webrev")
+                                            .webrevStorageBase(Path.of("test"))
+                                            .webrevStorageBaseUri(webrevServer.uri())
+                                            .issueTracker(URIBuilder.base("http://issues.test/browse/").build())
+                                            .build();
 
             // Populate the projects repository
             var reviewFile = Path.of("reviewfile.txt");
@@ -633,16 +659,20 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mlBot = new MailingListBridgeBot(from, author, archive, "master",
-                                                 censusBuilder.build(), "master",
-                                                 listAddress, Set.of(), Set.of(),
-                                                 listServer.getArchive(),
-                                                 listServer.getSMTP(),
-                                                 archive, "webrev", Path.of("test"),
-                                                 webrevServer.uri(),
-                                                 Set.of(), Map.of(),
-                                                 URIBuilder.base("http://issues.test/browse/").build(),
-                                                 Map.of(), Duration.ZERO);
+            var mlBot = MailingListBridgeBot.newBuilder()
+                                            .from(from)
+                                            .repo(author)
+                                            .archive(archive)
+                                            .censusRepo(censusBuilder.build())
+                                            .list(listAddress)
+                                            .listArchive(listServer.getArchive())
+                                            .smtpServer(listServer.getSMTP())
+                                            .webrevStorageRepository(archive)
+                                            .webrevStorageRef("webrev")
+                                            .webrevStorageBase(Path.of("test"))
+                                            .webrevStorageBaseUri(webrevServer.uri())
+                                            .issueTracker(URIBuilder.base("http://issues.test/browse/").build())
+                                            .build();
 
             // Populate the projects repository
             var reviewFile = Path.of("reviewfile.txt");
@@ -686,16 +716,20 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mlBot = new MailingListBridgeBot(from, author, archive, "master",
-                                                 censusBuilder.build(), "master",
-                                                 listAddress, Set.of(), Set.of(),
-                                                 listServer.getArchive(),
-                                                 listServer.getSMTP(),
-                                                 archive, "webrev", Path.of("test"),
-                                                 webrevServer.uri(),
-                                                 Set.of(), Map.of(),
-                                                 URIBuilder.base("http://issues.test/browse/").build(),
-                                                 Map.of(), Duration.ZERO);
+            var mlBot = MailingListBridgeBot.newBuilder()
+                                            .from(from)
+                                            .repo(author)
+                                            .archive(archive)
+                                            .censusRepo(censusBuilder.build())
+                                            .list(listAddress)
+                                            .listArchive(listServer.getArchive())
+                                            .smtpServer(listServer.getSMTP())
+                                            .webrevStorageRepository(archive)
+                                            .webrevStorageRef("webrev")
+                                            .webrevStorageBase(Path.of("test"))
+                                            .webrevStorageBaseUri(webrevServer.uri())
+                                            .issueTracker(URIBuilder.base("http://issues.test/browse/").build())
+                                            .build();
 
             // Populate the projects repository
             var reviewFile = Path.of("reviewfile.txt");
@@ -758,15 +792,20 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mlBot = new MailingListBridgeBot(from, author, archive, "master",
-                                                 censusBuilder.build(), "master",
-                                                 listAddress, Set.of(), Set.of(),
-                                                 listServer.getArchive(), listServer.getSMTP(),
-                                                 archive, "webrev", Path.of("test"),
-                                                 webrevServer.uri(),
-                                                 Set.of(), Map.of(),
-                                                 URIBuilder.base("http://issues.test/browse/").build(),
-                                                 Map.of(), Duration.ZERO);
+            var mlBot = MailingListBridgeBot.newBuilder()
+                                            .from(from)
+                                            .repo(author)
+                                            .archive(archive)
+                                            .censusRepo(censusBuilder.build())
+                                            .list(listAddress)
+                                            .listArchive(listServer.getArchive())
+                                            .smtpServer(listServer.getSMTP())
+                                            .webrevStorageRepository(archive)
+                                            .webrevStorageRef("webrev")
+                                            .webrevStorageBase(Path.of("test"))
+                                            .webrevStorageBaseUri(webrevServer.uri())
+                                            .issueTracker(URIBuilder.base("http://issues.test/browse/").build())
+                                            .build();
 
             // Populate the projects repository
             var reviewFile = Path.of("reviewfile.txt");
@@ -819,15 +858,20 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mlBot = new MailingListBridgeBot(from, author, archive, "master",
-                                                 censusBuilder.build(), "master",
-                                                 listAddress, Set.of(), Set.of(),
-                                                 listServer.getArchive(), listServer.getSMTP(),
-                                                 archive, "webrev", Path.of("test"),
-                                                 webrevServer.uri(),
-                                                 Set.of(), Map.of(),
-                                                 URIBuilder.base("http://issues.test/browse/").build(),
-                                                 Map.of(), Duration.ZERO);
+            var mlBot = MailingListBridgeBot.newBuilder()
+                                            .from(from)
+                                            .repo(author)
+                                            .archive(archive)
+                                            .censusRepo(censusBuilder.build())
+                                            .list(listAddress)
+                                            .listArchive(listServer.getArchive())
+                                            .smtpServer(listServer.getSMTP())
+                                            .webrevStorageRepository(archive)
+                                            .webrevStorageRef("webrev")
+                                            .webrevStorageBase(Path.of("test"))
+                                            .webrevStorageBaseUri(webrevServer.uri())
+                                            .issueTracker(URIBuilder.base("http://issues.test/browse/").build())
+                                            .build();
 
             // Populate the projects repository
             var reviewFile = Path.of("reviewfile.txt");
@@ -944,15 +988,20 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var sender = EmailAddress.from("test", "test@test.mail");
-            var mlBot = new MailingListBridgeBot(sender, author, archive, "master",
-                                                 censusBuilder.build(), "master",
-                                                 listAddress, Set.of(), Set.of(),
-                                                 listServer.getArchive(), listServer.getSMTP(),
-                                                 archive, "webrev", Path.of("test"),
-                                                 webrevServer.uri(),
-                                                 Set.of(), Map.of(),
-                                                 URIBuilder.base("http://issues.test/browse/").build(),
-                                                 Map.of(), Duration.ZERO);
+            var mlBot = MailingListBridgeBot.newBuilder()
+                                            .from(sender)
+                                            .repo(author)
+                                            .archive(archive)
+                                            .censusRepo(censusBuilder.build())
+                                            .list(listAddress)
+                                            .listArchive(listServer.getArchive())
+                                            .smtpServer(listServer.getSMTP())
+                                            .webrevStorageRepository(archive)
+                                            .webrevStorageRef("webrev")
+                                            .webrevStorageBase(Path.of("test"))
+                                            .webrevStorageBaseUri(webrevServer.uri())
+                                            .issueTracker(URIBuilder.base("http://issues.test/browse/").build())
+                                            .build();
 
             // Populate the projects repository
             var reviewFile = Path.of("reviewfile.txt");
@@ -1035,15 +1084,21 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var sender = EmailAddress.from("test", "test@test.mail");
-            var mlBot = new MailingListBridgeBot(sender, author, archive, "archive",
-                                                 censusBuilder.build(), "master",
-                                                 listAddress, Set.of(), Set.of(),
-                                                 listServer.getArchive(), listServer.getSMTP(),
-                                                 archive, "webrev", Path.of("test"),
-                                                 webrevServer.uri(),
-                                                 Set.of(), Map.of(),
-                                                 URIBuilder.base("http://issues.test/browse/").build(),
-                                                 Map.of(), Duration.ZERO);
+            var mlBot = MailingListBridgeBot.newBuilder()
+                                            .from(sender)
+                                            .repo(author)
+                                            .archive(archive)
+                                            .archiveRef("archive")
+                                            .censusRepo(censusBuilder.build())
+                                            .list(listAddress)
+                                            .listArchive(listServer.getArchive())
+                                            .smtpServer(listServer.getSMTP())
+                                            .webrevStorageRepository(archive)
+                                            .webrevStorageRef("webrev")
+                                            .webrevStorageBase(Path.of("test"))
+                                            .webrevStorageBaseUri(webrevServer.uri())
+                                            .issueTracker(URIBuilder.base("http://issues.test/browse/").build())
+                                            .build();
 
             // Populate the projects repository
             var reviewFile = Path.of("reviewfile.txt");
@@ -1120,17 +1175,21 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mlBot = new MailingListBridgeBot(from, author, archive, "master",
-                                                 censusBuilder.build(), "master",
-                                                 listAddress,
-                                                 Set.of(ignored.forge().currentUser().userName()),
-                                                 Set.of(),
-                                                 listServer.getArchive(), listServer.getSMTP(),
-                                                 archive, "webrev", Path.of("test"),
-                                                 webrevServer.uri(),
-                                                 Set.of(), Map.of(),
-                                                 URIBuilder.base("http://issues.test/browse/").build(),
-                                                 Map.of(), Duration.ZERO);
+            var mlBot = MailingListBridgeBot.newBuilder()
+                                            .from(from)
+                                            .repo(author)
+                                            .archive(archive)
+                                            .censusRepo(censusBuilder.build())
+                                            .list(listAddress)
+                                            .ignoredUsers(Set.of(ignored.forge().currentUser().userName()))
+                                            .listArchive(listServer.getArchive())
+                                            .smtpServer(listServer.getSMTP())
+                                            .webrevStorageRepository(archive)
+                                            .webrevStorageRef("webrev")
+                                            .webrevStorageBase(Path.of("test"))
+                                            .webrevStorageBaseUri(webrevServer.uri())
+                                            .issueTracker(URIBuilder.base("http://issues.test/browse/").build())
+                                            .build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -1173,10 +1232,10 @@ class MailingListBridgeBotTests {
             // The webrev comment should not contain duplicate entries
             comments = pr.comments();
             webrevComments = comments.stream()
-                                         .filter(comment -> comment.author().equals(author.forge().currentUser()))
-                                         .filter(comment -> comment.body().contains("webrev"))
-                                         .filter(comment -> comment.body().contains(editHash.hex()))
-                                         .collect(Collectors.toList());
+                                     .filter(comment -> comment.author().equals(author.forge().currentUser()))
+                                     .filter(comment -> comment.body().contains("webrev"))
+                                     .filter(comment -> comment.body().contains(editHash.hex()))
+                                     .collect(Collectors.toList());
             assertEquals(1, webrevComments.size());
             assertEquals(1, countSubstrings(webrevComments.get(0).body(), "webrev.00"));
         }
@@ -1197,15 +1256,20 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addReviewer(reviewer.forge().currentUser().id())
                                            .addAuthor(author.forge().currentUser().id());
-            var mlBot = new MailingListBridgeBot(from, author, archive, "master",
-                                                 censusBuilder.build(), "master",
-                                                 listAddress, Set.of(), Set.of(),
-                                                 listServer.getArchive(), listServer.getSMTP(),
-                                                 archive, "webrev", Path.of("test"),
-                                                 webrevServer.uri(),
-                                                 Set.of(), Map.of(),
-                                                 URIBuilder.base("http://issues.test/browse/").build(),
-                                                 Map.of(), Duration.ZERO);
+            var mlBot = MailingListBridgeBot.newBuilder()
+                                            .from(from)
+                                            .repo(author)
+                                            .archive(archive)
+                                            .censusRepo(censusBuilder.build())
+                                            .list(listAddress)
+                                            .listArchive(listServer.getArchive())
+                                            .smtpServer(listServer.getSMTP())
+                                            .webrevStorageRepository(archive)
+                                            .webrevStorageRef("webrev")
+                                            .webrevStorageBase(Path.of("test"))
+                                            .webrevStorageBaseUri(webrevServer.uri())
+                                            .issueTracker(URIBuilder.base("http://issues.test/browse/").build())
+                                            .build();
 
             // Populate the projects repository
             var reviewFile = Path.of("reviewfile.txt");
@@ -1281,17 +1345,22 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mlBot = new MailingListBridgeBot(from, author, archive, "master",
-                                                 censusBuilder.build(), "master",
-                                                 listAddress,
-                                                 Set.of(ignored.forge().currentUser().userName()),
-                                                 Set.of(Pattern.compile("ignore this comment", Pattern.MULTILINE | Pattern.DOTALL)),
-                                                 listServer.getArchive(), listServer.getSMTP(),
-                                                 archive, "webrev", Path.of("test"),
-                                                 webrevServer.uri(),
-                                                 Set.of(), Map.of(),
-                                                 URIBuilder.base("http://issues.test/browse/").build(),
-                                                 Map.of(), Duration.ZERO);
+            var mlBot = MailingListBridgeBot.newBuilder()
+                                            .from(from)
+                                            .repo(author)
+                                            .archive(archive)
+                                            .censusRepo(censusBuilder.build())
+                                            .list(listAddress)
+                                            .ignoredUsers(Set.of(ignored.forge().currentUser().userName()))
+                                            .ignoredComments(Set.of(Pattern.compile("ignore this comment", Pattern.MULTILINE | Pattern.DOTALL)))
+                                            .listArchive(listServer.getArchive())
+                                            .smtpServer(listServer.getSMTP())
+                                            .webrevStorageRepository(archive)
+                                            .webrevStorageRef("webrev")
+                                            .webrevStorageBase(Path.of("test"))
+                                            .webrevStorageBaseUri(webrevServer.uri())
+                                            .issueTracker(URIBuilder.base("http://issues.test/browse/").build())
+                                            .build();
 
             // Populate the projects repository
             var reviewFile = Path.of("reviewfile.txt");
@@ -1343,15 +1412,20 @@ class MailingListBridgeBotTests {
                                            .addReviewer(reviewer.forge().currentUser().id())
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mlBot = new MailingListBridgeBot(from, author, archive, "master", censusBuilder.build(), "master",
-                                                 listAddress, Set.of(), Set.of(),
-                                                 listServer.getArchive(),
-                                                 listServer.getSMTP(),
-                                                 archive, "webrev", Path.of("test"),
-                                                 webrevServer.uri(),
-                                                 Set.of(), Map.of(),
-                                                 URIBuilder.base("http://issues.test/browse/").build(),
-                                                 Map.of(), Duration.ZERO);
+            var mlBot = MailingListBridgeBot.newBuilder()
+                                            .from(from)
+                                            .repo(author)
+                                            .archive(archive)
+                                            .censusRepo(censusBuilder.build())
+                                            .list(listAddress)
+                                            .listArchive(listServer.getArchive())
+                                            .smtpServer(listServer.getSMTP())
+                                            .webrevStorageRepository(archive)
+                                            .webrevStorageRef("webrev")
+                                            .webrevStorageBase(Path.of("test"))
+                                            .webrevStorageBaseUri(webrevServer.uri())
+                                            .issueTracker(URIBuilder.base("http://issues.test/browse/").build())
+                                            .build();
 
             // Populate the projects repository
             var reviewFile = Path.of("reviewfile.txt");


### PR DESCRIPTION
Hi all,

Please review this change that implements waiting for a configured period of time before bridging PR comments to mailing lists. It also contains a refactoring to construct the mailing list bridge bot with a builder.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-182](https://bugs.openjdk.java.net/browse/SKARA-182): Implement a cooldown period when bridging pull request comments to mailing lists


## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)