### PR TITLE
347: Display additional errors in the pull request status message (if any)

### DIFF
--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -699,6 +699,11 @@ class CheckTests {
             assertEquals(CheckStatus.FAILURE, check.status());
             assertTrue(check.summary().orElseThrow().contains("The pull request body must not be empty."));
 
+            // Additional errors should be displayed in the body
+            var updatedPr = author.pullRequest(pr.id());
+            assertTrue(updatedPr.body().contains("## Problems"));
+            assertTrue(updatedPr.body().contains("The pull request body must not be empty."));
+
             // The PR should not yet be ready for review
             assertFalse(pr.labels().contains("rfr"));
             assertFalse(pr.labels().contains("ready"));
@@ -710,6 +715,11 @@ class CheckTests {
             // The PR should now be ready for review
             assertTrue(pr.labels().contains("rfr"));
             assertFalse(pr.labels().contains("ready"));
+
+            // The additional errors should be gone
+            updatedPr = author.pullRequest(pr.id());
+            assertFalse(updatedPr.body().contains("## Problems"));
+            assertFalse(updatedPr.body().contains("The pull request body must not be empty."));
         }
     }
 


### PR DESCRIPTION
Hi all,

Please review this change that displays additional errors in the pull request status message (if any), as they can be a bit hard to find in the check status.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-347](https://bugs.openjdk.java.net/browse/SKARA-347): Show failed "PR body should not be empty" check in "Progress"


### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/566/head:pull/566`
`$ git checkout pull/566`
