### PR TITLE
Remove unnecessary merge test

### DIFF
--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
@@ -215,61 +215,6 @@ class MergeTests {
     }
 
     @Test
-    void mergedCommitsFailingJCheck(TestInfo testInfo) throws IOException {
-        try (var credentials = new HostCredentials(testInfo);
-             var tempFolder = new TemporaryDirectory()) {
-
-            var author = credentials.getHostedRepository();
-            var integrator = credentials.getHostedRepository();
-            var censusBuilder = credentials.getCensusBuilder()
-                                           .addCommitter(author.forge().currentUser().id())
-                                           .addReviewer(integrator.forge().currentUser().id());
-            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
-
-            // Populate the projects repository
-            var localRepoFolder = tempFolder.path().resolve("localrepo");
-            var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
-            var masterHash = localRepo.resolve("master").orElseThrow();
-            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
-
-            // Make a change in another branch that will not pass jcheck
-            var otherHash = CheckableRepository.appendAndCommit(localRepo, "Change in other with trails..   ",
-                                                                "Bad change in other");
-            localRepo.push(otherHash, author.url(), "other", true);
-
-            // Go back to the original master
-            localRepo.checkout(masterHash, true);
-
-            // Make a change with a corresponding PR
-            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated", StandardCharsets.UTF_8);
-            localRepo.add(unrelated);
-            localRepo.commit("Unrelated", "some", "some@one");
-            localRepo.merge(otherHash);
-            var mergeHash = localRepo.commit("Merge commit", "some", "some@one");
-            localRepo.push(mergeHash, author.url(), "edit", true);
-            var pr = credentials.createPullRequest(author, "master", "edit", "Merge " + author.name() + ":other");
-
-            // Approve it as another user
-            var approvalPr = integrator.pullRequest(pr.id());
-            approvalPr.addReview(Review.Verdict.APPROVED, "Approved");
-
-            // Let the bot check the status
-            TestBotRunner.runPeriodicItems(mergeBot);
-
-            // Push it
-            pr.addComment("/integrate");
-            TestBotRunner.runPeriodicItems(mergeBot);
-
-            // The bot should reply with a failure message
-            var error = pr.comments().stream()
-                          .filter(comment -> comment.body().contains("did not complete successfully"))
-                          .count();
-            assertEquals(1, error, () -> pr.comments().stream().map(Comment::body).collect(Collectors.joining("\n\n")));
-        }
-    }
-
-    @Test
     void invalidSourceRepo(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
              var tempFolder = new TemporaryDirectory()) {


### PR DESCRIPTION
Hi all,

Please review this small change that removes a failing test. The test checked that all merged commits also passed jcheck, but this is not actually something that is required. (For example, when merging between projects the reviewer rules / roles are most likely different).

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)