### PR TITLE
260: CSR command should handle null resolution

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CSRCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CSRCommand.java
@@ -117,8 +117,15 @@ public class CSRCommand implements CommandHandler {
             return;
         }
 
-        var resolution = csr.properties().get("resolution").get("name").asString();
-        if (csr.state() == Issue.State.CLOSED && resolution.equals("Approved")) {
+        var resolution = csr.properties().get("resolution");
+        var resolutionName = "Unresolved";
+        if (!resolution.isNull() && resolution.asObject().contains("name")) {
+            var nameField = resolution.get("name");
+            if (nameField.isString()) {
+                resolutionName = resolution.get("name").asString();
+            }
+        }
+        if (csr.state() == Issue.State.CLOSED && resolutionName.equals("Approved")) {
             reply.println("the issue for this pull request, (" + jbsIssue.get().id() + ")[" + jbsIssue.get().webUrl() + "], already has " +
                           "an approved CSR request: (" + csr.id() + ")[" + csr.webUrl() + "]");
         } else {

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CSRTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CSRTests.java
@@ -378,4 +378,47 @@ class CSRTests {
             assertLastCommentContains(pr, "has been approved.");
         }
     }
+
+    @Test
+    void csrWithNullResolution(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var reviewer = credentials.getHostedRepository();
+            var bot = credentials.getHostedRepository();
+            var issues = credentials.getIssueProject();
+            var issue = issues.createIssue("This is an issue", List.of(), Map.of());
+
+            var csr = issues.createIssue("This is an approved CSR", List.of(), Map.of("resolution", JSON.of()));
+            csr.setState(Issue.State.OPEN);
+            issue.addLink(Link.create(csr, "csr for").build());
+
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addReviewer(reviewer.forge().currentUser().id())
+                                           .addCommitter(author.forge().currentUser().id());
+            var prBot = PullRequestBot.newBuilder().repo(bot).issueProject(issues).censusRepo(censusBuilder.build()).build();
+
+            // Populate the projects repository
+            var localRepoFolder = tempFolder.path().resolve("localrepo");
+            var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", issue.id() + ": This is an issue");
+
+            // Require CSR
+            var prAsReviewer = reviewer.pullRequest(pr.id());
+            prAsReviewer.addComment("/csr");
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // The bot should reply with a message that the PR will not be integrated until the CSR is approved
+            assertLastCommentContains(pr, "this pull request will not be integrated until the [CSR]");
+            assertLastCommentContains(pr, "for issue ");
+            assertLastCommentContains(pr, "has been approved.");
+        }
+    }
 }

--- a/json/src/main/java/org/openjdk/skara/json/JSONArray.java
+++ b/json/src/main/java/org/openjdk/skara/json/JSONArray.java
@@ -44,6 +44,11 @@ public class JSONArray implements JSONValue, Iterable<JSONValue> {
     }
 
     @Override
+    public boolean isArray() {
+        return true;
+    }
+
+    @Override
     public JSONArray asArray() {
         return this;
     }

--- a/json/src/main/java/org/openjdk/skara/json/JSONBoolean.java
+++ b/json/src/main/java/org/openjdk/skara/json/JSONBoolean.java
@@ -30,6 +30,11 @@ public class JSONBoolean implements JSONValue {
     }
 
     @Override
+    public boolean isBoolean() {
+        return true;
+    }
+
+    @Override
     public boolean asBoolean() {
         return value;
     }

--- a/json/src/main/java/org/openjdk/skara/json/JSONDecimal.java
+++ b/json/src/main/java/org/openjdk/skara/json/JSONDecimal.java
@@ -30,6 +30,11 @@ public class JSONDecimal implements JSONValue {
     }
 
     @Override
+    public boolean isDouble() {
+        return true;
+    }
+
+    @Override
     public double asDouble() {
         return value;
     }

--- a/json/src/main/java/org/openjdk/skara/json/JSONNumber.java
+++ b/json/src/main/java/org/openjdk/skara/json/JSONNumber.java
@@ -34,6 +34,16 @@ class JSONNumber implements JSONValue {
     }
 
     @Override
+    public boolean isInt() {
+        return true;
+    }
+
+    @Override
+    public boolean isLong() {
+        return true;
+    }
+
+    @Override
     public int asInt() {
         return Math.toIntExact(value);
     }

--- a/json/src/main/java/org/openjdk/skara/json/JSONObject.java
+++ b/json/src/main/java/org/openjdk/skara/json/JSONObject.java
@@ -55,6 +55,11 @@ public class JSONObject implements JSONValue {
     }
 
     @Override
+    public boolean isObject() {
+        return true;
+    }
+
+    @Override
     public JSONObject asObject() {
         return this;
     }

--- a/json/src/main/java/org/openjdk/skara/json/JSONString.java
+++ b/json/src/main/java/org/openjdk/skara/json/JSONString.java
@@ -30,6 +30,11 @@ class JSONString implements JSONValue {
     }
 
     @Override
+    public boolean isString() {
+        return true;
+    }
+
+    @Override
     public String asString() {
         return value;
     }

--- a/json/src/main/java/org/openjdk/skara/json/JSONValue.java
+++ b/json/src/main/java/org/openjdk/skara/json/JSONValue.java
@@ -54,6 +54,34 @@ public interface JSONValue {
         throw new IllegalStateException("Unsupported conversion to object");
     }
 
+    default boolean isInt() {
+        return false;
+    }
+
+    default boolean isLong() {
+        return false;
+    }
+
+    default boolean isDouble() {
+        return false;
+    }
+
+    default boolean isString() {
+        return false;
+    }
+
+    default boolean isBoolean() {
+        return false;
+    }
+
+    default boolean isArray() {
+        return false;
+    }
+
+    default boolean isObject() {
+        return false;
+    }
+
     default boolean isNull() {
         return false;
     }

--- a/json/src/test/java/org/openjdk/skara/json/JSONParserTests.java
+++ b/json/src/test/java/org/openjdk/skara/json/JSONParserTests.java
@@ -469,6 +469,14 @@ public class JSONParserTests {
     public void testIsNull() {
         var json = JSON.parse("[{\"id\":705,\"type\":null,\"body\":\"description\"}]");
         assertTrue(json.get(0).get("type").isNull());
+        assertFalse(json.get(0).get("type").isInt());
+        assertFalse(json.get(0).get("type").isLong());
+        assertFalse(json.get(0).get("type").isDouble());
+        assertFalse(json.get(0).get("type").isString());
+        assertFalse(json.get(0).get("type").isBoolean());
+        assertFalse(json.get(0).get("type").isArray());
+        assertFalse(json.get(0).get("type").isObject());
+
         assertFalse(json.get(0).get("id").isNull());
     }
 
@@ -497,5 +505,110 @@ public class JSONParserTests {
     public void testObjectWithWhitespace() {
         var json = JSON.parse("{ \"foo\": { } }");
         assertEquals(0, json.get("foo").asObject().fields().size());
+    }
+
+    @Test
+    public void testIsInt() {
+        var json = JSON.parse("{ \"foo\": 1 }");
+
+        assertTrue(json.get("foo").isInt());
+        assertTrue(json.get("foo").isLong());
+
+        assertFalse(json.get("foo").isDouble());
+        assertFalse(json.get("foo").isString());
+        assertFalse(json.get("foo").isBoolean());
+        assertFalse(json.get("foo").isArray());
+        assertFalse(json.get("foo").isObject());
+        assertFalse(json.get("foo").isNull());
+    }
+
+    @Test
+    public void testIsLong() {
+        var json = JSON.parse("{ \"foo\": 1337 }");
+
+        assertTrue(json.get("foo").isInt());
+        assertTrue(json.get("foo").isLong());
+
+        assertFalse(json.get("foo").isDouble());
+        assertFalse(json.get("foo").isString());
+        assertFalse(json.get("foo").isBoolean());
+        assertFalse(json.get("foo").isArray());
+        assertFalse(json.get("foo").isObject());
+        assertFalse(json.get("foo").isNull());
+    }
+
+    @Test
+    public void testIsDouble() {
+        var json = JSON.parse("{ \"foo\": 17.7 }");
+
+        assertTrue(json.get("foo").isDouble());
+
+        assertFalse(json.get("foo").isInt());
+        assertFalse(json.get("foo").isLong());
+        assertFalse(json.get("foo").isBoolean());
+        assertFalse(json.get("foo").isString());
+        assertFalse(json.get("foo").isArray());
+        assertFalse(json.get("foo").isObject());
+        assertFalse(json.get("foo").isNull());
+    }
+
+    @Test
+    public void testIsString() {
+        var json = JSON.parse("{ \"foo\": \"bar\" }");
+
+        assertTrue(json.get("foo").isString());
+
+        assertFalse(json.get("foo").isInt());
+        assertFalse(json.get("foo").isLong());
+        assertFalse(json.get("foo").isDouble());
+        assertFalse(json.get("foo").isBoolean());
+        assertFalse(json.get("foo").isArray());
+        assertFalse(json.get("foo").isObject());
+        assertFalse(json.get("foo").isNull());
+    }
+
+    @Test
+    public void testIsBoolean() {
+        var json = JSON.parse("{ \"foo\": true }");
+
+        assertTrue(json.get("foo").isBoolean());
+
+        assertFalse(json.get("foo").isInt());
+        assertFalse(json.get("foo").isLong());
+        assertFalse(json.get("foo").isDouble());
+        assertFalse(json.get("foo").isString());
+        assertFalse(json.get("foo").isArray());
+        assertFalse(json.get("foo").isObject());
+        assertFalse(json.get("foo").isNull());
+    }
+
+    @Test
+    public void testIsArray() {
+        var json = JSON.parse("{ \"foo\": [1,2,3] }");
+
+        assertTrue(json.get("foo").isArray());
+
+        assertFalse(json.get("foo").isInt());
+        assertFalse(json.get("foo").isLong());
+        assertFalse(json.get("foo").isDouble());
+        assertFalse(json.get("foo").isBoolean());
+        assertFalse(json.get("foo").isString());
+        assertFalse(json.get("foo").isObject());
+        assertFalse(json.get("foo").isNull());
+    }
+
+    @Test
+    public void testIsObject() {
+        var json = JSON.parse("{ \"foo\": { \"bar\": true } }");
+
+        assertTrue(json.get("foo").isObject());
+
+        assertFalse(json.get("foo").isInt());
+        assertFalse(json.get("foo").isLong());
+        assertFalse(json.get("foo").isDouble());
+        assertFalse(json.get("foo").isBoolean());
+        assertFalse(json.get("foo").isString());
+        assertFalse(json.get("foo").isArray());
+        assertFalse(json.get("foo").isNull());
     }
 }


### PR DESCRIPTION
Hi all,

please review this patch that fixes an issue with the `/csr` command. Issues in
JBS of "CSR" type can have `null` as the value for the `"resolution"` field,
something that the `CSRCommand` did not anticipate. This patch makes the
`CSRCommand` much more defensive when interpreting JSON.

I also added a number of methods to `JSONValue` for querying the type of a
`JSONValue` to allow code to safely use the `as*` methods.

Testing:
- `make test` passes on Linux x64
- added a unit test that showcase the issue
- added unit tests for new `JSONValue` methods

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-260](https://bugs.openjdk.java.net/browse/SKARA-260): CSR command should handle null resolution


## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)