### PR TITLE
cli: add trees command

### DIFF
--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -60,7 +60,8 @@ images {
         'hg-openjdk-import': 'org.openjdk.skara.cli/org.openjdk.skara.cli.HgOpenJDKImport',
         'git-sync': 'org.openjdk.skara.cli/org.openjdk.skara.cli.GitSync',
         'git-publish': 'org.openjdk.skara.cli/org.openjdk.skara.cli.GitPublish',
-        'git-proxy': 'org.openjdk.skara.cli/org.openjdk.skara.cli.GitProxy'
+        'git-proxy': 'org.openjdk.skara.cli/org.openjdk.skara.cli.GitProxy',
+        'git-trees': 'org.openjdk.skara.cli/org.openjdk.skara.cli.GitTrees'
     ]
 
     ext.modules = ['jdk.crypto.ec']

--- a/cli/src/main/java/org/openjdk/skara/cli/GitSkara.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitSkara.java
@@ -175,6 +175,7 @@ public class GitSkara {
         commands.put("sync", GitSync::main);
         commands.put("publish", GitPublish::main);
         commands.put("proxy", GitProxy::main);
+        commands.put("trees", GitTrees::main);
 
         commands.put("update", GitSkara::update);
         commands.put("help", GitSkara::usage);

--- a/cli/src/main/java/org/openjdk/skara/cli/GitTrees.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitTrees.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.cli;
+
+import org.openjdk.skara.proxy.HttpProxy;
+import org.openjdk.skara.version.Version;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class GitTrees {
+    private static Path root(boolean isMercurial) throws IOException, InterruptedException {
+        var pb = isMercurial ?
+            new ProcessBuilder("hg", "root") :
+            new ProcessBuilder("git", "rev-parse", "--show-toplevel");
+        pb.redirectOutput(ProcessBuilder.Redirect.PIPE);
+        pb.redirectError(ProcessBuilder.Redirect.INHERIT);
+        var p = pb.start();
+        var output = new String(p.getInputStream().readAllBytes(), StandardCharsets.UTF_8).strip();
+        var res = p.waitFor();
+        if (res != 0) {
+            System.exit(res);
+        }
+
+        return Path.of(output);
+    }
+
+    private static List<Path> subrepos(Path root, boolean isMercurial) throws IOException {
+        var r = Files.walk(root)
+                    .filter(d -> d.getFileName().toString().equals(isMercurial ? ".hg" : ".git"))
+                    .map(d -> d.getParent())
+                    .filter(d -> !d.equals(root))
+                    .map(d -> root.relativize(d))
+                    .sorted()
+                    .collect(Collectors.toList());
+        return r;
+    }
+
+    private static Path treesFile(Path root, boolean isMercurial) {
+        return root.resolve(isMercurial ? ".hg" : ".git").resolve("trees");
+    }
+
+    private static List<Path> tconfig(Path root, boolean isMercurial) throws IOException {
+        var subrepos = subrepos(root, isMercurial);
+        var treesFile = treesFile(root, isMercurial);
+        Files.write(treesFile, subrepos.stream().map(Path::toString).collect(Collectors.toList()));
+        return subrepos;
+    }
+
+    private static List<Path> trees(Path root, boolean isMercurial) throws IOException {
+        var file = treesFile(root, isMercurial);
+        if (Files.exists(file)) {
+            var lines = Files.readAllLines(file);
+            return lines.stream().map(Path::of).collect(Collectors.toList());
+        }
+
+        return null;
+    }
+
+    public static void main(String[] args) throws IOException, InterruptedException {
+        if (args.length == 1 && args[0].equals("--version")) {
+            System.out.println("git-trees version: " + Version.fromManifest().orElse("unknown"));
+            System.exit(0);
+        }
+
+        if (args.length == 1 && args[0].equals("-h")) {
+            System.out.println("git-trees version: " + Version.fromManifest().orElse("unknown"));
+            System.exit(0);
+        }
+
+        HttpProxy.setup();
+
+        var isMercurial = args.length > 0 && (args[0].equals("--mercurial") || args[0].equals("-m"));
+        var root = root(isMercurial);
+        var trees = trees(root, isMercurial);
+        if (trees == null) {
+            trees = tconfig(root, isMercurial);
+        }
+
+        var command = new ArrayList<String>();
+        command.add(isMercurial ? "hg" : "git");
+        for (var i = isMercurial ? 1 : 0; i < args.length; i++) {
+            command.add(args[i]);
+        }
+        System.out.println("executing: " + String.join(" ", command));
+        var pb = new ProcessBuilder(command);
+        pb.inheritIO();
+
+        System.out.println("[" + root.toString() + "]");
+        pb.directory(root.toFile());
+        var ret = pb.start().waitFor();
+
+        for (var path : trees) {
+            System.out.println("[" + root.resolve(path).toString() + "]");
+            pb.directory(root.resolve(path).toFile());
+            ret += pb.start().waitFor();
+        }
+
+        System.exit(ret);
+    }
+}

--- a/skara.gitconfig
+++ b/skara.gitconfig
@@ -34,3 +34,23 @@
         sync = ! git skara sync
         publish = ! git skara publish
         proxy = ! git skara proxy
+        trees = ! git skara trees
+
+        tcommit = trees commit
+        tconfig = trees config
+        tdiff = trees diff
+        tlog = trees log
+        tmerge = trees merge
+        tremote = trees remote
+        tpull = trees pull
+        tpush = trees push
+        tcheckout = trees checkout
+        tstatus = trees status
+        ttag = trees tag
+
+        tdefpath = trees defpath
+        tsync = trees sync
+        tinfo = trees info
+        tpublish = trees publish
+        tskara = trees skara
+        tproxy = trees proxy

--- a/skara.py
+++ b/skara.py
@@ -40,7 +40,7 @@ else:
             return func
         return decorator
 
-def _skara(ui, args, **opts):
+def _update_if_needed(ui):
     skara = os.path.dirname(os.path.realpath(__file__))
     git_skara = os.path.join(skara, 'bin', 'bin', 'git-skara')
     if not os.path.isfile(git_skara):
@@ -58,14 +58,35 @@ def _skara(ui, args, **opts):
         if os.path.isdir(skara_bin):
             shutil.rmtree(skara_bin)
         shutil.move(skara_build, skara_bin)
+    return git_skara
 
+def _opts_to_flags(cmd = None, **opts):
+    args = []
     for k in opts:
-        if opts[k] == True:
-            args.append('--' + k.replace('_', '-'))
-        elif opts[k] != b'' and opts[k] != False:
-            args.append('--' + k)
-            args.append(opts[k])
-    return subprocess.call([git_skara] + args)
+        name = k.replace('_', '-')
+        v = opts[k]
+        if v == True:
+            args.append('--' + name)
+        elif k == b'terse' and cmd == 'status':
+            if v != b'nothing':
+                args.append('--' + name)
+                args.append(str(v))
+        elif v != b'' and v != [] and v != None and v != False:
+            args.append('--' + name)
+            args.append(str(v))
+    return args
+
+def _skara(ui, args, **opts):
+    git_skara = _update_if_needed(ui)
+    flags = _opts_to_flags(**opts)
+    ret = subprocess.call([git_skara] + args + flags)
+    sys.exit(ret)
+
+def _trees(ui, command, *args, **opts):
+    git_skara = _update_if_needed(ui)
+    flags = _opts_to_flags(command, **opts)
+    ret = subprocess.call([git_skara] + ['trees', '--mercurial', command] + flags + list(args))
+    sys.exit(ret)
 
 skara_opts = [
 ]
@@ -76,7 +97,7 @@ def skara(ui, repo, action=None, **opts):
     """
     if action == None:
         action = 'help'
-    sys.exit(_skara(ui, [action, '--mercurial'], **opts))
+    _skara(ui, [action, '--mercurial'], **opts)
 
 webrev_opts = [
     (b'r', b'rev', b'', b'Compare against specified revision'),
@@ -95,7 +116,7 @@ def webrev(ui, repo, **opts):
     Builds a set of HTML files suitable for doing a
     code review of source changes via a web page
     """
-    sys.exit(_skara(ui, ['webrev', '--mercurial'], **opts))
+    _skara(ui, ['webrev', '--mercurial'], **opts)
 
 jcheck_opts = [
     (b'r', b'rev', b'', b'Check the specified revision or range (default: tip)'),
@@ -111,7 +132,7 @@ def jcheck(ui, repo, **opts):
     """
     OpenJDK changeset checker
     """
-    sys.exit(_skara(ui, ['jcheck', '--mercurial'], **opts))
+    _skara(ui, ['jcheck', '--mercurial'], **opts)
 
 defpath_opts = [
     (b'u', b'username', b'', b'Username for push URL'),
@@ -125,4 +146,47 @@ def defpath(ui, repo, **opts):
     """
     Examine and manipulate default path settings
     """
-    sys.exit(_skara(ui, ['defpath', '--mercurial'], **opts))
+    _skara(ui, ['defpath', '--mercurial'], **opts)
+
+@command(b'tclone', norepo=True)
+def tclone(ui, source, dest=None, **opts):
+    repo = mercurial.hg.peer(ui, opts, source)
+    trees = sorted(list(repo.listkeys(b'trees').values()))
+    ui.status(b'cloning %s\n' % source)
+    if mercurial.commands.clone(ui, source, dest, **opts):
+        return True
+
+    dest = os.path.basename(source) if dest == None else dest
+    with open(os.path.join(dest, '.hg', 'files'), 'w') as f:
+        f.write('\n'.join(trees))
+
+    for t in sorted(trees, key=len):
+        tsource = source + b'/' + t
+        tdest = os.path.join(dest, t)
+
+        ui.status(b'\n')
+        ui.status(b'cloning %s\n' % tsource)
+        ui.status(b'destination directory: %s\n' % tdest)
+        if mercurial.commands.clone(ui, tsource, tdest, **opts):
+            return True
+
+def extsetup(ui):
+    this = sys.modules[__name__]
+    for cmd in [b'commit', b'config', b'diff', b'heads', b'incoming',
+                b'outgoing', b'log', b'merge', b'parents', b'paths',
+                b'pull', b'push', b'status', b'summary', b'update',
+                b'tag', b'tip']:
+        def f(ui, repo, action = cmd, *args, **opts):
+            _trees(ui, action, *args, **opts)
+        tcommand = command(b't' + cmd, [], b'')(f)
+        tcommand.__doc__ = str(getattr(mercurial.commands, cmd).__doc__)
+        cte = mercurial.cmdutil.findcmd(cmd, mercurial.commands.table)[1]
+        cmdtable[b't' + cmd] = (tcommand, cte[1], cte[2])
+
+    f = lambda ui, repo, *args, **opts: _trees(ui, 'defpath', *args, **opts)
+    tdefpath = command(b'tdefpath', defpath_opts, b'hg tdefpath')(f)
+    tdefpath.__doc__ = defpath.__doc__
+
+    cte = mercurial.cmdutil.findcmd(b'clone', mercurial.commands.table)[1]
+    tclone.__doc__ = mercurial.commands.clone.__doc__
+    cmdtable[b'tclone'] = (tclone, cte[1], cte[2])


### PR DESCRIPTION
Hi all,

please review this patch that adds
[trees](https://hg.openjdk.java.net/code-tools/trees) functionality to Skara.
This is mainly for those who want to use Skara for working with Mercurial today
and are missing the trees functionality, but I also added a couple of trees
"commands" like `tstatus`. `tpull` etc. to `skara.gitconfig`.

Testing:
- Manual testing of both Mercurial and Git trees commands

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/599/head:pull/599`
`$ git checkout pull/599`
