### PR TITLE
Use a different (empty) thread prefix for failed automerge PRs

### DIFF
--- a/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
+++ b/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
@@ -494,11 +494,13 @@ class MergeBot implements Bot, WorkItem {
                     message.add("Thanks,");
                     message.add("J. Duke");
 
-                    fork.createPullRequest(prTarget,
-                                           toBranch.name(),
-                                           branchDesc,
-                                           title,
-                                           message);
+                    var prFromFork = fork.createPullRequest(prTarget,
+                                                            toBranch.name(),
+                                                            branchDesc,
+                                                            title,
+                                                            message);
+                    var prFromTarget = prTarget.pullRequest(prFromFork.id());
+                    prFromTarget.addLabel("failed-auto-merge");
                 }
             }
         } catch (IOException e) {

--- a/bots/merge/src/test/java/org/openjdk/skara/bots/merge/MergeBotTests.java
+++ b/bots/merge/src/test/java/org/openjdk/skara/bots/merge/MergeBotTests.java
@@ -184,6 +184,7 @@ class MergeBotTests {
             assertEquals(1, pullRequests.size());
             var pr = pullRequests.get(0);
             assertEquals("Cannot automatically merge test:master to master", pr.title());
+            assertTrue(pr.labels().contains("failed-auto-merge"));
         }
     }
 

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveItem.java
@@ -53,7 +53,7 @@ class ArchiveItem {
         return new ArchiveItem(null, "fc", created, updated, pr.author(), Map.of("PR-Head-Hash", head.hex(),
                                                                                  "PR-Base-Hash", base.hex(),
                                                                                  "PR-Thread-Prefix", threadPrefix),
-                               () -> subjectPrefix + threadPrefix + ": " + pr.title(),
+                               () -> subjectPrefix + threadPrefix + (threadPrefix.isEmpty() ? "" : ": ") + pr.title(),
                                () -> "",
                                () -> ArchiveMessages.composeConversation(pr, localRepo, base, head),
                                () -> {
@@ -112,7 +112,7 @@ class ArchiveItem {
                             ZonedDateTime created, ZonedDateTime updated, Hash lastBase, Hash lastHead, Hash base,
                             Hash head, int index, ArchiveItem parent, String subjectPrefix, String threadPrefix) {
         return new ArchiveItem(parent,"ha" + head.hex(), created, updated, pr.author(), Map.of("PR-Head-Hash", head.hex(), "PR-Base-Hash", base.hex()),
-                               () -> String.format("Re: %s[Rev %02d] %s: %s", subjectPrefix, index, threadPrefix, pr.title()),
+                               () -> String.format("Re: %s[Rev %02d] %s%s", subjectPrefix, index, threadPrefix + (threadPrefix.isEmpty() ? "" : ": "), pr.title()),
                                () -> "",
                                () -> {
                                    if (lastBase.equals(base)) {

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
@@ -70,6 +70,8 @@ class ReviewArchive {
         } else {
             if (pr.state() != Issue.State.OPEN) {
                 threadPrefix = "FYI";
+            } else if (pr.labels().contains("failed-auto-merge")) {
+                threadPrefix = "";
             }
         }
 

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -424,6 +424,61 @@ class MailingListBridgeBotTests {
     }
 
     @Test
+    void archiveFailedAutoMerge(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory();
+             var archiveFolder = new TemporaryDirectory();
+             var webrevFolder = new TemporaryDirectory();
+             var listServer = new TestMailmanServer();
+             var webrevServer = new TestWebrevServer()) {
+            var author = credentials.getHostedRepository();
+            var archive = credentials.getHostedRepository();
+            var ignored = credentials.getHostedRepository();
+            var listAddress = EmailAddress.parse(listServer.createList("test"));
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addAuthor(author.forge().currentUser().id());
+            var from = EmailAddress.from("test", "test@test.mail");
+            var mlBot = MailingListBridgeBot.newBuilder()
+                                            .from(from)
+                                            .repo(author)
+                                            .archive(archive)
+                                            .censusRepo(censusBuilder.build())
+                                            .list(listAddress)
+                                            .ignoredUsers(Set.of(ignored.forge().currentUser().userName()))
+                                            .listArchive(listServer.getArchive())
+                                            .smtpServer(listServer.getSMTP())
+                                            .webrevStorageRepository(archive)
+                                            .webrevStorageRef("webrev")
+                                            .webrevStorageBase(Path.of("test"))
+                                            .webrevStorageBaseUri(webrevServer.uri())
+                                            .issueTracker(URIBuilder.base("http://issues.test/browse/").build())
+                                            .build();
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, archive.url(), "webrev", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo, "A simple change",
+                                                               "Change msg\n\nWith several lines");
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(archive, "master", "edit", "Cannot automatically merge");
+            pr.setBody("This is an automated merge PR");
+            pr.addLabel("failed-auto-merge");
+
+            // Run an archive pass
+            TestBotRunner.runPeriodicItems(mlBot);
+            TestBotRunner.runPeriodicItems(mlBot);
+
+            // The archive should contain an entry
+            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            assertTrue(archiveContains(archiveFolder.path(), "Subject: Cannot automatically merge"));
+        }
+    }
+
+    @Test
     void reviewComment(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
              var tempFolder = new TemporaryDirectory();


### PR DESCRIPTION
Hi all,

Please review this change that skips the "RFR: " prefix on mailing list threads initiated by a failed automerge PR.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/542/head:pull/542`
`$ git checkout pull/542`
