### PR TITLE
csr-bot: allow other bots to run

### DIFF
--- a/bots/csr/src/main/java/org/openjdk/skara/bots/csr/CSRBot.java
+++ b/bots/csr/src/main/java/org/openjdk/skara/bots/csr/CSRBot.java
@@ -52,7 +52,7 @@ class CSRBot implements Bot, WorkItem {
     @Override
     public boolean concurrentWith(WorkItem other) {
         if (!(other instanceof CSRBot)) {
-            return false;
+            return true;
         }
 
         return !repo.webUrl().equals(((CSRBot) other).repo.webUrl());


### PR DESCRIPTION
Hi all,

please review this embarrassing patch that makes other bots allowed to run at
the same time as the `CSRBot`.

Testing:
- `make test` passes on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/544/head:pull/544`
`$ git checkout pull/544`
