### PR TITLE
318: The "outdated" label should be renamed to "merge-conlict"

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -609,16 +609,16 @@ class CheckRun {
             var commitMessage = String.join("\n", commit.message());
             var readyForIntegration = visitor.getMessages().isEmpty() && additionalErrors.isEmpty();
             updateMergeReadyComment(readyForIntegration, commitMessage, comments, activeReviews, rebasePossible);
-            if (readyForIntegration) {
+            if (readyForIntegration && rebasePossible) {
                 newLabels.add("ready");
             } else {
                 newLabels.remove("ready");
             }
             if (!rebasePossible) {
                 addOutdatedComment(comments);
-                newLabels.add("outdated");
+                newLabels.add("merge-conflict");
             } else {
-                newLabels.remove("outdated");
+                newLabels.remove("merge-conflict");
             }
 
             // Ensure that the ready for sponsor label is up to date

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -564,6 +564,7 @@ class CheckTests {
 
             // Get all messages up to date
             TestBotRunner.runPeriodicItems(mergeBot);
+            assertTrue(pr.labels().contains("ready"));
 
             // Push something conflicting to master
             localRepo.checkout(masterHash, true);
@@ -581,7 +582,8 @@ class CheckTests {
             assertEquals(1, updated);
 
             // The PR should be flagged as outdated
-            assertTrue(pr.labels().contains("outdated"));
+            assertTrue(pr.labels().contains("merge-conflict"));
+            assertFalse(pr.labels().contains("ready"));
 
             // An instructional message should have been bosted
             var help = pr.comments().stream()
@@ -608,7 +610,8 @@ class CheckTests {
             assertEquals(1, updated);
 
             // The PR should not be flagged as outdated
-            assertFalse(pr.labels().contains("outdated"));
+            assertFalse(pr.labels().contains("merge-conflict"));
+            assertTrue(pr.labels().contains("ready"));
         }
     }
 

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/Utils.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/Utils.java
@@ -160,8 +160,8 @@ class Utils {
             return "READY";
         } else if (labels.contains("rfr")) {
             return "RFR";
-        } else if (labels.contains("outdated")) {
-            return "OUTDATED";
+        } else if (labels.contains("merge-conflict")) {
+            return "CONFLICT";
         } else if (labels.contains("oca")) {
             return "OCA";
         } else {


### PR DESCRIPTION
Hi all,

Please review this change that renames the outdated label, and also drops the ready label for PRs with merge conflicts.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-318](https://bugs.openjdk.java.net/browse/SKARA-318): The "outdated" label should be renamed to "merge-conlict"


### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/531/head:pull/531`
`$ git checkout pull/531`
