### PR TITLE
378: Create merge conflict webrevs for "merge style" PRs without merge commit

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveItem.java
@@ -48,6 +48,40 @@ class ArchiveItem {
         }
     }
 
+    private static Optional<Commit> conflictCommit(PullRequest pr, Repository localRepo, Hash head) {
+        try {
+            localRepo.checkout(head, true);
+        } catch (IOException e) {
+            return Optional.empty();
+        }
+
+        try {
+            localRepo.merge(pr.targetHash());
+            // No problem means no conflict
+            return Optional.empty();
+        } catch (IOException e) {
+            try {
+                var status = localRepo.status();
+                var unmerged = status.stream()
+                                     .filter(entry -> entry.status().isUnmerged())
+                                     .map(entry -> entry.source().path())
+                                     .filter(Optional::isPresent)
+                                     .map(Optional::get)
+                                     .collect(Collectors.toList());
+
+                // Drop the successful merges from the stage
+                localRepo.reset(head, false);
+                // Add the unmerged files as-is (retaining the conflict markers)
+                localRepo.add(unmerged);
+                var hash = localRepo.commit("Conflicts in " + pr.title(), "duke", "duke@openjdk.org");
+                localRepo.clean();
+                return localRepo.lookup(hash);
+            } catch (IOException ioException) {
+                return Optional.empty();
+            }
+        }
+    }
+
     static ArchiveItem from(PullRequest pr, Repository localRepo, HostUserToEmailAuthor hostUserToEmailAuthor,
                             URI issueTracker, String issuePrefix, WebrevStorage.WebrevGenerator webrevGenerator,
                             WebrevNotification webrevNotification, ZonedDateTime created, ZonedDateTime updated,
@@ -60,9 +94,11 @@ class ArchiveItem {
                                () -> ArchiveMessages.composeConversation(pr),
                                () -> {
                                    if (PullRequestUtils.isMerge(pr)) {
-                                       //TODO: Try to merge in target - generate possible conflict webrev
-                                       var mergeCommit = mergeCommit(pr, localRepo, head);
                                        var mergeWebrevs = new ArrayList<WebrevDescription>();
+                                       var conflictCommit = conflictCommit(pr, localRepo, head);
+                                       conflictCommit.ifPresent(commit -> mergeWebrevs.add(
+                                               webrevGenerator.generate(commit.parentDiffs().get(0), "00.conflicts", WebrevDescription.Type.MERGE_CONFLICT, pr.targetRef())));
+                                       var mergeCommit = mergeCommit(pr, localRepo, head);
                                        if (mergeCommit.isPresent()) {
                                            for (int i = 0; i < mergeCommit.get().parentDiffs().size(); ++i) {
                                                var diff = mergeCommit.get().parentDiffs().get(i);

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
@@ -265,8 +265,15 @@ class ArchiveMessages {
         var commits = commits(localRepo, base, head);
         String webrevLinks;
         if (webrevs.size() > 0) {
-            webrevLinks = "The webrev" + (webrevs.size() > 1 ? "s" : "") + " contain" + (webrevs.size() == 1 ? "s" : "") +
-                    " only the adjustments done while merging with regards to each parent branch:\n" +
+            var containsConflicts = webrevs.stream().anyMatch(w -> w.type().equals(WebrevDescription.Type.MERGE_CONFLICT));
+            var containsMergeDiffs = webrevs.stream().anyMatch(w -> w.type().equals(WebrevDescription.Type.MERGE_TARGET) ||
+                    w.type().equals(WebrevDescription.Type.MERGE_SOURCE));
+
+            webrevLinks = "The webrev" + (webrevs.size() > 1 ? "s" : "") + " contain" + (webrevs.size() == 1 ? "s" : "") + " " +
+                    (containsConflicts ? "the conflicts with " + pr.targetRef() : "") +
+                    (containsConflicts && containsMergeDiffs ? " and " : "") +
+                    (containsMergeDiffs ? "the adjustments done while merging with regards to each parent branch" : "")
+                    +":\n" +
                     webrevs.stream()
                            .map(d -> String.format(" - %s: %s", d.shortLabel(), d.uri()))
                            .collect(Collectors.joining("\n")) + "\n\n";

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevDescription.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevDescription.java
@@ -29,7 +29,8 @@ public class WebrevDescription {
         FULL,
         INCREMENTAL,
         MERGE_TARGET,
-        MERGE_SOURCE
+        MERGE_SOURCE,
+        MERGE_CONFLICT
     }
 
     private final URI uri;
@@ -48,6 +49,10 @@ public class WebrevDescription {
         this.description = null;
     }
 
+    public Type type() {
+        return type;
+    }
+
     public URI uri() {
         return uri;
     }
@@ -62,6 +67,8 @@ public class WebrevDescription {
                 return "Merge target" + (description != null ? " (" + description + ")" : "");
             case MERGE_SOURCE:
                 return "Merge source" + (description != null ? " (" + description + ")" : "");
+            case MERGE_CONFLICT:
+                return "Merge conflicts" + (description != null ? " (" + description + ")" : "");
 
         }
         throw new RuntimeException("Unknown type");
@@ -77,6 +84,8 @@ public class WebrevDescription {
                 return description != null ? description : "merge target";
             case MERGE_SOURCE:
                 return description != null ? description : "merge source";
+            case MERGE_CONFLICT:
+                return "merge conflicts";
 
         }
         throw new RuntimeException("Unknown type");

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -1732,6 +1732,78 @@ class MailingListBridgeBotTests {
     }
 
     @Test
+    void mergeWebrevConflict(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory();
+             var archiveFolder = new TemporaryDirectory();
+             var listServer = new TestMailmanServer();
+             var webrevServer = new TestWebrevServer()) {
+            var author = credentials.getHostedRepository();
+            var archive = credentials.getHostedRepository();
+            var commenter = credentials.getHostedRepository();
+            var listAddress = EmailAddress.parse(listServer.createList("test"));
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addAuthor(author.forge().currentUser().id());
+            var from = EmailAddress.from("test", "test@test.mail");
+            var mlBot = MailingListBridgeBot.newBuilder()
+                                            .from(from)
+                                            .repo(author)
+                                            .archive(archive)
+                                            .archiveRef("archive")
+                                            .censusRepo(censusBuilder.build())
+                                            .list(listAddress)
+                                            .listArchive(listServer.getArchive())
+                                            .smtpServer(listServer.getSMTP())
+                                            .webrevStorageRepository(archive)
+                                            .webrevStorageRef("webrev")
+                                            .webrevStorageBase(Path.of("test"))
+                                            .webrevStorageBaseUri(webrevServer.uri())
+                                            .issueTracker(URIBuilder.base("http://issues.test/browse/").build())
+                                            .build();
+
+            // Populate the projects repository
+            var reviewFile = Path.of("reviewfile.txt");
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(), reviewFile);
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, archive.url(), "archive", true);
+            localRepo.push(masterHash, archive.url(), "webrev", true);
+
+            // Create a merge
+            var editOnlyFile = Path.of("editonly.txt");
+            Files.writeString(localRepo.root().resolve(editOnlyFile), "Only added in the edit");
+            localRepo.add(editOnlyFile);
+            var editHash = CheckableRepository.appendAndCommit(localRepo, "Edited");
+            localRepo.checkout(masterHash, true);
+            var masterOnlyFile = Path.of("masteronly.txt");
+            Files.writeString(localRepo.root().resolve(masterOnlyFile), "Only added in master");
+            localRepo.add(masterOnlyFile);
+            var updatedMasterHash = CheckableRepository.appendAndCommit(localRepo, "Master change");
+            localRepo.push(updatedMasterHash, author.url(), "master");
+            localRepo.push(editHash, author.url(), "edit", true);
+
+            // Make a merge PR
+            var pr = credentials.createPullRequest(archive, "master", "edit", "Merge edit");
+            pr.setBody("This is now ready");
+
+            // Run an archive pass
+            TestBotRunner.runPeriodicItems(mlBot);
+            listServer.processIncoming();
+
+            // The archive should contain a merge style webrev
+            Repository.materialize(archiveFolder.path(), archive.url(), "archive");
+            assertTrue(archiveContains(archiveFolder.path(), "The webrev contains the conflicts with master:"));
+            assertTrue(archiveContains(archiveFolder.path(), pr.id() + "/webrev.00.conflicts"));
+            assertTrue(archiveContains(archiveFolder.path(), "2 lines in 2 files changed: 2 ins; 0 del; 0 mod"));
+
+            // The PR should contain a webrev comment
+            assertEquals(1, pr.comments().size());
+            var webrevComment = pr.comments().get(0);
+            assertTrue(webrevComment.body().contains("Merge conflicts"));
+        }
+    }
+
+    @Test
     void mergeWebrevNoConflict(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
              var tempFolder = new TemporaryDirectory();


### PR DESCRIPTION
Hi all,

Please review this change that creates a webrev containing only the merge conflicts for merge PRs that conflict with their target.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-378](https://bugs.openjdk.java.net/browse/SKARA-378): Create merge conflict webrevs for "merge style" PRs without merge commit


### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/598/head:pull/598`
`$ git checkout pull/598`
