### PR TITLE
build: update to Gradle 6.3

### DIFF
--- a/deps.env
+++ b/deps.env
@@ -7,5 +7,5 @@ JDK_MACOS_X64_SHA256="593c5c9dc0978db21b06d6219dc8584b76a59c79d57e6ec1b28ad0d848
 JDK_WINDOWS_X64_URL="https://download.java.net/java/GA/jdk13.0.1/cec27d702aa74d5a8630c65ae61e4305/9/GPL/openjdk-13.0.1_windows-x64_bin.zip"
 JDK_WINDOWS_X64_SHA256="438a6920f1851b1eeb6f09f05d9f91c4423c6586f7a1a7ccbb19df76ea5901ee"
 
-GRADLE_URL="https://services.gradle.org/distributions/gradle-6.0-bin.zip"
-GRADLE_SHA256="5a3578b9f0bb162f5e08cf119f447dfb8fa950cedebb4d2a977e912a11a74b91"
+GRADLE_URL="https://services.gradle.org/distributions/gradle-6.3-bin.zip"
+GRADLE_SHA256="038794feef1f4745c6347107b6726279d1c824f3fc634b60f86ace1e9fbd1768"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -19,5 +19,5 @@
 # or visit www.oracle.com if you need additional information or have any
 # questions.
 
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0-bin.zip
-distributionSha256Sum=5a3578b9f0bb162f5e08cf119f447dfb8fa950cedebb4d2a977e912a11a74b91
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-bin.zip
+distributionSha256Sum=038794feef1f4745c6347107b6726279d1c824f3fc634b60f86ace1e9fbd1768


### PR DESCRIPTION
Hi all,

please review this patch that updates Gradle to version 6.3.

Testing:
- `sh gradlew images`
- `sh gradlew test`

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/614/head:pull/614`
`$ git checkout pull/614`
