### PR TITLE
Preserve paragraph breaks when word wrapping

### DIFF
--- a/email/src/main/java/org/openjdk/skara/email/WordWrap.java
+++ b/email/src/main/java/org/openjdk/skara/email/WordWrap.java
@@ -92,7 +92,7 @@ public class WordWrap {
                 var nextLine = lines.peekFirst();
                 if (nextLine != null) {
                     var nextIndent = indentation(nextLine);
-                    if (!indentation.equals(filterIndent(nextIndent))) {
+                    if (nextLine.isBlank() || !indentation.equals(filterIndent(nextIndent))) {
                         lines.addFirst(filterIndent(indentation) + split.getValue());
                     } else {
                         lines.removeFirst();

--- a/email/src/test/java/org/openjdk/skara/email/WordWrapTests.java
+++ b/email/src/test/java/org/openjdk/skara/email/WordWrapTests.java
@@ -57,4 +57,9 @@ public class WordWrapTests {
                                                                   "Ok, I will fix that in a new commit!",
                                                           10));
     }
+
+    @Test
+    void emptyLines() {
+        assertEquals("hello\nthere\n\nyou", WordWrap.wrapBody("hello there\n\nyou", 3));
+    }
 }


### PR DESCRIPTION
Hi all,

Please review this change that ensures that paragraph breaks are preserved when breaking long lines.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/488/head:pull/488`
`$ git checkout pull/488`
