### PR TITLE
339: Only show link to CONTRIBUTING.md if it exists

### DIFF
--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrateTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrateTests.java
@@ -688,4 +688,80 @@ class IntegrateTests {
             assertTrue(CheckableRepository.hasBeenEdited(pushedRepo));
         }
     }
+
+    @Test
+    void missingContributingFile(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory();
+             var pushedFolder = new TemporaryDirectory()) {
+
+            var author = credentials.getHostedRepository();
+            var integrator = credentials.getHostedRepository();
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addCommitter(author.forge().currentUser().id())
+                                           .addReviewer(integrator.forge().currentUser().id());
+            var prBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
+
+            // Approve it as another user
+            var approvalPr = integrator.pullRequest(pr.id());
+            approvalPr.addReview(Review.Verdict.APPROVED, "Approved");
+
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // The bot should reply with an instructional message and no link to CONTRIBUTING.md
+            var lastComment = pr.comments().get(pr.comments().size() - 1);
+            assertFalse(lastComment.body().contains("CONTRIBUTING.md"));
+        }
+    }
+
+    @Test
+    void existingContributingFile(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory();
+             var pushedFolder = new TemporaryDirectory()) {
+
+            var author = credentials.getHostedRepository();
+            var integrator = credentials.getHostedRepository();
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addCommitter(author.forge().currentUser().id())
+                                           .addReviewer(integrator.forge().currentUser().id());
+            var prBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
+            var contributingFile = localRepo.root().resolve("CONTRIBUTING.md");
+            Files.writeString(contributingFile, "Patches welcome!\n");
+            localRepo.add(contributingFile);
+            localRepo.commit("Add CONTRIBUTING.md", "duke", "duke@openjdk.org");
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
+
+            // Approve it as another user
+            var approvalPr = integrator.pullRequest(pr.id());
+            approvalPr.addReview(Review.Verdict.APPROVED, "Approved");
+
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // The bot should reply with an instructional message and no link to CONTRIBUTING.md
+            var lastComment = pr.comments().get(pr.comments().size() - 1);
+            assertTrue(lastComment.body().contains("CONTRIBUTING.md"));
+        }
+    }
 }


### PR DESCRIPTION
Hi all,

please review this patch that ensures that the pull request only shows a link to
a `CONTRIBUTING.md` file in the integration message if a `CONTRIBUTING.md`
actually exists.

Testing:
- Added two new unit tests
- `make test` passes on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-339](https://bugs.openjdk.java.net/browse/SKARA-339): Only show link to CONTRIBUTING.md if it exists


### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/551/head:pull/551`
`$ git checkout pull/551`
