### PR TITLE
Accept trailing slash in URIs for git fork

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitFork.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitFork.java
@@ -271,7 +271,14 @@ public class GitFork {
             exit("error: could not connect to host " + webURI.getHost());
         }
 
-        var hostedRepo = host.get().repository(webURI.getPath().substring(1)).orElseThrow(() ->
+        var repositoryPath = webURI.getPath().substring(1);
+
+        if (repositoryPath.endsWith("/")) {
+            repositoryPath =
+                    repositoryPath.substring(0, repositoryPath.length() - 1);
+        }
+
+        var hostedRepo = host.get().repository(repositoryPath).orElseThrow(() ->
             new IOException("Could not find repository at " + webURI.toString())
         );
 


### PR DESCRIPTION
Consider a command like this:
$ git fork https://github.com/openjdk/skara/

This fails with a fairly cryptic error:
Apr 09, 2020 11:39:44 AM org.openjdk.skara.network.RestRequest transformBadResponse
WARNING: org.openjdk.skara.network.RestRequest$QueryBuilder@2a17b7b6
Apr 09, 2020 11:39:44 AM org.openjdk.skara.network.RestRequest transformBadResponse
WARNING: {"message":"Not Found","documentation_url":"https://developer.github.com/v3"}
Exception in thread "main" java.lang.RuntimeException: Request returned bad status: 404
        at org.openjdk.skara.network/org.openjdk.skara.network.RestRequest.transformBadResponse(RestRequest.java:285)
        at org.openjdk.skara.network/org.openjdk.skara.network.RestRequest.execute(RestRequest.java:325)
        at org.openjdk.skara.network/org.openjdk.skara.network.RestRequest$QueryBuilder.execute(RestRequest.java:156)
        at org.openjdk.skara.forge/org.openjdk.skara.forge.github.GitHubRepository.fork(GitHubRepository.java:231)
        at org.openjdk.skara.cli/org.openjdk.skara.cli.GitFork.main(GitFork.java:278)
        at org.openjdk.skara.cli/org.openjdk.skara.cli.GitSkara.main(GitSkara.java:186)

The cause is the trailing '/', which is normally accepted when accessing the repository through a web browser, or when cloning the repository. This patch changes the git fork to also accept trailing slashes, by removing them before the GitHubRepository repository instance is created. It is not quite clear if this should be solved at some other level, but felt like a better approach to keep the APIs clean (i.e. just plain repository names), and do normalization in the UI tools.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**) ⚠️ Review applies to dcba05815db488c6c69ec84082ff74a6796fe59e

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/575/head:pull/575`
`$ git checkout pull/575`
