### PR TITLE
267: Be more tolerant when parsing mbox files

### DIFF
--- a/email/src/main/java/org/openjdk/skara/email/EmailAddress.java
+++ b/email/src/main/java/org/openjdk/skara/email/EmailAddress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,9 +55,10 @@ public class EmailAddress {
         this.domain = domain;
     }
 
-    private static Pattern decoratedAddressPattern = Pattern.compile("(?<name>.*?)(?:\\s*)<(?<local>.*)@(?<domain>.*?)>");
+    private final static Pattern decoratedAddressPattern = Pattern.compile("(?<name>.*?)(?:\\s*)<(?<local>.*)@(?<domain>.*?)>");
     private final static Pattern obfuscatedPattern = Pattern.compile("(?<local>.*) at (?<domain>.*) \\((?<name>.*)\\)");
-    private static Pattern plainAddressPattern = Pattern.compile("(?<name>)(?<local>.*)@(?<domain>.*?)");
+    private final static Pattern plainAddressPattern = Pattern.compile("(?<name>)(?<local>.*)@(?<domain>.*?)");
+    private final static Pattern unqualifiedDecoratedAddressPattern = Pattern.compile("(?<name>.*?)(?:\\s*)<(?<local>.*)(?<domain>)>");
 
     public static EmailAddress parse(String address) {
         var matcher = decoratedAddressPattern.matcher(address);
@@ -66,7 +67,10 @@ public class EmailAddress {
             if (!matcher.matches()) {
                 matcher = plainAddressPattern.matcher(address);
                 if (!matcher.matches()) {
-                    throw new IllegalArgumentException("Cannot parse email address: " + address);
+                    matcher = unqualifiedDecoratedAddressPattern.matcher(address);
+                    if (!matcher.matches()) {
+                        throw new IllegalArgumentException("Cannot parse email address: " + address);
+                    }
                 }
             }
         }

--- a/email/src/test/java/org/openjdk/skara/email/EmailAddressTests.java
+++ b/email/src/test/java/org/openjdk/skara/email/EmailAddressTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 class EmailAddressTests {
-
     @Test
     void simple() {
         var address = EmailAddress.parse("Full Name <full@name.com>");
@@ -55,4 +54,12 @@ class EmailAddressTests {
         assertEquals("no", address.localPart());
     }
 
+    @Test
+    void noDomain() {
+        var address = EmailAddress.parse("<noone.ever.>");
+        assertFalse(address.fullName().isPresent());
+        assertEquals("noone.ever.@", address.address());
+        assertEquals("", address.domain());
+        assertEquals("noone.ever.", address.localPart());
+    }
 }


### PR DESCRIPTION
Hi all,

Please review this change that allows parsing of mail id's encountered in the wild.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-267](https://bugs.openjdk.java.net/browse/SKARA-267): Be more tolerant when parsing mbox files


## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)