### PR TITLE
397: Extend the additional errors section with hidden jcheck entries

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -157,7 +157,7 @@ class CheckRun {
             checkBuilder.complete(true);
         } else {
             checkBuilder.title("Required");
-            var summary = Stream.concat(visitor.getMessages().stream(), additionalErrors.stream())
+            var summary = Stream.concat(visitor.messages().stream(), additionalErrors.stream())
                                 .sorted()
                                 .map(m -> "- " + m)
                                 .collect(Collectors.joining("\n"));
@@ -274,13 +274,16 @@ class CheckRun {
         progressBody.append("### Progress\n");
         progressBody.append(getChecksList(visitor));
 
-        if (!additionalErrors.isEmpty()) {
+        var allAdditionalErrors = Stream.concat(visitor.hiddenMessages().stream(), additionalErrors.stream())
+                                        .sorted()
+                                        .collect(Collectors.toList());
+        if (!allAdditionalErrors.isEmpty()) {
             progressBody.append("\n\n### Error");
-            if (additionalErrors.size() > 1) {
+            if (allAdditionalErrors.size() > 1) {
                 progressBody.append("s");
             }
             progressBody.append("\n");
-            progressBody.append(getAdditionalErrorsList(additionalErrors));
+            progressBody.append(getAdditionalErrorsList(allAdditionalErrors));
         }
 
         var issue = Issue.fromString(pr.title());
@@ -632,7 +635,7 @@ class CheckRun {
 
             var commit = localRepo.lookup(localHash).orElseThrow();
             var commitMessage = String.join("\n", commit.message());
-            var readyForIntegration = visitor.getMessages().isEmpty() && additionalErrors.isEmpty();
+            var readyForIntegration = visitor.messages().isEmpty() && additionalErrors.isEmpty();
             updateMergeReadyComment(readyForIntegration, commitMessage, comments, activeReviews, rebasePossible);
             if (readyForIntegration && rebasePossible) {
                 newLabels.add("ready");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
@@ -116,10 +116,10 @@ public class IntegrateCommand implements CommandHandler {
             var issues = checkablePr.createVisitor(localHash, censusInstance);
             var additionalConfiguration = AdditionalConfiguration.get(localRepo, localHash, pr.repository().forge().currentUser(), allComments);
             checkablePr.executeChecks(localHash, censusInstance, issues, additionalConfiguration);
-            if (!issues.getMessages().isEmpty()) {
+            if (!issues.messages().isEmpty()) {
                 reply.print("Your merge request cannot be fulfilled at this time, as ");
                 reply.println("your changes failed the final jcheck:");
-                issues.getMessages().stream()
+                issues.messages().stream()
                       .map(line -> " * " + line)
                       .forEach(reply::println);
                 return;

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
@@ -102,10 +102,10 @@ public class SponsorCommand implements CommandHandler {
             var issues = checkablePr.createVisitor(localHash, censusInstance);
             var additionalConfiguration = AdditionalConfiguration.get(localRepo, localHash, pr.repository().forge().currentUser(), allComments);
             checkablePr.executeChecks(localHash, censusInstance, issues, additionalConfiguration);
-            if (!issues.getMessages().isEmpty()) {
+            if (!issues.messages().isEmpty()) {
                 reply.print("Your merge request cannot be fulfilled at this time, as ");
                 reply.println("your changes failed the final jcheck:");
-                issues.getMessages().stream()
+                issues.messages().stream()
                       .map(line -> " * " + line)
                       .forEach(reply::println);
                 return;


### PR DESCRIPTION
Hi all,

Please review this change that displays jcheck failure messages that are "hidden" (not shown as an item in the progress list) in the PR body error section.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-397](https://bugs.openjdk.java.net/browse/SKARA-397): Extend the additional errors section with hidden jcheck entries


### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/620/head:pull/620`
`$ git checkout pull/620`
