### PR TITLE
266: Allow getting commit metadata for a range

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
@@ -107,7 +107,7 @@ class ArchiveMessages {
         try {
             if (base.equals(lastBase)) {
                 if (localRepository.isAncestor(lastHead, head)) {
-                    var updateCount = localRepository.commits(lastHead.hex() + ".." + head.hex()).stream().count();
+                    var updateCount = localRepository.commitMetadata(lastHead.hex() + ".." + head.hex()).size();
                     return "The pull request has been updated with " + updateCount + " additional commit" + (updateCount != 1 ? "s" : "") + ".";
                 } else {
                     return "Previous commits in this pull request have been removed, probably due to a force push. " +

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryWorkItem.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryWorkItem.java
@@ -291,16 +291,4 @@ public class RepositoryWorkItem implements WorkItem {
             throw new UncheckedIOException(e);
         }
     }
-
-    @Override
-    public String toString() {
-        return "RepositoryWorkItem{" +
-                "repository=" + repository +
-                ", storagePath=" + storagePath +
-                ", branches=" + branches +
-                ", tagStorageBuilder=" + tagStorageBuilder +
-                ", branchStorageBuilder=" + branchStorageBuilder +
-                ", updaters=" + updaters +
-                '}';
-    }
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryWorkItem.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryWorkItem.java
@@ -67,7 +67,7 @@ public class RepositoryWorkItem implements WorkItem {
         var bestParent = candidates.stream()
                                    .map(c -> {
                                        try {
-                                           return new AbstractMap.SimpleEntry<>(c, localRepo.commits(c.hash().hex() + ".." + ref.hash(), true).asList());
+                                           return new AbstractMap.SimpleEntry<>(c, localRepo.commitMetadata(c.hash().hex() + ".." + ref.hash()));
                                        } catch (IOException e) {
                                            throw new UncheckedIOException(e);
                                        }
@@ -78,13 +78,18 @@ public class RepositoryWorkItem implements WorkItem {
             throw new RuntimeException("Excessive amount of unique commits on new branch " + ref.name() +
                                                " detected (" + bestParent.getValue().size() + ") - skipping notifications");
         }
-        for (var updater : updaters) {
-            if (updater.isIdempotent() != runOnlyIdempotent) {
-                continue;
+        try {
+            var bestParentCommits = localRepo.commits(bestParent.getKey().hash().hex() + ".." + ref.hash(), true);
+            for (var updater : updaters) {
+                if (updater.isIdempotent() != runOnlyIdempotent) {
+                    continue;
+                }
+                var branch = new Branch(ref.name());
+                var parent = new Branch(bestParent.getKey().name());
+                updater.handleNewBranch(repository, localRepo, bestParentCommits.asList(), parent, branch);
             }
-            var branch = new Branch(ref.name());
-            var parent = new Branch(bestParent.getKey().name());
-            updater.handleNewBranch(repository, localRepo, bestParent.getValue(), parent, branch);
+        } catch (IOException e) {
+            e.printStackTrace();
         }
     }
 
@@ -107,17 +112,17 @@ public class RepositoryWorkItem implements WorkItem {
             history.setBranchHash(branch, ref.hash());
             handleNewRef(localRepo, ref, allRefs, false);
         } else {
-            var commits = localRepo.commits(lastHash.get() + ".." + ref.hash()).asList();
-            if (commits.size() == 0) {
+            var commitMetadata = localRepo.commitMetadata(lastHash.get() + ".." + ref.hash());
+            if (commitMetadata.size() == 0) {
                 return;
             }
-            if (commits.size() > 1000) {
+            if (commitMetadata.size() > 1000) {
                 history.setBranchHash(branch, ref.hash());
                 throw new RuntimeException("Excessive amount of new commits on branch " + branch.name() +
-                                                   " detected (" + commits.size() + ") - skipping notifications");
+                                                   " detected (" + commitMetadata.size() + ") - skipping notifications");
             }
 
-            Collections.reverse(commits);
+            var commits = localRepo.commits(lastHash.get() + ".." + ref.hash(), true).asList();
             handleUpdatedRef(localRepo, ref, commits, true);
             history.setBranchHash(branch, ref.hash());
             handleUpdatedRef(localRepo, ref, commits, false);
@@ -285,5 +290,17 @@ public class RepositoryWorkItem implements WorkItem {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+    }
+
+    @Override
+    public String toString() {
+        return "RepositoryWorkItem{" +
+                "repository=" + repository +
+                ", storagePath=" + storagePath +
+                ", branches=" + branches +
+                ", tagStorageBuilder=" + tagStorageBuilder +
+                ", branchStorageBuilder=" + branchStorageBuilder +
+                ", updaters=" + updaters +
+                '}';
     }
 }

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/TestRepository.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/TestRepository.java
@@ -132,6 +132,10 @@ class TestRepository implements ReadOnlyRepository {
         return Optional.empty();
     }
 
+    public List<CommitMetadata> commitMetadata(String range) throws IOException {
+        return List.of();
+    }
+
     public List<CommitMetadata> commitMetadata() throws IOException {
         return List.of();
     }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
@@ -48,6 +48,7 @@ public interface ReadOnlyRepository {
     Optional<Commit> lookup(Branch b) throws IOException;
     Optional<Commit> lookup(Tag t) throws IOException;
     List<CommitMetadata> commitMetadata() throws IOException;
+    List<CommitMetadata> commitMetadata(String range) throws IOException;
     Path root() throws IOException;
     boolean exists() throws IOException;
     boolean isHealthy() throws IOException;

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -190,9 +190,9 @@ public class GitRepository implements Repository {
         return lookup(hash);
     }
 
-    public List<CommitMetadata> commitMetadata() throws IOException {
-        var revisions = "--all";
-        var p = start("git", "rev-list", "--format=" + GitCommitMetadata.FORMAT, "--no-abbrev", "--reverse", "--no-color", revisions);
+    @Override
+    public List<CommitMetadata> commitMetadata(String range) throws IOException {
+        var p = start("git", "rev-list", "--format=" + GitCommitMetadata.FORMAT, "--no-abbrev", "--reverse", "--no-color", range);
         var reader = new UnixStreamReader(p.getInputStream());
         var result = new ArrayList<CommitMetadata>();
 
@@ -208,6 +208,11 @@ public class GitRepository implements Repository {
 
         await(p);
         return result;
+    }
+
+    @Override
+    public List<CommitMetadata> commitMetadata() throws IOException {
+        return commitMetadata("--all");
     }
 
     private List<Hash> refs() throws IOException {

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -251,6 +251,11 @@ public class HgRepository implements Repository {
     }
 
     @Override
+    public List<CommitMetadata> commitMetadata(String range) throws IOException {
+        throw new RuntimeException("not implemented yet");
+    }
+
+    @Override
     public List<CommitMetadata> commitMetadata() throws IOException {
         var ext = Files.createTempFile("ext", ".py");
         copyResource(EXT_PY, ext);


### PR DESCRIPTION
Hi all,

Please review this change that implements getting commit metadata for a range (for git repositories). This is in turn used in a few places in the bots where the full commit information isn't needed, such as counting them.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-266](https://bugs.openjdk.java.net/browse/SKARA-266): Allow getting commit metadata for a range


## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**) **Note!** Review applies to 7af18a9446a6f944d673a61b91676805288a6050