### PR TITLE
364: The bots should not fetch tags by default

### DIFF
--- a/bots/forward/src/main/java/org/openjdk/skara/bots/forward/ForwardBot.java
+++ b/bots/forward/src/main/java/org/openjdk/skara/bots/forward/ForwardBot.java
@@ -85,7 +85,8 @@ class ForwardBot implements Bot, WorkItem {
             log.info("Fetching " + fromHostedRepo.name() + ":" + fromBranch.name() +
                      " to " + toBranch.name());
             var fetchHead = toLocalRepo.fetch(fromHostedRepo.url(),
-                                              fromBranch.name() + ":" + toBranch.name());
+                                              fromBranch.name() + ":" + toBranch.name(),
+                                              false);
             log.info("Pushing " + toBranch.name() + " to " + toHostedRepo.name());
             toLocalRepo.push(fetchHead, toHostedRepo.url(), toBranch.name(), false);
         } catch (IOException e) {

--- a/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
+++ b/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
@@ -231,12 +231,12 @@ class MergeBot implements Bot, WorkItem {
         // Sync personal fork
         var remoteBranches = repo.remoteBranches(target.url().toString());
         for (var branch : remoteBranches) {
-            var fetchHead = repo.fetch(target.url(), branch.hash().hex());
+            var fetchHead = repo.fetch(target.url(), branch.hash().hex(), false);
             repo.push(fetchHead, fork.url(), branch.name());
         }
 
         // Must fetch once to update refs/heads
-        repo.fetchAll();
+        repo.fetchAll(false);
 
         return repo;
     }
@@ -411,7 +411,7 @@ class MergeBot implements Bot, WorkItem {
 
                 log.info("Trying to merge " + fromRepo.name() + ":" + fromBranch.name() + " to " + toBranch.name());
                 log.info("Fetching " + fromRepo.name() + ":" + fromBranch.name());
-                var fetchHead = repo.fetch(fromRepo.url(), fromBranch.name());
+                var fetchHead = repo.fetch(fromRepo.url(), fromBranch.name(), false);
                 var head = repo.resolve(toBranch.name()).orElseThrow(() ->
                         new IOException("Could not resolve branch " + toBranch.name())
                 );

--- a/bots/mirror/src/main/java/org/openjdk/skara/bots/mirror/MirrorBot.java
+++ b/bots/mirror/src/main/java/org/openjdk/skara/bots/mirror/MirrorBot.java
@@ -91,12 +91,12 @@ class MirrorBot implements Bot, WorkItem {
 
             if (shouldMirrorEverything) {
                 log.info("Pulling " + from.name());
-                repo.fetchAll();
+                repo.fetchAll(false);
                 log.info("Pushing to " + to.name());
                 repo.pushAll(to.url());
             } else {
                 for (var branch : branches) {
-                    var fetchHead = repo.fetch(from.url(), branch.name());
+                    var fetchHead = repo.fetch(from.url(), branch.name(), false);
                     repo.push(fetchHead, to.url(), branch.name());
                 }
             }

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
@@ -80,7 +80,7 @@ class ArchiveWorkItem implements WorkItem {
                 var localHead = localRepo.head();
                 localRepo.add(localRepo.root().resolve("."));
                 var hash = localRepo.commit(message, bot.emailAddress().fullName().orElseThrow(), bot.emailAddress().address());
-                var remoteHead = localRepo.fetch(bot.archiveRepo().url(), bot.archiveRef());
+                var remoteHead = localRepo.fetch(bot.archiveRepo().url(), bot.archiveRef(), false);
                 if (!localHead.equals(remoteHead)) {
                     log.info("Remote head has changed - attempting a rebase");
                     localRepo.rebase(remoteHead, bot.emailAddress().fullName().orElseThrow(), bot.emailAddress().address());
@@ -295,7 +295,7 @@ class ArchiveWorkItem implements WorkItem {
             var repository = pr.repository();
             var localRepoPath = scratchPath.resolve("mlbridge-mergebase");
             var localRepo = hostedRepositoryPool.checkout(pr, localRepoPath.resolve(repository.name()));
-            localRepo.fetch(repository.url(), "+" + pr.targetRef() + ":mlbridge_prinstance");
+            localRepo.fetch(repository.url(), "+" + pr.targetRef() + ":mlbridge_prinstance", false);
 
             var targetHash = pr.targetHash();
             var headHash = pr.headHash();

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/CensusInstance.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/CensusInstance.java
@@ -87,7 +87,7 @@ class CensusInstance {
             var localRepo = Repository.get(repoFolder)
                                       .or(() -> Optional.of(initialize(censusRepo, censusRef, repoFolder)))
                                       .orElseThrow();
-            var hash = localRepo.fetch(censusRepo.url(), censusRef);
+            var hash = localRepo.fetch(censusRepo.url(), censusRef, false);
             localRepo.checkout(hash, true);
         } catch (IOException e) {
             initialize(censusRepo, censusRef, repoFolder);

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryWorkItem.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryWorkItem.java
@@ -265,7 +265,7 @@ public class RepositoryWorkItem implements WorkItem {
                                      .stream()
                                      .filter(ref -> branches.matcher(ref.name()).matches())
                                      .collect(Collectors.toList());
-            localRepo.fetchAll();
+            localRepo.fetchAll(false);
 
             var history = UpdateHistory.create(tagStorageBuilder, historyPath.resolve("tags"), branchStorageBuilder, historyPath.resolve("branches"));
             var errors = new ArrayList<Throwable>();

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CensusInstance.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CensusInstance.java
@@ -87,7 +87,7 @@ class CensusInstance {
             var localRepo = Repository.get(repoFolder)
                                       .or(() -> Optional.of(initialize(censusRepo, censusRef, repoFolder)))
                                       .orElseThrow();
-            var hash = localRepo.fetch(censusRepo.url(), censusRef);
+            var hash = localRepo.fetch(censusRepo.url(), censusRef, false);
             localRepo.checkout(hash, true);
         } catch (IOException e) {
             initialize(censusRepo, censusRef, repoFolder);

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -196,7 +196,7 @@ class CheckRun {
                                 new RuntimeException("Could not find repository " + source.get().repositoryName)
                         );
                         try {
-                            var sourceHash = prInstance.localRepo().fetch(mergeSourceRepo.url(), source.get().branchName);
+                            var sourceHash = prInstance.localRepo().fetch(mergeSourceRepo.url(), source.get().branchName, false);
                             var mergeCommit = commits.get(mergeCommitIndex);
                             for (int i = 1; i < mergeCommit.parents().size(); ++i) {
                                 if (!prInstance.localRepo().isAncestor(mergeCommit.parents().get(i), sourceHash)) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestInstance.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestInstance.java
@@ -56,7 +56,7 @@ class PullRequestInstance {
         // Materialize the PR's source and target ref
         var repository = pr.repository();
         localRepo = hostedRepositoryPool.checkout(pr, localRepoPath.resolve(repository.name()));
-        localRepo.fetch(repository.url(), "+" + pr.targetRef() + ":pr_prinstance");
+        localRepo.fetch(repository.url(), "+" + pr.targetRef() + ":pr_prinstance", false);
 
         targetHash = pr.targetHash();
         headHash = pr.headHash();

--- a/bots/submit/src/main/java/org/openjdk/skara/bots/submit/SubmitBotWorkItem.java
+++ b/bots/submit/src/main/java/org/openjdk/skara/bots/submit/SubmitBotWorkItem.java
@@ -86,7 +86,7 @@ public class SubmitBotWorkItem implements WorkItem {
         try {
             var localRepo = Repository.materialize(prFolder, pr.repository().url(),
                                                    "+" + pr.targetRef() + ":submit_" + pr.repository().name());
-            var headHash = localRepo.fetch(pr.repository().url(), pr.headHash().hex());
+            var headHash = localRepo.fetch(pr.repository().url(), pr.headHash().hex(), false);
 
             var checkBuilder = CheckBuilder.create(executor.checkName(), headHash);
             pr.createCheck(checkBuilder.build());

--- a/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestWorkItem.java
+++ b/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestWorkItem.java
@@ -404,7 +404,7 @@ public class TestWorkItem implements WorkItem {
                             return new RuntimeException("Repository in " + localRepoDir + " has vanished");
                     });
                 }
-                fetchHead = localRepo.fetch(repository.url(), pr.headHash().hex());
+                fetchHead = localRepo.fetch(repository.url(), pr.headHash().hex(), false);
                 localRepo.checkout(fetchHead, true);
                 job = ci.submit(localRepoDir, jobs, jobId);
             } catch (IOException e) {

--- a/bots/topological/src/main/java/org/openjdk/skara/bots/topological/TopologicalBot.java
+++ b/bots/topological/src/main/java/org/openjdk/skara/bots/topological/TopologicalBot.java
@@ -81,7 +81,7 @@ class TopologicalBot implements Bot, WorkItem {
                         .orElseThrow(() -> new RuntimeException("Repository in " + dir + " has vanished"));
             }
 
-            repo.fetchAll();
+            repo.fetchAll(false);
             var depsFile = repo.root().resolve(depsFileName);
 
             var orderedBranches = orderedBranches(repo, depsFile);

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
@@ -41,8 +41,14 @@ public interface Repository extends ReadOnlyRepository {
     default void checkout(Branch b) throws IOException {
         checkout(b, false);
     }
-    Hash fetch(URI uri, String refspec) throws IOException;
-    void fetchAll() throws IOException;
+    default Hash fetch(URI uri, String refspec) throws IOException {
+        return fetch(uri, refspec, true);
+    }
+    Hash fetch(URI uri, String refspec, boolean includeTags) throws IOException;
+    default void fetchAll() throws IOException {
+        fetchAll(false);
+    }
+    void fetchAll(boolean includeTags) throws IOException;
     void fetchRemote(String remote) throws IOException;
     void pushAll(URI uri) throws IOException;
     void push(Hash hash, URI uri, String ref, boolean force) throws IOException;

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -397,16 +397,35 @@ public class GitRepository implements Repository {
     }
 
     @Override
-    public Hash fetch(URI uri, String refspec) throws IOException {
-        try (var p = capture("git", "fetch", "--recurse-submodules=on-demand", "--tags", uri.toString(), refspec)) {
+    public Hash fetch(URI uri, String refspec, boolean includeTags) throws IOException {
+        var cmd = new ArrayList<String>();
+        cmd.addAll(List.of("git", "fetch", "--recurse-submodules=on-demand"));
+        if (includeTags) {
+            cmd.add("--tags");
+        } else {
+            cmd.add("--no-tags");
+        }
+        cmd.add(uri.toString());
+        cmd.add(refspec);
+        try (var p = capture(cmd)) {
             await(p);
             return resolve("FETCH_HEAD").get();
         }
     }
 
     @Override
-    public void fetchAll() throws IOException {
-        try (var p = capture("git", "fetch", "--recurse-submodules=on-demand", "--tags", "--prune", "--prune-tags", "--all")) {
+    public void fetchAll(boolean includeTags) throws IOException {
+        var cmd = new ArrayList<String>();
+        cmd.addAll(List.of("git", "fetch", "--recurse-submodules=on-demand"));
+        cmd.add("--prune");
+        if (includeTags) {
+            cmd.add("--tags");
+            cmd.add("--prune-tags");
+        } else {
+            cmd.add("--no-tags");
+        }
+        cmd.add("--all");
+        try (var p = capture(cmd)) {
             await(p);
         }
     }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -403,7 +403,8 @@ public class HgRepository implements Repository {
     }
 
     @Override
-    public Hash fetch(URI uri, String refspec) throws IOException {
+    public Hash fetch(URI uri, String refspec, boolean includeTags) throws IOException {
+        // Ignore includeTags, Mercurial always fetches tags
         return fetch(uri != null ? uri.toString() : null, refspec);
     }
 
@@ -437,7 +438,8 @@ public class HgRepository implements Repository {
     }
 
     @Override
-    public void fetchAll() throws IOException {
+    public void fetchAll(boolean includeTags) throws IOException {
+        // Ignore includeTags, Mercurial always fetches tags
         var pullPaths = new ArrayList<URI>();
         try (var p = capture("hg", "paths")) {
             var res = await(p);


### PR DESCRIPTION
Hi all,

please review this patch that makes the bots *not* fetch tags by default.
Fetching tags should be an explicit action, not something that happens as a side
effect of fetching commits.

Testing:
- `make test` on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-364](https://bugs.openjdk.java.net/browse/SKARA-364): The bots should not fetch tags by default


### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/583/head:pull/583`
`$ git checkout pull/583`
