### PR TITLE
322: Improve error message on non-author /integrate

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
@@ -57,7 +57,17 @@ public class IntegrateCommand implements CommandHandler {
     @Override
     public void handle(PullRequestBot bot, PullRequest pr, CensusInstance censusInstance, Path scratchPath, String args, Comment comment, List<Comment> allComments, PrintWriter reply) {
         if (!comment.author().equals(pr.author())) {
-            reply.println("Only the author (@" + pr.author().userName() + ") is allowed to issue the `integrate` command.");
+            reply.print("Only the author (@" + pr.author().userName() + ") is allowed to issue the `integrate` command.");
+
+            // If the command author is allowed to sponsor this change, suggest that command
+            var readyHash = ReadyForSponsorTracker.latestReadyForSponsor(pr.repository().forge().currentUser(), allComments);
+            if (readyHash.isPresent()) {
+                if (ProjectPermissions.mayCommit(censusInstance, comment.author())) {
+                    reply.print(" As this PR is ready to be sponsored, and you are an eligible sponsor, did you mean to issue the `/sponsor` command?");
+                    return;
+                }
+            }
+            reply.println();
             return;
         }
 


### PR DESCRIPTION
Hi all,

Please review this change that gives a more helpful error message if a potential sponsor issues the /integrate command when they probably wanted to do /sponsor.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-322](https://bugs.openjdk.java.net/browse/SKARA-322): Improve error message on non-author /integrate


### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/527/head:pull/527`
`$ git checkout pull/527`
