### PR TITLE
274: Remove quoted part of top-level reply emails in GitHub comments

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/CommentPosterWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/CommentPosterWorkItem.java
@@ -77,11 +77,12 @@ public class CommentPosterWorkItem implements WorkItem {
         var marker = String.format(bridgedMailMarker,
                                  Base64.getEncoder().encodeToString(email.id().address().getBytes(StandardCharsets.UTF_8)));
 
+        var filteredEmail = QuoteFilter.stripLinkBlock(email.body(), pr.webUrl());
         var body = marker + "\n" +
                 "*Mailing list message from [" + email.author().fullName().orElse(email.author().localPart()) +
                 "](mailto:" + email.author().address() + ") on [" + email.sender().localPart() +
                 "](mailto:" + email.sender().address() + "):*\n\n" +
-                TextToMarkdown.escapeFormatting(email.body());
+                TextToMarkdown.escapeFormatting(filteredEmail);
         if (body.length() > 64000) {
             body = body.substring(0, 64000) + "...\n\n" + "" +
                     "This message was too large to bridge in full, and has been truncated. " +

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/QuoteFilter.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/QuoteFilter.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.mlbridge;
+
+import java.net.URI;
+import java.util.*;
+import java.util.regex.Pattern;
+
+class QuoteFilter {
+    private static final Pattern leadingQuotesPattern = Pattern.compile("^([>\\s]+).*");
+
+    private static Optional<String> leadingQuotes(String line) {
+        var leadingQuotesMatcher = leadingQuotesPattern.matcher(line);
+        if (leadingQuotesMatcher.matches()) {
+            if (leadingQuotesMatcher.group(1).contains(">")) {
+                return Optional.of(leadingQuotesMatcher.group(1).trim());
+            }
+        }
+        return Optional.empty();
+    }
+
+    // Strip all quote blocks containing a certain link
+    public static String stripLinkBlock(String body, URI link) {
+        var ret = new ArrayList<String>();
+        var buffer = new LinkedList<String>();
+        String dropPrefix = null;
+
+        for (var line : body.split("\\R")) {
+            if (dropPrefix != null && line.startsWith(dropPrefix)) {
+                continue;
+            }
+            dropPrefix = null;
+
+            if (line.contains(link.toString())) {
+                var prefix = leadingQuotes(line);
+                if (prefix.isEmpty()) {
+                    buffer.add(line);
+                    continue;
+                }
+                dropPrefix = prefix.get();
+
+                // Drop any previous lines with the same prefix
+                while (!buffer.isEmpty()) {
+                    if (buffer.peekLast().startsWith(dropPrefix)) {
+                        buffer.removeLast();
+                    } else {
+                        break;
+                    }
+                }
+                // Any remaining lines in buffer should be kept in the final result
+                ret.addAll(buffer);
+                buffer.clear();
+            } else {
+                buffer.add(line);
+            }
+        }
+
+        ret.addAll(buffer);
+        return String.join("\n", ret);
+    }
+}

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/QuoteFilterTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/QuoteFilterTests.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.mlbridge;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class QuoteFilterTests {
+    @Test
+    void simple() {
+        assertEquals("a\nb", QuoteFilter.stripLinkBlock("a\nb", URI.create("http://test")));
+        assertEquals("a", QuoteFilter.stripLinkBlock("a\n> b\n> http://test", URI.create("http://test")));
+        assertEquals("a\nc", QuoteFilter.stripLinkBlock("a\n> b\n> http://test\nc", URI.create("http://test")));
+        assertEquals("a\nc", QuoteFilter.stripLinkBlock("a\n> > b\n> http://test\nc", URI.create("http://test")));
+        assertEquals("a\n> b\nc", QuoteFilter.stripLinkBlock("a\n> b\n> > http://test\nc", URI.create("http://test")));
+        assertEquals("a\n> b\nc", QuoteFilter.stripLinkBlock("a\n> b\n> > http://test\n> > d\nc", URI.create("http://test")));
+    }
+
+    @Test
+    void notQuoted() {
+        assertEquals("a\nhttp://test", QuoteFilter.stripLinkBlock("a\nhttp://test", URI.create("http://test")));
+    }
+
+    @Test
+    void trailingSpace() {
+        assertEquals("a\nc", QuoteFilter.stripLinkBlock("a\n>> b\n>>\n>> http://test\nc", URI.create("http://test")));
+    }
+
+}


### PR DESCRIPTION
Hi all,

Please review this change that looks for quoted parts in bridged emails which can be safely discarded, as the context is clearly visible anyway in the GitHub web UI.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-274](https://bugs.openjdk.java.net/browse/SKARA-274): Remove quoted part of top-level reply emails in GitHub comments


### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/625/head:pull/625`
`$ git checkout pull/625`
