### PR TITLE
merge-bot: update message for failed merges

### DIFF
--- a/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
+++ b/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
@@ -37,6 +37,7 @@ import java.time.Month;
 import java.time.temporal.WeekFields;
 import java.time.ZonedDateTime;
 import java.util.*;
+import java.util.stream.Collectors;
 import java.util.logging.Logger;
 
 class MergeBot implements Bot, WorkItem {
@@ -391,12 +392,12 @@ class MergeBot implements Bot, WorkItem {
                     error = e;
                 }
 
+                var targetName = Path.of(target.name()).getFileName();
+                var fromName = Path.of(fromRepo.name()).getFileName();
+                var fromDesc = targetName.equals(fromName) ? fromBranch : fromName + ":" + fromBranch;
                 if (error == null) {
                     log.info("Pushing successful merge");
                     if (!isAncestor) {
-                        var targetName = Path.of(target.name()).getFileName();
-                        var fromName = Path.of(fromRepo.name()).getFileName();
-                        var fromDesc = targetName.equals(fromName) ? fromBranch : fromName + ":" + fromBranch;
                         repo.commit("Automatic merge of " + fromDesc + " into " + toBranch,
                                 "duke", "duke@openjdk.org");
                     }
@@ -404,6 +405,7 @@ class MergeBot implements Bot, WorkItem {
                 } else {
                     log.info("Got error: " + error.getMessage());
                     log.info("Aborting unsuccesful merge");
+                    var status = repo.status();
                     repo.abortMerge();
 
                     var fromRepoName = Path.of(fromRepo.webUrl().getPath()).getFileName();
@@ -412,23 +414,44 @@ class MergeBot implements Bot, WorkItem {
 
                     log.info("Creating pull request to alert");
                     var mergeBase = repo.mergeBase(fetchHead, head);
-                    var commits = repo.commits(mergeBase.hex() + ".." + fetchHead.hex(), true).asList();
 
                     var message = new ArrayList<String>();
                     message.add(marker);
                     message.add("<!-- " + fetchHead.hex() + " -->");
-                    message.add("The following commits from `" + fromRepo.name() + ":" + fromBranch.name() +
-                                "` could *not* be automatically merged into `" + toBranch.name() + "`:");
-                    message.add("");
-                    for (var commit : commits) {
-                        message.add("- " + commit.hash().abbreviate() + ": " + commit.message().get(0));
+
+                    var commits = repo.commits(mergeBase.hex() + ".." + fetchHead.hex(), true).asList();
+                    if (commits.size() <= 10) {
+                        message.add("The following commits from " + fromDesc + " could *not* be " +
+                                    "automatically merged into " + toBranch.name() + ":");
+                        message.add("");
+                        for (var commit : commits) {
+                            message.add("- " + commit.hash().abbreviate() + ": " + commit.message().get(0));
+                        }
+                        message.add("");
+                    } else {
+                        message.add("Could *not* automatically merge " + commits.size() + " commits from " +
+                                    fromDesc + " into " + toBranch.name() + ".");
+                    }
+
+                    var unmerged = status.stream().filter(s -> s.status().isUnmerged()).collect(Collectors.toList());
+                    if (unmerged.size() <= 10) {
+                        message.add("The following files contains merge conflicts:");
+                        message.add("");
+                        for (var fileStatus : unmerged) {
+                            message.add("- " + fileStatus.source().path().orElseThrow());
+                        }
+                    } else {
+                        message.add("Over " + unmerged.size() + " files contains merge conflicts.");
                     }
                     message.add("");
+
                     message.add("To manually resolve these merge conflicts, please create a personal fork of " +
                                 target.webUrl() + " and execute the following commands:");
                     message.add("");
                     message.add("```bash");
                     message.add("$ git checkout " + toBranch.name());
+                    message.add("$ git pull " + target.webUrl() + " " + toBranch.name());
+                    message.add("$ git checkout --branch merge-" + fromBranch.name() + "-into-" + toBranch.name());
                     message.add("$ git pull " + fromRepo.webUrl() + " " + fromBranch.name());
                     message.add("```");
                     message.add("");
@@ -436,11 +459,22 @@ class MergeBot implements Bot, WorkItem {
                     message.add("");
                     message.add("```bash");
                     message.add("$ git add paths/to/files/with/conflicts");
-                    message.add("$ git commit -m 'Merge'");
+                    message.add("$ git commit -m 'Merge " + fromDesc + "'");
                     message.add("```");
                     message.add("");
-                    message.add("Push the resolved merge conflict to your personal fork and " +
-                                "create a pull request towards this repository.");
+                    message.add("Push the merge commit to your personal fork:");
+                    message.add("");
+                    message.add("```bash");
+                    message.add("$ git push -u origin merge-" + fromBranch.name() + "-into-" + toBranch.name());
+                    message.add("```");
+                    message.add("");
+                    message.add("Now processed to create a pull request towards this repository.");
+                    message.add("If you are using the [Skara](https://wiki.openjdk.java.net/display/skara#Skara-Skara)" +
+                                "CLI tooling then you can run the following command to create the pull request:");
+                    message.add("");
+                    message.add("```bash");
+                    message.add("$ git pr create");
+                    message.add("```");
                     message.add("");
                     message.add("This pull request will be closed automatically by a bot once " +
                                 "the merge conflicts have been resolved.");

--- a/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
+++ b/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
@@ -468,7 +468,7 @@ class MergeBot implements Bot, WorkItem {
                     message.add("$ git push -u origin merge-" + fromBranch.name() + "-into-" + toBranch.name());
                     message.add("```");
                     message.add("");
-                    message.add("Now processed to create a pull request towards this repository.");
+                    message.add("Now proceed to create a pull request towards this repository.");
                     message.add("If you are using the [Skara](https://wiki.openjdk.java.net/display/skara#Skara-Skara)" +
                                 "CLI tooling then you can run the following command to create the pull request:");
                     message.add("");

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/TestRepository.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/TestRepository.java
@@ -233,6 +233,10 @@ class TestRepository implements ReadOnlyRepository {
         return Collections.emptyList();
     }
 
+    public List<StatusEntry> status() throws IOException {
+        return Collections.emptyList();
+    }
+
     public boolean contains(Branch b, Hash h) throws IOException {
         return false;
     }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
@@ -78,6 +78,7 @@ public interface ReadOnlyRepository {
 
     void dump(FileEntry entry, Path to) throws IOException;
     List<StatusEntry> status(Hash from, Hash to) throws IOException;
+    List<StatusEntry> status() throws IOException;
     Diff diff(Hash base, Hash head) throws IOException;
     Diff diff(Hash base, Hash head, List<Path> files) throws IOException;
     Diff diff(Hash head) throws IOException;

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Status.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Status.java
@@ -30,7 +30,8 @@ public class Status {
         DELETED,
         RENAMED,
         COPIED,
-        MODIFIED
+        MODIFIED,
+        UNMERGED
     }
 
     private Operation op;
@@ -61,6 +62,10 @@ public class Status {
         return op == Operation.MODIFIED;
     }
 
+    public boolean isUnmerged() {
+        return op == Operation.UNMERGED;
+    }
+
     public int score() {
         return score;
     }
@@ -76,6 +81,10 @@ public class Status {
 
         if (c == 'D') {
             return new Status(Operation.DELETED, -1);
+        }
+
+        if (c == 'U') {
+            return new Status(Operation.UNMERGED, -1);
         }
 
         if (c == 'R') {
@@ -103,6 +112,9 @@ public class Status {
         }
         if (c == 'D') {
             return new Status(Operation.DELETED, -1);
+        }
+        if (c == 'U') {
+            return new Status(Operation.UNMERGED, -1);
         }
 
         var score = 0;
@@ -135,6 +147,8 @@ public class Status {
                 return "D";
             case MODIFIED:
                 return "M";
+            case UNMERGED:
+                return "U";
             case RENAMED:
                 return "R" + score;
             case COPIED:

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -827,7 +827,20 @@ public class GitRepository implements Repository {
 
     @Override
     public List<StatusEntry> status(Hash from, Hash to) throws IOException {
-        try (var p = capture("git", "diff", "--raw", "--find-renames=99%", "--find-copies=99%", "--find-copies-harder", "--no-abbrev", "--no-color", from.hex(), to.hex())) {
+        var cmd = new ArrayList<String>();
+        cmd.addAll(List.of("git", "diff", "--raw",
+                                          "--find-renames=99%",
+                                          "--find-copies=99%",
+                                          "--find-copies-harder",
+                                          "--no-abbrev",
+                                          "--no-color"));
+        if (from != null) {
+            cmd.add(from.hex());
+        }
+        if (to != null) {
+            cmd.add(to.hex());
+        }
+        try (var p = capture(cmd)) {
             var res = await(p);
             var entries = new ArrayList<StatusEntry>();
             for (var line : res.stdout()) {
@@ -835,6 +848,11 @@ public class GitRepository implements Repository {
             }
             return entries;
         }
+    }
+
+    @Override
+    public List<StatusEntry> status() throws IOException {
+        return status(null, null);
     }
 
     @Override

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -750,6 +750,12 @@ public class HgRepository implements Repository {
     }
 
     @Override
+    public List<StatusEntry> status() throws IOException {
+        // TODO: can use merge.mergestate.read(repo) to implement diff-git-raw-workspace
+        throw new RuntimeException("Not implemented yet");
+    }
+
+    @Override
     public void dump(FileEntry entry, Path to) throws IOException {
         var output = to.toAbsolutePath();
         try (var p = capture("hg", "cat", "--output=" + output.toString(),

--- a/vcs/src/main/java/org/openjdk/skara/vcs/tools/PatchHeader.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/tools/PatchHeader.java
@@ -101,6 +101,8 @@ public class PatchHeader {
             targetPath = Path.of(parts[1]);
         } else if (status.isDeleted()) {
             sourcePath = Path.of(parts[1]);
+        } else if (status.isUnmerged()) {
+            sourcePath = Path.of(parts[1]);
         } else {
             // either copied or renamed
             sourcePath = Path.of(parts[1]);

--- a/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
@@ -2076,4 +2076,41 @@ public class RepositoryTests {
             assertEquals(List.of(upstream.defaultBranch()), upstreamBranches);
         }
     }
+
+    @ParameterizedTest
+    @EnumSource(VCS.class)
+    void testUnmergedStatus(VCS vcs) throws IOException {
+        assumeTrue(vcs == VCS.GIT);
+        try (var dir = new TemporaryDirectory(false)) {
+            var r = Repository.init(dir.path(), vcs);
+
+            var readme = dir.path().resolve("README");
+            Files.write(readme, List.of("Hello, world!"));
+            r.add(readme);
+            var first = r.commit("Added README", "duke", "duke@openjdk.java.net");
+
+            Files.write(readme, List.of("One more line"), WRITE, APPEND);
+            r.add(readme);
+            var second = r.commit("Modified README", "duke", "duke@openjdk.java.net");
+
+            r.checkout(first, false);
+
+            Files.write(readme, List.of("Another line"), WRITE, APPEND);
+            r.add(readme);
+            var third = r.commit("Modified README again", "duke", "duke@openjdk.java.net");
+
+            assertThrows(IOException.class, () -> { r.merge(second); });
+
+            var status = r.status();
+            for (var s : status) {
+                System.out.println(s.status() + " " + s.source().path().get());
+            }
+            assertEquals(2, status.size());
+            var statusEntry = status.get(0);
+            assertTrue(statusEntry.status().isUnmerged());
+            assertEquals(Path.of("README"), statusEntry.source().path().get());
+            assertEquals(Optional.empty(), statusEntry.source().type());
+            assertEquals("0".repeat(40), statusEntry.source().hash().hex());
+        }
+    }
 }


### PR DESCRIPTION
Hi all,

please review this patch that updates the merge bot to produce a nicer message
(and clearer instructions) in the failed merge pull requests. The message will
now include the files that contains merge conflicts. I also updated the message
to limit the number of files and commits it lists (currently capped to ten
each). Finally I also fixed the instructions for fixing a merge conflict to be
correct :smile:

Testing:
- added unit test for `ReadOnlyRepository::status`
- `make test` passes on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**) **Note!** Review applies to 176d03a497297daf4f439fdf89f90776fcf1d00a