### PR TITLE
build: update JUnit to 5.6.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,12 +43,12 @@ configure(subprojects.findAll() { it.name != 'bots' }) {
     }
 
     dependencies {
-        testImplementation 'org.junit.jupiter:junit-jupiter-api:5.5.2'
-        testImplementation 'org.junit.jupiter:junit-jupiter-params:5.5.2'
-        testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.5.2'
+        testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.2'
+        testImplementation 'org.junit.jupiter:junit-jupiter-params:5.6.2'
+        testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.6.2'
         // Force Gradle to load the JUnit Platform Launcher from the module-path, as
         // configured in buildSrc/.../ModulePlugin.java -- see SKARA-69 for details.
-        testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.5.2'
+        testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.6.2'
     }
 
     compileJava.options.encoding = 'UTF-8'

--- a/test/build.gradle
+++ b/test/build.gradle
@@ -39,9 +39,9 @@ dependencies {
     implementation project(':mailinglist')
     implementation project(':proxy')
 
-    implementation 'org.junit.jupiter:junit-jupiter-api:5.3.1'
-    implementation 'org.junit.jupiter:junit-jupiter-params:5.3.1'
-    runtimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.3.1'
+    implementation 'org.junit.jupiter:junit-jupiter-api:5.6.2'
+    implementation 'org.junit.jupiter:junit-jupiter-params:5.6.2'
+    runtimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.6.2'
 }
 
 publishing {


### PR DESCRIPTION
Hi all,

please review this patch that updates JUnit (API and engine) to 5.6.2 and JUnit
platform to 1.6.2.

Testing:
- `sh gradlew test` passes on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/613/head:pull/613`
`$ git checkout pull/613`
