### PR TITLE
merge-bot: no need to force push

### DIFF
--- a/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
+++ b/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
@@ -456,7 +456,7 @@ class MergeBot implements Bot, WorkItem {
 
                     var numBranchesInFork = repo.remoteBranches(fork.webUrl().toString()).size();
                     var branchDesc = Integer.toString(numBranchesInFork + 1);
-                    repo.push(fetchHead, fork.url(), branchDesc, true);
+                    repo.push(fetchHead, fork.url(), branchDesc);
 
                     log.info("Creating pull request to alert");
                     var mergeBase = repo.mergeBase(fetchHead, head);


### PR DESCRIPTION
Hi all,

please review this small patch that makes the merge bot no longer use force
pushes. The redesigned merge bot has no need for force pushes, all "from"
branches (branches in bot's fork) will have a unique name, so there should never
be a conflict when pushing.

Testing:
- `make test` on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/582/head:pull/582`
`$ git checkout pull/582`
