### PR TITLE
forge: add HostedRepository.nonTransformedWebUrl

### DIFF
--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
@@ -92,6 +92,11 @@ class InMemoryHostedRepository implements HostedRepository {
     }
 
     @Override
+    public URI nonTransformedWebUrl() {
+        return webUrl();
+    }
+
+    @Override
     public URI webUrl(Hash hash) {
         return null;
     }

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
@@ -56,6 +56,7 @@ public interface HostedRepository {
     Optional<HostedRepository> parent();
     URI url();
     URI webUrl();
+    URI nonTransformedWebUrl();
     URI webUrl(Hash hash);
     VCS repositoryType();
     String fileContents(String filename, String ref);

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubHost.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubHost.java
@@ -137,11 +137,15 @@ public class GitHubHost implements Forge {
     }
 
     URI getWebURI(String endpoint) {
+        return getWebURI(endpoint, true);
+    }
+
+    URI getWebURI(String endpoint, boolean transform) {
         var baseWebUri = URIBuilder.base(uri)
                                    .setPath(endpoint)
                                    .build();
 
-        if (webUriPattern == null) {
+        if (webUriPattern == null || !transform) {
             return baseWebUri;
         }
 

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -189,6 +189,12 @@ public class GitHubRepository implements HostedRepository {
     }
 
     @Override
+    public URI nonTransformedWebUrl() {
+        var endpoint = "/" + repository;
+        return gitHubHost.getWebURI(endpoint, false);
+    }
+
+    @Override
     public URI webUrl(Hash hash) {
         var endpoint = "/" + repository + "/commit/" + hash.abbreviate();
         return gitHubHost.getWebURI(endpoint);

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -160,6 +160,11 @@ public class GitLabRepository implements HostedRepository {
     }
 
     @Override
+    public URI nonTransformedWebUrl() {
+        return webUrl();
+    }
+
+    @Override
     public URI webUrl(Hash hash) {
         return URIBuilder.base(gitLabHost.getUri())
                          .setPath("/" + projectName + "/commit/" + hash.abbreviate())

--- a/forge/src/test/java/org/openjdk/skara/forge/github/GitHubHostTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/github/GitHubHostTests.java
@@ -41,4 +41,14 @@ class GitHubHostTests {
             assertEquals(new URI("http://www.example.com/another/hello"), host.getWebURI("/test/hello"));
         }
     }
+
+    @Test
+    void nonTransformedWebUrl() throws IOException, URISyntaxException {
+        try (var tempFolder = new TemporaryDirectory()) {
+            var host = new GitHubHost(URIBuilder.base("http://www.example.com").build(),
+                                      Pattern.compile("^(http://www.example.com)/test/(.*)$"), "$1/another/$2");
+            assertEquals(new URI("http://www.example.com/another/hello"), host.getWebURI("/test/hello"));
+            assertEquals(new URI("http://www.example.com/test/hello"), host.getWebURI("/test/hello", false));
+        }
+    }
 }

--- a/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
@@ -127,6 +127,11 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
     }
 
     @Override
+    public URI nonTransformedWebUrl() {
+        return url();
+    }
+
+    @Override
     public URI webUrl(Hash hash) {
         try {
             return new URI(url().toString() + "/" + hash.hex());


### PR DESCRIPTION
Hi all,

please review this patch that adds the method `HostedRepository.nonTransformedWebUrl`. This will be used in a follow-up patch to improve the message from the `MergeBot`.

Testing:
- `make test` passes on Linux x64
- Added one new unit test

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/546/head:pull/546`
`$ git checkout pull/546`
