### PR TITLE
Add checkout instructions to PR body

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -346,7 +346,7 @@ class CheckRun {
 
         progressBody.append("\n\n## Instructions\n");
         progressBody.append("To checkout these changes locally:\n");
-        progressBody.append(bashCodeBlock(checkoutCommands(pr)));
+        progressBody.append(bashCodeBlock(checkoutCommands()));
 
         return progressBody.toString();
     }
@@ -355,7 +355,7 @@ class CheckRun {
         return "```bash\n" + content + "```\n";
     }
 
-    private static String checkoutCommands(PullRequest pr) {
+    private String checkoutCommands() {
         var repoUrl = pr.repository().webUrl();
         return
            "$ git fetch " + repoUrl + " " + pr.fetchRef() + ":pull/" + pr.id() + "\n" +

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -302,7 +302,7 @@ class CheckRun {
 
     private String getStatusMessage(List<Comment> comments, List<Review> reviews, PullRequestCheckIssueVisitor visitor) {
         var progressBody = new StringBuilder();
-        progressBody.append("</hr>");
+        progressBody.append("---------");
         progressBody.append("### Progress\n");
         progressBody.append(getChecksList(visitor));
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -302,7 +302,8 @@ class CheckRun {
 
     private String getStatusMessage(List<Comment> comments, List<Review> reviews, PullRequestCheckIssueVisitor visitor) {
         var progressBody = new StringBuilder();
-        progressBody.append("## Progress\n");
+        progressBody.append("</hr>");
+        progressBody.append("### Progress\n");
         progressBody.append(getChecksList(visitor));
 
         var issue = Issue.fromString(pr.title());
@@ -311,13 +312,14 @@ class CheckRun {
             var allIssues = new ArrayList<Issue>();
             allIssues.add(issue.get());
             allIssues.addAll(SolvesTracker.currentSolved(pr.repository().forge().currentUser(), comments));
-            progressBody.append("\n\n## Issue");
+            progressBody.append("\n\n### Issue");
             if (allIssues.size() > 1) {
                 progressBody.append("s");
             }
             progressBody.append("\n");
             for (var currentIssue : allIssues) {
                 var iss = issueProject.issue(currentIssue.id());
+                progressBody.append(" * ");
                 if (iss.isPresent()) {
                     progressBody.append("[");
                     progressBody.append(iss.get().id());
@@ -335,31 +337,27 @@ class CheckRun {
         }
 
         getReviewersList(reviews).ifPresent(reviewers -> {
-            progressBody.append("\n\n## Reviewers\n");
+            progressBody.append("\n\n### Reviewers\n");
             progressBody.append(reviewers);
         });
 
         getContributorsList(comments).ifPresent(contributors -> {
-            progressBody.append("\n\n## Contributors\n");
+            progressBody.append("\n\n### Contributors\n");
             progressBody.append(contributors);
         });
 
-        progressBody.append("\n\n## Instructions\n");
+        progressBody.append("\n\n### Download\n");
         progressBody.append("To checkout these changes locally:\n");
-        progressBody.append(bashCodeBlock(checkoutCommands()));
+        progressBody.append(checkoutCommands());
 
         return progressBody.toString();
-    }
-
-    private static String bashCodeBlock(String content) {
-        return "```bash\n" + content + "```\n";
     }
 
     private String checkoutCommands() {
         var repoUrl = pr.repository().webUrl();
         return
-           "$ git fetch " + repoUrl + " " + pr.fetchRef() + ":pull/" + pr.id() + "\n" +
-           "$ git checkout pull/" + pr.id() + "\n";
+           "`$ git fetch " + repoUrl + " " + pr.fetchRef() + ":pull/" + pr.id() + "`\n" +
+           "`$ git checkout pull/" + pr.id() + "`\n";
     }
 
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -347,7 +347,6 @@ class CheckRun {
         });
 
         progressBody.append("\n\n### Download\n");
-        progressBody.append("To checkout these changes locally:\n");
         progressBody.append(checkoutCommands());
 
         return progressBody.toString();
@@ -359,7 +358,6 @@ class CheckRun {
            "`$ git fetch " + repoUrl + " " + pr.fetchRef() + ":pull/" + pr.id() + "`\n" +
            "`$ git checkout pull/" + pr.id() + "`\n";
     }
-
 
     private String updateStatusMessage(String message) {
         var description = pr.body();

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -344,8 +344,24 @@ class CheckRun {
             progressBody.append(contributors);
         });
 
+        progressBody.append("\n\n## Instructions\n");
+        progressBody.append("To checkout these changes locally:\n");
+        progressBody.append(bashCodeBlock(checkoutCommands(pr)));
+
         return progressBody.toString();
     }
+
+    private static String bashCodeBlock(String content) {
+        return "```bash\n" + content + "```\n";
+    }
+
+    private static String checkoutCommands(PullRequest pr) {
+        var repoUrl = pr.repository().webUrl();
+        return
+           "$ git fetch " + repoUrl + " " + pr.fetchRef() + ":pull/" + pr.id() + "\n" +
+           "$ git checkout pull/" + pr.id() + "\n";
+    }
+
 
     private String updateStatusMessage(String message) {
         var description = pr.body();

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ContributorTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ContributorTests.java
@@ -332,7 +332,7 @@ class ContributorTests {
             var contributorsHeaderIndex = -1;
             for (var i = 0; i < body.length; i++) {
                 var line = body[i];
-                if (line.equals("## Contributors")) {
+                if (line.equals("### Contributors")) {
                     contributorsHeaderIndex = i;
                     break;
                 }
@@ -352,7 +352,7 @@ class ContributorTests {
 
             // Verify that body does not contain "Contributors" section
             for (var line : pr.body().split("\n")) {
-                assertNotEquals("## Contributors", line);
+                assertNotEquals("### Contributors", line);
             }
         }
     }


### PR DESCRIPTION
Hi,

I'd like let the pr bot add the fetch comamnd found in the automatic emails to the PR body, so that people using only GitHub can see the instructions as well.

This adds a new "Instructions" section to the body of the PR message:

> ## Instructions
> To checkout these changes locally:
> ```bash
> $ git fetch https://git.openjdk.java.net/panama-foreign pull/16/head:pull/16
> $ git checkout pull/16
> ```

Testing:
- Running `.\gradlew test`

Any other recommendations for testing this?

Thanks,
Jorn
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)