### PR TITLE
git-pr: recognize more forms on integration comments

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
@@ -1106,10 +1106,12 @@ public class GitPr {
                     }
                     var lines = comment.body().split("\n");
                     if (lines.length > 0 && lines[0].equals(expected)) {
-                        if (lines.length == 3 && lines[2].startsWith("Pushed as commit")) {
-                            var output = removeTrailing(lines[2], ".");
-                            System.out.println(output);
-                            System.exit(0);
+                        for (var line : lines) {
+                            if (line.startsWith("Pushed as commit")) {
+                                var output = removeTrailing(line, ".");
+                                System.out.println(output);
+                                System.exit(0);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Hi all,

please review this small patch that makes `git pr integrate` recognize multiple
forms of integration result comments (for example ones with rebase information).

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)