### PR TITLE
Add HostUserDetails::email

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubHost.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubHost.java
@@ -196,7 +196,8 @@ public class GitHubHost implements Forge {
         if (name == null) {
             name = login;
         }
-        return new HostUser(id, login, name);
+        var email = details.get("email").asString();
+        return new HostUser(id, login, name, email);
     }
 
     @Override

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabHost.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabHost.java
@@ -114,7 +114,8 @@ public class GitLabHost implements Forge {
         var id = details.get("id").asInt();
         var username = details.get("username").asString();
         var name = details.get("name").asString();
-        return new HostUser(id, username, name);
+        var email = details.get("email").asString();
+        return new HostUser(id, username, name, email);
     }
 
     @Override

--- a/host/src/main/java/org/openjdk/skara/host/HostUser.java
+++ b/host/src/main/java/org/openjdk/skara/host/HostUser.java
@@ -23,6 +23,7 @@
 package org.openjdk.skara.host;
 
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 public class HostUser {
@@ -30,23 +31,41 @@ public class HostUser {
     private final String username;
     private final Supplier<String> nameSupplier;
     private String name;
+    private String email;
 
-    public HostUser(String id, String username, Supplier<String> nameSupplier) {
+    public HostUser(String id, String username, Supplier<String> nameSupplier, String email) {
         this.id = id;
         this.username = username;
         this.nameSupplier = nameSupplier;
+        this.email = email;
+    }
+
+    public HostUser(String id, String username, Supplier<String> nameSupplier) {
+        this(id, username, nameSupplier, null);
     }
 
     public HostUser(String id, String username, String name) {
         this(id, username, () -> name);
     }
 
+    public HostUser(String id, String username, String name, String email) {
+        this(id, username, () -> name, email);
+    }
+
     public HostUser(int id, String username, String name) {
         this(String.valueOf(id), username, name);
     }
 
+    public HostUser(int id, String username, String name, String email) {
+        this(String.valueOf(id), username, name, email);
+    }
+
     public HostUser(int id, String username, Supplier<String> nameSupplier) {
         this(String.valueOf(id), username, nameSupplier);
+    }
+
+    public HostUser(int id, String username, Supplier<String> nameSupplier, String email) {
+        this(String.valueOf(id), username, nameSupplier, email);
     }
 
     @Override
@@ -80,6 +99,10 @@ public class HostUser {
             name = nameSupplier.get();
         }
         return name;
+    }
+
+    public Optional<String> email() {
+        return Optional.ofNullable(email);
     }
 
     @Override


### PR DESCRIPTION
Hi all,

please review this patch that adds the method `HostUserDetails::email`. It is
rare for user to have public emails, but the bots can now take advantage of
those rare cases.

Testing:
- `make test` on Linux x64 passes

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)