### PR TITLE
325: Transient network errors can cause skipped notifications

### DIFF
--- a/storage/build.gradle
+++ b/storage/build.gradle
@@ -26,6 +26,7 @@ module {
     test {
         requires 'org.junit.jupiter.api'
         requires 'org.junit.jupiter.params'
+        requires 'org.openjdk.skara.test'
         opens 'org.openjdk.skara.storage' to 'org.junit.platform.commons'
     }
 }
@@ -36,6 +37,8 @@ dependencies {
     implementation project(':forge')
     implementation project(':issuetracker')
     implementation project(':vcs')
+
+    testImplementation project(':test')
 }
 
 publishing {

--- a/storage/src/main/java/org/openjdk/skara/storage/HostedRepositoryStorage.java
+++ b/storage/src/main/java/org/openjdk/skara/storage/HostedRepositoryStorage.java
@@ -63,7 +63,10 @@ class HostedRepositoryStorage<T> implements Storage<T> {
                 localRepository = Repository.init(localStorage, repository.repositoryType());
                 var storage = Files.writeString(localStorage.resolve(fileName), "");
                 localRepository.add(storage);
-                localRepository.commit(message, authorName, authorEmail);
+                var firstCommit = localRepository.commit(message, authorName, authorEmail);
+
+                // If the materialization failed for any other reason than the remote ref not existing, this will fail
+                localRepository.push(firstCommit, repository.url(), ref);
             }
             this.localRepository = localRepository;
             hash = localRepository.head();

--- a/storage/src/test/java/org/openjdk/skara/storage/HostedRepositoryStorageTests.java
+++ b/storage/src/test/java/org/openjdk/skara/storage/HostedRepositoryStorageTests.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.storage;
+
+import org.junit.jupiter.api.*;
+import org.openjdk.skara.test.*;
+import org.openjdk.skara.vcs.*;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.stream.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class HostedRepositoryStorageTests {
+    String serializer(Collection<String> added, Set<String> existing) {
+        return Stream.concat(added.stream(), existing.stream())
+                .distinct()
+                .sorted()
+                .collect(Collectors.joining("\n"));
+    }
+
+    Set<String> deserializer(String serialized) {
+        return serialized.lines().collect(Collectors.toSet());
+    }
+
+    @Test
+    void failedMaterialization(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+                var tempFolder = new TemporaryDirectory()) {
+            var repo = credentials.getHostedRepository();
+            var storage = new HostedRepositoryStorage<>(repo, tempFolder.path(), "master", "test.txt",
+                                                        "duke", "duke@openjdk.java.org",
+                                                        "Updated storage", this::serializer, this::deserializer);
+            storage.put(List.of("a", "b"));
+
+            // Corrupt the destination path and materialize again
+            var localRepo = Repository.init(tempFolder.path(), VCS.GIT);
+            localRepo.checkout(new Branch("storage"));
+            assertThrows(RuntimeException.class, () -> new HostedRepositoryStorage<>(repo, tempFolder.path(), "master", "test.txt",
+                                                                                     "duke", "duke@openjdk.java.org",
+                                                                                     "Updated storage", this::serializer, this::deserializer));
+        }
+    }
+}


### PR DESCRIPTION
Hi all,

Please review this change that ensures that a remote storage repository is not considered empty when materialization fails for unrelated reasons.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-325](https://bugs.openjdk.java.net/browse/SKARA-325): Transient network errors can cause skipped notifications


### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/523/head:pull/523`
`$ git checkout pull/523`
