### PR TITLE
git-pr: status cannot handle rfr label correctly

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
@@ -161,16 +161,16 @@ public class GitPr {
         var labels = pr.labels();
         if (pr.isDraft()) {
             return "DRAFT";
-        } else if (labels.contains("rfr")) {
-            return "RFR";
+        } else if (labels.contains("integrated")) {
+            return "INTEGRATED";
         } else if (labels.contains("ready")) {
             return "READY";
+        } else if (labels.contains("rfr")) {
+            return "RFR";
         } else if (labels.contains("outdated")) {
             return "OUTDATED";
         } else if (labels.contains("oca")) {
             return "OCA";
-        } else if (labels.contains("integrated")) {
-            return "INTEGRATED";
         } else {
             var checks = pr.checks(pr.headHash());
             var jcheck = Optional.ofNullable(checks.get("jcheck"));


### PR DESCRIPTION
Hi all,

please review this small pull request that updates how the status for a pull
request is calculated. We changed a while back to keep the "rfr" label on pull
requests that are ready (a PR is still "ready for review" even if it already has
been reviewed). `git pr status` wasn't updated however, so it printed the wrong
status for pull requests. This patch fixes this issue, so `git pr status` once
again works correctly.

Testing:
- Manual testing of `git pr status` and `git pr list`

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)