### PR TITLE
Retry the mbox push action a few times in case of concurrent updates

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
@@ -75,13 +75,25 @@ class ArchiveWorkItem implements WorkItem {
     }
 
     private void pushMbox(Repository localRepo, String message) {
-        try {
-            localRepo.add(localRepo.root().resolve("."));
-            var hash = localRepo.commit(message, bot.emailAddress().fullName().orElseThrow(), bot.emailAddress().address());
-            localRepo.push(hash, bot.archiveRepo().url(), bot.archiveRef());
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
+        IOException lastException = null;
+        for (int counter = 0; counter < 3; ++counter) {
+            try {
+                var localHead = localRepo.head();
+                localRepo.add(localRepo.root().resolve("."));
+                var hash = localRepo.commit(message, bot.emailAddress().fullName().orElseThrow(), bot.emailAddress().address());
+                var remoteHead = localRepo.fetch(bot.archiveRepo().url(), bot.archiveRef());
+                if (!localHead.equals(remoteHead)) {
+                    log.info("Remote head has changed - attempting a rebase");
+                    localRepo.rebase(remoteHead, bot.emailAddress().fullName().orElseThrow(), bot.emailAddress().address());
+                    hash = localRepo.head();
+                }
+                localRepo.push(hash, bot.archiveRepo().url(), bot.archiveRef());
+                return;
+            } catch (IOException e) {
+                lastException = e;
+            }
         }
+        throw new UncheckedIOException(lastException);
     }
 
     private Repository materializeArchive(Path scratchPath) {


### PR DESCRIPTION
Hi all,

Please review this small change that retries the mbox push action a few times, to avoid errors when there are concurrent updates (to unrelated mboxes). Also performs a rebase action if needed to decrease the chance of an error.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)