### PR TITLE
Make the rest request error transform optional

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubHost.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubHost.java
@@ -217,7 +217,7 @@ public class GitHubHost implements Forge {
     @Override
     public Optional<HostUser> user(String username) {
         var details = request.get("users/" + URLEncoder.encode(username, StandardCharsets.UTF_8))
-                             .onError(r -> JSON.of())
+                             .onError(r -> Optional.of(JSON.of()))
                              .execute();
         if (details.isNull()) {
             return Optional.empty();

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -469,7 +469,7 @@ public class GitHubPullRequest implements PullRequest {
                .onError(r -> {
                    // The GitHub API explicitly states that 404 is the response for deleting labels currently not set
                    if (r.statusCode() == 404) {
-                       return JSONValue.fromNull();
+                       return Optional.of(JSONValue.fromNull());
                    }
                    throw new RuntimeException("Invalid response");
                })

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabHost.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabHost.java
@@ -89,14 +89,12 @@ public class GitLabHost implements Forge {
         var encodedName = URLEncoder.encode(name, StandardCharsets.US_ASCII);
 
         var project = request.get("projects/" + encodedName)
-                                     .onError(r -> r.statusCode() == 404 ? JSON.object().put("retry", true) : null)
-                                     .execute();
+                             .onError(r -> r.statusCode() == 404 ? Optional.of(JSON.object().put("retry", true)) : Optional.empty())
+                             .execute();
         if (project.contains("retry")) {
             // Depending on web server configuration, GitLab may need double escaping of project names
             encodedName = URLEncoder.encode(encodedName, StandardCharsets.US_ASCII);
-            project = request.get("projects/" + encodedName)
-                                     .onError(r -> r.statusCode() == 404 ? JSON.object().put("retry", true) : null)
-                                     .execute();
+            project = request.get("projects/" + encodedName).execute();
         }
         return project.asObject();
     }
@@ -122,7 +120,7 @@ public class GitLabHost implements Forge {
     public Optional<HostUser> user(String username) {
         var details = request.get("users")
                              .param("username", username)
-                             .onError(r -> JSON.of())
+                             .onError(r -> Optional.of(JSON.of()))
                              .execute();
 
         if (details.isNull()) {
@@ -175,7 +173,7 @@ public class GitLabHost implements Forge {
             throw new IllegalArgumentException("Group id is not a number: " + groupId);
         }
         var details = request.get("groups/" + gid + "/members/" + user.id())
-                             .onError(r -> JSON.of())
+                             .onError(r -> Optional.of(JSON.of()))
                              .execute();
         return !details.isNull();
     }

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -179,8 +179,8 @@ public class GitLabRepository implements HostedRepository {
                           .onError(response -> {
                               // Retry once with additional escaping of the path fragment
                               var escapedConfName = URLEncoder.encode(confName, StandardCharsets.UTF_8);
-                              return request.get("repository/files/" + escapedConfName)
-                                            .param("ref", ref).execute();
+                              return Optional.of(request.get("repository/files/" + escapedConfName)
+                                            .param("ref", ref).execute());
                           })
                           .execute();
         var content = Base64.getDecoder().decode(conf.get("content").asString());
@@ -234,7 +234,7 @@ public class GitLabRepository implements HostedRepository {
         var namespace = gitLabHost.currentUser().userName();
         request.post("fork")
                .body("namespace", namespace)
-               .onError(r -> r.statusCode() == 409 ? JSON.object().put("exists", true) : null)
+               .onError(r -> r.statusCode() == 409 ? Optional.of(JSON.object().put("exists", true)) : Optional.empty())
                .execute();
         var nameOnlyStart = projectName.lastIndexOf('/');
         var nameOnly = nameOnlyStart >= 0 ? projectName.substring(nameOnlyStart + 1) : projectName;

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraHost.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraHost.java
@@ -82,7 +82,7 @@ public class JiraHost implements IssueTracker {
     @Override
     public boolean isValid() {
         var version = request.get("serverInfo")
-                             .onError(r -> JSON.object().put("invalid", true))
+                             .onError(r -> Optional.of(JSON.object().put("invalid", true)))
                              .execute();
         return !version.contains("invalid");
     }
@@ -96,7 +96,7 @@ public class JiraHost implements IssueTracker {
     public Optional<HostUser> user(String username) {
         var data = request.get("user")
                           .param("username", username)
-                          .onError(r -> JSON.of())
+                          .onError(r -> Optional.of(JSON.of()))
                           .execute();
         if (data.isNull()) {
             return Optional.empty();

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraProject.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraProject.java
@@ -280,11 +280,8 @@ public class JiraProject implements IssueProject {
         }
         var issueRequest = request.restrict("issue/" + id);
         var issue = issueRequest.get("")
-                           .onError(r -> r.statusCode() < 500 ? JSON.object().put("NOT_FOUND", true) : null)
-                           .execute();
-        if (issue == null) {
-            throw new RuntimeException("Server error when trying to fetch issue " + id);
-        }
+                                .onError(r -> r.statusCode() < 500 ? Optional.of(JSON.object().put("NOT_FOUND", true)) : Optional.empty())
+                                .execute();
         if (!issue.contains("NOT_FOUND")) {
             return Optional.of(new JiraIssue(this, issueRequest, issue));
         } else {

--- a/network/src/test/java/org/openjdk/skara/network/RestRequestTests.java
+++ b/network/src/test/java/org/openjdk/skara/network/RestRequestTests.java
@@ -24,7 +24,6 @@ package org.openjdk.skara.network;
 
 import com.sun.net.httpserver.*;
 import org.openjdk.skara.json.*;
-import org.openjdk.skara.network.*;
 
 import org.junit.jupiter.api.Test;
 
@@ -132,7 +131,7 @@ class RestRequestTests {
         try (var receiver = new RestReceiver("{}", 400)) {
             var request = new RestRequest(receiver.getEndpoint());
             var response = request.post("/test")
-                   .onError(r -> JSON.object().put("transformed", true))
+                   .onError(r -> Optional.of(JSON.object().put("transformed", true)))
                    .execute();
             assertTrue(response.contains("transformed"));
         }


### PR DESCRIPTION
Hi all,

Please review this change that allows the rest request error transform functional to only transform certain errors, and let the rest be handled as untransformed.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/468/head:pull/468`
`$ git checkout pull/468`
