### PR TITLE
Avoid an empty line in footers for a comment-only review

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
@@ -326,8 +326,11 @@ class ArchiveMessages {
     static String composeReviewFooter(PullRequest pr, Review review, HostUserToUserName hostUserToUserName, HostUserToRole hostUserToRole) {
         var result = new StringBuilder();
         if (review.body().isPresent() && !review.body().get().isBlank()) {
-            result.append(composeReviewVerdict(review, hostUserToUserName, hostUserToRole));
-            result.append("\n\n");
+            var verdict = composeReviewVerdict(review, hostUserToUserName, hostUserToRole);
+            if (!verdict.isBlank()) {
+                result.append(verdict);
+                result.append("\n\n");
+            }
         }
         result.append(composeReplyFooter(pr));
         return result.toString();


### PR DESCRIPTION
Hi all,

Please review this small change that avoids putting an extra empty line in a bridged review comment, if the review doesn't have a verdict.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/499/head:pull/499`
`$ git checkout pull/499`
