### PR TITLE
Standardize pr bot scratch folder names and detect invalid directories

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -149,7 +149,7 @@ class CheckWorkItem extends PullRequestWorkItem {
 
             try {
                 var seedPath = bot.seedStorage().orElse(scratchPath.resolve("seeds"));
-                var prInstance = new PullRequestInstance(scratchPath.resolve("pr"),
+                var prInstance = new PullRequestInstance(scratchPath.resolve("pr").resolve("check"),
                                                          new HostedRepositoryPool(seedPath),
                                                          pr,
                                                          bot.ignoreStaleReviews());

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandWorkItem.java
@@ -147,7 +147,7 @@ public class CommandWorkItem extends PullRequestWorkItem {
 
         var census = CensusInstance.create(bot.censusRepo(), bot.censusRef(), scratchPath.resolve("census"), pr);
         for (var entry : unprocessedCommands) {
-            processCommand(pr, census, scratchPath.resolve("pr"), entry.getKey(), entry.getValue(), comments);
+            processCommand(pr, census, scratchPath.resolve("pr").resolve("command"), entry.getKey(), entry.getValue(), comments);
         }
     }
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
@@ -76,7 +76,7 @@ public class IntegrateCommand implements CommandHandler {
         // Run a final jcheck to ensure the change has been properly reviewed
         try {
             var sanitizedUrl = URLEncoder.encode(pr.repository().webUrl().toString(), StandardCharsets.UTF_8);
-            var path = scratchPath.resolve("pr.integrate").resolve(sanitizedUrl);
+            var path = scratchPath.resolve("integrate").resolve(sanitizedUrl);
 
             var seedPath = bot.seedStorage().orElse(scratchPath.resolve("seeds"));
             var prInstance = new PullRequestInstance(path,

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
@@ -64,7 +64,7 @@ public class LabelerWorkItem extends PullRequestWorkItem {
         }
         try {
             var seedPath = bot.seedStorage().orElse(scratchPath.resolve("seeds"));
-            var prInstance = new PullRequestInstance(scratchPath.resolve("labeler"),
+            var prInstance = new PullRequestInstance(scratchPath.resolve("pr").resolve("labeler"),
                                                      new HostedRepositoryPool(seedPath),
                                                      pr,
                                                      bot.ignoreStaleReviews());

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
@@ -71,7 +71,7 @@ public class SponsorCommand implements CommandHandler {
         // Execute merge
         try {
             var sanitizedUrl = URLEncoder.encode(pr.repository().webUrl().toString(), StandardCharsets.UTF_8);
-            var path = scratchPath.resolve("pr.sponsor").resolve(sanitizedUrl);
+            var path = scratchPath.resolve("sponsor").resolve(sanitizedUrl);
 
             var seedPath = bot.seedStorage().orElse(scratchPath.resolve("seeds"));
             var prInstance = new PullRequestInstance(path,

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepositoryPool.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepositoryPool.java
@@ -112,16 +112,18 @@ public class HostedRepositoryPool {
                     log.throwing("HostedRepositoryInstance", "preserveOldClone", e);
                 }
             }
-            var preserved = seed.resolveSibling(seed.getFileName().toString() + "-" + reason + "-" + UUID.randomUUID());
-            log.severe("Invalid local repository detected (" + reason + ") - preserved in: " + preserved);
-            try {
-                Files.move(path, preserved);
-            } catch (IOException e) {
-                log.severe("Failed to preserve old clone at " + path);
-                log.throwing("HostedRepositoryInstance", "preserveOldClone", e);
-            } finally {
-                if (Files.exists(path)) {
-                    clearDirectory(path);
+            if (Files.exists(path)) {
+                var preserved = seed.resolveSibling(seed.getFileName().toString() + "-" + reason + "-" + UUID.randomUUID());
+                log.severe("Invalid local repository detected (" + reason + ") - preserved in: " + preserved);
+                try {
+                    Files.move(path, preserved);
+                } catch (IOException e) {
+                    log.severe("Failed to preserve old clone at " + path);
+                    log.throwing("HostedRepositoryInstance", "preserveOldClone", e);
+                } finally {
+                    if (Files.exists(path)) {
+                        clearDirectory(path);
+                    }
                 }
             }
         }
@@ -129,6 +131,7 @@ public class HostedRepositoryPool {
         private NewClone materializeClone(Path path) throws IOException {
             var localRepo = Repository.get(path);
             if (localRepo.isEmpty()) {
+                removeOldClone(path, "norepo");
                 return fetchRef(cloneSeeded(path));
             } else {
                 var localRepoInstance = localRepo.get();


### PR DESCRIPTION
Hi all,

Please review this small change that ensures that the PR bot uses unique folders for scratch repositories, and removes invalid destination directories before attempting a fresh clone.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)