### PR TITLE
Make Host::user return Optional<String>

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/IssueUpdater.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/IssueUpdater.java
@@ -288,7 +288,9 @@ public class IssueUpdater implements RepositoryUpdateConsumer, PullRequestUpdate
                         var username = findIssueUsername(commit);
                         if (username.isPresent()) {
                             var assignee = issueProject.issueTracker().user(username.get());
-                            issue.setAssignees(List.of(assignee));
+                            if (assignee.isPresent()) {
+                                issue.setAssignees(List.of(assignee.get()));
+                            }
                         }
                     }
                 }

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryContinuousIntegration.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryContinuousIntegration.java
@@ -59,8 +59,8 @@ class InMemoryContinuousIntegration implements ContinuousIntegration {
     }
 
     @Override
-    public HostUser user(String username) {
-        return users.get(username);
+    public Optional<HostUser> user(String username) {
+        return Optional.ofNullable(users.get(username));
     }
 
     @Override

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHost.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHost.java
@@ -42,8 +42,8 @@ class InMemoryHost implements Forge {
     }
 
     @Override
-    public HostUser user(String username) {
-        return null;
+    public Optional<HostUser> user(String username) {
+        return Optional.empty();
     }
 
     @Override

--- a/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
@@ -801,6 +801,8 @@ public class GitPr {
                     var usernames = Arrays.asList(arguments.get("assignees").asString().split(","));
                     var assignees = usernames.stream()
                                              .map(u -> host.user(u))
+                                             .filter(Optional::isPresent)
+                                             .map(Optional::get)
                                              .collect(Collectors.toList());
                     pr.setAssignees(assignees);
                 }
@@ -1058,6 +1060,8 @@ public class GitPr {
                 var usernames = Arrays.asList(assigneesOption.split(","));
                 var assignees = usernames.stream()
                                          .map(u -> host.user(u))
+                                         .filter(Optional::isPresent)
+                                         .map(Optional::get)
                                          .collect(Collectors.toList());
                 pr.setAssignees(assignees);
             }
@@ -1371,6 +1375,8 @@ public class GitPr {
                 var usernames = Arrays.asList(assigneesOption.split(","));
                 var assignees = usernames.stream()
                     .map(u -> host.user(u))
+                    .filter(Optional::isPresent)
+                    .map(Optional::get)
                     .collect(Collectors.toList());
                 pr.setAssignees(assignees);
             }

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubHost.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubHost.java
@@ -128,7 +128,7 @@ public class GitHubHost implements Forge {
 
     private String getFullName(String userName) {
         var details = user(userName);
-        return details.fullName();
+        return details.get().fullName();
     }
 
     // Most GitHub API's return user information in this format
@@ -182,9 +182,15 @@ public class GitHubHost implements Forge {
     }
 
     @Override
-    public HostUser user(String username) {
-        var details = request.get("users/" + URLEncoder.encode(username, StandardCharsets.UTF_8)).execute().asObject();
-        return asHostUser(details);
+    public Optional<HostUser> user(String username) {
+        var details = request.get("users/" + URLEncoder.encode(username, StandardCharsets.UTF_8))
+                             .onError(r -> JSON.of())
+                             .execute();
+        if (details.isNull()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(asHostUser(details.asObject()));
     }
 
     private static HostUser asHostUser(JSONObject details) {
@@ -205,7 +211,7 @@ public class GitHubHost implements Forge {
             if (application != null) {
                 var appDetails = application.getAppDetails();
                 var appName = appDetails.get("name").asString() + "[bot]";
-                currentUser = user(appName);
+                currentUser = user(appName).get();
             } else if (pat != null) {
                 // Cannot always trust username in PAT, e.g. Git Credential Manager
                 // on Windows always return "PersonalAccessToken" as username.

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabHost.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabHost.java
@@ -118,13 +118,22 @@ public class GitLabHost implements Forge {
     }
 
     @Override
-    public HostUser user(String username) {
-        var details = request.get("users").param("username", username).execute().asArray();
-        if (details.size() != 1) {
-            throw new RuntimeException("Couldn't find user: " + username);
+    public Optional<HostUser> user(String username) {
+        var details = request.get("users")
+                             .param("username", username)
+                             .onError(r -> JSON.of())
+                             .execute();
+
+        if (details.isNull()) {
+            return Optional.empty();
         }
 
-        return parseUserDetails(details.get(0).asObject());
+        var users = details.asArray();
+        if (users.size() != 1) {
+            return Optional.empty();
+        }
+
+        return Optional.of(parseUserDetails(users.get(0).asObject()));
     }
 
     @Override

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -66,7 +66,7 @@ public class GitLabMergeRequest implements PullRequest {
 
     @Override
     public HostUser author() {
-        return repository.forge().user(json.get("author").get("username").asString());
+        return repository.forge().user(json.get("author").get("username").asString()).get();
     }
 
     @Override
@@ -122,7 +122,7 @@ public class GitLabMergeRequest implements PullRequest {
                               }
                           }
                           var id = obj.get("id").asInt();
-                          return new Review(createdAt, reviewer, verdict, hash, id, null);
+                          return new Review(createdAt, reviewer.get(), verdict, hash, id, null);
                       })
                       .collect(Collectors.toList());
     }
@@ -624,7 +624,7 @@ public class GitLabMergeRequest implements PullRequest {
         var assignee = json.get("assignee").asObject();
         if (assignee != null) {
             var user = repository.forge().user(assignee.get("username").asString());
-            return List.of(user);
+            return List.of(user.get());
         }
         return Collections.emptyList();
     }

--- a/host/src/main/java/org/openjdk/skara/host/Host.java
+++ b/host/src/main/java/org/openjdk/skara/host/Host.java
@@ -22,9 +22,11 @@
  */
 package org.openjdk.skara.host;
 
+import java.util.Optional;
+
 public interface Host {
     boolean isValid();
-    HostUser user(String username);
+    Optional<HostUser> user(String username);
     HostUser currentUser();
     boolean isMemberOf(String groupId, HostUser user);
 }

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraHost.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraHost.java
@@ -93,14 +93,19 @@ public class JiraHost implements IssueTracker {
     }
 
     @Override
-    public HostUser user(String username) {
+    public Optional<HostUser> user(String username) {
         var data = request.get("user")
                           .param("username", username)
+                          .onError(r -> JSON.of())
                           .execute();
+        if (data.isNull()) {
+            return Optional.empty();
+        }
+
         var user = new HostUser(data.get("name").asString(),
                                 data.get("name").asString(),
                                 data.get("displayName").asString());
-        return user;
+        return Optional.of(user);
     }
 
     @Override

--- a/issuetracker/src/test/java/org/openjdk/skara/issuetracker/IssueTrackerTests.java
+++ b/issuetracker/src/test/java/org/openjdk/skara/issuetracker/IssueTrackerTests.java
@@ -50,7 +50,7 @@ class IssueTrackerTests {
 
             var userName = project.issueTracker().currentUser().userName();
             var user = project.issueTracker().user(userName);
-            assertEquals(userName, user.userName());
+            assertEquals(userName, user.get().userName());
 
             var issue = credentials.createIssue(project, "Test issue");
             issue.setTitle("Updated title");
@@ -84,7 +84,7 @@ class IssueTrackerTests {
 
             var userName = project.issueTracker().currentUser().userName();
             var user = project.issueTracker().user(userName);
-            assertEquals(userName, user.userName());
+            assertEquals(userName, user.get().userName());
 
             var issue = credentials.createIssue(project, "Test issue");
             issue.setBody("This is now the body");

--- a/test/src/main/java/org/openjdk/skara/test/TestHost.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHost.java
@@ -115,11 +115,13 @@ public class TestHost implements Forge, IssueTracker {
     }
 
     @Override
-    public HostUser user(String username) {
-        return data.users.stream()
-                    .filter(user -> user.userName().equals(username))
-                    .findAny()
-                    .orElseThrow();
+    public Optional<HostUser> user(String username) {
+        return data.users
+                   .stream()
+                   .filter(user -> user.userName().equals(username))
+                   .map(user -> Optional.of(user))
+                   .findAny()
+                   .orElseThrow();
     }
 
     @Override


### PR DESCRIPTION
Hi all,

please review this refactoring that makes `Host::user` return an
`Optional<String>` to support cases when a username does not map to a user.

Testing:
- `make test` passes on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)