### PR TITLE
git-pr: friendly help message when missing action

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
@@ -538,9 +538,11 @@ public class GitPr {
                   .helptext("Print the version of this tool")
                   .optional());
 
+        var actions = List.of("list", "fetch", "show", "checkout", "apply", "integrate",
+                              "approve", "create", "close", "update", "test", "status");
         var inputs = List.of(
             Input.position(0)
-                 .describe("list|fetch|show|checkout|apply|integrate|approve|create|close|update|test|status")
+                 .describe(String.join("|", actions))
                  .singular()
                  .optional(),
             Input.position(1)
@@ -604,6 +606,15 @@ public class GitPr {
             if (lines.size() == 1) {
                 action = lines.get(0);
             }
+        }
+
+        if (action == null) {
+            System.err.println("error: you must supply a valid action:");
+            for (var a : actions) {
+                System.err.println("       - " + a);
+            }
+            System.err.println("You can also configure a default action by running 'git configure --global pr.default <action>'");
+            System.exit(1);
         }
 
         if (!shouldUseToken &&


### PR DESCRIPTION
Hi all,

please review this small patch that makes `git pr` print a more friendly help
message when no action is specified.

Testing:
- Manual testing of `git pr`

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)