### PR TITLE
git-pr: integrate should handle sponsor messages

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrIntegrate.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrIntegrate.java
@@ -107,6 +107,11 @@ public class GitPrIntegrate {
                             var output = removeTrailing(line, ".");
                             System.out.println(output);
                             System.exit(0);
+                        } else if (line.startsWith("Your change (at version ") &&
+                                   line.endsWith(") is now ready to be sponsored by a Committer.")) {
+                            var output = removeTrailing(line, ".");
+                            System.out.println(output);
+                            System.exit(0);
                         }
                     }
                 }


### PR DESCRIPTION
Hi all,

please review this small patch that makes `git pr integrate` handle replies from
the bots about the PR needing a sponsor.

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/484/head:pull/484`
`$ git checkout pull/484`
