### PR TITLE
git-pr: rename "update" to "set"

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
@@ -552,7 +552,7 @@ public class GitPr {
                   .optional());
 
         var actions = List.of("list", "fetch", "show", "checkout", "apply", "integrate",
-                              "approve", "create", "close", "update", "test", "status");
+                              "approve", "create", "close", "set", "test", "status");
         var inputs = List.of(
             Input.position(0)
                  .describe(String.join("|", actions))
@@ -1383,7 +1383,7 @@ public class GitPr {
             var remoteRepo = getHostedRepositoryFor(uri, repo, host);
             var pr = remoteRepo.pullRequest(prId.asString());
             pr.setState(PullRequest.State.CLOSED);
-        } else if (action.equals("update")) {
+        } else if (action.equals("set")) {
             var prId = arguments.at(1);
             if (!prId.isPresent()) {
                 exit("error: missing pull request identifier");
@@ -1391,7 +1391,7 @@ public class GitPr {
 
             var remoteRepo = getHostedRepositoryFor(uri, repo, host);
             var pr = remoteRepo.pullRequest(prId.asString());
-            var assigneesOption = getOption("assignees", "update", arguments);
+            var assigneesOption = getOption("assignees", "set", arguments);
             if (assigneesOption != null) {
                 var usernames = Arrays.asList(assigneesOption.split(","));
                 var assignees = usernames.stream()


### PR DESCRIPTION
Hi all,

please review this patch that renames the `git pr` subcommand `update` to `set`.
This is done for a couple of reasons:

- `update` can be viewed as appending or enhancing whereas `set` better reflects
  that we do set some fields (i.e. all existing values for the field has to be
  repeated for appending).
- `update` is freed up to be user for future commands
- `set` is shorter than `update` :smiley:

Examples of how the command is intended to be used are `git pr set
--assignees=rwestberg`, `git pr set --reviewers=JornVernee` and `git pr set
--no-draft`.

Testing:
- Manual testing of `git pr set`

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)