### PR TITLE
build: update to JDK 14.0.1

### DIFF
--- a/bots/cli/build.gradle
+++ b/bots/cli/build.gradle
@@ -87,8 +87,8 @@ images {
         options = ["--module-path", "plugins"]
         bundles = ['zip', 'tar.gz']
         jdk {
-            url = 'https://download.java.net/java/GA/jdk13.0.1/cec27d702aa74d5a8630c65ae61e4305/9/GPL/openjdk-13.0.1_linux-x64_bin.tar.gz'
-            sha256 = '2e01716546395694d3fad54c9b36d1cd46c5894c06f72d156772efbcf4b41335'
+            url = 'https://download.java.net/java/GA/jdk14.0.1/664493ef4a6946b186ff29eb326336a2/7/GPL/openjdk-14.0.1_linux-x64_bin.tar.gz'
+            sha256 = '22ce248e0bd69f23028625bede9d1b3080935b68d011eaaf9e241f84d6b9c4cc'
         }
     }
 }

--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -71,8 +71,8 @@ images {
         launchers = ext.launchers
         bundles = ['zip', 'tar.gz']
         jdk {
-            url = 'https://download.java.net/java/GA/jdk13.0.1/cec27d702aa74d5a8630c65ae61e4305/9/GPL/openjdk-13.0.1_windows-x64_bin.zip'
-            sha256 = '438a6920f1851b1eeb6f09f05d9f91c4423c6586f7a1a7ccbb19df76ea5901ee'
+            url = 'https://download.java.net/java/GA/jdk14.0.1/664493ef4a6946b186ff29eb326336a2/7/GPL/openjdk-14.0.1_windows-x64_bin.zip'
+            sha256 = '26255f3f2fe7168ec0dce9d9f3825649c18540ba86279a7506c7f17dd3e537f9'
         }
     }
 
@@ -82,8 +82,8 @@ images {
         man = 'cli/resources/man'
         bundles = ['zip', 'tar.gz']
         jdk {
-            url = 'https://download.java.net/java/GA/jdk13.0.1/cec27d702aa74d5a8630c65ae61e4305/9/GPL/openjdk-13.0.1_linux-x64_bin.tar.gz'
-            sha256 = '2e01716546395694d3fad54c9b36d1cd46c5894c06f72d156772efbcf4b41335'
+            url = 'https://download.java.net/java/GA/jdk14.0.1/664493ef4a6946b186ff29eb326336a2/7/GPL/openjdk-14.0.1_linux-x64_bin.tar.gz'
+            sha256 = '22ce248e0bd69f23028625bede9d1b3080935b68d011eaaf9e241f84d6b9c4cc'
         }
     }
 
@@ -93,8 +93,8 @@ images {
         man = 'cli/resources/man'
         bundles = ['zip', 'tar.gz']
         jdk {
-            url = 'https://download.java.net/java/GA/jdk13.0.1/cec27d702aa74d5a8630c65ae61e4305/9/GPL/openjdk-13.0.1_osx-x64_bin.tar.gz'
-            sha256 = '593c5c9dc0978db21b06d6219dc8584b76a59c79d57e6ec1b28ad0d848a7713f'
+            url = 'https://download.java.net/java/GA/jdk14.0.1/664493ef4a6946b186ff29eb326336a2/7/GPL/openjdk-14.0.1_osx-x64_bin.tar.gz'
+            sha256 = 'd8aa6806e6cc99724395563bf02fc6907a7c801f4caef85b96ad44927193da07'
         }
     }
 

--- a/deps.env
+++ b/deps.env
@@ -1,11 +1,11 @@
-JDK_LINUX_X64_URL="https://download.java.net/java/GA/jdk13.0.1/cec27d702aa74d5a8630c65ae61e4305/9/GPL/openjdk-13.0.1_linux-x64_bin.tar.gz"
-JDK_LINUX_X64_SHA256="2e01716546395694d3fad54c9b36d1cd46c5894c06f72d156772efbcf4b41335"
+JDK_LINUX_X64_URL="https://download.java.net/java/GA/jdk14.0.1/664493ef4a6946b186ff29eb326336a2/7/GPL/openjdk-14.0.1_linux-x64_bin.tar.gz"
+JDK_LINUX_X64_SHA256="22ce248e0bd69f23028625bede9d1b3080935b68d011eaaf9e241f84d6b9c4cc"
 
-JDK_MACOS_X64_URL="https://download.java.net/java/GA/jdk13.0.1/cec27d702aa74d5a8630c65ae61e4305/9/GPL/openjdk-13.0.1_osx-x64_bin.tar.gz"
-JDK_MACOS_X64_SHA256="593c5c9dc0978db21b06d6219dc8584b76a59c79d57e6ec1b28ad0d848a7713f"
+JDK_MACOS_X64_URL="https://download.java.net/java/GA/jdk14.0.1/664493ef4a6946b186ff29eb326336a2/7/GPL/openjdk-14.0.1_osx-x64_bin.tar.gz"
+JDK_MACOS_X64_SHA256="d8aa6806e6cc99724395563bf02fc6907a7c801f4caef85b96ad44927193da07"
 
-JDK_WINDOWS_X64_URL="https://download.java.net/java/GA/jdk13.0.1/cec27d702aa74d5a8630c65ae61e4305/9/GPL/openjdk-13.0.1_windows-x64_bin.zip"
-JDK_WINDOWS_X64_SHA256="438a6920f1851b1eeb6f09f05d9f91c4423c6586f7a1a7ccbb19df76ea5901ee"
+JDK_WINDOWS_X64_URL="https://download.java.net/java/GA/jdk14.0.1/664493ef4a6946b186ff29eb326336a2/7/GPL/openjdk-14.0.1_windows-x64_bin.zip"
+JDK_WINDOWS_X64_SHA256="26255f3f2fe7168ec0dce9d9f3825649c18540ba86279a7506c7f17dd3e537f9"
 
 GRADLE_URL="https://services.gradle.org/distributions/gradle-6.3-bin.zip"
 GRADLE_SHA256="038794feef1f4745c6347107b6726279d1c824f3fc634b60f86ace1e9fbd1768"


### PR DESCRIPTION
Hi all,

please review this patch that updates the JDK for Skara to version 14.0.1.

Testing:
- `sh gradlew images`
- `sh gradlew test`

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/615/head:pull/615`
`$ git checkout pull/615`
