### PR TITLE
mirror-bot: support mirroring of selected branches

### DIFF
--- a/bots/mirror/src/main/java/org/openjdk/skara/bots/mirror/MirrorBotFactory.java
+++ b/bots/mirror/src/main/java/org/openjdk/skara/bots/mirror/MirrorBotFactory.java
@@ -23,10 +23,12 @@
 package org.openjdk.skara.bots.mirror;
 
 import org.openjdk.skara.bot.*;
+import org.openjdk.skara.vcs.Branch;
 
 import java.io.*;
 import java.nio.file.Files;
 import java.util.*;
+import java.util.stream.Collectors;
 import java.util.logging.Logger;
 
 public class MirrorBotFactory implements BotFactory {
@@ -55,8 +57,15 @@ public class MirrorBotFactory implements BotFactory {
             var toName = repo.get("to").asString();
             var toRepo = configuration.repository(toName);
 
+            var branchNames = repo.contains("branches")?
+                repo.get("branches").asString().split(",") : new String[0];
+            var branches = Arrays.stream(branchNames)
+                                 .map(Branch::new)
+                                 .collect(Collectors.toList());
+
+
             log.info("Setting up mirroring from " + fromRepo.name() + "to " + toRepo.name());
-            bots.add(new MirrorBot(storage, fromRepo, toRepo));
+            bots.add(new MirrorBot(storage, fromRepo, toRepo, branches));
         }
         return bots;
     }

--- a/bots/mirror/src/test/java/org/openjdk/skara/bots/mirror/MirrorBotTests.java
+++ b/bots/mirror/src/test/java/org/openjdk/skara/bots/mirror/MirrorBotTests.java
@@ -219,4 +219,52 @@ class MirrorBotTests {
             assertTrue(toBranches.contains(new Branch("third")));
         }
     }
+
+    @Test
+    void mirrorSelectedBranches(TestInfo testInfo) throws IOException {
+        try (var temp = new TemporaryDirectory()) {
+            var host = TestHost.createNew(List.of(new HostUser(0, "duke", "J. Duke")));
+
+            var fromDir = temp.path().resolve("from.git");
+            var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
+            var fromHostedRepo = new TestHostedRepository(host, "test", fromLocalRepo);
+
+            var toDir = temp.path().resolve("to.git");
+            var toLocalRepo = Repository.init(toDir, VCS.GIT);
+            var gitConfig = toDir.resolve(".git").resolve("config");
+            Files.write(gitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
+                        StandardOpenOption.APPEND);
+            var toHostedRepo = new TestHostedRepository(host, "test-mirror", toLocalRepo);
+
+            var newFile = fromDir.resolve("this-file-cannot-exist.txt");
+            Files.writeString(newFile, "Hello world\n");
+            fromLocalRepo.add(newFile);
+            var first = fromLocalRepo.commit("An additional commit", "duke", "duke@openjdk.org");
+            var featureBranch = fromLocalRepo.branch(first, "feature");
+            fromLocalRepo.checkout(featureBranch, false);
+            assertEquals(Optional.of(featureBranch), fromLocalRepo.currentBranch());
+
+            Files.writeString(newFile, "Hello again\n", StandardOpenOption.APPEND);
+            fromLocalRepo.add(newFile);
+            var second = fromLocalRepo.commit("An additional commit", "duke", "duke@openjdk.org");
+
+            assertEquals(Optional.of(first), fromLocalRepo.resolve("master"));
+            assertEquals(Optional.of(second), fromLocalRepo.resolve("feature"));
+
+            var fromCommits = fromLocalRepo.commits().asList();
+            assertEquals(2, fromCommits.size());
+
+            var toCommits = toLocalRepo.commits().asList();
+            assertEquals(0, toCommits.size());
+
+            var storage = temp.path().resolve("storage");
+            var bot = new MirrorBot(storage, fromHostedRepo, toHostedRepo, List.of(new Branch("master")));
+            TestBotRunner.runPeriodicItems(bot);
+
+            toCommits = toLocalRepo.commits().asList();
+            assertEquals(1, toCommits.size());
+            assertEquals(first, toCommits.get(0).hash());
+            assertEquals(List.of(new Branch("master")), toLocalRepo.branches());
+        }
+    }
 }


### PR DESCRIPTION
Hi all,

please review this patch that enables the mirror bot to mirror only selected
branches (instead of all as is done today). This is useful for projects who
might have a `master` that is a replica of `jdk:master`, but don't want tags
(nor potentially other branches) from the
[jdk](https://git.openjdk.java.net/jdk) repository.

Testing:
- `make test` passes on Linux x64
- Added a new unit test

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/536/head:pull/536`
`$ git checkout pull/536`
