### PR TITLE
Update to Gradle 6.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ repository:
 - git-translate - translate between [Mercurial](https://mercurial-scm.org/)
 and [Git](https://git-scm.com/) hashes
 - git-skara - learn about and update the Skara CLI tools
+- git-trees - run a git command in a tree of repositories
 - git-publish - publishes a local branch to a remote repository
 
 There are also CLI tools available for importing OpenJDK
@@ -44,8 +45,8 @@ external Git source code hosting providers are available:
 
 ## Building
 
-[JDK 13](http://jdk.java.net/13/) or later and [Gradle](https://gradle.org/)
-6.0 or later is required for building. To build the project on macOS or
+[JDK 14](http://jdk.java.net/14/) or later and [Gradle](https://gradle.org/)
+6.4.1 or later is required for building. To build the project on macOS or
 GNU/Linux x64, just run the following command from the source tree root:
 
 ```bash
@@ -67,7 +68,7 @@ also want to build the bot images run `sh gradlew images` on GNU/Linux or
 
 If you want to build on an operating system other than GNU/Linux, macOS or
 Windows _or_ if you want to build on a CPU architecture other than x64, then
-ensure that you have JDK 13 or later installed locally. You can then run the
+ensure that you have JDK 14 or later installed locally. You can then run the
 following command from the source tree root:
 
 ```bash
@@ -82,8 +83,8 @@ tree root.
 If you don't want the build to automatically download any dependencies, then
 you must ensure that you have installed the following software locally:
 
-- JDK 13 or later
-- Gradle 6.0 or later
+- JDK 14 or later
+- Gradle 6.4.1 or later
 
 To create a build then run the command:
 
@@ -164,7 +165,7 @@ When running `make install` the default value of `prefix` is `$HOME/.local`.
 
 ## Testing
 
-[JUnit](https://junit.org/junit5/) 5.5.2 or later is required to run the unit
+[JUnit](https://junit.org/junit5/) 5.6.2 or later is required to run the unit
 tests. To run the tests, execute following command from the source tree root:
 
 ```bash

--- a/deps.env
+++ b/deps.env
@@ -7,5 +7,5 @@ JDK_MACOS_X64_SHA256="d8aa6806e6cc99724395563bf02fc6907a7c801f4caef85b96ad449271
 JDK_WINDOWS_X64_URL="https://download.java.net/java/GA/jdk14.0.1/664493ef4a6946b186ff29eb326336a2/7/GPL/openjdk-14.0.1_windows-x64_bin.zip"
 JDK_WINDOWS_X64_SHA256="26255f3f2fe7168ec0dce9d9f3825649c18540ba86279a7506c7f17dd3e537f9"
 
-GRADLE_URL="https://services.gradle.org/distributions/gradle-6.3-bin.zip"
-GRADLE_SHA256="038794feef1f4745c6347107b6726279d1c824f3fc634b60f86ace1e9fbd1768"
+GRADLE_URL="https://services.gradle.org/distributions/gradle-6.4.1-bin.zip"
+GRADLE_SHA256="e58cdff0cee6d9b422dcd08ebeb3177bc44eaa09bd9a2e838ff74c408fe1cbcd"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -19,5 +19,5 @@
 # or visit www.oracle.com if you need additional information or have any
 # questions.
 
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-bin.zip
-distributionSha256Sum=038794feef1f4745c6347107b6726279d1c824f3fc634b60f86ace1e9fbd1768
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.4.1-bin.zip
+distributionSha256Sum=e58cdff0cee6d9b422dcd08ebeb3177bc44eaa09bd9a2e838ff74c408fe1cbcd


### PR DESCRIPTION
Hi all.

please review this patch that updates Gradle to 6.4.1. I also went over the README to document the versions of tools used for building and testing.

Testing:
- [x] `make test` passes on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/635/head:pull/635`
`$ git checkout pull/635`
