### PR TITLE
cli: add git-proxy tool

### DIFF
--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -59,7 +59,8 @@ images {
         'git-skara': 'org.openjdk.skara.cli/org.openjdk.skara.cli.GitSkara',
         'hg-openjdk-import': 'org.openjdk.skara.cli/org.openjdk.skara.cli.HgOpenJDKImport',
         'git-sync': 'org.openjdk.skara.cli/org.openjdk.skara.cli.GitSync',
-        'git-publish': 'org.openjdk.skara.cli/org.openjdk.skara.cli.GitPublish'
+        'git-publish': 'org.openjdk.skara.cli/org.openjdk.skara.cli.GitPublish',
+        'git-proxy': 'org.openjdk.skara.cli/org.openjdk.skara.cli.GitProxy'
     ]
 
     ext.modules = ['jdk.crypto.ec']

--- a/cli/src/main/java/org/openjdk/skara/cli/GitProxy.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitProxy.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.cli;
+
+import org.openjdk.skara.proxy.HttpProxy;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+
+public class GitProxy {
+    private static String gitConfig(String key) throws IOException, InterruptedException {
+        var pb = new ProcessBuilder("git", "config", key);
+        pb.redirectOutput(ProcessBuilder.Redirect.PIPE);
+        pb.redirectError(ProcessBuilder.Redirect.INHERIT);
+        var p = pb.start();
+        var bytes = p.getInputStream().readAllBytes();
+        var res = p.waitFor();
+        if (res == 0) {
+            return new String(bytes, StandardCharsets.UTF_8).trim();
+        }
+        return "";
+    }
+
+    private static String proxyEnvironmentVariable() {
+        for (var key : List.of("http_proxy", "https_proxy")) {
+            var proxy = System.getenv(key);
+            if (proxy == null) {
+                proxy = System.getenv(key.toUpperCase());
+            }
+            if (proxy != null) {
+                return proxy;
+            }
+        }
+        return "";
+    }
+
+    public static void main(String[] args) throws IOException, InterruptedException {
+        String proxyArgument = null;
+        for (var i = 0; i < args.length; i++) {
+            var arg = args[i];
+            if (arg.equals("-c") && i < (args.length - 1)) {
+                var next = args[i + 1];
+                if (next.startsWith("http.proxy")) {
+                    var parts = next.split("=");
+                    if (parts.length == 2) {
+                        proxyArgument = parts[1];
+                        break;
+                    }
+                }
+            }
+        }
+
+        HttpProxy.setup(proxyArgument);
+
+        var httpsProxyHost = System.getProperty("https.proxyHost");
+        var httpProxyHost = System.getProperty("http.proxyHost");
+
+        if (httpsProxyHost == null && httpProxyHost == null) {
+            System.err.println("error: no proxy host specified");
+            System.err.println("");
+            System.err.println("Either set the git config variable 'http.proxy' or");
+            System.err.println("set the environment variables HTTP_PROXY and/or HTTPS_PROXY");
+            System.exit(1);
+        }
+
+        var httpsProxyPort = System.getProperty("https.proxyPort");
+        var httpProxyPort = System.getProperty("http.proxyPort");
+        var proxyHost = httpsProxyHost != null ? httpsProxyHost : httpProxyHost;
+        var proxyPort = httpsProxyPort != null ? httpsProxyPort : httpProxyPort;
+        var proxy = proxyHost + ":" + proxyPort;
+
+        System.out.println("info: using proxy " + proxy);
+
+        var gitArgs = new ArrayList<String>();
+        gitArgs.add("git");
+        gitArgs.addAll(Arrays.asList(args));
+        var pb = new ProcessBuilder(gitArgs);
+        var env = pb.environment();
+
+        if (httpProxyHost != null) {
+            env.put("HTTP_PROXY", proxy);
+            env.put("http_proxy", proxy);
+        }
+        if (httpsProxyHost != null) {
+            env.put("HTTPS_PROXY", proxy);
+            env.put("https_proxy", proxy);
+        }
+
+        var os = System.getProperty("os.name").toLowerCase();
+        if (os.startsWith("win")) {
+            for (var dir : System.getenv("PATH").split(";")) {
+                if (dir.endsWith("Git\\cmd") || dir.endsWith("Git\\bin")) {
+                    var gitDir = Path.of(dir).getParent();
+                    var connect = gitDir.resolve("mingw64").resolve("bin").resolve("connect.exe");
+                    if (Files.exists(connect)) {
+                        env.put("GIT_SSH_COMMAND", "ssh -o ProxyCommand='" + connect.toAbsolutePath() +
+                                                   " -H " + proxy + " %h %p'");
+                        break;
+                    }
+                }
+            }
+        } else if (os.startsWith("mac")) {
+            // Need to use the BSD netcat since homebrew might install GNU netcat
+            env.put("GIT_SSH_COMMAND", "ssh -o ProxyCommand='/usr/bin/nc -X connect -x " + proxy + " %h %p'");
+        } else {
+            // Assume GNU/Linux and GNU netcat
+            env.put("GIT_SSH_COMMAND", "ssh -o ProxyCommand='nc --proxy " + proxy + " %h %p'");
+        }
+        pb.inheritIO();
+        System.exit(pb.start().waitFor());
+    }
+}

--- a/proxy/src/main/java/org/openjdk/skara/proxy/HttpProxy.java
+++ b/proxy/src/main/java/org/openjdk/skara/proxy/HttpProxy.java
@@ -47,6 +47,28 @@ public class HttpProxy {
     }
 
     public static void setup() {
+        setup(null);
+    }
+
+    public static void setup(String argument) {
+        if (argument != null) {
+            if (!argument.startsWith("http://") &&
+                !argument.startsWith("https://")) {
+                // Try to parse it as a http url - we only care about the host and port
+                argument = "http://" + argument;
+            }
+
+            try {
+                var uri = new URI(argument);
+                for (var protocol : List.of("http", "https")) {
+                    setProxyHostAndPortBasedOn(protocol, uri);
+                }
+                return;
+            } catch (URISyntaxException e) {
+                // pass
+            }
+        }
+
         try {
             var pb = new ProcessBuilder("git", "config", "http.proxy");
             pb.redirectOutput(ProcessBuilder.Redirect.PIPE);


### PR DESCRIPTION
Hi all,

please review this patch that adds a small new tool: `git-proxy`. `git-proxy`
can be used to set up the `HTTPS_PROXY` and `HTTP_PROXY` environment
variables based on either the `http.proxy` configuration setting or the `-c
http.proxy=` argument. Finally `git-proxy` will also set up the
`GIT_SSH_COMMAND` environment variable to use the `CONNECT` method for tunneling
SSH over an HTTP proxy.

Testing:
- manual testing of `git-proxy`
- `make test` passes on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/585/head:pull/585`
`$ git checkout pull/585`
