### PR TITLE
jcheck: check for bad whitespace in commit message

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
@@ -192,6 +192,12 @@ class PullRequestCheckIssueVisitor implements IssueVisitor {
     }
 
     @Override
+    public void visit(MessageWhitespaceIssue issue) {
+        var message = String.join("\n", issue.commit().message());
+        throw new IllegalStateException("Commit message contains bad whitespace: " + message);
+    }
+
+    @Override
     public void visit(IssuesIssue issue) {
         messages.add("The commit message does not reference any issue. To add an issue reference to this PR, " +
                 "edit the title to be of the format `issue number`: `message`.");

--- a/cli/src/main/java/org/openjdk/skara/cli/JCheckCLIVisitor.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/JCheckCLIVisitor.java
@@ -217,6 +217,22 @@ class JCheckCLIVisitor implements IssueVisitor {
         }
     }
 
+    public void visit(MessageWhitespaceIssue i) {
+        if (!ignore.contains(i.check().name())) {
+            String desc = null;
+            if (i.kind().isTab()) {
+                desc = "tab";
+            } else if (i.kind().isCR()) {
+                desc = "carriage-return";
+            } else {
+                desc = "trailing whitespace";
+            }
+            println(i, "contains " + desc + " on line " + i.line() + " in commit message:");
+            System.out.println("> " + i.commit().message().get(i.line() - 1));
+            hasDisplayedErrors = true;
+        }
+    }
+
     public void visit(IssuesIssue i) {
         if (!ignore.contains(i.check().name())) {
             println(i, "missing reference to JBS issue in commit message");

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/IssueVisitor.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/IssueVisitor.java
@@ -38,6 +38,7 @@ public interface IssueVisitor {
     void visit(AuthorEmailIssue issue);
     void visit(WhitespaceIssue issue);
     void visit(MessageIssue issue);
+    void visit(MessageWhitespaceIssue issue);
     void visit(IssuesIssue issue);
     void visit(ExecutableIssue issue);
     void visit(BlacklistIssue issue);

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/MessageWhitespaceIssue.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/MessageWhitespaceIssue.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.jcheck;
+
+public class MessageWhitespaceIssue extends CommitIssue {
+    public static enum Whitespace {
+        TAB,
+        CR,
+        TRAILING;
+
+        public boolean isTab() {
+            return this == TAB;
+        }
+
+        public boolean isCR() {
+            return this == CR;
+        }
+
+        public boolean isTrailing() {
+            return this == TRAILING;
+        }
+    }
+
+    private final Whitespace kind;
+    private final int line;
+
+    private MessageWhitespaceIssue(CommitIssue.Metadata metadata, Whitespace kind, int line) {
+        super(metadata);
+        this.kind = kind;
+        this.line = line;
+    }
+
+    public Whitespace kind() {
+        return kind;
+    }
+
+    public int line() {
+        return line;
+    }
+
+    static MessageWhitespaceIssue tab(int line, CommitIssue.Metadata metadata) {
+        return new MessageWhitespaceIssue(metadata, Whitespace.TAB, line);
+    }
+
+    static MessageWhitespaceIssue cr(int line, CommitIssue.Metadata metadata) {
+        return new MessageWhitespaceIssue(metadata, Whitespace.CR, line);
+    }
+
+    static MessageWhitespaceIssue trailing(int line, CommitIssue.Metadata metadata) {
+        return new MessageWhitespaceIssue(metadata, Whitespace.TRAILING, line);
+    }
+
+    @Override
+    public void accept(IssueVisitor visitor) {
+        visitor.visit(this);
+    }
+}

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/JCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/JCheckTests.java
@@ -183,6 +183,11 @@ class JCheckTests {
         }
 
         @Override
+        public void visit(MessageWhitespaceIssue e) {
+            issues.add(e);
+        }
+
+        @Override
         public void visit(IssuesIssue e) {
             issues.add(e);
         }

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/MessageCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/MessageCheckTests.java
@@ -112,4 +112,46 @@ class MessageCheckTests {
         assertEquals(Severity.ERROR, issue.severity());
         assertEquals(MessageCheck.class, issue.check().getClass());
     }
+
+    @Test
+    void tabInCommitMessageShouldFail() {
+        var commit = commit(List.of("\tBugfix"));
+        var message = message(commit);
+        var check = new MessageCheck(utils);
+        var issues = toList(check.check(commit, message, conf()));
+
+        assertEquals(1, issues.size());
+        assertTrue(issues.get(0) instanceof MessageWhitespaceIssue);
+        var issue = (MessageWhitespaceIssue) issues.get(0);
+        assertEquals(MessageWhitespaceIssue.Whitespace.TAB, issue.kind());
+        assertEquals(1, issue.line());
+    }
+
+    @Test
+    void crInCommitMessageShouldFail() {
+        var commit = commit(List.of("Bugfix\r"));
+        var message = message(commit);
+        var check = new MessageCheck(utils);
+        var issues = toList(check.check(commit, message, conf()));
+
+        assertEquals(1, issues.size());
+        assertTrue(issues.get(0) instanceof MessageWhitespaceIssue);
+        var issue = (MessageWhitespaceIssue) issues.get(0);
+        assertEquals(MessageWhitespaceIssue.Whitespace.CR, issue.kind());
+        assertEquals(1, issue.line());
+    }
+
+    @Test
+    void trailingWhitespaceInMessageShouldFail() {
+        var commit = commit(List.of("Bugfix "));
+        var message = message(commit);
+        var check = new MessageCheck(utils);
+        var issues = toList(check.check(commit, message, conf()));
+
+        assertEquals(1, issues.size());
+        assertTrue(issues.get(0) instanceof MessageWhitespaceIssue);
+        var issue = (MessageWhitespaceIssue) issues.get(0);
+        assertEquals(MessageWhitespaceIssue.Whitespace.TRAILING, issue.kind());
+        assertEquals(1, issue.line());
+    }
 }


### PR DESCRIPTION
Hi all,

please review this patch that updates the "message" check in JCheck to also
check for bad whitespace (tabs, carriage return, trailing) in commit messages.

Testing:
- `make test` passes on Linux x64
- Added three new unit tests

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/526/head:pull/526`
`$ git checkout pull/526`
