### PR TITLE
Improve handling of squash and rebase of PRs

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -52,8 +52,6 @@ class CheckRun {
     private final String mergeReadyMarker = "<!-- PullRequestBot merge is ready comment -->";
     private final String outdatedHelpMarker = "<!-- PullRequestBot outdated help comment -->";
     private final String sourceBranchWarningMarker = "<!-- PullRequestBot source branch warning comment -->";
-    private final Pattern mergeSourceFullPattern = Pattern.compile("^Merge ([-/\\w]+):([-\\w]+)$");
-    private final Pattern mergeSourceBranchOnlyPattern = Pattern.compile("^Merge ([-\\w]+)$");
     private final Set<String> newLabels;
 
     private CheckRun(CheckWorkItem workItem, PullRequest pr, PullRequestInstance prInstance, List<Comment> comments,
@@ -112,40 +110,6 @@ class CheckRun {
         return ((names.size() == 1) && emails.size() == 1);
     }
 
-    private static class MergeSource {
-        private final String repositoryName;
-        private final String branchName;
-
-        private MergeSource(String repositoryName, String branchName) {
-            this.repositoryName = repositoryName;
-            this.branchName = branchName;
-        }
-    }
-
-    private Optional<MergeSource> mergeSource() {
-        var repoMatcher = mergeSourceFullPattern.matcher(pr.title());
-        if (!repoMatcher.matches()) {
-            var branchMatcher = mergeSourceBranchOnlyPattern.matcher(pr.title());
-            if (!branchMatcher.matches()) {
-                return Optional.empty();
-            }
-
-            // Verify that the branch exists
-            var isValidBranch = prInstance.remoteBranches().stream()
-                                          .map(Reference::name)
-                                          .anyMatch(branch -> branch.equals(branchMatcher.group(1)));
-            if (!isValidBranch) {
-                // Assume the name refers to a sibling repository
-                var repoName = Path.of(pr.repository().name()).resolveSibling(branchMatcher.group(1)).toString();
-                return Optional.of(new MergeSource(repoName, "master"));
-            }
-
-            return Optional.of(new MergeSource(pr.repository().name(), branchMatcher.group(1)));
-        }
-
-        return Optional.of(new MergeSource(repoMatcher.group(1), repoMatcher.group(2)));
-    }
-
     // Additional bot-specific checks that are not handled by JCheck
     private List<String> botSpecificChecks(Hash finalHash) throws IOException {
         var ret = new ArrayList<String>();
@@ -172,55 +136,6 @@ class CheckRun {
                     "the commits in the PR. However, the commits in this PR have inconsistent user names and/or " +
                     "email addresses. Please amend the commits.";
             ret.add(error);
-        }
-
-        if (pr.title().startsWith("Merge")) {
-            var commits = prInstance.localRepo().commitMetadata(baseHash, finalHash);
-            if (commits.size() < 2) {
-                ret.add("A Merge PR must contain at least two commits that are not already present in the target.");
-            } else {
-                // Find the first merge commit - the very last commit is not eligible (as the merge needs a parent)
-                int mergeCommitIndex = commits.size();
-                for (int i = 0; i < commits.size() - 1; ++i) {
-                    if (commits.get(i).isMerge()) {
-                        mergeCommitIndex = i;
-                        break;
-                    }
-                }
-                if (mergeCommitIndex >= commits.size() - 1) {
-                    ret.add("A Merge PR must contain a merge commit as well as at least one other commit from the merge source.");
-                }
-
-                var source = mergeSource();
-                if (source.isPresent()) {
-                    try {
-                        var mergeSourceRepo = pr.repository().forge().repository(source.get().repositoryName).orElseThrow(() ->
-                                new RuntimeException("Could not find repository " + source.get().repositoryName)
-                        );
-                        try {
-                            var sourceHash = prInstance.localRepo().fetch(mergeSourceRepo.url(), source.get().branchName, false);
-                            var mergeCommit = commits.get(mergeCommitIndex);
-                            for (int i = 0; i < mergeCommit.parents().size(); ++i) {
-                                if (!prInstance.localRepo().isAncestor(mergeCommit.parents().get(i), sourceHash)) {
-                                    if (!mergeCommit.parents().get(i).equals(prInstance.targetHash())) {
-                                        ret.add("The merge contains commits that are neither ancestors of the source nor the target.");
-                                        break;
-                                    }
-                                }
-                            }
-                        } catch (IOException e) {
-                            ret.add("Could not fetch branch `" + source.get().branchName + "` from project `" +
-                                            source.get().repositoryName + "` - check that they are correct.");
-                        }
-                    } catch (RuntimeException e) {
-                        ret.add("Could not find project `" +
-                                        source.get().repositoryName + "` - check that it is correct.");
-                    }
-                } else {
-                    ret.add("Could not determine the source for this merge. A Merge PR title must be specified on the format: " +
-                            "Merge `project`:`branch` to allow verification of the merge contents.");
-                }
-            }
         }
 
         for (var blocker : workItem.bot.blockingCheckLabels().entrySet()) {
@@ -684,7 +599,7 @@ class CheckRun {
             try {
                 localHash = prInstance.commit(commitHash, censusInstance.namespace(), censusDomain, null);
             } catch (CommitFailure e) {
-                additionalErrors = List.of("It was not possible to create a commit for the changes in this PR: " + e.getMessage());
+                additionalErrors = List.of(e.getMessage());
                 localHash = prInstance.baseHash();
             }
             PullRequestCheckIssueVisitor visitor = prInstance.createVisitor(localHash, censusInstance);

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
@@ -155,8 +155,7 @@ public class IntegrateCommand implements CommandHandler {
             }
         } catch (Exception e) {
             log.throwing("IntegrateCommand", "handle", e);
-            reply.println("An error occurred during final integration jcheck");
-            throw new RuntimeException(e);
+            reply.println("An error occurred during final integration jcheck. No push attempt will be made.");
         }
     }
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
@@ -130,8 +130,7 @@ public class SponsorCommand implements CommandHandler {
             }
         } catch (Exception e) {
             log.throwing("SponsorCommand", "handle", e);
-            reply.println("An error occurred during sponsored integration");
-            throw new RuntimeException(e);
+            reply.println("An error occurred during sponsored integration. No push attempt will be made.");
         }
     }
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
@@ -81,9 +81,6 @@ public class SponsorCommand implements CommandHandler {
                                                      new HostedRepositoryPool(seedPath),
                                                      pr,
                                                      bot.ignoreStaleReviews());
-            var localHash = prInstance.commit(censusInstance.namespace(), censusInstance.configuration().census().domain(),
-                                         comment.author().id());
-
             // Validate the target hash if requested
             var rebaseMessage = new StringWriter();
             if (!args.isBlank()) {
@@ -97,15 +94,14 @@ public class SponsorCommand implements CommandHandler {
 
             // Now rebase onto the target hash
             var rebaseWriter = new PrintWriter(rebaseMessage);
-            var rebasedHash = prInstance.rebase(localHash, rebaseWriter);
+            var rebasedHash = prInstance.mergeTarget(rebaseWriter);
             if (rebasedHash.isEmpty()) {
                 reply.println(rebaseMessage.toString());
                 return;
-            } else {
-                if (!rebasedHash.get().equals(localHash)) {
-                    localHash = rebasedHash.get();
-                }
             }
+
+            var localHash = prInstance.commit(rebasedHash.get(), censusInstance.namespace(), censusInstance.configuration().census().domain(),
+                    comment.author().id());
 
             var issues = prInstance.createVisitor(localHash, censusInstance);
             var additionalConfiguration = AdditionalConfiguration.get(prInstance.localRepo(), localHash, pr.repository().forge().currentUser(), allComments);

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -1180,6 +1180,7 @@ class CheckTests {
             assertEquals(1, checks.size());
             var check = checks.get("jcheck");
             assertEquals(CheckStatus.FAILURE, check.status());
+            assertEquals("- This PR contains no changes", check.summary().orElseThrow());
         }
     }
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
@@ -209,7 +209,6 @@ class MergeTests {
     }
 
     @Test
-    @Disabled
     void branchMergeRebase(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
              var tempFolder = new TemporaryDirectory()) {
@@ -304,7 +303,6 @@ class MergeTests {
     }
 
     @Test
-    @Disabled
     void branchMergeAdditionalCommits(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
              var tempFolder = new TemporaryDirectory()) {
@@ -411,6 +409,10 @@ class MergeTests {
             assertEquals("integrationcommitter1@openjdk.java.net", headCommit.author().email());
             assertEquals("Generated Committer 1", headCommit.committer().name());
             assertEquals("integrationcommitter1@openjdk.java.net", headCommit.committer().email());
+
+            // The latest content from the source and the updated master should be present
+            assertEquals("New on master", Files.readString(pushedRepoFolder.resolve("newmaster.txt")));
+            assertEquals("Unrelated", Files.readString(pushedRepoFolder.resolve("unrelated.txt")));
         }
     }
 
@@ -468,7 +470,7 @@ class MergeTests {
             assertEquals(1, error, () -> pr.comments().stream().map(Comment::body).collect(Collectors.joining("\n\n")));
 
             var check = pr.checks(mergeHash).get("jcheck");
-            assertEquals("- It was not possible to create a commit for the changes in this PR: A merge PR is only allowed to contain a single merge commit. You will need to amend your commits.", check.summary().orElseThrow());
+            assertEquals("- The merge commit must have a commit on the target branch as one of its parents.", check.summary().orElseThrow());
         }
     }
 
@@ -714,7 +716,7 @@ class MergeTests {
             assertEquals(1, error, () -> pr.comments().stream().map(Comment::body).collect(Collectors.joining("\n\n")));
 
             var check = pr.checks(mergeHash).get("jcheck");
-            assertEquals("- The merge contains commits that are neither ancestors of the source nor the target.", check.summary().orElseThrow());
+            assertEquals("- A merge PR must contain a merge commit as well as at least one other commit from the merge source.", check.summary().orElseThrow());
         }
     }
 
@@ -846,7 +848,7 @@ class MergeTests {
             assertEquals(1, error, () -> pr.comments().stream().map(Comment::body).collect(Collectors.joining("\n\n")));
 
             var check = pr.checks(mergeHash).get("jcheck");
-            assertEquals("- The merge contains commits that are neither ancestors of the source nor the target.", check.summary().orElseThrow());
+            assertEquals("- The merge commit must have a commit on the target branch as one of its parents.", check.summary().orElseThrow());
         }
     }
 
@@ -902,8 +904,7 @@ class MergeTests {
             assertEquals(1, error, () -> pr.comments().stream().map(Comment::body).collect(Collectors.joining("\n\n")));
 
             var check = pr.checks(mergeHash).get("jcheck");
-            assertEquals("- Could not determine the source for this merge. A Merge PR title must be specified on the format: Merge `project`:`branch` to allow verification of the merge contents.\n" +
-                                 "- Merge commit message is not Merge, but: Merge this or that", check.summary().orElseThrow());
+            assertEquals("- Could not determine the source for this merge. A Merge PR title must be specified on the format: Merge `project`:`branch` to allow verification of the merge contents.", check.summary().orElseThrow());
         }
     }
 }

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/TestRepository.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/TestRepository.java
@@ -301,6 +301,11 @@ class TestRepository implements ReadOnlyRepository {
         return null;
     }
 
+    @Override
+    public Tree tree(Hash h) throws IOException {
+        return null;
+    }
+
     public Optional<Tag.Annotated> annotate(Tag tag) throws IOException {
         return null;
     }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
@@ -105,6 +105,13 @@ public interface ReadOnlyRepository {
     List<Reference> remoteBranches(String remote) throws IOException;
     List<String> remotes() throws IOException;
     List<Submodule> submodules() throws IOException;
+    Tree tree(Hash h) throws IOException;
+    default Tree tree(Commit c) throws IOException {
+        return tree(c.hash());
+    }
+    default Tree tree(CommitMetadata c) throws IOException {
+        return tree(c.hash());
+    }
 
     static Optional<ReadOnlyRepository> get(Path p) throws IOException {
         return Repository.get(p).map(r -> r);

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
@@ -93,15 +93,15 @@ public interface Repository extends ReadOnlyRepository {
                 String committerName,
                 String committerEmail,
                 ZonedDateTime committerDate) throws IOException;
-    Hash commit(Hash content,
-                List<Hash> parents,
-                String message,
+    Hash commit(String message,
                 String authorName,
                 String authorEmail,
                 ZonedDateTime authorDate,
                 String committerName,
                 String committerEmail,
-                ZonedDateTime committerDate) throws IOException;
+                ZonedDateTime committerDate,
+                List<Hash> parents,
+                Tree tree) throws IOException;
     Hash amend(String message,
                String authorName,
                String authorEmail) throws IOException;

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
@@ -93,6 +93,15 @@ public interface Repository extends ReadOnlyRepository {
                 String committerName,
                 String committerEmail,
                 ZonedDateTime committerDate) throws IOException;
+    Hash commit(Hash content,
+                List<Hash> parents,
+                String message,
+                String authorName,
+                String authorEmail,
+                ZonedDateTime authorDate,
+                String committerName,
+                String committerEmail,
+                ZonedDateTime committerDate) throws IOException;
     Hash amend(String message,
                String authorName,
                String authorEmail) throws IOException;

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Tree.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Tree.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.vcs;
+
+import java.util.Objects;
+
+public class Tree {
+    private final Hash hash;
+
+    public Tree(Hash hash) {
+        this.hash = hash;
+    }
+
+    public Hash hash() {
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Tree tree = (Tree) o;
+        return hash.equals(tree.hash);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(hash);
+    }
+
+    @Override
+    public String toString() {
+        return "Tree{" +
+                "hash=" + hash +
+                '}';
+    }
+}

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -617,6 +617,11 @@ public class HgRepository implements Repository {
     }
 
     @Override
+    public Hash commit(Hash content, List<Hash> parents, String message, String authorName, String authorEmail, ZonedDateTime authorDate, String committerName, String committerEmail, ZonedDateTime committerDate) throws IOException {
+        throw new RuntimeException("not implemented yet");
+    }
+
+    @Override
     public Hash amend(String message, String authorName, String authorEmail) throws IOException {
         var user = authorEmail == null ? authorName : authorName + " <" + authorEmail + ">";
         try (var p = capture("hg", "commit", "--amend", "--message=" + message, "--user=" + user)) {

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -617,7 +617,7 @@ public class HgRepository implements Repository {
     }
 
     @Override
-    public Hash commit(Hash content, List<Hash> parents, String message, String authorName, String authorEmail, ZonedDateTime authorDate, String committerName, String committerEmail, ZonedDateTime committerDate) throws IOException {
+    public Hash commit(String message, String authorName, String authorEmail, ZonedDateTime authorDate, String committerName, String committerEmail, ZonedDateTime committerDate, List<Hash> parents, Tree tree) throws IOException {
         throw new RuntimeException("not implemented yet");
     }
 
@@ -1301,6 +1301,11 @@ public class HgRepository implements Repository {
         }
 
         return modules;
+    }
+
+    @Override
+    public Tree tree(Hash h) throws IOException {
+        throw new RuntimeException("not implemented yet");
     }
 
     @Override


### PR DESCRIPTION
Hi all,

Please review this change that improves how we perform squashing and rebasing before doing the final integration. Instead of using squash / rebase, simply merge the latest state of the target branch. Use the final state (tree) to create the commit, and specify the proper parents. This has the benefit of working for merge PRs as well.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/589/head:pull/589`
`$ git checkout pull/589`
