### PR TITLE
gitlab: avoid NPE in GitLabForgeFactory.create

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabForgeFactory.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabForgeFactory.java
@@ -21,7 +21,7 @@ public class GitLabForgeFactory implements ForgeFactory {
     @Override
     public Forge create(URI uri, Credential credential, JSONObject configuration) {
         var name = "GitLab";
-        if (configuration.contains("name")) {
+        if (configuration != null && configuration.contains("name")) {
             name = configuration.get("name").asString();
         }
         if (credential != null) {


### PR DESCRIPTION
Hi all,

please review this small patch that fixes an NPE in `GitLabForgeFactory.create`.

Testing:
- `make test` passes on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/595/head:pull/595`
`$ git checkout pull/595`
