### PR TITLE
forge: use correct endpoint for GitLab branches

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -267,7 +267,7 @@ public class GitLabRepository implements HostedRepository {
 
     @Override
     public List<HostedBranch> branches() {
-        var branches = request.get("branches").execute();
+        var branches = request.get("repository/branches").execute();
         return branches.stream()
                        .map(b -> new HostedBranch(b.get("name").asString(),
                                                   new Hash(b.get("commit").get("id").asString())))


### PR DESCRIPTION
Hi all,

please review this small patch that fixes the "branches" endpoint for
`GitLabRepository` (it is `/repository/branches`, not `/branches`).

Testing:
- `make test` passes on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/572/head:pull/572`
`$ git checkout pull/572`
