### PR TITLE
webrev: do not fetch remote branches

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitWebrev.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitWebrev.java
@@ -36,6 +36,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.file.*;
 import java.util.*;
+import java.util.logging.Level;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -142,6 +143,14 @@ public class GitWebrev {
                   .fullname("no-outgoing")
                   .helptext("Do not compare against remote, use only 'status'")
                   .optional(),
+            Switch.shortcut("")
+                  .fullname("verbose")
+                  .helptext("Turn on verbose output")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("debug")
+                  .helptext("Turn on debugging output")
+                  .optional(),
             Switch.shortcut("v")
                   .fullname("version")
                   .helptext("Print the version of this tool")
@@ -160,6 +169,11 @@ public class GitWebrev {
         if (arguments.contains("version")) {
             System.out.println("git-webrev version: " + version);
             System.exit(0);
+        }
+
+        if (arguments.contains("verbose") || arguments.contains("debug")) {
+            var level = arguments.contains("debug") ? Level.FINER : Level.FINE;
+            Logging.setup(level);
         }
 
         var cwd = Paths.get("").toAbsolutePath();
@@ -251,10 +265,9 @@ public class GitWebrev {
                         var head = repo.head();
                         var shortestDistance = -1;
                         var pullPath = repo.pullPath(remote);
-                        var remoteBranches = repo.remoteBranches(remote);
-                        for (var remoteBranch : remoteBranches) {
-                            var fetchHead = repo.fetch(URI.create(pullPath), remoteBranch.name());
-                            var mergeBase = repo.mergeBase(fetchHead, head);
+                        for (var branch : repo.branches(remote)) {
+                            var branchHead = repo.resolve(branch).orElseThrow();
+                            var mergeBase = repo.mergeBase(branchHead, head);
                             var distance = repo.commitMetadata(mergeBase, head).size();
                             if (shortestDistance == -1 || distance < shortestDistance) {
                                 rev = mergeBase;

--- a/cli/src/main/java/org/openjdk/skara/cli/GitWebrev.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitWebrev.java
@@ -177,7 +177,7 @@ public class GitWebrev {
         }
 
         var cwd = Paths.get("").toAbsolutePath();
-        var repository = Repository.get(cwd);
+        var repository = ReadOnlyRepository.get(cwd);
         if (!repository.isPresent()) {
             System.err.println(String.format("error: %s is not a repository", cwd.toString()));
             System.exit(1);


### PR DESCRIPTION
Hi all,

please review this patch that makes webrev use the branches under `remote/`
(e.g. `origin/`) to when calculating the closest remote branch. There is no need
to fetch the remote branches.

Testing:
- Manual testing of `git webrev`

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**) ⚠️ Review applies to 28cfac8f2e1981bbb927b2db34c5c9527e6a5501

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/560/head:pull/560`
`$ git checkout pull/560`
