### PR TITLE
396: Add some additional help for empty PRs

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -50,11 +50,13 @@ class CheckRun {
     private final Hash baseHash;
     private final CheckablePullRequest checkablePullRequest;
 
-    private final Logger log = Logger.getLogger("org.openjdk.skara.bots.pr");
-    private final String progressMarker = "<!-- Anything below this marker will be automatically updated, please do not edit manually! -->";
-    private final String mergeReadyMarker = "<!-- PullRequestBot merge is ready comment -->";
-    private final String outdatedHelpMarker = "<!-- PullRequestBot outdated help comment -->";
-    private final String sourceBranchWarningMarker = "<!-- PullRequestBot source branch warning comment -->";
+    private static final Logger log = Logger.getLogger("org.openjdk.skara.bots.pr");
+    private static final String progressMarker = "<!-- Anything below this marker will be automatically updated, please do not edit manually! -->";
+    private static final String mergeReadyMarker = "<!-- PullRequestBot merge is ready comment -->";
+    private static final String outdatedHelpMarker = "<!-- PullRequestBot outdated help comment -->";
+    private static final String sourceBranchWarningMarker = "<!-- PullRequestBot source branch warning comment -->";
+    private static final String emptyPrBodyMarker = "<!--\nReplace this text with a description of your pull request (also remove the surrounding HTML comment markers).\n" +
+            "If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.\n-->";
     private final Set<String> newLabels;
 
     private CheckRun(CheckWorkItem workItem, PullRequest pr, Repository localRepo, List<Comment> comments,
@@ -358,7 +360,11 @@ class CheckRun {
             log.info("Progress already up to date");
             return description;
         }
-        var newBody = bodyWithoutStatus() + "\n" + progressMarker + "\n" + message;
+        var originalBody = bodyWithoutStatus();
+        if (originalBody.isBlank()) {
+            originalBody = emptyPrBodyMarker;
+        }
+        var newBody = originalBody + "\n" + progressMarker + "\n" + message;
 
         // TODO? Retrieve the body again here to lower the chance of concurrent updates
         pr.setBody(newBody);

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -704,6 +704,9 @@ class CheckTests {
             assertTrue(updatedPr.body().contains("## Error"));
             assertTrue(updatedPr.body().contains("The pull request body must not be empty."));
 
+            // There should be an indicator of where the pr body should be entered
+            assertTrue(updatedPr.body().contains("Replace this text with a description of your pull request"));
+
             // The PR should not yet be ready for review
             assertFalse(pr.labels().contains("rfr"));
             assertFalse(pr.labels().contains("ready"));
@@ -720,6 +723,9 @@ class CheckTests {
             updatedPr = author.pullRequest(pr.id());
             assertFalse(updatedPr.body().contains("## Error"));
             assertFalse(updatedPr.body().contains("The pull request body must not be empty."));
+
+            // And no new helper marker
+            assertFalse(updatedPr.body().contains("Replace this text with a description of your pull request"));
         }
     }
 


### PR DESCRIPTION
Hi all,

Please review this change that adds a placeholder message that can help the user to determine how exactly the "empty PR body" error should be remedied.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-396](https://bugs.openjdk.java.net/browse/SKARA-396): Add some additional help for empty PRs


### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/621/head:pull/621`
`$ git checkout pull/621`
