### PR TITLE
401: Allow a PR author to manually add reviewers

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -22,19 +22,18 @@
  */
 package org.openjdk.skara.bots.pr;
 
-import org.openjdk.skara.census.Contributor;
+import org.openjdk.skara.email.EmailAddress;
 import org.openjdk.skara.forge.*;
 import org.openjdk.skara.host.HostUser;
-import org.openjdk.skara.issuetracker.*;
+import org.openjdk.skara.issuetracker.Comment;
 import org.openjdk.skara.vcs.*;
 import org.openjdk.skara.vcs.openjdk.Issue;
-import org.openjdk.skara.email.EmailAddress;
 
 import java.io.*;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.logging.Logger;
-import java.util.regex.*;
+import java.util.regex.Matcher;
 import java.util.stream.*;
 
 class CheckRun {
@@ -251,11 +250,7 @@ class CheckRun {
         // Check for manually added reviewers
         if (!ignoreStaleReviews) {
             var namespace = censusInstance.namespace();
-            var allReviewers = reviews.stream()
-                                      .map(review -> namespace.get(review.reviewer().id()))
-                                      .filter(Objects::nonNull)
-                                      .map(Contributor::username)
-                                      .collect(Collectors.toSet());
+            var allReviewers = PullRequestUtils.reviewerNames(reviews, namespace);
             var additionalEntries = new ArrayList<String>();
             for (var additional : Reviewers.reviewers(pr.repository().forge().currentUser(), comments)) {
                 if (!allReviewers.contains(additional)) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -39,7 +39,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 class CheckWorkItem extends PullRequestWorkItem {
-    private final Pattern metadataComments = Pattern.compile("<!-- (?:(add|remove) contributor)|(?:summary: ')|(?:solves: ')|(?:additional required reviewers)");
+    private final Pattern metadataComments = Pattern.compile("<!-- (?:(add|remove) (?:contributor|reviewer))|(?:summary: ')|(?:solves: ')|(?:additional required reviewers)");
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots.pr");
 
     CheckWorkItem(PullRequestBot bot, PullRequest pr, Consumer<RuntimeException> errorHandler) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
@@ -56,6 +56,21 @@ public class CheckablePullRequest {
 
         var comments = pr.comments();
         var currentUser = pr.repository().forge().currentUser();
+
+        if (!ignoreStaleReviews) {
+            var allReviewers = activeReviews.stream()
+                                            .map(review -> namespace.get(review.reviewer().id()))
+                                            .filter(Objects::nonNull)
+                                            .map(Contributor::username)
+                                            .collect(Collectors.toSet());
+            var additionalReviewers = Reviewers.reviewers(currentUser, comments);
+            for (var additionalReviewer : additionalReviewers) {
+                if (!allReviewers.contains(additionalReviewer)) {
+                    reviewers.add(additionalReviewer);
+                }
+            }
+        }
+
         var additionalContributors = Contributors.contributors(currentUser,
                                                                comments).stream()
                                                  .map(email -> Author.fromString(email.toString()))

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
@@ -45,24 +45,16 @@ public class CheckablePullRequest {
     }
 
     private String commitMessage(List<Review> activeReviews, Namespace namespace) throws IOException {
-        var reviewers = activeReviews.stream()
-                                     .filter(review -> !ignoreStaleReviews || review.hash().equals(pr.headHash()))
-                                     .filter(review -> review.verdict() == Review.Verdict.APPROVED)
-                                     .map(review -> review.reviewer().id())
-                                     .map(namespace::get)
-                                     .filter(Objects::nonNull)
-                                     .map(Contributor::username)
-                                     .collect(Collectors.toList());
-
+        var eligibleReviews = activeReviews.stream()
+                                           .filter(review -> !ignoreStaleReviews || review.hash().equals(pr.headHash()))
+                                           .filter(review -> review.verdict() == Review.Verdict.APPROVED)
+                                           .collect(Collectors.toList());
+        var reviewers = PullRequestUtils.reviewerNames(eligibleReviews, namespace);
         var comments = pr.comments();
         var currentUser = pr.repository().forge().currentUser();
 
         if (!ignoreStaleReviews) {
-            var allReviewers = activeReviews.stream()
-                                            .map(review -> namespace.get(review.reviewer().id()))
-                                            .filter(Objects::nonNull)
-                                            .map(Contributor::username)
-                                            .collect(Collectors.toSet());
+            var allReviewers = PullRequestUtils.reviewerNames(activeReviews, namespace);
             var additionalReviewers = Reviewers.reviewers(currentUser, comments);
             for (var additionalReviewer : additionalReviewers) {
                 if (!allReviewers.contains(additionalReviewer)) {
@@ -84,7 +76,7 @@ public class CheckablePullRequest {
             commitMessageBuilder.issues(additionalIssues);
         }
         commitMessageBuilder.contributors(additionalContributors)
-                            .reviewers(reviewers);
+                            .reviewers(new ArrayList<>(reviewers));
         summary.ifPresent(commitMessageBuilder::summary);
 
         return String.join("\n", commitMessageBuilder.format(CommitMessageFormatters.v1));

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandWorkItem.java
@@ -50,7 +50,8 @@ public class CommandWorkItem extends PullRequestWorkItem {
             "issue", new IssueCommand(),
             "solves", new IssueCommand("solves"),
             "reviewers", new ReviewersCommand(),
-            "csr", new CSRCommand()
+            "csr", new CSRCommand(),
+            "reviewer", new ReviewerCommand()
     );
 
     static class HelpCommand implements CommandHandler {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewerCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewerCommand.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.pr;
+
+import org.openjdk.skara.census.Contributor;
+import org.openjdk.skara.forge.PullRequest;
+import org.openjdk.skara.issuetracker.Comment;
+
+import java.io.PrintWriter;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class ReviewerCommand implements CommandHandler {
+    private static final Pattern commandPattern = Pattern.compile("^(add|remove)\\s+(.+)$");
+
+    private void showHelp(PullRequest pr, PrintWriter reply) {
+        reply.println("Syntax: `/reviewer (add|remove) [@user | openjdk-user]`. For example:");
+        reply.println();
+        reply.println(" * `/reviewer add @openjdk-bot`");
+        reply.println(" * `/reviewer add duke`");
+    }
+
+    private Optional<Contributor> parseUser(String user, PullRequest pr, CensusInstance censusInstance) {
+        user = user.strip();
+        if (user.isEmpty()) {
+            return Optional.empty();
+        }
+        Contributor contributor;
+        if (user.charAt(0) == '@') {
+            var platformUser = pr.repository().forge().user(user.substring(1));
+            if (platformUser.isEmpty()) {
+                return Optional.empty();
+            }
+            contributor = censusInstance.namespace().get(platformUser.get().id());
+            if (contributor == null) {
+                return Optional.empty();
+            }
+        } else {
+            contributor = censusInstance.census().contributor(user);
+            if (contributor == null) {
+                return Optional.empty();
+            }
+        }
+        return Optional.of(contributor);
+    }
+
+    @Override
+    public void handle(PullRequestBot bot, PullRequest pr, CensusInstance censusInstance, Path scratchPath, String args, Comment comment, List<Comment> allComments, PrintWriter reply) {
+        if (!comment.author().equals(pr.author())) {
+            reply.println("Only the author (@" + pr.author().userName() + ") is allowed to issue the `reviewer` command.");
+            return;
+        }
+        if (bot.ignoreStaleReviews()) {
+            reply.println("This project requires authenticated reviews - please ask your reviewer to flag this PR as reviewed.");
+            return;
+        }
+
+        var matcher = commandPattern.matcher(args);
+        if (!matcher.matches()) {
+            showHelp(pr, reply);
+            return;
+        }
+
+        var reviewer = parseUser(matcher.group(2), pr, censusInstance);
+        if (reviewer.isEmpty()) {
+            reply.println("Could not parse `" + matcher.group(2) + "` as a valid reviewer.");
+            showHelp(pr, reply);;
+            return;
+        }
+
+        var namespace = censusInstance.namespace();
+        var authenticatedReviewers = pr.reviews().stream()
+                                       .map(review -> namespace.get(review.reviewer().id()))
+                                       .map(Contributor::username)
+                                       .filter(Objects::nonNull)
+                                       .collect(Collectors.toSet());
+
+        switch (matcher.group(1)) {
+            case "add": {
+                if (!authenticatedReviewers.contains(reviewer.get().username())) {
+                    reply.println(Reviewers.addReviewerMarker(reviewer.get()));
+                    reply.println("Reviewer `" + reviewer.get().username() + "` successfully added.");
+                } else {
+                    reply.println("Reviewer `" + reviewer.get().username() + "` has already made an authenticated review of this PR, and does not need to be added manually.");
+                }
+                break;
+            }
+            case "remove": {
+                var existing = new HashSet<>(Reviewers.reviewers(pr.repository().forge().currentUser(), allComments));
+                if (existing.contains(reviewer.get().username())) {
+                    reply.println(Reviewers.removeReviewerMarker(reviewer.get()));
+                    reply.println("Reviewer `" + reviewer.get().username() + "` successfully removed.");
+                } else {
+                    if (existing.isEmpty()) {
+                        reply.println("There are no additional reviewers associated with this pull request.");
+                    } else {
+                        reply.println("Reviewer `" + reviewer.get().username() + "` was not found.");
+                        reply.println("Current additional reviewers are:");
+                        for (var e : existing) {
+                            reply.println("- `" + e + "`");
+                        }
+                    }
+                    break;
+                }
+                break;
+            }
+        }
+    }
+
+    @Override
+    public String description() {
+        return "adds or removes additional reviewers for a PR";
+    }
+}

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewerCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewerCommand.java
@@ -23,14 +23,13 @@
 package org.openjdk.skara.bots.pr;
 
 import org.openjdk.skara.census.Contributor;
-import org.openjdk.skara.forge.PullRequest;
+import org.openjdk.skara.forge.*;
 import org.openjdk.skara.issuetracker.Comment;
 
 import java.io.PrintWriter;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 public class ReviewerCommand implements CommandHandler {
     private static final Pattern commandPattern = Pattern.compile("^(add|remove)\\s+(.+)$");
@@ -91,12 +90,7 @@ public class ReviewerCommand implements CommandHandler {
         }
 
         var namespace = censusInstance.namespace();
-        var authenticatedReviewers = pr.reviews().stream()
-                                       .map(review -> namespace.get(review.reviewer().id()))
-                                       .map(Contributor::username)
-                                       .filter(Objects::nonNull)
-                                       .collect(Collectors.toSet());
-
+        var authenticatedReviewers = PullRequestUtils.reviewerNames(pr.reviews(), namespace);
         switch (matcher.group(1)) {
             case "add": {
                 if (!authenticatedReviewers.contains(reviewer.get().username())) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/Reviewers.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/Reviewers.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.pr;
+
+import org.openjdk.skara.census.Contributor;
+import org.openjdk.skara.host.HostUser;
+import org.openjdk.skara.issuetracker.Comment;
+
+import java.util.*;
+import java.util.regex.*;
+import java.util.stream.Collectors;
+
+class Reviewers {
+    private final static String addMarker = "<!-- add reviewer: '%s' -->";
+    private final static String removeMarker = "<!-- remove reviewer: '%s' -->";
+    private final static Pattern markerPattern = Pattern.compile("<!-- (add|remove) reviewer: '(.*?)' -->");
+
+    static String addReviewerMarker(Contributor contributor) {
+        return String.format(addMarker, contributor.username());
+    }
+
+    static String removeReviewerMarker(Contributor contributor) {
+        return String.format(removeMarker, contributor.username());
+    }
+
+    static List<String> reviewers(HostUser botUser, List<Comment> comments) {
+        var reviewerActions = comments.stream()
+                                         .filter(comment -> comment.author().equals(botUser))
+                                         .map(comment -> markerPattern.matcher(comment.body()))
+                                         .filter(Matcher::find)
+                                         .collect(Collectors.toList());
+        var contributors = new LinkedHashSet<String>();
+        for (var action : reviewerActions) {
+            switch (action.group(1)) {
+                case "add":
+                    contributors.add(action.group(2));
+                    break;
+                case "remove":
+                    contributors.remove(action.group(2));
+                    break;
+            }
+        }
+
+        return new ArrayList<>(contributors);
+    }
+}

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ReviewerTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ReviewerTests.java
@@ -1,0 +1,463 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.pr;
+
+import org.junit.jupiter.api.*;
+import org.openjdk.skara.forge.Review;
+import org.openjdk.skara.test.*;
+import org.openjdk.skara.vcs.Repository;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.openjdk.skara.bots.pr.PullRequestAsserts.assertLastCommentContains;
+
+class ReviewerTests {
+    @Test
+    void simple(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var integrator = credentials.getHostedRepository();
+            var extra = credentials.getHostedRepository();
+
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addReviewer(integrator.forge().currentUser().id())
+                                           .addAuthor(extra.forge().currentUser().id())
+                                           .addCommitter(author.forge().currentUser().id());
+            var prBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
+
+            // Populate the projects repository
+            var localRepoFolder = tempFolder.path().resolve("localrepo");
+            var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
+
+            // Issue an invalid command
+            pr.addComment("/reviewer hello");
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // The bot should reply with an error message
+            assertLastCommentContains(pr,"Syntax");
+
+            // Add a reviewer
+            pr.addComment("/reviewer add @" + integrator.forge().currentUser().userName());
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // The bot should now consider the PR ready
+            assertLastCommentContains(pr,"This change now passes all automated pre-integration checks");
+
+            // Remove it again
+            pr.addComment("/reviewer remove @" + integrator.forge().currentUser().userName());
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // The bot should reply with a success message
+            assertLastCommentContains(pr,"successfully removed");
+
+            // Remove something that isn't there
+            pr.addComment("/reviewer remove @" + integrator.forge().currentUser().userName());
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // The bot should reply with an error message
+            assertLastCommentContains(pr,"There are no additional reviewers associated with this pull request");
+
+            // Add the reviewer again
+            pr.addComment("/reviewer add integrationreviewer1");
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // But also add the review the old-fashioned way
+            var approvalPr = integrator.pullRequest(pr.id());
+            approvalPr.addReview(Review.Verdict.APPROVED, "Approved");
+            TestBotRunner.runPeriodicItems(prBot);
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // The commit message preview should contain the reviewer once
+            var creditLine = pr.comments().stream()
+                               .flatMap(comment -> comment.body().lines())
+                               .filter(line -> line.contains("Reviewed-by"))
+                               .findAny()
+                               .orElseThrow();
+            assertEquals("Reviewed-by: integrationreviewer1", creditLine);
+
+            var pushed = pr.comments().stream()
+                           .filter(comment -> comment.body().contains("change now passes all automated"))
+                           .count();
+            assertEquals(1, pushed);
+
+            // Add a second reviewer
+            pr.addComment("/reviewer add integrationauthor2");
+            TestBotRunner.runPeriodicItems(prBot);
+            TestBotRunner.runPeriodicItems(prBot);
+
+            creditLine = pr.comments().stream()
+                           .flatMap(comment -> comment.body().lines())
+                           .filter(line -> line.contains("Reviewed-by"))
+                           .findAny()
+                           .orElseThrow();
+            assertEquals("Reviewed-by: integrationreviewer1, integrationauthor2", creditLine);
+
+            // Integrate
+            pr.addComment("/integrate");
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // The bot should reply with an ok message
+            assertLastCommentContains(pr,"Pushed as commit");
+
+            // The change should now be present on the master branch
+            var pushedFolder = tempFolder.path().resolve("pushed");
+            var pushedRepo = Repository.materialize(pushedFolder, author.url(), "master");
+            assertTrue(CheckableRepository.hasBeenEdited(pushedRepo));
+
+            var headHash = pushedRepo.resolve("HEAD").orElseThrow();
+            var headCommit = pushedRepo.commits(headHash.hex() + "^.." + headHash.hex()).asList().get(0);
+
+            // The contributor should be credited
+            creditLine = headCommit.message().stream()
+                    .filter(line -> line.contains("Reviewed-by"))
+                    .findAny()
+                    .orElseThrow();
+            assertEquals("Reviewed-by: integrationreviewer1, integrationauthor2", creditLine);
+        }
+    }
+
+    @Test
+    void invalidCommandAuthor(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var integrator = credentials.getHostedRepository();
+            var external = credentials.getHostedRepository();
+
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addAuthor(author.forge().currentUser().id());
+            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
+
+            // Issue a contributor command not as the PR author
+            var externalPr = external.pullRequest(pr.id());
+            externalPr.addComment("/reviewer add integrationauthor1");
+            TestBotRunner.runPeriodicItems(mergeBot);
+
+            // The bot should reply with an error message
+            var error = pr.comments().stream()
+                          .filter(comment -> comment.body().contains("Only the author"))
+                          .count();
+            assertEquals(1, error);
+        }
+    }
+
+    @Test
+    void invalidReviewer(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var integrator = credentials.getHostedRepository();
+
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addReviewer(integrator.forge().currentUser().id())
+                                           .addCommitter(author.forge().currentUser().id());
+            var prBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
+
+            // Populate the projects repository
+            var localRepoFolder = tempFolder.path().resolve("localrepo");
+            var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
+
+            // Use a full name
+            pr.addComment("/reviewer add Moo <Foo.Bar (at) host.com>");
+            TestBotRunner.runPeriodicItems(prBot);
+            assertLastCommentContains(pr, "Could not parse `Moo <Foo.Bar (at) host.com>` as a valid reviewer");
+
+            // Empty platform id
+            pr.addComment("/reviewer add @");
+            TestBotRunner.runPeriodicItems(prBot);
+            assertLastCommentContains(pr, "Could not parse `@` as a valid reviewer");
+
+            // Unknown platform id
+            pr.addComment("/reviewer add @someone");
+            TestBotRunner.runPeriodicItems(prBot);
+            assertLastCommentContains(pr, "Could not parse `@someone` as a valid reviewer");
+
+            // Unknown openjdk user
+            pr.addComment("/reviewer add someone");
+            TestBotRunner.runPeriodicItems(prBot);
+            assertLastCommentContains(pr, "Could not parse `someone` as a valid reviewer");
+        }
+    }
+
+    @Test
+    void platformUser(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var integrator = credentials.getHostedRepository();
+
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addAuthor(integrator.forge().currentUser().id())
+                                           .addCommitter(author.forge().currentUser().id());
+            var prBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
+
+            // Populate the projects repository
+            var localRepoFolder = tempFolder.path().resolve("localrepo");
+            var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
+
+            // Use a platform name
+            pr.addComment("/reviewer add @" + author.forge().currentUser().userName());
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // The bot should reply
+            assertLastCommentContains(pr, "Reviewer `integrationcommitter2` successfully added.");
+        }
+    }
+
+    @Test
+    void openJdkUser(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var integrator = credentials.getHostedRepository();
+
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addAuthor(integrator.forge().currentUser().id())
+                                           .addCommitter(author.forge().currentUser().id());
+            var prBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
+
+            // Populate the projects repository
+            var localRepoFolder = tempFolder.path().resolve("localrepo");
+            var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
+
+            // Use a platform name
+            pr.addComment("/reviewer add integrationauthor1");
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // The bot should reply
+            assertLastCommentContains(pr, "Reviewer `integrationauthor1` successfully added.");
+        }
+    }
+
+    @Test
+    void removeReviewer(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var integrator = credentials.getHostedRepository();
+
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addAuthor(integrator.forge().currentUser().id())
+                                           .addCommitter(author.forge().currentUser().id());
+            var prBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
+
+            // Populate the projects repository
+            var localRepoFolder = tempFolder.path().resolve("localrepo");
+            var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
+
+            // Remove a reviewer that hasn't been added
+            pr.addComment("/reviewer remove integrationauthor1");
+            TestBotRunner.runPeriodicItems(prBot);
+            assertLastCommentContains(pr, "There are no additional reviewers associated with this pull request.");
+
+            // Add a reviewer
+            pr.addComment("/reviewer add integrationauthor1");
+            TestBotRunner.runPeriodicItems(prBot);
+            assertLastCommentContains(pr, "successfully added.");
+
+            // Remove another (not added) reviewer
+            pr.addComment("/reviewer remove integrationcommitter2");
+            TestBotRunner.runPeriodicItems(prBot);
+            assertLastCommentContains(pr, "Reviewer `integrationcommitter2` was not found.");
+            assertLastCommentContains(pr, "Current additional reviewers are:");
+            assertLastCommentContains(pr, "- `integrationauthor1`");
+
+            // Remove an existing reviewer
+            pr.addComment("/reviewer remove integrationauthor1");
+            TestBotRunner.runPeriodicItems(prBot);
+            assertLastCommentContains(pr, "successfully removed.");
+        }
+    }
+
+    @Test
+    void prBodyUpdates(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var integrator = credentials.getHostedRepository();
+
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addAuthor(integrator.forge().currentUser().id())
+                                           .addCommitter(author.forge().currentUser().id());
+            var prBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
+
+            // Populate the projects repository
+            var localRepoFolder = tempFolder.path().resolve("localrepo");
+            var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
+
+            // Add a reviewer
+            pr.addComment("/reviewer add integrationauthor1");
+            TestBotRunner.runPeriodicItems(prBot);
+            TestBotRunner.runPeriodicItems(prBot);
+            assertLastCommentContains(pr, "successfully added.");
+
+            // Verify that body is updated
+            var body = pr.body().split("\n");
+            var contributorsHeaderIndex = -1;
+            for (var i = 0; i < body.length; i++) {
+                var line = body[i];
+                if (line.equals("### Reviewers")) {
+                    contributorsHeaderIndex = i;
+                    break;
+                }
+            }
+            assertNotEquals(contributorsHeaderIndex, -1);
+            var contributors = new ArrayList<String>();
+            for (var i = contributorsHeaderIndex + 1; i < body.length && body[i].startsWith(" * "); i++) {
+                contributors.add(body[i].substring(3));
+            }
+            assertEquals(1, contributors.size());
+            assertEquals("integrationauthor1 - Author ⚠️ Added manually", contributors.get(0));
+
+            // Remove contributor
+            pr.addComment("/reviewer remove integrationauthor1");
+            TestBotRunner.runPeriodicItems(prBot);
+            assertLastCommentContains(pr, "successfully removed.");
+
+            // Verify that body does not contain a "Reviewers" section
+            for (var line : pr.body().split("\n")) {
+                assertNotEquals("### Reviewers", line);
+            }
+            assertFalse(pr.body().contains("Added manually"));
+
+            // Add it once more
+            pr.addComment("/reviewer add integrationauthor1");
+            TestBotRunner.runPeriodicItems(prBot);
+            TestBotRunner.runPeriodicItems(prBot);
+            assertLastCommentContains(pr, "successfully added.");
+            assertTrue(pr.body().contains("Added manually"));
+
+            // Now add an authenticated review from the same reviewer
+            var integratorPr = integrator.pullRequest(pr.id());
+            integratorPr.addReview(Review.Verdict.APPROVED, "Looks good");
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // The reviewer should no longer be listed as added manually
+            assertFalse(pr.body().contains("Added manually"));
+        }
+    }
+
+    @Test
+    void addAuthenticated(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var integrator = credentials.getHostedRepository();
+            var extra = credentials.getHostedRepository();
+
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addReviewer(integrator.forge().currentUser().id())
+                                           .addAuthor(extra.forge().currentUser().id())
+                                           .addCommitter(author.forge().currentUser().id());
+            var prBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
+
+            // Populate the projects repository
+            var localRepoFolder = tempFolder.path().resolve("localrepo");
+            var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
+
+            // Add the review the old-fashioned way
+            var approvalPr = integrator.pullRequest(pr.id());
+            approvalPr.addReview(Review.Verdict.APPROVED, "Approved");
+            TestBotRunner.runPeriodicItems(prBot);
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // Try to add it manually as well
+            pr.addComment("/reviewer add integrationreviewer1");
+            TestBotRunner.runPeriodicItems(prBot);
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // The bot should reply with an error message
+            assertLastCommentContains(pr,"Reviewer `integrationreviewer1` has already made an authenticated review of this PR");
+        }
+    }
+}

--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequestUtils.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequestUtils.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.skara.forge;
 
+import org.openjdk.skara.census.*;
 import org.openjdk.skara.vcs.*;
 
 import java.io.IOException;
@@ -171,5 +172,13 @@ public class PullRequestUtils {
             patch.source().path().ifPresent(ret::add);
         }
         return ret;
+    }
+
+    public static Set<String> reviewerNames(List<Review> reviews, Namespace namespace) {
+        return reviews.stream()
+                      .map(review -> namespace.get(review.reviewer().id()))
+                      .filter(Objects::nonNull)
+                      .map(Contributor::username)
+                      .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 }


### PR DESCRIPTION
Hi all,

Please review this change that adds a `/reviewer` command that allows the PR author to manually add reviewers. The implementation is fairly similar to the `/contributor` command.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-401](https://bugs.openjdk.java.net/browse/SKARA-401): Allow a PR author to manually add reviewers


### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - **Reviewer**) ⚠️ Review applies to b9586b6280827c260541b1b9be482a644ffe15f7

### Download
`$ git fetch https://git.openjdk.java.net/skara pull/630/head:pull/630`
`$ git checkout pull/630`
