### PR TITLE
forge: support project id for GitLab repos

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabHost.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabHost.java
@@ -95,7 +95,6 @@ public class GitLabHost implements Forge {
 
     JSONObject getProjectInfo(String name) {
         var encodedName = URLEncoder.encode(name, StandardCharsets.US_ASCII);
-
         var project = request.get("projects/" + encodedName)
                              .onError(r -> r.statusCode() == 404 ? Optional.of(JSON.object().put("retry", true)) : Optional.empty())
                              .execute();
@@ -105,6 +104,12 @@ public class GitLabHost implements Forge {
             project = request.get("projects/" + encodedName).execute();
         }
         return project.asObject();
+    }
+
+    JSONObject getProjectInfo(int id) {
+        return request.get("projects/" + Integer.toString(id))
+                      .execute()
+                      .asObject();
     }
 
     @Override

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -268,7 +268,7 @@ public class GitLabMergeRequest implements PullRequest {
     @Override
     public HostedRepository sourceRepository() {
         return new GitLabRepository((GitLabHost) repository.forge(),
-                                    json.get("source_project_id").asString());
+                                    json.get("source_project_id").asInt());
     }
 
     @Override

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -43,8 +43,16 @@ public class GitLabRepository implements HostedRepository {
     private final Pattern mergeRequestPattern;
 
     public GitLabRepository(GitLabHost gitLabHost, String projectName) {
+        this(gitLabHost, gitLabHost.getProjectInfo(projectName));
+    }
+
+    public GitLabRepository(GitLabHost gitLabHost, int id) {
+        this(gitLabHost, gitLabHost.getProjectInfo(id));
+    }
+
+    private GitLabRepository(GitLabHost gitLabHost, JSONValue json) {
         this.gitLabHost = gitLabHost;
-        json = gitLabHost.getProjectInfo(projectName);
+        this.json = json;
         this.projectName = json.get("path_with_namespace").asString();
 
         var id = json.get("id").asInt();


### PR DESCRIPTION
Hi all,

please review this patch that makes `GitLabRepository` work with project id:s as
well as project names. I had to make a few changes to the `GitLabRepository`
constructor and add a new `getProjectInfo` overload to `GitLabHost`.

Testing:
- `make test` on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/574/head:pull/574`
`$ git checkout pull/574`
