### PR TITLE
cli: use credentials when pushing to https URLs

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/pr/Utils.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/Utils.java
@@ -464,6 +464,9 @@ class Utils {
             }
             exit("error: failed to connect to host: " + forgeURI);
         }
+        if (credentials != null) {
+            GitCredentials.approve(credentials);
+        }
         return forge.get();
     }
 }


### PR DESCRIPTION
Hi all,

please review this patch that makes `git-sync` and `git-publish` use credentials
when they are pushing to `https://` URLs. I also update all `git-pr` to approve
credentials that have been used successfully.

Testing:
- Manual testing of `git-sync`, `git-publish` and `git-pr` together with
  `https://` URLs

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/541/head:pull/541`
`$ git checkout pull/541`
