### PR TITLE
295: jcheck should always use configuration from the target branch

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestInstance.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestInstance.java
@@ -224,8 +224,8 @@ class PullRequestInstance {
     }
 
     void executeChecks(Hash localHash, CensusInstance censusInstance, PullRequestCheckIssueVisitor visitor, List<String> additionalConfiguration) throws Exception {
-        try (var issues = JCheck.check(localRepo(), censusInstance.census(), CommitMessageParsers.v1, "HEAD^!",
-                                       localHash, new HashMap<>(), new HashSet<>(), additionalConfiguration)) {
+        try (var issues = JCheck.check(localRepo(), censusInstance.census(), CommitMessageParsers.v1, localHash,
+                                       targetHash, additionalConfiguration)) {
             for (var issue : issues) {
                 issue.accept(visitor);
             }

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/JCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/JCheckTests.java
@@ -35,7 +35,7 @@ import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 class JCheckTests {
     static class CheckableRepository {
@@ -63,7 +63,7 @@ class JCheckTests {
             }
             repo.add(checkConf);
 
-            repo.commit("Initial commit", "duke", "duke@openjdk.java.net");
+            repo.commit("Initial commit\n\nReviewed-by: user2", "user3", "user3@openjdk.java.net");
 
             return repo;
         }
@@ -75,10 +75,10 @@ class JCheckTests {
             var contributorsContent = List.of(
                     "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>",
                     "<contributors>",
-                    "    <contributor username=\"user_1\" full-name=\"User Number 1\" />",
-                    "    <contributor username=\"user_2\" full-name=\"User Number 2\" />",
-                    "    <contributor username=\"user_3\" full-name=\"User Number 3\" />",
-                    "    <contributor username=\"user_4\" full-name=\"User Number 4\" />",
+                    "    <contributor username=\"user1\" full-name=\"User Number 1\" />",
+                    "    <contributor username=\"user2\" full-name=\"User Number 2\" />",
+                    "    <contributor username=\"user3\" full-name=\"User Number 3\" />",
+                    "    <contributor username=\"user4\" full-name=\"User Number 4\" />",
                     "</contributors>");
             Files.write(contributorsFile, contributorsContent);
 
@@ -90,8 +90,8 @@ class JCheckTests {
                     "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>",
                     "<group name=\"test\" full-name=\"TEST\">",
                     "    <lead username=\"user_4\" />",
-                    "    <member username=\"user_1\" since=\"1\" />",
-                    "    <member username=\"user_2\" since=\"1\" />",
+                    "    <member username=\"user1\" since=\"0\" />",
+                    "    <member username=\"user2\" since=\"0\" />",
                     "</group>");
             Files.write(testGroupFile, testGroupContent);
 
@@ -102,10 +102,10 @@ class JCheckTests {
             var testProjectContent = List.of(
                     "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>",
                     "<project name=\"test\" full-name=\"TEST\" sponsor=\"test\">",
-                    "    <lead username=\"user_1\" since=\"1\" />",
-                    "    <reviewer username=\"user_2\" since=\"1\" />",
-                    "    <committer username=\"user_3\" since=\"1\" />",
-                    "    <author username=\"user_4\" since=\"1\" />",
+                    "    <lead username=\"user1\" since=\"0\" />",
+                    "    <reviewer username=\"user2\" since=\"0\" />",
+                    "    <committer username=\"user3\" since=\"0\" />",
+                    "    <author username=\"user4\" since=\"0\" />",
                     "</project>");
             Files.write(testProjectFile, testProjectContent);
 
@@ -116,8 +116,8 @@ class JCheckTests {
             var namespaceContent = List.of(
                     "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>",
                     "<namespace name=\"github.com\">",
-                    "    <user id=\"1234567\" census=\"user_1\" />",
-                    "    <user id=\"2345678\" census=\"user_2\" />",
+                    "    <user id=\"1234567\" census=\"user1\" />",
+                    "    <user id=\"2345678\" census=\"user2\" />",
                     "</namespace>");
             Files.write(namespaceFile, namespaceContent);
 
@@ -285,7 +285,49 @@ class JCheckTests {
             var census = Census.parse(censusPath);
 
             var visitor = new TestVisitor();
-            try (var issues = JCheck.check(repo, census, CommitMessageParsers.v1, first.hex() + ".." + second.hex())) {
+            try (var issues = JCheck.check(repo, census, CommitMessageParsers.v1, first.hex() + ".." + second.hex(), Map.of(), Set.of())) {
+                for (var issue : issues) {
+                    issue.accept(visitor);
+                }
+            }
+            assertEquals(Set.of("org.openjdk.skara.jcheck.TooFewReviewersIssue"), visitor.issueNames());
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(VCS.class)
+    void checkOverridingConfiguration(VCS vcs) throws Exception {
+        try (var dir = new TemporaryDirectory()) {
+            var repoPath = dir.path().resolve("repo");
+            var repo = CheckableRepository.create(repoPath, vcs);
+
+            var initialCommit = repo.commits().asList().get(0);
+
+            var jcheckConf = repoPath.resolve(".jcheck").resolve("conf");
+            assertTrue(Files.exists(jcheckConf));
+            Files.writeString(jcheckConf, "[checks \"reviewers\"]\nminimum = 0\n",
+                              StandardOpenOption.WRITE, StandardOpenOption.APPEND);
+            repo.add(jcheckConf);
+            var secondCommit = repo.commit("Do not require reviews", "user3", "user3@openjdk.java.net");
+
+            var censusPath = dir.path().resolve("census");
+            Files.createDirectories(censusPath);
+            CensusCreator.populateCensusDirectory(censusPath);
+            var census = Census.parse(censusPath);
+
+            // Check the last commit without reviewers, should pass since .jcheck/conf was updated
+            var range = initialCommit.hash().hex() + ".." + secondCommit.hex();
+            var visitor = new TestVisitor();
+            try (var issues = JCheck.check(repo, census, CommitMessageParsers.v1, range, Map.of(), Set.of())) {
+                for (var issue : issues) {
+                    issue.accept(visitor);
+                }
+            }
+            assertEquals(Set.of(), visitor.issues());
+
+            // Check the last commit without reviewers with the initial .jcheck/conf. Should fail
+            // due to missing reviewers.
+            try (var issues = JCheck.check(repo, census, CommitMessageParsers.v1, secondCommit, initialCommit.hash(), List.of())) {
                 for (var issue : issues) {
                     issue.accept(visitor);
                 }

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/TestRepository.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/TestRepository.java
@@ -304,4 +304,16 @@ class TestRepository implements ReadOnlyRepository {
     public Optional<Tag.Annotated> annotate(Tag tag) throws IOException {
         return null;
     }
+
+    public String range(Hash h) {
+        return null;
+    }
+
+    public String rangeInclusive(Hash from, Hash to) {
+        return null;
+    }
+
+    public String rangeExclusive(Hash from, Hash to) {
+        return null;
+    }
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
@@ -60,6 +60,9 @@ public interface ReadOnlyRepository {
     List<CommitMetadata> commitMetadata(Hash from, Hash to, List<Path> paths) throws IOException;
     List<CommitMetadata> commitMetadata(String range, List<Path> paths, boolean reverse) throws IOException;
     List<CommitMetadata> commitMetadata(Hash from, Hash to, List<Path> paths, boolean reverse) throws IOException;
+    String range(Hash h);
+    String rangeInclusive(Hash from, Hash to);
+    String rangeExclusive(Hash from, Hash to);
     Path root() throws IOException;
     boolean exists() throws IOException;
     boolean isHealthy() throws IOException;

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -1318,4 +1318,19 @@ public class GitRepository implements Repository {
             await(p);
         }
     }
+
+    @Override
+    public String range(Hash h) {
+        return h.hex() + "^!";
+    }
+
+    @Override
+    public String rangeInclusive(Hash from, Hash to) {
+        return from.hex() + "^.." + to.hex();
+    }
+
+    @Override
+    public String rangeExclusive(Hash from, Hash to) {
+        return from.hex() + ".." + to.hex();
+    }
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -1331,4 +1331,19 @@ public class HgRepository implements Repository {
         }
         Files.write(hgrc, lines, StandardOpenOption.WRITE, StandardOpenOption.APPEND);
     }
+
+    @Override
+    public String range(Hash h) {
+        return h.hex();
+    }
+
+    @Override
+    public String rangeInclusive(Hash from, Hash to) {
+        return from.hex() + ":" + to.hex();
+    }
+
+    @Override
+    public String rangeExclusive(Hash from, Hash to) {
+        return from.hex() + ":" + to.hex() + "-" + from.hex();
+    }
 }

--- a/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
@@ -2176,4 +2176,52 @@ public class RepositoryTests {
             assertEquals(Hash.zero(), statusEntry.source().hash());
         }
     }
+
+    @ParameterizedTest
+    @EnumSource(VCS.class)
+    void testRangeSingle(VCS vcs) throws IOException {
+        try (var dir = new TemporaryDirectory()) {
+            var repo = Repository.init(dir.path(), vcs);
+            var range = repo.range(new Hash("0123456789"));
+            if (vcs == VCS.GIT) {
+                assertEquals("0123456789^!", range);
+            } else if (vcs == VCS.HG) {
+                assertEquals("0123456789", range);
+            } else {
+                fail("Unexpected vcs: " + vcs);
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(VCS.class)
+    void testRangeInclusive(VCS vcs) throws IOException {
+        try (var dir = new TemporaryDirectory()) {
+            var repo = Repository.init(dir.path(), vcs);
+            var range = repo.rangeInclusive(new Hash("01234"), new Hash("56789"));
+            if (vcs == VCS.GIT) {
+                assertEquals("01234^..56789", range);
+            } else if (vcs == VCS.HG) {
+                assertEquals("01234:56789", range);
+            } else {
+                fail("Unexpected vcs: " + vcs);
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(VCS.class)
+    void testRangeExclusive(VCS vcs) throws IOException {
+        try (var dir = new TemporaryDirectory()) {
+            var repo = Repository.init(dir.path(), vcs);
+            var range = repo.rangeExclusive(new Hash("01234"), new Hash("56789"));
+            if (vcs == VCS.GIT) {
+                assertEquals("01234..56789", range);
+            } else if (vcs == VCS.HG) {
+                assertEquals("01234:56789-01234", range);
+            } else {
+                fail("Unexpected vcs: " + vcs);
+            }
+        }
+    }
 }


### PR DESCRIPTION
Hi all,

please review this patch that ensures that the bots always use the .jcheck/conf
from the target branch when checking pull requests.

Testing:
- `make test` passes on Linux x64
- Added a few new unit tests

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-295](https://bugs.openjdk.java.net/browse/SKARA-295): jcheck should always use configuration from the target branch


### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/491/head:pull/491`
`$ git checkout pull/491`
