### PR TITLE
384: Suggest issue command instead of solves command

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CSRCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CSRCommand.java
@@ -23,14 +23,12 @@
 package org.openjdk.skara.bots.pr;
 
 import org.openjdk.skara.forge.PullRequest;
-import org.openjdk.skara.issuetracker.Comment;
-import org.openjdk.skara.issuetracker.Issue;
+import org.openjdk.skara.issuetracker.*;
 import org.openjdk.skara.json.JSON;
 
 import java.io.PrintWriter;
 import java.nio.file.Path;
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.List;
 
 public class CSRCommand implements CommandHandler {
     private static final String CSR_LABEL = "csr";
@@ -48,7 +46,7 @@ public class CSRCommand implements CommandHandler {
     private static void jbsReply(PullRequest pr, PrintWriter writer) {
         writer.println("@" + pr.author().userName() + " this pull request must refer to an issue in " +
                       "[JBS](https://bugs.openjdk.java.net) to be able to link it to a CSR request. To refer this pull request to " +
-                      "an issue in JBS, please use the `/solves` command in a comment in this pull request.");
+                      "an issue in JBS, please use the `/issue` command in a comment in this pull request.");
     }
 
     private static void linkReply(PullRequest pr, Issue issue, PrintWriter writer) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -427,7 +427,7 @@ class CheckRun {
 
         message.append("- If you would like to add a summary, use the `/summary` command.\n");
         message.append("- To credit additional contributors, use the `/contributor` command.\n");
-        message.append("- To add additional solved issues, use the `/solves` command.\n");
+        message.append("- To add additional solved issues, use the `/issue` command.\n");
 
         var divergingCommits = checkablePullRequest.divergingCommits();
         if (divergingCommits.size() > 0) {


### PR DESCRIPTION
Hi all,

Please review this minor change that suggest the `issue` command instead of `solves`.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-384](https://bugs.openjdk.java.net/browse/SKARA-384): Suggest issue command instead of solves command


### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/616/head:pull/616`
`$ git checkout pull/616`
