### PR TITLE
Only check the head commit

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestInstance.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestInstance.java
@@ -223,7 +223,7 @@ class PullRequestInstance {
     }
 
     void executeChecks(Hash localHash, CensusInstance censusInstance, PullRequestCheckIssueVisitor visitor, List<String> additionalConfiguration) throws Exception {
-        try (var issues = JCheck.check(localRepo(), censusInstance.census(), CommitMessageParsers.v1, "HEAD~1..HEAD",
+        try (var issues = JCheck.check(localRepo(), censusInstance.census(), CommitMessageParsers.v1, "HEAD^!",
                                        localHash, new HashMap<>(), new HashSet<>(), additionalConfiguration)) {
             for (var issue : issues) {
                 issue.accept(visitor);


### PR DESCRIPTION
Hi all,

Please review this small change that ensures that jcheck only looks at the HEAD commit in a PR, i.e. the squashed one for a regular PR, or the merge commit for a merge PR.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)