### PR TITLE
301: Keep track of branch progress per notifier

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/IssueUpdater.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/IssueUpdater.java
@@ -357,6 +357,11 @@ public class IssueUpdater implements RepositoryUpdateConsumer, PullRequestUpdate
     }
 
     @Override
+    public String name() {
+        return "issue";
+    }
+
+    @Override
     public void handleNewIssue(PullRequest pr, org.openjdk.skara.vcs.openjdk.Issue issue) {
         var realIssue = issueProject.issue(issue.id());
         if (realIssue.isEmpty()) {

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/JsonUpdater.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/JsonUpdater.java
@@ -111,4 +111,9 @@ public class JsonUpdater implements RepositoryUpdateConsumer {
     public boolean isIdempotent() {
         return false;
     }
+
+    @Override
+    public String name() {
+        return "json";
+    }
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/MailingListUpdater.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/MailingListUpdater.java
@@ -384,4 +384,9 @@ public class MailingListUpdater implements RepositoryUpdateConsumer {
     public boolean isIdempotent() {
         return false;
     }
+
+    @Override
+    public String name() {
+        return "ml";
+    }
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryUpdateConsumer.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryUpdateConsumer.java
@@ -34,4 +34,5 @@ public interface RepositoryUpdateConsumer {
     void handleTagCommit(HostedRepository repository, Repository localRepository, Commit commit, Tag tag, Tag.Annotated annotation);
     void handleNewBranch(HostedRepository repository, Repository localRepository, List<Commit> commits, Branch parent, Branch branch);
     boolean isIdempotent();
+    String name();
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/ResolvedBranch.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/ResolvedBranch.java
@@ -28,10 +28,12 @@ import java.util.Objects;
 
 class ResolvedBranch {
     private final Branch branch;
+    private final String updater;
     private final Hash hash;
 
-    ResolvedBranch(Branch branch, Hash hash) {
+    ResolvedBranch(Branch branch, String updater, Hash hash) {
         this.branch = branch;
+        this.updater = updater;
         this.hash = hash;
     }
 
@@ -39,13 +41,12 @@ class ResolvedBranch {
         return branch;
     }
 
-    public Hash hash() {
-        return hash;
+    public String updater() {
+        return updater;
     }
 
-    @Override
-    public String toString() {
-        return branch.name() + ":" + hash().hex();
+    public Hash hash() {
+        return hash;
     }
 
     @Override
@@ -57,12 +58,11 @@ class ResolvedBranch {
             return false;
         }
         ResolvedBranch that = (ResolvedBranch) o;
-        return Objects.equals(branch, that.branch) &&
-                Objects.equals(hash, that.hash);
+        return branch.equals(that.branch) && updater.equals(that.updater) && hash.equals(that.hash);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(branch, hash);
+        return Objects.hash(branch, updater, hash);
     }
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/UpdateHistory.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/UpdateHistory.java
@@ -27,30 +27,44 @@ import org.openjdk.skara.vcs.*;
 
 import java.nio.file.Path;
 import java.util.*;
+import java.util.function.Function;
 import java.util.stream.*;
 
 class UpdateHistory {
-
     private final Storage<Tag> tagStorage;
     private final Storage<ResolvedBranch> branchStorage;
 
-    private Map<Branch, Hash> branches;
+    private Map<String, Hash> branchHashes;
     private Set<Tag> tags;
+
+    private List<ResolvedBranch> parseSerializedEntry(String entry) {
+        var parts = entry.split(" ");
+        if (parts.length == 2) {
+            // Transform legacy entry
+            var issueEntry = new ResolvedBranch(new Branch(parts[0]), "issue", new Hash(parts[1]));
+            var mlEntry = new ResolvedBranch(new Branch(parts[0]), "ml", new Hash(parts[1]));
+            return List.of(issueEntry, mlEntry);
+        }
+        return List.of(new ResolvedBranch(new Branch(parts[0]), parts[1], new Hash(parts[2])));
+    }
 
     private Set<ResolvedBranch> loadBranches(String current) {
         return current.lines()
-                      .map(line -> line.split(" "))
-                      .map(entry -> new ResolvedBranch(new Branch(entry[0]), new Hash(entry[1])))
+                      .flatMap(line -> parseSerializedEntry(line).stream())
                       .collect(Collectors.toSet());
+    }
+
+    private String serializeEntry(ResolvedBranch entry) {
+        return entry.branch().toString() + " " + entry.updater() + " " + entry.hash().toString();
     }
 
     private String serializeBranches(Collection<ResolvedBranch> added, Set<ResolvedBranch> existing) {
         var updatedBranches = existing.stream()
-                                      .collect(Collectors.toMap(ResolvedBranch::branch,
-                                                                ResolvedBranch::hash));
-        added.forEach(a -> updatedBranches.put(a.branch(), a.hash()));
-        return updatedBranches.entrySet().stream()
-                              .map(entry -> entry.getKey().toString() + " " + entry.getValue().toString())
+                                      .collect(Collectors.toMap(entry -> entry.branch().toString() + ":" + entry.updater(),
+                                                                Function.identity()));
+        added.forEach(a -> updatedBranches.put(a.branch().toString() + ":" + a.updater(), a));
+        return updatedBranches.values().stream()
+                              .map(this::serializeEntry)
                               .sorted()
                               .collect(Collectors.joining("\n"));
     }
@@ -73,9 +87,9 @@ class UpdateHistory {
         return tagStorage.current();
     }
 
-    private Map<Branch, Hash> currentBranchHashes() {
+    private Map<String, Hash> currentBranchHashes() {
         return branchStorage.current().stream()
-                .collect(Collectors.toMap(ResolvedBranch::branch, ResolvedBranch::hash));
+                .collect(Collectors.toMap(rb -> rb.branch().toString() + " " + rb.updater(), ResolvedBranch::hash));
     }
 
     private UpdateHistory(StorageBuilder<Tag> tagStorageBuilder, Path tagLocation, StorageBuilder<ResolvedBranch> branchStorageBuilder, Path branchLocation) {
@@ -90,7 +104,7 @@ class UpdateHistory {
                 .materialize(branchLocation);
 
         tags = currentTags();
-        branches = currentBranchHashes();
+        branchHashes = currentBranchHashes();
     }
 
     static UpdateHistory create(StorageBuilder<Tag> tagStorageBuilder, Path tagLocation, StorageBuilder<ResolvedBranch> branchStorageBuilder, Path branchLocation) {
@@ -116,25 +130,29 @@ class UpdateHistory {
         return tags.contains(tag);
     }
 
-    void setBranchHash(Branch branch, Hash hash) {
-        var entry = new ResolvedBranch(branch, hash);
+    void setBranchHash(Branch branch, String updater, Hash hash) {
+        var entry = new ResolvedBranch(branch, updater, hash);
 
         branchStorage.put(entry);
         var newBranchHashes = currentBranchHashes();
 
         // Sanity check
-        if (branches != null) {
-            for (var existingBranch : branches.keySet()) {
+        if (branchHashes != null) {
+            for (var existingBranch : branchHashes.keySet()) {
                 if (!newBranchHashes.containsKey(existingBranch)) {
                     throw new RuntimeException("Hash information for branch '" + existingBranch + "' is missing");
                 }
             }
         }
-        branches = newBranchHashes;
+        branchHashes = newBranchHashes;
     }
 
-    Optional<Hash> branchHash(Branch branch) {
-        var hash = branches.get(branch);
-        return Optional.ofNullable(hash);
+    Optional<Hash> branchHash(Branch branch, String updater) {
+        var entry = branchHashes.get(branch.toString() + " " + updater);
+        return Optional.ofNullable(entry);
+    }
+
+    boolean isEmpty() {
+        return branchHashes.isEmpty();
     }
 }

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdateHistoryTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdateHistoryTests.java
@@ -84,17 +84,42 @@ class UpdateHistoryTests {
 
             var history = createHistory(repository, ref);
 
-            history.setBranchHash(new Branch("1"), new Hash("a"));
-            history.setBranchHash(new Branch("2"), new Hash("b"));
-            history.setBranchHash(new Branch("1"), new Hash("c"));
+            history.setBranchHash(new Branch("1"), "a", new Hash("a"));
+            history.setBranchHash(new Branch("2"), "a", new Hash("b"));
+            history.setBranchHash(new Branch("1"), "a", new Hash("c"));
 
-            assertEquals(new Hash("c"), history.branchHash(new Branch("1")).orElseThrow());
-            assertEquals(new Hash("b"), history.branchHash(new Branch("2")).orElseThrow());
+            assertEquals(new Hash("c"), history.branchHash(new Branch("1"), "a").orElseThrow());
+            assertEquals(new Hash("b"), history.branchHash(new Branch("2"), "a").orElseThrow());
 
             var newHistory = createHistory(repository, ref);
 
-            assertEquals(new Hash("c"), newHistory.branchHash(new Branch("1")).orElseThrow());
-            assertEquals(new Hash("b"), newHistory.branchHash(new Branch("2")).orElseThrow());
+            assertEquals(new Hash("c"), newHistory.branchHash(new Branch("1"), "a").orElseThrow());
+            assertEquals(new Hash("b"), newHistory.branchHash(new Branch("2"), "a").orElseThrow());
+        }
+    }
+
+    @Test
+    void branchesSeparateUpdaters(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo)) {
+            var repository = credentials.getHostedRepository();
+            var ref = resetHostedRepository(repository);
+
+            var history = createHistory(repository, ref);
+
+            history.setBranchHash(new Branch("1"), "a", new Hash("a"));
+            history.setBranchHash(new Branch("2"), "a", new Hash("b"));
+            history.setBranchHash(new Branch("1"), "b", new Hash("c"));
+            history.setBranchHash(new Branch("2"), "a", new Hash("d"));
+
+            assertEquals(new Hash("a"), history.branchHash(new Branch("1"), "a").orElseThrow());
+            assertEquals(new Hash("d"), history.branchHash(new Branch("2"), "a").orElseThrow());
+            assertEquals(new Hash("c"), history.branchHash(new Branch("1"), "b").orElseThrow());
+
+            var newHistory = createHistory(repository, ref);
+
+            assertEquals(new Hash("a"), newHistory.branchHash(new Branch("1"), "a").orElseThrow());
+            assertEquals(new Hash("d"), newHistory.branchHash(new Branch("2"), "a").orElseThrow());
+            assertEquals(new Hash("c"), newHistory.branchHash(new Branch("1"), "b").orElseThrow());
         }
     }
 

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdaterTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdaterTests.java
@@ -29,7 +29,9 @@ import org.openjdk.skara.json.*;
 import org.openjdk.skara.mailinglist.MailingListServerFactory;
 import org.openjdk.skara.storage.StorageBuilder;
 import org.openjdk.skara.test.*;
+import org.openjdk.skara.vcs.*;
 import org.openjdk.skara.vcs.Tag;
+import org.openjdk.skara.vcs.openjdk.OpenJDKTag;
 
 import org.junit.jupiter.api.*;
 
@@ -1909,6 +1911,113 @@ class UpdaterTests {
             updatedIssue = issueProject.issue(issue.id()).orElseThrow();
             comments = updatedIssue.comments();
             assertEquals(1, comments.size());
+        }
+    }
+
+    private static class TestRepositoryUpdateConsumer implements RepositoryUpdateConsumer {
+        private final String name;
+        private final boolean idempotent;
+        private int updateCount = 0;
+        private boolean shouldFail = false;
+
+        TestRepositoryUpdateConsumer(String name, boolean idempotent) {
+            this.name = name;
+            this.idempotent = idempotent;
+        }
+
+        @Override
+        public void handleCommits(HostedRepository repository, Repository localRepository, List<Commit> commits,
+                                  Branch branch) {
+            updateCount++;
+            if (shouldFail) {
+                throw new RuntimeException("induced failure");
+            }
+        }
+
+        @Override
+        public void handleOpenJDKTagCommits(HostedRepository repository, Repository localRepository,
+         List<Commit> commits, OpenJDKTag tag, Tag.Annotated annotated) {
+            throw new RuntimeException("unexpected");
+        }
+
+        @Override
+        public void handleTagCommit(HostedRepository repository, Repository localRepository, Commit commit, Tag tag,
+         Tag.Annotated annotation) {
+            throw new RuntimeException("unexpected");
+        }
+
+        @Override
+        public void handleNewBranch(HostedRepository repository, Repository localRepository, List<Commit> commits,
+         Branch parent, Branch branch) {
+            throw new RuntimeException("unexpected");
+        }
+
+        @Override
+        public boolean isIdempotent() {
+            return idempotent;
+        }
+
+        @Override
+        public String name() {
+            return name;
+        }
+    }
+
+    @Test
+    void testIdempotenceMix(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var repo = credentials.getHostedRepository();
+            var repoFolder = tempFolder.path().resolve("repo");
+            var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
+            credentials.commitLock(localRepo);
+            localRepo.pushAll(repo.url());
+
+            var tagStorage = createTagStorage(repo);
+            var branchStorage = createBranchStorage(repo);
+            var prIssuesStorage = createPullRequestIssuesStorage(repo);
+            var storageFolder = tempFolder.path().resolve("storage");
+
+            var idempotent = new TestRepositoryUpdateConsumer("i", true);
+            var nonIdempotent = new TestRepositoryUpdateConsumer("ni", false);
+            var notifyBot = NotifyBot.newBuilder()
+                                     .repository(repo)
+                                     .storagePath(storageFolder)
+                                     .branches(Pattern.compile("master"))
+                                     .tagStorageBuilder(tagStorage)
+                                     .branchStorageBuilder(branchStorage)
+                                     .prIssuesStorageBuilder(prIssuesStorage)
+                                     .updaters(List.of(idempotent, nonIdempotent))
+                                     .build();
+
+            // Initialize history
+            TestBotRunner.runPeriodicItems(notifyBot);
+
+            // Create an issue and commit a fix
+            var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", "Fix stuff");
+            localRepo.push(editHash, repo.url(), "master");
+            TestBotRunner.runPeriodicItems(notifyBot);
+
+            // Both updaters should have run
+            assertEquals(1, idempotent.updateCount);
+            assertEquals(1, nonIdempotent.updateCount);
+
+            var nextEditHash = CheckableRepository.appendAndCommit(localRepo, "Yet another line", "Fix more stuff");
+            localRepo.push(nextEditHash, repo.url(), "master");
+
+            idempotent.shouldFail = true;
+            nonIdempotent.shouldFail = true;
+            assertThrows(RuntimeException.class, () -> TestBotRunner.runPeriodicItems(notifyBot));
+
+            // Both updaters should have run again
+            assertEquals(2, idempotent.updateCount);
+            assertEquals(2, nonIdempotent.updateCount);
+
+            assertThrows(RuntimeException.class, () -> TestBotRunner.runPeriodicItems(notifyBot));
+
+            // But now only the idempotent one should have been retried
+            assertEquals(3, idempotent.updateCount);
+            assertEquals(2, nonIdempotent.updateCount);
         }
     }
 }


### PR DESCRIPTION
Hi all,

Please review this change that makes the repository notifier keep track of the latest reported branch separately for each kind of notifier. This allows other notifications to proceed even if a single notifier fails (such as when the issue tracker is unavailable but email still works).

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-301](https://bugs.openjdk.java.net/browse/SKARA-301): Separate repo notifiers


### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**) ⚠️ Review applies to 04abb20b02c38118cf6544fd415879b98e527904

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/509/head:pull/509`
`$ git checkout pull/509`
