### PR TITLE
Reuse HttpClient instances

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
@@ -49,6 +49,9 @@ class WebrevStorage {
     private final URI baseUri;
     private final EmailAddress author;
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots.mlbridge");
+    private static final HttpClient client = HttpClient.newBuilder()
+                                                       .connectTimeout(Duration.ofSeconds(10))
+                                                       .build();
 
     WebrevStorage(HostedRepository storage, String ref, Path baseFolder, URI baseUri, EmailAddress author) {
         this.baseFolder = baseFolder;
@@ -178,9 +181,7 @@ class WebrevStorage {
     private void awaitPublication(URI uri, Duration timeout) throws IOException {
         var end = Instant.now().plus(timeout);
         var uriBuilder = URIBuilder.base(uri);
-        var client = HttpClient.newBuilder()
-                               .connectTimeout(Duration.ofSeconds(30))
-                               .build();
+
         while (Instant.now().isBefore(end)) {
             var uncachedUri = uriBuilder.setQuery(Map.of("nocache", UUID.randomUUID().toString())).build();
             log.fine("Validating webrev URL: " + uncachedUri);

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubApplication.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubApplication.java
@@ -96,6 +96,9 @@ public class GitHubApplication {
     private final Token installationToken;
 
     private final Logger log;
+    private static final HttpClient client = HttpClient.newBuilder()
+                                                       .connectTimeout(Duration.ofSeconds(10))
+                                                       .build();
 
     static class GitHubConfigurationError extends RuntimeException {
         public GitHubConfigurationError(String message) {
@@ -174,9 +177,6 @@ public class GitHubApplication {
 
     private String generateInstallationToken() throws Token.GeneratorError {
         var tokens = URIBuilder.base(apiBase).setPath("/installations/" + id + "/access_tokens").build();
-        var client = HttpClient.newBuilder()
-                               .connectTimeout(Duration.ofSeconds(10))
-                               .build();
 
         try {
             var response = client.send(
@@ -208,9 +208,6 @@ public class GitHubApplication {
 
     JSONObject getAppDetails() {
         var details = URIBuilder.base(apiBase).setPath("/app").build();
-        var client = HttpClient.newBuilder()
-                               .connectTimeout(Duration.ofSeconds(10))
-                               .build();
 
         try {
             var response = client.send(

--- a/mailinglist/src/main/java/org/openjdk/skara/mailinglist/mailman/MailmanList.java
+++ b/mailinglist/src/main/java/org/openjdk/skara/mailinglist/mailman/MailmanList.java
@@ -40,6 +40,9 @@ public class MailmanList implements MailingList {
     private final Logger log = Logger.getLogger("org.openjdk.skara.mailinglist");
     private final ConcurrentMap<URI, HttpResponse<String>> pageCache = new ConcurrentHashMap<>();
     private List<Conversation> cachedConversations = new ArrayList<>();
+    private static final HttpClient client = HttpClient.newBuilder()
+                                                       .connectTimeout(Duration.ofSeconds(10))
+                                                       .build();
 
     MailmanList(MailmanServer server, EmailAddress name) {
         this.server = server;
@@ -106,8 +109,6 @@ public class MailmanList implements MailingList {
 
     @Override
     public List<Conversation> conversations(Duration maxAge) {
-        var client = HttpClient.newHttpClient();
-
         // Order pages by most recent first
         var potentialPages = getMonthRange(maxAge).stream()
                                                   .sorted(Comparator.reverseOrder())


### PR DESCRIPTION
Hi all,

Please review this change that improves reuse of HttpClient instances, as they can be shared and creating new ones causes unnecessary thread creation.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/534/head:pull/534`
`$ git checkout pull/534`
