### PR TITLE
jcheck: add asString when parsing INI values

### DIFF
--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/JCheckConfiguration.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/JCheckConfiguration.java
@@ -87,7 +87,7 @@ public class JCheckConfiguration {
             shouldCheckMessage = true;
         }
         var checkDuplicateIssues = old.get("bugids");
-        if (checkDuplicateIssues == null || !checkDuplicateIssues.equals("dup")) {
+        if (checkDuplicateIssues == null || !checkDuplicateIssues.asString().equals("dup")) {
             error += ",duplicate-issues";
         }
         config.add(error);


### PR DESCRIPTION
Hi all,

please review this patch that adds a call to `toString` when comparing the value
for the `bugids` field from the `.jcheck/conf` of older format.

Testing:
- `make test` passes on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/548/head:pull/548`
`$ git checkout pull/548`
