### PR TITLE
merge-bot: clearer merge messages when merging between repos

### DIFF
--- a/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
+++ b/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
@@ -391,7 +391,10 @@ class MergeBot implements Bot, WorkItem {
                 if (error == null) {
                     log.info("Pushing successful merge");
                     if (!isAncestor) {
-                        repo.commit("Automatic merge of " + fromBranch + " into " + toBranch,
+                        var targetName = Path.of(target.name()).getFileName();
+                        var fromName = Path.of(fromRepo.name()).getFileName();
+                        var fromDesc = targetName.equals(fromName) ? fromBranch : fromName + ":" + fromBranch;
+                        repo.commit("Automatic merge of " + fromDesc + " into " + toBranch,
                                 "duke", "duke@openjdk.org");
                     }
                     repo.push(toBranch, target.url().toString(), false);

--- a/bots/merge/src/test/java/org/openjdk/skara/bots/merge/MergeBotTests.java
+++ b/bots/merge/src/test/java/org/openjdk/skara/bots/merge/MergeBotTests.java
@@ -109,7 +109,7 @@ class MergeBotTests {
             var known = Set.of(toHashA, fromHashB, toHashC);
             var merge = toCommits.stream().filter(c -> !known.contains(c.hash())).findAny().get();
             assertTrue(merge.isMerge());
-            assertEquals(List.of("Automatic merge of master into master"), merge.message());
+            assertEquals(List.of("Automatic merge of test:master into master"), merge.message());
             assertEquals("duke", merge.author().name());
             assertEquals("duke@openjdk.org", merge.author().email());
 
@@ -538,7 +538,7 @@ class MergeBotTests {
             var known = Set.of(toHashA, fromHashB, toHashC);
             var merge = toCommits.stream().filter(c -> !known.contains(c.hash())).findAny().get();
             assertTrue(merge.isMerge());
-            assertEquals(List.of("Automatic merge of master into master"), merge.message());
+            assertEquals(List.of("Automatic merge of test:master into master"), merge.message());
             assertEquals("duke", merge.author().name());
             assertEquals("duke@openjdk.org", merge.author().email());
 
@@ -583,7 +583,7 @@ class MergeBotTests {
             var toGitConfig = toDir.resolve(".git").resolve("config");
             Files.write(toGitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
                         StandardOpenOption.APPEND);
-            var toHostedRepo = new TestHostedRepository(host, "test-mirror", toLocalRepo);
+            var toHostedRepo = new TestHostedRepository(host, "test", toLocalRepo);
 
             var forkDir = temp.path().resolve("fork.git");
             var forkLocalRepo = Repository.init(forkDir, VCS.GIT);
@@ -774,7 +774,7 @@ class MergeBotTests {
             var known = Set.of(toHashA, fromHashB, toHashC);
             var merge = toCommits.stream().filter(c -> !known.contains(c.hash())).findAny().get();
             assertTrue(merge.isMerge());
-            assertEquals(List.of("Automatic merge of master into master"), merge.message());
+            assertEquals(List.of("Automatic merge of test:master into master"), merge.message());
             assertEquals("duke", merge.author().name());
             assertEquals("duke@openjdk.org", merge.author().email());
 
@@ -825,7 +825,7 @@ class MergeBotTests {
             var toGitConfig = toDir.resolve(".git").resolve("config");
             Files.write(toGitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
                         StandardOpenOption.APPEND);
-            var toHostedRepo = new TestHostedRepository(host, "test-mirror", toLocalRepo);
+            var toHostedRepo = new TestHostedRepository(host, "test", toLocalRepo);
 
             var forkDir = temp.path().resolve("fork.git");
             var forkLocalRepo = Repository.init(forkDir, VCS.GIT);
@@ -946,7 +946,7 @@ class MergeBotTests {
             var toGitConfig = toDir.resolve(".git").resolve("config");
             Files.write(toGitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
                         StandardOpenOption.APPEND);
-            var toHostedRepo = new TestHostedRepository(host, "test-mirror", toLocalRepo);
+            var toHostedRepo = new TestHostedRepository(host, "test", toLocalRepo);
 
             var forkDir = temp.path().resolve("fork.git");
             var forkLocalRepo = Repository.init(forkDir, VCS.GIT);


### PR DESCRIPTION
Hi all,

please review this small patch that makes the commit message a bit clearer when
the merge bot merges branches in _different_ repositories. For example, if the
bot merges openjdk/jdk:master to openjdk/panama-foreign:master, the message will
now be:

> Automatic merge of jdk:master into master

Testing:
- `make test` passes on Linux x64
- Updated unit tests to test for new message style

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)