### PR TITLE
251: Bypass PR update cache when the cooldown period expires for a bridge candidate

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
@@ -44,12 +44,14 @@ class ArchiveWorkItem implements WorkItem {
     private final PullRequest pr;
     private final MailingListBridgeBot bot;
     private final Consumer<RuntimeException> exceptionConsumer;
+    private final Consumer<Instant> retryConsumer;
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots.mlbridge");
 
-    ArchiveWorkItem(PullRequest pr, MailingListBridgeBot bot, Consumer<RuntimeException> exceptionConsumer) {
+    ArchiveWorkItem(PullRequest pr, MailingListBridgeBot bot, Consumer<RuntimeException> exceptionConsumer, Consumer<Instant> retryConsumer) {
         this.pr = pr;
         this.bot = bot;
         this.exceptionConsumer = exceptionConsumer;
+        this.retryConsumer = retryConsumer;
     }
 
     @Override
@@ -288,7 +290,8 @@ class ArchiveWorkItem implements WorkItem {
                                                       (index, full, inc) -> updateWebrevComment(comments, index, full, inc),
                                                       user -> getAuthorAddress(census, user),
                                                       user -> getAuthorUserName(census, user),
-                                                      user -> getAuthorRole(census, user));
+                                                      user -> getAuthorRole(census, user),
+                                                      retryConsumer);
             if (newMails.isEmpty()) {
                 return;
             }

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/CooldownQuarantine.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/CooldownQuarantine.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.mlbridge;
+
+import org.openjdk.skara.forge.*;
+
+import java.time.*;
+import java.util.*;
+import java.util.logging.Logger;
+
+public class CooldownQuarantine {
+    private final Map<HostedRepository, String> repositoryIds = new HashMap<>();
+    private final Map<String, Instant> quarantineEnd = new HashMap<>();
+
+    private final Logger log = Logger.getLogger("org.openjdk.skara.bots.mlbridge");
+
+    private String getUniqueId(PullRequest pr) {
+        var repo = pr.repository();
+        if (!repositoryIds.containsKey(repo)) {
+            repositoryIds.put(repo, Integer.toString(repositoryIds.size()));
+        }
+        return repositoryIds.get(repo) + ";" + pr.id();
+    }
+
+    public synchronized boolean inQuarantine(PullRequest pr) {
+        var uniqueId = getUniqueId(pr);
+
+        if (!quarantineEnd.containsKey(uniqueId)) {
+            return false;
+        }
+        var end = quarantineEnd.get(uniqueId);
+        if (end.isBefore(Instant.now())) {
+            log.info("Released from cooldown quarantine: " + pr.repository().name() + "#" + pr.id());
+            quarantineEnd.remove(uniqueId);
+            return false;
+        }
+        log.info("Quarantined due to cooldown: " + pr.repository().name() + "#" + pr.id());
+        return true;
+    }
+
+    public synchronized void updateQuarantineEnd(PullRequest pr, Instant end) {
+        var uniqueId = getUniqueId(pr);
+        var currentEnd = quarantineEnd.getOrDefault(uniqueId, Instant.now());
+        if (end.isAfter(currentEnd)) {
+            quarantineEnd.put(uniqueId, end);
+        }
+    }
+}

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/CooldownQuarantine.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/CooldownQuarantine.java
@@ -29,21 +29,11 @@ import java.util.*;
 import java.util.logging.Logger;
 
 public class CooldownQuarantine {
-    private final Map<HostedRepository, String> repositoryIds = new HashMap<>();
     private final Map<String, Instant> quarantineEnd = new HashMap<>();
-
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots.mlbridge");
 
-    private String getUniqueId(PullRequest pr) {
-        var repo = pr.repository();
-        if (!repositoryIds.containsKey(repo)) {
-            repositoryIds.put(repo, Integer.toString(repositoryIds.size()));
-        }
-        return repositoryIds.get(repo) + ";" + pr.id();
-    }
-
     public synchronized boolean inQuarantine(PullRequest pr) {
-        var uniqueId = getUniqueId(pr);
+        var uniqueId = pr.webUrl().toString();
 
         if (!quarantineEnd.containsKey(uniqueId)) {
             return false;
@@ -59,7 +49,7 @@ public class CooldownQuarantine {
     }
 
     public synchronized void updateQuarantineEnd(PullRequest pr, Instant end) {
-        var uniqueId = getUniqueId(pr);
+        var uniqueId = pr.webUrl().toString();
         var currentEnd = quarantineEnd.getOrDefault(uniqueId, Instant.now());
         if (end.isAfter(currentEnd)) {
             quarantineEnd.put(uniqueId, end);

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBot.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBot.java
@@ -28,7 +28,7 @@ import org.openjdk.skara.forge.*;
 
 import java.net.URI;
 import java.nio.file.Path;
-import java.time.Duration;
+import java.time.*;
 import java.util.*;
 import java.util.regex.Pattern;
 
@@ -52,6 +52,7 @@ public class MailingListBridgeBot implements Bot {
     private final PullRequestUpdateCache updateCache;
     private final Duration sendInterval;
     private final Duration cooldown;
+    private final CooldownQuarantine cooldownQuarantine;
 
     MailingListBridgeBot(EmailAddress from, HostedRepository repo, HostedRepository archive, String archiveRef,
                          HostedRepository censusRepo, String censusRef, EmailAddress list,
@@ -78,9 +79,10 @@ public class MailingListBridgeBot implements Bot {
         this.sendInterval = sendInterval;
         this.cooldown = cooldown;
 
-        this.webrevStorage = new WebrevStorage(webrevStorageRepository, webrevStorageRef, webrevStorageBase,
-                                               webrevStorageBaseUri, from);
-        this.updateCache = new PullRequestUpdateCache();
+        webrevStorage = new WebrevStorage(webrevStorageRepository, webrevStorageRef, webrevStorageBase,
+                                          webrevStorageBaseUri, from);
+        updateCache = new PullRequestUpdateCache();
+        cooldownQuarantine = new CooldownQuarantine();
     }
 
     static MailingListBridgeBotBuilder newBuilder() {
@@ -164,8 +166,10 @@ public class MailingListBridgeBot implements Bot {
         List<WorkItem> ret = new LinkedList<>();
 
         for (var pr : codeRepo.pullRequests()) {
-            if (updateCache.needsUpdate(pr)) {
-                ret.add(new ArchiveWorkItem(pr, this, e -> updateCache.invalidate(pr)));
+            if (!cooldownQuarantine.inQuarantine(pr) || updateCache.needsUpdate(pr)) {
+                ret.add(new ArchiveWorkItem(pr, this,
+                                            e -> updateCache.invalidate(pr),
+                                            r -> cooldownQuarantine.updateQuarantineEnd(pr, r)));
             }
         }
 

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -34,14 +34,17 @@ import org.junit.jupiter.api.*;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
-import java.time.Duration;
+import java.time.*;
 import java.util.*;
+import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class MailingListBridgeBotTests {
+    private final Logger log = Logger.getLogger("org.openjdk.skara.bots.mlbridge.test");
+
     private Optional<String> archiveContents(Path archive) {
         try {
             var mbox = Files.find(archive, 50, (path, attrs) -> path.toString().endsWith(".mbox")).findAny();
@@ -1520,6 +1523,85 @@ class MailingListBridgeBotTests {
             // Check the archive
             Repository.materialize(archiveFolder.path(), archive.url(), "master");
             assertTrue(archiveContains(archiveFolder.path(), "Looks good"));
+        }
+    }
+
+    @Test
+    void retryAfterCooldown(TestInfo testInfo) throws IOException, InterruptedException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory();
+             var archiveFolder = new TemporaryDirectory();
+             var listServer = new TestMailmanServer();
+             var webrevServer = new TestWebrevServer()) {
+            var bot = credentials.getHostedRepository();
+            var author = credentials.getHostedRepository();
+            var archive = credentials.getHostedRepository();
+            var listAddress = EmailAddress.parse(listServer.createList("test"));
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addAuthor(author.forge().currentUser().id());
+            var from = EmailAddress.from("test", "test@test.mail");
+            var cooldown = Duration.ofMillis(500);
+            var mlBotBuilder = MailingListBridgeBot.newBuilder()
+                                                   .from(from)
+                                                   .repo(bot)
+                                                   .ignoredUsers(Set.of(bot.forge().currentUser().userName()))
+                                                   .archive(archive)
+                                                   .censusRepo(censusBuilder.build())
+                                                   .list(listAddress)
+                                                   .listArchive(listServer.getArchive())
+                                                   .smtpServer(listServer.getSMTP())
+                                                   .webrevStorageRepository(archive)
+                                                   .webrevStorageRef("webrev")
+                                                   .webrevStorageBase(Path.of("test"))
+                                                   .webrevStorageBaseUri(webrevServer.uri())
+                                                   .issueTracker(URIBuilder.base("http://issues.test/browse/").build());
+
+            // Populate the projects repository
+            var reviewFile = Path.of("reviewfile.txt");
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(), reviewFile);
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, archive.url(), "webrev", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo, "Line 1\nLine 2\nLine 3\nLine 4");
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(archive, "master", "edit", "This is a pull request");
+            pr.setBody("This is now ready");
+
+            var mlBot = mlBotBuilder.cooldown(cooldown).build();
+            Thread.sleep(cooldown.toMillis());
+            TestBotRunner.runPeriodicItems(mlBot);
+            listServer.processIncoming();
+
+            // Make a comment and run the check within the cooldown period
+            int counter;
+            for (counter = 1; counter < 10; ++counter) {
+                var start = Instant.now();
+                pr.addComment("Looks good - " + counter + " -");
+
+                // The bot should not bridge the comment due to cooldown
+                TestBotRunner.runPeriodicItems(mlBot);
+                var elapsed = Duration.between(start, Instant.now());
+                if (elapsed.compareTo(cooldown) < 0) {
+                    break;
+                } else {
+                    log.info("Didn't do the test in time - retrying (elapsed: " + elapsed + " required: " + cooldown + ")");
+                    listServer.processIncoming();
+                    cooldown = cooldown.multipliedBy(2);
+                    mlBot = mlBotBuilder.cooldown(cooldown).build();
+                }
+            }
+            assertThrows(RuntimeException.class, () -> listServer.processIncoming(Duration.ofMillis(1)));
+
+            // But after the cooldown period has passed, it should
+            Thread.sleep(cooldown.toMillis());
+            TestBotRunner.runPeriodicItems(mlBot);
+            listServer.processIncoming();
+
+            // Check the archive
+            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            assertTrue(archiveContains(archiveFolder.path(), "Looks good - " + counter + " -"));
         }
     }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequestUpdateCache.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequestUpdateCache.java
@@ -29,18 +29,8 @@ import java.util.*;
 import java.util.logging.Logger;
 
 public class PullRequestUpdateCache {
-    private final Map<HostedRepository, String> repositoryIds = new HashMap<>();
     private final Map<String, ZonedDateTime> lastUpdates = new HashMap<>();
-
     private final Logger log = Logger.getLogger("org.openjdk.skara.host");
-
-    private String getUniqueId(PullRequest pr) {
-        var repo = pr.repository();
-        if (!repositoryIds.containsKey(repo)) {
-            repositoryIds.put(repo, Integer.toString(repositoryIds.size()));
-        }
-        return repositoryIds.get(repo) + ";" + pr.id();
-    }
 
     public synchronized boolean needsUpdate(PullRequest pr) {
         // GitLab CE does not update this field on events such as adding an award
@@ -48,7 +38,7 @@ public class PullRequestUpdateCache {
             return true;
         }
 
-        var uniqueId = getUniqueId(pr);
+        var uniqueId = pr.webUrl().toString();
         var update = pr.updatedAt();
 
         if (!lastUpdates.containsKey(uniqueId)) {
@@ -65,7 +55,7 @@ public class PullRequestUpdateCache {
     }
 
     public synchronized void invalidate(PullRequest pr) {
-        var uniqueId = getUniqueId(pr);
+        var uniqueId = pr.webUrl().toString();
         lastUpdates.remove(uniqueId);
     }
 }


### PR DESCRIPTION
Hi all,

Please review this change that ensures that the mailing list bridge bot retries the bridge operation if it was initially delayed due to the configured cooldown period.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-251](https://bugs.openjdk.java.net/browse/SKARA-251): Bypass PR update cache when the cooldown period expires for a bridge candidate


## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)