### PR TITLE
Use different scratch folders for different repos

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestInstance.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestInstance.java
@@ -49,7 +49,7 @@ class PullRequestInstance {
 
         // Materialize the PR's source and target ref
         var repository = pr.repository();
-        localRepo = hostedRepositoryPool.checkout(pr, localRepoPath);
+        localRepo = hostedRepositoryPool.checkout(pr, localRepoPath.resolve(repository.name()));
         localRepo.fetch(repository.url(), "+" + pr.targetRef() + ":pr_prinstance");
 
         targetHash = pr.targetHash();


### PR DESCRIPTION
Hi all,

Please review this small change that ensures that different repositories get different scratch folders when inspected by the pullrequest bot, which should increase performance.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)