### PR TITLE
git-webrev: create links for bug ids in commit messages

### DIFF
--- a/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
@@ -1963,7 +1963,7 @@ public class RepositoryTests {
     @ParameterizedTest
     @EnumSource(VCS.class)
     void testAnnotateTag(VCS vcs) throws IOException {
-        try (var dir = new TemporaryDirectory()) {
+        try (var dir = new TemporaryDirectory(false)) {
             var repo = Repository.init(dir.path(), vcs);
             var readme = repo.root().resolve("README");
             var now = ZonedDateTime.now();

--- a/webrev/src/main/java/org/openjdk/skara/webrev/MetadataFormatter.java
+++ b/webrev/src/main/java/org/openjdk/skara/webrev/MetadataFormatter.java
@@ -23,9 +23,27 @@
 package org.openjdk.skara.webrev;
 
 import org.openjdk.skara.vcs.*;
+import org.openjdk.skara.vcs.openjdk.Issue;
+
+import java.util.function.Function;
 
 class MetadataFormatter {
+    private final Function<String, String> issueLinker;
+
+    MetadataFormatter(Function<String, String> issueLinker) {
+        this.issueLinker = issueLinker;
+    }
+
     String format(CommitMetadata metadata) {
-        return "<u>" + metadata.hash().abbreviate() +"</u>: " + metadata.message().get(0);
+        var prefix = metadata.hash().abbreviate() + ": ";
+        var subject = metadata.message().get(0);
+        var issue = Issue.fromString(subject);
+        if (issueLinker != null && issue.isPresent()) {
+            var id = issue.get().id();
+            var desc = issue.get().description();
+            var url = issueLinker.apply(id);
+            return prefix + "<a href=\"" + url + "\">" + id + "</a>: " + desc;
+        }
+        return prefix + subject;
     }
 }


### PR DESCRIPTION
Hi all,

please review this patch that creates links to
[JBS](https://bugs.openjdk.java.net) for issue id:s in commit messages. This
patch also creates a link to the upstream revision if possible. Finally I also
updated some of the titles to match `webrev.ksh`.

The reason for not using the types `IssueProject` and `PullRequest` is that
`webrev.ksh` has traditionally never required a network connection. The bots
however are free to do so and can therefore provide better implementations for
`issueLinker` and `commitLinker`. This work will be done in a follow-up patch.

Testing:
- `make test` passes on Linux x64
- Manual testing of `git-webrev`

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)