### PR TITLE
315: Publish command is not in GitSkara.java

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitSkara.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitSkara.java
@@ -117,6 +117,7 @@ public class GitSkara {
         commands.put("info", GitInfo::main);
         commands.put("translate", GitTranslate::main);
         commands.put("sync", GitSync::main);
+        commands.put("publish", GitPublish::main);
         commands.put("update", GitSkara::update);
         commands.put("help", GitSkara::usage);
 


### PR DESCRIPTION
Hi all,

please review this small patch that adds the `publish` command to
`GitSkara.java` so that `git skara publish` works.

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-315](https://bugs.openjdk.java.net/browse/SKARA-315): Publish command is not in GitSkara.java


### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/515/head:pull/515`
`$ git checkout pull/515`
