### PR TITLE
webrev: check that issue linker is not null

### DIFF
--- a/webrev/src/main/java/org/openjdk/skara/webrev/Webrev.java
+++ b/webrev/src/main/java/org/openjdk/skara/webrev/Webrev.java
@@ -207,8 +207,8 @@ public class Webrev {
             var total = fileViews.stream().map(FileView::stats).mapToInt(WebrevStats::total).sum();
             var stats = new WebrevStats(diff.added(), diff.removed(), diff.modified(), total);
 
-            var issueForWebrev = issue == null ? null : issueLinker.apply(issue);
-            var tailEndURL = commitLinker == null ? null : commitLinker.apply(tailEnd.hex());
+            var issueForWebrev = issue != null && issueLinker != null ? issueLinker.apply(issue) : null;
+            var tailEndURL = commitLinker != null ? commitLinker.apply(tailEnd.hex()) : null;
             try (var w = Files.newBufferedWriter(output.resolve("index.html"))) {
                 var index = new IndexView(fileViews,
                                           title,


### PR DESCRIPTION
Hi all,

please review this small fix that ensures that `Webrev` checks that _both_
`issue` and `issueLinker` are not `null` before applying `issueLinker`. I also
updated the following line for `commitLinker` to use the same style of check for
consistency.

Testing:
- `make test` passes on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)