### PR TITLE
git-pr: do not assume a master branch

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
@@ -233,9 +233,9 @@ public class GitPr {
         return issues;
     }
 
-    private static String jbsProjectFromJcheckConf(Repository repo) throws IOException {
-        var conf = JCheckConfiguration.from(repo, repo.resolve("master").orElseThrow(() ->
-            new IOException("Could not resolve 'master' branch")
+    private static String jbsProjectFromJcheckConf(Repository repo, String targetBranch) throws IOException {
+        var conf = JCheckConfiguration.from(repo, repo.resolve(targetBranch).orElseThrow(() ->
+            new IOException("Could not resolve '" + targetBranch + "' branch")
         ));
 
         return conf.general().jbs();
@@ -959,7 +959,7 @@ public class GitPr {
                 }
             }
 
-            var project = jbsProjectFromJcheckConf(repo);
+            var project = jbsProjectFromJcheckConf(repo, targetBranch);
             var issue = getIssue(currentBranch, project);
             var file = Files.createTempFile("PULL_REQUEST_", ".md");
             if (issue.isPresent()) {

--- a/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
@@ -34,6 +34,7 @@ public interface ReadOnlyRepository {
     Optional<Bookmark> currentBookmark() throws IOException;
     Branch defaultBranch() throws IOException;
     List<Branch> branches() throws IOException;
+    List<Branch> branches(String remote) throws IOException;
     Optional<Tag> defaultTag() throws IOException;
     List<Tag> tags() throws IOException;
     Commits commits() throws IOException;

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -120,6 +120,15 @@ public class GitRepository implements Repository {
         }
     }
 
+    public List<Branch> branches(String remote) throws IOException {
+        try (var p = capture("git", "for-each-ref", "--format=%(refname:short)", "refs/remotes/" + remote + "/")) {
+            return await(p).stdout()
+                           .stream()
+                           .map(Branch::new)
+                           .collect(Collectors.toList());
+        }
+    }
+
     public List<Tag> tags() throws IOException {
         try (var p = capture("git", "for-each-ref", "--format=%(refname:short)", "refs/tags")) {
             return await(p).stdout()

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -133,6 +133,12 @@ public class HgRepository implements Repository {
     }
 
     @Override
+    public List<Branch> branches(String remote) throws IOException {
+        // Mercurial does not have namespacing of branch names
+        return branches();
+    }
+
+    @Override
     public List<Tag> tags() throws IOException {
         try (var p = capture("hg", "tags")) {
             return await(p).stdout()


### PR DESCRIPTION
Hi all,

please review this patch that makes `git pr` work even though no `master` branch
is present (which is the case if you clone a repository that uses a different
default branch). The fix consists of two parts:

- Use a better algorithm for detecting the target branch. `git pr create` will
  now pick the "closest" branch that exists in the upstream (parent) repository
  as the target branch by default.
- Read the .jcheck/conf file from the target branch

Testing:
- Manually tested `git pr create` on different repositories on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)