### PR TITLE
289: Notifier and mailing list bridge does not recognize RFR email prefixes

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBot.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBot.java
@@ -66,7 +66,7 @@ public class MailingListArchiveReaderBot implements Bot {
             parsedEmailIds.add(first.id());
 
             // Not an RFR - cannot match a PR
-            if (!conversation.first().subject().startsWith("RFR")) {
+            if (!conversation.first().subject().contains("RFR: ")) {
                 return;
             }
 

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBotTests.java
@@ -156,6 +156,7 @@ class MailingListArchiveReaderBotTests {
                                             .webrevStorageBase(Path.of("test"))
                                             .webrevStorageBaseUri(webrevServer.uri())
                                             .issueTracker(URIBuilder.base("http://issues.test/browse/").build())
+                                            .repoInSubject(true)
                                             .build();
 
             // The mailing list as well

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/MailingListUpdater.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/MailingListUpdater.java
@@ -169,7 +169,7 @@ public class MailingListUpdater implements RepositoryUpdateConsumer {
         var ret = new ArrayList<Commit>();
 
         var rfrsConvos = list.conversations(Duration.ofDays(365)).stream()
-                       .filter(conv -> conv.first().subject().startsWith("RFR: "))
+                       .filter(conv -> conv.first().subject().contains("RFR: "))
                        .collect(Collectors.toList());
 
         for (var commit : commits) {

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdaterTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdaterTests.java
@@ -644,7 +644,7 @@ class UpdaterTests {
             assertThrows(RuntimeException.class, () -> listServer.processIncoming(Duration.ofMillis(1)));
 
             // Simulate an RFR email
-            var rfr = Email.create("RFR: My PR", "PR:\n" + pr.webUrl().toString())
+            var rfr = Email.create("[repo/branch] RFR: My PR", "PR:\n" + pr.webUrl().toString())
                            .author(EmailAddress.from("duke", "duke@duke.duke"))
                            .recipient(listAddress)
                            .build();
@@ -673,7 +673,7 @@ class UpdaterTests {
             assertEquals(listAddress, prEmail.sender());
             assertEquals(EmailAddress.from("testauthor", "ta@none.none"), prEmail.author());
             assertEquals(prEmail.recipients(), List.of(listAddress));
-            assertEquals("[Integrated] RFR: My PR", prEmail.subject());
+            assertEquals("[Integrated] [repo/branch] RFR: My PR", prEmail.subject());
             assertFalse(prEmail.subject().contains("master"));
             assertTrue(prEmail.body().contains("Changeset: " + editHash.abbreviate()));
             assertTrue(prEmail.body().contains("23456789: More fixes"));


### PR DESCRIPTION
Hi all,

Please review this change that fixes a problem where generated RFR emails that are prefixed with branch or repository names are not found by the notifier and the mailing list bridge.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-289](https://bugs.openjdk.java.net/browse/SKARA-289): Notifier and mailing list bridge does not recognize RFR email prefixes


### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/477/head:pull/477`
`$ git checkout pull/477`
