### PR TITLE
Failed merge commit message should not throw, but report a failure

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
@@ -119,7 +119,8 @@ class PullRequestCheckIssueVisitor implements IssueVisitor {
     @Override
     public void visit(MergeMessageIssue e) {
         var message = String.join("\n", e.commit().message());
-        throw new IllegalStateException("Merge commit message is not " + e.expected() + ", but: " + message);
+        messages.add("Merge commit message is not " + e.expected() + ", but: " + message);
+        failedChecks.add(e.check().getClass());
     }
 
     @Override


### PR DESCRIPTION
Hi all,

Please review this change that makes sure that a failing "merge" jcheck does not throw, but properly reports an error.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/580/head:pull/580`
`$ git checkout pull/580`
