### PR TITLE
mirror-bot: use to repo to restrict concurrency

### DIFF
--- a/bots/mirror/src/main/java/org/openjdk/skara/bots/mirror/MirrorBot.java
+++ b/bots/mirror/src/main/java/org/openjdk/skara/bots/mirror/MirrorBot.java
@@ -62,14 +62,14 @@ class MirrorBot implements Bot, WorkItem {
             return true;
         }
         var otherBot = (MirrorBot) other;
-        return !from.name().equals(otherBot.from.name());
+        return !to.name().equals(otherBot.to.name());
     }
 
     @Override
     public void run(Path scratchPath) {
         try {
             var sanitizedUrl =
-                URLEncoder.encode(from.webUrl().toString(), StandardCharsets.UTF_8);
+                URLEncoder.encode(to.webUrl().toString(), StandardCharsets.UTF_8);
             var dir = storage.resolve(sanitizedUrl);
             Repository repo = null;
 
@@ -83,7 +83,7 @@ class MirrorBot implements Bot, WorkItem {
                     repo = Repository.clone(to.url(), dir);
                 }
             } else {
-                log.info("Found existing scratch directory for " + from.name());
+                log.info("Found existing scratch directory for " + to.name());
                 repo = Repository.get(dir).orElseThrow(() -> {
                         return new RuntimeException("Repository in " + dir + " has vanished");
                 });


### PR DESCRIPTION
Hi all,

please review this patch that makes the mirror bot use the `to` repository for
determining if whether multiple mirror work items can run concurrently. This
means the also must the `to` directory for creating its storage.

Testing:
- `make test` passes on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/594/head:pull/594`
`$ git checkout pull/594`
