### PR TITLE
Handle empty GitLab merge requests

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -88,8 +88,9 @@ public class GitLabMergeRequest implements PullRequest {
                              .sorted(Comparator.comparing(cd -> cd.date))
                              .collect(Collectors.toList());
 
+        // It's possible to create a merge request without any commits
         if (commits.size() == 0) {
-            throw new RuntimeException("Reviews on a PR without any commits?");
+            return List.of();
         }
 
         return request.get("award_emoji").execute().stream()


### PR DESCRIPTION
Hi all,

Please review this small change that allows empty GitLab merge requests to be inspected.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/633/head:pull/633`
`$ git checkout pull/633`
