### PR TITLE
292: Add comment to PR when it becomes outdated

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -49,6 +49,7 @@ class CheckRun {
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots.pr");
     private final String progressMarker = "<!-- Anything below this marker will be automatically updated, please do not edit manually! -->";
     private final String mergeReadyMarker = "<!-- PullRequestBot merge is ready comment -->";
+    private final String outdatedHelpMarker = "<!-- PullRequestBot outdated help comment -->";
     private final Pattern mergeSourceFullPattern = Pattern.compile("^Merge ([-/\\w]+):([-\\w]+)$");
     private final Pattern mergeSourceBranchOnlyPattern = Pattern.compile("^Merge ([-\\w]+)$");
     private final Set<String> newLabels;
@@ -533,6 +534,27 @@ class CheckRun {
         }
     }
 
+    private void addOutdatedComment(List<Comment> comments) {
+        var existing = findComment(comments, outdatedHelpMarker);
+        if (existing.isPresent()) {
+            // Only add the comment once per PR
+            return;
+        }
+        var message = "@" + pr.author().userName() + " this pull request can no longer be integrated into " +
+                "`" + pr.targetRef() + "` due to one or more merge conflicts. To resolve these merge conflicts " +
+                "and update this pull request you can run the following commands:\n" +
+                "```bash\n" +
+                "git checkout " + pr.sourceRef() + "\n" +
+                "git fetch " + pr.repository().webUrl() + " " + pr.targetRef() + "\n" +
+                "git merge FETCH_HEAD\n" +
+                "# resolve conflicts and follow the instructions given by git merge\n" +
+                "git commit -m \"Merge " + pr.targetRef() + "\"\n" +
+                "git push\n" +
+                "```\n" +
+                outdatedHelpMarker;
+        pr.addComment(message);
+    }
+
     private void checkStatus() {
         var checkBuilder = CheckBuilder.create("jcheck", pr.headHash());
         var censusDomain = censusInstance.configuration().census().domain();
@@ -586,6 +608,7 @@ class CheckRun {
                 newLabels.remove("ready");
             }
             if (!rebasePossible) {
+                addOutdatedComment(comments);
                 newLabels.add("outdated");
             } else {
                 newLabels.remove("outdated");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -542,7 +542,7 @@ class CheckRun {
         }
         var message = "@" + pr.author().userName() + " this pull request can no longer be integrated into " +
                 "`" + pr.targetRef() + "` due to one or more merge conflicts. To resolve these merge conflicts " +
-                "and update this pull request you can run the following commands:\n" +
+                "and update this pull request you can run the following commands in the local repository for your personal fork:\n" +
                 "```bash\n" +
                 "git checkout " + pr.sourceRef() + "\n" +
                 "git fetch " + pr.repository().webUrl() + " " + pr.targetRef() + "\n" +

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -583,6 +583,12 @@ class CheckTests {
             // The PR should be flagged as outdated
             assertTrue(pr.labels().contains("outdated"));
 
+            // An instructional message should have been bosted
+            var help = pr.comments().stream()
+                         .filter(comment -> comment.body().contains("To resolve these merge conflicts"))
+                         .count();
+            assertEquals(1, help);
+
             // But it should still pass jcheck
             var checks = pr.checks(editHash);
             assertEquals(1, checks.size());


### PR DESCRIPTION
Hi all,

Please review this change that posts an instructional message on how to sync with the target branch the first time a PR is marked as outdated.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-292](https://bugs.openjdk.java.net/browse/SKARA-292): Add comment to PR whent it becomes outdated


### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**) ⚠️ Review applies to 0a148746897584186859ddd73042f76eea8d79e6

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/513/head:pull/513`
`$ git checkout pull/513`
