### PR TITLE
377: Remove special handling of failed-auto-merge label

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
@@ -67,8 +67,6 @@ class ReviewArchive {
         } else {
             if (pr.state() != Issue.State.OPEN) {
                 threadPrefix = "FYI";
-            } else if (pr.labels().contains("failed-auto-merge")) {
-                threadPrefix = "";
             }
         }
 


### PR DESCRIPTION
Hi all,

please review this patch that makes merge pull requests created by the
openjdk-bot to get the proper "RFR:" prefix. The pull requests generated by the
bot are as real as any other pull request :smile:

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-377](https://bugs.openjdk.java.net/browse/SKARA-377): Remove special handling of failed-auto-merge label


### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/597/head:pull/597`
`$ git checkout pull/597`
