### PR TITLE
merge-bot: use correct credentials for listing PRs

### DIFF
--- a/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
+++ b/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
@@ -251,8 +251,11 @@ class MergeBot implements Bot, WorkItem {
             // Must fetch once to update refs/heads
             repo.fetchAll();
 
-            var prs = target.pullRequests();
-            var currentUser = target.forge().currentUser();
+            var prTarget = fork.forge().repository(target.name()).orElseThrow(() ->
+                    new IllegalStateException("Can't get well-known repository " + target.name())
+            );
+            var prs = prTarget.pullRequests();
+            var currentUser = prTarget.forge().currentUser();
 
             for (var spec : specs) {
                 var toBranch = spec.toBranch();
@@ -441,9 +444,6 @@ class MergeBot implements Bot, WorkItem {
                     message.add("");
                     message.add("This pull request will be closed automatically by a bot once " +
                                 "the merge conflicts have been resolved.");
-                    var prTarget = fork.forge().repository(target.name()).orElseThrow(() ->
-                            new IllegalStateException("Can't get well-known repository " + target.name())
-                    );
                     fork.createPullRequest(prTarget,
                                            toBranch.name(),
                                            branchDesc,


### PR DESCRIPTION
Hi all,

please review this small patch that fixes some additional credential confusion
in the merge bot. The bot did not use correct credentials for listing the pull
requests for the target repository.

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)