### PR TITLE
merge-bot: use commitMetadata when listing commits

### DIFF
--- a/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
+++ b/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
@@ -463,7 +463,7 @@ class MergeBot implements Bot, WorkItem {
                     message.add(marker);
                     message.add("<!-- " + fetchHead.hex() + " -->");
 
-                    var commits = repo.commits(mergeBase.hex() + ".." + fetchHead.hex(), true).asList();
+                    var commits = repo.commitMetadata(mergeBase.hex() + ".." + fetchHead.hex(), true);
                     var numCommits = commits.size();
                     var are = numCommits > 1 ? "are" : "is";
                     var s = numCommits > 1 ? "s" : "";


### PR DESCRIPTION
Hi all,

please review this patch that makes the automatic merge bot use `commitMetadata`
instead of `commits` to speed up listing of large commit ranges.

Testing:
- `make test` passes on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/578/head:pull/578`
`$ git checkout pull/578`
