### PR TITLE
352: Set X-Git-URL and X-Git-Changeset headers for push notification emails

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/MailingListUpdater.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/MailingListUpdater.java
@@ -214,6 +214,7 @@ public class MailingListUpdater implements RepositoryUpdateConsumer {
                              .author(commitToAuthor(commit))
                              .recipient(recipient)
                              .headers(headers)
+                             .headers(commitHeaders(repository, commits))
                              .build();
 
             try {
@@ -246,6 +247,7 @@ public class MailingListUpdater implements RepositoryUpdateConsumer {
                          .author(commitAddress)
                          .recipient(recipient)
                          .headers(headers)
+                         .headers(commitHeaders(repository, commits))
                          .build();
 
         try {
@@ -253,6 +255,15 @@ public class MailingListUpdater implements RepositoryUpdateConsumer {
         } catch (RuntimeException e) {
             throw new NonRetriableException(e);
         }
+    }
+
+    private Map<String, String> commitHeaders(HostedRepository repository, List<Commit> commits) {
+        var ret = new HashMap<String, String>();
+        ret.put("X-Git-URL", repository.webUrl().toString());
+        if (!commits.isEmpty()) {
+            ret.put("X-Git-Changeset", commits.get(0).hash().hex());
+        }
+        return ret;
     }
 
     @Override
@@ -302,7 +313,8 @@ public class MailingListUpdater implements RepositoryUpdateConsumer {
         var email = Email.create(subject, writer.toString())
                          .sender(sender)
                          .recipient(recipient)
-                         .headers(headers);
+                         .headers(headers)
+                         .headers(commitHeaders(repository, commits));
 
         if (annotation != null) {
             email.author(annotationToAuthor(annotation));
@@ -334,7 +346,8 @@ public class MailingListUpdater implements RepositoryUpdateConsumer {
         var email = Email.create(subject, writer.toString())
                          .sender(sender)
                          .recipient(recipient)
-                         .headers(headers);
+                         .headers(headers)
+                         .headers(commitHeaders(repository, List.of(commit)));
 
         if (annotation != null) {
             email.author(annotationToAuthor(annotation));
@@ -398,6 +411,7 @@ public class MailingListUpdater implements RepositoryUpdateConsumer {
                          .author(finalAuthor)
                          .recipient(recipient)
                          .headers(headers)
+                         .headers(commitHeaders(repository, commits))
                          .build();
         try {
             list.post(email);

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdaterTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdaterTests.java
@@ -267,6 +267,10 @@ class UpdaterTests {
             assertEquals("value1", email.headerValue("extra1"));
             assertTrue(email.hasHeader("extra2"));
             assertEquals("value2", email.headerValue("extra2"));
+            assertTrue(email.hasHeader("X-Git-URL"));
+            assertEquals(repo.webUrl().toString(), email.headerValue("X-Git-URL"));
+            assertTrue(email.hasHeader("X-Git-Changeset"));
+            assertEquals(editHash.hex(), email.headerValue("X-Git-Changeset"));
         }
     }
 
@@ -335,6 +339,10 @@ class UpdaterTests {
             assertTrue(email.body().contains("Changeset: " + editHash2.abbreviate()));
             assertTrue(email.body().contains("3456789A: Even more fixes"));
             assertFalse(email.body().contains(masterHash.abbreviate()));
+            assertTrue(email.hasHeader("X-Git-URL"));
+            assertEquals(repo.webUrl().toString(), email.headerValue("X-Git-URL"));
+            assertTrue(email.hasHeader("X-Git-Changeset"));
+            assertEquals(editHash1.hex(), email.headerValue("X-Git-Changeset"));
         }
     }
 
@@ -469,6 +477,10 @@ class UpdaterTests {
             assertTrue(email.body().contains("3456789A: Even more fixes"));
             assertFalse(email.body().contains(masterHash.abbreviate()));
             assertFalse(email.body().contains("456789AB: Yet more fixes"));
+            assertTrue(email.hasHeader("X-Git-URL"));
+            assertEquals(repo.webUrl().toString(), email.headerValue("X-Git-URL"));
+            assertTrue(email.hasHeader("X-Git-Changeset"));
+            assertEquals(editHash1.hex(), email.headerValue("X-Git-Changeset"));
 
             localRepo.checkout(branch, true);
             var editHash3 = CheckableRepository.appendAndCommit(localRepo, "Another branch", "456789AB: Yet more fixes");
@@ -489,6 +501,10 @@ class UpdaterTests {
             assertTrue(email.body().contains("456789AB: Yet more fixes"));
             assertFalse(email.body().contains("Changeset: " + editHash2.abbreviate()));
             assertFalse(email.body().contains("3456789A: Even more fixes"));
+            assertTrue(email.hasHeader("X-Git-URL"));
+            assertEquals(repo.webUrl().toString(), email.headerValue("X-Git-URL"));
+            assertTrue(email.hasHeader("X-Git-Changeset"));
+            assertEquals(editHash3.hex(), email.headerValue("X-Git-Changeset"));
         }
     }
 
@@ -580,6 +596,10 @@ class UpdaterTests {
             assertFalse(email.body().contains(masterHash.abbreviate()));
             assertTrue(email.hasHeader("extra1"));
             assertEquals("value1", email.headerValue("extra1"));
+            assertTrue(email.hasHeader("X-Git-URL"));
+            assertEquals(repo.webUrl().toString(), email.headerValue("X-Git-URL"));
+            assertTrue(email.hasHeader("X-Git-Changeset"));
+            assertEquals(editHash.hex(), email.headerValue("X-Git-Changeset"));
 
             // Now push the other one without a matching PR - PR_ONLY will not generate a mail
             localRepo.push(otherHash, repo.url(), "master");


### PR DESCRIPTION
Hi all,

Please review this change that sets X-Git-URL and X-Git-Changeset headers for push notification emails.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-352](https://bugs.openjdk.java.net/browse/SKARA-352): Set X-Git-URL and X-Git-Changeset headers for push notification emails


### Reviewers
 * J. Duke ([duke](@openjdk-bot) - no project role)
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/561/head:pull/561`
`$ git checkout pull/561`
