### PR TITLE
383: More fuzzy matching of bug ids in PR titles

### DIFF
--- a/bots/csr/src/main/java/org/openjdk/skara/bots/csr/CSRBot.java
+++ b/bots/csr/src/main/java/org/openjdk/skara/bots/csr/CSRBot.java
@@ -83,12 +83,12 @@ class CSRBot implements Bot, WorkItem {
                 continue;
             }
 
-            var issue = org.openjdk.skara.vcs.openjdk.Issue.fromString(pr.title());
+            var issue = org.openjdk.skara.vcs.openjdk.Issue.fromStringRelaxed(pr.title());
             if (issue.isEmpty()) {
                 log.info("No issue found in title for " + describe(pr));
                 continue;
             }
-            var jbsIssue = project.issue(issue.get().id());
+            var jbsIssue = project.issue(issue.get().shortId());
             if (jbsIssue.isEmpty()) {
                 log.info("No issue found in JBS for " + describe(pr));
                 continue;

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
@@ -137,8 +137,8 @@ class ArchiveMessages {
     }
 
     private static Optional<String> issueUrl(PullRequest pr, URI issueTracker, String projectPrefix) {
-        var issue = Issue.fromString(pr.title());
-        return issue.map(value -> URIBuilder.base(issueTracker).appendPath(projectPrefix + "-" + value.id()).build().toString());
+        var issue = Issue.fromStringRelaxed(pr.title());
+        return issue.map(value -> URIBuilder.base(issueTracker).appendPath(projectPrefix + "-" + value.shortId()).build().toString());
     }
 
     private static String stats(Repository localRepo, Hash base, Hash head) {

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
@@ -71,12 +71,12 @@ class WebrevStorage {
                             .pullRequest(pr.webUrl().toString())
                             .username(fullName);
 
-        var issue = Issue.fromString(pr.title());
+        var issue = Issue.fromStringRelaxed(pr.title());
         if (issue.isPresent()) {
             var conf = JCheckConfiguration.from(localRepository, head);
             if (!conf.isEmpty()) {
                 var project = conf.get().general().jbs() != null ? conf.get().general().jbs() : conf.get().general().project();
-                var id = issue.get().id();
+                var id = issue.get().shortId();
                 IssueTracker issueTracker = null;
                 try {
                     issueTracker = IssueTracker.from("jira", URI.create("https://bugs.openjdk.java.net"));

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/IssueUpdater.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/IssueUpdater.java
@@ -248,7 +248,7 @@ public class IssueUpdater implements RepositoryUpdateConsumer, PullRequestUpdate
             var commitNotification = CommitFormatters.toTextBrief(repository, commit);
             var commitMessage = CommitMessageParsers.v1.parse(commit);
             for (var commitIssue : commitMessage.issues()) {
-                var optionalIssue = issueProject.issue(commitIssue.id());
+                var optionalIssue = issueProject.issue(commitIssue.shortId());
                 if (optionalIssue.isEmpty()) {
                     log.severe("Cannot update issue " + commitIssue.id() + " with commit " + commit.hash().abbreviate()
                                        + " - issue not found in issue project");
@@ -347,7 +347,7 @@ public class IssueUpdater implements RepositoryUpdateConsumer, PullRequestUpdate
 
     @Override
     public void handleNewIssue(PullRequest pr, org.openjdk.skara.vcs.openjdk.Issue issue) {
-        var realIssue = issueProject.issue(issue.id());
+        var realIssue = issueProject.issue(issue.shortId());
         if (realIssue.isEmpty()) {
             log.warning("Pull request " + pr + " added unknown issue: " + issue.id());
             return;
@@ -367,7 +367,7 @@ public class IssueUpdater implements RepositoryUpdateConsumer, PullRequestUpdate
 
     @Override
     public void handleRemovedIssue(PullRequest pr, org.openjdk.skara.vcs.openjdk.Issue issue) {
-        var realIssue = issueProject.issue(issue.id());
+        var realIssue = issueProject.issue(issue.shortId());
         if (realIssue.isEmpty()) {
             log.warning("Pull request " + pr + " removed unknown issue: " + issue.id());
             return;

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/JsonUpdater.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/JsonUpdater.java
@@ -51,7 +51,7 @@ public class JsonUpdater implements RepositoryUpdateConsumer {
         var parsedMessage = CommitMessageParsers.v1.parse(commit);
         var issueIds = JSON.array();
         for (var issue : parsedMessage.issues()) {
-            issueIds.add(JSON.of(issue.id()));
+            issueIds.add(JSON.of(issue.shortId()));
         }
         ret.put("issue", issueIds);
         ret.put("user", commit.author().name());
@@ -67,7 +67,7 @@ public class JsonUpdater implements RepositoryUpdateConsumer {
 
         var issueIds = JSON.array();
         for (var issue : issues) {
-            issueIds.add(JSON.of(issue.id()));
+            issueIds.add(JSON.of(issue.shortId()));
         }
 
         ret.put("issue", issueIds);

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CSRCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CSRCommand.java
@@ -22,7 +22,7 @@
  */
 package org.openjdk.skara.bots.pr;
 
-import org.openjdk.skara.forge.PullRequest;
+import org.openjdk.skara.forge.*;
 import org.openjdk.skara.issuetracker.*;
 import org.openjdk.skara.json.JSON;
 
@@ -83,7 +83,7 @@ public class CSRCommand implements CommandHandler {
         }
 
         var issueProject = bot.issueProject();
-        var issue = org.openjdk.skara.vcs.openjdk.Issue.fromString(pr.title());
+        var issue = org.openjdk.skara.vcs.openjdk.Issue.fromStringRelaxed(pr.title());
         if (issue.isEmpty()) {
             csrReply(reply);
             jbsReply(pr, reply);
@@ -91,7 +91,7 @@ public class CSRCommand implements CommandHandler {
             return;
         }
 
-        var jbsIssue = issueProject.issue(issue.get().id());
+        var jbsIssue = issueProject.issue(issue.get().shortId());
         if (jbsIssue.isEmpty()) {
             csrReply(reply);
             jbsReply(pr, reply);

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -270,6 +270,14 @@ class CheckRun {
         }
     }
 
+    private boolean relaxedEquals(String s1, String s2) {
+        return s1.trim()
+                 .replaceAll("\\s+", " ")
+                 .equalsIgnoreCase(s2.trim()
+                                     .replaceAll("\\s+", " "));
+    }
+
+
     private String getStatusMessage(List<Comment> comments, List<Review> reviews, PullRequestCheckIssueVisitor visitor, List<String> additionalErrors) {
         var progressBody = new StringBuilder();
         progressBody.append("---------\n");
@@ -288,7 +296,7 @@ class CheckRun {
             progressBody.append(getAdditionalErrorsList(allAdditionalErrors));
         }
 
-        var issue = Issue.fromString(pr.title());
+        var issue = Issue.fromStringRelaxed(pr.title());
         var issueProject = workItem.bot.issueProject();
         if (issueProject != null && issue.isPresent()) {
             var allIssues = new ArrayList<Issue>();
@@ -301,25 +309,36 @@ class CheckRun {
             progressBody.append("\n");
             for (var currentIssue : allIssues) {
                 progressBody.append(" * ");
-                try {
-                    var iss = issueProject.issue(currentIssue.id());
-                    if (iss.isPresent()) {
-                        progressBody.append("[");
-                        progressBody.append(iss.get().id());
-                        progressBody.append("](");
-                        progressBody.append(iss.get().webUrl());
-                        progressBody.append("): ");
-                        progressBody.append(iss.get().title());
-                        progressBody.append("\n");
-                    } else {
-                        progressBody.append("⚠️ Failed to retrieve information on issue `");
+                if (currentIssue.project().isPresent() && !currentIssue.project().get().equals(issueProject.name())) {
+                    progressBody.append("⚠️ Issue `");
+                    progressBody.append(currentIssue.id());
+                    progressBody.append("` does not belong to the `");
+                    progressBody.append(issueProject.name());
+                    progressBody.append("` project.");
+                } else {
+                    try {
+                        var iss = issueProject.issue(currentIssue.shortId());
+                        if (iss.isPresent()) {
+                            progressBody.append("[");
+                            progressBody.append(iss.get().id());
+                            progressBody.append("](");
+                            progressBody.append(iss.get().webUrl());
+                            progressBody.append("): ");
+                            progressBody.append(iss.get().title());
+                            if (!relaxedEquals(iss.get().title(), currentIssue.description())) {
+                                progressBody.append(" ⚠️ Title mismatch between PR and JBS.");
+                            }
+                            progressBody.append("\n");
+                        } else {
+                            progressBody.append("⚠️ Failed to retrieve information on issue `");
+                            progressBody.append(currentIssue.id());
+                            progressBody.append("`.\n");
+                        }
+                    } catch (RuntimeException e) {
+                        progressBody.append("⚠️ Temporary failure when trying to retrieve information on issue `");
                         progressBody.append(currentIssue.id());
                         progressBody.append("`.\n");
                     }
-                } catch (RuntimeException e) {
-                    progressBody.append("⚠️ Temporary failure when trying to retrieve information on issue `");
-                    progressBody.append(currentIssue.id());
-                    progressBody.append("`.\n");
                 }
             }
         }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
@@ -63,7 +63,7 @@ public class CheckablePullRequest {
 
         var additionalIssues = SolvesTracker.currentSolved(currentUser, comments);
         var summary = Summary.summary(currentUser, comments);
-        var issue = Issue.fromString(pr.title());
+        var issue = Issue.fromStringRelaxed(pr.title());
         var commitMessageBuilder = issue.map(CommitMessage::title).orElseGet(() -> CommitMessage.title(pr.title()));
         if (issue.isPresent()) {
             commitMessageBuilder.issues(additionalIssues);

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SolvesTracker.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SolvesTracker.java
@@ -37,11 +37,11 @@ public class SolvesTracker {
 
     static String setSolvesMarker(Issue issue) {
         var encodedDescription = Base64.getEncoder().encodeToString(issue.description().getBytes(StandardCharsets.UTF_8));
-        return String.format(solvesMarker, issue.id(), encodedDescription);
+        return String.format(solvesMarker, issue.shortId(), encodedDescription);
     }
 
     static String removeSolvesMarker(Issue issue) {
-        return String.format(solvesMarker, issue.id(), "");
+        return String.format(solvesMarker, issue.shortId(), "");
     }
 
     static List<Issue> currentSolved(HostUser botUser, List<Comment> comments) {

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -974,6 +974,16 @@ class CheckTests {
             assertFalse(pr.body().contains("My first issue"));
             assertTrue(pr.body().contains("My second issue"));
 
+            // The PR title does not match the issue title
+            assertTrue(pr.body().contains("Title mismatch"));
+
+            // Correct it
+            pr.setTitle(issue2.id() + " - " + issue2.title());
+
+            // Check the status again - it should now match
+            TestBotRunner.runPeriodicItems(checkBot);
+            assertFalse(pr.body().contains("Title mismatch"));
+
             // Use an invalid issue key
             var issueKey = issue1.id().replace("TEST", "BADPROJECT");
             pr.setTitle(issueKey + ": This is a pull request");
@@ -982,7 +992,7 @@ class CheckTests {
             TestBotRunner.runPeriodicItems(checkBot);
             assertFalse(pr.body().contains("My first issue"));
             assertFalse(pr.body().contains("My second issue"));
-            assertTrue(pr.body().contains("Failed to retrieve"));
+            assertTrue(pr.body().contains("does not belong to the `TEST` project"));
 
             // Now drop the issue key
             issueKey = issue1.id().replace("TEST-", "");

--- a/cli/src/main/java/org/openjdk/skara/cli/GitInfo.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitInfo.java
@@ -230,7 +230,7 @@ public class GitInfo {
             var decoration = useDecoration? "Review: " : "";
             var project = jbsProject(repo, hash);
             if (message.issues().size() == 1) {
-                var issueId = message.issues().get(0).id();
+                var issueId = message.issues().get(0).shortId();
                 var issueTracker = IssueTracker.from("jira", JBS);
                 var issue = issueTracker.project(project).issue(issueId);
                 if (issue.isPresent()) {
@@ -254,11 +254,11 @@ public class GitInfo {
                 }
                 var decoration = useDecoration ? "- " : "";
                 for (var issue : issues) {
-                    System.out.println(decoration + uri + issue.id());
+                    System.out.println(decoration + uri + issue.shortId());
                 }
             } else if (issues.size() == 1) {
                 var decoration = useDecoration ? "Issue: " : "";
-                System.out.println(decoration + uri + issues.get(0).id());
+                System.out.println(decoration + uri + issues.get(0).shortId());
             }
         }
     }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/CommitMessageFormatters.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/CommitMessageFormatters.java
@@ -22,10 +22,10 @@
  */
 package org.openjdk.skara.vcs.openjdk;
 
+import org.openjdk.skara.vcs.Author;
+
 import java.util.*;
 import java.util.stream.Collectors;
-
-import org.openjdk.skara.vcs.Author;
 
 public class CommitMessageFormatters {
     public static class V0 implements CommitMessageFormatter {
@@ -40,7 +40,7 @@ public class CommitMessageFormatters {
             var lines = new ArrayList<String>();
 
             for (var issue : message.issues()) {
-                lines.add(issue.toString());
+                lines.add(issue.toShortString());
             }
             for (var summary : message.summaries()) {
                 lines.add("Summary: " + summary);
@@ -71,7 +71,7 @@ public class CommitMessageFormatters {
                 lines.add(message.title());
             } else {
                 for (var issue : message.issues()) {
-                    lines.add(issue.toString());
+                    lines.add(issue.toShortString());
                 }
             }
 

--- a/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/CommitMessageParsers.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/CommitMessageParsers.java
@@ -22,13 +22,11 @@
  */
 package org.openjdk.skara.vcs.openjdk;
 
-import java.util.*;
-import java.util.stream.Collectors;
-import java.time.*;
-import java.util.regex.Pattern;
-import java.util.regex.Matcher;
+import org.openjdk.skara.vcs.Author;
 
-import org.openjdk.skara.vcs.*;
+import java.util.*;
+import java.util.regex.*;
+import java.util.stream.Collectors;
 
 import static org.openjdk.skara.vcs.openjdk.CommitMessageSyntax.*;
 
@@ -107,7 +105,7 @@ public class CommitMessageParsers {
                 title = lines.get(0);
                 i++;
             } else {
-                title = issues.stream().map(Issue::toString).collect(Collectors.joining("\n"));
+                title = issues.stream().map(Issue::toShortString).collect(Collectors.joining("\n"));
             }
 
             var firstDelimiter = true;

--- a/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/Issue.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/Issue.java
@@ -27,7 +27,7 @@ import java.util.regex.Pattern;
 
 public class Issue {
     private final String project;
-    private final String id;
+    private final String shortId;
     private final String description;
 
     private final static Pattern relaxedIssueParsePattern = Pattern.compile("^((?:[A-Z][A-Z0-9]+-)?[0-9]+)[^\\p{Alnum}]+(\\S.*)$");
@@ -36,10 +36,10 @@ public class Issue {
         if (id.contains("-")) {
             var idSplit = id.split("-", 2);
             project = idSplit[0];
-            this.id = idSplit[1];
+            this.shortId = idSplit[1];
         } else {
             project = null;
-            this.id = id;
+            this.shortId = id;
         }
 
         this.description = description;
@@ -50,11 +50,11 @@ public class Issue {
     }
 
     public String id() {
-        return (project != null ? project + "-" : "") + id;
+        return (project != null ? project + "-" : "") + shortId;
     }
 
     public String shortId() {
-        return id;
+        return shortId;
     }
 
     public String description() {
@@ -86,7 +86,7 @@ public class Issue {
     }
 
     public String toShortString() {
-        return id + ": " + description;
+        return shortId + ": " + description;
     }
 
     @Override
@@ -95,12 +95,12 @@ public class Issue {
         if (o == null || getClass() != o.getClass()) return false;
         Issue issue = (Issue) o;
         return Objects.equals(project, issue.project) &&
-                id.equals(issue.id) &&
+                shortId.equals(issue.shortId) &&
                 description.equals(issue.description);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(project, id, description);
+        return Objects.hash(project, shortId, description);
     }
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/Issue.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/Issue.java
@@ -24,18 +24,36 @@ package org.openjdk.skara.vcs.openjdk;
 
 import java.util.*;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 public class Issue {
+    private final String project;
     private final String id;
     private final String description;
 
+    private final static Pattern relaxedIssueParsePattern = Pattern.compile("^((?:[A-Z][A-Z0-9]+-)?[0-9]+)[^\\p{Alnum}]+(\\S.*)$");
+
     public Issue(String id, String description) {
-        this.id = id;
+        if (id.contains("-")) {
+            var idSplit = id.split("-", 2);
+            project = idSplit[0];
+            this.id = idSplit[1];
+        } else {
+            project = null;
+            this.id = id;
+        }
+
         this.description = description;
     }
 
+    public Optional<String> project() {
+        return Optional.ofNullable(project);
+    }
+
     public String id() {
+        return (project != null ? project + "-" : "") + id;
+    }
+
+    public String shortId() {
         return id;
     }
 
@@ -53,24 +71,36 @@ public class Issue {
         return Optional.empty();
     }
 
+    public static Optional<Issue> fromStringRelaxed(String s) {
+        var relaxedIssueParseMatcher = relaxedIssueParsePattern.matcher(s.trim());
+        if (relaxedIssueParseMatcher.matches()) {
+            return Optional.of(new Issue(relaxedIssueParseMatcher.group(1), relaxedIssueParseMatcher.group(2)));
+        }
+
+        return Optional.empty();
+    }
+
     @Override
     public String toString() {
+        return id() + ": " + description;
+    }
+
+    public String toShortString() {
         return id + ": " + description;
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hash(id, description);
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Issue issue = (Issue) o;
+        return Objects.equals(project, issue.project) &&
+                id.equals(issue.id) &&
+                description.equals(issue.description);
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (!(o instanceof Issue)) {
-            return false;
-        }
-
-        var other = (Issue) o;
-        return Objects.equals(id, other.id) &&
-               Objects.equals(description, other.description);
+    public int hashCode() {
+        return Objects.hash(project, id, description);
     }
 }


### PR DESCRIPTION
Hi all,

Please review this change that allows a more relaxed matching of bug ids in PR titles. Also contains a bit of refactoring to make it explicit when the project name could be part of the bug id. There were several places that expected the project name to not be present (as they would fetch the issue using the key from a specific project) - these now explicitly use the shortId.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-383](https://bugs.openjdk.java.net/browse/SKARA-383): More fuzzy matching of bug ids in PR titles


### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - **Reviewer**) ⚠️ Review applies to bc885ebec68dbf874714d55adb44eac6c8dc1d00

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/623/head:pull/623`
`$ git checkout pull/623`
