### PR TITLE
Use very defensive programming in CSRCommand

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CSRCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CSRCommand.java
@@ -25,6 +25,7 @@ package org.openjdk.skara.bots.pr;
 import org.openjdk.skara.forge.PullRequest;
 import org.openjdk.skara.issuetracker.Comment;
 import org.openjdk.skara.issuetracker.Issue;
+import org.openjdk.skara.json.JSON;
 
 import java.io.PrintWriter;
 import java.nio.file.Path;
@@ -117,9 +118,9 @@ public class CSRCommand implements CommandHandler {
             return;
         }
 
-        var resolution = csr.properties().get("resolution");
         var resolutionName = "Unresolved";
-        if (!resolution.isNull() && resolution.asObject().contains("name")) {
+        var resolution = csr.properties().getOrDefault("resolution", JSON.of());
+        if (resolution.isObject() && resolution.asObject().contains("name")) {
             var nameField = resolution.get("name");
             if (nameField.isString()) {
                 resolutionName = resolution.get("name").asString();

--- a/json/src/test/java/org/openjdk/skara/json/JSONParserTests.java
+++ b/json/src/test/java/org/openjdk/skara/json/JSONParserTests.java
@@ -611,4 +611,12 @@ public class JSONParserTests {
         assertFalse(json.get("foo").isArray());
         assertFalse(json.get("foo").isNull());
     }
+
+    @Test
+    public void testJSONObjectWithNullField() {
+        var json = JSON.parse("{ \"foo\": null }");
+
+        assertNotNull(json.get("foo"));
+        assertTrue(json.get("foo").isNull());
+    }
 }


### PR DESCRIPTION
Hi all,

please review this follow-up patch to 5632c91342c703d2197aad402492c3679762638e
that uses even more defensive programming to avoid `null` pointers.

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)