### PR TITLE
contributor command: friendlier message when removing contributor

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ContributorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ContributorCommand.java
@@ -72,7 +72,15 @@ public class ContributorCommand implements CommandHandler {
                     reply.println(Contributors.removeContributorMarker(contributor));
                     reply.println("Contributor `" + contributor.toString() + "` successfully removed.");
                 } else {
-                    reply.println("Contributor `" + contributor.toString() + "` was not found.");
+                    if (existing.isEmpty()) {
+                        reply.println("There are no additional contributors associated with this pull request.");
+                    } else {
+                        reply.println("Contributor `" + contributor.toString() + "` was not found.");
+                        reply.println("Current additional contributors are:");
+                        for (var e : existing) {
+                            reply.println("- `" + e.toString() + "`");
+                        }
+                    }
                     break;
                 }
                 break;

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ContributorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ContributorCommand.java
@@ -55,11 +55,11 @@ public class ContributorCommand implements CommandHandler {
             case "add": {
                 var fullName = contributor.fullName().orElseThrow(IllegalStateException::new);
                 if (!fullNamePattern.matcher(fullName).matches()) {
-                    reply.println("The full name is *not* of the format " + CommitMessageSyntax.REAL_NAME_REGEX);
+                    reply.println("The full name is *not* of the format `" + CommitMessageSyntax.REAL_NAME_REGEX + "`");
                     break;
                 }
                 if (!emailPattern.matcher(contributor.address()).matches()) {
-                    reply.println("The email is *not* of the format " + CommitMessageSyntax.EMAIL_ADDR_REGEX);
+                    reply.println("The email is *not* of the format `" + CommitMessageSyntax.EMAIL_ADDR_REGEX + "`");
                     break;
                 }
                 reply.println(Contributors.addContributorMarker(contributor));

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ContributorTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ContributorTests.java
@@ -84,7 +84,7 @@ class ContributorTests {
             TestBotRunner.runPeriodicItems(prBot);
 
             // The bot should reply with an error message
-            assertLastCommentContains(pr,"was not found");
+            assertLastCommentContains(pr,"There are no additional contributors associated with this pull request");
 
             // Now add someone back again
             pr.addComment("/contributor add Test Person <test@test.test>");
@@ -246,6 +246,54 @@ class ContributorTests {
 
             // The bot should reply with an error message
             assertLastCommentContains(pr, "The email is *not* of the format");
+        }
+    }
+
+    @Test
+    void removeContributor(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var integrator = credentials.getHostedRepository();
+
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addReviewer(integrator.forge().currentUser().id())
+                                           .addCommitter(author.forge().currentUser().id());
+            var prBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
+
+            // Populate the projects repository
+            var localRepoFolder = tempFolder.path().resolve("localrepo");
+            var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
+
+            // Remove a contributor that hasn't been added
+            pr.addComment("/contributor remove Foo Bar <foo.bar@host.com>");
+            TestBotRunner.runPeriodicItems(prBot);
+            assertLastCommentContains(pr, "There are no additional contributors associated with this pull request.");
+
+            // Add a contributor
+            pr.addComment("/contributor add Foo Bar <foo.bar@host.com>");
+            TestBotRunner.runPeriodicItems(prBot);
+            assertLastCommentContains(pr, "successfully added.");
+
+            // Remove another (not added) contributor
+            pr.addComment("/contributor remove Baz Bar <baz.bar@host.com>");
+            TestBotRunner.runPeriodicItems(prBot);
+            assertLastCommentContains(pr, "Contributor `Baz Bar <baz.bar@host.com>` was not found.");
+            assertLastCommentContains(pr, "Current additional contributors are:");
+            assertLastCommentContains(pr, "- `Foo Bar <foo.bar@host.com>`");
+
+            // Remove an existing contributor
+            pr.addComment("/contributor remove Foo Bar <foo.bar@host.com>");
+            TestBotRunner.runPeriodicItems(prBot);
+            assertLastCommentContains(pr, "successfully removed.");
         }
     }
 }


### PR DESCRIPTION
Hi all,

please review this patch that prints a bit friendlier message when removing a
contributors. The message will now include the contributors associated with the
pull request _if_ the given contributor is not one of them.

Testing:
- added a new unit test for the feature
- `make test` passes on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)