### PR TITLE
394: Merge bot conflict resolution interaction requires separate credentials

### DIFF
--- a/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
+++ b/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
@@ -43,6 +43,7 @@ import java.util.stream.Collectors;
 import java.util.logging.Logger;
 
 class MergeBot implements Bot, WorkItem {
+    private final String integrationCommand = "/integrate\n<!-- Valid self-command -->";
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots");;
     private final Path storage;
 
@@ -326,10 +327,10 @@ class MergeBot implements Bot, WorkItem {
                             var integrateComments =
                                 comments.stream()
                                         .filter(c -> c.author().equals(currentUser))
-                                        .filter(c -> c.body().equals("/integrate"))
+                                        .filter(c -> c.body().equals(integrationCommand))
                                         .collect(Collectors.toList());
                             if (integrateComments.isEmpty()) {
-                                pr.addComment("/integrate");
+                                pr.addComment(integrationCommand);
                             } else {
                                 var lastIntegrateComment = integrateComments.get(integrateComments.size() - 1);
                                 var id = lastIntegrateComment.id();
@@ -349,7 +350,7 @@ class MergeBot implements Bot, WorkItem {
                                     var errorPrefix = "@openjdk-bot Your merge request cannot be fulfilled at this time";
                                     if (lines.length > 1 && lines[1].startsWith(errorPrefix)) {
                                         // Try again
-                                        pr.addComment("/integrate");
+                                        pr.addComment(integrationCommand);
                                     }
                                     // Other reply, potentially due to rebase issue, just
                                     // wait for the labeler to add appropriate labels.

--- a/bots/merge/src/test/java/org/openjdk/skara/bots/merge/MergeBotTests.java
+++ b/bots/merge/src/test/java/org/openjdk/skara/bots/merge/MergeBotTests.java
@@ -660,7 +660,7 @@ class MergeBotTests {
             pr = pullRequests.get(0);
             var numComments = pr.comments().size();
             var lastComment = pr.comments().get(pr.comments().size() - 1);
-            assertEquals("/integrate", lastComment.body());
+            assertEquals("/integrate\n<!-- Valid self-command -->", lastComment.body());
 
             // Running the bot again should not result in another comment
             TestBotRunner.runPeriodicItems(bot);

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandWorkItem.java
@@ -34,12 +34,12 @@ import java.util.regex.*;
 import java.util.stream.*;
 
 public class CommandWorkItem extends PullRequestWorkItem {
-    private final Logger log = Logger.getLogger("org.openjdk.skara.bots.pr");
+    private static final Logger log = Logger.getLogger("org.openjdk.skara.bots.pr");
 
-    private final Pattern commandPattern = Pattern.compile("^/(.*)");
-    private final String commandReplyMarker = "<!-- Jmerge command reply message (%s) -->";
-    private final Pattern commandReplyPattern = Pattern.compile("<!-- Jmerge command reply message \\((\\S+)\\) -->");
-    private final String selfCommandMarker = "<!-- Valid self-command -->";
+    private static final Pattern commandPattern = Pattern.compile("^/(.*)");
+    private static final String commandReplyMarker = "<!-- Jmerge command reply message (%s) -->";
+    private static final Pattern commandReplyPattern = Pattern.compile("<!-- Jmerge command reply message \\((\\S+)\\) -->");
+    private static final String selfCommandMarker = "<!-- Valid self-command -->";
 
     private final static Map<String, CommandHandler> commandHandlers = Map.of(
             "help", new HelpCommand(),
@@ -87,8 +87,8 @@ public class CommandWorkItem extends PullRequestWorkItem {
                               .collect(Collectors.toSet());
 
         return comments.stream()
+                       .filter(comment -> !comment.author().equals(self) || comment.body().endsWith(selfCommandMarker))
                        .map(comment -> new AbstractMap.SimpleEntry<>(comment, commandPattern.matcher(comment.body())))
-                       .filter(entry -> !entry.getKey().author().equals(self) || entry.getKey().body().endsWith(selfCommandMarker))
                        .filter(entry -> entry.getValue().find())
                        .filter(entry -> !handled.contains(entry.getKey().id()))
                        .map(entry -> new AbstractMap.SimpleEntry<>(entry.getValue().group(1), entry.getKey()))

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CommandTests.java
@@ -129,7 +129,6 @@ class CommandTests {
             // Issue an command using the bot account
             var botPr = integrator.pullRequest(pr.id());
             botPr.addComment("/help");
-            TestBotRunner.runPeriodicItems(mergeBot);
 
             // The bot should not reply
             assertEquals(1, pr.comments().size());
@@ -146,7 +145,7 @@ class CommandTests {
             var help = pr.comments().stream()
                          .filter(comment -> comment.body().contains("Available commands"))
                          .filter(comment -> comment.body().contains("help"))
-                          .count();
+                         .count();
             assertEquals(1, help);
         }
     }


### PR DESCRIPTION
Hi all,

Please review this change that allows the pull request bot to recognize specially formatted command comments made by "itself" (most likely another bot using the same credentials).

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-394](https://bugs.openjdk.java.net/browse/SKARA-394): Merge bot conflict resolution interaction requires separate credentials


### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - **Reviewer**) ⚠️ Review applies to d76f6b4b61b15ccb3404326ecac7951377e80aff

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/618/head:pull/618`
`$ git checkout pull/618`
