### PR TITLE
310: RFR thread integration messages should check target branch

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/MailingListUpdater.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/MailingListUpdater.java
@@ -182,6 +182,11 @@ public class MailingListUpdater implements RepositoryUpdateConsumer {
 
             var candidate = candidates.get(0);
             var prLink = candidate.webUrl();
+            if (!candidate.targetRef().equals(branch.name())) {
+                log.warning("Pull request " + prLink + " targets " + candidate.targetRef() + " - commit is on " + branch.toString() + " - skipping");
+                ret.add(commit);
+                continue;
+            }
             var prLinkPattern = Pattern.compile("^(?:PR: )?" + Pattern.quote(prLink.toString()), Pattern.MULTILINE);
 
             var rfrCandidates = rfrsConvos.stream()


### PR DESCRIPTION
Hi all,

Please review this change that ensures that when the notifier sends a threaded integration message, the PR in the RFR thread targets the branch that the notifier is looking at.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-310](https://bugs.openjdk.java.net/browse/SKARA-310): RFR thread integration messages should check target branch


### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/512/head:pull/512`
`$ git checkout pull/512`
