### PR TITLE
280: Notifier should support repo/branch prefixes

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/MailingListUpdaterBuilder.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/MailingListUpdaterBuilder.java
@@ -40,6 +40,8 @@ public class MailingListUpdaterBuilder {
     private MailingListUpdater.Mode mode = MailingListUpdater.Mode.ALL;
     private Map<String, String> headers = Map.of();
     private Pattern allowedAuthorDomains = Pattern.compile(".*");
+    private boolean repoInSubject = false;
+    private Pattern branchInSubject = Pattern.compile("a^"); // Does not match anything
 
     public MailingListUpdaterBuilder list(MailingList list) {
         this.list = list;
@@ -96,8 +98,18 @@ public class MailingListUpdaterBuilder {
         return this;
     }
 
+    public MailingListUpdaterBuilder repoInSubject(boolean repoInSubject) {
+        this.repoInSubject = repoInSubject;
+        return this;
+    }
+
+    public MailingListUpdaterBuilder branchInSubject(Pattern branchInSubject) {
+        this.branchInSubject = branchInSubject;
+        return this;
+    }
+
     public MailingListUpdater build() {
         return new MailingListUpdater(list, recipient, sender, author, includeBranch, reportNewTags, reportNewBranches,
-                                      reportNewBuilds, mode, headers, allowedAuthorDomains);
+                                      reportNewBuilds, mode, headers, allowedAuthorDomains, repoInSubject, branchInSubject);
     }
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/NotifyBotFactory.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/NotifyBotFactory.java
@@ -145,6 +145,13 @@ public class NotifyBotFactory implements BotFactory {
                     if (mailinglist.contains("builds")) {
                         mailingListUpdaterBuilder.reportNewBuilds(mailinglist.get("builds").asBoolean());
                     }
+                    if (mailinglist.contains("reponame")) {
+                        mailingListUpdaterBuilder.repoInSubject(mailinglist.get("reponame").asBoolean());
+                    }
+                    if (mailinglist.contains("branchname")) {
+                        mailingListUpdaterBuilder.branchInSubject(Pattern.compile(mailinglist.get("branchname").asString()));
+                    }
+
                     updaters.add(mailingListUpdaterBuilder.build());
                 }
             }

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdaterTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdaterTests.java
@@ -1086,6 +1086,93 @@ class UpdaterTests {
     }
 
     @Test
+    void testMailingListBranchPrefix(TestInfo testInfo) throws IOException {
+        try (var listServer = new TestMailmanServer();
+             var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var repo = credentials.getHostedRepository();
+            var repoFolder = tempFolder.path().resolve("repo");
+            var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            credentials.commitLock(localRepo);
+            localRepo.pushAll(repo.url());
+
+            var listAddress = EmailAddress.parse(listServer.createList("test"));
+            var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
+            var mailmanList = mailmanServer.getList(listAddress.address());
+            var tagStorage = createTagStorage(repo);
+            var branchStorage = createBranchStorage(repo);
+            var prIssuesStorage = createPullRequestIssuesStorage(repo);
+            var storageFolder = tempFolder.path().resolve("storage");
+
+            var sender = EmailAddress.from("duke", "duke@duke.duke");
+            var updater = MailingListUpdater.newBuilder()
+                                            .list(mailmanList)
+                                            .recipient(listAddress)
+                                            .sender(sender)
+                                            .reportNewTags(false)
+                                            .reportNewBranches(false)
+                                            .reportNewBuilds(false)
+                                            .mode(MailingListUpdater.Mode.PR)
+                                            .repoInSubject(true)
+                                            .branchInSubject(Pattern.compile(".*"))
+                                            .build();
+            var notifyBot = NotifyBot.newBuilder()
+                                     .repository(repo)
+                                     .storagePath(storageFolder)
+                                     .branches(Pattern.compile("master"))
+                                     .tagStorageBuilder(tagStorage)
+                                     .branchStorageBuilder(branchStorage)
+                                     .prIssuesStorageBuilder(prIssuesStorage)
+                                     .updaters(List.of(updater))
+                                     .build();
+
+            // No mail should be sent on the first run as there is no history
+            TestBotRunner.runPeriodicItems(notifyBot);
+            assertThrows(RuntimeException.class, () -> listServer.processIncoming(Duration.ofMillis(1)));
+
+            var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", "23456789: More fixes");
+            localRepo.push(editHash, repo.url(), "edit");
+            var pr = credentials.createPullRequest(repo, "master", "edit", "RFR: My PR");
+
+            // PR hasn't been integrated yet, so there should be no mail
+            TestBotRunner.runPeriodicItems(notifyBot);
+            assertThrows(RuntimeException.class, () -> listServer.processIncoming(Duration.ofMillis(1)));
+
+            // Simulate an RFR email
+            var rfr = Email.create("RFR: My PR", "PR:\n" + pr.webUrl().toString())
+                           .author(EmailAddress.from("duke", "duke@duke.duke"))
+                           .recipient(listAddress)
+                           .build();
+            mailmanList.post(rfr);
+            listServer.processIncoming();
+
+            // And an integration
+            pr.addComment("Pushed as commit " + editHash.hex() + ".");
+            localRepo.push(editHash, repo.url(), "master");
+
+            TestBotRunner.runPeriodicItems(notifyBot);
+            listServer.processIncoming();
+
+            var conversations = mailmanList.conversations(Duration.ofDays(1));
+            conversations.sort(Comparator.comparing(conversation -> conversation.first().subject()));
+            assertEquals(1, conversations.size());
+
+            var prConversation = conversations.get(0);
+
+            var prEmail = prConversation.replies(prConversation.first()).get(0);
+            assertEquals(listAddress, prEmail.sender());
+            assertEquals(EmailAddress.from("testauthor", "ta@none.none"), prEmail.author());
+            assertEquals(prEmail.recipients(), List.of(listAddress));
+            assertEquals("[" + repo.name() + ":master] [Integrated] RFR: My PR", prEmail.subject());
+            assertTrue(prEmail.body().contains("Changeset: " + editHash.abbreviate()));
+            assertTrue(prEmail.body().contains("23456789: More fixes"));
+            assertFalse(prEmail.body().contains("Committer"));
+            assertFalse(prEmail.body().contains(masterHash.abbreviate()));
+        }
+    }
+
+    @Test
     void testMailingListNoIdempotence(TestInfo testInfo) throws IOException {
         try (var listServer = new TestMailmanServer();
              var credentials = new HostCredentials(testInfo);


### PR DESCRIPTION
Hi all,

Please review this change that add support for repo/branch prefixes to the mails sent by the PR notifier.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-280](https://bugs.openjdk.java.net/browse/SKARA-280): Notifier should support repo/branch prefixes


## Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)