### PR TITLE
258: jcheck reviewers check has wrong default values

### DIFF
--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/ReviewersConfiguration.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/ReviewersConfiguration.java
@@ -79,11 +79,11 @@ public class ReviewersConfiguration {
             return DEFAULT;
         }
 
-        var lead = s.get("lead", DEFAULT.lead());
-        var reviewers = s.get("reviewers", DEFAULT.reviewers());
-        var committers = s.get("committers", DEFAULT.committers());
-        var authors = s.get("authors", DEFAULT.authors());
-        var contributors = s.get("contributors", DEFAULT.contributors());
+        var lead = s.get("lead", 0);
+        var reviewers = s.get("reviewers", 0);
+        var committers = s.get("committers", 0);
+        var authors = s.get("authors", 0);
+        var contributors = s.get("contributors", 0);
 
         if (s.contains("minimum")) {
             // Reset defaults to 0

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/ReviewersCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/ReviewersCheckTests.java
@@ -415,4 +415,35 @@ class ReviewersCheckTests {
         assertEquals(Severity.ERROR, issue.severity());
         assertEquals(check, issue.check());
     }
+
+    @Test
+    void modernConfigurationShouldAcceptCommitterRole() throws IOException {
+        var commit = commit(List.of("foo"));
+        var check = new ReviewersCheck(census(), utils);
+        var modernConf = new ArrayList<>(CONFIGURATION);
+        modernConf.add("committers = 1");
+
+        var issues = toList(check.check(commit, message(commit), JCheckConfiguration.parse(modernConf)));
+        assertEquals(0, issues.size());
+
+        commit = commit(List.of("bar"));
+        issues = toList(check.check(commit, message(commit), JCheckConfiguration.parse(modernConf)));
+        assertEquals(0, issues.size());
+
+        commit = commit(List.of("baz"));
+        issues = toList(check.check(commit, message(commit), JCheckConfiguration.parse(modernConf)));
+        assertEquals(0, issues.size());
+
+        commit = commit(List.of("qux"));
+        issues = toList(check.check(commit, message(commit), JCheckConfiguration.parse(modernConf)));
+        assertEquals(1, issues.size());
+        assertTrue(issues.get(0) instanceof TooFewReviewersIssue);
+        var issue = (TooFewReviewersIssue) issues.get(0);
+        assertEquals(0, issue.numActual());
+        assertEquals(1, issue.numRequired());
+        assertEquals("committer", issue.role());
+        assertEquals(commit, issue.commit());
+        assertEquals(Severity.ERROR, issue.severity());
+        assertEquals(check, issue.check());
+    }
 }


### PR DESCRIPTION
Hi all,

please review this patch that fixes the default value for the "new" style
configuration of the "reviewers" check in jcheck.

Testing:
- added a new unit test
- all unit tests pass on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-258](https://bugs.openjdk.java.net/browse/SKARA-258): jcheck reviewers check has wrong default values


## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)