### PR TITLE
git-webrev: use HEAD when branch has no commits

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitWebrev.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitWebrev.java
@@ -212,7 +212,11 @@ public class GitWebrev {
                     rev = resolve(repo, "HEAD");
                 } else {
                     var commits = repo.commitMetadata("origin..HEAD", true);
-                    rev = resolve(repo, commits.get(0).hash().hex() + "^");
+                    if (commits.isEmpty()) {
+                        rev = resolve(repo, "HEAD");
+                    } else {
+                        rev = resolve(repo, commits.get(0).hash().hex() + "^");
+                    }
                 }
             }
         }


### PR DESCRIPTION
Hi all,

please review this small patch that fixes an issue with the default value for
`--rev` for `git-webrev`. If the current branch has no commits then
`origin..HEAD` will be an empty range, so in that case we should just fall back
to `HEAD`.

Testing:
- Manual testing of `git-webrev` on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/508/head:pull/508`
`$ git checkout pull/508`
