### PR TITLE
Improve combining of nested review replies

### DIFF
--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -413,7 +413,7 @@ class MailingListBridgeBotTests {
 
             // Make several file specific comments
             var first = pr.addReviewComment(masterHash, editHash, reviewFile.toString(), 2, "Review comment");
-            pr.addReviewComment(masterHash, editHash, reviewFile.toString(), 2, "Another review comment");
+            var second = pr.addReviewComment(masterHash, editHash, reviewFile.toString(), 2, "Another review comment");
             pr.addReviewComment(masterHash, editHash, reviewFile.toString(), 2, "Further review comment");
             pr.addReviewComment(masterHash, editHash, reviewFile.toString(), 2, "Final review comment");
             TestBotRunner.runPeriodicItems(mlBot);
@@ -443,8 +443,9 @@ class MailingListBridgeBotTests {
             assertTrue(reviewReply.body().contains("Review comment\n\n"), reviewReply.body());
             assertTrue(reviewReply.body().contains("Another review comment"), reviewReply.body());
 
-            // Now reply to the first (collapsed) comment
+            // Now reply to the first and second (collapsed) comment
             pr.addReviewCommentReply(first, "I agree");
+            pr.addReviewCommentReply(second, "Not with this one though");
             TestBotRunner.runPeriodicItems(mlBot);
             listServer.processIncoming();
 
@@ -645,7 +646,7 @@ class MailingListBridgeBotTests {
 
             // Sanity check the archive
             Repository.materialize(archiveFolder.path(), archive.url(), "master");
-            assertEquals(3, archiveContainsCount(archiveFolder.path(), "^On.*wrote:"));
+            assertEquals(2, archiveContainsCount(archiveFolder.path(), "^On.*wrote:"));
         }
     }
 


### PR DESCRIPTION
Hi all,

Please review this change that improves combining review comment replies. As GitHub allows replying in batches to multiple review comments, such replies should be combined into a single email when possible.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/475/head:pull/475`
`$ git checkout pull/475`
