### PR TITLE
Check updated PRs for mailing list archive bridging

### DIFF
--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -1642,26 +1642,36 @@ class MailingListBridgeBotTests {
 
             // Make a comment and run the check within the cooldown period
             int counter;
+            boolean noMailReceived = false;
             for (counter = 1; counter < 10; ++counter) {
                 var start = Instant.now();
                 pr.addComment("Looks good - " + counter + " -");
 
                 // The bot should not bridge the comment due to cooldown
                 TestBotRunner.runPeriodicItems(mlBot);
+                try {
+                    noMailReceived = false;
+                    listServer.processIncoming(Duration.ofMillis(1));
+                } catch (RuntimeException e) {
+                    noMailReceived = true;
+                }
                 var elapsed = Duration.between(start, Instant.now());
                 if (elapsed.compareTo(cooldown) < 0) {
                     break;
                 } else {
                     log.info("Didn't do the test in time - retrying (elapsed: " + elapsed + " required: " + cooldown + ")");
-                    // Make sure to run the bot once more after the cooldown has expired to reset the state
+                    // Ensure that the cooldown expires
                     Thread.sleep(cooldown.toMillis());
-                    TestBotRunner.runPeriodicItems(mlBot);
-                    listServer.processIncoming();
+                    // If no mail was received, we have to flush it out
+                    if (noMailReceived) {
+                        TestBotRunner.runPeriodicItems(mlBot);
+                        listServer.processIncoming();
+                    }
                     cooldown = cooldown.multipliedBy(2);
                     mlBot = mlBotBuilder.cooldown(cooldown).build();
                 }
             }
-            assertThrows(RuntimeException.class, () -> listServer.processIncoming(Duration.ofMillis(1)));
+            assertTrue(noMailReceived);
 
             // But after the cooldown period has passed, it should
             Thread.sleep(cooldown.toMillis());
@@ -1724,6 +1734,7 @@ class MailingListBridgeBotTests {
 
             // Make a new revision and run the check within the cooldown period
             int counter;
+            boolean noMailReceived = false;
             for (counter = 1; counter < 10; ++counter) {
                 var start = Instant.now();
                 var revHash = CheckableRepository.appendAndCommit(localRepo, "more stuff", "Update number - " + counter + " -");
@@ -1731,20 +1742,29 @@ class MailingListBridgeBotTests {
 
                 // The bot should not bridge the new revision due to cooldown
                 TestBotRunner.runPeriodicItems(mlBot);
+                try {
+                    noMailReceived = false;
+                    listServer.processIncoming(Duration.ofMillis(1));
+                } catch (RuntimeException e) {
+                    noMailReceived = true;
+                }
                 var elapsed = Duration.between(start, Instant.now());
                 if (elapsed.compareTo(cooldown) < 0) {
                     break;
                 } else {
                     log.info("Didn't do the test in time - retrying (elapsed: " + elapsed + " required: " + cooldown + ")");
-                    // Make sure to run the bot once more after the cooldown has expired to reset the state
+                    // Ensure that the cooldown expires
                     Thread.sleep(cooldown.toMillis());
-                    TestBotRunner.runPeriodicItems(mlBot);
-                    listServer.processIncoming();
+                    // If no mail was received, we have to flush it out
+                    if (noMailReceived) {
+                        TestBotRunner.runPeriodicItems(mlBot);
+                        listServer.processIncoming();
+                    }
                     cooldown = cooldown.multipliedBy(2);
                     mlBot = mlBotBuilder.cooldown(cooldown).build();
                 }
             }
-            assertThrows(RuntimeException.class, () -> listServer.processIncoming(Duration.ofMillis(1)));
+            assertTrue(noMailReceived);
 
             // But after the cooldown period has passed, it should
             Thread.sleep(cooldown.toMillis());

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
@@ -27,6 +27,7 @@ import org.openjdk.skara.json.JSONValue;
 import org.openjdk.skara.vcs.*;
 
 import java.net.URI;
+import java.time.ZonedDateTime;
 import java.util.*;
 
 class InMemoryHostedRepository implements HostedRepository {
@@ -57,6 +58,11 @@ class InMemoryHostedRepository implements HostedRepository {
 
     @Override
     public List<PullRequest> pullRequests() {
+        return null;
+    }
+
+    @Override
+    public List<PullRequest> pullRequests(ZonedDateTime updatedAfter) {
         return null;
     }
 

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
@@ -26,6 +26,7 @@ import org.openjdk.skara.json.JSONValue;
 import org.openjdk.skara.vcs.*;
 
 import java.net.URI;
+import java.time.ZonedDateTime;
 import java.util.*;
 
 public interface HostedRepository {
@@ -37,7 +38,18 @@ public interface HostedRepository {
                                   List<String> body,
                                   boolean draft);
     PullRequest pullRequest(String id);
+
+    /**
+     * Returns a list of all open pull requests.
+     */
     List<PullRequest> pullRequests();
+
+    /**
+     * Returns a list of all pull requests (both open and closed) that have been updated after the
+     * provided time, ordered by latest updated first. If there are many pull requests that
+     * match, the list may have been truncated.
+     */
+    List<PullRequest> pullRequests(ZonedDateTime updatedAfter);
     List<PullRequest> findPullRequestsWithComment(String author, String body);
     Optional<PullRequest> parsePullRequestUrl(String url);
     String name();

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -29,6 +29,7 @@ import org.openjdk.skara.vcs.*;
 
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -126,6 +127,19 @@ public class GitHubRepository implements HostedRepository {
     public List<PullRequest> pullRequests() {
         return request.get("pulls").execute().asArray().stream()
                       .map(jsonValue -> new GitHubPullRequest(this, jsonValue, request))
+                      .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<PullRequest> pullRequests(ZonedDateTime updatedAfter) {
+        return request.get("pulls")
+                      .param("state", "all")
+                      .param("sort", "updated")
+                      .param("direction", "desc")
+                      .maxPages(1)
+                      .execute().asArray().stream()
+                      .map(jsonValue -> new GitHubPullRequest(this, jsonValue, request))
+                      .filter(pr -> pr.updatedAt().isAfter(updatedAfter))
                       .collect(Collectors.toList());
     }
 

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -29,7 +29,8 @@ import org.openjdk.skara.vcs.*;
 
 import java.net.*;
 import java.nio.charset.StandardCharsets;
-import java.time.Duration;
+import java.time.*;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -107,6 +108,16 @@ public class GitLabRepository implements HostedRepository {
     public List<PullRequest> pullRequests() {
         return request.get("merge_requests")
                       .param("state", "opened")
+                      .execute().stream()
+                      .map(value -> new GitLabMergeRequest(this, value, request))
+                      .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<PullRequest> pullRequests(ZonedDateTime updatedAfter) {
+        return request.get("merge_requests")
+                      .param("order_by", "updated_at")
+                      .param("updated_after", updatedAfter.format(DateTimeFormatter.ISO_DATE_TIME))
                       .execute().stream()
                       .map(value -> new GitLabMergeRequest(this, value, request))
                       .collect(Collectors.toList());

--- a/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
@@ -29,6 +29,7 @@ import org.openjdk.skara.vcs.*;
 import java.io.*;
 import java.net.*;
 import java.nio.file.Path;
+import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -70,6 +71,14 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
     @Override
     public List<PullRequest> pullRequests() {
         return new ArrayList<>(host.getPullRequests(this));
+    }
+
+    @Override
+    public List<PullRequest> pullRequests(ZonedDateTime updatedAfter) {
+        return host.getPullRequests(this).stream()
+                   .filter(pr -> pr.updatedAt().isAfter(updatedAfter))
+                   .sorted(Comparator.comparing(PullRequest::updatedAt).reversed())
+                   .collect(Collectors.toList());
     }
 
     @Override


### PR DESCRIPTION
Hi all,

Please review this change that introduces support for fetching pull requests updated after a certain time/date. This allows catching comments made to closed PRs, without having to check every closed PR (which would be too expensive). 

Since certain forges (e.g. GitLab) do not update the updatedAt on every type of update, perform the regular check on all open issues periodically as well to catch any such updates.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)