### PR TITLE
git-fork: use --fast-forward instead of --pull when syncing

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitFork.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitFork.java
@@ -372,7 +372,7 @@ public class GitFork {
                 System.out.println("done");
 
                 if (shouldSync) {
-                    GitSync.sync(repo, new String[]{"--from", "upstream", "--to", "origin", "--pull"});
+                    GitSync.sync(repo, new String[]{"--from", "upstream", "--to", "origin", "--fast-forward"});
                 }
 
                 var setupPrePushHooksOption = getOption("setup-pre-push-hooks", subsection, arguments);


### PR DESCRIPTION
Hi all,

please review this small patch that makes `git fork` use `--fast-forward` when
running `git-sync` instead of `--pull`. Using `--fast-forward` ensures that all
branches in the newly cloned repository will be up to date.

Testing:
- Manual testing of `git fork` on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/482/head:pull/482`
`$ git checkout pull/482`
