### PR TITLE
contributor command: better validation of input

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ContributorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ContributorCommand.java
@@ -25,6 +25,7 @@ package org.openjdk.skara.bots.pr;
 import org.openjdk.skara.email.EmailAddress;
 import org.openjdk.skara.forge.PullRequest;
 import org.openjdk.skara.issuetracker.Comment;
+import org.openjdk.skara.vcs.openjdk.CommitMessageSyntax;
 
 import java.io.PrintWriter;
 import java.nio.file.Path;
@@ -33,6 +34,8 @@ import java.util.regex.Pattern;
 
 public class ContributorCommand implements CommandHandler {
     private static final Pattern commandPattern = Pattern.compile("^(add|remove)\\s+(.*?\\s+<\\S+>)$");
+    private static final Pattern fullNamePattern = Pattern.compile(CommitMessageSyntax.REAL_NAME_REGEX);
+    private static final Pattern emailPattern = Pattern.compile(CommitMessageSyntax.EMAIL_ADDR_REGEX);
 
     @Override
     public void handle(PullRequestBot bot, PullRequest pr, CensusInstance censusInstance, Path scratchPath, String args, Comment comment, List<Comment> allComments, PrintWriter reply) {
@@ -49,11 +52,21 @@ public class ContributorCommand implements CommandHandler {
 
         var contributor = EmailAddress.parse(matcher.group(2));
         switch (matcher.group(1)) {
-            case "add":
+            case "add": {
+                var fullName = contributor.fullName().orElseThrow(IllegalStateException::new);
+                if (!fullNamePattern.matcher(fullName).matches()) {
+                    reply.println("The full name is *not* of the format " + CommitMessageSyntax.REAL_NAME_REGEX);
+                    break;
+                }
+                if (!emailPattern.matcher(contributor.address()).matches()) {
+                    reply.println("The email is *not* of the format " + CommitMessageSyntax.EMAIL_ADDR_REGEX);
+                    break;
+                }
                 reply.println(Contributors.addContributorMarker(contributor));
                 reply.println("Contributor `" + contributor.toString() + "` successfully added.");
                 break;
-            case "remove":
+            }
+            case "remove": {
                 var existing = new HashSet<>(Contributors.contributors(pr.repository().forge().currentUser(), allComments));
                 if (existing.contains(contributor)) {
                     reply.println(Contributors.removeContributorMarker(contributor));
@@ -63,6 +76,7 @@ public class ContributorCommand implements CommandHandler {
                     break;
                 }
                 break;
+            }
         }
     }
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ContributorTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ContributorTests.java
@@ -182,4 +182,70 @@ class ContributorTests {
             assertEquals(1, error);
         }
     }
+
+    @Test
+    void invalidFullName(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var integrator = credentials.getHostedRepository();
+
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addReviewer(integrator.forge().currentUser().id())
+                                           .addCommitter(author.forge().currentUser().id());
+            var prBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
+
+            // Populate the projects repository
+            var localRepoFolder = tempFolder.path().resolve("localrepo");
+            var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
+
+            // Use an invalid full name
+            pr.addComment("/contributor add Foo! Bar <foo.bar@host.com>");
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // The bot should reply with an error message
+            assertLastCommentContains(pr, "The full name is *not* of the format");
+        }
+    }
+
+    @Test
+    void invalidEmail(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var integrator = credentials.getHostedRepository();
+
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addReviewer(integrator.forge().currentUser().id())
+                                           .addCommitter(author.forge().currentUser().id());
+            var prBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
+
+            // Populate the projects repository
+            var localRepoFolder = tempFolder.path().resolve("localrepo");
+            var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
+
+            // Use an invalid full name
+            pr.addComment("/contributor add Foo Bar <Foo.Bar@host.com>");
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // The bot should reply with an error message
+            assertLastCommentContains(pr, "The email is *not* of the format");
+        }
+    }
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/CommitMessageSyntax.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/CommitMessageSyntax.java
@@ -26,8 +26,8 @@ import java.util.regex.Pattern;
 
 public class CommitMessageSyntax {
         private static final String OPENJDK_USERNAME_REGEX = "[-.a-z0-9]+";
-        private static final String EMAIL_ADDR_REGEX = "[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]+";
-        private static final String REAL_NAME_REGEX = "[-_a-zA-Z0-9][-_ a-zA-Z0-9'.]+";
+        public static final String EMAIL_ADDR_REGEX = "[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]+";
+        public static final String REAL_NAME_REGEX = "[-_a-zA-Z0-9][-_ a-zA-Z0-9'.]+";
         private static final String REAL_NAME_AND_EMAIL_ATTR_REGEX = REAL_NAME_REGEX + " +<" + EMAIL_ADDR_REGEX + ">";
         private static final String ATTR_REGEX = "(?:(?:" + EMAIL_ADDR_REGEX + ")|(?:" + REAL_NAME_AND_EMAIL_ATTR_REGEX + "))";
 


### PR DESCRIPTION
Hi all,

please review this patch that adds a bit more strict validation of the input to
the `/contributor add` command. This is done to ensure that the resulting
`Co-authored-by` trailer in the final commit message will be approved by jcheck.

Testing:
- Added two additional unit tests for validation
- `make test` passes on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)