### PR TITLE
merge-bot: provide default values in conf

### DIFF
--- a/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBotFactory.java
+++ b/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBotFactory.java
@@ -23,6 +23,7 @@
 package org.openjdk.skara.bots.merge;
 
 import org.openjdk.skara.bot.*;
+import org.openjdk.skara.json.JSON;
 import org.openjdk.skara.vcs.Branch;
 
 import java.io.*;
@@ -181,12 +182,12 @@ public class MergeBotFactory implements BotFactory {
                     }
                 }
 
-                var name = spec.get("name").asString();
-                var dependencies = spec.get("dependencies")
+                var name = spec.getOrDefault("name", JSON.of()).asString();
+                var dependencies = spec.getOrDefault("dependencies", JSON.array())
                                        .stream()
                                        .map(e -> e.asString())
                                        .collect(Collectors.toList());
-                var prerequisites = spec.get("prerequisites")
+                var prerequisites = spec.getOrDefault("prerequisites", JSON.array())
                                         .stream()
                                         .map(e -> e.asString())
                                         .map(configuration::repository)

--- a/json/src/main/java/org/openjdk/skara/json/JSONObject.java
+++ b/json/src/main/java/org/openjdk/skara/json/JSONObject.java
@@ -113,6 +113,10 @@ public class JSONObject implements JSONValue {
         return value.get(k);
     }
 
+    public JSONValue getOrDefault(String k, JSONValue fallback) {
+        return value.getOrDefault(k, fallback);
+    }
+
     public List<Field> fields() {
         return value.entrySet()
                     .stream()

--- a/json/src/main/java/org/openjdk/skara/json/JSONValue.java
+++ b/json/src/main/java/org/openjdk/skara/json/JSONValue.java
@@ -98,6 +98,10 @@ public interface JSONValue {
         return asObject().get(field);
     }
 
+    default JSONValue getOrDefault(String field, JSONValue fallback) {
+        return asObject().getOrDefault(field, fallback);
+    }
+
     default JSONValue get(int i) {
         return asArray().get(i);
     }


### PR DESCRIPTION
Hi all,

please review this small patch that makes `MergeBotFactory` provide default
values for specification fields in the configures.

Testing:
- `make test` passes on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/606/head:pull/606`
`$ git checkout pull/606`
