### PR TITLE
Add testReport task to create a combined report

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,8 @@ configure(subprojects.findAll() { it.name != 'bots' }) {
             events "passed", "skipped", "failed"
             exceptionFormat "full"
         }
+
+        reports.html.enabled = false
     }
 
     publishing {
@@ -94,6 +96,28 @@ configure(subprojects.findAll() { it.name != 'bots' }) {
 
 task test {
     subprojects.findAll() { !it.getTasksByName('test', false).isEmpty() }.each { dependsOn "${it.path}:test" }
+}
+
+task testReport(type: TestReport) {
+    destinationDir = file("$buildDir/reports/allTests")
+
+    def failureCount = 0
+    subprojects.findAll()*.getTasksByName('test', false).each { it.each {
+        it.ignoreFailures = true
+        it.afterSuite { td, tr ->
+            if (td.getParent() == null) {
+                failureCount += tr.getFailedTestCount()
+            }
+        }}
+    }
+
+    reportOn subprojects.findAll()*.getTasksByName('test', false)
+
+    doLast {
+        if (failureCount > 0) {
+            throw new GradleException("There were " + failureCount + " failing tests. See the report at: " + destinationDir);
+        }
+    }
 }
 
 task clean {


### PR DESCRIPTION
Hi all,

Please review this change that adds a new gradle task `testReport` that runs all tests (continuing even if there are failures) and creates a combined report afterwards.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/569/head:pull/569`
`$ git checkout pull/569`
