### PR TITLE
Fix equals check for non-web links

### DIFF
--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/Link.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/Link.java
@@ -108,8 +108,8 @@ public class Link {
         }
         Link link = (Link) o;
         return resolved == link.resolved &&
-                uri.equals(link.uri) &&
-                title.equals(link.title) &&
+                Objects.equals(uri, link.uri) &&
+                Objects.equals(title, link.title) &&
                 Objects.equals(relationship, link.relationship) &&
                 Objects.equals(linked, link.linked) &&
                 Objects.equals(summary, link.summary) &&

--- a/issuetracker/src/test/java/org/openjdk/skara/issuetracker/IssueTrackerTests.java
+++ b/issuetracker/src/test/java/org/openjdk/skara/issuetracker/IssueTrackerTests.java
@@ -108,4 +108,32 @@ class IssueTrackerTests {
             assertEquals(0, links.size());
         }
     }
+
+    @Test
+    void addIssueLink(TestInfo info) throws IOException {
+        try (var credentials = new HostCredentials(info)) {
+            var project = credentials.getIssueProject();
+
+            var userName = project.issueTracker().currentUser().userName();
+            var user = project.issueTracker().user(userName);
+            assertEquals(userName, user.get().userName());
+
+            var issue1 = credentials.createIssue(project, "Test issue");
+            issue1.setBody("This is now the body");
+
+            var issue2 = credentials.createIssue(project, "Test issue 2");
+            var link = Link.create(issue1, "duplicated by").build();
+            issue2.addLink(link);
+
+            var links = issue2.links();
+            assertEquals(1, links.size());
+            assertEquals(link, links.get(0));
+
+            assertEquals(1, issue1.links().size());
+            var linkFromIssue1 = issue1.links().get(0);
+            issue1.removeLink(linkFromIssue1);
+            links = issue2.links();
+            assertEquals(0, links.size());
+        }
+    }
 }


### PR DESCRIPTION
Hi all,

Please review this small change that fixes the equals function for non-web issue links.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/634/head:pull/634`
`$ git checkout pull/634`
