### PR TITLE
merge-bot: specs can have prerequisites

### DIFF
--- a/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBotFactory.java
+++ b/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBotFactory.java
@@ -186,8 +186,19 @@ public class MergeBotFactory implements BotFactory {
                                        .stream()
                                        .map(e -> e.asString())
                                        .collect(Collectors.toList());
+                var prerequisites = spec.get("prerequisites")
+                                        .stream()
+                                        .map(e -> e.asString())
+                                        .map(configuration::repository)
+                                        .collect(Collectors.toList());
 
-                specs.add(new MergeBot.Spec(fromRepo, fromBranch, toBranch, frequency, name, dependencies));
+                specs.add(new MergeBot.Spec(fromRepo,
+                                            fromBranch,
+                                            toBranch,
+                                            frequency,
+                                            name,
+                                            dependencies,
+                                            prerequisites));
             }
 
             bots.add(new MergeBot(storage, targetRepo, forkRepo, specs));


### PR DESCRIPTION
Hi all,

please review this pull request that allows specifications for the merge bot to
have other repositories as prerequisites. Having a repository as a prerequisite
mean that the specification will not be executed if a repository that is a
prerequisite has any pull requests open due to automatic merge conflicts.

Testing:
- `make test` passes on Linux x64
- added a new unit test

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/604/head:pull/604`
`$ git checkout pull/604`
