### PR TITLE
vcs: add Hash::zero

### DIFF
--- a/forge/src/test/java/org/openjdk/skara/forge/CheckBuilderTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/CheckBuilderTests.java
@@ -34,7 +34,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class CheckBuilderTests {
     @Test
     void testFrom() {
-        var hash = new Hash("0".repeat(40));
         var name = "test";
         var title = "title";
         var summary = "summary";
@@ -45,7 +44,7 @@ class CheckBuilderTests {
         var completedAt = ZonedDateTime.now();
         var success = true;
 
-        var existing = CheckBuilder.create(name, hash)
+        var existing = CheckBuilder.create(name, Hash.zero())
                                    .title(title)
                                    .summary(summary)
                                    .metadata(metadata)

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/BinaryCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/BinaryCheckTests.java
@@ -37,7 +37,6 @@ import java.time.ZonedDateTime;
 import java.io.IOException;
 
 class BinaryCheckTests {
-    private static final Hash NULL_HASH = new Hash("0".repeat(40));
     private static final JCheckConfiguration conf = JCheckConfiguration.parse(List.of(
         "[general]",
         "project = test",
@@ -48,10 +47,10 @@ class BinaryCheckTests {
     private static List<Diff> textualParentDiffs(String filename, String mode) {
         var hunk = new Hunk(new Range(1, 0), List.of(),
                             new Range(1, 1), List.of("An additional line"));
-        var patch = new TextualPatch(Path.of(filename), FileType.fromOctal("100644"), NULL_HASH,
-                                     Path.of(filename), FileType.fromOctal(mode), NULL_HASH,
+        var patch = new TextualPatch(Path.of(filename), FileType.fromOctal("100644"), Hash.zero(),
+                                     Path.of(filename), FileType.fromOctal(mode), Hash.zero(),
                                      Status.from('M'), List.of(hunk));
-        var diff = new Diff(NULL_HASH, NULL_HASH, List.of(patch));
+        var diff = new Diff(Hash.zero(), Hash.zero(), List.of(patch));
         return List.of(diff);
     }
 
@@ -90,9 +89,9 @@ class BinaryCheckTests {
     void binaryFileShouldFail() throws IOException {
         var hunk = BinaryHunk.ofLiteral(8, List.of("asdfasdf8"));
         var patch = new BinaryPatch(null, null, null,
-                                    Path.of("file.bin"), FileType.fromOctal("100644"), NULL_HASH,
+                                    Path.of("file.bin"), FileType.fromOctal("100644"), Hash.zero(),
                                     Status.from('A'), List.of(hunk));
-        var diff = new Diff(NULL_HASH, NULL_HASH, List.of(patch));
+        var diff = new Diff(Hash.zero(), Hash.zero(), List.of(patch));
         var commit = commit(List.of(diff));
         var message = message(commit);
         var check = new BinaryCheck();

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/ExecutableCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/ExecutableCheckTests.java
@@ -37,7 +37,6 @@ import java.time.ZonedDateTime;
 import java.io.IOException;
 
 class ExecutableCheckTests {
-    private static final Hash NULL_HASH = new Hash("0".repeat(40));
     private static final JCheckConfiguration conf = JCheckConfiguration.parse(List.of(
         "[general]",
         "project = test",
@@ -48,10 +47,10 @@ class ExecutableCheckTests {
     private static List<Diff> parentDiffs(String filename, String mode) {
         var hunk = new Hunk(new Range(1, 0), List.of(),
                             new Range(1, 1), List.of("An additional line"));
-        var patch = new TextualPatch(Path.of(filename), FileType.fromOctal("100644"), NULL_HASH,
-                                     Path.of(filename), FileType.fromOctal(mode), NULL_HASH,
+        var patch = new TextualPatch(Path.of(filename), FileType.fromOctal("100644"), Hash.zero(),
+                                     Path.of(filename), FileType.fromOctal(mode), Hash.zero(),
                                      Status.from('M'), List.of(hunk));
-        var diff = new Diff(NULL_HASH, NULL_HASH, List.of(patch));
+        var diff = new Diff(Hash.zero(), Hash.zero(), List.of(patch));
         return List.of(diff);
     }
 

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/HgTagCommitCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/HgTagCommitCheckTests.java
@@ -38,14 +38,13 @@ import java.time.ZonedDateTime;
 import java.io.IOException;
 
 class HgTagCommitCheckTests {
-    private static final Hash NULL_HASH = new Hash("0".repeat(40));
     private static List<Diff> parentDiffs(String line) {
         var hunk = new Hunk(new Range(1, 0), List.of(),
                             new Range(1, 1), List.of(line));
-        var patch = new TextualPatch(Path.of(".hgtags"), FileType.fromOctal("100644"), NULL_HASH,
-                                     Path.of(".hgtags"), FileType.fromOctal("100644"), NULL_HASH,
+        var patch = new TextualPatch(Path.of(".hgtags"), FileType.fromOctal("100644"), Hash.zero(),
+                                     Path.of(".hgtags"), FileType.fromOctal("100644"), Hash.zero(),
                                      Status.from('M'), List.of(hunk));
-        var diff = new Diff(NULL_HASH, NULL_HASH, List.of(patch));
+        var diff = new Diff(Hash.zero(), Hash.zero(), List.of(patch));
         return List.of(diff);
     }
 
@@ -67,13 +66,12 @@ class HgTagCommitCheckTests {
     }
 
     private static Commit mergeCommit() {
-        var hash = new Hash("0".repeat(40));
         var author = new Author("Foo Bar", "foo@bar.org");
         var parents = List.of(new Hash("12345789012345789012345678901234567890"),
                               new Hash("12345789012345789012345678901234567890"));
         var message = List.of("Merge");
         var date = ZonedDateTime.now();
-        var metadata = new CommitMetadata(hash, parents, author, author, date, message);
+        var metadata = new CommitMetadata(Hash.zero(), parents, author, author, date, message);
         return new Commit(metadata, List.of());
     }
 
@@ -104,7 +102,7 @@ class HgTagCommitCheckTests {
 
     @Test
     void commitThatDoesNotAddTagShouldPass() {
-        var commit = commit(new Hash("0".repeat(40)), List.of(), List.of());
+        var commit = commit(Hash.zero(), List.of(), List.of());
         var check = new HgTagCommitCheck(new Utilities());
         var issues = toList(check.check(commit, message(commit), conf));
         assertEquals(0, issues.size());
@@ -165,15 +163,15 @@ class HgTagCommitCheckTests {
 
         var hunk1 = new Hunk(new Range(1, 0), List.of(),
                             new Range(1, 1), List.of(targetHash + " " + tag));
-        var patch1 = new TextualPatch(Path.of(".hgtags"), FileType.fromOctal("100644"), NULL_HASH,
-                               Path.of(".hgtags"), FileType.fromOctal("100644"), NULL_HASH,
+        var patch1 = new TextualPatch(Path.of(".hgtags"), FileType.fromOctal("100644"), Hash.zero(),
+                               Path.of(".hgtags"), FileType.fromOctal("100644"), Hash.zero(),
                                Status.from('M'), List.of(hunk1));
         var hunk2 = new Hunk(new Range(1, 0), List.of(),
                             new Range(1, 1), List.of("An additional line"));
-        var patch2 = new TextualPatch(Path.of("README"), FileType.fromOctal("100644"), NULL_HASH,
-                                      Path.of("README"), FileType.fromOctal("100644"), NULL_HASH,
+        var patch2 = new TextualPatch(Path.of("README"), FileType.fromOctal("100644"), Hash.zero(),
+                                      Path.of("README"), FileType.fromOctal("100644"), Hash.zero(),
                                       Status.from('M'), List.of(hunk2));
-        var diff = new Diff(NULL_HASH, NULL_HASH, List.of(patch1, patch2));
+        var diff = new Diff(Hash.zero(), Hash.zero(), List.of(patch1, patch2));
         var diffs = List.of(diff);
 
         var commitHash = "1111222233334444555566667777888899990000";
@@ -201,10 +199,10 @@ class HgTagCommitCheckTests {
                             new Range(1, 1), List.of(targetHash + " " + tag));
         var hunk2 = new Hunk(new Range(1, 0), List.of(),
                             new Range(2, 1), List.of(targetHash + " " + "skara-11+23"));
-        var patch = new TextualPatch(Path.of(".hgtags"), FileType.fromOctal("100644"), NULL_HASH,
-                                     Path.of(".hgtags"), FileType.fromOctal("100644"), NULL_HASH,
+        var patch = new TextualPatch(Path.of(".hgtags"), FileType.fromOctal("100644"), Hash.zero(),
+                                     Path.of(".hgtags"), FileType.fromOctal("100644"), Hash.zero(),
                                      Status.from('M'), List.of(hunk1, hunk2));
-        var diff = new Diff(NULL_HASH, NULL_HASH, List.of(patch));
+        var diff = new Diff(Hash.zero(), Hash.zero(), List.of(patch));
         var diffs = List.of(diff);
 
         var commitHash = "1111222233334444555566667777888899990000";

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/WhitespaceCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/WhitespaceCheckTests.java
@@ -38,14 +38,13 @@ import java.time.ZonedDateTime;
 import java.io.IOException;
 
 class WhitespaceCheckTests {
-    private static final Hash NULL_HASH = new Hash("0".repeat(40));
     private static List<Diff> parentDiffs(String filename, String line) {
         var hunk = new Hunk(new Range(1, 0), List.of(),
                             new Range(1, 1), List.of(line));
-        var patch = new TextualPatch(Path.of(filename), FileType.fromOctal("100644"), NULL_HASH,
-                                     Path.of(filename), FileType.fromOctal("100644"), NULL_HASH,
+        var patch = new TextualPatch(Path.of(filename), FileType.fromOctal("100644"), Hash.zero(),
+                                     Path.of(filename), FileType.fromOctal("100644"), Hash.zero(),
                                      Status.from('M'), List.of(hunk));
-        var diff = new Diff(NULL_HASH, NULL_HASH, List.of(patch));
+        var diff = new Diff(Hash.zero(), Hash.zero(), List.of(patch));
         return List.of(diff);
     }
 

--- a/vcs/src/main/java/org/openjdk/skara/vcs/CommitMetadata.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/CommitMetadata.java
@@ -27,8 +27,6 @@ import java.time.*;
 import java.time.format.*;
 
 public class CommitMetadata {
-    private static final Hash NULL_HASH = new Hash("0".repeat(40));
-
     private final Hash hash;
     private final List<Hash> parents;
     private final Author author;
@@ -72,7 +70,7 @@ public class CommitMetadata {
     }
 
     public boolean isInitialCommit() {
-        return numParents() == 1 && parents.get(0).equals(NULL_HASH);
+        return numParents() == 1 && parents.get(0).equals(Hash.zero());
     }
 
     public boolean isMerge() {

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Hash.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Hash.java
@@ -23,10 +23,15 @@
 package org.openjdk.skara.vcs;
 
 public class Hash {
+    private static final Hash ZERO = new Hash("0".repeat(40));
     private final String hex;
 
     public Hash(String hex) {
         this.hex = hex;
+    }
+
+    public static Hash zero() {
+        return ZERO;
     }
 
     @Override

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Patch.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Patch.java
@@ -139,7 +139,7 @@ public abstract class Patch {
             w.write("\n");
 
             w.append("index ");
-            w.append("0".repeat(40));
+            w.append(Hash.zero().hex());
             w.append("..");
             w.append(target.hash().hex());
             w.write("\n");
@@ -151,7 +151,7 @@ public abstract class Patch {
             w.append("index ");
             w.append(source.hash().hex());
             w.append("..");
-            w.append("0".repeat(40));
+            w.append(Hash.zero().hex());
             w.write("\n");
         } else if (status.isCopied()) {
             w.append("similarity index ");

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitCommitMetadata.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitCommitMetadata.java
@@ -62,7 +62,7 @@ class GitCommitMetadata {
 
         var parentHashes = reader.readLine();
         if (parentHashes.equals("")) {
-            parentHashes = "0".repeat(40);
+            parentHashes = Hash.zero().hex();
         }
         var parents = new ArrayList<Hash>();
         for (var parentHash : parentHashes.split(" ")) {

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -348,7 +348,7 @@ public class HgRepository implements Repository {
         }
 
         var tip = resolve("tip");
-        return tip.isEmpty() || tip.get().hex().equals("0".repeat(40));
+        return tip.isEmpty() || tip.get().equals(Hash.zero());
     }
 
     @Override

--- a/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/convert/GitToHgConverter.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/convert/GitToHgConverter.java
@@ -79,7 +79,7 @@ public class GitToHgConverter implements Converter {
         for (var line : lines) {
             var parts = line.split(" ");
             var hash = parts[0];
-            if (hash.equals("0".repeat(40))) {
+            if (hash.equals(Hash.zero().hex())) {
                 result.append(line);
             } else {
                 var tag = parts[1];

--- a/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/convert/HgToGitConverter.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/convert/HgToGitConverter.java
@@ -352,7 +352,7 @@ public class HgToGitConverter implements Converter {
                                      .stream()
                                      .map(Hash::new)
                                      .collect(Collectors.toList());
-            if (parentHashes.size() == 1 && parentHashes.get(0).equals(new Hash("0".repeat(40)))) {
+            if (parentHashes.size() == 1 && parentHashes.get(0).equals(Hash.zero())) {
                 parentHashes = new ArrayList<Hash>();
             }
             pipe.readln(); // skip parent revisions
@@ -481,7 +481,7 @@ public class HgToGitConverter implements Converter {
                             var parts = line.split(" ");
                             var hash = parts[0];
                             var tag = parts[1];
-                            if (hash.equals("0".repeat(40))) {
+                            if (hash.equals(Hash.zero().hex())) {
                                 tags.remove(tag);
                             } else {
                                 tags.put(tag, commit);

--- a/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
@@ -276,9 +276,8 @@ public class RepositoryTests {
             assertEquals(1, commit.numParents());
             assertEquals(1, commit.parents().size());
 
-            var nullHash = "0".repeat(40);
             var parent = commit.parents().get(0);
-            assertEquals(nullHash, parent.hex());
+            assertEquals(Hash.zero(), parent);
 
             assertTrue(commit.isInitialCommit());
             assertFalse(commit.isMerge());
@@ -288,7 +287,7 @@ public class RepositoryTests {
             assertEquals(1, diffs.size());
 
             var diff = diffs.get(0);
-            assertEquals(nullHash, diff.from().hex());
+            assertEquals(Hash.zero(), diff.from());
             assertEquals(hash, diff.to());
 
             assertEquals(0, diff.removed());
@@ -2174,7 +2173,7 @@ public class RepositoryTests {
             assertTrue(statusEntry.status().isUnmerged());
             assertEquals(Path.of("README"), statusEntry.source().path().get());
             assertEquals(Optional.empty(), statusEntry.source().type());
-            assertEquals("0".repeat(40), statusEntry.source().hash().hex());
+            assertEquals(Hash.zero(), statusEntry.source().hash());
         }
     }
 }


### PR DESCRIPTION
Hi all,

please review this small refactoring that adds the method `Hash::zero`
representing an empty hash. The zero hash was already used throughout the code
base but in a less clear way.

Testing:
- `make test` passes on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/469/head:pull/469`
`$ git checkout pull/469`
