### PR TITLE
git-sync: use ref names instead of hashes

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitSync.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitSync.java
@@ -210,7 +210,7 @@ public class GitSync {
             }
             System.out.print("Syncing " + from + "/" + name + " to " + to + "/" + name + "... ");
             System.out.flush();
-            var fetchHead = repo.fetch(fromPullPath, branch.hash().hex());
+            var fetchHead = repo.fetch(fromPullPath, branch.name());
             repo.push(fetchHead, toPushPath, name);
             System.out.println("done");
         }


### PR DESCRIPTION
Hi all,

please review this small patch that makes `git sync` avoid using SHA-1 hashes
when executing `git fetch`. There was nothing wrong with this approach, but
older `git` clients have problems when the ref to fetch is a SHA-1 hash. There
is no drawback in using the ref name instead, it only increases compatibility
with older `git` clients.

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)