### PR TITLE
forge: add method diffUrl to PullRequest

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
@@ -86,10 +86,6 @@ class ArchiveMessages {
         }
     }
 
-    private static String diffUrl(PullRequest pr) {
-        return pr.webUrl() + ".diff";
-    }
-
     private static String fetchCommand(PullRequest pr) {
         var repoUrl = pr.repository().webUrl();
         return "git fetch " + repoUrl + " " + pr.fetchRef() + ":pull/" + pr.id();
@@ -151,7 +147,7 @@ class ArchiveMessages {
                 " Webrev: " + webrev + "\n" +
                 issueString +
                 "  Stats: " + stats(localRepo, base, head) + "\n" +
-                "  Patch: " + diffUrl(pr) + "\n" +
+                "  Patch: " + pr.diffUrl().toString() + "\n" +
                 "  Fetch: " + fetchCommand(pr) + "\n\n" +
                 composeReplyFooter(pr);
     }
@@ -163,7 +159,7 @@ class ArchiveMessages {
                 "Changes: " + pr.changeUrl() + "\n" +
                 " Webrev: " + fullWebrev.toString() + "\n" +
                 "  Stats: " + stats(localRepo, base, head) + "\n" +
-                "  Patch: " + diffUrl(pr) + "\n" +
+                "  Patch: " + pr.diffUrl().toString() + "\n" +
                 "  Fetch: " + fetchCommand(pr) + "\n\n" +
                 composeReplyFooter(pr);
     }
@@ -179,7 +175,7 @@ class ArchiveMessages {
                 " - full: " + fullWebrev.toString() + "\n" +
                 " - incr: " + incrementalWebrev.toString() + "\n\n" +
                 "  Stats: " + stats(localRepo, lastHead, head) + "\n" +
-                "  Patch: " + diffUrl(pr) + "\n" +
+                "  Patch: " + pr.diffUrl().toString() + "\n" +
                 "  Fetch: " + fetchCommand(pr) + "\n\n" +
                 composeReplyFooter(pr);
     }

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
@@ -272,4 +272,9 @@ class InMemoryPullRequest implements PullRequest {
     public IssueProject project() {
         return null;
     }
+
+    @Override
+    public URI diffUrl() {
+        return null;
+    }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
@@ -108,6 +108,11 @@ public interface PullRequest extends Issue {
      */
     Map<String, Check> checks(Hash hash);
 
+    /** Returns a link to the patch/diff file
+     * @return
+     */
+    URI diffUrl();
+
     /**
      * Creates a new check.
      * @param check

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -547,4 +547,9 @@ public class GitHubPullRequest implements PullRequest {
     public void removeProperty(String name) {
         throw new RuntimeException("not implemented yet");
     }
+
+    @Override
+    public URI diffUrl() {
+        return URI.create(webUrl() + ".diff");
+    }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -674,4 +674,9 @@ public class GitLabMergeRequest implements PullRequest {
     public void removeProperty(String name) {
         throw new RuntimeException("not implemented yet");
     }
+
+    @Override
+    public URI diffUrl() {
+        return URI.create(webUrl() + ".diff");
+    }
 }

--- a/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
@@ -212,4 +212,9 @@ public class TestPullRequest extends TestIssue implements PullRequest {
             throw new RuntimeException(e);
         }
     }
+
+    @Override
+    public URI diffUrl() {
+        return URI.create(webUrl().toString() + ".diff");
+    }
 }


### PR DESCRIPTION
Hi all,

please review this small patch that adds the method `PullRequest::diffUrl`.
Although the implementation is the same for both `GitHubPullRequest` and
`GitLabMergeRequest` I chose to not do a `default` method to highlight that this
is more of a coincidence than a rule.

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/459/head:pull/459`
`$ git checkout pull/459`
