### PR TITLE
314: Add help command to git-pr

### DIFF
--- a/args/src/main/java/org/openjdk/skara/args/Flag.java
+++ b/args/src/main/java/org/openjdk/skara/args/Flag.java
@@ -45,19 +45,19 @@ public class Flag {
         return isSwitch;
     }
 
-    String fullname() {
+    public String fullname() {
         return fullname;
     }
 
-    String shortcut() {
+    public String shortcut() {
         return shortcut;
     }
 
-    String description() {
+    public String description() {
         return description;
     }
 
-    String helptext() {
+    public String helptext() {
         return helptext;
     }
 

--- a/args/src/main/java/org/openjdk/skara/args/MultiCommandParser.java
+++ b/args/src/main/java/org/openjdk/skara/args/MultiCommandParser.java
@@ -46,7 +46,9 @@ public class MultiCommandParser {
                                    .collect(Collectors.toMap(
                                            Command::name,
                                            Function.identity()));
-        this.subCommands.put("help", helpCommand());
+        if (!commands.stream().anyMatch(c -> c.name().equals("help"))) {
+            this.subCommands.put("help", helpCommand());
+        }
     }
 
     private Command helpCommand() {

--- a/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
@@ -31,7 +31,10 @@ import java.util.List;
 public class GitPr {
     public static void main(String[] args) throws Exception {
         var commands = List.of(
-                    Default.name("list")
+                    Default.name("help")
+                           .helptext("show help text")
+                           .main(GitPrHelp::main),
+                    Command.name("list")
                            .helptext("list open pull requests")
                            .main(GitPrList::main),
                     Command.name("fetch")

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrApply.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrApply.java
@@ -31,43 +31,43 @@ import java.nio.file.Files;
 import java.util.List;
 
 public class GitPrApply {
+    static List<Flag> flags = List.of(
+        Option.shortcut("u")
+              .fullname("username")
+              .describe("NAME")
+              .helptext("Username on host")
+              .optional(),
+        Option.shortcut("r")
+              .fullname("remote")
+              .describe("NAME")
+              .helptext("Name of remote, defaults to 'origin'")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("no-token")
+              .helptext("Do not use a personal access token (PAT)")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("verbose")
+              .helptext("Turn on verbose output")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("debug")
+              .helptext("Turn on debugging output")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("version")
+              .helptext("Print the version of this tool")
+              .optional()
+    );
+
+    static List<Input> inputs = List.of(
+        Input.position(0)
+             .describe("ID")
+             .singular()
+             .optional()
+    );
+
     public static void main(String[] args) throws IOException {
-        var flags = List.of(
-            Option.shortcut("u")
-                  .fullname("username")
-                  .describe("NAME")
-                  .helptext("Username on host")
-                  .optional(),
-            Option.shortcut("r")
-                  .fullname("remote")
-                  .describe("NAME")
-                  .helptext("Name of remote, defaults to 'origin'")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("no-token")
-                  .helptext("Do not use a personal access token (PAT)")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("verbose")
-                  .helptext("Turn on verbose output")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("debug")
-                  .helptext("Turn on debugging output")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("version")
-                  .helptext("Print the version of this tool")
-                  .optional()
-        );
-
-        var inputs = List.of(
-            Input.position(0)
-                 .describe("ID")
-                 .singular()
-                 .optional()
-        );
-
         var parser = new ArgumentParser("git-pr", flags, inputs);
         var arguments = parse(parser, args);
         var repo = getRepo();

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrApprove.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrApprove.java
@@ -31,38 +31,39 @@ import java.io.IOException;
 import java.util.List;
 
 public class GitPrApprove {
-    public static void main(String[] args) throws IOException {
-        var flags = List.of(
-            Option.shortcut("u")
-                  .fullname("username")
-                  .describe("NAME")
-                  .helptext("Username on host")
-                  .optional(),
-            Option.shortcut("r")
-                  .fullname("remote")
-                  .describe("NAME")
-                  .helptext("Name of remote, defaults to 'origin'")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("verbose")
-                  .helptext("Turn on verbose output")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("debug")
-                  .helptext("Turn on debugging output")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("version")
-                  .helptext("Print the version of this tool")
-                  .optional()
-        );
+    static final List<Flag> flags = List.of(
+        Option.shortcut("u")
+              .fullname("username")
+              .describe("NAME")
+              .helptext("Username on host")
+              .optional(),
+        Option.shortcut("r")
+              .fullname("remote")
+              .describe("NAME")
+              .helptext("Name of remote, defaults to 'origin'")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("verbose")
+              .helptext("Turn on verbose output")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("debug")
+              .helptext("Turn on debugging output")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("version")
+              .helptext("Print the version of this tool")
+              .optional()
+    );
 
-        var inputs = List.of(
-            Input.position(0)
-                 .describe("ID")
-                 .singular()
-                 .optional()
-        );
+    static final List<Input> inputs = List.of(
+        Input.position(0)
+             .describe("ID")
+             .singular()
+             .optional()
+    );
+
+    public static void main(String[] args) throws IOException {
         var parser = new ArgumentParser("git-pr", flags, inputs);
         var arguments = parse(parser, args);
         var repo = getRepo();

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrCheckout.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrCheckout.java
@@ -30,48 +30,48 @@ import java.io.IOException;
 import java.util.List;
 
 public class GitPrCheckout {
+    static final List<Flag> flags = List.of(
+        Option.shortcut("u")
+              .fullname("username")
+              .describe("NAME")
+              .helptext("Username on host")
+              .optional(),
+        Option.shortcut("r")
+              .fullname("remote")
+              .describe("NAME")
+              .helptext("Name of remote, defaults to 'origin'")
+              .optional(),
+        Option.shortcut("b")
+              .fullname("branch")
+              .describe("NAME")
+              .helptext("Name of target branch, defaults to 'master'")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("no-token")
+              .helptext("Do not use a personal access token (PAT)")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("verbose")
+              .helptext("Turn on verbose output")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("debug")
+              .helptext("Turn on debugging output")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("version")
+              .helptext("Print the version of this tool")
+              .optional()
+    );
+
+    static final List<Input> inputs = List.of(
+        Input.position(0)
+             .describe("ID")
+             .singular()
+             .optional()
+    );
+
     public static void main(String[] args) throws IOException {
-        var flags = List.of(
-            Option.shortcut("u")
-                  .fullname("username")
-                  .describe("NAME")
-                  .helptext("Username on host")
-                  .optional(),
-            Option.shortcut("r")
-                  .fullname("remote")
-                  .describe("NAME")
-                  .helptext("Name of remote, defaults to 'origin'")
-                  .optional(),
-            Option.shortcut("b")
-                  .fullname("branch")
-                  .describe("NAME")
-                  .helptext("Name of target branch, defaults to 'master'")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("no-token")
-                  .helptext("Do not use a personal access token (PAT)")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("verbose")
-                  .helptext("Turn on verbose output")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("debug")
-                  .helptext("Turn on debugging output")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("version")
-                  .helptext("Print the version of this tool")
-                  .optional()
-        );
-
-        var inputs = List.of(
-            Input.position(0)
-                 .describe("ID")
-                 .singular()
-                 .optional()
-        );
-
         var parser = new ArgumentParser("git-pr", flags, inputs);
         var arguments = parse(parser, args);
         var repo = getRepo();

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrClose.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrClose.java
@@ -31,39 +31,39 @@ import java.io.IOException;
 import java.util.List;
 
 public class GitPrClose {
+    static final List<Flag> flags = List.of(
+        Option.shortcut("u")
+              .fullname("username")
+              .describe("NAME")
+              .helptext("Username on host")
+              .optional(),
+        Option.shortcut("r")
+              .fullname("remote")
+              .describe("NAME")
+              .helptext("Name of remote, defaults to 'origin'")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("verbose")
+              .helptext("Turn on verbose output")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("debug")
+              .helptext("Turn on debugging output")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("version")
+              .helptext("Print the version of this tool")
+              .optional()
+    );
+
+    static final List<Input> inputs = List.of(
+        Input.position(0)
+             .describe("ID")
+             .singular()
+             .optional()
+    );
+
     public static void main(String[] args) throws IOException, InterruptedException {
-        var flags = List.of(
-            Option.shortcut("u")
-                  .fullname("username")
-                  .describe("NAME")
-                  .helptext("Username on host")
-                  .optional(),
-            Option.shortcut("r")
-                  .fullname("remote")
-                  .describe("NAME")
-                  .helptext("Name of remote, defaults to 'origin'")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("verbose")
-                  .helptext("Turn on verbose output")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("debug")
-                  .helptext("Turn on debugging output")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("version")
-                  .helptext("Print the version of this tool")
-                  .optional()
-        );
-
-        var inputs = List.of(
-            Input.position(0)
-                 .describe("ID")
-                 .singular()
-                 .optional()
-        );
-
         var parser = new ArgumentParser("git-pr", flags, inputs);
         var arguments = parse(parser, args);
         var repo = getRepo();

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrCreate.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrCreate.java
@@ -40,64 +40,64 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class GitPrCreate {
+    static final List<Flag> flags = List.of(
+        Option.shortcut("u")
+              .fullname("username")
+              .describe("NAME")
+              .helptext("Username on host")
+              .optional(),
+        Option.shortcut("r")
+              .fullname("remote")
+              .describe("NAME")
+              .helptext("Name of remote, defaults to 'origin'")
+              .optional(),
+        Option.shortcut("b")
+              .fullname("branch")
+              .describe("NAME")
+              .helptext("Name of target branch, defaults to 'master'")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("ignore-workspace")
+              .helptext("Ignore local changes in worktree and staging area when creating pull request")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("ignore-local-commits")
+              .helptext("Ignore local commits not pushed when creating pull request")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("publish")
+              .helptext("Publish the local branch before creating the pull request")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("jcheck")
+              .helptext("Run jcheck before creating the pull request")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("draft")
+              .helptext("Create a pull request in draft state")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("verbose")
+              .helptext("Turn on verbose output")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("debug")
+              .helptext("Turn on debugging output")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("version")
+              .helptext("Print the version of this tool")
+              .optional()
+    );
+
+    static final List<Input> inputs = List.of(
+        Input.position(0)
+             .describe("ID")
+             .singular()
+             .optional()
+    );
+
     public static void main(String[] args) throws IOException, InterruptedException {
-        var flags = List.of(
-            Option.shortcut("u")
-                  .fullname("username")
-                  .describe("NAME")
-                  .helptext("Username on host")
-                  .optional(),
-            Option.shortcut("r")
-                  .fullname("remote")
-                  .describe("NAME")
-                  .helptext("Name of remote, defaults to 'origin'")
-                  .optional(),
-            Option.shortcut("b")
-                  .fullname("branch")
-                  .describe("NAME")
-                  .helptext("Name of target branch, defaults to 'master'")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("ignore-workspace")
-                  .helptext("Ignore local changes in worktree and staging area when creating pull request")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("ignore-local-commits")
-                  .helptext("Ignore local commits not pushed when creating pull request")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("publish")
-                  .helptext("Publish the local branch before creating the pull request")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("jcheck")
-                  .helptext("Run jcheck before creating the pull request")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("draft")
-                  .helptext("Create a pull request in draft state")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("verbose")
-                  .helptext("Turn on verbose output")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("debug")
-                  .helptext("Turn on debugging output")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("version")
-                  .helptext("Print the version of this tool")
-                  .optional()
-        );
-
-        var inputs = List.of(
-            Input.position(0)
-                 .describe("ID")
-                 .singular()
-                 .optional()
-        );
-
         var parser = new ArgumentParser("git-pr", flags, inputs);
         var arguments = parse(parser, args);
         var repo = getRepo();

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrFetch.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrFetch.java
@@ -30,48 +30,48 @@ import java.io.IOException;
 import java.util.List;
 
 public class GitPrFetch {
+    static final List<Flag> flags = List.of(
+        Option.shortcut("u")
+              .fullname("username")
+              .describe("NAME")
+              .helptext("Username on host")
+              .optional(),
+        Option.shortcut("r")
+              .fullname("remote")
+              .describe("NAME")
+              .helptext("Name of remote, defaults to 'origin'")
+              .optional(),
+        Option.shortcut("b")
+              .fullname("branch")
+              .describe("NAME")
+              .helptext("Name of target branch, defaults to 'master'")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("no-token")
+              .helptext("Do not use a personal access token (PAT)")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("verbose")
+              .helptext("Turn on verbose output")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("debug")
+              .helptext("Turn on debugging output")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("version")
+              .helptext("Print the version of this tool")
+              .optional()
+    );
+
+    static final List<Input> inputs = List.of(
+        Input.position(0)
+             .describe("ID")
+             .singular()
+             .optional()
+    );
+
     public static void main(String[] args) throws IOException {
-        var flags = List.of(
-            Option.shortcut("u")
-                  .fullname("username")
-                  .describe("NAME")
-                  .helptext("Username on host")
-                  .optional(),
-            Option.shortcut("r")
-                  .fullname("remote")
-                  .describe("NAME")
-                  .helptext("Name of remote, defaults to 'origin'")
-                  .optional(),
-            Option.shortcut("b")
-                  .fullname("branch")
-                  .describe("NAME")
-                  .helptext("Name of target branch, defaults to 'master'")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("no-token")
-                  .helptext("Do not use a personal access token (PAT)")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("verbose")
-                  .helptext("Turn on verbose output")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("debug")
-                  .helptext("Turn on debugging output")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("version")
-                  .helptext("Print the version of this tool")
-                  .optional()
-        );
-
-        var inputs = List.of(
-            Input.position(0)
-                 .describe("ID")
-                 .singular()
-                 .optional()
-        );
-
         var parser = new ArgumentParser("git-pr", flags, inputs);
         var arguments = parse(parser, args);
         var repo = getRepo();

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrHelp.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrHelp.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.cli.pr;
+
+import org.openjdk.skara.args.*;
+import org.openjdk.skara.version.Version;
+import org.openjdk.skara.cli.Logging;
+
+import java.util.*;
+import java.util.logging.Level;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class GitPrHelp {
+    private static final class Pair<T1, T2> {
+        T1 e1;
+        T2 e2;
+
+        Pair(T1 e1, T2 e2) {
+            this.e1 = e1;
+            this.e2 = e2;
+        }
+
+        static <T3, T4> Pair<T3, T4> of(T3 e1, T4 e2) {
+            return new Pair<T3, T4>(e1, e2);
+        }
+
+        T1 first() {
+            return e1;
+        }
+
+        T2 second() {
+            return e2;
+        }
+    }
+
+    private static final Map<String, Pair<List<Input>, List<Flag>>> commands = new HashMap<>();
+
+    static {
+        commands.put("list", Pair.of(GitPrList.inputs, GitPrList.flags));
+        commands.put("fetch", Pair.of(GitPrFetch.inputs, GitPrFetch.flags));
+        commands.put("show", Pair.of(GitPrShow.inputs, GitPrShow.flags));
+        commands.put("checkout", Pair.of(GitPrCheckout.inputs, GitPrCheckout.flags));
+        commands.put("apply", Pair.of(GitPrApply.inputs, GitPrApply.flags));
+        commands.put("integrate", Pair.of(GitPrIntegrate.inputs, GitPrIntegrate.flags));
+        commands.put("approve", Pair.of(GitPrApprove.inputs, GitPrApprove.flags));
+        commands.put("create", Pair.of(GitPrCreate.inputs, GitPrCreate.flags));
+        commands.put("close", Pair.of(GitPrClose.inputs, GitPrClose.flags));
+        commands.put("set", Pair.of(GitPrSet.inputs, GitPrSet.flags));
+        commands.put("sponsor", Pair.of(GitPrSponsor.inputs, GitPrSponsor.flags));
+        commands.put("test", Pair.of(GitPrTest.inputs, GitPrTest.flags));
+        commands.put("info", Pair.of(GitPrInfo.inputs, GitPrInfo.flags));
+    }
+
+    private static String describe(List<Input> inputs) {
+        return inputs.stream().map(Input::toString).collect(Collectors.joining(" "));
+    }
+
+    private static<T> TreeSet<T> sorted(Set<T> s) {
+        return new TreeSet<T>(s);
+    }
+
+    private static void showHelpFor(String command) {
+        var inputs = commands.get(command).first();
+        var flags = commands.get(command).second();
+
+        System.out.println("- " + command);
+        System.out.println("  Usage: git pr " + command + " " + describe(inputs));
+        System.out.println("  Flags:");
+        ArgumentParser.showFlags(System.out, flags, " ".repeat(4));
+    }
+
+    public static void main(String[] args) {
+        var flags = List.of(
+            Switch.shortcut("h")
+                  .fullname("help")
+                  .helptext("Show help")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("verbose")
+                  .helptext("Turn on verbose output")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("debug")
+                  .helptext("Turn on debugging output")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("version")
+                  .helptext("Print the version of this tool")
+                  .optional()
+        );
+
+        var inputs = List.of(
+            Input.position(0)
+                 .describe("COMMAND")
+                 .singular()
+                 .optional()
+        );
+
+        var parser = new ArgumentParser("git-pr", flags, inputs);
+        var arguments = parser.parse(args);
+        if (arguments.contains("version")) {
+            System.out.println("git-pr version: " + Version.fromManifest().orElse("unknown"));
+            System.exit(0);
+        }
+        if (arguments.contains("verbose") || arguments.contains("debug")) {
+            var level = arguments.contains("debug") ? Level.FINER : Level.FINE;
+            Logging.setup(level);
+        }
+
+        if (arguments.at(0).isPresent()) {
+            var command = arguments.at(0).asString();
+            if (commands.keySet().contains(command)) {
+               showHelpFor(command);
+               System.exit(0);
+            } else {
+                System.err.println("error: unknown sub-command: " + command);
+                System.err.println("");
+                System.err.println("Available sub-commands are:");
+                for (var subcommand : sorted(commands.keySet())) {
+                    System.err.println("- " + subcommand);
+                }
+                System.exit(1);
+            }
+        }
+
+        System.out.println("git-pr is used for interacting with pull requeqsts from a command line.");
+        System.out.println("The following commands are available:");
+        for (var command : sorted(commands.keySet())) {
+            showHelpFor(command);
+        }
+    }
+}

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrHelp.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrHelp.java
@@ -80,14 +80,13 @@ public class GitPrHelp {
         return new TreeSet<T>(s);
     }
 
-    private static void showHelpFor(String command) {
+    private static void showHelpFor(String command, int indentation) {
         var inputs = commands.get(command).first();
         var flags = commands.get(command).second();
 
-        System.out.println("- " + command);
-        System.out.println("  Usage: git pr " + command + " " + describe(inputs));
-        System.out.println("  Flags:");
-        ArgumentParser.showFlags(System.out, flags, " ".repeat(4));
+        System.out.println(" ".repeat(indentation) + "Usage: git pr " + command + " " + describe(inputs));
+        System.out.println(" ".repeat(indentation) + "Flags:");
+        ArgumentParser.showFlags(System.out, flags, " ".repeat(indentation + 2));
     }
 
     public static void main(String[] args) {
@@ -131,7 +130,7 @@ public class GitPrHelp {
         if (arguments.at(0).isPresent()) {
             var command = arguments.at(0).asString();
             if (commands.keySet().contains(command)) {
-               showHelpFor(command);
+               showHelpFor(command, 0);
                System.exit(0);
             } else {
                 System.err.println("error: unknown sub-command: " + command);
@@ -147,7 +146,8 @@ public class GitPrHelp {
         System.out.println("git-pr is used for interacting with pull requeqsts from a command line.");
         System.out.println("The following commands are available:");
         for (var command : sorted(commands.keySet())) {
-            showHelpFor(command);
+            System.out.println("- " + command);
+            showHelpFor(command, 2);
         }
     }
 }

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrInfo.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrInfo.java
@@ -34,95 +34,95 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 public class GitPrInfo {
+    static final List<Flag> flags = List.of(
+        Option.shortcut("u")
+              .fullname("username")
+              .describe("NAME")
+              .helptext("Username on host")
+              .optional(),
+        Option.shortcut("r")
+              .fullname("remote")
+              .describe("NAME")
+              .helptext("Name of remote, defaults to 'origin'")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("no-decoration")
+              .helptext("Hide any decorations when listing PRs")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("no-token")
+              .helptext("Do not use a personal access token (PAT)")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("checks")
+              .helptext("Show information about checks")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("author")
+              .helptext("Show the author of the pull request")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("title")
+              .helptext("Show the title of the pull request")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("assignees")
+              .helptext("Show the assignees of the pull request")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("reviewers")
+              .helptext("Show the reviewers of the pull request")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("contributors")
+              .helptext("Show the additional contributors to the pull request")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("issues")
+              .helptext("Show the issues associated with the pull request")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("commits")
+              .helptext("Show the commits in pull request")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("branch")
+              .helptext("Show the target branch for the pull request")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("url")
+              .helptext("Show the url for the pull request")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("status")
+              .helptext("Show the status for the pull request")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("labels")
+              .helptext("Show the labels for the pull request")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("verbose")
+              .helptext("Turn on verbose output")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("debug")
+              .helptext("Turn on debugging output")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("version")
+              .helptext("Print the version of this tool")
+              .optional()
+    );
+
+    static final List<Input> inputs = List.of(
+        Input.position(0)
+             .describe("ID")
+             .singular()
+             .optional()
+    );
+
     public static void main(String[] args) throws IOException {
-        var flags = List.of(
-            Option.shortcut("u")
-                  .fullname("username")
-                  .describe("NAME")
-                  .helptext("Username on host")
-                  .optional(),
-            Option.shortcut("r")
-                  .fullname("remote")
-                  .describe("NAME")
-                  .helptext("Name of remote, defaults to 'origin'")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("no-decoration")
-                  .helptext("Hide any decorations when listing PRs")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("no-token")
-                  .helptext("Do not use a personal access token (PAT)")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("checks")
-                  .helptext("Show information about checks")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("author")
-                  .helptext("Show the author of the pull request")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("title")
-                  .helptext("Show the title of the pull request")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("assignees")
-                  .helptext("Show the assignees of the pull request")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("reviewers")
-                  .helptext("Show the reviewers of the pull request")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("contributors")
-                  .helptext("Show the additional contributors to the pull request")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("issues")
-                  .helptext("Show the issues associated with the pull request")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("commits")
-                  .helptext("Show the commits in pull request")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("branch")
-                  .helptext("Show the target branch for the pull request")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("url")
-                  .helptext("Show the url for the pull request")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("status")
-                  .helptext("Show the status for the pull request")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("labels")
-                  .helptext("Show the labels for the pull request")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("verbose")
-                  .helptext("Turn on verbose output")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("debug")
-                  .helptext("Turn on debugging output")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("version")
-                  .helptext("Print the version of this tool")
-                  .optional()
-        );
-
-        var inputs = List.of(
-            Input.position(0)
-                 .describe("ID")
-                 .singular()
-                 .optional()
-        );
-
         var parser = new ArgumentParser("git-pr", flags, inputs);
         var arguments = parse(parser, args);
         var repo = getRepo();

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrIntegrate.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrIntegrate.java
@@ -30,43 +30,43 @@ import java.io.IOException;
 import java.util.List;
 
 public class GitPrIntegrate {
+    static final List<Flag> flags = List.of(
+        Option.shortcut("u")
+              .fullname("username")
+              .describe("NAME")
+              .helptext("Username on host")
+              .optional(),
+        Option.shortcut("r")
+              .fullname("remote")
+              .describe("NAME")
+              .helptext("Name of remote, defaults to 'origin'")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("atomic")
+              .helptext("Integrate the pull request atomically")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("verbose")
+              .helptext("Turn on verbose output")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("debug")
+              .helptext("Turn on debugging output")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("version")
+              .helptext("Print the version of this tool")
+              .optional()
+    );
+
+    static final List<Input> inputs = List.of(
+        Input.position(0)
+             .describe("ID")
+             .singular()
+             .optional()
+    );
+
     public static void main(String[] args) throws IOException, InterruptedException {
-        var flags = List.of(
-            Option.shortcut("u")
-                  .fullname("username")
-                  .describe("NAME")
-                  .helptext("Username on host")
-                  .optional(),
-            Option.shortcut("r")
-                  .fullname("remote")
-                  .describe("NAME")
-                  .helptext("Name of remote, defaults to 'origin'")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("atomic")
-                  .helptext("Integrate the pull request atomically")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("verbose")
-                  .helptext("Turn on verbose output")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("debug")
-                  .helptext("Turn on debugging output")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("version")
-                  .helptext("Print the version of this tool")
-                  .optional()
-        );
-
-        var inputs = List.of(
-            Input.position(0)
-                 .describe("ID")
-                 .singular()
-                 .optional()
-        );
-
         var parser = new ArgumentParser("git-pr", flags, inputs);
         var arguments = parse(parser, args);
         var repo = getRepo();

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrList.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrList.java
@@ -37,79 +37,79 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 public class GitPrList {
+    static final List<Flag> flags = List.of(
+        Option.shortcut("u")
+              .fullname("username")
+              .describe("NAME")
+              .helptext("Username on host")
+              .optional(),
+        Option.shortcut("r")
+              .fullname("remote")
+              .describe("NAME")
+              .helptext("Name of remote, defaults to 'origin'")
+              .optional(),
+        Option.shortcut("")
+              .fullname("authors")
+              .describe("LIST")
+              .helptext("Comma separated list of authors")
+              .optional(),
+        Option.shortcut("")
+              .fullname("assignees")
+              .describe("LIST")
+              .helptext("Comma separated list of assignees")
+              .optional(),
+        Option.shortcut("")
+              .fullname("labels")
+              .describe("LIST")
+              .helptext("Comma separated list of labels")
+              .optional(),
+        Option.shortcut("")
+              .fullname("issues")
+              .describe("LIST")
+              .helptext("Comma separated list of issues")
+              .optional(),
+        Option.shortcut("")
+              .fullname("columns")
+              .describe("id,title,author,assignees,labels")
+              .helptext("Comma separated list of columns to show")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("no-decoration")
+              .helptext("Hide any decorations when listing PRs")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("no-draft")
+              .helptext("Hide all pull requests in draft state")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("no-token")
+              .helptext("Do not use a personal access token (PAT)")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("verbose")
+              .helptext("Turn on verbose output")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("debug")
+              .helptext("Turn on debugging output")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("version")
+              .helptext("Print the version of this tool")
+              .optional());
+
+    static final List<Input> inputs = List.of(
+        Input.position(0)
+             .describe("ID")
+             .singular()
+             .optional()
+    );
+
     private static int longest(List<String> strings) {
         return strings.stream().mapToInt(String::length).max().orElse(0);
     }
 
     public static void main(String[] args) throws IOException {
-        var flags = List.of(
-            Option.shortcut("u")
-                  .fullname("username")
-                  .describe("NAME")
-                  .helptext("Username on host")
-                  .optional(),
-            Option.shortcut("r")
-                  .fullname("remote")
-                  .describe("NAME")
-                  .helptext("Name of remote, defaults to 'origin'")
-                  .optional(),
-            Option.shortcut("")
-                  .fullname("authors")
-                  .describe("LIST")
-                  .helptext("Comma separated list of authors")
-                  .optional(),
-            Option.shortcut("")
-                  .fullname("assignees")
-                  .describe("LIST")
-                  .helptext("Comma separated list of assignees")
-                  .optional(),
-            Option.shortcut("")
-                  .fullname("labels")
-                  .describe("LIST")
-                  .helptext("Comma separated list of labels")
-                  .optional(),
-            Option.shortcut("")
-                  .fullname("issues")
-                  .describe("LIST")
-                  .helptext("Comma separated list of issues")
-                  .optional(),
-            Option.shortcut("")
-                  .fullname("columns")
-                  .describe("id,title,author,assignees,labels")
-                  .helptext("Comma separated list of columns to show")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("no-decoration")
-                  .helptext("Hide any decorations when listing PRs")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("no-draft")
-                  .helptext("Hide all pull requests in draft state")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("no-token")
-                  .helptext("Do not use a personal access token (PAT)")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("verbose")
-                  .helptext("Turn on verbose output")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("debug")
-                  .helptext("Turn on debugging output")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("version")
-                  .helptext("Print the version of this tool")
-                  .optional());
-
-        var inputs = List.of(
-            Input.position(0)
-                 .describe("ID")
-                 .singular()
-                 .optional()
-        );
-
         var parser = new ArgumentParser("git-pr", flags, inputs);
         var arguments = parse(parser, args);
         var repo = getRepo();

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrSet.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrSet.java
@@ -47,65 +47,65 @@ import java.util.regex.Matcher;
 import java.util.stream.Collectors;
 
 public class GitPrSet {
+    static final List<Flag> flags = List.of(
+        Option.shortcut("u")
+              .fullname("username")
+              .describe("NAME")
+              .helptext("Username on host")
+              .optional(),
+        Option.shortcut("r")
+              .fullname("remote")
+              .describe("NAME")
+              .helptext("Name of remote, defaults to 'origin'")
+              .optional(),
+        Option.shortcut("")
+              .fullname("assignees")
+              .describe("LIST")
+              .helptext("Comma separated list of assignees")
+              .optional(),
+        Option.shortcut("")
+              .fullname("title")
+              .describe("MESSAGE")
+              .helptext("The title of the pull request")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("open")
+              .helptext("Set the pull request's state to open")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("closed")
+              .helptext("Set the pull request's state to closed")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("body")
+              .helptext("Set the body of the pull request")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("no-draft")
+              .helptext("Mark the pull request as not draft")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("verbose")
+              .helptext("Turn on verbose output")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("debug")
+              .helptext("Turn on debugging output")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("version")
+              .helptext("Print the version of this tool")
+              .optional()
+    );
+
+    static final List<Input> inputs = List.of(
+        Input.position(0)
+             .describe("ID")
+             .singular()
+             .optional()
+    );
+
     public static void main(String[] args) throws IOException, InterruptedException {
-        var flags = List.of(
-            Option.shortcut("u")
-                  .fullname("username")
-                  .describe("NAME")
-                  .helptext("Username on host")
-                  .optional(),
-            Option.shortcut("r")
-                  .fullname("remote")
-                  .describe("NAME")
-                  .helptext("Name of remote, defaults to 'origin'")
-                  .optional(),
-            Option.shortcut("")
-                  .fullname("assignees")
-                  .describe("LIST")
-                  .helptext("Comma separated list of assignees")
-                  .optional(),
-            Option.shortcut("")
-                  .fullname("title")
-                  .describe("MESSAGE")
-                  .helptext("The title of the pull request")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("open")
-                  .helptext("Set the pull request's state to open")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("closed")
-                  .helptext("Set the pull request's state to closed")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("body")
-                  .helptext("Set the body of the pull request")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("no-draft")
-                  .helptext("Mark the pull request as not draft")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("verbose")
-                  .helptext("Turn on verbose output")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("debug")
-                  .helptext("Turn on debugging output")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("version")
-                  .helptext("Print the version of this tool")
-                  .optional()
-        );
-
-        var inputs = List.of(
-            Input.position(0)
-                 .describe("ID")
-                 .singular()
-                 .optional()
-        );
-
         var parser = new ArgumentParser("git-pr", flags, inputs);
         var arguments = parse(parser, args);
         var repo = getRepo();

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrShow.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrShow.java
@@ -30,43 +30,43 @@ import java.io.IOException;
 import java.util.List;
 
 public class GitPrShow {
+    static final List<Flag> flags = List.of(
+        Option.shortcut("u")
+              .fullname("username")
+              .describe("NAME")
+              .helptext("Username on host")
+              .optional(),
+        Option.shortcut("r")
+              .fullname("remote")
+              .describe("NAME")
+              .helptext("Name of remote, defaults to 'origin'")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("no-token")
+              .helptext("Do not use a personal access token (PAT)")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("verbose")
+              .helptext("Turn on verbose output")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("debug")
+              .helptext("Turn on debugging output")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("version")
+              .helptext("Print the version of this tool")
+              .optional()
+    );
+
+    static final List<Input> inputs = List.of(
+        Input.position(0)
+             .describe("ID")
+             .singular()
+             .optional()
+    );
+
     public static void main(String[] args) throws IOException, InterruptedException {
-        var flags = List.of(
-            Option.shortcut("u")
-                  .fullname("username")
-                  .describe("NAME")
-                  .helptext("Username on host")
-                  .optional(),
-            Option.shortcut("r")
-                  .fullname("remote")
-                  .describe("NAME")
-                  .helptext("Name of remote, defaults to 'origin'")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("no-token")
-                  .helptext("Do not use a personal access token (PAT)")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("verbose")
-                  .helptext("Turn on verbose output")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("debug")
-                  .helptext("Turn on debugging output")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("version")
-                  .helptext("Print the version of this tool")
-                  .optional()
-        );
-
-        var inputs = List.of(
-            Input.position(0)
-                 .describe("ID")
-                 .singular()
-                 .optional()
-        );
-
         var parser = new ArgumentParser("git-pr", flags, inputs);
         var arguments = parse(parser, args);
         var repo = getRepo();

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrSponsor.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrSponsor.java
@@ -30,38 +30,39 @@ import java.io.IOException;
 import java.util.List;
 
 public class GitPrSponsor {
-    public static void main(String[] args) throws IOException, InterruptedException {
-        var flags = List.of(
-            Option.shortcut("u")
-                  .fullname("username")
-                  .describe("NAME")
-                  .helptext("Username on host")
-                  .optional(),
-            Option.shortcut("r")
-                  .fullname("remote")
-                  .describe("NAME")
-                  .helptext("Name of remote, defaults to 'origin'")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("verbose")
-                  .helptext("Turn on verbose output")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("debug")
-                  .helptext("Turn on debugging output")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("version")
-                  .helptext("Print the version of this tool")
-                  .optional()
-        );
+    static final List<Flag> flags = List.of(
+        Option.shortcut("u")
+              .fullname("username")
+              .describe("NAME")
+              .helptext("Username on host")
+              .optional(),
+        Option.shortcut("r")
+              .fullname("remote")
+              .describe("NAME")
+              .helptext("Name of remote, defaults to 'origin'")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("verbose")
+              .helptext("Turn on verbose output")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("debug")
+              .helptext("Turn on debugging output")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("version")
+              .helptext("Print the version of this tool")
+              .optional()
+    );
 
-        var inputs = List.of(
-            Input.position(0)
-                 .describe("ID")
-                 .singular()
-                 .optional()
-        );
+    static final List<Input> inputs = List.of(
+        Input.position(0)
+             .describe("ID")
+             .singular()
+             .optional()
+    );
+
+    public static void main(String[] args) throws IOException, InterruptedException {
         var parser = new ArgumentParser("git-pr", flags, inputs);
         var arguments = parse(parser, args);
         var repo = getRepo();

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrTest.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrTest.java
@@ -30,38 +30,39 @@ import java.io.IOException;
 import java.util.List;
 
 public class GitPrTest {
-    public static void main(String[] args) throws IOException, InterruptedException {
-        var flags = List.of(
-            Option.shortcut("u")
-                  .fullname("username")
-                  .describe("NAME")
-                  .helptext("Username on host")
-                  .optional(),
-            Option.shortcut("r")
-                  .fullname("remote")
-                  .describe("NAME")
-                  .helptext("Name of remote, defaults to 'origin'")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("verbose")
-                  .helptext("Turn on verbose output")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("debug")
-                  .helptext("Turn on debugging output")
-                  .optional(),
-            Switch.shortcut("")
-                  .fullname("version")
-                  .helptext("Print the version of this tool")
-                  .optional()
-        );
+    static final List<Flag> flags = List.of(
+        Option.shortcut("u")
+              .fullname("username")
+              .describe("NAME")
+              .helptext("Username on host")
+              .optional(),
+        Option.shortcut("r")
+              .fullname("remote")
+              .describe("NAME")
+              .helptext("Name of remote, defaults to 'origin'")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("verbose")
+              .helptext("Turn on verbose output")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("debug")
+              .helptext("Turn on debugging output")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("version")
+              .helptext("Print the version of this tool")
+              .optional()
+    );
 
-        var inputs = List.of(
-            Input.position(0)
-                 .describe("ID")
-                 .singular()
-                 .optional()
-        );
+    static final List<Input> inputs = List.of(
+        Input.position(0)
+             .describe("ID")
+             .singular()
+             .optional()
+    );
+
+    public static void main(String[] args) throws IOException, InterruptedException {
         var parser = new ArgumentParser("git-pr", flags, inputs);
         var arguments = parse(parser, args);
         var repo = getRepo();


### PR DESCRIPTION
Hi all,

please review this patch that enhances the default `help` command for `git pr`
by quite a bit. `git pr` will now be default list the usage and flags for all
available sub-commands. A user can now also run `git pr help <sub-command>`,
e.g. `git pr help set`:

```
$ git pr help set
Usage: git pr set [<ID>]
Flags:
  -u, --username NAME   Username on host
  -r, --remote NAME     Name of remote, defaults to 'origin'
      --assignees LIST  Comma separated list of assignees
      --title MESSAGE   The title of the pull request
      --open            Set the pull request's state to open
      --closed          Set the pull request's state to closed
      --body            Set the body of the pull request
      --no-draft        Mark the pull request as not draft
      --verbose         Turn on verbose output
      --debug           Turn on debugging output
      --version         Print the version of this tool
```

Testing:
- Manual testing of `git pr` on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-314](https://bugs.openjdk.java.net/browse/SKARA-314): Add help command to git-pr


### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/521/head:pull/521`
`$ git checkout pull/521`
