### PR TITLE
391: Abort merge if source branch merge isn't fast-forward

### DIFF
--- a/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
+++ b/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
@@ -478,6 +478,9 @@ class MergeBot implements Bot, WorkItem {
                     new IllegalStateException("Could not get remote branch name for " + toBranch.name())
                 ));
                 repo.merge(remoteBranch); // should always be a fast-forward merge
+                if (!repo.isClean()) {
+                    throw new RuntimeException("Local repository isn't clean after fast-forward merge - has the fork diverged unexpectedly?");
+                }
 
                 log.info("Trying to merge " + fromRepo.name() + ":" + fromBranch.name() + " to " + toBranch.name());
                 log.info("Fetching " + fromRepo.name() + ":" + fromBranch.name());


### PR DESCRIPTION
Hi all,

Please review this change that ensures that the merge bot's local storage has been cleanly updated with the latest destination changes (through a fast-forward merge). Otherwise, it's possible for an error to be detected when doing the actual merge, even though it should succeed.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-391](https://bugs.openjdk.java.net/browse/SKARA-391): Abort merge if source branch merge isn't fast-forward


### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/622/head:pull/622`
`$ git checkout pull/622`
