### PR TITLE
[cli] fix typo in GitPrHelp

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrHelp.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrHelp.java
@@ -143,7 +143,7 @@ public class GitPrHelp {
             }
         }
 
-        System.out.println("git-pr is used for interacting with pull requeqsts from a command line.");
+        System.out.println("git-pr is used for interacting with pull requests from a command line.");
         System.out.println("The following commands are available:");
         for (var command : sorted(commands.keySet())) {
             System.out.println("- " + command);


### PR DESCRIPTION
a trivial patch to fix a typo in GitPrHelp  (s/requeqsts/requests)
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/627/head:pull/627`
`$ git checkout pull/627`
