### PR TITLE
Do not use pull in merge bot

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
@@ -102,6 +102,7 @@ public interface Repository extends ReadOnlyRepository {
     void delete(Branch b) throws IOException;
     void rebase(Hash hash, String committerName, String committerEmail) throws IOException;
     void merge(Hash hash) throws IOException;
+    void merge(Branch branch) throws IOException;
     void merge(Hash hash, String strategy) throws IOException;
     void abortMerge() throws IOException;
     void addRemote(String name, String path) throws IOException;

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -916,11 +916,20 @@ public class GitRepository implements Repository {
 
     @Override
     public void merge(Hash h) throws IOException {
-        merge(h, null);
+        merge(h.hex(), null);
+    }
+
+    @Override
+    public void merge(Branch b) throws IOException {
+        merge(b.name(), null);
     }
 
     @Override
     public void merge(Hash h, String strategy) throws IOException {
+        merge(h.hex(), strategy);
+    }
+
+    private void merge(String ref, String strategy) throws IOException {
         var cmd = new ArrayList<String>();
         cmd.addAll(List.of("git", "-c", "user.name=unused", "-c", "user.email=unused",
                            "merge", "--no-commit"));
@@ -928,7 +937,7 @@ public class GitRepository implements Repository {
             cmd.add("-s");
             cmd.add(strategy);
         }
-        cmd.add(h.hex());
+        cmd.add(ref);
         try (var p = capture(cmd)) {
             await(p);
         }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -857,15 +857,24 @@ public class HgRepository implements Repository {
 
     @Override
     public void merge(Hash h) throws IOException {
-        merge(h, null);
+        merge(h.hex(), null);
     }
 
     @Override
-    public void merge(Hash h, String stragegy) throws IOException {
+    public void merge(Branch b) throws IOException {
+        merge(b.name(), null);
+    }
+
+    @Override
+    public void merge(Hash h, String strategy) throws IOException {
+        merge(h.hex(), strategy);
+    }
+
+    private void merge(String ref, String strategy) throws IOException {
         var cmd = new ArrayList<String>();
-        cmd.addAll(List.of("hg", "merge", "--rev=" + h.hex()));
-        if (stragegy != null) {
-            cmd.add("--tool=" + stragegy);
+        cmd.addAll(List.of("hg", "merge", "--rev=" + ref));
+        if (strategy != null) {
+            cmd.add("--tool=" + strategy);
         }
         try (var p = capture(cmd)) {
             await(p);


### PR DESCRIPTION
Hi all,

please review this patch that ensures that merge bot do not use pull (it should
only use merge operations).

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)