### PR TITLE
Use unique folder per repo for notifier materialization

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryWorkItem.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryWorkItem.java
@@ -266,7 +266,7 @@ public class RepositoryWorkItem implements WorkItem {
         var repositoryPool = new HostedRepositoryPool(storagePath.resolve("seeds"));
 
         try {
-            var localRepo = repositoryPool.materialize(repository, scratchPath.resolve("notify").resolve("repowi"));
+            var localRepo = repositoryPool.materialize(repository, scratchPath.resolve("notify").resolve("repowi").resolve(repository.name()));
             var knownRefs = localRepo.remoteBranches(repository.url().toString())
                                      .stream()
                                      .filter(ref -> branches.matcher(ref.name()).matches())


### PR DESCRIPTION
Hi all,

Please review this minor change that ensures the notifier uses a unique folder name for materialization different repositories. Otherwise there can be tag conflicts.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/455/head:pull/455`
`$ git checkout pull/455`
