### PR TITLE
trees: add treconfigure command

### DIFF
--- a/skara.gitconfig
+++ b/skara.gitconfig
@@ -48,6 +48,7 @@
         tstatus = trees status
         ttag = trees tag
 
+        treconfigure = trees treconfigure
         tdefpath = trees defpath
         tsync = trees sync
         tinfo = trees info

--- a/skara.py
+++ b/skara.py
@@ -170,6 +170,13 @@ def tclone(ui, source, dest=None, **opts):
         if mercurial.commands.clone(ui, tsource, tdest, **opts):
             return True
 
+@command(b'treconfigure', [], b'hg treconfigure')
+def treconfigure(ui, repo, **opts):
+    """
+    Reconfigures the trees files for all sub-repositories
+    """
+    _trees(ui, 'treconfigure')
+
 def extsetup(ui):
     this = sys.modules[__name__]
     for cmd in [b'commit', b'config', b'diff', b'heads', b'incoming',


### PR DESCRIPTION
Hi all,

please review this patch that adds the `hg/git treconfigure` command. The
`treconfigure` can be used to re-initialize the trees configuration for a set of
repositories. This is useful when a user has, either by mistake or on purpose,
renamed and/or moved a repository in a "forest".

_Note_: the existing `trees.py` extension offered the command `hg tconfig`, but
that command clashes with the `config` command present in both `hg` and `git` (a
user can't run the command `config` in all repositories in a "forest"). For the
Skara port of `trees.py` I opted to instead provide the `treconfigure` command
to avoid name clashes.

Testing:
- Manual testing of `git treconfigure` and `hg treconfigure`

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/612/head:pull/612`
`$ git checkout pull/612`
