### PR TITLE
319: git-info uses wrong JBS project

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitInfo.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitInfo.java
@@ -62,8 +62,8 @@ public class GitInfo {
         return lines.size() == 1 && lines.get(0).toLowerCase().equals("true");
     }
 
-    private static String jbsProject(ReadOnlyRepository repo) throws IOException {
-        var conf = JCheckConfiguration.from(repo);
+    private static String jbsProject(ReadOnlyRepository repo, Hash hash) throws IOException {
+        var conf = JCheckConfiguration.from(repo, hash);
         return conf.general().jbs().toUpperCase();
     }
 
@@ -228,7 +228,7 @@ public class GitInfo {
 
         if (showReview) {
             var decoration = useDecoration? "Review: " : "";
-            var project = jbsProject(repo);
+            var project = jbsProject(repo, hash);
             if (message.issues().size() == 1) {
                 var issueId = message.issues().get(0).id();
                 var issueTracker = IssueTracker.from("jira", JBS);
@@ -245,7 +245,7 @@ public class GitInfo {
             }
         }
         if (showIssues) {
-            var project = jbsProject(repo);
+            var project = jbsProject(repo, hash);
             var uri = JBS + "/browse/" + project + "-";
             var issues = message.issues();
             if (issues.size() > 1) {


### PR DESCRIPTION
Hi all,

please review this patch that ensures that `git pr` reads the .jcheck/conf from
the given revision, *not* from `master`.

Testing:
- Manual testing of `git-info` on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-319](https://bugs.openjdk.java.net/browse/SKARA-319): git-info uses wrong JBS project


### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/516/head:pull/516`
`$ git checkout pull/516`
