### PR TITLE
341: Show target branch in integration message

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -547,7 +547,7 @@ class CheckRun {
             }
         } else if (rebasePossible) {
             message.append("\n");
-            message.append("➡️ To integrate this PR with the above commit message, type ");
+            message.append("➡️ To integrate this PR with the above commit message to the `" + pr.targetRef() + "` branch, type ");
             message.append("`/integrate` in a new comment.\n");
         }
         message.append(mergeReadyMarker);

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrateTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrateTests.java
@@ -69,6 +69,15 @@ class IntegrateTests {
             var approvalPr = integrator.pullRequest(pr.id());
             approvalPr.addReview(Review.Verdict.APPROVED, "Approved");
 
+            // The bot should reply with integration message
+            TestBotRunner.runPeriodicItems(mergeBot);
+            var integrateComments =
+                pr.comments()
+                  .stream()
+                  .filter(c -> c.body().contains("To integrate this PR with the above commit message to the `master` branch"))
+                  .count();
+            assertEquals(1, integrateComments);
+
             // Attempt a merge (the bot should only process the first one)
             pr.addComment("/integrate");
             pr.addComment("/integrate");


### PR DESCRIPTION
Hi all,

please review this small patch that clarifies which branch the commit will be
integrated to when running `/integrate`.

Testing:
- Update one unit test
- `make test` passes on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-341](https://bugs.openjdk.java.net/browse/SKARA-341): Show target branch in integration message


### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/563/head:pull/563`
`$ git checkout pull/563`
