### PR TITLE
skara: add aliases for publish and proxy

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitSkara.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitSkara.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -174,6 +174,7 @@ public class GitSkara {
         commands.put("translate", GitTranslate::main);
         commands.put("sync", GitSync::main);
         commands.put("publish", GitPublish::main);
+        commands.put("proxy", GitProxy::main);
 
         commands.put("update", GitSkara::update);
         commands.put("help", GitSkara::usage);

--- a/skara.gitconfig
+++ b/skara.gitconfig
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -32,3 +32,5 @@
         info = ! git skara info
         translate = ! git skara translate
         sync = ! git skara sync
+        publish = ! git skara publish
+        proxy = ! git skara proxy


### PR DESCRIPTION
Hi all,

please review this small patch that aliases for `git-publish` and `git-proxy`
to `skara.gitconfig`.

Testing:
- Manual testing of `git publish` and `git proxy`

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/587/head:pull/587`
`$ git checkout pull/587`
