### PR TITLE
merge-bot: use correct credentials when creating PR

### DIFF
--- a/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
+++ b/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
@@ -441,7 +441,10 @@ class MergeBot implements Bot, WorkItem {
                     message.add("");
                     message.add("This pull request will be closed automatically by a bot once " +
                                 "the merge conflicts have been resolved.");
-                    fork.createPullRequest(target,
+                    var prTarget = fork.forge().repository(target.name()).orElseThrow(() ->
+                            new IllegalStateException("Can't get well-known repository " + target.name())
+                    );
+                    fork.createPullRequest(prTarget,
                                            toBranch.name(),
                                            branchDesc,
                                            title,


### PR DESCRIPTION
Hi all,

please review this small fix that ensures that merge bot creates a "merge
conflict" PR with the correct credentials.

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)