### PR TITLE
302: PR body updater should use .jcheck/conf from target branch

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestInstance.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestInstance.java
@@ -219,7 +219,7 @@ class PullRequestInstance {
     }
 
     PullRequestCheckIssueVisitor createVisitor(Hash localHash, CensusInstance censusInstance) throws IOException {
-        var checks = JCheck.checks(localRepo(), censusInstance.census(), localHash);
+        var checks = JCheck.checksFor(localRepo(), censusInstance.census(), targetHash);
         return new PullRequestCheckIssueVisitor(checks);
     }
 

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/JCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/JCheck.java
@@ -138,11 +138,11 @@ public class JCheck {
         return new HashSet<>(conf.checks().enabled(commitChecks));
     }
 
-    private Set<Check> checksForCommits() throws IOException {
+    private Set<Check> checksForRange() throws IOException {
         try (var commits = repository.commits(revisionRange)) {
             return commits.stream()
-                    .flatMap(commit -> checksForCommit(commit).stream())
-                    .collect(Collectors.toSet());
+                          .flatMap(commit -> checksForCommit(commit).stream())
+                          .collect(Collectors.toSet());
         }
     }
 
@@ -266,17 +266,17 @@ public class JCheck {
         return check(repository, census, parser, branchRegex, tagRegex, revisionRange, whitelist, blacklist, List.of(), null);
     }
 
-    public static Set<Check> checks(ReadOnlyRepository repository, Census census, Hash hash) throws IOException {
+    public static Set<Check> checksFor(ReadOnlyRepository repository, Census census, Hash hash) throws IOException {
         var jcheck = new JCheck(repository,
                                 census,
                                 CommitMessageParsers.v1,
-                                hash.hex() + "^.." + hash.hex(),
+                                repository.range(hash),
                                 Pattern.compile(".*"),
                                 Pattern.compile(".*"),
                                 new HashMap<String, Set<Hash>>(),
                                 new HashSet<Hash>(),
                                 List.of(),
                                 null);
-        return jcheck.checksForCommits();
+        return jcheck.checksForRange();
     }
 }

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/JCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/JCheckTests.java
@@ -255,7 +255,7 @@ class JCheckTests {
             CensusCreator.populateCensusDirectory(censusPath);
             var census = Census.parse(censusPath);
 
-            var checks = JCheck.checks(repo, census, first);
+            var checks = JCheck.checksFor(repo, census, first);
             var checkNames = checks.stream()
                                    .map(Check::name)
                                    .collect(Collectors.toSet());


### PR DESCRIPTION
Hi all,

please reviews this patch that makes the pull request body updater use the
.jcheck/conf from the pull request's target branch when populating the
"Progress" list.

Testing:
- Updated one unit test
- `make test` passes on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-302](https://bugs.openjdk.java.net/browse/SKARA-302): PR body updater should use .jcheck/conf from target branch


### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/507/head:pull/507`
`$ git checkout pull/507`
