### PR TITLE
git-sync: use refspec instead of --prune-tags

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -413,7 +413,9 @@ public class GitRepository implements Repository {
 
     @Override
     public void fetchRemote(String remote) throws IOException {
-        try (var p = capture("git", "fetch", "--recurse-submodules=on-demand", "--prune", remote, "+refs/tags/*:refs/tags/*")) {
+        var lines = config("remote." + remote + ".fetch");
+        var refspec = lines.size() == 1 ? lines.get(0) : "+refs/heads/*:refs/remotes/" + remote + "/*";
+        try (var p = capture("git", "fetch", "--recurse-submodules=on-demand", "--prune", remote, refspec, "+refs/tags/*:refs/tags/*")) {
             await(p);
         }
     }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -413,7 +413,7 @@ public class GitRepository implements Repository {
 
     @Override
     public void fetchRemote(String remote) throws IOException {
-        try (var p = capture("git", "fetch", "--recurse-submodules=on-demand", "--tags", "--prune", "--prune-tags", remote)) {
+        try (var p = capture("git", "fetch", "--recurse-submodules=on-demand", "--prune", remote, "+refs/tags/*:refs/tags/*")) {
             await(p);
         }
     }


### PR DESCRIPTION
Hi all,

please review this small patch that uses a refspec instead of `--prune-tags` for
`GitRepository.fetchRemote`. The flag `--prune-tags` was introduced in Git 2.17
and we want to support older Git versions, so I opted to use a refspec instead
to achieve the same effect.

Testing:
- Manual testing of `git sync` on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/529/head:pull/529`
`$ git checkout pull/529`
