### PR TITLE
cli: better hg support in git-jcheck

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitJCheck.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitJCheck.java
@@ -163,8 +163,9 @@ public class GitJCheck {
 
         HttpProxy.setup();
 
+        var isMercurial = getSwitch("mercurial", arguments);
         var setupPrePushHooksOption = getOption("setup-pre-push-hooks", arguments);
-        if (setupPrePushHooksOption != null) {
+        if (!isMercurial && setupPrePushHooksOption != null) {
             var hookFile = repo.root().resolve(".git").resolve("hooks").resolve("pre-push");
             Files.createDirectories(hookFile.getParent());
             var lines = List.of(
@@ -193,11 +194,10 @@ public class GitJCheck {
             return 0;
         }
 
-        var isMercurial = getSwitch("mercurial", arguments);
         var isPrePush = getSwitch("pre-push", arguments);
         var ranges = new ArrayList<String>();
         var targetBranches = new HashSet<String>();
-        if (isPrePush) {
+        if (!isMercurial && isPrePush) {
             var reader = new BufferedReader(new InputStreamReader(System.in));
             var lines = reader.lines().collect(Collectors.toList());
             for (var line : lines) {
@@ -281,7 +281,7 @@ public class GitJCheck {
 
         var lines = repo.config("jcheck.pre-push.branches");
         var shouldCheckRemoteBranches = lines.size() == 1 && lines.get(0).toLowerCase().equals("true");
-        if (isPrePush && shouldCheckRemoteBranches &&
+        if (!isMercurial && isPrePush && shouldCheckRemoteBranches &&
             !Files.exists(repo.root().resolve(".git").resolve("GIT_SYNC_RUNNING"))) {
             var url = arguments.get("push-url").asString();
             if (url == null) {
@@ -322,12 +322,13 @@ public class GitJCheck {
             }
         }
 
-        var visitor = new JCheckCLIVisitor(ignore);
+        var visitor = new JCheckCLIVisitor(ignore, isMercurial);
         lines = repo.config("jcheck.pre-push.commits");
         var shouldCheckCommits = lines.size() == 1 && lines.get(0).toLowerCase().equals("true");
+        var commitMessageParser = isMercurial ? CommitMessageParsers.v0 : CommitMessageParsers.v1;
         if (!isPrePush || shouldCheckCommits) {
             for (var range : ranges) {
-                try (var errors = JCheck.check(repo, census, CommitMessageParsers.v1, range, whitelist, blacklist)) {
+                try (var errors = JCheck.check(repo, census, commitMessageParser, range, whitelist, blacklist)) {
                     for (var error : errors) {
                         error.accept(visitor);
                     }

--- a/cli/src/main/java/org/openjdk/skara/cli/JCheckCLIVisitor.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/JCheckCLIVisitor.java
@@ -32,14 +32,16 @@ import java.util.stream.Collectors;
 
 class JCheckCLIVisitor implements IssueVisitor {
     private final Set<String> ignore;
+    private final boolean isMercurial;
     private boolean hasDisplayedErrors;
 
     public JCheckCLIVisitor() {
-        this(Set.of());
+        this(Set.of(), false);
     }
 
-    public JCheckCLIVisitor(Set<String> ignore) {
+    public JCheckCLIVisitor(Set<String> ignore, boolean isMercurial) {
         this.ignore = ignore;
+        this.isMercurial = isMercurial;
         this.hasDisplayedErrors = false;
     }
 
@@ -242,7 +244,7 @@ class JCheckCLIVisitor implements IssueVisitor {
     }
 
     public void visit(AuthorEmailIssue i) {
-        if (!ignore.contains(i.check().name())) {
+        if (!ignore.contains(i.check().name()) && !isMercurial) {
             println(i, "missing author email");
             hasDisplayedErrors = true;
         }
@@ -256,7 +258,7 @@ class JCheckCLIVisitor implements IssueVisitor {
     }
 
     public void visit(CommitterEmailIssue i) {
-        if (!ignore.contains(i.check().name())) {
+        if (!ignore.contains(i.check().name()) && !isMercurial) {
             var domain = i.expectedDomain();
             println(i, "missing committer email from domain " + domain);
             hasDisplayedErrors = true;


### PR DESCRIPTION
Hi all,

please review this patch that adds better support for the `--mercurial` flag to
`git-jcheck`. Some newer (git specific) features will be disabled when
`--mercurial` is passed and errors will not be shown for missing email
addresses.

Testing:
- Manual testing of `git jcheck --mercurial` on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/528/head:pull/528`
`$ git checkout pull/528`
