### PR TITLE
Make the notifier retry logic more granular

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/JsonUpdater.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/JsonUpdater.java
@@ -76,17 +76,19 @@ public class JsonUpdater implements RepositoryUpdateConsumer {
     }
 
     @Override
-    public void handleCommits(HostedRepository repository, Repository localRepository, List<Commit> commits, Branch branch) {
+    public void handleCommits(HostedRepository repository, Repository localRepository, List<Commit> commits, Branch branch) throws NonRetriableException {
         try (var writer = new JsonUpdateWriter(path, repository.name())) {
             for (var commit : commits) {
                 var json = commitToChanges(repository, localRepository, commit, defaultBuild);
                 writer.write(json);
             }
+        } catch (RuntimeException e) {
+            throw new NonRetriableException(e);
         }
     }
 
     @Override
-    public void handleOpenJDKTagCommits(HostedRepository repository, Repository localRepository, List<Commit> commits, OpenJDKTag tag, Tag.Annotated annotation) {
+    public void handleOpenJDKTagCommits(HostedRepository repository, Repository localRepository, List<Commit> commits, OpenJDKTag tag, Tag.Annotated annotation) throws NonRetriableException {
         var build = String.format("b%02d", tag.buildNum());
         try (var writer = new JsonUpdateWriter(path, repository.name())) {
             var issues = new ArrayList<Issue>();
@@ -96,6 +98,8 @@ public class JsonUpdater implements RepositoryUpdateConsumer {
             }
             var json = issuesToChanges(repository, localRepository, issues, build);
             writer.write(json);
+        } catch (RuntimeException e) {
+            throw new NonRetriableException(e);
         }
     }
 
@@ -105,11 +109,6 @@ public class JsonUpdater implements RepositoryUpdateConsumer {
 
     @Override
     public void handleNewBranch(HostedRepository repository, Repository localRepository, List<Commit> commits, Branch parent, Branch branch) {
-    }
-
-    @Override
-    public boolean isIdempotent() {
-        return false;
     }
 
     @Override

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/NonRetriableException.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/NonRetriableException.java
@@ -23,13 +23,13 @@
 package org.openjdk.skara.bots.notify;
 
 public class NonRetriableException extends Exception {
-    private final RuntimeException cause;
+    private final Throwable cause;
 
-    public NonRetriableException(RuntimeException cause) {
+    public NonRetriableException(Throwable cause) {
         this.cause = cause;
     }
 
-    public RuntimeException cause() {
+    public Throwable cause() {
         return cause;
     }
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/NonRetriableException.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/NonRetriableException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,16 +22,14 @@
  */
 package org.openjdk.skara.bots.notify;
 
-import org.openjdk.skara.forge.HostedRepository;
-import org.openjdk.skara.vcs.*;
-import org.openjdk.skara.vcs.openjdk.OpenJDKTag;
+public class NonRetriableException extends Exception {
+    private final RuntimeException cause;
 
-import java.util.List;
+    public NonRetriableException(RuntimeException cause) {
+        this.cause = cause;
+    }
 
-public interface RepositoryUpdateConsumer {
-    void handleCommits(HostedRepository repository, Repository localRepository, List<Commit> commits, Branch branch) throws NonRetriableException;
-    void handleOpenJDKTagCommits(HostedRepository repository, Repository localRepository, List<Commit> commits, OpenJDKTag tag, Tag.Annotated annotated) throws NonRetriableException;
-    void handleTagCommit(HostedRepository repository, Repository localRepository, Commit commit, Tag tag, Tag.Annotated annotation) throws NonRetriableException;
-    void handleNewBranch(HostedRepository repository, Repository localRepository, List<Commit> commits, Branch parent, Branch branch) throws NonRetriableException;
-    String name();
+    public RuntimeException cause() {
+        return cause;
+    }
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/NotifyBot.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/NotifyBot.java
@@ -24,8 +24,7 @@ package org.openjdk.skara.bots.notify;
 
 import org.openjdk.skara.bot.*;
 import org.openjdk.skara.forge.*;
-import org.openjdk.skara.storage.*;
-import org.openjdk.skara.vcs.Tag;
+import org.openjdk.skara.storage.StorageBuilder;
 
 import java.nio.file.Path;
 import java.util.*;
@@ -37,8 +36,8 @@ class NotifyBot implements Bot {
     private final HostedRepository repository;
     private final Path storagePath;
     private final Pattern branches;
-    private final StorageBuilder<Tag> tagStorageBuilder;
-    private final StorageBuilder<ResolvedBranch> branchStorageBuilder;
+    private final StorageBuilder<UpdatedTag> tagStorageBuilder;
+    private final StorageBuilder<UpdatedBranch> branchStorageBuilder;
     private final StorageBuilder<PullRequestIssues> prIssuesStorageBuilder;
     private final List<RepositoryUpdateConsumer> updaters;
     private final List<PullRequestUpdateConsumer> prUpdaters;
@@ -46,8 +45,8 @@ class NotifyBot implements Bot {
     private final Set<String> readyLabels;
     private final Map<String, Pattern> readyComments;
 
-    NotifyBot(HostedRepository repository, Path storagePath, Pattern branches, StorageBuilder<Tag> tagStorageBuilder,
-              StorageBuilder<ResolvedBranch> branchStorageBuilder, StorageBuilder<PullRequestIssues> prIssuesStorageBuilder,
+    NotifyBot(HostedRepository repository, Path storagePath, Pattern branches, StorageBuilder<UpdatedTag> tagStorageBuilder,
+              StorageBuilder<UpdatedBranch> branchStorageBuilder, StorageBuilder<PullRequestIssues> prIssuesStorageBuilder,
               List<RepositoryUpdateConsumer> updaters, List<PullRequestUpdateConsumer> prUpdaters,
               Set<String> readyLabels, Map<String, Pattern> readyComments) {
         this.repository = repository;

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/NotifyBotBuilder.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/NotifyBotBuilder.java
@@ -24,7 +24,6 @@ package org.openjdk.skara.bots.notify;
 
 import org.openjdk.skara.forge.HostedRepository;
 import org.openjdk.skara.storage.StorageBuilder;
-import org.openjdk.skara.vcs.Tag;
 
 import java.nio.file.Path;
 import java.util.*;
@@ -34,8 +33,8 @@ public class NotifyBotBuilder {
     private HostedRepository repository;
     private Path storagePath;
     private Pattern branches;
-    private StorageBuilder<Tag> tagStorageBuilder;
-    private StorageBuilder<ResolvedBranch> branchStorageBuilder;
+    private StorageBuilder<UpdatedTag> tagStorageBuilder;
+    private StorageBuilder<UpdatedBranch> branchStorageBuilder;
     private StorageBuilder<PullRequestIssues> prIssuesStorageBuilder;
     private List<RepositoryUpdateConsumer> updaters = List.of();
     private List<PullRequestUpdateConsumer> prUpdaters = List.of();
@@ -57,12 +56,12 @@ public class NotifyBotBuilder {
         return this;
     }
 
-    public NotifyBotBuilder tagStorageBuilder(StorageBuilder<Tag> tagStorageBuilder) {
+    public NotifyBotBuilder tagStorageBuilder(StorageBuilder<UpdatedTag> tagStorageBuilder) {
         this.tagStorageBuilder = tagStorageBuilder;
         return this;
     }
 
-    public NotifyBotBuilder branchStorageBuilder(StorageBuilder<ResolvedBranch> branchStorageBuilder) {
+    public NotifyBotBuilder branchStorageBuilder(StorageBuilder<UpdatedBranch> branchStorageBuilder) {
         this.branchStorageBuilder = branchStorageBuilder;
         return this;
     }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/NotifyBotFactory.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/NotifyBotFactory.java
@@ -187,9 +187,9 @@ public class NotifyBotFactory implements BotFactory {
 
             var baseName = repo.value().contains("basename") ? repo.value().get("basename").asString() : configuration.repositoryName(repoName);
 
-            var tagStorageBuilder = new StorageBuilder<Tag>(baseName + ".tags.txt")
+            var tagStorageBuilder = new StorageBuilder<UpdatedTag>(baseName + ".tags.txt")
                     .remoteRepository(databaseRepo, databaseRef, databaseName, databaseEmail, "Added tag for " + repoName);
-            var branchStorageBuilder = new StorageBuilder<ResolvedBranch>(baseName + ".branches.txt")
+            var branchStorageBuilder = new StorageBuilder<UpdatedBranch>(baseName + ".branches.txt")
                     .remoteRepository(databaseRepo, databaseRef, databaseName, databaseEmail, "Added branch hash for " + repoName);
             var issueStorageBuilder = new StorageBuilder<PullRequestIssues>(baseName + ".prissues.txt")
                     .remoteRepository(databaseRepo, databaseRef, databaseName, databaseEmail, "Added pull request issue info for " + repoName);

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryWorkItem.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryWorkItem.java
@@ -92,8 +92,8 @@ public class RepositoryWorkItem implements WorkItem {
         updater.handleCommits(repository, localRepo, commits, branch);
     }
 
-    private List<RuntimeException> handleRef(Repository localRepo, UpdateHistory history, Reference ref, Collection<Reference> allRefs) throws IOException {
-        var errors = new ArrayList<RuntimeException>();
+    private List<Throwable> handleRef(Repository localRepo, UpdateHistory history, Reference ref, Collection<Reference> allRefs) throws IOException {
+        var errors = new ArrayList<Throwable>();
         var branch = new Branch(ref.name());
         for (var updater : updaters) {
             var lastHash = history.branchHash(branch, updater.name());
@@ -151,8 +151,8 @@ public class RepositoryWorkItem implements WorkItem {
         }
     }
 
-    private List<RuntimeException> handleTags(Repository localRepo, UpdateHistory history, RepositoryUpdateConsumer updater) throws IOException {
-        var errors = new ArrayList<RuntimeException>();
+    private List<Throwable> handleTags(Repository localRepo, UpdateHistory history, RepositoryUpdateConsumer updater) throws IOException {
+        var errors = new ArrayList<Throwable>();
         var tags = localRepo.tags();
         var newTags = tags.stream()
                           .filter(tag -> !history.hasTag(tag, updater.name()))
@@ -268,7 +268,7 @@ public class RepositoryWorkItem implements WorkItem {
             localRepo.fetchAll();
 
             var history = UpdateHistory.create(tagStorageBuilder, historyPath.resolve("tags"), branchStorageBuilder, historyPath.resolve("branches"));
-            var errors = new ArrayList<RuntimeException>();
+            var errors = new ArrayList<Throwable>();
 
             for (var updater : updaters) {
                 errors.addAll(handleTags(localRepo, history, updater));

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/UpdateHistory.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/UpdateHistory.java
@@ -31,68 +31,87 @@ import java.util.function.Function;
 import java.util.stream.*;
 
 class UpdateHistory {
-    private final Storage<Tag> tagStorage;
-    private final Storage<ResolvedBranch> branchStorage;
+    private final Storage<UpdatedTag> tagStorage;
+    private final Storage<UpdatedBranch> branchStorage;
 
     private Map<String, Hash> branchHashes;
-    private Set<Tag> tags;
+    private Map<String, Boolean> tagRetries;
 
-    private List<ResolvedBranch> parseSerializedEntry(String entry) {
+    private List<UpdatedBranch> parseSerializedBranch(String entry) {
         var parts = entry.split(" ");
         if (parts.length == 2) {
             // Transform legacy entry
-            var issueEntry = new ResolvedBranch(new Branch(parts[0]), "issue", new Hash(parts[1]));
-            var mlEntry = new ResolvedBranch(new Branch(parts[0]), "ml", new Hash(parts[1]));
+            var issueEntry = new UpdatedBranch(new Branch(parts[0]), "issue", new Hash(parts[1]));
+            var mlEntry = new UpdatedBranch(new Branch(parts[0]), "ml", new Hash(parts[1]));
             return List.of(issueEntry, mlEntry);
         }
-        return List.of(new ResolvedBranch(new Branch(parts[0]), parts[1], new Hash(parts[2])));
+        return List.of(new UpdatedBranch(new Branch(parts[0]), parts[1], new Hash(parts[2])));
     }
 
-    private Set<ResolvedBranch> loadBranches(String current) {
+    private Set<UpdatedBranch> loadBranches(String current) {
         return current.lines()
-                      .flatMap(line -> parseSerializedEntry(line).stream())
+                      .flatMap(line -> parseSerializedBranch(line).stream())
                       .collect(Collectors.toSet());
     }
 
-    private String serializeEntry(ResolvedBranch entry) {
+    private String serializeBranch(UpdatedBranch entry) {
         return entry.branch().toString() + " " + entry.updater() + " " + entry.hash().toString();
     }
 
-    private String serializeBranches(Collection<ResolvedBranch> added, Set<ResolvedBranch> existing) {
+    private String serializeBranches(Collection<UpdatedBranch> added, Set<UpdatedBranch> existing) {
         var updatedBranches = existing.stream()
                                       .collect(Collectors.toMap(entry -> entry.branch().toString() + ":" + entry.updater(),
                                                                 Function.identity()));
         added.forEach(a -> updatedBranches.put(a.branch().toString() + ":" + a.updater(), a));
         return updatedBranches.values().stream()
-                              .map(this::serializeEntry)
+                              .map(this::serializeBranch)
                               .sorted()
                               .collect(Collectors.joining("\n"));
     }
 
-    private Set<Tag> loadTags(String current) {
+    private List<UpdatedTag> parseSerializedTag(String entry) {
+        var parts = entry.split(" ");
+        if (parts.length == 1) {
+            // Transform legacy entry
+            var issueEntry = new UpdatedTag(new Tag(entry), "issue", false);
+            var mlEntry = new UpdatedTag(new Tag(entry), "ml", false);
+            return List.of(issueEntry, mlEntry);
+        }
+        return List.of(new UpdatedTag(new Tag(parts[0]), parts[1], parts[2].equals("retry")));
+    }
+
+    private Set<UpdatedTag> loadTags(String current) {
         return current.lines()
-                      .map(Tag::new)
+                      .flatMap(line -> parseSerializedTag(line).stream())
                       .collect(Collectors.toSet());
     }
 
-    private String serializeTags(Collection<Tag> added, Set<Tag> existing) {
-        return Stream.concat(existing.stream(),
-                             added.stream())
-                     .map(Tag::toString)
-                     .sorted()
-                     .collect(Collectors.joining("\n"));
+    private String serializeTag(UpdatedTag entry) {
+        return entry.tag().toString() + " " + entry.updater() + " " + (entry.shouldRetry() ? "retry" : "done");
     }
 
-    private Set<Tag> currentTags() {
-        return tagStorage.current();
+    private String serializeTags(Collection<UpdatedTag> added, Set<UpdatedTag> existing) {
+        var updatedTags = existing.stream()
+                                  .collect(Collectors.toMap(entry -> entry.tag().toString() + ":" + entry.updater(),
+                                                            Function.identity()));
+        added.forEach(a -> updatedTags.put(a.tag().toString() + ":" + a.updater(), a));
+        return updatedTags.values().stream()
+                          .map(this::serializeTag)
+                          .sorted()
+                          .collect(Collectors.joining("\n"));
     }
 
     private Map<String, Hash> currentBranchHashes() {
         return branchStorage.current().stream()
-                .collect(Collectors.toMap(rb -> rb.branch().toString() + " " + rb.updater(), ResolvedBranch::hash));
+                            .collect(Collectors.toMap(rb -> rb.branch().toString() + " " + rb.updater(), UpdatedBranch::hash));
     }
 
-    private UpdateHistory(StorageBuilder<Tag> tagStorageBuilder, Path tagLocation, StorageBuilder<ResolvedBranch> branchStorageBuilder, Path branchLocation) {
+    private Map<String, Boolean> currentTags() {
+        return tagStorage.current().stream()
+                         .collect(Collectors.toMap(u -> u.tag().toString() + " " + u.updater(), UpdatedTag::shouldRetry));
+    }
+
+    private UpdateHistory(StorageBuilder<UpdatedTag> tagStorageBuilder, Path tagLocation, StorageBuilder<UpdatedBranch> branchStorageBuilder, Path branchLocation) {
         this.tagStorage = tagStorageBuilder
                 .serializer(this::serializeTags)
                 .deserializer(this::loadTags)
@@ -103,48 +122,41 @@ class UpdateHistory {
                 .deserializer(this::loadBranches)
                 .materialize(branchLocation);
 
-        tags = currentTags();
+        tagRetries = currentTags();
         branchHashes = currentBranchHashes();
     }
 
-    static UpdateHistory create(StorageBuilder<Tag> tagStorageBuilder, Path tagLocation, StorageBuilder<ResolvedBranch> branchStorageBuilder, Path branchLocation) {
+    static UpdateHistory create(StorageBuilder<UpdatedTag> tagStorageBuilder, Path tagLocation, StorageBuilder<UpdatedBranch> branchStorageBuilder, Path branchLocation) {
         return new UpdateHistory(tagStorageBuilder, tagLocation, branchStorageBuilder, branchLocation);
     }
 
-    void addTags(Collection<Tag> addedTags) {
-        tagStorage.put(addedTags);
-        var newTags = currentTags();
-
-        if (addedTags != null) {
-            for (var existingTag : addedTags) {
-                if (!newTags.contains(existingTag)) {
-                    throw new RuntimeException("Tag '" + existingTag + "' has been removed");
-                }
-            }
-        }
-
-        tags = currentTags();
+    void addTags(Collection<Tag> addedTags, String updater) {
+        var newEntries = addedTags.stream()
+                                  .map(t -> new UpdatedTag(t, updater, false))
+                                  .collect(Collectors.toSet());
+        tagStorage.put(newEntries);
+        tagRetries = currentTags();
     }
 
-    boolean hasTag(Tag tag) {
-        return tags.contains(tag);
+    void retryTagUpdate(Tag tagToRetry, String updater) {
+        var entry = new UpdatedTag(tagToRetry, updater, true);
+        tagStorage.put(List.of(entry));
+        tagRetries = currentTags();
+    }
+
+    boolean hasTag(Tag tag, String updater) {
+        return tagRetries.containsKey(tag.toString() + " " + updater);
+    }
+
+    boolean shouldRetryTagUpdate(Tag tag, String updater) {
+        return tagRetries.getOrDefault(tag.toString() + " " + updater, false);
     }
 
     void setBranchHash(Branch branch, String updater, Hash hash) {
-        var entry = new ResolvedBranch(branch, updater, hash);
+        var entry = new UpdatedBranch(branch, updater, hash);
 
         branchStorage.put(entry);
-        var newBranchHashes = currentBranchHashes();
-
-        // Sanity check
-        if (branchHashes != null) {
-            for (var existingBranch : branchHashes.keySet()) {
-                if (!newBranchHashes.containsKey(existingBranch)) {
-                    throw new RuntimeException("Hash information for branch '" + existingBranch + "' is missing");
-                }
-            }
-        }
-        branchHashes = newBranchHashes;
+        branchHashes = currentBranchHashes();
     }
 
     Optional<Hash> branchHash(Branch branch, String updater) {

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/UpdatedBranch.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/UpdatedBranch.java
@@ -26,12 +26,12 @@ import org.openjdk.skara.vcs.*;
 
 import java.util.Objects;
 
-class ResolvedBranch {
+class UpdatedBranch {
     private final Branch branch;
     private final String updater;
     private final Hash hash;
 
-    ResolvedBranch(Branch branch, String updater, Hash hash) {
+    UpdatedBranch(Branch branch, String updater, Hash hash) {
         this.branch = branch;
         this.updater = updater;
         this.hash = hash;
@@ -57,7 +57,7 @@ class ResolvedBranch {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        ResolvedBranch that = (ResolvedBranch) o;
+        UpdatedBranch that = (UpdatedBranch) o;
         return branch.equals(that.branch) && updater.equals(that.updater) && hash.equals(that.hash);
     }
 

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/UpdatedTag.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/UpdatedTag.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.notify;
+
+import org.openjdk.skara.vcs.Tag;
+
+import java.util.Objects;
+
+public class UpdatedTag {
+    private final Tag tag;
+    private final String updater;
+    private final boolean shouldRetry;
+
+    public UpdatedTag(Tag tag, String updater, boolean shouldRetry) {
+        this.tag = tag;
+        this.updater = updater;
+        this.shouldRetry = shouldRetry;
+    }
+
+    public Tag tag() {
+        return tag;
+    }
+
+    public String updater() {
+        return updater;
+    }
+
+    public boolean shouldRetry() {
+        return shouldRetry;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        UpdatedTag that = (UpdatedTag) o;
+        return shouldRetry == that.shouldRetry &&
+                tag.equals(that.tag) &&
+                updater.equals(that.updater);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(tag, updater, shouldRetry);
+    }
+}

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdateHistoryTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdateHistoryTests.java
@@ -50,9 +50,9 @@ class UpdateHistoryTests {
 
     private UpdateHistory createHistory(HostedRepository repository, String ref) throws IOException {
         var folder = Files.createTempDirectory("updatehistory");
-        var tagStorage = new StorageBuilder<Tag>("tags.txt")
+        var tagStorage = new StorageBuilder<UpdatedTag>("tags.txt")
                                        .remoteRepository(repository, ref, "Duke", "duke@openjdk.java.net", "Updated tags");
-        var branchStorage = new StorageBuilder<ResolvedBranch>("branches.txt")
+        var branchStorage = new StorageBuilder<UpdatedBranch>("branches.txt")
                 .remoteRepository(repository, ref, "Duke", "duke@openjdk.java.net", "Updated branches");
         return UpdateHistory.create(tagStorage,folder.resolve("tags"), branchStorage, folder.resolve("branches"));
     }
@@ -64,15 +64,15 @@ class UpdateHistoryTests {
             var ref = resetHostedRepository(repository);
             var history = createHistory(repository, ref);
 
-            history.addTags(List.of(new Tag("1"), new Tag("2")));
+            history.addTags(List.of(new Tag("1"), new Tag("2")), "a");
 
-            assertTrue(history.hasTag(new Tag("1")));
-            assertTrue(history.hasTag(new Tag("2")));
+            assertTrue(history.hasTag(new Tag("1"), "a"));
+            assertTrue(history.hasTag(new Tag("2"), "a"));
 
             var newHistory = createHistory(repository, ref);
 
-            assertTrue(newHistory.hasTag(new Tag("1")));
-            assertTrue(newHistory.hasTag(new Tag("2")));
+            assertTrue(newHistory.hasTag(new Tag("1"), "a"));
+            assertTrue(newHistory.hasTag(new Tag("2"), "a"));
         }
     }
 
@@ -124,36 +124,91 @@ class UpdateHistoryTests {
     }
 
     @Test
+    void tagsSeparateUpdaters(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo)) {
+            var repository = credentials.getHostedRepository();
+            var ref = resetHostedRepository(repository);
+            var history = createHistory(repository, ref);
+
+            history.addTags(List.of(new Tag("1"), new Tag("2")), "a");
+            history.addTags(List.of(new Tag("2"), new Tag("3")), "b");
+
+            assertTrue(history.hasTag(new Tag("1"), "a"));
+            assertTrue(history.hasTag(new Tag("2"), "a"));
+            assertFalse(history.hasTag(new Tag("3"), "a"));
+            assertFalse(history.hasTag(new Tag("1"), "b"));
+            assertTrue(history.hasTag(new Tag("2"), "b"));
+            assertTrue(history.hasTag(new Tag("3"), "b"));
+
+            var newHistory = createHistory(repository, ref);
+
+            assertTrue(newHistory.hasTag(new Tag("1"), "a"));
+            assertTrue(newHistory.hasTag(new Tag("2"), "a"));
+            assertFalse(newHistory.hasTag(new Tag("3"), "a"));
+            assertFalse(newHistory.hasTag(new Tag("1"), "b"));
+            assertTrue(newHistory.hasTag(new Tag("2"), "b"));
+            assertTrue(newHistory.hasTag(new Tag("3"), "b"));
+        }
+    }
+
+    @Test
+    void tagsMarkRetry(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo)) {
+            var repository = credentials.getHostedRepository();
+            var ref = resetHostedRepository(repository);
+            var history = createHistory(repository, ref);
+
+            history.addTags(List.of(new Tag("1"), new Tag("2")), "a");
+            history.addTags(List.of(new Tag("2"), new Tag("3")), "b");
+
+            history.retryTagUpdate(new Tag("1"), "a");
+            history.retryTagUpdate(new Tag("2"), "b");
+
+            assertTrue(history.shouldRetryTagUpdate(new Tag("1"), "a"));
+            assertFalse(history.shouldRetryTagUpdate(new Tag("2"), "a"));
+            assertTrue(history.shouldRetryTagUpdate(new Tag("2"), "b"));
+            assertFalse(history.shouldRetryTagUpdate(new Tag("3"), "b"));
+
+            var newHistory = createHistory(repository, ref);
+
+            assertTrue(newHistory.shouldRetryTagUpdate(new Tag("1"), "a"));
+            assertFalse(newHistory.shouldRetryTagUpdate(new Tag("2"), "a"));
+            assertTrue(newHistory.shouldRetryTagUpdate(new Tag("2"), "b"));
+            assertFalse(newHistory.shouldRetryTagUpdate(new Tag("3"), "b"));
+        }
+    }
+
+    @Test
     void tagsConcurrentModification(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo)) {
             var repository = credentials.getHostedRepository();
             var ref = resetHostedRepository(repository);
             var history = createHistory(repository, ref);
 
-            history.addTags(List.of(new Tag("1"), new Tag("2")));
+            history.addTags(List.of(new Tag("1"), new Tag("2")), "a");
 
-            assertTrue(history.hasTag(new Tag("1")));
-            assertTrue(history.hasTag(new Tag("2")));
+            assertTrue(history.hasTag(new Tag("1"), "a"));
+            assertTrue(history.hasTag(new Tag("2"), "a"));
 
             var history1 = createHistory(repository, ref);
-            assertTrue(history1.hasTag(new Tag("1")));
-            assertTrue(history1.hasTag(new Tag("2")));
-            assertFalse(history1.hasTag(new Tag("3")));
-            assertFalse(history1.hasTag(new Tag("4")));
+            assertTrue(history1.hasTag(new Tag("1"), "a"));
+            assertTrue(history1.hasTag(new Tag("2"), "a"));
+            assertFalse(history1.hasTag(new Tag("3"), "a"));
+            assertFalse(history1.hasTag(new Tag("4"), "a"));
 
             var history2 = createHistory(repository, ref);
-            assertTrue(history2.hasTag(new Tag("1")));
-            assertTrue(history2.hasTag(new Tag("2")));
-            assertFalse(history2.hasTag(new Tag("3")));
-            assertFalse(history2.hasTag(new Tag("4")));
+            assertTrue(history2.hasTag(new Tag("1"), "a"));
+            assertTrue(history2.hasTag(new Tag("2"), "a"));
+            assertFalse(history2.hasTag(new Tag("3"), "a"));
+            assertFalse(history2.hasTag(new Tag("4"), "a"));
 
-            history1.addTags(Set.of(new Tag("3")));
-            history2.addTags(Set.of(new Tag("4")));
+            history1.addTags(Set.of(new Tag("3")), "a");
+            history2.addTags(Set.of(new Tag("4")), "a");
 
-            assertTrue(history1.hasTag(new Tag("3")));
-            assertFalse(history1.hasTag(new Tag("4")));
-            assertTrue(history2.hasTag(new Tag("3")));
-            assertTrue(history2.hasTag(new Tag("4")));
+            assertTrue(history1.hasTag(new Tag("3"), "a"));
+            assertFalse(history1.hasTag(new Tag("4"), "a"));
+            assertTrue(history2.hasTag(new Tag("3"), "a"));
+            assertTrue(history2.hasTag(new Tag("4"), "a"));
         }
     }
 }

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdaterTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdaterTests.java
@@ -55,13 +55,13 @@ class UpdaterTests {
                     .collect(Collectors.toList());
     }
 
-    private StorageBuilder<Tag> createTagStorage(HostedRepository repository) {
-        return new StorageBuilder<Tag>("tags.txt")
+    private StorageBuilder<UpdatedTag> createTagStorage(HostedRepository repository) {
+        return new StorageBuilder<UpdatedTag>("tags.txt")
                 .remoteRepository(repository, "history", "Duke", "duke@openjdk.java.net", "Updated tags");
     }
 
-    private StorageBuilder<ResolvedBranch> createBranchStorage(HostedRepository repository) {
-        return new StorageBuilder<ResolvedBranch>("branches.txt")
+    private StorageBuilder<UpdatedBranch> createBranchStorage(HostedRepository repository) {
+        return new StorageBuilder<UpdatedBranch>("branches.txt")
                 .remoteRepository(repository, "history", "Duke", "duke@openjdk.java.net", "Updated branches");
     }
 
@@ -1927,10 +1927,14 @@ class UpdaterTests {
 
         @Override
         public void handleCommits(HostedRepository repository, Repository localRepository, List<Commit> commits,
-                                  Branch branch) {
+                                  Branch branch) throws NonRetriableException {
             updateCount++;
             if (shouldFail) {
-                throw new RuntimeException("induced failure");
+                if (idempotent) {
+                    throw new RuntimeException("induced failure");
+                } else {
+                    throw new NonRetriableException(new RuntimeException("unretriable failure"));
+                }
             }
         }
 
@@ -1950,11 +1954,6 @@ class UpdaterTests {
         public void handleNewBranch(HostedRepository repository, Repository localRepository, List<Commit> commits,
          Branch parent, Branch branch) {
             throw new RuntimeException("unexpected");
-        }
-
-        @Override
-        public boolean isIdempotent() {
-            return idempotent;
         }
 
         @Override


### PR DESCRIPTION
Hi all,

Please review this change that makes the notifier retry logic more granular. Instead of marking an entire notifier as either retriable or not, allow a notifier to throw a NonRetriableException if a non-retriable operation fails.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**) ⚠️ Review applies to db69a722261f814564991b17b219f37db97b2c1e

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/510/head:pull/510`
`$ git checkout pull/510`
