### PR TITLE
404: Add a blank line after quoted blocks in TextToMarkdown

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/TextToMarkdown.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/TextToMarkdown.java
@@ -22,11 +22,13 @@
  */
 package org.openjdk.skara.bots.mlbridge;
 
+import java.util.ArrayList;
 import java.util.regex.*;
 
 public class TextToMarkdown {
     private static final Pattern punctuationPattern = Pattern.compile("([!\"#$%&'()*+,\\-./:;<=?@\\[\\]^_`{|}~])", Pattern.MULTILINE);
     private static final Pattern indentedPattern = Pattern.compile("^ {4}", Pattern.MULTILINE);
+    private static final Pattern quoteBlockPattern = Pattern.compile("^(>(>|\\s)*\\s.*$)", Pattern.MULTILINE);
 
     private static String escapeBackslashes(String text) {
         return text.replace("\\", "\\\\");
@@ -42,7 +44,24 @@ public class TextToMarkdown {
         return indentedMatcher.replaceAll("&#32;   ");
     }
 
+    private static String separateQuoteBlocks(String text) {
+        var ret = new ArrayList<String>();
+        var lastLineQuoted = false;
+        for (var line : text.split("\\R")) {
+            if ((line.length() > 0) && (line.charAt(0) == '>')) {
+                lastLineQuoted = true;
+            } else {
+                if (lastLineQuoted && !line.isBlank()) {
+                    ret.add("");
+                }
+                lastLineQuoted = false;
+            }
+            ret.add(line);
+        }
+        return String.join("\n", ret);
+    }
+
     static String escapeFormatting(String text) {
-        return escapeIndention(escapePunctuation(escapeBackslashes(text)));
+        return escapeIndention(escapePunctuation(escapeBackslashes(separateQuoteBlocks(text))));
     }
 }

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/TextToMarkdownTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/TextToMarkdownTests.java
@@ -48,4 +48,12 @@ class TextToMarkdownTests {
     void escapedPattern() {
         assertEquals("1\\$2", TextToMarkdown.escapeFormatting("1$2"));
     }
+
+    @Test
+    void separateQuoteBlocks() {
+        assertEquals("> 1\n\n2", TextToMarkdown.escapeFormatting("> 1\n2"));
+        assertEquals("> 1\n\n2", TextToMarkdown.escapeFormatting("> 1\n\n2"));
+        assertEquals("> 1\n> 2\n\n3", TextToMarkdown.escapeFormatting("> 1\n> 2\n3"));
+        assertEquals("> 1\n> 2\n\n3", TextToMarkdown.escapeFormatting("> 1\n> 2\n\n3"));
+    }
 }


### PR DESCRIPTION
Hi all,

Please review this change that inserts an blank line after quoted blocks in case there isn't one already, which matches how an email client would render the text.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-404](https://bugs.openjdk.java.net/browse/SKARA-404): Add a blank line after quoted blocks in TextToMarkdown


### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/632/head:pull/632`
`$ git checkout pull/632`
