### PR TITLE
vcs: use --recurse-submodules when pulling

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -1178,6 +1178,7 @@ public class GitRepository implements Repository {
         var cmd = new ArrayList<String>();
         cmd.add("git");
         cmd.add("pull");
+        cmd.add("--recurse-submodules");
         if (remote != null) {
             cmd.add(remote);
         }


### PR DESCRIPTION
Hi all,

please review this small patch that adds `--recurse-submodules` when running
`GitRepository.pull`.

Testing:
- `make test` passes on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/539/head:pull/539`
`$ git checkout pull/539`
