### PR TITLE
Allow reading the resolution property in Jira issues

### DIFF
--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraProject.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraProject.java
@@ -120,16 +120,20 @@ public class JiraProject implements IssueProject {
     }
 
     private static final Set<String> knownProperties = Set.of("issuetype", "fixVersions", "versions", "priority", "components");
+    private static final Set<String> readOnlyProperties = Set.of("resolution");
 
-    boolean isAllowedProperty(String name) {
+    boolean isAllowedProperty(String name, boolean forWrite) {
         if (knownProperties.contains(name)) {
+            return true;
+        }
+        if (!forWrite && readOnlyProperties.contains(name)) {
             return true;
         }
         return name.startsWith("customfield_");
     }
 
     Optional<JSONValue> decodeProperty(String name, JSONValue value) {
-        if (!isAllowedProperty(name)) {
+        if (!isAllowedProperty(name, false)) {
             return Optional.empty();
         }
         if (value.isNull()) {
@@ -154,7 +158,7 @@ public class JiraProject implements IssueProject {
     }
 
     Optional<JSONValue> encodeProperty(String name, JSONValue value) {
-        if (!isAllowedProperty(name)) {
+        if (!isAllowedProperty(name, true)) {
             return Optional.empty();
         }
 


### PR DESCRIPTION
Hi all,

Please review this change that makes the `resolution` property available for reading in a Jira issue. It cannot be set, as it is special (can only be set when transitioning an issue).

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/504/head:pull/504`
`$ git checkout pull/504`
