### PR TITLE
362: Only amend merge commits that has the target branch as parent

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -178,11 +178,12 @@ class CheckRun {
             if (commits.size() < 2) {
                 ret.add("A Merge PR must contain at least two commits that are not already present in the target.");
             } else {
-                // Find the last merge commit - the very last commit is not eligible (as the merge needs a parent)
+                // Find the first merge commit - the very last commit is not eligible (as the merge needs a parent)
                 int mergeCommitIndex = commits.size();
                 for (int i = 0; i < commits.size() - 1; ++i) {
                     if (commits.get(i).isMerge()) {
                         mergeCommitIndex = i;
+                        break;
                     }
                 }
                 if (mergeCommitIndex >= commits.size() - 1) {
@@ -198,10 +199,12 @@ class CheckRun {
                         try {
                             var sourceHash = prInstance.localRepo().fetch(mergeSourceRepo.url(), source.get().branchName);
                             var mergeCommit = commits.get(mergeCommitIndex);
-                            for (int i = 1; i < mergeCommit.parents().size(); ++i) {
+                            for (int i = 0; i < mergeCommit.parents().size(); ++i) {
                                 if (!prInstance.localRepo().isAncestor(mergeCommit.parents().get(i), sourceHash)) {
-                                    ret.add("The merge contains commits that are not ancestors of the source.");
-                                    break;
+                                    if (!mergeCommit.parents().get(i).equals(prInstance.targetHash())) {
+                                        ret.add("The merge contains commits that are neither ancestors of the source nor the target.");
+                                        break;
+                                    }
                                 }
                             }
                         } catch (IOException e) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestInstance.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestInstance.java
@@ -139,7 +139,7 @@ class PullRequestInstance {
     }
 
     private Hash commitMerge(List<Review> activeReviews, Namespace namespace, String censusDomain, String sponsorId) throws IOException, CommitFailure {
-        // Find the single merge commit with an incoming parent outside of the merge target
+        // Find the first merge commit with an incoming parent outside of the merge target
         // The very last commit is not eligible (as the merge needs a parent)
         var commits = localRepo.commitMetadata(baseHash, headHash);
         int mergeCommitIndex = commits.size();
@@ -152,11 +152,8 @@ class PullRequestInstance {
                     }
                 }
                 if (isSourceMerge) {
-                    if (mergeCommitIndex != commits.size()) {
-                        // TODO: We could allow this
-                        throw new CommitFailure("A merge PR is only allowed to contain a single merge commit with incoming changes. Please amend!");
-                    }
                     mergeCommitIndex = i;
+                    break;
                 } else {
                     // TODO: We can solve this with retroactive rerere
                     throw new CommitFailure("A merge PR is only allowed to contain a single merge commit. You will need to amend your commits.");

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
@@ -209,6 +209,7 @@ class MergeTests {
     }
 
     @Test
+    @Disabled
     void branchMergeRebase(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
              var tempFolder = new TemporaryDirectory()) {
@@ -303,6 +304,7 @@ class MergeTests {
     }
 
     @Test
+    @Disabled
     void branchMergeAdditionalCommits(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
              var tempFolder = new TemporaryDirectory()) {
@@ -466,7 +468,7 @@ class MergeTests {
             assertEquals(1, error, () -> pr.comments().stream().map(Comment::body).collect(Collectors.joining("\n\n")));
 
             var check = pr.checks(mergeHash).get("jcheck");
-            assertEquals("- It was not possible to create a commit for the changes in this PR: No merge commit containing commits from another branch than the target was found", check.summary().orElseThrow());
+            assertEquals("- It was not possible to create a commit for the changes in this PR: A merge PR is only allowed to contain a single merge commit. You will need to amend your commits.", check.summary().orElseThrow());
         }
     }
 

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -727,7 +727,7 @@ public class GitRepository implements Repository {
 
     @Override
     public void rebase(Hash hash, String committerName, String committerEmail) throws IOException {
-        try (var p = Process.capture("git", "rebase", "--onto", hash.hex(), "--root", "--rebase-merges")
+        try (var p = Process.capture("git", "rebase", "--onto", hash.hex(), "--root")
                             .environ("GIT_COMMITTER_NAME", committerName)
                             .environ("GIT_COMMITTER_EMAIL", committerEmail)
                             .workdir(dir)


### PR DESCRIPTION
Hi all,

Please review this change that avoids performing automatic rebasing of Merge PRs, as that doesn't work correctly in all cases.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-362](https://bugs.openjdk.java.net/browse/SKARA-362): Only amend merge commits that has the target branch as parent


### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**) ⚠️ Review applies to b5f320ec6fea563e1737b7dd7620c50aefa62b43

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/584/head:pull/584`
`$ git checkout pull/584`
