### PR TITLE
jcheck: add symlink check

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
@@ -208,7 +208,7 @@ class PullRequestCheckIssueVisitor implements IssueVisitor {
 
     @Override
     public void visit(SymlinkIssue issue) {
-        messages.add(String.format("Symbolic linkes are not allowed (file: %s)", issue.path()));
+        messages.add(String.format("Symbolic links are not allowed (file: %s)", issue.path()));
         failedChecks.add(issue.check().getClass());
         readyForReview = false;
     }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
@@ -207,6 +207,13 @@ class PullRequestCheckIssueVisitor implements IssueVisitor {
     }
 
     @Override
+    public void visit(SymlinkIssue issue) {
+        messages.add(String.format("Symbolic linkes are not allowed (file: %s)", issue.path()));
+        failedChecks.add(issue.check().getClass());
+        readyForReview = false;
+    }
+
+    @Override
     public void visit(BlacklistIssue issue) {
         log.fine("ignored: blacklisted commit");
     }

--- a/cli/src/main/java/org/openjdk/skara/cli/JCheckCLIVisitor.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/JCheckCLIVisitor.java
@@ -234,6 +234,13 @@ class JCheckCLIVisitor implements IssueVisitor {
         }
     }
 
+    public void visit(SymlinkIssue i) {
+        if (!ignore.contains(i.check().name())) {
+            println(i, "file " + i.path() + " is symbolic link");
+            hasDisplayedErrors = true;
+        }
+    }
+
     public void visit(AuthorNameIssue i) {
         if (!ignore.contains(i.check().name())) {
             println(i, "missing author name");

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/JCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/JCheck.java
@@ -77,6 +77,7 @@ public class JCheck {
             new MessageCheck(utils),
             new IssuesCheck(utils),
             new ExecutableCheck(),
+            new SymlinkCheck(),
             new BlacklistCheck(blacklist)
         );
         repositoryChecks = List.of(

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/JCheckConfiguration.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/JCheckConfiguration.java
@@ -73,7 +73,7 @@ public class JCheckConfiguration {
         config.add("jbs=JDK");
 
         config.add("[checks]");
-        var error = "error=blacklist,author,committer,reviewers,merge,hg-tag,message,issues,executable";
+        var error = "error=blacklist,author,committer,reviewers,merge,hg-tag,message,issues,executable,symlink";
         var shouldCheckWhitespace = false;
         var checkWhitespace = old.get("whitespace");
         if (checkWhitespace == null || !checkWhitespace.asString().equals("lax")) {

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/SymlinkCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/SymlinkCheck.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.jcheck;
+
+import org.openjdk.skara.vcs.Commit;
+import org.openjdk.skara.vcs.openjdk.CommitMessage;
+
+import java.util.Iterator;
+import java.util.ArrayList;
+import java.util.logging.Logger;
+
+public class SymlinkCheck extends CommitCheck {
+    private final Logger log = Logger.getLogger("org.openjdk.skara.jcheck.symlink");
+
+    @Override
+    Iterator<Issue> check(Commit commit, CommitMessage message, JCheckConfiguration conf) {
+        var metadata = CommitIssue.metadata(commit, message, conf, this);
+
+        var issues = new ArrayList<Issue>();
+        for (var diff : commit.parentDiffs()) {
+            for (var patch : diff.patches()) {
+                if (patch.target().type().isPresent()) {
+                    var type = patch.target().type().get();
+                    if (type.isSymbolicLink()) {
+                        var path = patch.target().path().get();
+                        log.finer("issue: " + path + " is symbolic link");
+                        issues.add(new SymlinkIssue(path, metadata));
+                    }
+                }
+            }
+        }
+
+        return issues.iterator();
+    }
+
+    @Override
+    public String name() {
+        return "symlink";
+    }
+
+    @Override
+    public String description() {
+        return "Files should not be symbolic links";
+    }
+}
+

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/SymlinkIssue.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/SymlinkIssue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,25 +22,23 @@
  */
 package org.openjdk.skara.jcheck;
 
-public interface IssueVisitor {
-    void visit(TagIssue issue);
-    void visit(BranchIssue issue);
-    void visit(DuplicateIssuesIssue issue);
-    void visit(SelfReviewIssue issue);
-    void visit(TooFewReviewersIssue issue);
-    void visit(InvalidReviewersIssue issue);
-    void visit(MergeMessageIssue issue);
-    void visit(HgTagCommitIssue issue);
-    void visit(CommitterIssue issue);
-    void visit(CommitterNameIssue issue);
-    void visit(CommitterEmailIssue issue);
-    void visit(AuthorNameIssue issue);
-    void visit(AuthorEmailIssue issue);
-    void visit(WhitespaceIssue issue);
-    void visit(MessageIssue issue);
-    void visit(IssuesIssue issue);
-    void visit(ExecutableIssue issue);
-    void visit(BlacklistIssue issue);
-    void visit(BinaryIssue issue);
-    void visit(SymlinkIssue issue);
+import java.nio.file.Path;
+
+public class SymlinkIssue extends CommitIssue {
+    private final Path path;
+
+    SymlinkIssue(Path path, CommitIssue.Metadata metadata) {
+        super(metadata);
+        this.path = path;
+    }
+
+    public Path path() {
+        return path;
+    }
+
+    @Override
+    public void accept(IssueVisitor v) {
+        v.visit(this);
+    }
 }
+

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/JCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/JCheckTests.java
@@ -198,6 +198,11 @@ class JCheckTests {
         }
 
         @Override
+        public void visit(SymlinkIssue e) {
+            issues.add(e);
+        }
+
+        @Override
         public void visit(AuthorNameIssue e) {
             issues.add(e);
         }

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/SymlinkCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/SymlinkCheckTests.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.jcheck;
+
+import org.openjdk.skara.vcs.*;
+import org.openjdk.skara.vcs.openjdk.*;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.ArrayList;
+import java.time.ZonedDateTime;
+import java.io.IOException;
+import java.nio.file.Path;
+
+class SymlinkCheckTests {
+    private final Utilities utils = new Utilities();
+
+    private static final List<String> CONFIGURATION = List.of(
+        "[general]",
+        "project = test",
+        "[checks]",
+        "error = symlink"
+    );
+
+    private static JCheckConfiguration conf() {
+        return JCheckConfiguration.parse(CONFIGURATION);
+    }
+
+    private static List<Diff> symlinkDiff(String filename) {
+        var patch = new TextualPatch(null, null, Hash.zero(),
+                                     Path.of(filename), FileType.fromOctal("120000"), Hash.zero(),
+                                     Status.from('A'), List.of());
+        var diff = new Diff(Hash.zero(), Hash.zero(), List.of(patch));
+        return List.of(diff);
+    }
+
+    private static List<Diff> diff(String filename, String line) {
+        var hunk = new Hunk(new Range(1, 0), List.of(),
+                            new Range(1, 1), List.of(line));
+        var patch = new TextualPatch(Path.of(filename), FileType.fromOctal("100644"), Hash.zero(),
+                                     Path.of(filename), FileType.fromOctal("100644"), Hash.zero(),
+                                     Status.from('M'), List.of(hunk));
+        var diff = new Diff(Hash.zero(), Hash.zero(), List.of(patch));
+        return List.of(diff);
+    }
+
+    private static Commit commit(List<Diff> diffs) {
+        var author = new Author("foo", "foo@localhost");
+        var hash = new Hash("0123456789012345678901234567890123456789");
+        var parents = List.of(hash);
+        var date = ZonedDateTime.now();
+        var metadata = new CommitMetadata(hash, parents, author, author, date, List.of("Added symlink"));
+        return new Commit(metadata, diffs);
+    }
+
+    private static Commit commitWithSymlink(String filename) {
+        return commit(symlinkDiff(filename));
+    }
+
+    private static Commit commitWithRegularFile(String filename, String line) {
+        return commit(diff(filename, line));
+    }
+
+    private static CommitMessage message(Commit c) {
+        return CommitMessageParsers.v1.parse(c);
+    }
+
+    private List<Issue> toList(Iterator<Issue> i) {
+        var list = new ArrayList<Issue>();
+        while (i.hasNext()) {
+            list.add(i.next());
+        }
+        return list;
+    }
+
+    @Test
+    void commitWithSymlinkShouldFail() {
+        var commit = commitWithSymlink("symlink");
+        var message = message(commit);
+        var check = new SymlinkCheck();
+        var issues = toList(check.check(commit, message, conf()));
+
+        assertEquals(1, issues.size());
+        assertTrue(issues.get(0) instanceof SymlinkIssue);
+        var issue = (SymlinkIssue) issues.get(0);
+        assertEquals("symlink", issue.path().toString());
+    }
+
+    @Test
+    void commitWithoutSymlinkShouldPass() {
+        var commit = commitWithRegularFile("README.txt", "Hello, world");
+        var message = message(commit);
+        var check = new SymlinkCheck();
+        var issues = toList(check.check(commit, message, conf()));
+        assertEquals(List.of(), issues);
+    }
+}


### PR DESCRIPTION
Hi all,

please review this patch that adds a check for symbolic links to JCheck.

Testing:
- `make test` passes on Linux x64
- Added two new unit tests

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**) ⚠️ Review applies to 69b8feddbc80898d6327b1aa3aeba9140ad6b8bd

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/525/head:pull/525`
`$ git checkout pull/525`
