### PR TITLE
Use proper value for GitLab PR state

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -363,7 +363,7 @@ public class GitLabMergeRequest implements PullRequest {
 
     @Override
     public State state() {
-        if (json.get("state").asString().equals("open")) {
+        if (json.get("state").asString().equals("opened")) {
             return State.OPEN;
         }
         return State.CLOSED;


### PR DESCRIPTION
Hi all,

Please review this change that properly parses the state of a GitLab PR.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * J. Duke ([duke](@openjdk-bot) - no project role)
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/576/head:pull/576`
`$ git checkout pull/576`
