### PR TITLE
Proper detection of legacy integration comment

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
@@ -71,7 +71,7 @@ class ReviewArchive {
     }
 
     private boolean hasLegacyIntegrationNotice(Hash hash) {
-        var legacyIntegrationPattern = Pattern.compile("Changeset: " + hash.abbreviate());
+        var legacyIntegrationPattern = Pattern.compile("Changeset\\\\?: " + hash.abbreviate());
         return ignoredComments.stream()
                               .map(Comment::body)
                               .map(legacyIntegrationPattern::matcher)

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -402,8 +402,8 @@ class MailingListBridgeBotTests {
 
             // Add legacy integration notice
             ignoredPr.addComment(
-                    "Changeset: " + editHash.abbreviate() + "\n" +
-                    "Author:    J. Duke <duke@openjdk.org>\n");
+                    "Changeset\\: " + editHash.abbreviate() + "\n" +
+                    "Author\\:    J. Duke \\<duke at openjdk\\.org\\>\n");
 
             // Run another archive pass
             TestBotRunner.runPeriodicItems(mlBot);


### PR DESCRIPTION
Hi all,

Please review this small change that updates the legacy integration pattern to match all forms of previously posted comments.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * J. Duke ([duke](@openjdk-bot) - no project role)
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/609/head:pull/609`
`$ git checkout pull/609`
