### PR TITLE
merge-bot: give each branch a new number as name

### DIFF
--- a/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
+++ b/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
@@ -453,7 +453,9 @@ class MergeBot implements Bot, WorkItem {
                     repo.abortMerge();
 
                     var fromRepoName = Path.of(fromRepo.webUrl().getPath()).getFileName();
-                    var branchDesc = Integer.toString(prs.size() + 1);
+
+                    var numBranchesInFork = repo.remoteBranches(fork.webUrl().toString()).size();
+                    var branchDesc = Integer.toString(numBranchesInFork + 1);
                     repo.push(fetchHead, fork.url(), branchDesc, true);
 
                     log.info("Creating pull request to alert");


### PR DESCRIPTION
Hi all,

please review this patch that makes the merge bot always increment its branch
names by one. The previous code (mistakenly) used the number of open pull
request, but that is not monotonically increasing. Since the merge bot does not
delete branches it has created, the number of branches should be monotonically
increasing :smile:

Testing:
- `make test` on Linux x64 passes

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/579/head:pull/579`
`$ git checkout pull/579`
