### PR TITLE
Avoid running the mailing list bridge too often

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/CooldownQuarantine.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/CooldownQuarantine.java
@@ -32,20 +32,26 @@ public class CooldownQuarantine {
     private final Map<String, Instant> quarantineEnd = new HashMap<>();
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots.mlbridge");
 
-    public synchronized boolean inQuarantine(PullRequest pr) {
+    enum Status {
+        NOT_IN_QUARANTINE,
+        IN_QUARANTINE,
+        JUST_RELEASED
+    }
+
+    public synchronized Status status(PullRequest pr) {
         var uniqueId = pr.webUrl().toString();
 
         if (!quarantineEnd.containsKey(uniqueId)) {
-            return false;
+            return Status.NOT_IN_QUARANTINE;
         }
         var end = quarantineEnd.get(uniqueId);
         if (end.isBefore(Instant.now())) {
             log.info("Released from cooldown quarantine: " + pr.repository().name() + "#" + pr.id());
             quarantineEnd.remove(uniqueId);
-            return false;
+            return Status.JUST_RELEASED;
         }
         log.info("Quarantined due to cooldown: " + pr.repository().name() + "#" + pr.id());
-        return true;
+        return Status.IN_QUARANTINE;
     }
 
     public synchronized void updateQuarantineEnd(PullRequest pr, Instant end) {

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBot.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBot.java
@@ -166,7 +166,12 @@ public class MailingListBridgeBot implements Bot {
         List<WorkItem> ret = new LinkedList<>();
 
         for (var pr : codeRepo.pullRequests()) {
-            if (!cooldownQuarantine.inQuarantine(pr) || updateCache.needsUpdate(pr)) {
+            var quarantineStatus = cooldownQuarantine.status(pr);
+            if (quarantineStatus == CooldownQuarantine.Status.IN_QUARANTINE) {
+                continue;
+            }
+            if ((quarantineStatus == CooldownQuarantine.Status.JUST_RELEASED) ||
+                    (quarantineStatus == CooldownQuarantine.Status.NOT_IN_QUARANTINE && updateCache.needsUpdate(pr))) {
                 ret.add(new ArchiveWorkItem(pr, this,
                                             e -> updateCache.invalidate(pr),
                                             r -> cooldownQuarantine.updateQuarantineEnd(pr, r)));


### PR DESCRIPTION
Hi all,

Please review this change that ensures that the mailing list bridge does not inspect PR's that haven't been updated when not needed - this is only needed when the cooldown period just expired.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)