### PR TITLE
The merge bot should use hostedrepository with proper credentials

### DIFF
--- a/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
+++ b/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
@@ -499,7 +499,7 @@ class MergeBot implements Bot, WorkItem {
                                                             branchDesc,
                                                             title,
                                                             message);
-                    var prFromTarget = prTarget.pullRequest(prFromFork.id());
+                    var prFromTarget = target.pullRequest(prFromFork.id());
                     prFromTarget.addLabel("failed-auto-merge");
                 }
             }


### PR DESCRIPTION
Hi all,

Please review this small change that ensures that when the merge bot tries to add a label, it uses proper credentials.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/545/head:pull/545`
`$ git checkout pull/545`
