### PR TITLE
Wrap long lines in generated email bodies

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
@@ -257,7 +257,9 @@ class ReviewArchive {
             var firstItem = itemList.get(0);
             var header = firstItem.header();
 
-            var combined = (header.isBlank() ? "" : header +  "\n\n") + body.toString() + (footer.length() == 0 ? "" : "\n\n-------------\n\n" + footer.toString());
+            var combined = (header.isBlank() ? "" : header +  "\n\n") +
+                    WordWrap.wrapBody(body.toString(), 120) +
+                    (footer.length() == 0 ? "" : "\n\n-------------\n\n" + footer.toString());
 
             var emailBuilder = Email.create(firstItem.subject(), combined);
             if (firstItem.parent().isPresent()) {

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -1156,7 +1156,7 @@ class MailingListBridgeBotTests {
             // The archive should reference the rebased push
             Repository.materialize(archiveFolder.path(), archive.url(), "archive");
             assertTrue(archiveContains(archiveFolder.path(), "updated with a new target base"));
-            assertTrue(archiveContains(archiveFolder.path(), "excludes the unrelated changes"));
+            assertTrue(archiveContains(archiveFolder.path(), "excludes"));
             assertTrue(archiveContains(archiveFolder.path(), pr.id() + "/webrev.01"));
             assertTrue(archiveContains(archiveFolder.path(), pr.id() + "/webrev.00-01"));
             assertTrue(archiveContains(archiveFolder.path(), "Original msg"));

--- a/email/src/main/java/org/openjdk/skara/email/WordWrap.java
+++ b/email/src/main/java/org/openjdk/skara/email/WordWrap.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.email;
+
+import java.util.*;
+
+public class WordWrap {
+    private static AbstractMap.Entry<String, String> splitAtLength(String line, int lineLength) {
+        if (line.length() <= lineLength) {
+            return new AbstractMap.SimpleEntry<>(line, "");
+        }
+        var splitAt = line.indexOf(' ');
+        if (splitAt == -1) {
+            return new AbstractMap.SimpleEntry<>(line, "");
+        }
+        while (splitAt < lineLength) {
+            var nextSplitCandidate = line.indexOf(' ', splitAt + 1);
+            if (nextSplitCandidate > lineLength || nextSplitCandidate == -1) {
+                break;
+            }
+            splitAt = nextSplitCandidate;
+        }
+        return new AbstractMap.SimpleEntry<>(line.substring(0, splitAt), line.substring(splitAt + 1));
+    }
+
+    private static String indentString(String line) {
+        for (int i = 0; i < line.length(); ++i) {
+            switch (line.charAt(i)) {
+                case ' ':
+                case '>':
+                case '-':
+                case '*':
+                    break;
+                default:
+                    return line.substring(0, i);
+            }
+        }
+        return line;
+    }
+
+    private static String filterIndent(String indent) {
+        return indent.replace('-', ' ').replace('*', ' ');
+    }
+
+    public static String wrapBody(String body, int lineLength) {
+        var ret = new StringBuilder();
+
+        var lines = new LinkedList<String>();
+        body.lines().forEach(lines::add);
+
+        while (!lines.isEmpty()) {
+            var line = lines.pollFirst();
+            var indent = indentString(line);
+            var split = splitAtLength(line.substring(indent.length()), lineLength);
+            if (!split.getValue().isBlank()) {
+                var nextLine = lines.peekFirst();
+                if (nextLine != null) {
+                    var nextIndent = indentString(nextLine);
+                    if (!indent.equals(filterIndent(nextIndent))) {
+                        lines.addFirst(filterIndent(indent) + split.getValue());
+                    } else {
+                        lines.removeFirst();
+                        lines.addFirst(filterIndent(indent) + split.getValue() + " " + nextLine.substring(indent.length()));
+                    }
+                } else {
+                    lines.addFirst(filterIndent(indent) + split.getValue());
+                }
+            }
+            if (ret.length() > 0) {
+                ret.append("\n");
+            }
+            ret.append(indent).append(split.getKey().stripTrailing());
+        }
+
+        return ret.toString();
+    }
+}

--- a/email/src/main/java/org/openjdk/skara/email/WordWrap.java
+++ b/email/src/main/java/org/openjdk/skara/email/WordWrap.java
@@ -25,34 +25,50 @@ package org.openjdk.skara.email;
 import java.util.*;
 
 public class WordWrap {
-    private static AbstractMap.Entry<String, String> splitAtLength(String line, int lineLength) {
+    private static boolean isIndentCharacter(char ch) {
+        switch (ch) {
+            case ' ':
+            case '>':
+            case '-':
+            case '*':
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private static Map.Entry<String, String> split(String line, int lineLength) {
         if (line.length() <= lineLength) {
             return new AbstractMap.SimpleEntry<>(line, "");
         }
-        var splitAt = line.indexOf(' ');
+        var splitAt = -1;
+        for (int i = 0; i < line.length() - 1; ++i) {
+            var cur = line.charAt(i);
+            var next = line.charAt(i + 1);
+            if (cur == ' ') {
+                if (!isIndentCharacter(next)) {
+                    if (i < lineLength) {
+                        splitAt = i;
+                    } else {
+                        // We'll never find a better match - if we don't have any candidate we have to split here even if lineLength is exceeded
+                        if (splitAt == -1) {
+                            splitAt = i;
+                        }
+                        break;
+                    }
+                }
+            }
+        }
         if (splitAt == -1) {
             return new AbstractMap.SimpleEntry<>(line, "");
-        }
-        while (splitAt < lineLength) {
-            var nextSplitCandidate = line.indexOf(' ', splitAt + 1);
-            if (nextSplitCandidate > lineLength || nextSplitCandidate == -1) {
-                break;
-            }
-            splitAt = nextSplitCandidate;
         }
         return new AbstractMap.SimpleEntry<>(line.substring(0, splitAt), line.substring(splitAt + 1));
     }
 
-    private static String indentString(String line) {
+    private static String indentation(String line) {
         for (int i = 0; i < line.length(); ++i) {
-            switch (line.charAt(i)) {
-                case ' ':
-                case '>':
-                case '-':
-                case '*':
-                    break;
-                default:
-                    return line.substring(0, i);
+            if (!isIndentCharacter(line.charAt(i))) {
+                return line.substring(0, i);
             }
         }
         return line;
@@ -70,26 +86,26 @@ public class WordWrap {
 
         while (!lines.isEmpty()) {
             var line = lines.pollFirst();
-            var indent = indentString(line);
-            var split = splitAtLength(line.substring(indent.length()), lineLength);
+            var indentation = indentation(line);
+            var split = split(line.substring(indentation.length()), lineLength);
             if (!split.getValue().isBlank()) {
                 var nextLine = lines.peekFirst();
                 if (nextLine != null) {
-                    var nextIndent = indentString(nextLine);
-                    if (!indent.equals(filterIndent(nextIndent))) {
-                        lines.addFirst(filterIndent(indent) + split.getValue());
+                    var nextIndent = indentation(nextLine);
+                    if (!indentation.equals(filterIndent(nextIndent))) {
+                        lines.addFirst(filterIndent(indentation) + split.getValue());
                     } else {
                         lines.removeFirst();
-                        lines.addFirst(filterIndent(indent) + split.getValue() + " " + nextLine.substring(indent.length()));
+                        lines.addFirst(filterIndent(indentation) + split.getValue() + " " + nextLine.substring(indentation.length()));
                     }
                 } else {
-                    lines.addFirst(filterIndent(indent) + split.getValue());
+                    lines.addFirst(filterIndent(indentation) + split.getValue());
                 }
             }
             if (ret.length() > 0) {
                 ret.append("\n");
             }
-            ret.append(indent).append(split.getKey().stripTrailing());
+            ret.append(indentation).append(split.getKey().stripTrailing());
         }
 
         return ret.toString();

--- a/email/src/test/java/org/openjdk/skara/email/WordWrapTests.java
+++ b/email/src/test/java/org/openjdk/skara/email/WordWrapTests.java
@@ -1,0 +1,34 @@
+package org.openjdk.skara.email;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class WordWrapTests {
+    @Test
+    void simple() {
+        assertEquals("hello\nthere\nyou", WordWrap.wrapBody("hello there you", 2));
+        assertEquals("hello\nthere", WordWrap.wrapBody("hello there", 7));
+        assertEquals("hello there", WordWrap.wrapBody("hello there", 20));
+        assertEquals("hello\nthere", WordWrap.wrapBody("hello   there", 7));
+    }
+
+    @Test
+    void indented() {
+        assertEquals("  hello\n  there", WordWrap.wrapBody("  hello there", 10));
+        assertEquals("  hello\n  there\n you", WordWrap.wrapBody("  hello there\n you", 10));
+    }
+
+    @Test
+    void quoted() {
+        assertEquals("> hello\n> there", WordWrap.wrapBody("> hello there", 10));
+        assertEquals("> hello\n> there\n> you", WordWrap.wrapBody("> hello there\n> you", 2));
+        assertEquals(">> hello\n>> there\n> you", WordWrap.wrapBody(">> hello there\n> you", 2));
+    }
+
+    @Test
+    void list() {
+        assertEquals(" - hello\n   there\n - you", WordWrap.wrapBody(" - hello there\n - you", 10));
+        assertEquals(" - hello\n   there", WordWrap.wrapBody(" - hello there", 10));
+    }
+}

--- a/email/src/test/java/org/openjdk/skara/email/WordWrapTests.java
+++ b/email/src/test/java/org/openjdk/skara/email/WordWrapTests.java
@@ -31,4 +31,30 @@ public class WordWrapTests {
         assertEquals(" - hello\n   there\n - you", WordWrap.wrapBody(" - hello there\n - you", 10));
         assertEquals(" - hello\n   there", WordWrap.wrapBody(" - hello there", 10));
     }
+
+    @Test
+    void notList() {
+        assertEquals("this\nis -\njust -\nnot\na\nlist", WordWrap.wrapBody("this is - just - not a list", 3));
+    }
+
+    @Test
+    void complex() {
+        assertEquals("> I had a\n" +
+                             "> few\n" +
+                             "> comments\n" +
+                             "> - fix the\n" +
+                             ">   spelling\n" +
+                             "> - remove\n" +
+                             ">   trailing\n" +
+                             ">   whitespace\n" +
+                             "Ok, I\n" +
+                             "will fix\n" +
+                             "that in a\n" +
+                             "new\n" +
+                             "commit!", WordWrap.wrapBody("> I had a few comments\n" +
+                                                                  "> - fix the spelling\n" +
+                                                                  "> - remove trailing whitespace\n" +
+                                                                  "Ok, I will fix that in a new commit!",
+                                                          10));
+    }
 }


### PR DESCRIPTION
Hi all,

Please review this change that wraps long lines in generated emails, to make them look nicer in the archives.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/476/head:pull/476`
`$ git checkout pull/476`
