### PR TITLE
Catch exceptions caused by trying to look up issues during jcheck

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -337,18 +337,24 @@ class CheckRun {
             }
             progressBody.append("\n");
             for (var currentIssue : allIssues) {
-                var iss = issueProject.issue(currentIssue.id());
                 progressBody.append(" * ");
-                if (iss.isPresent()) {
-                    progressBody.append("[");
-                    progressBody.append(iss.get().id());
-                    progressBody.append("](");
-                    progressBody.append(iss.get().webUrl());
-                    progressBody.append("): ");
-                    progressBody.append(iss.get().title());
-                    progressBody.append("\n");
-                } else {
-                    progressBody.append("⚠️ Failed to retrieve information on issue `");
+                try {
+                    var iss = issueProject.issue(currentIssue.id());
+                    if (iss.isPresent()) {
+                        progressBody.append("[");
+                        progressBody.append(iss.get().id());
+                        progressBody.append("](");
+                        progressBody.append(iss.get().webUrl());
+                        progressBody.append("): ");
+                        progressBody.append(iss.get().title());
+                        progressBody.append("\n");
+                    } else {
+                        progressBody.append("⚠️ Failed to retrieve information on issue `");
+                        progressBody.append(currentIssue.id());
+                        progressBody.append("`.\n");
+                    }
+                } catch (RuntimeException e) {
+                    progressBody.append("⚠️ Temporary failure when trying to retrieve information on issue `");
                     progressBody.append(currentIssue.id());
                     progressBody.append("`.\n");
                 }


### PR DESCRIPTION
Hi all,

Please review this small fix that catches exceptions that occur when trying to lookup information on Jira issues during a check run, as the information is only used for informational purposes.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/543/head:pull/543`
`$ git checkout pull/543`
