### PR TITLE
csr: avoid null pointer exceptions

### DIFF
--- a/bots/csr/src/main/java/org/openjdk/skara/bots/csr/CSRBot.java
+++ b/bots/csr/src/main/java/org/openjdk/skara/bots/csr/CSRBot.java
@@ -97,12 +97,21 @@ class CSRBot implements Bot, WorkItem {
             for (var link : jbsIssue.get().links()) {
                 var relationship = link.relationship();
                 if (relationship.isPresent() && relationship.get().equals("csr for")) {
+                    log.info("Found CSR for " + describe(pr));
+
                     var csr = link.issue().orElseThrow(
                             () -> new IllegalStateException("Link with title 'csr for' does not contain issue")
                     );
-                    var resolution = csr.properties().get("resolution").get("name").asString();
-                    log.info("Found CSR for " + describe(pr));
-                    if (csr.state() == Issue.State.CLOSED && resolution.equals("Approved")) {
+                    var resolution = csr.properties().get("resolution");
+                    if (resolution == null || resolution.isNull()) {
+                        continue;
+                    }
+                    var name = resolution.get("name");
+                    if (name == null || name.isNull()) {
+                        continue;
+                    }
+
+                    if (csr.state() == Issue.State.CLOSED && name.asString().equals("Approved")) {
                         log.info("CSR closed and approved for " + repo.name() + "#" + pr.id() + ", removing csr label");
                         pr.removeLabel(CSR_LABEL);
                         hasCSRLabel.remove(pr.id());


### PR DESCRIPTION
Hi all,

please review this patch that uses more defensive programming for the CSR bot. The CSR bot only cares about a JBS CSR issue that has a "Resolution" of "Approved", so we can be very defensive in examining the fields of the CSR issue.

Testing:
- `make test` passes on Linux x64
- Added two new unit tests

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/502/head:pull/502`
`$ git checkout pull/502`
