### PR TITLE
Improve merge bot commit message

### DIFF
--- a/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
+++ b/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
@@ -394,7 +394,7 @@ class MergeBot implements Bot, WorkItem {
                 if (error == null) {
                     log.info("Pushing successful merge");
                     if (!isAncestor) {
-                        repo.commit("Merge branch: '" + fromBranch + "' into: '" + toBranch + "'",
+                        repo.commit("Automatic merge of " + fromBranch + " into " + toBranch,
                                 "duke", "duke@openjdk.org");
                     }
                     repo.push(toBranch, target.url().toString(), false);

--- a/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
+++ b/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
@@ -394,7 +394,8 @@ class MergeBot implements Bot, WorkItem {
                 if (error == null) {
                     log.info("Pushing successful merge");
                     if (!isAncestor) {
-                        repo.commit("Merge", "duke", "duke@openjdk.org");
+                        repo.commit("Merge branch: '" + fromBranch + "' into: '" + toBranch + "'",
+                                "duke", "duke@openjdk.org");
                     }
                     repo.push(toBranch, target.url().toString(), false);
                 } else {

--- a/bots/merge/src/test/java/org/openjdk/skara/bots/merge/MergeBotTests.java
+++ b/bots/merge/src/test/java/org/openjdk/skara/bots/merge/MergeBotTests.java
@@ -109,7 +109,7 @@ class MergeBotTests {
             var known = Set.of(toHashA, fromHashB, toHashC);
             var merge = toCommits.stream().filter(c -> !known.contains(c.hash())).findAny().get();
             assertTrue(merge.isMerge());
-            assertEquals(List.of("Merge"), merge.message());
+            assertEquals(List.of("Merge branch: 'master' into: 'master'"), merge.message());
             assertEquals("duke", merge.author().name());
             assertEquals("duke@openjdk.org", merge.author().email());
 
@@ -538,7 +538,7 @@ class MergeBotTests {
             var known = Set.of(toHashA, fromHashB, toHashC);
             var merge = toCommits.stream().filter(c -> !known.contains(c.hash())).findAny().get();
             assertTrue(merge.isMerge());
-            assertEquals(List.of("Merge"), merge.message());
+            assertEquals(List.of("Merge branch: 'master' into: 'master'"), merge.message());
             assertEquals("duke", merge.author().name());
             assertEquals("duke@openjdk.org", merge.author().email());
 
@@ -653,7 +653,7 @@ class MergeBotTests {
             var known = Set.of(toHashA, fromHashB, toHashC);
             var merge = toCommits.stream().filter(c -> !known.contains(c.hash())).findAny().get();
             assertTrue(merge.isMerge());
-            assertEquals(List.of("Merge"), merge.message());
+            assertEquals(List.of("Merge branch: 'master' into: 'master'"), merge.message());
             assertEquals("duke", merge.author().name());
             assertEquals("duke@openjdk.org", merge.author().email());
 
@@ -774,7 +774,7 @@ class MergeBotTests {
             var known = Set.of(toHashA, fromHashB, toHashC);
             var merge = toCommits.stream().filter(c -> !known.contains(c.hash())).findAny().get();
             assertTrue(merge.isMerge());
-            assertEquals(List.of("Merge"), merge.message());
+            assertEquals(List.of("Merge branch: 'master' into: 'master'"), merge.message());
             assertEquals("duke", merge.author().name());
             assertEquals("duke@openjdk.org", merge.author().email());
 
@@ -895,7 +895,7 @@ class MergeBotTests {
             var known = Set.of(toHashA, fromHashB, toHashC);
             var merge = toCommits.stream().filter(c -> !known.contains(c.hash())).findAny().get();
             assertTrue(merge.isMerge());
-            assertEquals(List.of("Merge"), merge.message());
+            assertEquals(List.of("Merge branch: 'master' into: 'master'"), merge.message());
             assertEquals("duke", merge.author().name());
             assertEquals("duke@openjdk.org", merge.author().email());
 
@@ -1016,7 +1016,7 @@ class MergeBotTests {
             var known = Set.of(toHashA, fromHashB, toHashC);
             var merge = toCommits.stream().filter(c -> !known.contains(c.hash())).findAny().get();
             assertTrue(merge.isMerge());
-            assertEquals(List.of("Merge"), merge.message());
+            assertEquals(List.of("Merge branch: 'master' into: 'master'"), merge.message());
             assertEquals("duke", merge.author().name());
             assertEquals("duke@openjdk.org", merge.author().email());
 

--- a/bots/merge/src/test/java/org/openjdk/skara/bots/merge/MergeBotTests.java
+++ b/bots/merge/src/test/java/org/openjdk/skara/bots/merge/MergeBotTests.java
@@ -109,7 +109,7 @@ class MergeBotTests {
             var known = Set.of(toHashA, fromHashB, toHashC);
             var merge = toCommits.stream().filter(c -> !known.contains(c.hash())).findAny().get();
             assertTrue(merge.isMerge());
-            assertEquals(List.of("Merge branch: 'master' into: 'master'"), merge.message());
+            assertEquals(List.of("Automatic merge of master into master"), merge.message());
             assertEquals("duke", merge.author().name());
             assertEquals("duke@openjdk.org", merge.author().email());
 
@@ -538,7 +538,7 @@ class MergeBotTests {
             var known = Set.of(toHashA, fromHashB, toHashC);
             var merge = toCommits.stream().filter(c -> !known.contains(c.hash())).findAny().get();
             assertTrue(merge.isMerge());
-            assertEquals(List.of("Merge branch: 'master' into: 'master'"), merge.message());
+            assertEquals(List.of("Automatic merge of master into master"), merge.message());
             assertEquals("duke", merge.author().name());
             assertEquals("duke@openjdk.org", merge.author().email());
 
@@ -653,7 +653,7 @@ class MergeBotTests {
             var known = Set.of(toHashA, fromHashB, toHashC);
             var merge = toCommits.stream().filter(c -> !known.contains(c.hash())).findAny().get();
             assertTrue(merge.isMerge());
-            assertEquals(List.of("Merge branch: 'master' into: 'master'"), merge.message());
+            assertEquals(List.of("Automatic merge of master into master"), merge.message());
             assertEquals("duke", merge.author().name());
             assertEquals("duke@openjdk.org", merge.author().email());
 
@@ -774,7 +774,7 @@ class MergeBotTests {
             var known = Set.of(toHashA, fromHashB, toHashC);
             var merge = toCommits.stream().filter(c -> !known.contains(c.hash())).findAny().get();
             assertTrue(merge.isMerge());
-            assertEquals(List.of("Merge branch: 'master' into: 'master'"), merge.message());
+            assertEquals(List.of("Automatic merge of master into master"), merge.message());
             assertEquals("duke", merge.author().name());
             assertEquals("duke@openjdk.org", merge.author().email());
 
@@ -895,7 +895,7 @@ class MergeBotTests {
             var known = Set.of(toHashA, fromHashB, toHashC);
             var merge = toCommits.stream().filter(c -> !known.contains(c.hash())).findAny().get();
             assertTrue(merge.isMerge());
-            assertEquals(List.of("Merge branch: 'master' into: 'master'"), merge.message());
+            assertEquals(List.of("Automatic merge of master into master"), merge.message());
             assertEquals("duke", merge.author().name());
             assertEquals("duke@openjdk.org", merge.author().email());
 
@@ -1016,7 +1016,7 @@ class MergeBotTests {
             var known = Set.of(toHashA, fromHashB, toHashC);
             var merge = toCommits.stream().filter(c -> !known.contains(c.hash())).findAny().get();
             assertTrue(merge.isMerge());
-            assertEquals(List.of("Merge branch: 'master' into: 'master'"), merge.message());
+            assertEquals(List.of("Automatic merge of master into master"), merge.message());
             assertEquals("duke", merge.author().name());
             assertEquals("duke@openjdk.org", merge.author().email());
 


### PR DESCRIPTION
The current commit message the merge bot uses just says

> Merge

I'd like it if the message contained the branches involved as well, to be a little more informative. This patch changes the message to for instance:

> Merge branch: 'branchA' into: 'branchB'
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)