### PR TITLE
386: Move PR notification handling to the mailing list bridge

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveItem.java
@@ -222,6 +222,14 @@ class ArchiveItem {
                                () -> ArchiveMessages.composeReplyFooter(pr));
     }
 
+    static ArchiveItem integratedNotice(PullRequest pr, Repository localRepo, Commit commit, HostUserToEmailAuthor hostUserToEmailAuthor, ArchiveItem parent, String subjectPrefix, String threadPrefix) {
+        return new ArchiveItem(parent, "in", pr.updatedAt(), pr.updatedAt(), pr.author(), Map.of("PR-Integrated-Notice", "0"),
+                               () -> String.format("Re: [Integrated] %s%s%s", subjectPrefix, threadPrefix + (threadPrefix.isEmpty() ? "" : ": "), pr.title()),
+                               () -> ArchiveMessages.composeReplyHeader(parent.createdAt(), hostUserToEmailAuthor.author(parent.author())),
+                               () -> ArchiveMessages.composeIntegratedNotice(pr, localRepo, commit),
+                               () -> ArchiveMessages.composeReplyFooter(pr));
+    }
+
     private static Pattern mentionPattern = Pattern.compile("^@([\\w-]+).*");
 
     private static Optional<ArchiveItem> findLastMention(String commentText, List<ArchiveItem> eligibleParents) {

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
@@ -393,4 +393,20 @@ class ArchiveMessages {
     static String composeClosedNotice(PullRequest pr) {
         return "This pull request has been closed without being integrated.";
     }
+
+    static String composeIntegratedNotice(PullRequest pr, Repository localRepo, Commit commit) {
+        var result = new StringBuilder();
+        result.append("This pull request has now been integrated.\n\n");
+        result.append("Changeset: ").append(commit.hash().abbreviate()).append("\n");
+        result.append("Author:    ").append(commit.author().name()).append(" <").append(commit.author().email()).append(">\n");
+        if (!commit.author().equals(commit.committer())) {
+            result.append("Committer: ").append(commit.committer().name()).append(" <").append(commit.committer().email()).append(">\n");
+        }
+        result.append("URL:       ").append(pr.repository().webUrl(commit.hash())).append("\n");
+        result.append("Stats:     ").append(stats(localRepo, commit.hash(), commit.parents().get(0))).append("\n");
+        result.append("\n");
+        result.append(String.join("\n", commit.message()));
+
+        return result.toString();
+    }
 }

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
@@ -304,9 +304,10 @@ class ArchiveWorkItem implements WorkItem {
             // Regular comments
             for (var comment : comments) {
                 if (ignoreComment(comment.author(), comment.body())) {
-                    continue;
+                    archiver.addIgnored(comment);
+                } else {
+                    archiver.addComment(comment);
                 }
-                archiver.addComment(comment);
             }
 
             // Review comments

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -312,6 +312,76 @@ class MailingListBridgeBotTests {
                                                                "Change msg\n\nWith several lines");
             localRepo.push(editHash, author.url(), "edit", true);
             var pr = credentials.createPullRequest(archive, "master", "edit", "1234: This is a pull request");
+            pr.setBody("This is now ready");
+            pr.addLabel("rfr");
+
+            // Run an archive pass
+            TestBotRunner.runPeriodicItems(mlBot);
+            TestBotRunner.runPeriodicItems(mlBot);
+
+            // There should be an RFR thread
+            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            assertTrue(archiveContains(archiveFolder.path(), "Subject: RFR: 1234: This is a pull request"));
+
+            // Now it has been integrated
+            var ignoredPr = ignored.pullRequest(pr.id());
+            ignoredPr.setBody("This has been integrated");
+            ignoredPr.addLabel("integrated");
+            ignoredPr.addComment("Pushed as commit " + editHash + ".");
+            ignoredPr.setState(Issue.State.CLOSED);
+
+            // Run another archive pass
+            TestBotRunner.runPeriodicItems(mlBot);
+
+            // The archive should now contain another entry
+            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            assertTrue(archiveContains(archiveFolder.path(), "Subject: Re: \\[Integrated\\] RFR: 1234: This is a pull request"));
+            assertFalse(archiveContains(archiveFolder.path(), "\\[Closed\\]"));
+        }
+    }
+
+    @Test
+    void archiveDirectToIntegrated(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory();
+             var archiveFolder = new TemporaryDirectory();
+             var webrevFolder = new TemporaryDirectory();
+             var listServer = new TestMailmanServer();
+             var webrevServer = new TestWebrevServer()) {
+            var author = credentials.getHostedRepository();
+            var archive = credentials.getHostedRepository();
+            var ignored = credentials.getHostedRepository();
+            var listAddress = EmailAddress.parse(listServer.createList("test"));
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addAuthor(author.forge().currentUser().id());
+            var from = EmailAddress.from("test", "test@test.mail");
+            var mlBot = MailingListBridgeBot.newBuilder()
+                                            .from(from)
+                                            .repo(author)
+                                            .archive(archive)
+                                            .censusRepo(censusBuilder.build())
+                                            .list(listAddress)
+                                            .ignoredUsers(Set.of(ignored.forge().currentUser().userName()))
+                                            .listArchive(listServer.getArchive())
+                                            .smtpServer(listServer.getSMTP())
+                                            .webrevStorageRepository(archive)
+                                            .webrevStorageRef("webrev")
+                                            .webrevStorageBase(Path.of("test"))
+                                            .webrevStorageBaseUri(webrevServer.uri())
+                                            .issueTracker(URIBuilder.base("http://issues.test/browse/").build())
+                                            .build();
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, archive.url(), "webrev", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo, "A simple change",
+                                                               "Change msg\n\nWith several lines");
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(archive, "master", "edit", "1234: This is a pull request");
             pr.setBody("This should not be ready");
             pr.setState(Issue.State.CLOSED);
 
@@ -323,9 +393,11 @@ class MailingListBridgeBotTests {
             Repository.materialize(archiveFolder.path(), archive.url(), "master");
             assertFalse(archiveContains(archiveFolder.path(), "This is a pull request"));
 
-            // Flag it as ready for review
-            pr.setBody("This has already been integrated");
-            pr.addLabel("integrated");
+            // Now it has been integrated
+            var ignoredPr = ignored.pullRequest(pr.id());
+            ignoredPr.setBody("This has already been integrated");
+            ignoredPr.addLabel("integrated");
+            ignoredPr.addComment("Pushed as commit " + editHash + ".");
 
             // Run another archive pass
             TestBotRunner.runPeriodicItems(mlBot);

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/MailingListUpdater.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/MailingListUpdater.java
@@ -23,19 +23,17 @@
 package org.openjdk.skara.bots.notify;
 
 import org.openjdk.skara.email.*;
-import org.openjdk.skara.forge.HostedRepository;
+import org.openjdk.skara.forge.*;
 import org.openjdk.skara.mailinglist.MailingList;
 import org.openjdk.skara.vcs.*;
 import org.openjdk.skara.vcs.openjdk.OpenJDKTag;
 
 import java.io.*;
 import java.nio.file.Path;
-import java.time.Duration;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 public class MailingListUpdater implements RepositoryUpdateConsumer {
     private final MailingList list;
@@ -55,8 +53,7 @@ public class MailingListUpdater implements RepositoryUpdateConsumer {
 
     enum Mode {
         ALL,
-        PR,
-        PR_ONLY
+        PR
     }
 
     MailingListUpdater(MailingList list, EmailAddress recipient, EmailAddress sender, EmailAddress author,
@@ -165,14 +162,16 @@ public class MailingListUpdater implements RepositoryUpdateConsumer {
         return ret.toString();
     }
 
-    private List<Commit> filterAndSendPrCommits(HostedRepository repository, List<Commit> commits, Branch branch) throws NonRetriableException {
+    private List<Commit> filterPrCommits(HostedRepository repository, Repository localRepository, List<Commit> commits, Branch branch) throws NonRetriableException {
         var ret = new ArrayList<Commit>();
-
-        var rfrsConvos = list.conversations(Duration.ofDays(365)).stream()
-                       .filter(conv -> conv.first().subject().contains("RFR: "))
-                       .collect(Collectors.toList());
+        var mergedHashes = new HashSet<Hash>();
 
         for (var commit : commits) {
+            if (mergedHashes.contains(commit.hash())) {
+                log.info("Commit " + commit.hash() + " belongs to a merge PR - skipping");
+                continue;
+            }
+
             var candidates = repository.findPullRequestsWithComment(null, "Pushed as commit " + commit.hash() + ".");
             if (candidates.size() != 1) {
                 log.warning("Commit " + commit.hash() + " matches " + candidates.size() + " pull requests - expected 1");
@@ -183,44 +182,19 @@ public class MailingListUpdater implements RepositoryUpdateConsumer {
             var candidate = candidates.get(0);
             var prLink = candidate.webUrl();
             if (!candidate.targetRef().equals(branch.name())) {
-                log.warning("Pull request " + prLink + " targets " + candidate.targetRef() + " - commit is on " + branch.toString() + " - skipping");
-                ret.add(commit);
-                continue;
-            }
-            var prLinkPattern = Pattern.compile("^(?:PR: )?" + Pattern.quote(prLink.toString()), Pattern.MULTILINE);
-
-            var rfrCandidates = rfrsConvos.stream()
-                                    .filter(conv -> prLinkPattern.matcher(conv.first().body()).find())
-                                    .collect(Collectors.toList());
-            if (rfrCandidates.size() != 1) {
-                log.warning("Pull request " + prLink + " found in " + rfrCandidates.size() + " RFR threads - expected 1");
-                ret.add(commit);
-                continue;
-            }
-            var rfrConv = rfrCandidates.get(0);
-            var alreadyNotified = rfrConv.allMessages().stream()
-                                         .anyMatch(email -> email.subject().contains("[Integrated]") &&
-                                                 email.body().contains(commit.hash().abbreviate()));
-            if (alreadyNotified) {
-                log.warning("Pull request " + prLink + " already contains an integration message - skipping");
+                log.info("Pull request " + prLink + " targets " + candidate.targetRef() + " - commit is on " + branch.toString() + " - skipping");
                 ret.add(commit);
                 continue;
             }
 
-            var body = CommitFormatters.toText(repository, commit);
-            var email = Email.reply(rfrConv.first(), "Re: " + subjectPrefix(repository, branch) +
-                    "[Integrated] " + rfrConv.first().subject(), body)
-                             .sender(sender)
-                             .author(commitToAuthor(commit))
-                             .recipient(recipient)
-                             .headers(headers)
-                             .headers(commitHeaders(repository, commits))
-                             .build();
-
+            // For a merge PR, many other of these commits could belong here as well
             try {
-                list.post(email);
-            } catch (RuntimeException e) {
-                throw new NonRetriableException(e);
+                localRepository.fetch(repository.url(), candidate.fetchRef());
+                var baseHash = PullRequestUtils.baseHash(candidate, localRepository);
+                var prCommits = localRepository.commitMetadata(baseHash, candidate.headHash());
+                prCommits.forEach(prCommit -> mergedHashes.add(prCommit.hash()));
+            } catch (IOException e) {
+                log.warning("Could not fetch commits from " + prLink + " - cannot see if the belong to the PR");
             }
         }
 
@@ -268,22 +242,15 @@ public class MailingListUpdater implements RepositoryUpdateConsumer {
 
     @Override
     public void handleCommits(HostedRepository repository, Repository localRepository, List<Commit> commits, Branch branch) throws NonRetriableException {
-        switch (mode) {
-            case PR_ONLY:
-                filterAndSendPrCommits(repository, commits, branch);
-                break;
-            case PR:
-                commits = filterAndSendPrCommits(repository, commits, branch);
-                // fall-through
-            case ALL:
-                sendCombinedCommits(repository, commits, branch);
-                break;
+        if (mode == Mode.PR) {
+            commits = filterPrCommits(repository, localRepository, commits, branch);
         }
+        sendCombinedCommits(repository, commits, branch);
     }
 
     @Override
     public void handleOpenJDKTagCommits(HostedRepository repository, Repository localRepository, List<Commit> commits, OpenJDKTag tag, Tag.Annotated annotation) throws NonRetriableException {
-        if ((mode == Mode.PR_ONLY) || (!reportNewTags)) {
+        if (!reportNewTags) {
             return;
         }
         if (!reportNewBuilds) {
@@ -331,7 +298,7 @@ public class MailingListUpdater implements RepositoryUpdateConsumer {
 
     @Override
     public void handleTagCommit(HostedRepository repository, Repository localRepository, Commit commit, Tag tag, Tag.Annotated annotation) throws NonRetriableException {
-        if ((mode == Mode.PR_ONLY) || (!reportNewTags)) {
+        if (!reportNewTags) {
             return;
         }
         var writer = new StringWriter();
@@ -383,7 +350,7 @@ public class MailingListUpdater implements RepositoryUpdateConsumer {
 
     @Override
     public void handleNewBranch(HostedRepository repository, Repository localRepository, List<Commit> commits, Branch parent, Branch branch) throws NonRetriableException {
-        if ((mode == Mode.PR_ONLY) || (!reportNewBranches)) {
+        if (!reportNewBranches) {
             return;
         }
         var writer = new StringWriter();

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/MailingListUpdater.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/MailingListUpdater.java
@@ -29,7 +29,6 @@ import org.openjdk.skara.vcs.*;
 import org.openjdk.skara.vcs.openjdk.OpenJDKTag;
 
 import java.io.*;
-import java.nio.file.Path;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.logging.Logger;
@@ -47,8 +46,6 @@ public class MailingListUpdater implements RepositoryUpdateConsumer {
     private final Mode mode;
     private final Map<String, String> headers;
     private final Pattern allowedAuthorDomains;
-    private final boolean repoInSubject;
-    private final Pattern branchInSubject;
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots.notify");
 
     enum Mode {
@@ -58,8 +55,7 @@ public class MailingListUpdater implements RepositoryUpdateConsumer {
 
     MailingListUpdater(MailingList list, EmailAddress recipient, EmailAddress sender, EmailAddress author,
                        boolean includeBranch, boolean reportNewTags, boolean reportNewBranches, boolean reportNewBuilds,
-                       Mode mode, Map<String, String> headers, Pattern allowedAuthorDomains, boolean repoInSubject,
-                       Pattern branchInSubject) {
+                       Mode mode, Map<String, String> headers, Pattern allowedAuthorDomains) {
         this.list = list;
         this.recipient = recipient;
         this.sender = sender;
@@ -71,8 +67,6 @@ public class MailingListUpdater implements RepositoryUpdateConsumer {
         this.mode = mode;
         this.headers = headers;
         this.allowedAuthorDomains = allowedAuthorDomains;
-        this.repoInSubject = repoInSubject;
-        this.branchInSubject = branchInSubject;
     }
 
     static MailingListUpdaterBuilder newBuilder() {
@@ -138,28 +132,6 @@ public class MailingListUpdater implements RepositoryUpdateConsumer {
                 tag +
                 " for changeset " +
                 hash.abbreviate();
-    }
-
-    private String subjectPrefix(HostedRepository repository, Branch branch) {
-        var ret = new StringBuilder();
-        var branchName = branch.name();
-        var repoName = Path.of(repository.name()).getFileName().toString();
-        var useBranchInSubject = branchInSubject.matcher(branchName).matches();
-
-        if (useBranchInSubject || repoInSubject) {
-            ret.append("[");
-            if (repoInSubject) {
-                ret.append(repoName);
-                if (useBranchInSubject) {
-                    ret.append(":");
-                }
-            }
-            if (useBranchInSubject) {
-                ret.append(branchName);
-            }
-            ret.append("] ");
-        }
-        return ret.toString();
     }
 
     private List<Commit> filterPrCommits(HostedRepository repository, Repository localRepository, List<Commit> commits, Branch branch) throws NonRetriableException {

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/MailingListUpdaterBuilder.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/MailingListUpdaterBuilder.java
@@ -98,18 +98,8 @@ public class MailingListUpdaterBuilder {
         return this;
     }
 
-    public MailingListUpdaterBuilder repoInSubject(boolean repoInSubject) {
-        this.repoInSubject = repoInSubject;
-        return this;
-    }
-
-    public MailingListUpdaterBuilder branchInSubject(Pattern branchInSubject) {
-        this.branchInSubject = branchInSubject;
-        return this;
-    }
-
     public MailingListUpdater build() {
         return new MailingListUpdater(list, recipient, sender, author, includeBranch, reportNewTags, reportNewBranches,
-                                      reportNewBuilds, mode, headers, allowedAuthorDomains, repoInSubject, branchInSubject);
+                                      reportNewBuilds, mode, headers, allowedAuthorDomains);
     }
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/NotifyBotFactory.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/NotifyBotFactory.java
@@ -158,12 +158,6 @@ public class NotifyBotFactory implements BotFactory {
                     if (mailinglist.contains("builds")) {
                         mailingListUpdaterBuilder.reportNewBuilds(mailinglist.get("builds").asBoolean());
                     }
-                    if (mailinglist.contains("reponame")) {
-                        mailingListUpdaterBuilder.repoInSubject(mailinglist.get("reponame").asBoolean());
-                    }
-                    if (mailinglist.contains("branchname")) {
-                        mailingListUpdaterBuilder.branchInSubject(Pattern.compile(mailinglist.get("branchname").asString()));
-                    }
 
                     updaters.add(mailingListUpdaterBuilder.build());
                 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/NotifyBotFactory.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/NotifyBotFactory.java
@@ -28,7 +28,6 @@ import org.openjdk.skara.json.*;
 import org.openjdk.skara.mailinglist.MailingListServerFactory;
 import org.openjdk.skara.network.URIBuilder;
 import org.openjdk.skara.storage.StorageBuilder;
-import org.openjdk.skara.vcs.Tag;
 
 import java.net.URI;
 import java.nio.file.Path;
@@ -136,9 +135,6 @@ public class NotifyBotFactory implements BotFactory {
                         switch (mailinglist.get("mode").asString()) {
                             case "pr":
                                 mode = MailingListUpdater.Mode.PR;
-                                break;
-                            case "pr-only":
-                                mode = MailingListUpdater.Mode.PR_ONLY;
                                 break;
                             default:
                                 throw new RuntimeException("Unknown mode");

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdaterTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdaterTests.java
@@ -509,106 +509,6 @@ class UpdaterTests {
     }
 
     @Test
-    void testMailingListPROnly(TestInfo testInfo) throws IOException {
-        try (var listServer = new TestMailmanServer();
-             var credentials = new HostCredentials(testInfo);
-             var tempFolder = new TemporaryDirectory()) {
-            var repo = credentials.getHostedRepository();
-            var repoFolder = tempFolder.path().resolve("repo");
-            var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
-            var masterHash = localRepo.resolve("master").orElseThrow();
-            credentials.commitLock(localRepo);
-            localRepo.pushAll(repo.url());
-
-            var listAddress = EmailAddress.parse(listServer.createList("test"));
-            var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
-            var mailmanList = mailmanServer.getList(listAddress.address());
-            var tagStorage = createTagStorage(repo);
-            var branchStorage = createBranchStorage(repo);
-            var prIssuesStorage = createPullRequestIssuesStorage(repo);
-            var storageFolder = tempFolder.path().resolve("storage");
-
-            var sender = EmailAddress.from("duke", "duke@duke.duke");
-            var author = EmailAddress.from("author", "author@duke.duke");
-            var updater = MailingListUpdater.newBuilder()
-                                            .list(mailmanList)
-                                            .recipient(listAddress)
-                                            .sender(sender)
-                                            .author(author)
-                                            .reportNewTags(false)
-                                            .reportNewBranches(false)
-                                            .reportNewBuilds(false)
-                                            .mode(MailingListUpdater.Mode.PR_ONLY)
-                                            .headers(Map.of("extra1", "value1"))
-                                            .build();
-            var notifyBot = NotifyBot.newBuilder()
-                                     .repository(repo)
-                                     .storagePath(storageFolder)
-                                     .branches(Pattern.compile("master"))
-                                     .tagStorageBuilder(tagStorage)
-                                     .branchStorageBuilder(branchStorage)
-                                     .prIssuesStorageBuilder(prIssuesStorage)
-                                     .updaters(List.of(updater))
-                                     .build();
-
-            // No mail should be sent on the first run as there is no history
-            TestBotRunner.runPeriodicItems(notifyBot);
-            assertThrows(RuntimeException.class, () -> listServer.processIncoming(Duration.ofMillis(1)));
-
-            var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", "23456789: More fixes");
-            localRepo.push(editHash, repo.url(), "edit");
-            var pr = credentials.createPullRequest(repo, "master", "edit", "RFR: My PR");
-
-            // Create a potentially conflicting one
-            var otherHash = CheckableRepository.appendAndCommit(localRepo, "Another line", "23456789: More fixes");
-            localRepo.push(otherHash, repo.url(), "other");
-            var otherPr = credentials.createPullRequest(repo, "master", "other", "RFR: My other PR");
-
-            // PR hasn't been integrated yet, so there should be no mail
-            TestBotRunner.runPeriodicItems(notifyBot);
-            assertThrows(RuntimeException.class, () -> listServer.processIncoming(Duration.ofMillis(1)));
-
-            // Simulate an RFR email
-            var rfr = Email.create(sender, "RFR: My PR", "PR: " + pr.webUrl().toString())
-                    .recipient(listAddress)
-                    .build();
-            mailmanList.post(rfr);
-            listServer.processIncoming();
-
-            // And an integration
-            pr.addComment("Pushed as commit " + editHash.hex() + ".");
-            localRepo.push(editHash, repo.url(), "master");
-            TestBotRunner.runPeriodicItems(notifyBot);
-            listServer.processIncoming();
-
-            var conversations = mailmanList.conversations(Duration.ofDays(1));
-            assertEquals(1, conversations.size());
-            var first = conversations.get(0).first();
-            var email = conversations.get(0).replies(first).get(0);
-            assertEquals(listAddress, email.sender());
-            assertEquals(author, email.author());
-            assertEquals(email.recipients(), List.of(listAddress));
-            assertEquals("[Integrated] RFR: My PR", email.subject());
-            assertFalse(email.subject().contains("master"));
-            assertTrue(email.body().contains("Changeset: " + editHash.abbreviate()));
-            assertTrue(email.body().contains("23456789: More fixes"));
-            assertFalse(email.body().contains("Committer"));
-            assertFalse(email.body().contains(masterHash.abbreviate()));
-            assertTrue(email.hasHeader("extra1"));
-            assertEquals("value1", email.headerValue("extra1"));
-            assertTrue(email.hasHeader("X-Git-URL"));
-            assertEquals(repo.webUrl().toString(), email.headerValue("X-Git-URL"));
-            assertTrue(email.hasHeader("X-Git-Changeset"));
-            assertEquals(editHash.hex(), email.headerValue("X-Git-Changeset"));
-
-            // Now push the other one without a matching PR - PR_ONLY will not generate a mail
-            localRepo.push(otherHash, repo.url(), "master");
-            TestBotRunner.runPeriodicItems(notifyBot);
-            assertThrows(RuntimeException.class, () -> listServer.processIncoming(Duration.ofSeconds(1)));
-        }
-    }
-
-    @Test
     void testMailingListPROnlyMultipleBranches(TestInfo testInfo) throws IOException {
         try (var listServer = new TestMailmanServer();
              var credentials = new HostCredentials(testInfo);
@@ -768,7 +668,6 @@ class UpdaterTests {
 
             TestBotRunner.runPeriodicItems(notifyBot);
             listServer.processIncoming();
-            listServer.processIncoming();
 
             var conversations = mailmanList.conversations(Duration.ofDays(1));
             conversations.sort(Comparator.comparing(conversation -> conversation.first().subject()));
@@ -776,17 +675,7 @@ class UpdaterTests {
 
             var prConversation = conversations.get(0);
             var pushConversation = conversations.get(1);
-
-            var prEmail = prConversation.replies(prConversation.first()).get(0);
-            assertEquals(listAddress, prEmail.sender());
-            assertEquals(EmailAddress.from("testauthor", "ta@none.none"), prEmail.author());
-            assertEquals(prEmail.recipients(), List.of(listAddress));
-            assertEquals("[Integrated] [repo/branch] RFR: My PR", prEmail.subject());
-            assertFalse(prEmail.subject().contains("master"));
-            assertTrue(prEmail.body().contains("Changeset: " + editHash.abbreviate()));
-            assertTrue(prEmail.body().contains("23456789: More fixes"));
-            assertFalse(prEmail.body().contains("Committer"));
-            assertFalse(prEmail.body().contains(masterHash.abbreviate()));
+            assertEquals(1, prConversation.allMessages().size());
 
             var pushEmail = pushConversation.first();
             assertEquals(listAddress, pushEmail.sender());
@@ -864,22 +753,13 @@ class UpdaterTests {
             localRepo.push(editHash, repo.url(), "master", true);
 
             TestBotRunner.runPeriodicItems(notifyBot);
-            listServer.processIncoming();
+            assertThrows(RuntimeException.class, () -> listServer.processIncoming(Duration.ofMillis(1)));
 
             var conversations = mailmanList.conversations(Duration.ofDays(1));
             assertEquals(1, conversations.size());
 
             var prConversation = conversations.get(0);
-            var prEmail = prConversation.replies(prConversation.first()).get(0);
-            assertEquals(listAddress, prEmail.sender());
-            assertEquals(EmailAddress.from("testauthor", "ta@none.none"), prEmail.author());
-            assertEquals(prEmail.recipients(), List.of(listAddress));
-            assertEquals("[Integrated] RFR: My PR", prEmail.subject());
-            assertFalse(prEmail.subject().contains("master"));
-            assertTrue(prEmail.body().contains("Changeset: " + editHash.abbreviate()));
-            assertTrue(prEmail.body().contains("23456789: More fixes"));
-            assertFalse(prEmail.body().contains("Committer"));
-            assertFalse(prEmail.body().contains(masterHash.abbreviate()));
+            assertEquals(1, prConversation.allMessages().size());
 
             // Now push the change to another monitored branch
             localRepo.push(editHash, repo.url(), "other", true);
@@ -929,14 +809,13 @@ class UpdaterTests {
                                             .reportNewBranches(false)
                                             .headers(Map.of("extra1", "value1", "extra2", "value2"))
                                             .build();
-            var prOnlyUpdater = MailingListUpdater.newBuilder()
+            var noTagsUpdater = MailingListUpdater.newBuilder()
                                                   .list(mailmanList)
                                                   .recipient(listAddress)
                                                   .sender(sender)
                                                   .reportNewTags(false)
                                                   .reportNewBranches(false)
                                                   .reportNewBuilds(false)
-                                                  .mode(MailingListUpdater.Mode.PR_ONLY)
                                                   .build();
             var notifyBot = NotifyBot.newBuilder()
                                      .repository(repo)
@@ -945,7 +824,7 @@ class UpdaterTests {
                                      .tagStorageBuilder(tagStorage)
                                      .branchStorageBuilder(branchStorage)
                                      .prIssuesStorageBuilder(prIssuesStorage)
-                                     .updaters(List.of(updater, prOnlyUpdater))
+                                     .updaters(List.of(updater, noTagsUpdater))
                                      .build();
 
             // No mail should be sent on the first run as there is no history
@@ -1048,14 +927,13 @@ class UpdaterTests {
                                             .reportNewBuilds(false)
                                             .headers(Map.of("extra1", "value1", "extra2", "value2"))
                                             .build();
-            var prOnlyUpdater = MailingListUpdater.newBuilder()
+            var noTagsUpdater = MailingListUpdater.newBuilder()
                                                   .list(mailmanList)
                                                   .recipient(listAddress)
                                                   .sender(sender)
                                                   .reportNewTags(false)
                                                   .reportNewBranches(false)
                                                   .reportNewBuilds(false)
-                                                  .mode(MailingListUpdater.Mode.PR_ONLY)
                                                   .build();
             var notifyBot = NotifyBot.newBuilder()
                                      .repository(repo)
@@ -1064,7 +942,7 @@ class UpdaterTests {
                                      .tagStorageBuilder(tagStorage)
                                      .branchStorageBuilder(branchStorage)
                                      .prIssuesStorageBuilder(prIssuesStorage)
-                                     .updaters(List.of(updater, prOnlyUpdater))
+                                     .updaters(List.of(updater, noTagsUpdater))
                                      .build();
 
             // No mail should be sent on the first run as there is no history
@@ -1190,93 +1068,6 @@ class UpdaterTests {
             assertEquals(email.recipients(), List.of(listAddress));
             assertEquals("git: test: created branch newbranch2 based on the branch newbranch1 containing 0 unique commits", email.subject());
             assertEquals("The new branch newbranch2 is currently identical to the newbranch1 branch.", email.body());
-        }
-    }
-
-    @Test
-    void testMailingListBranchPrefix(TestInfo testInfo) throws IOException {
-        try (var listServer = new TestMailmanServer();
-             var credentials = new HostCredentials(testInfo);
-             var tempFolder = new TemporaryDirectory()) {
-            var repo = credentials.getHostedRepository();
-            var repoFolder = tempFolder.path().resolve("repo");
-            var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
-            var masterHash = localRepo.resolve("master").orElseThrow();
-            credentials.commitLock(localRepo);
-            localRepo.pushAll(repo.url());
-
-            var listAddress = EmailAddress.parse(listServer.createList("test"));
-            var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
-            var mailmanList = mailmanServer.getList(listAddress.address());
-            var tagStorage = createTagStorage(repo);
-            var branchStorage = createBranchStorage(repo);
-            var prIssuesStorage = createPullRequestIssuesStorage(repo);
-            var storageFolder = tempFolder.path().resolve("storage");
-
-            var sender = EmailAddress.from("duke", "duke@duke.duke");
-            var updater = MailingListUpdater.newBuilder()
-                                            .list(mailmanList)
-                                            .recipient(listAddress)
-                                            .sender(sender)
-                                            .reportNewTags(false)
-                                            .reportNewBranches(false)
-                                            .reportNewBuilds(false)
-                                            .mode(MailingListUpdater.Mode.PR)
-                                            .repoInSubject(true)
-                                            .branchInSubject(Pattern.compile(".*"))
-                                            .build();
-            var notifyBot = NotifyBot.newBuilder()
-                                     .repository(repo)
-                                     .storagePath(storageFolder)
-                                     .branches(Pattern.compile("master"))
-                                     .tagStorageBuilder(tagStorage)
-                                     .branchStorageBuilder(branchStorage)
-                                     .prIssuesStorageBuilder(prIssuesStorage)
-                                     .updaters(List.of(updater))
-                                     .build();
-
-            // No mail should be sent on the first run as there is no history
-            TestBotRunner.runPeriodicItems(notifyBot);
-            assertThrows(RuntimeException.class, () -> listServer.processIncoming(Duration.ofMillis(1)));
-
-            var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", "23456789: More fixes");
-            localRepo.push(editHash, repo.url(), "edit");
-            var pr = credentials.createPullRequest(repo, "master", "edit", "RFR: My PR");
-
-            // PR hasn't been integrated yet, so there should be no mail
-            TestBotRunner.runPeriodicItems(notifyBot);
-            assertThrows(RuntimeException.class, () -> listServer.processIncoming(Duration.ofMillis(1)));
-
-            // Simulate an RFR email
-            var rfr = Email.create("RFR: My PR", "PR:\n" + pr.webUrl().toString())
-                           .author(EmailAddress.from("duke", "duke@duke.duke"))
-                           .recipient(listAddress)
-                           .build();
-            mailmanList.post(rfr);
-            listServer.processIncoming();
-
-            // And an integration
-            pr.addComment("Pushed as commit " + editHash.hex() + ".");
-            localRepo.push(editHash, repo.url(), "master");
-
-            TestBotRunner.runPeriodicItems(notifyBot);
-            listServer.processIncoming();
-
-            var conversations = mailmanList.conversations(Duration.ofDays(1));
-            conversations.sort(Comparator.comparing(conversation -> conversation.first().subject()));
-            assertEquals(1, conversations.size());
-
-            var prConversation = conversations.get(0);
-
-            var prEmail = prConversation.replies(prConversation.first()).get(0);
-            assertEquals(listAddress, prEmail.sender());
-            assertEquals(EmailAddress.from("testauthor", "ta@none.none"), prEmail.author());
-            assertEquals(prEmail.recipients(), List.of(listAddress));
-            assertEquals("[" + repo.name() + ":master] [Integrated] RFR: My PR", prEmail.subject());
-            assertTrue(prEmail.body().contains("Changeset: " + editHash.abbreviate()));
-            assertTrue(prEmail.body().contains("23456789: More fixes"));
-            assertFalse(prEmail.body().contains("Committer"));
-            assertFalse(prEmail.body().contains(masterHash.abbreviate()));
         }
     }
 


### PR DESCRIPTION
Hi all,

Please review this change that moves the handling of PR integration notices from the notifier to the mailing list bridge. The notifier will continue to post the traditional `git:` messages only. This change also makes it easier to change the prefix handling, as this is now done in a single place.

It also checks if a PR has been integrated "manually" by a user with write access that uses the web UI integration button.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issues
 * [SKARA-386](https://bugs.openjdk.java.net/browse/SKARA-386): Move PR notification handling to the mailing list bridge
 * [SKARA-388](https://bugs.openjdk.java.net/browse/SKARA-388): Notification bot does not recognize a "Merged" PR


### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/605/head:pull/605`
`$ git checkout pull/605`
