### PR TITLE
git-pr: use multi-command argument parser

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
@@ -132,9 +132,9 @@ public class GitPr {
     }
 
 
-    private static String pullRequestIdArgument(Arguments arguments, ReadOnlyRepository repo) throws IOException {
-        if (arguments.at(1).isPresent()) {
-            return arguments.at(1).asString();
+    private static String pullRequestIdArgument(ReadOnlyRepository repo, Arguments arguments) throws IOException {
+        if (arguments.at(0).isPresent()) {
+            return arguments.at(0).asString();
         }
 
         var currentBranch = repo.currentBranch();
@@ -376,48 +376,6 @@ public class GitPr {
         await(pb.start(), 141);
     }
 
-    private static void gimport() throws IOException {
-        var pb = new ProcessBuilder("hg", "gimport");
-        pb.inheritIO();
-        await(pb.start());
-    }
-
-    private static void hgImport(Path patch) throws IOException {
-        var pb = new ProcessBuilder("hg", "import", "--no-commit", patch.toAbsolutePath().toString());
-        pb.inheritIO();
-        await(pb.start());
-    }
-
-    private static List<String> hgTags() throws IOException, InterruptedException {
-        var pb = new ProcessBuilder("hg", "tags", "--quiet");
-        pb.redirectOutput(ProcessBuilder.Redirect.PIPE);
-        pb.redirectError(ProcessBuilder.Redirect.INHERIT);
-        var p = pb.start();
-        var bytes = p.getInputStream().readAllBytes();
-        var exited = p.waitFor(1, TimeUnit.MINUTES);
-        var exitValue = p.exitValue();
-        if (!exited || exitValue != 0) {
-            throw new IOException("'hg tags' exited with value: " + exitValue);
-        }
-
-        return Arrays.asList(new String(bytes, StandardCharsets.UTF_8).split("\n"));
-    }
-
-    private static String hgResolve(String ref) throws IOException, InterruptedException {
-        var pb = new ProcessBuilder("hg", "log", "-r", ref, "--template", "{node}");
-        pb.redirectOutput(ProcessBuilder.Redirect.PIPE);
-        pb.redirectError(ProcessBuilder.Redirect.INHERIT);
-        var p = pb.start();
-        var bytes = p.getInputStream().readAllBytes();
-        var exited = p.waitFor(1, TimeUnit.MINUTES);
-        var exitValue = p.exitValue();
-        if (!exited || exitValue != 0) {
-            throw new IOException("'hg log' exited with value: " + exitValue);
-        }
-
-        return new String(bytes, StandardCharsets.UTF_8);
-    }
-
     private static Path diff(String ref, Hash hash) throws IOException {
         return diff(ref, hash, null);
     }
@@ -456,7 +414,62 @@ public class GitPr {
             s;
     }
 
-    public static void main(String[] args) throws IOException, InterruptedException {
+    private static Repository getRepo() throws IOException {
+        var cwd = Path.of("").toAbsolutePath();
+        return Repository.get(cwd).orElseThrow(() -> new IOException("no git repository found at " + cwd.toString()));
+    }
+
+    private static Arguments parse(ArgumentParser parser, String[] args) {
+        var arguments = parser.parse(args);
+        if (arguments.contains("version")) {
+            System.out.println("git-pr version: " + Version.fromManifest().orElse("unknown"));
+            System.exit(0);
+        }
+        if (arguments.contains("verbose") || arguments.contains("debug")) {
+            var level = arguments.contains("debug") ? Level.FINER : Level.FINE;
+            Logging.setup(level);
+        }
+        return arguments;
+    }
+
+    private static String getRemote(ReadOnlyRepository repo, Arguments arguments) throws IOException {
+        var remote = getOption("remote", arguments);
+        return remote == null ? "origin" : remote;
+    }
+
+    private static URI getURI(ReadOnlyRepository repo, Arguments arguments) throws IOException {
+        var remotePullPath = repo.pullPath(getRemote(repo, arguments));
+        return Remote.toWebURI(remotePullPath);
+    }
+
+    private static Forge getForge(URI uri, ReadOnlyRepository repo, Arguments arguments) throws IOException {
+        var username = getOption("username", arguments);
+        var token = System.getenv("GIT_TOKEN");
+        var shouldUseToken = !getSwitch("no-token", arguments);
+        var credentials = !shouldUseToken ?
+            null :
+            GitCredentials.fill(uri.getHost(), uri.getPath(), username, token, uri.getScheme());
+        var forgeURI = URI.create(uri.getScheme() + "://" + uri.getHost());
+        var forge = credentials == null ?
+            Forge.from(forgeURI) :
+            Forge.from(forgeURI, new Credential(credentials.username(), credentials.password()));
+        if (forge.isEmpty()) {
+            if (!shouldUseToken) {
+                if (arguments.contains("verbose")) {
+                    System.err.println("");
+                }
+                System.err.println("warning: using git-pr with --no-token may result in rate limiting from " + forgeURI);
+                if (!arguments.contains("verbose")) {
+                    System.err.println("         Re-run git-pr with --verbose to see if you are being rate limited");
+                    System.err.println("");
+                }
+            }
+            exit("error: failed to connect to host: " + forgeURI);
+        }
+        return forge.get();
+    }
+
+    private static void create(String[] args) throws IOException, InterruptedException {
         var flags = List.of(
             Option.shortcut("u")
                   .fullname("username")
@@ -472,6 +485,530 @@ public class GitPr {
                   .fullname("branch")
                   .describe("NAME")
                   .helptext("Name of target branch, defaults to 'master'")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("ignore-workspace")
+                  .helptext("Ignore local changes in worktree and staging area when creating pull request")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("ignore-local-commits")
+                  .helptext("Ignore local commits not pushed when creating pull request")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("publish")
+                  .helptext("Publish the local branch before creating the pull request")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("jcheck")
+                  .helptext("Run jcheck before creating the pull request")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("verbose")
+                  .helptext("Turn on verbose output")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("debug")
+                  .helptext("Turn on debugging output")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("version")
+                  .helptext("Print the version of this tool")
+                  .optional()
+        );
+
+        var inputs = List.of(
+            Input.position(0)
+                 .describe("ID")
+                 .singular()
+                 .optional()
+        );
+
+        var parser = new ArgumentParser("git-pr", flags, inputs);
+        var arguments = parse(parser, args);
+        var repo = getRepo();
+        var uri = getURI(repo, arguments);
+        var host = getForge(uri, repo, arguments);
+        var remote = getRemote(repo, arguments);
+        var currentBranch = repo.currentBranch().orElseGet(() -> {
+                System.err.println("error: the repository is in a detached HEAD state");
+                System.exit(1);
+                return null;
+        });
+        if (currentBranch.equals(repo.defaultBranch())) {
+            System.err.println("error: you should not create pull requests from the 'master' branch");
+            System.err.println("");
+            System.err.println("To create a local branch for your changes and restore the 'master' branch, run:");
+            System.err.println("");
+            System.err.println("    git checkout -b NAME-FOR-YOUR-LOCAL-BRANCH");
+            System.err.println("    git branch --force master origin/master");
+            System.err.println("");
+            System.exit(1);
+        }
+
+        var ignoreWorkspace = getSwitch("ignore-workspace", "create", arguments);
+        if (!ignoreWorkspace) {
+            var diff = repo.diff(repo.head());
+            if (!diff.patches().isEmpty()) {
+                System.err.println("error: there are uncommitted changes in your working tree:");
+                System.err.println("");
+                for (var patch : diff.patches()) {
+                    var path = patch.target().path().isPresent() ?
+                        patch.target().path().get() : patch.source().path().get();
+                    System.err.println("    " + patch.status().toString() + " " + path.toString());
+                }
+                System.err.println("");
+                System.err.println("If these changes are meant to be part of the pull request, run:");
+                System.err.println("");
+                System.err.println("    git commit -am 'Forgot to add some changes'");
+                System.err.println("");
+                System.err.println("If these changes are *not* meant to be part of the pull request, run:");
+                System.err.println("");
+                System.err.println("    git stash");
+                System.err.println("");
+                System.err.println("(You can later restore the changes by running: git stash pop)");
+                System.exit(1);
+            }
+        }
+
+        var upstream = repo.upstreamFor(currentBranch);
+        if (upstream.isEmpty()) {
+            var shouldPublish = getSwitch("publish", "create", arguments);
+            if (shouldPublish) {
+                GitPublish.main(new String[] { "--quiet", remote });
+                upstream = repo.upstreamFor(currentBranch);
+            } else {
+                System.err.println("error: there is no remote branch for the local branch '" + currentBranch.name() + "'");
+                System.err.println("");
+                System.err.println("A remote branch must be present at " + uri + " to create a pull request");
+                System.err.println("To create a remote branch and push the commits for your local branch, run:");
+                System.err.println("");
+                System.err.println("    git publish");
+                System.err.println("");
+                System.err.println("If you created the remote branch from another client, you must update this repository.");
+                System.err.println("To update remote information for this repository, run:");
+                System.err.println("");
+                System.err.println("    git fetch " + remote);
+                System.err.println("    git branch --set-upstream " + currentBranch + " " + remote + "/" + currentBranch);
+                System.err.println("");
+                System.exit(1);
+            }
+        }
+
+        var upstreamRefName = upstream.get().substring(remote.length() + 1);
+        repo.fetch(uri, upstreamRefName);
+
+        var shouldIgnoreLocalCommits = getSwitch("ignore-local-commits", "create", arguments);
+        if (!shouldIgnoreLocalCommits) {
+            var branchCommits = repo.commits(upstream.get() + ".." + currentBranch.name()).asList();
+            if (!branchCommits.isEmpty()) {
+                System.err.println("error: there are local commits on branch '" + currentBranch.name() + "' not present in the remote repository " + uri);
+                System.err.println("");
+                System.err.println("All commits must be present in the remote repository to be part of the pull request");
+                System.err.println("The following commits are not present in the remote repository:");
+                System.err.println("");
+                for (var commit : branchCommits) {
+                    System.err.println("- " + commit.hash().abbreviate() + ": " + commit.message().get(0));
+                }
+                System.err.println("");
+                System.err.println("To push the above local commits to the remote repository, run:");
+                System.err.println("");
+                System.err.println("    git push " + remote + " " + currentBranch.name());
+                System.err.println("");
+                System.exit(1);
+            }
+        }
+
+        var remoteRepo = host.repository(projectName(uri)).orElseThrow(() ->
+                new IOException("Could not find repository at " + uri.toString())
+        );
+        var parentRepo = remoteRepo.parent().orElseThrow(() ->
+                new IOException("error: remote repository " + uri + " is not a fork of any repository")
+        );
+
+        var targetBranch = getOption("branch", "create", arguments);
+        if (targetBranch == null) {
+            var upstreamBranchNames = repo.remoteBranches(parentRepo.webUrl().toString())
+                                          .stream()
+                                          .map(r -> r.name())
+                                          .collect(Collectors.toSet());
+            var remoteBranches = repo.branches(remote);
+            var candidates = new ArrayList<Branch>();
+            for (var b : remoteBranches) {
+                var withoutRemotePrefix = b.name().substring(remote.length() + 1);
+                if (upstreamBranchNames.contains(withoutRemotePrefix)) {
+                    candidates.add(b);
+                }
+            }
+
+            var localBranches = repo.branches();
+            Branch closest = null;
+            var shortestDistance = Integer.MAX_VALUE;
+            for (var b : candidates) {
+                var from = b.name();
+                for (var localBranch : localBranches) {
+                    var trackingBranch = repo.upstreamFor(localBranch);
+                    if (trackingBranch.isPresent() &&
+                        trackingBranch.get().equals(b.name())) {
+                        from = localBranch.name();
+                    }
+                }
+                var distance = repo.commitMetadata(from + "..." + currentBranch.name()).size();
+                if (distance < shortestDistance) {
+                    closest = b;
+                    shortestDistance = distance;
+                }
+            }
+
+            if (closest != null) {
+                targetBranch = closest.name().substring(remote.length() + 1);
+            } else {
+                System.err.println("error: cannot automatically infer target branch");
+                System.err.println("       use --branch to specify target branch");
+                System.exit(1);
+            }
+        }
+        var commits = repo.commits(targetBranch + ".." + upstream.get()).asList();
+        if (commits.isEmpty()) {
+            System.err.println("error: no difference between branches " + targetBranch + " and " + currentBranch.name());
+            System.err.println("       Cannot create an empty pull request, have you committed?");
+            System.exit(1);
+        }
+
+        var shouldRunJCheck = getSwitch("jcheck", "create", arguments);
+        if (shouldRunJCheck) {
+            var jcheckArgs = new String[]{ "--pull-request", "--rev", targetBranch + ".." + upstream.get() };
+            var err = GitJCheck.run(jcheckArgs);
+            if (err != 0) {
+                System.exit(err);
+            }
+        }
+
+        var project = jbsProjectFromJcheckConf(repo, targetBranch);
+        var issue = getIssue(currentBranch, project);
+        var file = Files.createTempFile("PULL_REQUEST_", ".md");
+        if (issue.isPresent()) {
+            Files.writeString(file, format(issue.get()) + "\n\n");
+        } else if (commits.size() == 1) {
+            var commit = commits.get(0);
+            issue = getIssue(commit, project);
+            if (issue.isPresent()) {
+                Files.writeString(file, format(issue.get()) + "\n\n");
+            } else {
+                var message = CommitMessageParsers.v1.parse(commit.message());
+                Files.writeString(file, message.title() + "\n");
+                if (!message.summaries().isEmpty()) {
+                    Files.write(file, message.summaries(), StandardOpenOption.APPEND);
+                }
+                if (!message.additional().isEmpty()) {
+                    Files.write(file, message.additional(), StandardOpenOption.APPEND);
+                }
+            }
+        } else {
+            Files.write(file, List.of(""));
+        }
+
+        appendPaddedHTMLComment(file, "Please enter the pull request message for your changes.");
+        appendPaddedHTMLComment(file, "The first line will be considered the subject, use a blank line to");
+        appendPaddedHTMLComment(file, "separate the subject from the body. These HTML comment lines will");
+        appendPaddedHTMLComment(file, "be removed automatically. An empty message aborts the pull request.");
+        appendPaddedHTMLComment(file, "");
+        appendPaddedHTMLComment(file, "Commits to be included from branch '" + currentBranch.name() + "':");
+        for (var commit : commits) {
+            var desc = commit.hash().abbreviate() + ": " + commit.message().get(0);
+            appendPaddedHTMLComment(file, "- " + desc);
+            if (!commit.isMerge()) {
+                var diff = commit.parentDiffs().get(0);
+                for (var patch : diff.patches()) {
+                    var status = patch.status();
+                    if (status.isModified()) {
+                        appendPaddedHTMLComment(file, "  M  " + patch.target().path().get().toString());
+                    } else if (status.isAdded()) {
+                        appendPaddedHTMLComment(file, "  A  " + patch.target().path().get().toString());
+                    } else if (status.isDeleted()) {
+                        appendPaddedHTMLComment(file, "  D  " + patch.source().path().get().toString());
+                    } else if (status.isRenamed()) {
+                        appendPaddedHTMLComment(file, "  R  " + patch.target().path().get().toString());
+                        appendPaddedHTMLComment(file, "      (" + patch.source().path().get().toString() + ")");
+                    } else if (status.isCopied()) {
+                        appendPaddedHTMLComment(file, "  C  " + patch.target().path().get().toString());
+                        appendPaddedHTMLComment(file, "      (" + patch.source().path().get().toString() + ")");
+                    }
+                }
+            }
+        }
+        appendPaddedHTMLComment(file, "");
+        if (issue.isPresent()) {
+            appendPaddedHTMLComment(file, "Issue:      " + issue.get().webUrl());
+        }
+        appendPaddedHTMLComment(file, "Repository: " + parentRepo.webUrl());
+        appendPaddedHTMLComment(file, "Branch:     " + targetBranch);
+
+        var success = spawnEditor(repo, file);
+        if (!success) {
+            System.err.println("error: editor exited with non-zero status code, aborting");
+            System.exit(1);
+        }
+        var lines = Files.readAllLines(file)
+                         .stream()
+                         .filter(l -> !(l.startsWith("<!--") && l.endsWith("-->")))
+                         .collect(Collectors.toList());
+        var isEmpty = lines.stream().allMatch(String::isEmpty);
+        if (isEmpty) {
+            System.err.println("error: no message present, aborting");
+            System.exit(1);
+        }
+
+        var title = lines.get(0);
+        List<String> body = null;
+        if (lines.size() > 1) {
+            body = lines.subList(1, lines.size())
+                        .stream()
+                        .dropWhile(String::isEmpty)
+                        .collect(Collectors.toList());
+        } else {
+            body = Collections.emptyList();
+        }
+
+        var pr = remoteRepo.createPullRequest(parentRepo, targetBranch, currentBranch.name(), title, body);
+        var assigneesOption = getOption("assignees", "create", arguments);
+        if (assigneesOption != null) {
+            var usernames = Arrays.asList(assigneesOption.split(","));
+            var assignees = usernames.stream()
+                                     .map(u -> host.user(u))
+                                     .filter(Optional::isPresent)
+                                     .map(Optional::get)
+                                     .collect(Collectors.toList());
+            pr.setAssignees(assignees);
+        }
+        System.out.println(pr.webUrl().toString());
+        Files.deleteIfExists(file);
+
+        repo.config("pr." + currentBranch.name(), "id", pr.id().toString());
+    }
+
+    private static void integrate(String[] args) throws IOException, InterruptedException {
+        var flags = List.of(
+            Option.shortcut("u")
+                  .fullname("username")
+                  .describe("NAME")
+                  .helptext("Username on host")
+                  .optional(),
+            Option.shortcut("r")
+                  .fullname("remote")
+                  .describe("NAME")
+                  .helptext("Name of remote, defaults to 'origin'")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("atomic")
+                  .helptext("Integrate the pull request atomically")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("verbose")
+                  .helptext("Turn on verbose output")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("debug")
+                  .helptext("Turn on debugging output")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("version")
+                  .helptext("Print the version of this tool")
+                  .optional()
+        );
+
+        var inputs = List.of(
+            Input.position(0)
+                 .describe("ID")
+                 .singular()
+                 .optional()
+        );
+
+        var parser = new ArgumentParser("git-pr", flags, inputs);
+        var arguments = parse(parser, args);
+        var repo = getRepo();
+        var uri = getURI(repo, arguments);
+        var host = getForge(uri, repo, arguments);
+        var id = pullRequestIdArgument(repo, arguments);
+        var pr = getPullRequest(uri, repo, host, id);
+        var isAtomic = getSwitch("atomic", "integrate", arguments);
+
+        var message = "/integrate";
+        if (isAtomic) {
+            var targetHash = repo.resolve(pr.targetRef());
+            if (!targetHash.isPresent()) {
+                exit("error: cannot resolve target branch " + pr.targetRef());
+            }
+            var sourceHash = repo.fetch(pr.repository().webUrl(), pr.fetchRef());
+            var mergeBase = repo.mergeBase(sourceHash, targetHash.get());
+            message += " " + mergeBase.hex();
+        }
+
+        var integrateComment = pr.addComment(message);
+
+        var seenIntegrateComment = false;
+        var expected = "<!-- Jmerge command reply message (" + integrateComment.id() + ") -->";
+        for (var i = 0; i < 90; i++) {
+            var comments = pr.comments();
+            for (var comment : comments) {
+                if (!seenIntegrateComment) {
+                    if (comment.id().equals(integrateComment.id())) {
+                        seenIntegrateComment = true;
+                    }
+                    continue;
+                }
+                var lines = comment.body().split("\n");
+                if (lines.length > 0 && lines[0].equals(expected)) {
+                    for (var line : lines) {
+                        if (line.startsWith("Pushed as commit")) {
+                            var output = removeTrailing(line, ".");
+                            System.out.println(output);
+                            System.exit(0);
+                        }
+                    }
+                }
+            }
+
+            Thread.sleep(2000);
+        }
+
+        System.err.println("error: timed out waiting for response to /integrate command");
+        System.exit(1);
+    }
+
+    private static void test(String[] args) throws IOException, InterruptedException {
+        var flags = List.of(
+            Option.shortcut("u")
+                  .fullname("username")
+                  .describe("NAME")
+                  .helptext("Username on host")
+                  .optional(),
+            Option.shortcut("r")
+                  .fullname("remote")
+                  .describe("NAME")
+                  .helptext("Name of remote, defaults to 'origin'")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("verbose")
+                  .helptext("Turn on verbose output")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("debug")
+                  .helptext("Turn on debugging output")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("version")
+                  .helptext("Print the version of this tool")
+                  .optional()
+        );
+
+        var inputs = List.of(
+            Input.position(0)
+                 .describe("ID")
+                 .singular()
+                 .optional()
+        );
+        var parser = new ArgumentParser("git-pr", flags, inputs);
+        var arguments = parse(parser, args);
+        var repo = getRepo();
+        var uri = getURI(repo, arguments);
+        var host = getForge(uri, repo, arguments);
+        var id = pullRequestIdArgument(repo, arguments);
+        var pr = getPullRequest(uri, repo, host, id);
+        var head = pr.headHash();
+        var testComment = pr.addComment("/test");
+
+        var seenTestComment = false;
+        for (var i = 0; i < 90; i++) {
+            var comments = pr.comments();
+            for (var comment : comments) {
+                if (!seenTestComment) {
+                    if (comment.id().equals(testComment.id())) {
+                        seenTestComment = true;
+                    }
+                    continue;
+                }
+                var lines = comment.body().split("\n");
+                var n = lines.length;
+                if (n > 0) {
+                    if (n == 4 &&
+                        lines[0].equals("<!-- TEST STARTED -->") &&
+                        lines[1].startsWith("<!-- github.com-") &&
+                        lines[2].equals("<!-- " + head.hex() + " -->")) {
+                        var output = removeTrailing(lines[3], ".");
+                        System.out.println(output);
+                        System.exit(0);
+                    } else if (n == 2 &&
+                               lines[0].equals("<!-- TEST ERROR -->")) {
+                        var output = removeTrailing(lines[1], ".");
+                        System.out.println(output);
+                        System.exit(1);
+                    } else if (n == 4 &&
+                               lines[0].equals("<!-- TEST PENDING -->") &&
+                               lines[1].equals("<!--- " + head.hex() + " -->")) {
+                        var output = removeTrailing(lines[3], ".");
+                        System.out.println(output);
+                        System.exit(0);
+                    }
+                }
+            }
+
+            Thread.sleep(2000);
+        }
+    }
+
+    private static void approve(String[] args) throws IOException, InterruptedException {
+        var flags = List.of(
+            Option.shortcut("u")
+                  .fullname("username")
+                  .describe("NAME")
+                  .helptext("Username on host")
+                  .optional(),
+            Option.shortcut("r")
+                  .fullname("remote")
+                  .describe("NAME")
+                  .helptext("Name of remote, defaults to 'origin'")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("verbose")
+                  .helptext("Turn on verbose output")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("debug")
+                  .helptext("Turn on debugging output")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("version")
+                  .helptext("Print the version of this tool")
+                  .optional()
+        );
+
+        var inputs = List.of(
+            Input.position(0)
+                 .describe("ID")
+                 .singular()
+                 .optional()
+        );
+        var parser = new ArgumentParser("git-pr", flags, inputs);
+        var arguments = parse(parser, args);
+        var repo = getRepo();
+        var uri = getURI(repo, arguments);
+        var host = getForge(uri, repo, arguments);
+        var id = pullRequestIdArgument(repo, arguments);
+        var pr = getPullRequest(uri, repo, host, id);
+        pr.addReview(Review.Verdict.APPROVED, "Looks good!");
+    }
+
+    private static void list(String[] args) throws IOException, InterruptedException {
+        var flags = List.of(
+            Option.shortcut("u")
+                  .fullname("username")
+                  .describe("NAME")
+                  .helptext("Username on host")
+                  .optional(),
+            Option.shortcut("r")
+                  .fullname("remote")
+                  .describe("NAME")
+                  .helptext("Name of remote, defaults to 'origin'")
                   .optional(),
             Option.shortcut("")
                   .fullname("authors")
@@ -507,36 +1044,8 @@ public class GitPr {
                   .helptext("Hide all pull requests in draft state")
                   .optional(),
             Switch.shortcut("")
-                  .fullname("ignore-workspace")
-                  .helptext("Ignore local changes in worktree and staging area when creating pull request")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("ignore-local-commits")
-                  .helptext("Ignore local commits not pushed when creating pull request")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("publish")
-                  .helptext("Publish the local branch before creating the pull request")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("atomic")
-                  .helptext("Integrate the pull request atomically")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("jcheck")
-                  .helptext("Run jcheck before creating the pull request")
-                  .optional(),
-            Switch.shortcut("")
                   .fullname("no-token")
-                  .helptext("Do not use a personal access token (PAT). Only works for read-only operations.")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("no-checks")
-                  .helptext("Do not show check status as part of the 'git pr status' output")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("mercurial")
-                  .helptext("Force use of Mercurial (hg)")
+                  .helptext("Do not use a personal access token (PAT)")
                   .optional(),
             Switch.shortcut("")
                   .fullname("verbose")
@@ -551,881 +1060,587 @@ public class GitPr {
                   .helptext("Print the version of this tool")
                   .optional());
 
-        var actions = List.of("list", "fetch", "show", "checkout", "apply", "integrate",
-                              "approve", "create", "close", "set", "test", "status");
         var inputs = List.of(
             Input.position(0)
-                 .describe(String.join("|", actions))
-                 .singular()
-                 .optional(),
-            Input.position(1)
                  .describe("ID")
                  .singular()
                  .optional()
         );
 
         var parser = new ArgumentParser("git-pr", flags, inputs);
-        var arguments = parser.parse(args);
+        var arguments = parse(parser, args);
+        var repo = getRepo();
+        var uri = getURI(repo, arguments);
+        var host = getForge(uri, repo, arguments);
+        var remoteRepo = getHostedRepositoryFor(uri, repo, host);
 
-        if (arguments.contains("version")) {
-            System.out.println("git-pr version: " + Version.fromManifest().orElse("unknown"));
-            System.exit(0);
+        var prs = remoteRepo.pullRequests();
+        var ids = new ArrayList<String>();
+        var titles = new ArrayList<String>();
+        var authors = new ArrayList<String>();
+        var assignees = new ArrayList<String>();
+        var labels = new ArrayList<String>();
+        var issues = new ArrayList<String>();
+        var branches = new ArrayList<String>();
+        var statuses = new ArrayList<String>();
+        var noDraft = getSwitch("no-draft", "list", arguments);
+
+        var authorsOption = getOption("authors", "list", arguments);
+        var filterAuthors = authorsOption == null ?
+            Set.of() :
+            new HashSet<>(Arrays.asList(authorsOption.split(",")));
+
+        var assigneesOption = getOption("assignees", "list", arguments);
+        var filterAssignees = assigneesOption == null ?
+            Set.of() :
+            Arrays.asList(assigneesOption.split(","));
+
+        var labelsOption = getOption("labels", "list", arguments);
+        var filterLabels = labelsOption == null ?
+            Set.of() :
+            Arrays.asList(labelsOption.split(","));
+
+        var issuesOption = getOption("issues", "list", arguments);
+        var filterIssues = issuesOption == null ?
+            Set.of() :
+            Arrays.asList(issuesOption.split(","));
+
+        var columnTitles = List.of("id", "title", "authors", "assignees", "labels", "issues", "branch", "status");
+        var columnValues = Map.of(columnTitles.get(0), ids,
+                                  columnTitles.get(1), titles,
+                                  columnTitles.get(2), authors,
+                                  columnTitles.get(3), assignees,
+                                  columnTitles.get(4), labels,
+                                  columnTitles.get(5), issues,
+                                  columnTitles.get(6), branches,
+                                  columnTitles.get(7), statuses);
+        var columnsOption = getOption("columns", "list", arguments);
+        var columns = columnsOption == null ?
+            List.of("id", "title", "authors", "status") :
+            Arrays.asList(columnsOption.split(","));
+
+        for (var column : columns) {
+            if (!columnTitles.contains(column)) {
+                System.err.println("error: unknown column: " + column);
+                System.err.println("       available columns are: " + String.join(",", columnTitles));
+                System.exit(1);
+            }
         }
 
-        if (arguments.contains("verbose") || arguments.contains("debug")) {
-            var level = arguments.contains("debug") ? Level.FINER : Level.FINE;
-            Logging.setup(level);
+        for (var pr : prs) {
+            if (pr.isDraft() && noDraft) {
+                continue;
+            }
+
+            var prAuthor = pr.author().userName();
+            if (!filterAuthors.isEmpty() && !filterAuthors.contains(prAuthor)) {
+                continue;
+            }
+
+            var prAssignees = pr.assignees().stream()
+                                .map(HostUser::userName)
+                                .collect(Collectors.toSet());
+            if (!filterAssignees.isEmpty() && !filterAssignees.stream().anyMatch(prAssignees::contains)) {
+                continue;
+            }
+
+            var prLabels = new HashSet<>(pr.labels());
+            if (!filterLabels.isEmpty() && !filterLabels.stream().anyMatch(prLabels::contains)) {
+                continue;
+            }
+
+            var prIssues = new HashSet<>(issuesFromPullRequest(pr));
+            if (!filterIssues.isEmpty() && !filterIssues.stream().anyMatch(prIssues::contains)) {
+                continue;
+            }
+
+
+            ids.add(pr.id());
+            titles.add(pr.title());
+            authors.add(prAuthor);
+            assignees.add(String.join(",", prAssignees));
+            labels.add(String.join(",", prLabels));
+            issues.add(String.join(",", prIssues));
+
+            if (pr.sourceRepository().webUrl().equals(uri)) {
+                branches.add(pr.sourceRef());
+            } else {
+                branches.add("");
+            }
+
+            if (columns.contains("status")) {
+                statuses.add(statusForPullRequest(pr).toLowerCase());
+            } else {
+                statuses.add("");
+            }
         }
+
+
+        String fmt = "";
+        for (var column : columns.subList(0, columns.size() - 1)) {
+            var values = columnValues.get(column);
+            var n = Math.max(column.length(), longest(values));
+            fmt += "%-" + n + "s    ";
+        }
+        fmt += "%s\n";
+
+        var noDecoration = getSwitch("no-decoration", "list", arguments);
+        if (!ids.isEmpty() && !noDecoration) {
+            var upperCase = columns.stream()
+                                   .map(String::toUpperCase)
+                                   .collect(Collectors.toList());
+            System.out.format(fmt, (Object[]) upperCase.toArray(new String[0]));
+        }
+        for (var i = 0; i < ids.size(); i++) {
+            final int n = i;
+            var row = columns.stream()
+                             .map(columnValues::get)
+                             .map(values -> values.get(n))
+                             .collect(Collectors.toList());
+            System.out.format(fmt, (Object[]) row.toArray(new String[0]));
+        }
+    }
+
+    private static void close(String[] args) throws IOException, InterruptedException {
+        var flags = List.of(
+            Option.shortcut("u")
+                  .fullname("username")
+                  .describe("NAME")
+                  .helptext("Username on host")
+                  .optional(),
+            Option.shortcut("r")
+                  .fullname("remote")
+                  .describe("NAME")
+                  .helptext("Name of remote, defaults to 'origin'")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("verbose")
+                  .helptext("Turn on verbose output")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("debug")
+                  .helptext("Turn on debugging output")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("version")
+                  .helptext("Print the version of this tool")
+                  .optional()
+        );
+
+        var inputs = List.of(
+            Input.position(0)
+                 .describe("ID")
+                 .singular()
+                 .optional()
+        );
+
+        var parser = new ArgumentParser("git-pr", flags, inputs);
+        var arguments = parse(parser, args);
+        var repo = getRepo();
+        var uri = getURI(repo, arguments);
+        var host = getForge(uri, repo, arguments);
+        var id = pullRequestIdArgument(repo, arguments);
+        var pr = getPullRequest(uri, repo, host, id);
+
+        pr.setState(PullRequest.State.CLOSED);
+    }
+
+    private static void set(String[] args) throws IOException, InterruptedException {
+        var flags = List.of(
+            Option.shortcut("u")
+                  .fullname("username")
+                  .describe("NAME")
+                  .helptext("Username on host")
+                  .optional(),
+            Option.shortcut("r")
+                  .fullname("remote")
+                  .describe("NAME")
+                  .helptext("Name of remote, defaults to 'origin'")
+                  .optional(),
+            Option.shortcut("")
+                  .fullname("assignees")
+                  .describe("LIST")
+                  .helptext("Comma separated list of assignees")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("verbose")
+                  .helptext("Turn on verbose output")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("debug")
+                  .helptext("Turn on debugging output")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("version")
+                  .helptext("Print the version of this tool")
+                  .optional()
+        );
+
+        var inputs = List.of(
+            Input.position(0)
+                 .describe("ID")
+                 .singular()
+                 .optional()
+        );
+
+        var parser = new ArgumentParser("git-pr", flags, inputs);
+        var arguments = parse(parser, args);
+        var repo = getRepo();
+        var uri = getURI(repo, arguments);
+        var host = getForge(uri, repo, arguments);
+        var id = pullRequestIdArgument(repo, arguments);
+        var pr = getPullRequest(uri, repo, host, id);
+
+        var assigneesOption = getOption("assignees", "set", arguments);
+        if (assigneesOption != null) {
+            var usernames = Arrays.asList(assigneesOption.split(","));
+            var assignees = usernames.stream()
+                .map(u -> host.user(u))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.toList());
+            pr.setAssignees(assignees);
+        }
+    }
+
+    private static void status(String[] args) throws IOException, InterruptedException {
+        var flags = List.of(
+            Option.shortcut("u")
+                  .fullname("username")
+                  .describe("NAME")
+                  .helptext("Username on host")
+                  .optional(),
+            Option.shortcut("r")
+                  .fullname("remote")
+                  .describe("NAME")
+                  .helptext("Name of remote, defaults to 'origin'")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("no-decoration")
+                  .helptext("Hide any decorations when listing PRs")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("no-token")
+                  .helptext("Do not use a personal access token (PAT)")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("no-checks")
+                  .helptext("Do not show check status as part of the 'git pr status' output")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("verbose")
+                  .helptext("Turn on verbose output")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("debug")
+                  .helptext("Turn on debugging output")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("version")
+                  .helptext("Print the version of this tool")
+                  .optional()
+        );
+
+        var inputs = List.of(
+            Input.position(0)
+                 .describe("ID")
+                 .singular()
+                 .optional()
+        );
+
+        var parser = new ArgumentParser("git-pr", flags, inputs);
+        var arguments = parse(parser, args);
+        var repo = getRepo();
+        var uri = getURI(repo, arguments);
+        var host = getForge(uri, repo, arguments);
+        var id = pullRequestIdArgument(repo, arguments);
+        var pr = getPullRequest(uri, repo, host, id);
+
+        var noDecoration = getSwitch("no-decoration", "status", arguments);
+        var decoration = noDecoration ? "" : "Status: ";
+        System.out.println(decoration + statusForPullRequest(pr));
+
+        var noChecks = getSwitch("no-checks", "status", arguments);
+        if (!noChecks) {
+            var checks = pr.checks(pr.headHash());
+            var jcheck = Optional.ofNullable(checks.get("jcheck"));
+            var submit = Optional.ofNullable(checks.get("submit"));
+            var showChecks = jcheck.isPresent() || submit.isPresent();
+            if (showChecks) {
+                System.out.println("Checks:");
+                if (jcheck.isPresent()) {
+                    System.out.println("- jcheck: " + statusForCheck(jcheck.get()));
+                }
+                if (submit.isPresent()) {
+                    System.out.println("- submit: " + statusForCheck(submit.get()));
+                }
+            }
+        }
+    }
+
+    private static void fetch(String[] args) throws IOException, InterruptedException {
+        var flags = List.of(
+            Option.shortcut("u")
+                  .fullname("username")
+                  .describe("NAME")
+                  .helptext("Username on host")
+                  .optional(),
+            Option.shortcut("r")
+                  .fullname("remote")
+                  .describe("NAME")
+                  .helptext("Name of remote, defaults to 'origin'")
+                  .optional(),
+            Option.shortcut("b")
+                  .fullname("branch")
+                  .describe("NAME")
+                  .helptext("Name of target branch, defaults to 'master'")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("no-token")
+                  .helptext("Do not use a personal access token (PAT)")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("verbose")
+                  .helptext("Turn on verbose output")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("debug")
+                  .helptext("Turn on debugging output")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("version")
+                  .helptext("Print the version of this tool")
+                  .optional()
+        );
+
+        var inputs = List.of(
+            Input.position(0)
+                 .describe("ID")
+                 .singular()
+                 .optional()
+        );
+
+        var parser = new ArgumentParser("git-pr", flags, inputs);
+        var arguments = parse(parser, args);
+        var repo = getRepo();
+        var uri = getURI(repo, arguments);
+        var host = getForge(uri, repo, arguments);
+        var id = pullRequestIdArgument(repo, arguments);
+        var pr = getPullRequest(uri, repo, host, id);
+
+        var fetchHead = repo.fetch(pr.repository().webUrl(), pr.fetchRef());
+        var branchName = getOption("branch", "fetch", arguments);
+        if (branchName != null) {
+            repo.branch(fetchHead, branchName);
+        } else {
+            System.out.println(fetchHead.hex());
+        }
+    }
+
+    private static void show(String[] args) throws IOException, InterruptedException {
+        var flags = List.of(
+            Option.shortcut("u")
+                  .fullname("username")
+                  .describe("NAME")
+                  .helptext("Username on host")
+                  .optional(),
+            Option.shortcut("r")
+                  .fullname("remote")
+                  .describe("NAME")
+                  .helptext("Name of remote, defaults to 'origin'")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("no-token")
+                  .helptext("Do not use a personal access token (PAT)")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("verbose")
+                  .helptext("Turn on verbose output")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("debug")
+                  .helptext("Turn on debugging output")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("version")
+                  .helptext("Print the version of this tool")
+                  .optional()
+        );
+
+        var inputs = List.of(
+            Input.position(0)
+                 .describe("ID")
+                 .singular()
+                 .optional()
+        );
+
+        var parser = new ArgumentParser("git-pr", flags, inputs);
+        var arguments = parse(parser, args);
+        var repo = getRepo();
+        var uri = getURI(repo, arguments);
+        var host = getForge(uri, repo, arguments);
+        var id = pullRequestIdArgument(repo, arguments);
+        var pr = getPullRequest(uri, repo, host, id);
+
+        var fetchHead = repo.fetch(pr.repository().webUrl(), pr.fetchRef());
+        show(pr.targetRef(), fetchHead);
+    }
+
+    private static void checkout(String[] args) throws IOException, InterruptedException {
+        var flags = List.of(
+            Option.shortcut("u")
+                  .fullname("username")
+                  .describe("NAME")
+                  .helptext("Username on host")
+                  .optional(),
+            Option.shortcut("r")
+                  .fullname("remote")
+                  .describe("NAME")
+                  .helptext("Name of remote, defaults to 'origin'")
+                  .optional(),
+            Option.shortcut("b")
+                  .fullname("branch")
+                  .describe("NAME")
+                  .helptext("Name of target branch, defaults to 'master'")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("no-token")
+                  .helptext("Do not use a personal access token (PAT)")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("verbose")
+                  .helptext("Turn on verbose output")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("debug")
+                  .helptext("Turn on debugging output")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("version")
+                  .helptext("Print the version of this tool")
+                  .optional()
+        );
+
+        var inputs = List.of(
+            Input.position(0)
+                 .describe("ID")
+                 .singular()
+                 .optional()
+        );
+
+        var parser = new ArgumentParser("git-pr", flags, inputs);
+        var arguments = parse(parser, args);
+        var repo = getRepo();
+        var uri = getURI(repo, arguments);
+        var host = getForge(uri, repo, arguments);
+        var id = pullRequestIdArgument(repo, arguments);
+        var pr = getPullRequest(uri, repo, host, id);
+
+        var fetchHead = repo.fetch(pr.repository().webUrl(), pr.fetchRef());
+	var branchName = getOption("branch", "checkout", arguments);
+	if (branchName != null) {
+	    var branch = repo.branch(fetchHead, branchName);
+	    repo.checkout(branch, false);
+	} else {
+	    repo.checkout(fetchHead, false);
+	}
+    }
+
+    private static void apply(String[] args) throws IOException, InterruptedException {
+        var flags = List.of(
+            Option.shortcut("u")
+                  .fullname("username")
+                  .describe("NAME")
+                  .helptext("Username on host")
+                  .optional(),
+            Option.shortcut("r")
+                  .fullname("remote")
+                  .describe("NAME")
+                  .helptext("Name of remote, defaults to 'origin'")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("no-token")
+                  .helptext("Do not use a personal access token (PAT)")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("verbose")
+                  .helptext("Turn on verbose output")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("debug")
+                  .helptext("Turn on debugging output")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("version")
+                  .helptext("Print the version of this tool")
+                  .optional()
+        );
+
+        var inputs = List.of(
+            Input.position(0)
+                 .describe("ID")
+                 .singular()
+                 .optional()
+        );
+
+        var parser = new ArgumentParser("git-pr", flags, inputs);
+        var arguments = parse(parser, args);
+        var repo = getRepo();
+        var uri = getURI(repo, arguments);
+        var host = getForge(uri, repo, arguments);
+        var id = pullRequestIdArgument(repo, arguments);
+        var pr = getPullRequest(uri, repo, host, id);
+
+        var fetchHead = repo.fetch(pr.repository().webUrl(), pr.fetchRef());
+        var patch = diff(pr.targetRef(), fetchHead);
+        apply(patch);
+        Files.deleteIfExists(patch);
+    }
+
+    public static void main(String[] args) throws Exception {
+        var commands = List.of(
+                    Default.name("list")
+                           .helptext("list open pull requests")
+                           .main(GitPr::list),
+                    Command.name("fetch")
+                           .helptext("fetch a pull request")
+                           .main(GitPr::fetch),
+                    Command.name("show")
+                           .helptext("show a pull request")
+                           .main(GitPr::show),
+                    Command.name("checkout")
+                           .helptext("checkout a pull request")
+                           .main(GitPr::checkout),
+                    Command.name("apply")
+                           .helptext("apply a pull request")
+                           .main(GitPr::apply),
+                    Command.name("integrate")
+                           .helptext("integrate a pull request")
+                           .main(GitPr::integrate),
+                    Command.name("approve")
+                           .helptext("approve a pull request")
+                           .main(GitPr::approve),
+                    Command.name("create")
+                           .helptext("create a pull request")
+                           .main(GitPr::create),
+                    Command.name("close")
+                           .helptext("close a pull request")
+                           .main(GitPr::close),
+                    Command.name("set")
+                           .helptext("set properties of a pull request")
+                           .main(GitPr::set),
+                    Command.name("test")
+                           .helptext("test a pull request")
+                           .main(GitPr::test),
+                    Command.name("status")
+                           .helptext("show status of a pull request")
+                           .main(GitPr::status)
+        );
 
         HttpProxy.setup();
 
-        var isMercurial = getSwitch("mercurial", arguments);
-        var cwd = Path.of("").toAbsolutePath();
-        var repo = Repository.get(cwd).orElseThrow(() -> new IOException("no git repository found at " + cwd.toString()));
-        var remote = getOption("remote", arguments);
-        if (remote == null) {
-            remote = isMercurial ? "default" : "origin";
-        }
-        var remotePullPath = repo.pullPath(remote);
-        var username = getOption("username", arguments);
-        var token = isMercurial ? System.getenv("HG_TOKEN") : System.getenv("GIT_TOKEN");
-        var uri = Remote.toWebURI(remotePullPath);
-        var shouldUseToken = !getSwitch("no-token", arguments);
-        var credentials = !shouldUseToken ?
-            null :
-            GitCredentials.fill(uri.getHost(), uri.getPath(), username, token, uri.getScheme());
-        var forgeURI = URI.create(uri.getScheme() + "://" + uri.getHost());
-        var forge = credentials == null ?
-            Forge.from(forgeURI) :
-            Forge.from(forgeURI, new Credential(credentials.username(), credentials.password()));
-        if (forge.isEmpty()) {
-            if (!shouldUseToken) {
-                if (arguments.contains("verbose")) {
-                    System.err.println("");
-                }
-                System.err.println("warning: using git-pr with --no-token may result in rate limiting from " + forgeURI);
-                if (!arguments.contains("verbose")) {
-                    System.err.println("         Re-run git-pr with --verbose to see if you are being rate limited");
-                    System.err.println("");
-                }
-            }
-            exit("error: failed to connect to host: " + forgeURI);
-        }
-        var host = forge.get();
-
-        var action = arguments.at(0).isPresent() ? arguments.at(0).asString() : null;
-        if (action == null) {
-            var lines = repo.config("pr.default");
-            if (lines.size() == 1) {
-                action = lines.get(0);
-            }
-        }
-
-        if (action == null) {
-            System.err.println("error: you must supply a valid action:");
-            for (var a : actions) {
-                System.err.println("       - " + a);
-            }
-            System.err.println("You can also configure a default action by running 'git configure --global pr.default <action>'");
-            System.exit(1);
-        }
-
-        if (!shouldUseToken &&
-            !List.of("list", "fetch", "show", "checkout", "apply").contains(action)) {
-            System.err.println("error: --no-token can only be used with read-only operations");
-            System.exit(1);
-        }
-
-        if (action.equals("create")) {
-            if (isMercurial) {
-                var currentBookmark = repo.currentBookmark();
-                if (!currentBookmark.isPresent()) {
-                    System.err.println("error: no bookmark is active, you must be on an active bookmark");
-                    System.err.println("");
-                    System.err.println("To create a bookmark and activate it, run:");
-                    System.err.println("");
-                    System.err.println("    hg bookmark NAME-FOR-YOUR-BOOKMARK");
-                    System.err.println("");
-                    System.exit(1);
-                }
-
-                var bookmark = currentBookmark.get();
-                if (bookmark.equals(new Bookmark("master"))) {
-                    System.err.println("error: you should not create pull requests from the 'master' bookmark");
-                    System.err.println("To create a bookmark and activate it, run:");
-                    System.err.println("");
-                    System.err.println("    hg bookmark NAME-FOR-YOUR-BOOKMARK");
-                    System.err.println("");
-                    System.exit(1);
-                }
-
-                var tags = hgTags();
-                var upstreams = tags.stream()
-                                    .filter(t -> t.endsWith(bookmark.name()))
-                                    .collect(Collectors.toList());
-                if (upstreams.isEmpty()) {
-                    System.err.println("error: there is no remote branch for the local bookmark '" + bookmark.name() + "'");
-                    System.err.println("");
-                    System.err.println("To create a remote branch and push the commits for your local branch, run:");
-                    System.err.println("");
-                    System.err.println("    hg push --bookmark " + bookmark.name());
-                    System.err.println("");
-                    System.exit(1);
-                }
-
-                var tagsAndHashes = new HashMap<String, String>();
-                for (var tag : tags) {
-                    tagsAndHashes.put(tag, hgResolve(tag));
-                }
-                var bookmarkHash = hgResolve(bookmark.name());
-                if (!tagsAndHashes.containsValue(bookmarkHash)) {
-                    System.err.println("error: there are local commits on bookmark '" + bookmark.name() + "' not present in a remote repository");
-                    System.err.println("");
-
-                    if (upstreams.size() == 1) {
-                        System.err.println("To push the local commits to the remote repository, run:");
-                        System.err.println("");
-                        System.err.println("    hg push --bookmark " + bookmark.name() + " " + upstreams.get(0));
-                        System.err.println("");
-                    } else {
-                        System.err.println("The following paths contains the " + bookmark.name() + " bookmark:");
-                        System.err.println("");
-                        for (var upstream : upstreams) {
-                            System.err.println("- " + upstream.replace("/" + bookmark.name(), ""));
-                        }
-                        System.err.println("");
-                        System.err.println("To push the local commits to a remote repository, run:");
-                        System.err.println("");
-                        System.err.println("    hg push --bookmark " + bookmark.name() + " <PATH>");
-                        System.err.println("");
-                    }
-                    System.exit(1);
-                }
-
-                var targetBranch = arguments.get("branch").orString("master");
-                var targetHash = hgResolve(targetBranch);
-                var commits = repo.commits(targetHash + ".." + bookmarkHash + "-" + targetHash).asList();
-                if (commits.isEmpty()) {
-                    System.err.println("error: no difference between bookmarks " + targetBranch + " and " + bookmark.name());
-                    System.err.println("       Cannot create an empty pull request, have you committed?");
-                    System.exit(1);
-                }
-
-                var diff = repo.diff(repo.head());
-                if (!diff.patches().isEmpty()) {
-                    System.err.println("error: there are uncommitted changes in your working tree:");
-                    System.err.println("");
-                    for (var patch : diff.patches()) {
-                        var path = patch.target().path().isPresent() ?
-                            patch.target().path().get() : patch.source().path().get();
-                        System.err.println("    " + patch.status().toString() + " " + path.toString());
-                    }
-                    System.err.println("");
-                    System.err.println("If these changes are meant to be part of the pull request, run:");
-                    System.err.println("");
-                    System.err.println("    hg commit --amend");
-                    System.err.println("    hg git-cleanup");
-                    System.err.println("    hg push --bookmark " + bookmark.name() + " <PATH>");
-                    System.err.println("    hg gimport");
-                    System.err.println("");
-                    System.err.println("If these changes are *not* meant to be part of the pull request, run:");
-                    System.err.println("");
-                    System.err.println("    hg shelve");
-                    System.err.println("");
-                    System.err.println("(You can later restore the changes by running: hg unshelve)");
-                    System.exit(1);
-                }
-
-                var remoteRepo = host.repository(projectName(uri)).orElseThrow(() ->
-                        new IOException("Could not find repository at " + uri.toString())
-                );
-                if (token == null) {
-                    GitCredentials.approve(credentials);
-                }
-                var parentRepo = remoteRepo.parent().orElseThrow(() ->
-                        new IOException("error: remote repository " + remotePullPath + " is not a fork of any repository"));
-
-                var file = Files.createTempFile("PULL_REQUEST_", ".txt");
-                if (commits.size() == 1) {
-                    var commit = commits.get(0);
-                    var message = CommitMessageParsers.v1.parse(commit.message());
-                    Files.writeString(file, message.title() + "\n");
-                    if (!message.summaries().isEmpty()) {
-                        Files.write(file, message.summaries(), StandardOpenOption.APPEND);
-                    }
-                    if (!message.additional().isEmpty()) {
-                        Files.write(file, message.additional(), StandardOpenOption.APPEND);
-                    }
-                } else {
-                    Files.write(file, List.of(""));
-                }
-                Files.write(file, List.of(
-                    "# Please enter the pull request message for your changes. Lines starting",
-                    "# with '#' will be ignored, and an empty message aborts the pull request.",
-                    "# The first line will be considered the subject, use a blank line to separate",
-                    "# the subject from the body.",
-                    "#",
-                    "# Commits to be included from branch '" + bookmark.name() + "'"
-                    ),
-                    StandardOpenOption.APPEND
-                );
-                for (var commit : commits) {
-                    var desc = commit.hash().abbreviate() + ": " + commit.message().get(0);
-                    Files.writeString(file, "# - " + desc + "\n", StandardOpenOption.APPEND);
-                }
-                Files.writeString(file, "#\n", StandardOpenOption.APPEND);
-                Files.writeString(file, "# Target repository: " + remotePullPath + "\n", StandardOpenOption.APPEND);
-                Files.writeString(file, "# Target branch: " + targetBranch + "\n", StandardOpenOption.APPEND);
-                var success = spawnEditor(repo, file);
-                if (!success) {
-                    System.err.println("error: editor exited with non-zero status code, aborting");
-                    System.exit(1);
-                }
-                var lines = Files.readAllLines(file)
-                                 .stream()
-                                 .filter(l -> !l.startsWith("#"))
-                                 .collect(Collectors.toList());
-                var isEmpty = lines.stream().allMatch(String::isEmpty);
-                if (isEmpty) {
-                    System.err.println("error: no message present, aborting");
-                    System.exit(1);
-                }
-
-                var title = lines.get(0);
-                List<String> body = null;
-                if (lines.size() > 1) {
-                    body = lines.subList(1, lines.size())
-                                .stream()
-                                .dropWhile(String::isEmpty)
-                                .collect(Collectors.toList());
-                } else {
-                    body = Collections.emptyList();
-                }
-
-                var pr = remoteRepo.createPullRequest(parentRepo, targetBranch, bookmark.name(), title, body);
-                if (arguments.contains("assignees")) {
-                    var usernames = Arrays.asList(arguments.get("assignees").asString().split(","));
-                    var assignees = usernames.stream()
-                                             .map(u -> host.user(u))
-                                             .filter(Optional::isPresent)
-                                             .map(Optional::get)
-                                             .collect(Collectors.toList());
-                    pr.setAssignees(assignees);
-                }
-                System.out.println(pr.webUrl().toString());
-                Files.deleteIfExists(file);
-
-                System.exit(0);
-            }
-            var currentBranch = repo.currentBranch().orElseGet(() -> {
-                    System.err.println("error: the repository is in a detached HEAD state");
-                    System.exit(1);
-                    return null;
-            });
-            if (currentBranch.equals(repo.defaultBranch())) {
-                System.err.println("error: you should not create pull requests from the 'master' branch");
-                System.err.println("");
-                System.err.println("To create a local branch for your changes and restore the 'master' branch, run:");
-                System.err.println("");
-                System.err.println("    git checkout -b NAME-FOR-YOUR-LOCAL-BRANCH");
-                System.err.println("    git branch --force master origin/master");
-                System.err.println("");
-                System.exit(1);
-            }
-
-            var ignoreWorkspace = getSwitch("ignore-workspace", "create", arguments);
-            if (!ignoreWorkspace) {
-                var diff = repo.diff(repo.head());
-                if (!diff.patches().isEmpty()) {
-                    System.err.println("error: there are uncommitted changes in your working tree:");
-                    System.err.println("");
-                    for (var patch : diff.patches()) {
-                        var path = patch.target().path().isPresent() ?
-                            patch.target().path().get() : patch.source().path().get();
-                        System.err.println("    " + patch.status().toString() + " " + path.toString());
-                    }
-                    System.err.println("");
-                    System.err.println("If these changes are meant to be part of the pull request, run:");
-                    System.err.println("");
-                    System.err.println("    git commit -am 'Forgot to add some changes'");
-                    System.err.println("");
-                    System.err.println("If these changes are *not* meant to be part of the pull request, run:");
-                    System.err.println("");
-                    System.err.println("    git stash");
-                    System.err.println("");
-                    System.err.println("(You can later restore the changes by running: git stash pop)");
-                    System.exit(1);
-                }
-            }
-
-            var upstream = repo.upstreamFor(currentBranch);
-            if (upstream.isEmpty()) {
-                var shouldPublish = getSwitch("publish", "create", arguments);
-                if (shouldPublish) {
-                    GitPublish.main(new String[] { "--quiet", remote });
-                    upstream = repo.upstreamFor(currentBranch);
-                } else {
-                    System.err.println("error: there is no remote branch for the local branch '" + currentBranch.name() + "'");
-                    System.err.println("");
-                    System.err.println("A remote branch must be present at " + remotePullPath + " to create a pull request");
-                    System.err.println("To create a remote branch and push the commits for your local branch, run:");
-                    System.err.println("");
-                    System.err.println("    git publish");
-                    System.err.println("");
-                    System.err.println("If you created the remote branch from another client, you must update this repository.");
-                    System.err.println("To update remote information for this repository, run:");
-                    System.err.println("");
-                    System.err.println("    git fetch " + remote);
-                    System.err.println("    git branch --set-upstream " + currentBranch + " " + remote + "/" + currentBranch);
-                    System.err.println("");
-                    System.exit(1);
-                }
-            }
-
-            var upstreamRefName = upstream.get().substring(remote.length() + 1);
-            repo.fetch(uri, upstreamRefName);
-
-            var shouldIgnoreLocalCommits = getSwitch("ignore-local-commits", "create", arguments);
-            if (!shouldIgnoreLocalCommits) {
-                var branchCommits = repo.commits(upstream.get() + ".." + currentBranch.name()).asList();
-                if (!branchCommits.isEmpty()) {
-                    System.err.println("error: there are local commits on branch '" + currentBranch.name() + "' not present in the remote repository " + remotePullPath);
-                    System.err.println("");
-                    System.err.println("All commits must be present in the remote repository to be part of the pull request");
-                    System.err.println("The following commits are not present in the remote repository:");
-                    System.err.println("");
-                    for (var commit : branchCommits) {
-                        System.err.println("- " + commit.hash().abbreviate() + ": " + commit.message().get(0));
-                    }
-                    System.err.println("");
-                    System.err.println("To push the above local commits to the remote repository, run:");
-                    System.err.println("");
-                    System.err.println("    git push " + remote + " " + currentBranch.name());
-                    System.err.println("");
-                    System.exit(1);
-                }
-            }
-
-            var remoteRepo = host.repository(projectName(uri)).orElseThrow(() ->
-                    new IOException("Could not find repository at " + uri.toString())
-            );
-            if (token == null) {
-                GitCredentials.approve(credentials);
-            }
-            var parentRepo = remoteRepo.parent().orElseThrow(() ->
-                    new IOException("error: remote repository " + remotePullPath + " is not a fork of any repository")
-            );
-
-            var targetBranch = getOption("branch", "create", arguments);
-            if (targetBranch == null) {
-                var upstreamBranchNames = repo.remoteBranches(parentRepo.webUrl().toString())
-                                              .stream()
-                                              .map(r -> r.name())
-                                              .collect(Collectors.toSet());
-                var remoteBranches = repo.branches(remote);
-                var candidates = new ArrayList<Branch>();
-                for (var b : remoteBranches) {
-                    var withoutRemotePrefix = b.name().substring(remote.length() + 1);
-                    if (upstreamBranchNames.contains(withoutRemotePrefix)) {
-                        candidates.add(b);
-                    }
-                }
-
-                var localBranches = repo.branches();
-                Branch closest = null;
-                var shortestDistance = Integer.MAX_VALUE;
-                for (var b : candidates) {
-                    var from = b.name();
-                    for (var localBranch : localBranches) {
-                        var trackingBranch = repo.upstreamFor(localBranch);
-                        if (trackingBranch.isPresent() &&
-                            trackingBranch.get().equals(b.name())) {
-                            from = localBranch.name();
-                        }
-                    }
-                    var distance = repo.commitMetadata(from + "..." + currentBranch.name()).size();
-                    if (distance < shortestDistance) {
-                        closest = b;
-                        shortestDistance = distance;
-                    }
-                }
-
-                if (closest != null) {
-                    targetBranch = closest.name().substring(remote.length() + 1);
-                } else {
-                    System.err.println("error: cannot automatically infer target branch");
-                    System.err.println("       use --branch to specify target branch");
-                    System.exit(1);
-                }
-            }
-            var commits = repo.commits(targetBranch + ".." + upstream.get()).asList();
-            if (commits.isEmpty()) {
-                System.err.println("error: no difference between branches " + targetBranch + " and " + currentBranch.name());
-                System.err.println("       Cannot create an empty pull request, have you committed?");
-                System.exit(1);
-            }
-
-            var shouldRunJCheck = getSwitch("jcheck", "create", arguments);
-            if (shouldRunJCheck) {
-                var jcheckArgs = new String[]{ "--pull-request", "--rev", targetBranch + ".." + upstream.get() };
-                var err = GitJCheck.run(jcheckArgs);
-                if (err != 0) {
-                    System.exit(err);
-                }
-            }
-
-            var project = jbsProjectFromJcheckConf(repo, targetBranch);
-            var issue = getIssue(currentBranch, project);
-            var file = Files.createTempFile("PULL_REQUEST_", ".md");
-            if (issue.isPresent()) {
-                Files.writeString(file, format(issue.get()) + "\n\n");
-            } else if (commits.size() == 1) {
-                var commit = commits.get(0);
-                issue = getIssue(commit, project);
-                if (issue.isPresent()) {
-                    Files.writeString(file, format(issue.get()) + "\n\n");
-                } else {
-                    var message = CommitMessageParsers.v1.parse(commit.message());
-                    Files.writeString(file, message.title() + "\n");
-                    if (!message.summaries().isEmpty()) {
-                        Files.write(file, message.summaries(), StandardOpenOption.APPEND);
-                    }
-                    if (!message.additional().isEmpty()) {
-                        Files.write(file, message.additional(), StandardOpenOption.APPEND);
-                    }
-                }
-            } else {
-                Files.write(file, List.of(""));
-            }
-
-            appendPaddedHTMLComment(file, "Please enter the pull request message for your changes.");
-            appendPaddedHTMLComment(file, "The first line will be considered the subject, use a blank line to");
-            appendPaddedHTMLComment(file, "separate the subject from the body. These HTML comment lines will");
-            appendPaddedHTMLComment(file, "be removed automatically. An empty message aborts the pull request.");
-            appendPaddedHTMLComment(file, "");
-            appendPaddedHTMLComment(file, "Commits to be included from branch '" + currentBranch.name() + "':");
-            for (var commit : commits) {
-                var desc = commit.hash().abbreviate() + ": " + commit.message().get(0);
-                appendPaddedHTMLComment(file, "- " + desc);
-                if (!commit.isMerge()) {
-                    var diff = commit.parentDiffs().get(0);
-                    for (var patch : diff.patches()) {
-                        var status = patch.status();
-                        if (status.isModified()) {
-                            appendPaddedHTMLComment(file, "  M  " + patch.target().path().get().toString());
-                        } else if (status.isAdded()) {
-                            appendPaddedHTMLComment(file, "  A  " + patch.target().path().get().toString());
-                        } else if (status.isDeleted()) {
-                            appendPaddedHTMLComment(file, "  D  " + patch.source().path().get().toString());
-                        } else if (status.isRenamed()) {
-                            appendPaddedHTMLComment(file, "  R  " + patch.target().path().get().toString());
-                            appendPaddedHTMLComment(file, "      (" + patch.source().path().get().toString() + ")");
-                        } else if (status.isCopied()) {
-                            appendPaddedHTMLComment(file, "  C  " + patch.target().path().get().toString());
-                            appendPaddedHTMLComment(file, "      (" + patch.source().path().get().toString() + ")");
-                        }
-                    }
-                }
-            }
-            appendPaddedHTMLComment(file, "");
-            if (issue.isPresent()) {
-                appendPaddedHTMLComment(file, "Issue:      " + issue.get().webUrl());
-            }
-            appendPaddedHTMLComment(file, "Repository: " + parentRepo.webUrl());
-            appendPaddedHTMLComment(file, "Branch:     " + targetBranch);
-
-            var success = spawnEditor(repo, file);
-            if (!success) {
-                System.err.println("error: editor exited with non-zero status code, aborting");
-                System.exit(1);
-            }
-            var lines = Files.readAllLines(file)
-                             .stream()
-                             .filter(l -> !(l.startsWith("<!--") && l.endsWith("-->")))
-                             .collect(Collectors.toList());
-            var isEmpty = lines.stream().allMatch(String::isEmpty);
-            if (isEmpty) {
-                System.err.println("error: no message present, aborting");
-                System.exit(1);
-            }
-
-            var title = lines.get(0);
-            List<String> body = null;
-            if (lines.size() > 1) {
-                body = lines.subList(1, lines.size())
-                            .stream()
-                            .dropWhile(String::isEmpty)
-                            .collect(Collectors.toList());
-            } else {
-                body = Collections.emptyList();
-            }
-
-            var pr = remoteRepo.createPullRequest(parentRepo, targetBranch, currentBranch.name(), title, body);
-            var assigneesOption = getOption("assignees", "create", arguments);
-            if (assigneesOption != null) {
-                var usernames = Arrays.asList(assigneesOption.split(","));
-                var assignees = usernames.stream()
-                                         .map(u -> host.user(u))
-                                         .filter(Optional::isPresent)
-                                         .map(Optional::get)
-                                         .collect(Collectors.toList());
-                pr.setAssignees(assignees);
-            }
-            System.out.println(pr.webUrl().toString());
-            Files.deleteIfExists(file);
-
-            repo.config("pr." + currentBranch.name(), "id", pr.id().toString());
-        } else if (action.equals("integrate")) {
-            var id = pullRequestIdArgument(arguments, repo);
-            var pr = getPullRequest(uri, repo, host, id);
-            var isAtomic = getSwitch("atomic", "integrate", arguments);
-
-            var message = "/integrate";
-            if (isAtomic) {
-                var targetHash = repo.resolve(pr.targetRef());
-                if (!targetHash.isPresent()) {
-                    exit("error: cannot resolve target branch " + pr.targetRef());
-                }
-                var sourceHash = repo.fetch(pr.repository().webUrl(), pr.fetchRef());
-                var mergeBase = repo.mergeBase(sourceHash, targetHash.get());
-                message += " " + mergeBase.hex();
-            }
-
-            var integrateComment = pr.addComment(message);
-
-            var seenIntegrateComment = false;
-            var expected = "<!-- Jmerge command reply message (" + integrateComment.id() + ") -->";
-            for (var i = 0; i < 90; i++) {
-                var comments = pr.comments();
-                for (var comment : comments) {
-                    if (!seenIntegrateComment) {
-                        if (comment.id().equals(integrateComment.id())) {
-                            seenIntegrateComment = true;
-                        }
-                        continue;
-                    }
-                    var lines = comment.body().split("\n");
-                    if (lines.length > 0 && lines[0].equals(expected)) {
-                        for (var line : lines) {
-                            if (line.startsWith("Pushed as commit")) {
-                                var output = removeTrailing(line, ".");
-                                System.out.println(output);
-                                System.exit(0);
-                            }
-                        }
-                    }
-                }
-
-                Thread.sleep(2000);
-            }
-
-            System.err.println("error: timed out waiting for response to /integrate command");
-            System.exit(1);
-        } else if (action.equals("test")) {
-            var id = pullRequestIdArgument(arguments, repo);
-            var pr = getPullRequest(uri, repo, host, id);
-            var head = pr.headHash();
-            var testComment = pr.addComment("/test");
-
-            var seenTestComment = false;
-            for (var i = 0; i < 90; i++) {
-                var comments = pr.comments();
-                for (var comment : comments) {
-                    if (!seenTestComment) {
-                        if (comment.id().equals(testComment.id())) {
-                            seenTestComment = true;
-                        }
-                        continue;
-                    }
-                    var lines = comment.body().split("\n");
-                    var n = lines.length;
-                    if (n > 0) {
-                        if (n == 4 &&
-                            lines[0].equals("<!-- TEST STARTED -->") &&
-                            lines[1].startsWith("<!-- github.com-") &&
-                            lines[2].equals("<!-- " + head.hex() + " -->")) {
-                            var output = removeTrailing(lines[3], ".");
-                            System.out.println(output);
-                            System.exit(0);
-                        } else if (n == 2 &&
-                                   lines[0].equals("<!-- TEST ERROR -->")) {
-                            var output = removeTrailing(lines[1], ".");
-                            System.out.println(output);
-                            System.exit(1);
-                        } else if (n == 4 &&
-                                   lines[0].equals("<!-- TEST PENDING -->") &&
-                                   lines[1].equals("<!--- " + head.hex() + " -->")) {
-                            var output = removeTrailing(lines[3], ".");
-                            System.out.println(output);
-                            System.exit(0);
-                        }
-                    }
-                }
-
-                Thread.sleep(2000);
-            }
-
-        } else if (action.equals("approve")) {
-            var id = arguments.at(1).isPresent() ? arguments.at(1).asString() : null;
-            if (id == null) {
-                exit("error: you must provide a pull request id");
-            }
-            var pr = getPullRequest(uri, repo, host, id);
-            pr.addReview(Review.Verdict.APPROVED, "Looks good!");
-        } else if (action.equals("list")) {
-            var remoteRepo = getHostedRepositoryFor(uri, repo, host);
-            var prs = remoteRepo.pullRequests();
-            var ids = new ArrayList<String>();
-            var titles = new ArrayList<String>();
-            var authors = new ArrayList<String>();
-            var assignees = new ArrayList<String>();
-            var labels = new ArrayList<String>();
-            var issues = new ArrayList<String>();
-            var branches = new ArrayList<String>();
-            var statuses = new ArrayList<String>();
-            var noDraft = getSwitch("no-draft", "list", arguments);
-
-            var authorsOption = getOption("authors", "list", arguments);
-            var filterAuthors = authorsOption == null ?
-                Set.of() :
-                new HashSet<>(Arrays.asList(authorsOption.split(",")));
-
-            var assigneesOption = getOption("assignees", "list", arguments);
-            var filterAssignees = assigneesOption == null ?
-                Set.of() :
-                Arrays.asList(assigneesOption.split(","));
-
-            var labelsOption = getOption("labels", "list", arguments);
-            var filterLabels = labelsOption == null ?
-                Set.of() :
-                Arrays.asList(labelsOption.split(","));
-
-            var issuesOption = getOption("issues", "list", arguments);
-            var filterIssues = issuesOption == null ?
-                Set.of() :
-                Arrays.asList(issuesOption.split(","));
-
-            var columnTitles = List.of("id", "title", "authors", "assignees", "labels", "issues", "branch", "status");
-            var columnValues = Map.of(columnTitles.get(0), ids,
-                                      columnTitles.get(1), titles,
-                                      columnTitles.get(2), authors,
-                                      columnTitles.get(3), assignees,
-                                      columnTitles.get(4), labels,
-                                      columnTitles.get(5), issues,
-                                      columnTitles.get(6), branches,
-                                      columnTitles.get(7), statuses);
-            var columnsOption = getOption("columns", "list", arguments);
-            var columns = columnsOption == null ?
-                List.of("id", "title", "authors", "status") :
-                Arrays.asList(columnsOption.split(","));
-
-            for (var column : columns) {
-                if (!columnTitles.contains(column)) {
-                    System.err.println("error: unknown column: " + column);
-                    System.err.println("       available columns are: " + String.join(",", columnTitles));
-                    System.exit(1);
-                }
-            }
-
-            for (var pr : prs) {
-                if (pr.isDraft() && noDraft) {
-                    continue;
-                }
-
-                var prAuthor = pr.author().userName();
-                if (!filterAuthors.isEmpty() && !filterAuthors.contains(prAuthor)) {
-                    continue;
-                }
-
-                var prAssignees = pr.assignees().stream()
-                                    .map(HostUser::userName)
-                                    .collect(Collectors.toSet());
-                if (!filterAssignees.isEmpty() && !filterAssignees.stream().anyMatch(prAssignees::contains)) {
-                    continue;
-                }
-
-                var prLabels = new HashSet<>(pr.labels());
-                if (!filterLabels.isEmpty() && !filterLabels.stream().anyMatch(prLabels::contains)) {
-                    continue;
-                }
-
-                var prIssues = new HashSet<>(issuesFromPullRequest(pr));
-                if (!filterIssues.isEmpty() && !filterIssues.stream().anyMatch(prIssues::contains)) {
-                    continue;
-                }
-
-
-                ids.add(pr.id());
-                titles.add(pr.title());
-                authors.add(prAuthor);
-                assignees.add(String.join(",", prAssignees));
-                labels.add(String.join(",", prLabels));
-                issues.add(String.join(",", prIssues));
-
-                if (pr.author().userName().equals(credentials.username()) &&
-                    pr.sourceRepository().webUrl().equals(uri)) {
-                    branches.add(pr.sourceRef());
-                } else {
-                    branches.add("");
-                }
-
-                if (columns.contains("status")) {
-                    statuses.add(statusForPullRequest(pr).toLowerCase());
-                } else {
-                    statuses.add("");
-                }
-            }
-
-
-            String fmt = "";
-            for (var column : columns.subList(0, columns.size() - 1)) {
-                var values = columnValues.get(column);
-                var n = Math.max(column.length(), longest(values));
-                fmt += "%-" + n + "s    ";
-            }
-            fmt += "%s\n";
-
-            var noDecoration = getSwitch("no-decoration", "list", arguments);
-            if (!ids.isEmpty() && !noDecoration) {
-                var upperCase = columns.stream()
-                                       .map(String::toUpperCase)
-                                       .collect(Collectors.toList());
-                System.out.format(fmt, (Object[]) upperCase.toArray(new String[0]));
-            }
-            for (var i = 0; i < ids.size(); i++) {
-                final int n = i;
-                var row = columns.stream()
-                                 .map(columnValues::get)
-                                 .map(values -> values.get(n))
-                                 .collect(Collectors.toList());
-                System.out.format(fmt, (Object[]) row.toArray(new String[0]));
-            }
-        } else if (action.equals("fetch") || action.equals("checkout") || action.equals("show") || action.equals("apply")) {
-            var prId = arguments.at(1);
-            if (!prId.isPresent()) {
-                exit("error: missing pull request identifier");
-            }
-
-            var remoteRepo = getHostedRepositoryFor(uri, repo, host);
-            var pr = remoteRepo.pullRequest(prId.asString());
-            var repoUrl = remoteRepo.webUrl();
-            var prHeadRef = pr.fetchRef();
-            var isHgGit = isMercurial && Repository.exists(repo.root().resolve(".hg").resolve("git"));
-            if (isHgGit) {
-                var hgGitRepo = Repository.get(repo.root().resolve(".hg").resolve("git")).get();
-                var hgGitFetchHead = hgGitRepo.fetch(repoUrl, prHeadRef);
-
-                if (action.equals("show") || action.equals("apply")) {
-                    var target = hgGitRepo.fetch(repoUrl, pr.targetRef());
-                    var hgGitMergeBase = hgGitRepo.mergeBase(target, hgGitFetchHead);
-
-                    if (action.equals("show")) {
-                        show(hgGitMergeBase.hex(), hgGitFetchHead, hgGitRepo.root());
-                    } else {
-                        var patch = diff(hgGitMergeBase.hex(), hgGitFetchHead, hgGitRepo.root());
-                        hgImport(patch);
-                        Files.delete(patch);
-                    }
-                } else if (action.equals("fetch") || action.equals("checkout")) {
-                    var hgGitRef = prHeadRef.endsWith("/head") ? prHeadRef.replace("/head", "") : prHeadRef;
-                    var hgGitBranches = hgGitRepo.branches();
-                    if (hgGitBranches.contains(new Branch(hgGitRef))) {
-                        hgGitRepo.delete(new Branch(hgGitRef));
-                    }
-                    hgGitRepo.branch(hgGitFetchHead, hgGitRef);
-                    gimport();
-                    var hgFetchHead = repo.resolve(hgGitRef).get();
-
-                    if (action.equals("fetch") && arguments.contains("branch")) {
-                        repo.branch(hgFetchHead, arguments.get("branch").asString());
-                    } else if (action.equals("checkout")) {
-                        repo.checkout(hgFetchHead);
-                        if (arguments.contains("branch")) {
-                            repo.branch(hgFetchHead, arguments.get("branch").asString());
-                        }
-                    }
-                } else {
-                    exit("Unexpected action: " + action);
-                }
-
-                return;
-            }
-
-            var fetchHead = repo.fetch(repoUrl, pr.fetchRef());
-            if (action.equals("fetch")) {
-                var branchName = getOption("branch", "fetch", arguments);
-                if (branchName != null) {
-                    repo.branch(fetchHead, branchName);
-                } else {
-                    System.out.println(fetchHead.hex());
-                }
-            } else if (action.equals("checkout")) {
-                var branchName = getOption("branch", "checkout", arguments);
-                if (branchName != null) {
-                    var branch = repo.branch(fetchHead, branchName);
-                    repo.checkout(branch, false);
-                } else {
-                    repo.checkout(fetchHead, false);
-                }
-            } else if (action.equals("show")) {
-                show(pr.targetRef(), fetchHead);
-            } else if (action.equals("apply")) {
-                var patch = diff(pr.targetRef(), fetchHead);
-                apply(patch);
-                Files.deleteIfExists(patch);
-            }
-        } else if (action.equals("close")) {
-            var prId = arguments.at(1);
-            if (!prId.isPresent()) {
-                exit("error: missing pull request identifier");
-            }
-
-            var remoteRepo = getHostedRepositoryFor(uri, repo, host);
-            var pr = remoteRepo.pullRequest(prId.asString());
-            pr.setState(PullRequest.State.CLOSED);
-        } else if (action.equals("set")) {
-            var prId = arguments.at(1);
-            if (!prId.isPresent()) {
-                exit("error: missing pull request identifier");
-            }
-
-            var remoteRepo = getHostedRepositoryFor(uri, repo, host);
-            var pr = remoteRepo.pullRequest(prId.asString());
-            var assigneesOption = getOption("assignees", "set", arguments);
-            if (assigneesOption != null) {
-                var usernames = Arrays.asList(assigneesOption.split(","));
-                var assignees = usernames.stream()
-                    .map(u -> host.user(u))
-                    .filter(Optional::isPresent)
-                    .map(Optional::get)
-                    .collect(Collectors.toList());
-                pr.setAssignees(assignees);
-            }
-        } else if (action.equals("status")) {
-            String id = pullRequestIdArgument(arguments, repo);
-            var pr = getPullRequest(uri, repo, host, id);
-            var noDecoration = getSwitch("no-decoration", "status", arguments);
-            var decoration = noDecoration ? "" : "Status: ";
-            System.out.println(decoration + statusForPullRequest(pr));
-
-            var noChecks = getSwitch("no-checks", "status", arguments);
-            if (!noChecks) {
-                var checks = pr.checks(pr.headHash());
-                var jcheck = Optional.ofNullable(checks.get("jcheck"));
-                var submit = Optional.ofNullable(checks.get("submit"));
-                var showChecks = jcheck.isPresent() || submit.isPresent();
-                if (showChecks) {
-                    System.out.println("Checks:");
-                    if (jcheck.isPresent()) {
-                        System.out.println("- jcheck: " + statusForCheck(jcheck.get()));
-                    }
-                    if (submit.isPresent()) {
-                        System.out.println("- submit: " + statusForCheck(submit.get()));
-                    }
-                }
-            }
-        } else {
-            exit("error: unexpected action: " + action);
-        }
+        var parser = new MultiCommandParser("git pr", commands);
+        var command = parser.parse(args);
+        command.execute();
     }
 }

--- a/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
@@ -1537,13 +1537,13 @@ public class GitPr {
         var pr = getPullRequest(uri, repo, host, id);
 
         var fetchHead = repo.fetch(pr.repository().webUrl(), pr.fetchRef());
-	var branchName = getOption("branch", "checkout", arguments);
-	if (branchName != null) {
-	    var branch = repo.branch(fetchHead, branchName);
-	    repo.checkout(branch, false);
-	} else {
-	    repo.checkout(fetchHead, false);
-	}
+        var branchName = getOption("branch", "checkout", arguments);
+        if (branchName != null) {
+            var branch = repo.branch(fetchHead, branchName);
+            repo.checkout(branch, false);
+        } else {
+            repo.checkout(fetchHead, false);
+        }
     }
 
     private static void apply(String[] args) throws IOException, InterruptedException {


### PR DESCRIPTION
Hi all,

please review this refactoring of `git pr` to start to use the
`MultiCommandParser`. This refactoring is needed for several reasons:

- not all subcommands support all options
- better help messages
- better reuse of utility functions
- the code was essentially one gigantic `main` function

I plan to split this file into multiple files, one for each command, but that is
for a later refactoring. I have tried to preserve the semantics of all commands
and have tested them locally.

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/458/head:pull/458`
`$ git checkout pull/458`
