### PR TITLE
Improve error message for non-authors creating Merge PRs

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
@@ -96,7 +96,7 @@ public class CheckablePullRequest {
 
         if (contributor == null) {
             if (PullRequestUtils.isMerge(pr)) {
-                throw new CommitFailure("Merges can only be performed by Committers.");
+                throw new CommitFailure("Merge PRs can only be created by known OpenJDK authors.");
             }
 
             // Use the information contained in the head commit - jcheck has verified that it contains sane values


### PR DESCRIPTION
Hi all,

Please review this small change that improves the error message when a non-author tries to create a Merge PR.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/608/head:pull/608`
`$ git checkout pull/608`
