### PR TITLE
306: Automatic merge conflicts PR only have repo in title when needed

### DIFF
--- a/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
+++ b/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
@@ -272,9 +272,13 @@ class MergeBot implements Bot, WorkItem {
                 ));
                 repo.merge(remoteBranch); // should always be a fast-forward merge
 
+                var targetName = Path.of(target.name()).getFileName();
+                var fromName = Path.of(fromRepo.name()).getFileName();
+                var fromDesc = targetName.equals(fromName) ? fromBranch : fromName + ":" + fromBranch;
+
                 // Check if merge conflict pull request is present
                 var shouldMerge = true;
-                var title = "Cannot automatically merge " + fromRepo.name() + ":" + fromBranch.name() + " to " + toBranch.name();
+                var title = "Cannot automatically merge " + fromDesc + " to " + toBranch.name();
                 var marker = "<!-- MERGE CONFLICTS -->";
                 for (var pr : prs) {
                     if (pr.title().equals(title) &&
@@ -392,9 +396,6 @@ class MergeBot implements Bot, WorkItem {
                     error = e;
                 }
 
-                var targetName = Path.of(target.name()).getFileName();
-                var fromName = Path.of(fromRepo.name()).getFileName();
-                var fromDesc = targetName.equals(fromName) ? fromBranch : fromName + ":" + fromBranch;
                 if (error == null) {
                     log.info("Pushing successful merge");
                     if (!isAncestor) {


### PR DESCRIPTION
Hi all,

please review this small patch that ensures that automatic merge conflicts PRs
only shows the repo in the title if the from and target repository differs.

Testing:
- `make test` on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-306](https://bugs.openjdk.java.net/browse/SKARA-306): Automatic merge conflicts PR only have repo in title when needed


### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/522/head:pull/522`
`$ git checkout pull/522`
