### PR TITLE
321: No RFR mail is sent if a PR is integrated very quickly

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveItem.java
@@ -49,9 +49,11 @@ class ArchiveItem {
     static ArchiveItem from(PullRequest pr, Repository localRepo, HostUserToEmailAuthor hostUserToEmailAuthor,
                             URI issueTracker, String issuePrefix, WebrevStorage.WebrevGenerator webrevGenerator,
                             WebrevNotification webrevNotification, ZonedDateTime created, ZonedDateTime updated,
-                            Hash base, Hash head, String subjectPrefix) {
-        return new ArchiveItem(null, "fc", created, updated, pr.author(), Map.of("PR-Head-Hash", head.hex(), "PR-Base-Hash", base.hex()),
-                               () -> subjectPrefix + "RFR: " + pr.title(),
+                            Hash base, Hash head, String subjectPrefix, String threadPrefix) {
+        return new ArchiveItem(null, "fc", created, updated, pr.author(), Map.of("PR-Head-Hash", head.hex(),
+                                                                                 "PR-Base-Hash", base.hex(),
+                                                                                 "PR-Thread-Prefix", threadPrefix),
+                               () -> subjectPrefix + threadPrefix + ": " + pr.title(),
                                () -> "",
                                () -> ArchiveMessages.composeConversation(pr, localRepo, base, head),
                                () -> {
@@ -108,9 +110,9 @@ class ArchiveItem {
     static ArchiveItem from(PullRequest pr, Repository localRepo, HostUserToEmailAuthor hostUserToEmailAuthor,
                             WebrevStorage.WebrevGenerator webrevGenerator, WebrevNotification webrevNotification,
                             ZonedDateTime created, ZonedDateTime updated, Hash lastBase, Hash lastHead, Hash base,
-                            Hash head, int index, ArchiveItem parent, String subjectPrefix) {
+                            Hash head, int index, ArchiveItem parent, String subjectPrefix, String threadPrefix) {
         return new ArchiveItem(parent,"ha" + head.hex(), created, updated, pr.author(), Map.of("PR-Head-Hash", head.hex(), "PR-Base-Hash", base.hex()),
-                               () -> String.format("Re: %s[Rev %02d] RFR: %s", subjectPrefix, index, pr.title()),
+                               () -> String.format("Re: %s[Rev %02d] %s: %s", subjectPrefix, index, threadPrefix, pr.title()),
                                () -> "",
                                () -> {
                                    if (lastBase.equals(base)) {

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
@@ -26,7 +26,7 @@ import org.openjdk.skara.bot.WorkItem;
 import org.openjdk.skara.email.*;
 import org.openjdk.skara.forge.*;
 import org.openjdk.skara.host.HostUser;
-import org.openjdk.skara.issuetracker.Comment;
+import org.openjdk.skara.issuetracker.*;
 import org.openjdk.skara.mailinglist.*;
 import org.openjdk.skara.vcs.Repository;
 
@@ -243,9 +243,17 @@ class ArchiveWorkItem implements WorkItem {
         // First determine if this PR should be inspected further or not
         if (sentMails.isEmpty()) {
             var labels = new HashSet<>(pr.labels());
-            for (var readyLabel : bot.readyLabels()) {
-                if (!labels.contains(readyLabel)) {
-                    log.fine("PR is not yet ready - missing label '" + readyLabel + "'");
+
+            if (pr.state() == Issue.State.OPEN) {
+                for (var readyLabel : bot.readyLabels()) {
+                    if (!labels.contains(readyLabel)) {
+                        log.fine("PR is not yet ready - missing label '" + readyLabel + "'");
+                        return;
+                    }
+                }
+            } else {
+                if (!labels.contains("integrated")) {
+                    log.fine("Closed PR was not integrated - will not initiate an RFR thread");
                     return;
                 }
             }

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBot.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBot.java
@@ -197,8 +197,8 @@ public class MailingListBridgeBot implements Bot {
             log.info("Fetching all open pull requests");
             prs = codeRepo.pullRequests();
         } else {
-            log.info("Fetching only pull requests updated after " + lastPartialUpdate.minus(cooldown));
-            prs = codeRepo.pullRequests(lastPartialUpdate.minus(cooldown));
+            log.info("Fetching recently updated pull requests (open and closed)");
+            prs = codeRepo.pullRequests(ZonedDateTime.now().minus(Duration.ofDays(14)));
             lastPartialUpdate = ZonedDateTime.now();
         }
 

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
@@ -78,10 +78,17 @@ class WebrevStorage {
                 var conf = JCheckConfiguration.from(localRepository, head);
                 var project = conf.general().jbs() != null ? conf.general().jbs() : conf.general().project();
                 var id = issue.get().id();
-                var issueTracker = IssueTracker.from("jira", URI.create("https://bugs.openjdk.java.net"));
-                var hostedIssue = issueTracker.project(project).issue(id);
-                if (hostedIssue.isPresent()) {
-                    builder = builder.issue(hostedIssue.get().webUrl().toString());
+                IssueTracker issueTracker = null;
+                try {
+                    issueTracker = IssueTracker.from("jira", URI.create("https://bugs.openjdk.java.net"));
+                } catch (RuntimeException e) {
+                    log.warning("Failed to create Jira issue tracker");
+                }
+                if (issueTracker != null) {
+                    var hostedIssue = issueTracker.project(project).issue(id);
+                    if (hostedIssue.isPresent()) {
+                        builder = builder.issue(hostedIssue.get().webUrl().toString());
+                    }
                 }
             }
         }

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -24,6 +24,7 @@ package org.openjdk.skara.bots.mlbridge;
 
 import org.openjdk.skara.email.EmailAddress;
 import org.openjdk.skara.forge.*;
+import org.openjdk.skara.issuetracker.Issue;
 import org.openjdk.skara.network.URIBuilder;
 import org.openjdk.skara.mailinglist.MailingListServerFactory;
 import org.openjdk.skara.test.*;
@@ -266,6 +267,158 @@ class MailingListBridgeBotTests {
                 assertEquals(listAddress, newMail.sender());
             }
             assertTrue(conversations.get(0).allMessages().get(2).body().contains("This is a comment 😄"));
+        }
+    }
+
+    @Test
+    void archiveIntegrated(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory();
+             var archiveFolder = new TemporaryDirectory();
+             var webrevFolder = new TemporaryDirectory();
+             var listServer = new TestMailmanServer();
+             var webrevServer = new TestWebrevServer()) {
+            var author = credentials.getHostedRepository();
+            var archive = credentials.getHostedRepository();
+            var ignored = credentials.getHostedRepository();
+            var listAddress = EmailAddress.parse(listServer.createList("test"));
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addAuthor(author.forge().currentUser().id());
+            var from = EmailAddress.from("test", "test@test.mail");
+            var mlBot = MailingListBridgeBot.newBuilder()
+                                            .from(from)
+                                            .repo(author)
+                                            .archive(archive)
+                                            .censusRepo(censusBuilder.build())
+                                            .list(listAddress)
+                                            .ignoredUsers(Set.of(ignored.forge().currentUser().userName()))
+                                            .listArchive(listServer.getArchive())
+                                            .smtpServer(listServer.getSMTP())
+                                            .webrevStorageRepository(archive)
+                                            .webrevStorageRef("webrev")
+                                            .webrevStorageBase(Path.of("test"))
+                                            .webrevStorageBaseUri(webrevServer.uri())
+                                            .issueTracker(URIBuilder.base("http://issues.test/browse/").build())
+                                            .build();
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, archive.url(), "webrev", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo, "A simple change",
+                                                               "Change msg\n\nWith several lines");
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(archive, "master", "edit", "1234: This is a pull request");
+            pr.setBody("This should not be ready");
+            pr.setState(Issue.State.CLOSED);
+
+            // Run an archive pass
+            TestBotRunner.runPeriodicItems(mlBot);
+            TestBotRunner.runPeriodicItems(mlBot);
+
+            // A PR that isn't ready for review should not be archived
+            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            assertFalse(archiveContains(archiveFolder.path(), "This is a pull request"));
+
+            // Flag it as ready for review
+            pr.setBody("This has already been integrated");
+            pr.addLabel("integrated");
+
+            // Run another archive pass
+            TestBotRunner.runPeriodicItems(mlBot);
+
+            // The archive should now contain an entry
+            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            assertTrue(archiveContains(archiveFolder.path(), "Subject: FYI: 1234: This is a pull request"));
+
+            var updatedHash = CheckableRepository.appendAndCommit(localRepo, "Another change");
+            localRepo.push(updatedHash, author.url(), "edit");
+
+            // Run another archive pass
+            TestBotRunner.runPeriodicItems(mlBot);
+
+            // The archive should now contain another entry
+            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            assertTrue(archiveContains(archiveFolder.path(), "Subject: Re: \\[Rev 01\\] FYI: 1234: This is a pull request"));
+        }
+    }
+
+    @Test
+    void archiveIntegratedRetainPrefix(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory();
+             var archiveFolder = new TemporaryDirectory();
+             var webrevFolder = new TemporaryDirectory();
+             var listServer = new TestMailmanServer();
+             var webrevServer = new TestWebrevServer()) {
+            var author = credentials.getHostedRepository();
+            var archive = credentials.getHostedRepository();
+            var ignored = credentials.getHostedRepository();
+            var listAddress = EmailAddress.parse(listServer.createList("test"));
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addAuthor(author.forge().currentUser().id());
+            var from = EmailAddress.from("test", "test@test.mail");
+            var mlBot = MailingListBridgeBot.newBuilder()
+                                            .from(from)
+                                            .repo(author)
+                                            .archive(archive)
+                                            .censusRepo(censusBuilder.build())
+                                            .list(listAddress)
+                                            .ignoredUsers(Set.of(ignored.forge().currentUser().userName()))
+                                            .listArchive(listServer.getArchive())
+                                            .smtpServer(listServer.getSMTP())
+                                            .webrevStorageRepository(archive)
+                                            .webrevStorageRef("webrev")
+                                            .webrevStorageBase(Path.of("test"))
+                                            .webrevStorageBaseUri(webrevServer.uri())
+                                            .issueTracker(URIBuilder.base("http://issues.test/browse/").build())
+                                            .build();
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, archive.url(), "webrev", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo, "A simple change",
+                                                               "Change msg\n\nWith several lines");
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(archive, "master", "edit", "1234: This is a pull request");
+            pr.setBody("This should be ready");
+
+            // Run an archive pass
+            TestBotRunner.runPeriodicItems(mlBot);
+            TestBotRunner.runPeriodicItems(mlBot);
+
+            // A PR that isn't ready for review should not be archived
+            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            assertFalse(archiveContains(archiveFolder.path(), "This is a pull request"));
+
+            // Flag it as ready for review
+            pr.addLabel("rfr");
+
+            // Run another archive pass
+            TestBotRunner.runPeriodicItems(mlBot);
+
+            // The archive should now contain an entry
+            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            assertTrue(archiveContains(archiveFolder.path(), "Subject: RFR: 1234: This is a pull request"));
+
+            // Close it and then push another change
+            pr.setState(Issue.State.CLOSED);
+            var updatedHash = CheckableRepository.appendAndCommit(localRepo, "Another change");
+            localRepo.push(updatedHash, author.url(), "edit");
+
+            // Run another archive pass
+            TestBotRunner.runPeriodicItems(mlBot);
+
+            // The archive should now contain another entry - should retain the RFR thread prefix
+            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            assertTrue(archiveContains(archiveFolder.path(), "Subject: Re: \\[Rev 01\\] RFR: 1234: This is a pull request"));
         }
     }
 

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -374,6 +374,7 @@ class MailingListBridgeBotTests {
                                             .webrevStorageRef("webrev")
                                             .webrevStorageBase(Path.of("test"))
                                             .webrevStorageBaseUri(webrevServer.uri())
+                                            .readyLabels(Set.of("rfr"))
                                             .issueTracker(URIBuilder.base("http://issues.test/browse/").build())
                                             .build();
 

--- a/test/src/main/java/org/openjdk/skara/test/TestHost.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHost.java
@@ -161,7 +161,6 @@ public class TestHost implements Forge, IssueTracker {
         return data.pullRequests.entrySet().stream()
                                 .sorted(Comparator.comparing(Map.Entry::getKey))
                                 .map(pr -> getPullRequest(repository, pr.getKey()))
-                                .filter(pr -> pr.state().equals(Issue.State.OPEN))
                                 .collect(Collectors.toList());
     }
 

--- a/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
@@ -23,6 +23,7 @@
 package org.openjdk.skara.test;
 
 import org.openjdk.skara.forge.*;
+import org.openjdk.skara.issuetracker.Issue;
 import org.openjdk.skara.json.JSONValue;
 import org.openjdk.skara.vcs.*;
 
@@ -70,7 +71,9 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
 
     @Override
     public List<PullRequest> pullRequests() {
-        return new ArrayList<>(host.getPullRequests(this));
+        return host.getPullRequests(this).stream()
+                   .filter(pr -> pr.state().equals(Issue.State.OPEN))
+                   .collect(Collectors.toList());
     }
 
     @Override


### PR DESCRIPTION
Hi all,

Please review this change that enables sending notification emails for PRs that have been integrated before an RFR mail was created.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-321](https://bugs.openjdk.java.net/browse/SKARA-321): No RFR mail is sent if a PR is integrated very quickly


### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/538/head:pull/538`
`$ git checkout pull/538`
