### PR TITLE
Fix problem with specifying a single issue with shorthand syntax

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IssueCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IssueCommand.java
@@ -66,6 +66,7 @@ public class IssueCommand implements CommandHandler {
     }
 
     private static final Pattern shortIssuePattern = Pattern.compile("((?:[A-Za-z]+-)?[0-9]+)(?:,| |$)");
+    private final static Pattern subCommandPattern = Pattern.compile("^(add|remove|delete|(?:[A-Za-z]+-)?[0-9]+:?)[ ,]?.*$");
 
     private List<Issue> parseIssueList(String allowedPrefix, String issueList) throws InvalidIssue {
         List<Issue> ret;
@@ -91,8 +92,6 @@ public class IssueCommand implements CommandHandler {
                   .map(issue -> issue.id().contains("-") ? new Issue(issue.id().split("-", 2)[1], issue.description()) : issue)
                   .collect(Collectors.toList());
     }
-
-    private final static Pattern subCommandPattern = Pattern.compile("^(add|remove|delete|(?:[A-Za-z]+-)?[0-9]+:?)[ ,]+.*$");
 
     IssueCommand(String name) {
         this.name = name;

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IssueTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IssueTests.java
@@ -191,6 +191,17 @@ class IssueTests {
             var issue2 = credentials.createIssue(issues, "Second");
             var issue2Number = Integer.parseInt(issue2.id().split("-")[1]);
 
+            // Add a single issue with the shorthand syntax
+            pr.addComment("/solves " + issue2Number);
+            TestBotRunner.runPeriodicItems(prBot);
+            assertLastCommentContains(pr, "Adding additional issue to solves list");
+            assertLastCommentContains(pr, ": Second");
+
+            // And remove it
+            pr.addComment("/solves delete " + issue2Number);
+            TestBotRunner.runPeriodicItems(prBot);
+            assertLastCommentContains(pr, "Removing additional issue from solves list: `" + issue2Number + "`");
+
             // Add two issues with the shorthand syntax
             pr.addComment("/issue " + issue1.id() + "," + issue2Number);
             TestBotRunner.runPeriodicItems(prBot);


### PR DESCRIPTION
Hi all,

Please review this small change that fixes a problem with specifying a single issue to the `/issues` (or `/solves`) command using the shorthand syntax.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/592/head:pull/592`
`$ git checkout pull/592`
