### PR TITLE
git-pr: git diff can exit with code 141

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
@@ -369,7 +369,7 @@ public class GitPr {
         pb.inheritIO();
 
         // git will return 141 (128 + 13) when it receive SIGPIPE (signal 13) from
-        // e.g. less when a user exits less when looking at a large diff. Therefore 
+        // e.g. less when a user exits less when looking at a large diff. Therefore
         // must allow 141 as a valid exit code.
         await(pb.start(), 141);
     }

--- a/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
@@ -271,10 +271,13 @@ public class GitPr {
         return Optional.empty();
     }
 
-    private static void await(Process p) throws IOException {
+    private static void await(Process p, Integer... allowedExitCodes) throws IOException {
+        var allowed = new HashSet<>(Arrays.asList(allowedExitCodes));
+        allowed.add(0);
         try {
             var res = p.waitFor();
-            if (res != 0) {
+
+            if (!allowed.contains(res)) {
                 throw new IOException("Unexpected exit code " + res);
             }
         } catch (InterruptedException e) {
@@ -364,7 +367,11 @@ public class GitPr {
             pb.directory(dir.toFile());
         }
         pb.inheritIO();
-        await(pb.start());
+
+        // git will return 141 (128 + 13) when it receive SIGPIPE (signal 13) from
+        // e.g. less when a user exits less when looking at a large diff. Therefore 
+        // must allow 141 as a valid exit code.
+        await(pb.start(), 141);
     }
 
     private static void gimport() throws IOException {


### PR DESCRIPTION
Hi all,

please review this small patch that allows `git diff` to exit with code 141
during the `git pr show` command. `git diff` might exit with code 141 if it is
using a pager (e.g. `less`) that works with signals (e.g. `SIGPIPE`). For
example, if a user is viewing a large(r) patch using `git diff` using `less` and
presses "q", then `SIGPIPE` is sent to `git diff` which therefore will exit with
code 128 + 13 = 141 (`SIGPIPE` is signal 13).

The fix is simple, just make `git pr show` allow `git diff` to exit with code
141.

Testing:
- Manual testing of `git pr show`

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)