### PR TITLE
Ensure pull requests instances are populated with complete json info

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -151,8 +151,9 @@ public class GitHubRepository implements HostedRepository {
         }
         var result = gitHubHost.runSearch(query);
         return result.get("items").stream()
-                .map(jsonValue -> new GitHubPullRequest(this, jsonValue, request))
-                .collect(Collectors.toList());
+                     .map(jsonValue -> jsonValue.get("number").asInt())
+                     .map(id -> pullRequest(id.toString()))
+                     .collect(Collectors.toList());
     }
 
     @Override


### PR DESCRIPTION
Hi all,

Please review this small change that ensures that pull requests found by searching on GitHub are populated with complete information.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/524/head:pull/524`
`$ git checkout pull/524`
