### PR TITLE
Parse older conversations, but only the most recent messages

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveReaderWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveReaderWorkItem.java
@@ -57,7 +57,7 @@ public class ArchiveReaderWorkItem implements WorkItem {
     @Override
     public void run(Path scratchPath) {
         // Give the bot a chance to act on all found messages
-        var conversations = list.conversations(Duration.ofDays(60));
+        var conversations = list.conversations(Duration.ofDays(365));
         for (var conversation : conversations) {
             bot.inspect(conversation);
         }

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBot.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBot.java
@@ -27,6 +27,7 @@ import org.openjdk.skara.email.*;
 import org.openjdk.skara.forge.*;
 import org.openjdk.skara.mailinglist.*;
 
+import java.time.*;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.logging.Logger;
@@ -92,8 +93,10 @@ public class MailingListArchiveReaderBot implements Bot {
             parsedEmailIds.remove(first.id());
         }
 
-        // Are there any new messages?
+        // Are there any new messages? We avoid looking further back than 14 days. If the bridge has been down
+        // for more than 14 days, this may have to be temporarily increased.
         var newMessages = conversation.allMessages().stream()
+                                      .filter(email -> email.date().isAfter(ZonedDateTime.now().minus(Duration.ofDays(14))))
                                       .filter(email -> !parsedEmailIds.contains(email.id()))
                                       .collect(Collectors.toList());
         if (newMessages.isEmpty()) {


### PR DESCRIPTION
Hi all,

Please review this small change that allows the mailing list bridge to parse older conversations, but filters out individual old messages. This will allow bridging of conversations that are longer than 60 days, but still avoids unnecessary checking for already bridged messages.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/498/head:pull/498`
`$ git checkout pull/498`
