### PR TITLE
build: respect git's http.proxy setting

### DIFF
--- a/gradlew
+++ b/gradlew
@@ -104,12 +104,14 @@ fi
 
 if [ -z "${HTTPS_PROXY}" -a -z "${https_proxy}" -a -z "${HTTP_PROXY}" -a -z "${http_proxy}" ]; then
     # No HTTP(S) proxy configured via environment, check if configured via Git
-    GIT_HTTP_PROXY="$(git config http.proxy)"
-    if [ ! -z "${GIT_HTTP_PROXY}" ]; then
-        export HTTPS_PROXY="${GIT_HTTP_PROXY}"
-        export https_proxy="${GIT_HTTP_PROXY}"
-        export HTTP_PROXY="${GIT_HTTP_PROXY}"
-        export http_proxy="${GIT_HTTP_PROXY}"
+    if exists git; then
+        GIT_HTTP_PROXY="$(git config http.proxy)"
+        if [ ! -z "${GIT_HTTP_PROXY}" ]; then
+            export HTTPS_PROXY="${GIT_HTTP_PROXY}"
+            export https_proxy="${GIT_HTTP_PROXY}"
+            export HTTP_PROXY="${GIT_HTTP_PROXY}"
+            export http_proxy="${GIT_HTTP_PROXY}"
+        fi
     fi
 fi
 

--- a/gradlew
+++ b/gradlew
@@ -102,6 +102,17 @@ if [ "${ARCH}" = "x86_64" ]; then
     esac
 fi
 
+if [ -z "${HTTPS_PROXY}" -a -z "${https_proxy}" -a -z "${HTTP_PROXY}" -a -z "${http_proxy}" ]; then
+    # No HTTP(S) proxy configured via environment, check if configured via Git
+    GIT_HTTP_PROXY="$(git config http.proxy)"
+    if [ ! -z "${GIT_HTTP_PROXY}" ]; then
+        export HTTPS_PROXY="${GIT_HTTP_PROXY}"
+        export https_proxy="${GIT_HTTP_PROXY}"
+        export HTTP_PROXY="${GIT_HTTP_PROXY}"
+        export http_proxy="${GIT_HTTP_PROXY}"
+    fi
+fi
+
 if [ ! -z "${JDK_URL}" ]; then
     JDK_FILENAME="${DIR}/.jdk/$(basename ${JDK_URL})"
     if [ "${OS}" = "Linux" -o "${OS}" = "Darwin" ]; then

--- a/gradlew
+++ b/gradlew
@@ -105,7 +105,7 @@ fi
 if [ -z "${HTTPS_PROXY}" -a -z "${https_proxy}" -a -z "${HTTP_PROXY}" -a -z "${http_proxy}" ]; then
     # No HTTP(S) proxy configured via environment, check if configured via Git
     if exists git; then
-        GIT_HTTP_PROXY="$(git config http.proxy)"
+        GIT_HTTP_PROXY="$(git config http.proxy || true)"
         if [ ! -z "${GIT_HTTP_PROXY}" ]; then
             export HTTPS_PROXY="${GIT_HTTP_PROXY}"
             export https_proxy="${GIT_HTTP_PROXY}"


### PR DESCRIPTION
Hi all,

please review this small patch that makes the `gradlew` script respect git's
`http.proxy` setting.

Testing:
- Manual testing of `sh gradlew`

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/586/head:pull/586`
`$ git checkout pull/586`
