### PR TITLE
365: Allows "merge style" PRs to have title of "Merge repo:tag"

### DIFF
--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
@@ -209,6 +209,92 @@ class MergeTests {
     }
 
     @Test
+    void tagMerge(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+
+            var author = credentials.getHostedRepository();
+            var integrator = credentials.getHostedRepository();
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addCommitter(author.forge().currentUser().id())
+                                           .addReviewer(integrator.forge().currentUser().id());
+            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
+
+            // Populate the projects repository
+            var localRepoFolder = tempFolder.path().resolve("localrepo");
+            var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Make more changes in another branch
+            var otherHash1 = CheckableRepository.appendAndCommit(localRepo, "First change in other",
+                                                                 "First other\n\nReviewed-by: integrationreviewer2");
+            localRepo.push(otherHash1, author.url(), "other", true);
+            var otherHash2 = CheckableRepository.appendAndCommit(localRepo, "Second change in other",
+                                                                 "Second other\n\nReviewed-by: integrationreviewer2");
+            var tag = localRepo.tag(otherHash2, "othertag", "Tagging other", "tagger", "tagger@one");
+            var tagHash = localRepo.lookup(tag).orElseThrow().hash();
+            localRepo.push(tagHash, author.url(), "refs/tags/othertag");
+
+            // Go back to the original master
+            localRepo.checkout(masterHash, true);
+
+            // Make a change with a corresponding PR
+            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated", StandardCharsets.UTF_8);
+            localRepo.add(unrelated);
+            var updatedMaster = localRepo.commit("Unrelated", "some", "some@one");
+            localRepo.push(updatedMaster, author.url(), "master");
+
+            localRepo.merge(otherHash2);
+            var mergeHash = localRepo.commit("Merge commit", "some", "some@one");
+            localRepo.push(mergeHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "Merge othertag");
+
+            // Approve it as another user
+            var approvalPr = integrator.pullRequest(pr.id());
+            approvalPr.addReview(Review.Verdict.APPROVED, "Approved");
+
+            // Let the bot check the status
+            TestBotRunner.runPeriodicItems(mergeBot);
+
+            // Push it
+            pr.addComment("/integrate");
+            TestBotRunner.runPeriodicItems(mergeBot);
+
+            // The bot should reply with an ok message
+            var pushed = pr.comments().stream()
+                           .filter(comment -> comment.body().contains("Pushed as commit"))
+                           .count();
+            assertEquals(1, pushed);
+
+            // The change should now be present on the master branch
+            var pushedRepoFolder = tempFolder.path().resolve("pushedrepo");
+            var pushedRepo = Repository.materialize(pushedRepoFolder, author.url(), "master");
+            assertTrue(CheckableRepository.hasBeenEdited(pushedRepo));
+
+            // The commits from the "other" branch should be preserved and not squashed (but not the merge commit)
+            var headHash = pushedRepo.resolve("HEAD").orElseThrow();
+            Set<Hash> commits;
+            try (var tempCommits = pushedRepo.commits(masterHash.hex() + ".." + headHash.hex())) {
+                commits = tempCommits.stream()
+                                     .map(Commit::hash)
+                                     .collect(Collectors.toSet());
+            }
+            assertTrue(commits.contains(otherHash1));
+            assertTrue(commits.contains(otherHash2));
+            assertFalse(commits.contains(mergeHash));
+
+            // Author and committer should updated in the merge commit
+            var headCommit = pushedRepo.commits(headHash.hex() + "^.." + headHash.hex()).asList().get(0);
+            assertEquals("Generated Committer 1", headCommit.author().name());
+            assertEquals("integrationcommitter1@openjdk.java.net", headCommit.author().email());
+            assertEquals("Generated Committer 1", headCommit.committer().name());
+            assertEquals("integrationcommitter1@openjdk.java.net", headCommit.committer().email());
+        }
+    }
+
+    @Test
     void branchMergeRebase(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
              var tempFolder = new TemporaryDirectory()) {
@@ -597,7 +683,7 @@ class MergeTests {
             assertEquals(1, error, () -> pr.comments().stream().map(Comment::body).collect(Collectors.joining("\n\n")));
 
             var check = pr.checks(mergeHash).get("jcheck");
-            assertEquals("- Could not fetch branch `otherxyz` from project `" + author.name() + "` - check that they are correct.", check.summary().orElseThrow());
+            assertEquals("- Could not find the branch or tag `otherxyz` in the project `" + author.name() + "` - check that it is correct.", check.summary().orElseThrow());
         }
     }
 

--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequestUtils.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequestUtils.java
@@ -24,7 +24,8 @@ package org.openjdk.skara.forge;
 
 import org.openjdk.skara.vcs.*;
 
-import java.io.*;
+import java.io.IOException;
+import java.net.URI;
 import java.nio.file.Path;
 import java.time.ZonedDateTime;
 import java.util.*;
@@ -37,41 +38,68 @@ public class PullRequestUtils {
                                 committer.name(), committer.email(), ZonedDateTime.now(), List.of(pr.targetHash()), localRepo.tree(finalHead));
     }
 
-    private static class MergeSource {
-        private final String repositoryName;
-        private final String branchName;
+    private final static Pattern mergeSourcePattern = Pattern.compile("^Merge ([-/\\w:]+)$");
 
-        private MergeSource(String repositoryName, String branchName) {
-            this.repositoryName = repositoryName;
-            this.branchName = branchName;
+    private static Optional<Hash> fetchRef(Repository localRepo, URI uri, String ref) throws IOException {
+        // Just a plain name - is this a branch?
+        try {
+            var hash = localRepo.fetch(uri, "+" + ref + ":refs/heads/merge_source", false);
+            return Optional.of(hash);
+        } catch (IOException e) {
         }
+
+        // Perhaps it is an actual tag object - it cannot be fetched to a branch ref
+        try {
+            var hash = localRepo.fetch(uri, "+" + ref + ":refs/tags/merge_source_tag", false);
+            return Optional.of(hash);
+        } catch (IOException e) {
+        }
+
+        return Optional.empty();
     }
 
-    private final static Pattern mergeSourceFullPattern = Pattern.compile("^Merge ([-/\\w]+):([-\\w]+)$");
-    private final static Pattern mergeSourceBranchOnlyPattern = Pattern.compile("^Merge ([-\\w]+)$");
-
-    private static Optional<MergeSource> mergeSource(PullRequest pr, Repository localRepo) {
-        var repoMatcher = mergeSourceFullPattern.matcher(pr.title());
-        if (!repoMatcher.matches()) {
-            var branchMatcher = mergeSourceBranchOnlyPattern.matcher(pr.title());
-            if (!branchMatcher.matches()) {
-                return Optional.empty();
-            }
-
-            // Verify that the branch exists
-            var isValidBranch = remoteBranches(pr, localRepo).stream()
-                                                             .map(Reference::name)
-                                                             .anyMatch(branch -> branch.equals(branchMatcher.group(1)));
-            if (!isValidBranch) {
-                // Assume the name refers to a sibling repository
-                var repoName = Path.of(pr.repository().name()).resolveSibling(branchMatcher.group(1)).toString();
-                return Optional.of(new MergeSource(repoName, "master"));
-            }
-
-            return Optional.of(new MergeSource(pr.repository().name(), branchMatcher.group(1)));
+    private static Hash fetchMergeSource(PullRequest pr, Repository localRepo) throws IOException, CommitFailure {
+        var sourceMatcher = mergeSourcePattern.matcher(pr.title());
+        if (!sourceMatcher.matches()) {
+            throw new CommitFailure("Could not determine the source for this merge. A Merge PR title must be specified on the format: " +
+                                            "Merge `project`:`branch` to allow verification of the merge contents.");
         }
 
-        return Optional.of(new MergeSource(repoMatcher.group(1), repoMatcher.group(2)));
+        var source = sourceMatcher.group(1);
+        String repoName;
+        String ref;
+        if (!source.contains(":")) {
+            // Try to fetch the source as a name of a ref (branch or tag)
+            var hash = fetchRef(localRepo, pr.repository().url(), source);
+            if (hash.isPresent()) {
+                return hash.get();
+            }
+
+            // Only valid option now is a repository - we default the ref to "master"
+            repoName = source;
+            ref = "master";
+        } else {
+            repoName = source.split(":", 2)[0];
+            ref = source.split(":", 2)[1];
+        }
+
+        // If the repository name is unqualified we assume it is a sibling
+        if (!repoName.contains("/")) {
+            repoName = Path.of(pr.repository().name()).resolveSibling(repoName).toString();
+        }
+
+        // Validate the repository
+        var sourceRepo = pr.repository().forge().repository(repoName);
+        if (sourceRepo.isEmpty()) {
+            throw new CommitFailure("Could not find project `" + repoName + "` - check that it is correct.");
+        }
+
+        var hash = fetchRef(localRepo, sourceRepo.get().url(), ref);
+        if (hash.isPresent()) {
+            return hash.get();
+        } else {
+            throw new CommitFailure("Could not find the branch or tag `" + ref + "` in the project `" + repoName + "` - check that it is correct.");
+        }
     }
 
     private static Hash findSourceHash(PullRequest pr, Repository localRepo, List<CommitMetadata> commits) throws IOException, CommitFailure {
@@ -79,28 +107,8 @@ public class PullRequestUtils {
             throw new CommitFailure("A merge PR must contain at least one commit that is not already present in the target.");
         }
 
-        var source = mergeSource(pr, localRepo);
-        if (source.isEmpty()) {
-            throw new CommitFailure("Could not determine the source for this merge. A Merge PR title must be specified on the format: " +
-                    "Merge `project`:`branch` to allow verification of the merge contents.");
-        }
-
         // Fetch the source
-        Hash sourceHead;
-        try {
-            var mergeSourceRepo = pr.repository().forge().repository(source.get().repositoryName).orElseThrow(() ->
-                    new RuntimeException("Could not find repository " + source.get().repositoryName)
-            );
-            try {
-                sourceHead = localRepo.fetch(mergeSourceRepo.url(), source.get().branchName, false);
-            } catch (IOException e) {
-                throw new CommitFailure("Could not fetch branch `" + source.get().branchName + "` from project `" +
-                        source.get().repositoryName + "` - check that they are correct.");
-            }
-        } catch (RuntimeException e) {
-            throw new CommitFailure("Could not find project `" +
-                    source.get().repositoryName + "` - check that it is correct.");
-        }
+        var sourceHead = fetchMergeSource(pr, localRepo);
 
         // Ensure that the source and the target are related
         try {
@@ -163,13 +171,5 @@ public class PullRequestUtils {
             patch.source().path().ifPresent(ret::add);
         }
         return ret;
-    }
-
-    private static List<Reference> remoteBranches(PullRequest pr, Repository localRepo) {
-        try {
-            return localRepo.remoteBranches(pr.repository().url().toString());
-        } catch (IOException e) {
-            return List.of();
-        }
     }
 }

--- a/test/src/main/java/org/openjdk/skara/test/TestHost.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHost.java
@@ -32,11 +32,13 @@ import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.util.*;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 public class TestHost implements Forge, IssueTracker {
     private final int currentUser;
     private HostData data;
+    private final Logger log = Logger.getLogger("org.openjdk.skara.test");
 
     private static class HostData {
         final List<HostUser> users = new ArrayList<>();
@@ -97,7 +99,8 @@ public class TestHost implements Forge, IssueTracker {
             localRepository = data.repositories.get(name);
         } else {
             if (data.repositories.size() > 0) {
-                throw new RuntimeException("A test host can only manage a single repository");
+                log.warning("A test host can only manage a single repository - reporting " + name + " as not found");
+                return Optional.empty();
             }
             localRepository = createLocalRepository();
             data.repositories.put(name, localRepository);


### PR DESCRIPTION
Hi all,

Please review this change that improves the merge sourcing for merge PRs and allows tags to be used as a source.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-365](https://bugs.openjdk.java.net/browse/SKARA-365): Allows "merge style" PRs to have title of "Merge repo:tag"


### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/610/head:pull/610`
`$ git checkout pull/610`
