### PR TITLE
Only set auth headers once when decoding paginated results

### DIFF
--- a/network/src/main/java/org/openjdk/skara/network/RestRequest.java
+++ b/network/src/main/java/org/openjdk/skara/network/RestRequest.java
@@ -199,9 +199,6 @@ public class RestRequest {
         var builder = HttpRequest.newBuilder()
                                  .uri(uri)
                                  .timeout(Duration.ofSeconds(30));
-        if (authGen != null) {
-            builder.headers(authGen.getAuthHeaders().toArray(new String[0]));
-        }
         return builder;
     }
 


### PR DESCRIPTION
Hi all,

Please review this small change that removes a redundant auth header setting when automatically decoding paginated results from a rest request.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/478/head:pull/478`
`$ git checkout pull/478`
