### PR TITLE
276: Merge style PRs should generate "merge" webrevs

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveItem.java
@@ -38,8 +38,7 @@ class ArchiveItem {
         this.footer = footer;
     }
 
-    // If the head commit is a merge commit with base as one parent, return the other one (the new content)
-    private static Optional<Hash> mergeParent(Repository localRepo, Hash base, Hash head) {
+    private static Optional<Commit> mergeCommit(Repository localRepo, Hash head) {
         try {
             var mergeCommit = localRepo.lookup(head);
             if (mergeCommit.isEmpty()) {
@@ -48,13 +47,7 @@ class ArchiveItem {
             if (!mergeCommit.get().isMerge()) {
                 return Optional.empty();
             }
-            for (var parent : mergeCommit.get().parents()) {
-                if (parent.equals(base) || localRepo.isAncestor(parent, base)) {
-                    continue;
-                }
-                return Optional.of(parent);
-            }
-            return Optional.empty();
+            return mergeCommit;
         } catch (IOException e) {
             return Optional.empty();
         }
@@ -69,16 +62,32 @@ class ArchiveItem {
                                () -> "",
                                () -> ArchiveMessages.composeConversation(pr, localRepo, base, head),
                                () -> {
+                                   var fullWebrev = webrevGenerator.generate(base, head, "00", WebrevDescription.Type.FULL);
                                    if (pr.title().startsWith("Merge")) {
-                                       var mergeCommitParent = mergeParent(localRepo, base, head);
-                                        if (mergeCommitParent.isPresent()) {
-                                            var mergeWebrev = webrevGenerator.generate(mergeCommitParent.get(), head, "00");
-                                            webrevNotification.notify(0, mergeWebrev, null);
-                                            return ArchiveMessages.composeMergeConversationFooter(pr, localRepo, mergeWebrev, base, mergeCommitParent.get(), head);
+                                       var mergeCommit = mergeCommit(localRepo, head);
+                                        if (mergeCommit.isPresent()) {
+                                            var mergeWebrevs = new ArrayList<WebrevDescription>();
+                                            mergeWebrevs.add(fullWebrev);
+                                            for (int i = 0; i < mergeCommit.get().parentDiffs().size(); ++i) {
+                                                var diff = mergeCommit.get().parentDiffs().get(i);
+                                                switch (i) {
+                                                    case 0:
+                                                        mergeWebrevs.add(webrevGenerator.generate(diff, String.format("00.%d", i), WebrevDescription.Type.MERGE_TARGET, pr.targetRef()));
+                                                        break;
+                                                    case 1:
+                                                        var mergeSource = pr.title().length() > 6 ? pr.title().substring(6) : null;
+                                                        mergeWebrevs.add(webrevGenerator.generate(diff, String.format("00.%d", i), WebrevDescription.Type.MERGE_SOURCE, mergeSource));
+                                                        break;
+                                                    default:
+                                                        mergeWebrevs.add(webrevGenerator.generate(diff, String.format("00.%d", i), WebrevDescription.Type.MERGE_SOURCE, null));
+                                                        break;
+                                                }
+                                            }
+                                            webrevNotification.notify(0, mergeWebrevs);
+                                            return ArchiveMessages.composeMergeConversationFooter(pr, localRepo, mergeWebrevs, base, head);
                                         }
                                    }
-                                   var fullWebrev = webrevGenerator.generate(base, head, "00");
-                                   webrevNotification.notify(0, fullWebrev, null);
+                                   webrevNotification.notify(0, List.of(fullWebrev));
                                    return ArchiveMessages.composeConversationFooter(pr, issueTracker, issuePrefix, localRepo, fullWebrev, base, head);
                                });
     }
@@ -123,19 +132,19 @@ class ArchiveItem {
                                    }
                                },
                                () -> {
-                                   var fullWebrev = webrevGenerator.generate(base, head, String.format("%02d", index));
+                                   var fullWebrev = webrevGenerator.generate(base, head, String.format("%02d", index), WebrevDescription.Type.FULL);
                                    if (lastBase.equals(base)) {
-                                       var incrementalWebrev = webrevGenerator.generate(lastHead, head, String.format("%02d-%02d", index - 1, index));
-                                       webrevNotification.notify(index, fullWebrev, incrementalWebrev);
+                                       var incrementalWebrev = webrevGenerator.generate(lastHead, head, String.format("%02d-%02d", index - 1, index), WebrevDescription.Type.INCREMENTAL);
+                                       webrevNotification.notify(index, List.of(fullWebrev, incrementalWebrev));
                                        return ArchiveMessages.composeIncrementalFooter(pr, localRepo, fullWebrev, incrementalWebrev, head, lastHead);
                                    } else {
                                        var rebasedLastHead = rebasedLastHead(localRepo, base, lastHead);
                                        if (rebasedLastHead.isPresent()) {
-                                           var incrementalWebrev = webrevGenerator.generate(rebasedLastHead.get(), head, String.format("%02d-%02d", index - 1, index));
-                                           webrevNotification.notify(index, fullWebrev, incrementalWebrev);
+                                           var incrementalWebrev = webrevGenerator.generate(rebasedLastHead.get(), head, String.format("%02d-%02d", index - 1, index), WebrevDescription.Type.INCREMENTAL);
+                                           webrevNotification.notify(index, List.of(fullWebrev, incrementalWebrev));
                                            return ArchiveMessages.composeIncrementalFooter(pr, localRepo, fullWebrev, incrementalWebrev, head, lastHead);
                                        } else {
-                                           webrevNotification.notify(index, fullWebrev, null);
+                                           webrevNotification.notify(index, List.of(fullWebrev));
                                            return ArchiveMessages.composeRebasedFooter(pr, localRepo, fullWebrev, base, head);
                                        }
                                    }

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveItem.java
@@ -40,14 +40,7 @@ class ArchiveItem {
 
     private static Optional<Commit> mergeCommit(Repository localRepo, Hash head) {
         try {
-            var mergeCommit = localRepo.lookup(head);
-            if (mergeCommit.isEmpty()) {
-                return Optional.empty();
-            }
-            if (!mergeCommit.get().isMerge()) {
-                return Optional.empty();
-            }
-            return mergeCommit;
+            return localRepo.lookup(head).filter(Commit::isMerge);
         } catch (IOException e) {
             return Optional.empty();
         }

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
@@ -252,6 +252,19 @@ class ArchiveMessages {
                 composeReplyFooter(pr);
     }
 
+    static String composeMergeConversationFooter(PullRequest pr, Repository localRepo, URI webrev, Hash base, Hash mergeParent, Hash head) {
+        var commits = commits(localRepo, base, head);
+        return "Note! To aid reviewing, the webrev only contains the adjustments done while merging, such as conflict resolution (if any).\n\nAll commit messages:\n" +
+                formatCommitMessagesBrief(commits).orElse("") + "\n\n" +
+                "Changes: " + pr.changeUrl() + "\n" +
+                " Webrev: " + webrev + "\n" +
+                "  Stats: " + stats(localRepo, mergeParent, head) + "\n" +
+                "   Full: " + stats(localRepo, base, head) + "\n" +
+                "  Patch: " + pr.diffUrl().toString() + "\n" +
+                "  Fetch: " + fetchCommand(pr) + "\n\n" +
+                composeReplyFooter(pr);
+    }
+
     static String composeRebasedFooter(PullRequest pr, Repository localRepo, URI fullWebrev, Hash base, Hash head) {
         return "Changes: " + pr.changeUrl() + "\n" +
                 " Webrev: " + fullWebrev.toString() + "\n" +

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
@@ -238,13 +238,13 @@ class ArchiveMessages {
     }
 
     // When changing this, ensure that the PR pattern in the notifier still matches
-    static String composeConversationFooter(PullRequest pr, URI issueProject, String projectPrefix, Repository localRepo, URI webrev, Hash base, Hash head) {
+    static String composeConversationFooter(PullRequest pr, URI issueProject, String projectPrefix, Repository localRepo, WebrevDescription webrev, Hash base, Hash head) {
         var commits = commits(localRepo, base, head);
         var issueString = issueUrl(pr, issueProject, projectPrefix).map(url -> "  Issue: " + url + "\n").orElse("");
         return "Commit messages:\n" +
                 formatCommitMessagesBrief(commits).orElse("") + "\n\n" +
                 "Changes: " + pr.changeUrl() + "\n" +
-                " Webrev: " + webrev + "\n" +
+                " Webrev: " + webrev.uri().toString() + "\n" +
                 issueString +
                 "  Stats: " + stats(localRepo, base, head) + "\n" +
                 "  Patch: " + pr.diffUrl().toString() + "\n" +
@@ -252,35 +252,46 @@ class ArchiveMessages {
                 composeReplyFooter(pr);
     }
 
-    static String composeMergeConversationFooter(PullRequest pr, Repository localRepo, URI webrev, Hash base, Hash mergeParent, Hash head) {
+    static String composeMergeConversationFooter(PullRequest pr, Repository localRepo, List<WebrevDescription> webrevs, Hash base, Hash head) {
         var commits = commits(localRepo, base, head);
-        return "Note! To aid reviewing, the webrev only contains the adjustments done while merging, such as conflict resolution (if any).\n\nAll commit messages:\n" +
+        var webrevLinks = "";
+        if (webrevs.size() > 1) {
+            webrevLinks = " Webrev: " + webrevs.get(0).uri() + "\n\n" +
+                    "The following webrevs contain only the adjustments done while merging with regards to each parent branch:\n" +
+                    webrevs.stream()
+                           .skip(1)
+                           .map(d -> String.format(" - %s: %s", d.shortLabel(), d.uri()))
+                           .collect(Collectors.joining("\n")) + "\n\n";
+        } else {
+            webrevLinks = " Webrev: " + webrevs.get(0).uri() + "\n\n" +
+                    "The merge commit only contains trivial merges, so no merge-specific webrevs have been generated.\n\n";
+        }
+        return "Commit messages:\n" +
                 formatCommitMessagesBrief(commits).orElse("") + "\n\n" +
                 "Changes: " + pr.changeUrl() + "\n" +
-                " Webrev: " + webrev + "\n" +
-                "  Stats: " + stats(localRepo, mergeParent, head) + "\n" +
-                "   Full: " + stats(localRepo, base, head) + "\n" +
-                "  Patch: " + pr.diffUrl().toString() + "\n" +
-                "  Fetch: " + fetchCommand(pr) + "\n\n" +
-                composeReplyFooter(pr);
-    }
-
-    static String composeRebasedFooter(PullRequest pr, Repository localRepo, URI fullWebrev, Hash base, Hash head) {
-        return "Changes: " + pr.changeUrl() + "\n" +
-                " Webrev: " + fullWebrev.toString() + "\n" +
+                webrevLinks +
                 "  Stats: " + stats(localRepo, base, head) + "\n" +
                 "  Patch: " + pr.diffUrl().toString() + "\n" +
                 "  Fetch: " + fetchCommand(pr) + "\n\n" +
                 composeReplyFooter(pr);
     }
 
-    static String composeIncrementalFooter(PullRequest pr, Repository localRepo, URI fullWebrev, URI incrementalWebrev, Hash head, Hash lastHead) {
+    static String composeRebasedFooter(PullRequest pr, Repository localRepo, WebrevDescription fullWebrev, Hash base, Hash head) {
+        return "Changes: " + pr.changeUrl() + "\n" +
+                " Webrev: " + fullWebrev.uri().toString() + "\n" +
+                "  Stats: " + stats(localRepo, base, head) + "\n" +
+                "  Patch: " + pr.diffUrl().toString() + "\n" +
+                "  Fetch: " + fetchCommand(pr) + "\n\n" +
+                composeReplyFooter(pr);
+    }
+
+    static String composeIncrementalFooter(PullRequest pr, Repository localRepo, WebrevDescription fullWebrev, WebrevDescription incrementalWebrev, Hash head, Hash lastHead) {
         return "Changes:\n" +
                 "  - all: " + pr.changeUrl() + "\n" +
                 "  - new: " + pr.changeUrl(lastHead) + "\n\n" +
                 "Webrevs:\n" +
-                " - full: " + fullWebrev.toString() + "\n" +
-                " - incr: " + incrementalWebrev.toString() + "\n\n" +
+                " - full: " + fullWebrev.uri().toString() + "\n" +
+                " - incr: " + incrementalWebrev.uri().toString() + "\n\n" +
                 "  Stats: " + stats(localRepo, lastHead, head) + "\n" +
                 "  Patch: " + pr.diffUrl().toString() + "\n" +
                 "  Fetch: " + fetchCommand(pr) + "\n\n" +

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
@@ -31,14 +31,13 @@ import org.openjdk.skara.mailinglist.*;
 import org.openjdk.skara.vcs.Repository;
 
 import java.io.*;
-import java.net.URI;
 import java.nio.file.Path;
 import java.time.*;
 import java.util.*;
 import java.util.function.*;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
-import java.util.stream.*;
+import java.util.stream.Collectors;
 
 class ArchiveWorkItem implements WorkItem {
     private final PullRequest pr;
@@ -131,24 +130,24 @@ class ArchiveWorkItem implements WorkItem {
     private static final String webrevHeaderMarker = "<!-- mlbridge webrev header -->";
     private static final String webrevListMarker = "<!-- mlbridge webrev list -->";
 
-    private void updateWebrevComment(List<Comment> comments, int index, URI fullWebrev, URI incWebrev) {
+    private void updateWebrevComment(List<Comment> comments, int index, List<WebrevDescription> webrevs) {
         var existing = comments.stream()
                                .filter(comment -> comment.author().equals(pr.repository().forge().currentUser()))
                                .filter(comment -> comment.body().contains(webrevCommentMarker))
                                .findAny();
+        var webrevDescriptions = webrevs.stream()
+                                        .map(d -> String.format("[%s](%s)", d.label(), d.uri()))
+                                        .collect(Collectors.joining(" - "));
         var comment = webrevCommentMarker + "\n";
         comment += webrevHeaderMarker + "\n";
         comment += "### Webrevs" + "\n";
         comment += webrevListMarker + "\n";
-        comment += " * " + String.format("%02d", index) + ": [Full](" + fullWebrev.toString() + ")";
-        if (incWebrev != null) {
-            comment += " - [Incremental](" + incWebrev.toString() + ")";
-        }
+        comment += " * " + String.format("%02d", index) + ": " + webrevDescriptions;
         comment += " (" + pr.headHash() + ")\n";
 
         if (existing.isPresent()) {
-            if (existing.get().body().contains(fullWebrev.toString())) {
-                log.fine("Webrev link already posted - skipping update");
+            if (existing.get().body().contains(webrevDescriptions)) {
+                log.fine("Webrev links already posted - skipping update");
                 return;
             }
             var previousListStart = existing.get().body().indexOf(webrevListMarker) + webrevListMarker.length() + 1;
@@ -328,7 +327,7 @@ class ArchiveWorkItem implements WorkItem {
 
             var webrevGenerator = bot.webrevStorage().generator(pr, localRepo, webrevPath);
             var newMails = archiver.generateNewEmails(sentMails, bot.cooldown(), localRepo, bot.issueTracker(), jbs.toUpperCase(), webrevGenerator,
-                                                      (index, full, inc) -> updateWebrevComment(comments, index, full, inc),
+                                                      (index, webrevs) -> updateWebrevComment(comments, index, webrevs),
                                                       user -> getAuthorAddress(census, user),
                                                       user -> getAuthorUserName(census, user),
                                                       user -> getAuthorRole(census, user),

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevDescription.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevDescription.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.mlbridge;
+
+import java.net.URI;
+
+public class WebrevDescription {
+    public enum Type {
+        FULL,
+        INCREMENTAL,
+        MERGE_TARGET,
+        MERGE_SOURCE
+    }
+
+    private final URI uri;
+    private final Type type;
+    private final String description;
+
+    public WebrevDescription(URI uri, Type type, String description) {
+        this.uri = uri;
+        this.type = type;
+        this.description = description;
+    }
+
+    public WebrevDescription(URI uri, Type type) {
+        this.uri = uri;
+        this.type = type;
+        this.description = null;
+    }
+
+    public URI uri() {
+        return uri;
+    }
+
+    public String label() {
+        switch (type) {
+            case FULL:
+                return "Full";
+            case INCREMENTAL:
+                return "Incremental";
+            case MERGE_TARGET:
+                return "Merge target" + (description != null ? " (" + description + ")" : "");
+            case MERGE_SOURCE:
+                return "Merge source" + (description != null ? " (" + description + ")" : "");
+
+        }
+        throw new RuntimeException("Unknown type");
+    }
+
+    public String shortLabel() {
+        switch (type) {
+            case FULL:
+                return "full";
+            case INCREMENTAL:
+                return "incr";
+            case MERGE_TARGET:
+                return description != null ? description : "merge target";
+            case MERGE_SOURCE:
+                return description != null ? description : "merge source";
+
+        }
+        throw new RuntimeException("Unknown type");
+    }
+}

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevNotification.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevNotification.java
@@ -22,9 +22,9 @@
  */
 package org.openjdk.skara.bots.mlbridge;
 
-import java.net.URI;
+import java.util.List;
 
 @FunctionalInterface
 interface WebrevNotification {
-    void notify(int index, URI full, URI incremental);
+    void notify(int index, List<WebrevDescription> webrevDescriptions);
 }

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -1359,6 +1359,70 @@ class MailingListBridgeBotTests {
     }
 
     @Test
+    void mergeWebrev(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory();
+             var archiveFolder = new TemporaryDirectory();
+             var listServer = new TestMailmanServer();
+             var webrevServer = new TestWebrevServer()) {
+            var author = credentials.getHostedRepository();
+            var archive = credentials.getHostedRepository();
+            var commenter = credentials.getHostedRepository();
+            var listAddress = EmailAddress.parse(listServer.createList("test"));
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addAuthor(author.forge().currentUser().id());
+            var from = EmailAddress.from("test", "test@test.mail");
+            var mlBot = MailingListBridgeBot.newBuilder()
+                                            .from(from)
+                                            .repo(author)
+                                            .archive(archive)
+                                            .archiveRef("archive")
+                                            .censusRepo(censusBuilder.build())
+                                            .list(listAddress)
+                                            .listArchive(listServer.getArchive())
+                                            .smtpServer(listServer.getSMTP())
+                                            .webrevStorageRepository(archive)
+                                            .webrevStorageRef("webrev")
+                                            .webrevStorageBase(Path.of("test"))
+                                            .webrevStorageBaseUri(webrevServer.uri())
+                                            .issueTracker(URIBuilder.base("http://issues.test/browse/").build())
+                                            .build();
+
+            // Populate the projects repository
+            var reviewFile = Path.of("reviewfile.txt");
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(), reviewFile);
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, archive.url(), "archive", true);
+            localRepo.push(masterHash, archive.url(), "webrev", true);
+
+            // Create a merge
+            var editHash = CheckableRepository.appendAndCommit(localRepo, "Edited");
+            localRepo.checkout(masterHash, true);
+            var updatedMasterHash = CheckableRepository.appendAndCommit(localRepo, "Master change");
+            localRepo.push(updatedMasterHash, author.url(), "master");
+            localRepo.merge(editHash, "ours");
+            var mergeCommit = localRepo.commit("Merged edit", "duke", "duke@openjdk.java.net");
+            localRepo.push(mergeCommit, author.url(), "edit", true);
+
+            // Make a merge PR
+            var pr = credentials.createPullRequest(archive, "master", "edit", "Merge");
+            pr.setBody("This is now ready");
+
+            // Run an archive pass
+            TestBotRunner.runPeriodicItems(mlBot);
+            listServer.processIncoming();
+
+            // The archive should contain a merge style webrev
+            Repository.materialize(archiveFolder.path(), archive.url(), "archive");
+            assertTrue(archiveContains(archiveFolder.path(), "webrev only contains"));
+            assertTrue(archiveContains(archiveFolder.path(), pr.id() + "/webrev.00"));
+            assertTrue(archiveContains(archiveFolder.path(), "Stats: 1 line in 1 file changed: 0 ins; 0 del; 1 mod"));
+            assertTrue(archiveContains(archiveFolder.path(), "Full: 0 lines in 0 files changed: 0 ins; 0 del; 0 mod"));
+        }
+    }
+
+    @Test
     void skipAddingExistingWebrev(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
              var tempFolder = new TemporaryDirectory();

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -1397,16 +1397,28 @@ class MailingListBridgeBotTests {
             localRepo.push(masterHash, archive.url(), "webrev", true);
 
             // Create a merge
+            var editOnlyFile = Path.of("editonly.txt");
+            Files.writeString(localRepo.root().resolve(editOnlyFile), "Only added in the edit");
+            localRepo.add(editOnlyFile);
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Edited");
             localRepo.checkout(masterHash, true);
+            var masterOnlyFile = Path.of("masteronly.txt");
+            Files.writeString(localRepo.root().resolve(masterOnlyFile), "Only added in master");
+            localRepo.add(masterOnlyFile);
             var updatedMasterHash = CheckableRepository.appendAndCommit(localRepo, "Master change");
             localRepo.push(updatedMasterHash, author.url(), "master");
             localRepo.merge(editHash, "ours");
             var mergeCommit = localRepo.commit("Merged edit", "duke", "duke@openjdk.java.net");
-            localRepo.push(mergeCommit, author.url(), "edit", true);
+            var mergeOnlyFile = Path.of("mergeonly.txt");
+            Files.writeString(localRepo.root().resolve(mergeOnlyFile), "Only added in the merge");
+            localRepo.add(mergeOnlyFile);
+            Files.writeString(localRepo.root().resolve(reviewFile), "Overwriting the conflict resolution");
+            localRepo.add(reviewFile);
+            var appendedCommit = localRepo.amend("Updated merge commit", "duke", "duke@openjdk.java.net");
+            localRepo.push(appendedCommit, author.url(), "edit", true);
 
             // Make a merge PR
-            var pr = credentials.createPullRequest(archive, "master", "edit", "Merge");
+            var pr = credentials.createPullRequest(archive, "master", "edit", "Merge edit");
             pr.setBody("This is now ready");
 
             // Run an archive pass
@@ -1415,10 +1427,15 @@ class MailingListBridgeBotTests {
 
             // The archive should contain a merge style webrev
             Repository.materialize(archiveFolder.path(), archive.url(), "archive");
-            assertTrue(archiveContains(archiveFolder.path(), "webrev only contains"));
-            assertTrue(archiveContains(archiveFolder.path(), pr.id() + "/webrev.00"));
-            assertTrue(archiveContains(archiveFolder.path(), "Stats: 1 line in 1 file changed: 0 ins; 0 del; 1 mod"));
-            assertTrue(archiveContains(archiveFolder.path(), "Full: 0 lines in 0 files changed: 0 ins; 0 del; 0 mod"));
+            assertTrue(archiveContains(archiveFolder.path(), "webrevs contain only the adjustments"));
+            assertTrue(archiveContains(archiveFolder.path(), pr.id() + "/webrev.00.0"));
+            assertTrue(archiveContains(archiveFolder.path(), "3 lines in 2 files changed: 1 ins; 1 del; 1 mod"));
+
+            // The PR should contain a webrev comment
+            assertEquals(1, pr.comments().size());
+            var webrevComment = pr.comments().get(0);
+            assertTrue(webrevComment.body().contains("Merge target"));
+            assertTrue(webrevComment.body().contains("Merge source"));
         }
     }
 

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/WebrevStorageTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/WebrevStorageTests.java
@@ -68,7 +68,7 @@ class WebrevStorageTests {
             var prRepo = Repository.materialize(prFolder, pr.repository().url(), "edit");
             var scratchFolder = tempFolder.path().resolve("scratch");
             var generator = storage.generator(pr, prRepo, scratchFolder);
-            generator.generate(masterHash, editHash, "00");
+            generator.generate(masterHash, editHash, "00", WebrevDescription.Type.FULL);
 
             // Check that the web link has been verified now and followed the redirect
             assertTrue(webrevServer.isChecked());
@@ -79,7 +79,7 @@ class WebrevStorageTests {
             assertTrue(Files.exists(repoFolder.resolve("test/" + pr.id() + "/webrev.00/index.html")));
 
             // Create it again - it will overwrite the previous one
-            generator.generate(masterHash, editHash, "00");
+            generator.generate(masterHash, editHash, "00", WebrevDescription.Type.FULL);
             Repository.materialize(repoFolder, archive.url(), "webrev");
             assertTrue(Files.exists(repoFolder.resolve("test/" + pr.id() + "/webrev.00/index.html")));
         }
@@ -121,7 +121,7 @@ class WebrevStorageTests {
             var prRepo = Repository.materialize(prFolder, pr.repository().url(), "edit");
             var scratchFolder = tempFolder.path().resolve("scratch");
             var generator = storage.generator(pr, prRepo, scratchFolder);
-            generator.generate(masterHash, editHash, "00");
+            generator.generate(masterHash, editHash, "00", WebrevDescription.Type.FULL);
 
             // Update the local repository and check that the webrev has been generated
             Repository.materialize(repoFolder, archive.url(), "webrev");

--- a/webrev/src/main/java/org/openjdk/skara/webrev/Webrev.java
+++ b/webrev/src/main/java/org/openjdk/skara/webrev/Webrev.java
@@ -126,6 +126,17 @@ public class Webrev {
         }
 
         public void generate(Hash tailEnd, Hash head) throws IOException {
+            var diff = head == null ?
+                    repository.diff(tailEnd, files) :
+                    repository.diff(tailEnd, head, files);
+            generate(diff, tailEnd, head);
+        }
+
+        public void generate(Diff diff) throws IOException {
+            generate(diff, diff.from(), diff.to());
+        }
+
+        private void generate(Diff diff, Hash tailEnd, Hash head) throws IOException {
             Files.createDirectories(output);
 
             copyResource(ANCNAV_HTML);
@@ -133,12 +144,8 @@ public class Webrev {
             copyResource(CSS);
             copyResource(ICON);
 
-            var diff = head == null ?
-                repository.diff(tailEnd, files) :
-                repository.diff(tailEnd, head, files);
-            var patchFile = output.resolve(Path.of(title).getFileName().toString() + ".patch");
-
             var patches = diff.patches();
+            var patchFile = output.resolve(Path.of(title).getFileName().toString() + ".patch");
             if (files != null && !files.isEmpty()) {
                 // Sort the patches according to how they are listed in the `files` list.
                 var byTargetPath = new HashMap<Path, Patch>();


### PR DESCRIPTION
Hi all,

Please review this change that for merge style PRs generate webrevs only containing the changes done in the merge commit.

Note that this is only a partial implementation, such webrevs should also be generated if there are further commits pushed to the PR.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-276](https://bugs.openjdk.java.net/browse/SKARA-276): Merge style PRs should generate "merge" webrevs


### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**) ⚠️ Review applies to 7c657eee8ac2a1b1b9679d7e656ed538fbff7021

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/501/head:pull/501`
`$ git checkout pull/501`
