### PR TITLE
jcheck: always reload configuration

### DIFF
--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/JCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/JCheck.java
@@ -47,8 +47,6 @@ public class JCheck {
     private final JCheckConfiguration overridingConfiguration;
     private final Logger log = Logger.getLogger("org.openjdk.skara.jcheck");
 
-    private JCheckConfiguration cachedConfiguration = null;
-
     JCheck(ReadOnlyRepository repository,
            Census census,
            CommitMessageParser parser,
@@ -104,22 +102,7 @@ public class JCheck {
         if (overridingConfiguration != null) {
             return Optional.of(overridingConfiguration);
         }
-        var confPath = Paths.get(".jcheck/conf");
-        var changesConfiguration = c.parentDiffs()
-                                    .stream()
-                                    .map(Diff::patches)
-                                    .flatMap(List::stream)
-                                    .anyMatch(p -> p.source().path().isPresent() && p.source().path().get().equals(confPath) ||
-                                                   p.target().path().isPresent() && p.target().path().get().equals(confPath));
-
-
-        if (changesConfiguration || cachedConfiguration == null) {
-            var confAtCommit = parseConfiguration(repository, c.hash(), additionalConfiguration);
-            confAtCommit.ifPresent(jCheckConfiguration -> cachedConfiguration = jCheckConfiguration);
-            return confAtCommit;
-        } else {
-            return Optional.of(cachedConfiguration);
-        }
+        return parseConfiguration(repository, c.hash(), additionalConfiguration);
     }
 
     private Iterator<Issue> checkCommit(Commit commit) {


### PR DESCRIPTION
Hi all,

please review this pull request that always reloads the .jcheck/conf from the
tree corresponding to a commit when checking said commit. The existing
optimization may not work that well with merged histories where there are two
branches with differing .jcheck/conf files. The performance impact from this
patch is barely noticeable, so I suggest we opt for a safer and simpler
implementation.

Testing:
- `make test` passes on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/492/head:pull/492`
`$ git checkout pull/492`
