### PR TITLE
git-pr: set should allow no assignees

### DIFF
--- a/args/src/main/java/org/openjdk/skara/args/Argument.java
+++ b/args/src/main/java/org/openjdk/skara/args/Argument.java
@@ -65,7 +65,7 @@ public class Argument {
     }
 
     public String asString() {
-        return via(Function.identity());
+        return value == null ? null : via(Function.identity());
     }
 
     public Argument or(int value) {

--- a/args/src/main/java/org/openjdk/skara/args/ArgumentParser.java
+++ b/args/src/main/java/org/openjdk/skara/args/ArgumentParser.java
@@ -161,7 +161,7 @@ public class ArgumentParser {
                 if (arg.contains("=")) {
                     var parts = arg.split("=");
                     var name = parts[0].substring(2); // remove leading '--'
-                    var value = parts[1];
+                    var value = parts.length == 2 ? parts[1] : null;
                     var flag = lookupFullname(name);
                     values.add(new FlagValue(flag, value));
                     seen.add(flag);

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrSet.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrSet.java
@@ -115,7 +115,9 @@ public class GitPrSet {
         var pr = getPullRequest(uri, repo, host, id);
 
         var assigneesOption = getOption("assignees", "set", arguments);
-        if (assigneesOption != null) {
+        if (assigneesOption == null) {
+            pr.setAssignees(List.of());
+        } else {
             var usernames = Arrays.asList(assigneesOption.split(","));
             var assignees = usernames.stream()
                 .map(u -> host.user(u))


### PR DESCRIPTION
Hi all,

please review this small patch that allows the `--assignees` option to `git pr
set` to be empty. That is, `git pr set --assignees=` should make the pull
request have no user assigned to it.

Testing:
- Manual testing of `git pr set --assignees=` on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/462/head:pull/462`
`$ git checkout pull/462`
