### PR TITLE
275: PR bot should allows merge-style PRs with only branch names

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -49,7 +49,8 @@ class CheckRun {
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots.pr");
     private final String progressMarker = "<!-- Anything below this marker will be automatically updated, please do not edit manually! -->";
     private final String mergeReadyMarker = "<!-- PullRequestBot merge is ready comment -->";
-    private final Pattern mergeSourcePattern = Pattern.compile("^Merge ([-/\\w]+):([-\\w]+$)");
+    private final Pattern mergeSourceFullPattern = Pattern.compile("^Merge ([-/\\w]+):([-\\w]+)$");
+    private final Pattern mergeSourceBranchOnlyPattern = Pattern.compile("^Merge ([-\\w]+)$");
     private final Set<String> newLabels;
 
     private CheckRun(CheckWorkItem workItem, PullRequest pr, PullRequestInstance prInstance, List<Comment> comments,
@@ -107,21 +108,27 @@ class CheckRun {
         return ((names.size() == 1) && emails.size() == 1);
     }
 
-    private Optional<String> mergeSourceRepository() {
-        var repoMatcher = mergeSourcePattern.matcher(pr.title());
-        if (!repoMatcher.matches()) {
-            return Optional.empty();
+    private static class MergeSource {
+        private final String repositoryName;
+        private final String branchName;
+
+        private MergeSource(String repositoryName, String branchName) {
+            this.repositoryName = repositoryName;
+            this.branchName = branchName;
         }
-        return Optional.of(repoMatcher.group(1));
     }
 
-    private Optional<String> mergeSourceBranch() {
-        var branchMatcher = mergeSourcePattern.matcher(pr.title());
-        if (!branchMatcher.matches()) {
-            return Optional.empty();
+    private Optional<MergeSource> mergeSource() {
+        var repoMatcher = mergeSourceFullPattern.matcher(pr.title());
+        if (!repoMatcher.matches()) {
+            var branchMatcher = mergeSourceBranchOnlyPattern.matcher(pr.title());
+            if (!branchMatcher.matches()) {
+                return Optional.empty();
+            }
+            return Optional.of(new MergeSource(pr.repository().name(), branchMatcher.group(1)));
         }
-        var mergeSourceBranch = branchMatcher.group(2);
-        return Optional.of(mergeSourceBranch);
+
+        return Optional.of(new MergeSource(repoMatcher.group(1), repoMatcher.group(2)));
     }
 
     // Additional bot-specific checks that are not handled by JCheck
@@ -155,25 +162,24 @@ class CheckRun {
                     ret.add("The top commit must be a merge commit.");
                 }
 
-                var sourceRepo = mergeSourceRepository();
-                var sourceBranch = mergeSourceBranch();
-                if (sourceBranch.isPresent() && sourceRepo.isPresent()) {
+                var source = mergeSource();
+                if (source.isPresent()) {
                     try {
-                        var mergeSourceRepo = pr.repository().forge().repository(sourceRepo.get()).orElseThrow(() ->
-                                new RuntimeException("Could not find repository " + sourceRepo.get())
+                        var mergeSourceRepo = pr.repository().forge().repository(source.get().repositoryName).orElseThrow(() ->
+                                new RuntimeException("Could not find repository " + source.get().repositoryName)
                         );
                         try {
-                            var sourceHash = prInstance.localRepo().fetch(mergeSourceRepo.url(), sourceBranch.get());
+                            var sourceHash = prInstance.localRepo().fetch(mergeSourceRepo.url(), source.get().branchName);
                             if (!prInstance.localRepo().isAncestor(commits.get(1).hash(), sourceHash)) {
                                 ret.add("The merge contains commits that are not ancestors of the source");
                             }
                         } catch (IOException e) {
-                            ret.add("Could not fetch branch `" + sourceBranch.get() + "` from project `" +
-                                            sourceRepo.get() + "` - check that they are correct.");
+                            ret.add("Could not fetch branch `" + source.get().branchName + "` from project `" +
+                                            source.get().repositoryName + "` - check that they are correct.");
                         }
                     } catch (RuntimeException e) {
                         ret.add("Could not find project `" +
-                                        sourceRepo.get() + "` - check that it is correct.");
+                                        source.get().repositoryName + "` - check that it is correct.");
                     }
                 } else {
                     ret.add("Could not determine the source for this merge. A Merge PR title must be specified on the format: " +

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
@@ -123,6 +123,88 @@ class MergeTests {
     }
 
     @Test
+    void branchMergeShortName(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+
+            var author = credentials.getHostedRepository();
+            var integrator = credentials.getHostedRepository();
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addCommitter(author.forge().currentUser().id())
+                                           .addReviewer(integrator.forge().currentUser().id());
+            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
+
+            // Populate the projects repository
+            var localRepoFolder = tempFolder.path().resolve("localrepo");
+            var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Make more changes in another branch
+            var otherHash1 = CheckableRepository.appendAndCommit(localRepo, "First change in other",
+                                                                 "First other\n\nReviewed-by: integrationreviewer2");
+            localRepo.push(otherHash1, author.url(), "other", true);
+            var otherHash2 = CheckableRepository.appendAndCommit(localRepo, "Second change in other",
+                                                                 "Second other\n\nReviewed-by: integrationreviewer2");
+            localRepo.push(otherHash2, author.url(), "other");
+
+            // Go back to the original master
+            localRepo.checkout(masterHash, true);
+
+            // Make a change with a corresponding PR
+            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated", StandardCharsets.UTF_8);
+            localRepo.add(unrelated);
+            localRepo.commit("Unrelated", "some", "some@one");
+            localRepo.merge(otherHash2);
+            var mergeHash = localRepo.commit("Merge commit", "some", "some@one");
+            localRepo.push(mergeHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "Merge other");
+
+            // Approve it as another user
+            var approvalPr = integrator.pullRequest(pr.id());
+            approvalPr.addReview(Review.Verdict.APPROVED, "Approved");
+
+            // Let the bot check the status
+            TestBotRunner.runPeriodicItems(mergeBot);
+
+            // Push it
+            pr.addComment("/integrate");
+            TestBotRunner.runPeriodicItems(mergeBot);
+
+            // The bot should reply with an ok message
+            var pushed = pr.comments().stream()
+                           .filter(comment -> comment.body().contains("Pushed as commit"))
+                           .count();
+            assertEquals(1, pushed);
+
+            // The change should now be present on the master branch
+            var pushedRepoFolder = tempFolder.path().resolve("pushedrepo");
+            var pushedRepo = Repository.materialize(pushedRepoFolder, author.url(), "master");
+            assertTrue(CheckableRepository.hasBeenEdited(pushedRepo));
+
+            // The commits from the "other" branch should be preserved and not squashed (but not the merge commit)
+            var headHash = pushedRepo.resolve("HEAD").orElseThrow();
+            Set<Hash> commits;
+            try (var tempCommits = pushedRepo.commits(masterHash.hex() + ".." + headHash.hex())) {
+                commits = tempCommits.stream()
+                                     .map(Commit::hash)
+                                     .collect(Collectors.toSet());
+            }
+            assertTrue(commits.contains(otherHash1));
+            assertTrue(commits.contains(otherHash2));
+            assertFalse(commits.contains(mergeHash));
+
+            // Author and committer should updated in the merge commit
+            var headCommit = pushedRepo.commits(headHash.hex() + "^.." + headHash.hex()).asList().get(0);
+            assertEquals("Generated Committer 1", headCommit.author().name());
+            assertEquals("integrationcommitter1@openjdk.java.net", headCommit.author().email());
+            assertEquals("Generated Committer 1", headCommit.committer().name());
+            assertEquals("integrationcommitter1@openjdk.java.net", headCommit.committer().email());
+        }
+    }
+
+    @Test
     void branchMergeRebase(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
              var tempFolder = new TemporaryDirectory()) {


### PR DESCRIPTION
Hi all,

Please review this change that allows merge-style PRs to only reference the source branch name, in case the source is in the same repository.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[SKARA-275](https://bugs.openjdk.java.net/browse/SKARA-275): PR bot should allows merge-style PRs with only branch names


## Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)