### PR TITLE
360: Always show instructions for atomic integrations

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -520,7 +520,7 @@ class CheckRun {
             message.append(pr.targetRef());
             message.append("` branch. ");
             if (rebasePossible) {
-                message.append("Since there are no conflicts, your changes will automatically be rebased on top of ");
+                message.append("As there are no conflicts, your changes will automatically be rebased on top of ");
                 message.append("these commits when integrating. If you prefer to avoid automatic rebasing, please merge `");
                 message.append(pr.targetRef());
                 message.append("` into your branch, and then specify the current head hash when integrating, like this: ");
@@ -533,6 +533,16 @@ class CheckRun {
                 message.append(pr.targetRef());
                 message.append("` into your branch before integrating.\n");
             }
+        } else {
+            message.append("\n");
+            message.append("There are currently no new commits on the `");
+            message.append(pr.targetRef());
+            message.append("` branch since the last update of the source branch of this PR. If another commit should be pushed before ");
+            message.append("you perform the `/integrate` command, your PR will be automatically rebased. If you would like to avoid ");
+            message.append("potential automatic rebasing, specify the current head hash when integrating, like this: ");
+            message.append("`/integrate ");
+            message.append(prInstance.targetHash());
+            message.append("`.\n");
         }
 
         if (!ProjectPermissions.mayCommit(censusInstance, pr.author())) {

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrateTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrateTests.java
@@ -71,11 +71,12 @@ class IntegrateTests {
 
             // The bot should reply with integration message
             TestBotRunner.runPeriodicItems(mergeBot);
-            var integrateComments =
-                pr.comments()
-                  .stream()
-                  .filter(c -> c.body().contains("To integrate this PR with the above commit message to the `master` branch"))
-                  .count();
+            var integrateComments = pr.comments()
+                                      .stream()
+                                      .filter(c -> c.body().contains("To integrate this PR with the above commit message to the `master` branch"))
+                                      .filter(c -> c.body().contains("If you would like to avoid potential automatic rebasing"))
+                                      .filter(c -> c.body().contains("`/integrate " + masterHash.hex() + "`"))
+                                      .count();
             assertEquals(1, integrateComments);
 
             // Attempt a merge (the bot should only process the first one)


### PR DESCRIPTION
Hi all,

Please review this change that always shows the option of making an atomic (no automatic rebase) integration.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-360](https://bugs.openjdk.java.net/browse/SKARA-360): Always show instructions for atomic integrations


### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/581/head:pull/581`
`$ git checkout pull/581`
