### PR TITLE
279: Optionally only update project-specific issues

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/IssueUpdater.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/IssueUpdater.java
@@ -257,14 +257,14 @@ public class IssueUpdater implements RepositoryUpdateConsumer, PullRequestUpdate
 
                 String requestedVersion = null;
                 if (prOnly) {
-                    var pullRequests = issue.links().stream()
+                    var pullRequestCount = issue.links().stream()
                                             .filter(link -> link.title().orElse("notitle").equals("Review"))
                                             .filter(link -> link.summary().orElse("nosummary").startsWith(repository.name() + "/"))
                                             .map(link -> link.summary().orElseThrow().substring(repository.name().length() + 1))
                                             .map(repository::pullRequest)
                                             .filter(pr -> pr.targetRef().equals(branch.name()))
-                                            .collect(Collectors.toList());
-                    if (pullRequests.size() == 0) {
+                                            .count();
+                    if (pullRequestCount == 0) {
                         log.info("Skipping commit " + commit.hash().abbreviate() + " for repository " + repository.name() +
                                          " on branch " + branch.name() + " - no matching PR found");
                         continue;

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/IssueUpdater.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/IssueUpdater.java
@@ -47,9 +47,11 @@ public class IssueUpdater implements RepositoryUpdateConsumer, PullRequestUpdate
     private final URI commitIcon;
     private final boolean setFixVersion;
     private final Map<String, String> fixVersions;
+    private final boolean prOnly;
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots.notify");
 
-    IssueUpdater(IssueProject issueProject, boolean reviewLink, URI reviewIcon, boolean commitLink, URI commitIcon,boolean setFixVersion, Map<String, String> fixVersions) {
+    IssueUpdater(IssueProject issueProject, boolean reviewLink, URI reviewIcon, boolean commitLink, URI commitIcon,
+                 boolean setFixVersion, Map<String, String> fixVersions, boolean prOnly) {
         this.issueProject = issueProject;
         this.reviewLink = reviewLink;
         this.reviewIcon = reviewIcon;
@@ -57,6 +59,7 @@ public class IssueUpdater implements RepositoryUpdateConsumer, PullRequestUpdate
         this.commitIcon = commitIcon;
         this.setFixVersion = setFixVersion;
         this.fixVersions = fixVersions;
+        this.prOnly = prOnly;
     }
 
     private final static Set<String> primaryTypes = Set.of("Bug", "New Feature", "Enhancement", "Task", "Sub-task");
@@ -252,25 +255,40 @@ public class IssueUpdater implements RepositoryUpdateConsumer, PullRequestUpdate
                     continue;
                 }
 
-                // The actual issue to be updated can change depending on the fix version
                 String requestedVersion = null;
-                if (setFixVersion) {
-                    requestedVersion = fixVersions != null ? fixVersions.getOrDefault(branch.name(), null) : null;
-                    if (requestedVersion == null) {
-                        try {
-                            var conf = localRepository.lines(Path.of(".jcheck/conf"), commit.hash());
-                            if (conf.isPresent()) {
-                                var parsed = JCheckConfiguration.parse(conf.get());
-                                var version = parsed.general().version();
-                                requestedVersion = version.orElse(null);
-                            }
-                        } catch (IOException e) {
-                            throw new RuntimeException(e);
-                        }
+                if (prOnly) {
+                    var pullRequests = issue.links().stream()
+                                            .filter(link -> link.title().orElse("notitle").equals("Review"))
+                                            .filter(link -> link.summary().orElse("nosummary").startsWith(repository.name() + "/"))
+                                            .map(link -> link.summary().orElseThrow().substring(repository.name().length() + 1))
+                                            .map(repository::pullRequest)
+                                            .filter(pr -> pr.targetRef().equals(branch.name()))
+                                            .collect(Collectors.toList());
+                    if (pullRequests.size() == 0) {
+                        log.info("Skipping commit " + commit.hash().abbreviate() + " for repository " + repository.name() +
+                                         " on branch " + branch.name() + " - no matching PR found");
+                        continue;
                     }
+                } else {
+                    // The actual issue to be updated can change depending on the fix version
+                    if (setFixVersion) {
+                        requestedVersion = fixVersions != null ? fixVersions.getOrDefault(branch.name(), null) : null;
+                        if (requestedVersion == null) {
+                            try {
+                                var conf = localRepository.lines(Path.of(".jcheck/conf"), commit.hash());
+                                if (conf.isPresent()) {
+                                    var parsed = JCheckConfiguration.parse(conf.get());
+                                    var version = parsed.general().version();
+                                    requestedVersion = version.orElse(null);
+                                }
+                            } catch (IOException e) {
+                                throw new RuntimeException(e);
+                            }
+                        }
 
-                    if (requestedVersion != null) {
-                        issue = findIssue(issue, requestedVersion);
+                        if (requestedVersion != null) {
+                            issue = findIssue(issue, requestedVersion);
+                        }
                     }
                 }
 

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/NotifyBotFactory.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/NotifyBotFactory.java
@@ -164,7 +164,15 @@ public class NotifyBotFactory implements BotFactory {
                     fixVersions = issuesConf.get("fixversions").fields().stream()
                                             .collect(Collectors.toMap(JSONObject.Field::name, f -> f.value().asString()));
                 }
-                var updater = new IssueUpdater(issueProject, reviewLink, reviewIcon, commitLink, commitIcon, setFixVersion, fixVersions);
+                var prOnly = false;
+                if (issuesConf.contains("pronly")) {
+                    prOnly = issuesConf.get("pronly").asBoolean();
+                    if (setFixVersion) {
+                        throw new RuntimeException("cannot combine pronly with fixversions");
+                    }
+                }
+                var updater = new IssueUpdater(issueProject, reviewLink, reviewIcon, commitLink, commitIcon,
+                                               setFixVersion, fixVersions, prOnly);
                 updaters.add(updater);
                 prUpdaters.add(updater);
             }

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdaterTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdaterTests.java
@@ -1008,7 +1008,7 @@ class UpdaterTests {
 
             var issueProject = credentials.getIssueProject();
             var commitIcon = URI.create("http://www.example.com/commit.png");
-            var updater = new IssueUpdater(issueProject, false, null, true, commitIcon, true, null);
+            var updater = new IssueUpdater(issueProject, false, null, true, commitIcon, true, null, false);
             var notifyBot = new NotifyBot(repo, storageFolder, Pattern.compile("master"), tagStorage, branchStorage,
                                           prIssuesStorage, List.of(updater), List.of(), Set.of(), Map.of());
 
@@ -1064,7 +1064,7 @@ class UpdaterTests {
 
             var issueProject = credentials.getIssueProject();
             var commitIcon = URI.create("http://www.example.com/commit.png");
-            var updater = new IssueUpdater(issueProject, false, null, true, commitIcon, true, null);
+            var updater = new IssueUpdater(issueProject, false, null, true, commitIcon, true, null, false);
             var notifyBot = new NotifyBot(repo, storageFolder, Pattern.compile("master"), tagStorage, branchStorage,
                                           prIssuesStorage, List.of(updater), List.of(), Set.of(), Map.of());
 
@@ -1105,7 +1105,7 @@ class UpdaterTests {
 
             var issueProject = credentials.getIssueProject();
             var commitIcon = URI.create("http://www.example.com/commit.png");
-            var updater = new IssueUpdater(issueProject, false, null, false, commitIcon, true, Map.of("master", "2.0"));
+            var updater = new IssueUpdater(issueProject, false, null, false, commitIcon, true, Map.of("master", "2.0"), false);
             var notifyBot = new NotifyBot(repo, storageFolder, Pattern.compile("master"), tagStorage, branchStorage,
                                           prIssuesStorage, List.of(updater), List.of(), Set.of(), Map.of());
 
@@ -1150,7 +1150,7 @@ class UpdaterTests {
 
             var issueProject = credentials.getIssueProject();
             var commitIcon = URI.create("http://www.example.com/commit.png");
-            var updater = new IssueUpdater(issueProject, false, null, true, commitIcon, true, null);
+            var updater = new IssueUpdater(issueProject, false, null, true, commitIcon, true, null, false);
             var notifyBot = new NotifyBot(repo, storageFolder, Pattern.compile("master"), tagStorage, branchStorage,
                                           prIssuesStorage, List.of(updater), List.of(), Set.of(), Map.of());
 
@@ -1213,7 +1213,7 @@ class UpdaterTests {
             var storageFolder = tempFolder.path().resolve("storage");
 
             var issueProject = credentials.getIssueProject();
-            var updater = new IssueUpdater(issueProject, false, null, false, null, true, Map.of("master", "12u14"));
+            var updater = new IssueUpdater(issueProject, false, null, false, null, true, Map.of("master", "12u14"), false);
             var notifyBot = new NotifyBot(repo, storageFolder, Pattern.compile("master"), tagStorage, branchStorage,
                                           prIssuesStorage, List.of(updater), List.of(), Set.of(), Map.of());
 
@@ -1249,7 +1249,7 @@ class UpdaterTests {
             var storageFolder = tempFolder.path().resolve("storage");
 
             var issueProject = credentials.getIssueProject();
-            var updater = new IssueUpdater(issueProject, false, null, false, null, true, Map.of("master", "12u14"));
+            var updater = new IssueUpdater(issueProject, false, null, false, null, true, Map.of("master", "12u14"), false);
             var notifyBot = new NotifyBot(repo, storageFolder, Pattern.compile("master"), tagStorage, branchStorage,
                                           prIssuesStorage, List.of(updater), List.of(), Set.of(), Map.of());
 
@@ -1285,7 +1285,7 @@ class UpdaterTests {
             var storageFolder = tempFolder.path().resolve("storage");
 
             var issueProject = credentials.getIssueProject();
-            var updater = new IssueUpdater(issueProject, false, null, false, null, true, Map.of("master", "12.0.2"));
+            var updater = new IssueUpdater(issueProject, false, null, false, null, true, Map.of("master", "12.0.2"), false);
             var notifyBot = new NotifyBot(repo, storageFolder, Pattern.compile("master"), tagStorage, branchStorage,
                                           prIssuesStorage, List.of(updater), List.of(), Set.of(), Map.of());
 
@@ -1357,7 +1357,7 @@ class UpdaterTests {
 
             var issueProject = credentials.getIssueProject();
             var reviewIcon = URI.create("http://www.example.com/review.png");
-            var updater = new IssueUpdater(issueProject, true, reviewIcon, false, null, false, null);
+            var updater = new IssueUpdater(issueProject, true, reviewIcon, false, null, false, null, false);
             var notifyBot = new NotifyBot(repo, storageFolder, Pattern.compile("master"), tagStorage, branchStorage,
                                           prIssuesStorage, List.of(), List.of(updater), Set.of("rfr"),
                                           Map.of(reviewer.forge().currentUser().userName(), Pattern.compile("This is now ready")));
@@ -1446,7 +1446,7 @@ class UpdaterTests {
 
             var issueProject = credentials.getIssueProject();
             var reviewIcon = URI.create("http://www.example.com/review.png");
-            var updater = new IssueUpdater(issueProject, false, reviewIcon, false, null, false,null);
+            var updater = new IssueUpdater(issueProject, false, reviewIcon, false, null, false,null, false);
             var notifyBot = new NotifyBot(repo, storageFolder, Pattern.compile("master"), tagStorage, branchStorage,
                                           prIssuesStorage, List.of(), List.of(updater), Set.of("rfr"),
                                           Map.of(reviewer.forge().currentUser().userName(), Pattern.compile("This is now ready")));
@@ -1473,6 +1473,68 @@ class UpdaterTests {
             // The issue should still not contain a link to the PR
             var links = issue.links();
             assertEquals(0, links.size());
+        }
+    }
+
+    @Test
+    void testPullRequestPROnly(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var repo = credentials.getHostedRepository();
+            var repoFolder = tempFolder.path().resolve("repo");
+            var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
+            credentials.commitLock(localRepo);
+            localRepo.pushAll(repo.url());
+
+            var tagStorage = createTagStorage(repo);
+            var branchStorage = createBranchStorage(repo);
+            var prIssuesStorage = createPullRequestIssuesStorage(repo);
+            var storageFolder = tempFolder.path().resolve("storage");
+
+            var issueProject = credentials.getIssueProject();
+            var reviewIcon = URI.create("http://www.example.com/review.png");
+            var updater = new IssueUpdater(issueProject, true, reviewIcon, false, null, false, null, true);
+            var notifyBot = new NotifyBot(repo, storageFolder, Pattern.compile(".*"), tagStorage, branchStorage,
+                                          prIssuesStorage, List.of(updater), List.of(updater), Set.of(), Map.of());
+
+            // Initialize history
+            localRepo.push(localRepo.resolve("master").orElseThrow(), repo.url(), "other");
+            TestBotRunner.runPeriodicItems(notifyBot);
+
+            // Create an issue and a pull request to fix it
+            var issue = issueProject.createIssue("This is an issue", List.of("Indeed"), Map.of("issuetype", JSON.of("Enhancement")));
+            var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", issue.id() + ": Fix that issue");
+            localRepo.push(editHash, repo.url(), "edit", true);
+            var pr = credentials.createPullRequest(repo, "other", "edit", issue.id() + ": Fix that issue");
+            pr.setBody("\n\n## Issue\n[" + issue.id() + "](http://www.test.test/): The issue");
+            TestBotRunner.runPeriodicItems(notifyBot);
+
+            // The issue should now contain a link to the PR
+            var links = issue.links();
+            assertEquals(1, links.size());
+            assertEquals(pr.webUrl(), links.get(0).uri().orElseThrow());
+            assertEquals(reviewIcon, links.get(0).iconUrl().orElseThrow());
+
+            // Simulate integration
+            localRepo.push(editHash, repo.url(), "other");
+            TestBotRunner.runPeriodicItems(notifyBot);
+
+            // The changeset should be reflected in a comment
+            var updatedIssue = issueProject.issue(issue.id()).orElseThrow();
+
+            var comments = updatedIssue.comments();
+            assertEquals(1, comments.size());
+            var comment = comments.get(0);
+            assertTrue(comment.body().contains(editHash.abbreviate()));
+
+            // Now simulate a merge to another branch
+            localRepo.push(editHash, repo.url(), "master");
+            TestBotRunner.runPeriodicItems(notifyBot);
+
+            // No additional comment should have been made
+            updatedIssue = issueProject.issue(issue.id()).orElseThrow();
+            comments = updatedIssue.comments();
+            assertEquals(1, comments.size());
         }
     }
 }


### PR DESCRIPTION
Hi all,

Please review this change that allows the issue notifier to only update issues when the commit originates from a matching PR. This can be used for projects that merge commits from/to different branches, but only want to be notified about the original commit resulting from a PR integration.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-279](https://bugs.openjdk.java.net/browse/SKARA-279): Optionally only update project-specific issues 


## Approvers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)