### PR TITLE
Use quoting to direct comment threading

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
@@ -160,7 +160,15 @@ class ReviewArchive {
         return ret;
     }
 
-    private String quoteSelectedParents(List<ArchiveItem> parentsToQuote) {
+    // Parents to quote are provided with the newest item first. If the item already has quoted
+    // a parent, use that as the quote and return an empty string.
+    private String quoteSelectedParents(List<ArchiveItem> parentsToQuote, ArchiveItem first) {
+        if (parentsToQuote.isEmpty()) {
+            return "";
+        }
+        if (ArchiveItem.containsQuote(first.body(), parentsToQuote.get(0).body())) {
+            return "";
+        }
         Collections.reverse(parentsToQuote);
         var ret = "";
         for (var parent : parentsToQuote) {
@@ -233,7 +241,7 @@ class ReviewArchive {
                     body.append("\n\n");
                 }
                 var newQuotes = parentsToQuote(item, 2, quotedParents);
-                var quote = quoteSelectedParents(newQuotes);
+                var quote = quoteSelectedParents(newQuotes, item);
                 if (!quote.isBlank()) {
                     body.append(quote);
                     body.append("\n\n");

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -780,6 +780,71 @@ class MailingListBridgeBotTests {
     }
 
     @Test
+    void commentWithQuote(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory();
+             var archiveFolder = new TemporaryDirectory();
+             var listServer = new TestMailmanServer();
+             var webrevServer = new TestWebrevServer()) {
+            var author = credentials.getHostedRepository();
+            var reviewer = credentials.getHostedRepository();
+            var archive = credentials.getHostedRepository();
+            var listAddress = EmailAddress.parse(listServer.createList("test"));
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addReviewer(reviewer.forge().currentUser().id())
+                                           .addAuthor(author.forge().currentUser().id());
+            var from = EmailAddress.from("test", "test@test.mail");
+            var mlBot = MailingListBridgeBot.newBuilder()
+                                            .from(from)
+                                            .repo(author)
+                                            .archive(archive)
+                                            .censusRepo(censusBuilder.build())
+                                            .list(listAddress)
+                                            .listArchive(listServer.getArchive())
+                                            .smtpServer(listServer.getSMTP())
+                                            .webrevStorageRepository(archive)
+                                            .webrevStorageRef("webrev")
+                                            .webrevStorageBase(Path.of("test"))
+                                            .webrevStorageBaseUri(webrevServer.uri())
+                                            .issueTracker(URIBuilder.base("http://issues.test/browse/").build())
+                                            .build();
+
+            // Populate the projects repository
+            var reviewFile = Path.of("reviewfile.txt");
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(), reviewFile);
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, archive.url(), "webrev", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(archive, "master", "edit", "This is a pull request");
+            pr.setBody("This is now ready");
+            TestBotRunner.runPeriodicItems(mlBot);
+            listServer.processIncoming();
+
+            // Make two comments from different authors
+            var reviewPr = reviewer.pullRequest(pr.id());
+            reviewPr.addComment("First comment\nsecond line");
+            pr.addComment("Second comment\nfourth line");
+
+            TestBotRunner.runPeriodicItems(mlBot);
+            listServer.processIncoming();
+
+            pr.addComment(">First comm\n\nreply to first");
+            TestBotRunner.runPeriodicItems(mlBot);
+            listServer.processIncoming();
+
+            // The first comment should be quoted more often than the second
+            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            assertEquals(2, archiveContainsCount(archiveFolder.path(), "First comment"));
+            assertEquals(3, archiveContainsCount(archiveFolder.path(), "First comm"));
+            assertEquals(1, archiveContainsCount(archiveFolder.path(), "Second comment"));
+        }
+    }
+
+    @Test
     void reviewContext(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
              var tempFolder = new TemporaryDirectory();


### PR DESCRIPTION
Hi all,

Please review this change that checks if a comment contains a quote from a previous post. If it does, that post will be considered the parent when selecting which thread to post in. Also avoid automatic quoting in that case, to let the user select what to quote.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/495/head:pull/495`
`$ git checkout pull/495`
