### PR TITLE
335: The JBS notifier should use a different method to find PRs

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/IssueUpdater.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/IssueUpdater.java
@@ -265,16 +265,16 @@ public class IssueUpdater implements RepositoryUpdateConsumer, PullRequestUpdate
 
                 String requestedVersion = null;
                 if (prOnly) {
-                    var pullRequestCount = issue.links().stream()
-                                            .filter(link -> link.title().orElse("notitle").equals("Review"))
-                                            .filter(link -> link.summary().orElse("nosummary").startsWith(repository.name() + "/"))
-                                            .map(link -> link.summary().orElseThrow().substring(repository.name().length() + 1))
-                                            .map(repository::pullRequest)
-                                            .filter(pr -> pr.targetRef().equals(branch.name()))
-                                            .count();
-                    if (pullRequestCount == 0) {
-                        log.info("Skipping commit " + commit.hash().abbreviate() + " for repository " + repository.name() +
-                                         " on branch " + branch.name() + " - no matching PR found");
+                    var candidates = repository.findPullRequestsWithComment(null, "Pushed as commit " + commit.hash() + ".");
+                    if (candidates.size() != 1) {
+                        log.info("IssueUpdater@" + issue.id() + ": Skipping commit " + commit.hash().abbreviate() + " for repository " + repository.name() +
+                                         " on branch " + branch.name() + " - " + candidates.size() + " matching PRs found (needed 1)");
+                        continue;
+                    }
+                    var candidate = candidates.get(0);
+                    var prLink = candidate.webUrl();
+                    if (!candidate.targetRef().equals(branch.name())) {
+                        log.info("IssueUpdater@" + issue.id() + ": Pull request " + prLink + " targets " + candidate.targetRef() + " - commit is on " + branch.toString() + " - skipping");
                         continue;
                     }
                 } else {

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdaterTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdaterTests.java
@@ -1998,6 +1998,7 @@ class UpdaterTests {
             assertEquals(reviewIcon, links.get(0).iconUrl().orElseThrow());
 
             // Simulate integration
+            pr.addComment("Pushed as commit " + editHash.hex() + ".");
             localRepo.push(editHash, repo.url(), "other");
             TestBotRunner.runPeriodicItems(notifyBot);
 


### PR DESCRIPTION
Hi all,

Please review this change that ensures that the JBS notifier properly searches for a matching PR.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-335](https://bugs.openjdk.java.net/browse/SKARA-335): The JBS notifier should use a different method to find PRs


### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/567/head:pull/567`
`$ git checkout pull/567`
