### PR TITLE
jcheck: report all issues from "committer" check

### DIFF
--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/CommitterCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/CommitterCheckTests.java
@@ -210,7 +210,7 @@ class CommitterCheckTests {
         var check = new CommitterCheck(census());
         var issues = toList(check.check(commit, message, conf()));
 
-        assertEquals(1, issues.size());
+        assertEquals(2, issues.size());
         assertTrue(issues.get(0) instanceof CommitterNameIssue);
         var issue = (CommitterNameIssue) issues.get(0);
         assertEquals(commit, issue.commit());
@@ -228,7 +228,7 @@ class CommitterCheckTests {
         var check = new CommitterCheck(census());
         var issues = toList(check.check(commit, message, conf()));
 
-        assertEquals(1, issues.size());
+        assertEquals(2, issues.size());
         assertTrue(issues.get(0) instanceof CommitterEmailIssue);
         var issue = (CommitterEmailIssue) issues.get(0);
         assertEquals(commit, issue.commit());


### PR DESCRIPTION
Hi all,

please review this patch that ensures that the "committer" check in JCheck
reports all issues at once instead of one at a time.

Testing:
- `make test` on Linux x64
- Updated two unit tests

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/532/head:pull/532`
`$ git checkout pull/532`
