### PR TITLE
Always set commit_id and comments when adding review

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -122,6 +122,8 @@ public class GitHubPullRequest implements PullRequest {
                 break;
         }
         query.put("body", body);
+        query.put("commit_id", headHash().hex());
+        query.put("comments", JSON.array());
         request.post("pulls/" + json.get("number").toString() + "/reviews")
                .body(query)
                .execute();


### PR DESCRIPTION
Hi all,

please review this small patch that ensures that we always set the fields
`commit_id` and `comments` when adding a review to a GitHub pull request.

Testing:
- Manual testing using `git pr approve`

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)