### PR TITLE
296: git webrev fails

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitWebrev.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitWebrev.java
@@ -203,11 +203,19 @@ public class GitWebrev {
             }
         }
 
-        var rev = arguments.contains("rev") ?
-            resolve(repo, arguments.get("rev").asString()) :
-            noOutgoing ?
-                resolve(repo, isMercurial ? "tip" : "HEAD") :
-                resolve(repo, isMercurial ? "min(outgoing())^" : "origin" + "/" + "master");
+        var rev = arguments.contains("rev") ? resolve(repo, arguments.get("rev").asString()) : null;
+        if (rev == null) {
+            if (isMercurial) {
+                resolve(repo, noOutgoing ? "tip" : "min(outgoing())^");
+            } else {
+                if (noOutgoing) {
+                    rev = resolve(repo, "HEAD");
+                } else {
+                    var commits = repo.commitMetadata("origin..HEAD", true);
+                    rev = resolve(repo, commits.get(0).hash().hex() + "^");
+                }
+            }
+        }
 
         var issue = arguments.contains("cr") ? arguments.get("cr").asString() : null;
         if (issue != null) {


### PR DESCRIPTION
Hi all,

please review this patch that sets the default value for `--rev` to
the parent of `origin..HEAD` (essentially the same as Mercurial's revset
expression `min(outgoing())^`).

Testing:
- Manual testing of `git-webrev` on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-296](https://bugs.openjdk.java.net/browse/SKARA-296): git webrev fails


### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/506/head:pull/506`
`$ git checkout pull/506`
