### PR TITLE
vcs: handle nested repositories

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
@@ -135,11 +135,26 @@ public interface Repository extends ReadOnlyRepository {
     }
 
     static Optional<Repository> get(Path p) throws IOException {
-        var r = GitRepository.get(p);
-        if (r.isPresent()) {
-            return r;
+        var gitRepo = GitRepository.get(p);
+        var hgRepo = HgRepository.get(p);
+        if (gitRepo.isPresent() && hgRepo.isEmpty()) {
+            return gitRepo;
+        } else if (gitRepo.isEmpty() && hgRepo.isPresent()) {
+            return hgRepo;
+        } else if (gitRepo.isPresent() && hgRepo.isPresent()) {
+            // Nested repositories
+            var gitRoot = gitRepo.get().root();
+            var hgRoot = hgRepo.get().root();
+            if (gitRoot.equals(hgRoot)) {
+                throw new IOException(p.toString() + " contains both a hg and git repository");
+            }
+            if (hgRoot.startsWith(gitRoot)) {
+                return hgRepo;
+            } else {
+                return gitRepo;
+            }
         }
-        return HgRepository.get(p);
+        return Optional.empty();
     }
 
     static boolean exists(Path p) throws IOException {


### PR DESCRIPTION
Hi all,

please review this patch that makes `Repository.get` (and
`ReadOnlyRepository.get`) able to handle nested repositories.

Testing:
- `make test` passes on Linux x64
- Added three new unit tests

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/496/head:pull/496`
`$ git checkout pull/496`
