### PR TITLE
Handle links already deleted

### DIFF
--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraIssue.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraIssue.java
@@ -436,6 +436,7 @@ public class JiraIssue implements Issue {
     private void removeWebLink(Link link) {
         request.delete("/remotelink")
                .param("globalId", "skaralink=" + link.uri().orElseThrow().toString())
+               .onError(e -> e.statusCode() == 404 ? JSON.object().put("already_deleted", true) : null)
                .execute();
     }
 

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraIssue.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraIssue.java
@@ -436,7 +436,7 @@ public class JiraIssue implements Issue {
     private void removeWebLink(Link link) {
         request.delete("/remotelink")
                .param("globalId", "skaralink=" + link.uri().orElseThrow().toString())
-               .onError(e -> e.statusCode() == 404 ? JSON.object().put("already_deleted", true) : null)
+               .onError(e -> e.statusCode() == 404 ? Optional.of(JSON.object().put("already_deleted", true)) : Optional.empty())
                .execute();
     }
 


### PR DESCRIPTION
Hi all,

Please review this small change that gracefully handles removing Jira links that have already been deleted.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**) ⚠️ Review applies to 2d237d75654a994b5c90f84358a017472e5672d9

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/467/head:pull/467`
`$ git checkout pull/467`
