### PR TITLE
jcheck: allow pattern for merge commit messages

### DIFF
--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/MergeMessageCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/MergeMessageCheck.java
@@ -27,6 +27,7 @@ import org.openjdk.skara.vcs.openjdk.CommitMessage;
 
 import java.util.Iterator;
 import java.util.logging.Logger;
+import java.util.regex.Pattern;
 
 public class MergeMessageCheck extends CommitCheck {
     private final Logger log = Logger.getLogger("org.openjdk.skara.jcheck.merge");
@@ -36,11 +37,11 @@ public class MergeMessageCheck extends CommitCheck {
             return iterator();
         }
 
-        var expected = conf.checks().merge().message();
-        if (commit.message().size() != 1 || !commit.message().get(0).equals(expected)) {
+        var pattern = Pattern.compile(conf.checks().merge().message());
+        if (commit.message().size() != 1 || !pattern.matcher(commit.message().get(0)).matches()) {
             var metadata = CommitIssue.metadata(commit, message, conf, this);
             log.finer("issue: wrong merge message");
-            return iterator(new MergeMessageIssue(expected, metadata));
+            return iterator(new MergeMessageIssue(pattern.toString(), metadata));
         }
 
         return iterator();

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/MergeMessageCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/MergeMessageCheckTests.java
@@ -103,4 +103,16 @@ class MergeMessageCheckTests {
         assertEquals(1, issues.size());
         assertTrue(issues.get(0) instanceof MergeMessageIssue);
     }
+
+    @Test
+    void usingRegexShouldWork() throws IOException {
+        var commit = commit(List.of("Merge 'feature' into 'master'"));
+        var message = message(commit);
+        var check = new MergeMessageCheck();
+        var conf = new ArrayList<>(CONFIGURATION);
+        conf.set(conf.size() - 1, "message = Merge \\'[a-z]+\\' into \\'[a-z]+\\'");
+        var issues = toList(check.check(commit, message, JCheckConfiguration.parse(conf)));
+
+        assertEquals(List.of(), issues);
+    }
 }


### PR DESCRIPTION
Hi all,

please review this patch that allows for the merge message variable in the
.jcheck/conf to be a pattern. I added an additional unit test for this feature.

Testing:
- `make test` passes on Linux x64
- Added an additional unit test

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/493/head:pull/493`
`$ git checkout pull/493`
