### PR TITLE
publish: add flag --follow

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitPublish.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitPublish.java
@@ -27,9 +27,11 @@ import org.openjdk.skara.vcs.*;
 import org.openjdk.skara.version.Version;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.net.URI;
 import java.util.*;
+import java.util.stream.Collectors;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 
@@ -42,7 +44,69 @@ public class GitPublish {
         };
     }
 
-    private static int pushAndTrack(String remote, Branch b, boolean isQuiet) throws IOException, InterruptedException {
+    private static class RecordingOutputStream extends OutputStream {
+        private final OutputStream target;
+        private final boolean shouldForward;
+        private byte[] output;
+        private int index;
+
+        RecordingOutputStream(OutputStream target, boolean shouldForward) {
+            this.target = target;
+            this.shouldForward = shouldForward;
+            this.output = new byte[1024];
+            this.index = 0;
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+            if (index == output.length) {
+                output = Arrays.copyOf(output, output.length * 2);
+            }
+            output[index] = (byte) b;
+            index++;
+
+            if (shouldForward) {
+                target.write(b);
+                target.flush();
+            }
+        }
+
+        String output() {
+            return new String(output, 0, index + 1, StandardCharsets.UTF_8);
+        }
+    }
+
+    private static int pushAndFollow(String remote, Branch b, boolean isQuiet, String browser) throws IOException, InterruptedException {
+        var pb = new ProcessBuilder("git", "push", "--set-upstream", "--progress", remote, b.name());
+        if (isQuiet) {
+            pb.redirectOutput(ProcessBuilder.Redirect.DISCARD);
+        } else {
+            pb.redirectOutput(ProcessBuilder.Redirect.INHERIT);
+        }
+        pb.redirectError(ProcessBuilder.Redirect.PIPE);
+        var p = pb.start();
+        var recording = new RecordingOutputStream(System.err, !isQuiet);
+        p.getErrorStream().transferTo(recording);
+        int err = p.waitFor();
+        if (err == 0) {
+            var lines = recording.output().lines().collect(Collectors.toList());
+            for (var line : lines) {
+                if (line.startsWith("remote:")) {
+                    var parts = line.split("\\s");
+                    for (var part : parts) {
+                        if (part.startsWith("https://")) {
+                            var browserPB = new ProcessBuilder(browser, part);
+                            browserPB.start().waitFor(); // don't care about status
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        return err;
+    }
+
+    private static int push(String remote, Branch b, boolean isQuiet) throws IOException, InterruptedException {
         var cmd = new ArrayList<String>();
         cmd.addAll(List.of("git", "push"));
         if (isQuiet) {
@@ -50,20 +114,8 @@ public class GitPublish {
         }
         cmd.addAll(List.of("--set-upstream", remote, b.name()));
         var pb = new ProcessBuilder(cmd);
-        if (isQuiet) {
-            pb.redirectOutput(ProcessBuilder.Redirect.DISCARD);
-            pb.redirectError(ProcessBuilder.Redirect.PIPE);
-        } else {
-            pb.inheritIO();
-        }
-        var p = pb.start();
-        var errorOutput = p.getErrorStream().readAllBytes();
-        int err = p.waitFor();
-        if (err != 0) {
-            System.out.write(errorOutput, 0, errorOutput.length);
-            System.out.flush();
-        }
-        return err;
+        pb.inheritIO();
+        return pb.start().waitFor();
     }
 
     private static String getOption(String name, Arguments arguments, ReadOnlyRepository repo) throws IOException {
@@ -71,16 +123,28 @@ public class GitPublish {
             return arguments.get(name).asString();
         }
 
-        var lines = repo.config("sync." + name);
+        var lines = repo.config("publish." + name);
         return lines.size() == 1 ? lines.get(0) : null;
     }
 
+    private static boolean getSwitch(String name, Arguments arguments, ReadOnlyRepository repo) throws IOException {
+        if (arguments.contains(name)) {
+            return true;
+        }
+
+        var lines = repo.config("publish." + name);
+        return lines.size() == 1 && lines.get(0).toLowerCase().equals("true");
+    }
 
     public static void main(String[] args) throws IOException, InterruptedException {
         var flags = List.of(
             Switch.shortcut("q")
                   .fullname("quiet")
                   .helptext("Silence all output")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("follow")
+                  .helptext("Open link provided by remote")
                   .optional(),
             Switch.shortcut("")
                   .fullname("verbose")
@@ -146,14 +210,27 @@ public class GitPublish {
             System.exit(1);
         }
 
-        var isQuiet = arguments.contains("quiet");
-        if (!isQuiet) {
-            var lines = repo.config("publish.quiet");
-            isQuiet = lines.size() == 1 && lines.get(0).toLowerCase().equals("true");
+        var branch = repo.currentBranch().get();
+        var isQuiet = getSwitch("quiet", arguments, repo);
+        var shouldFollow = getSwitch("follow", arguments, repo);
+        int err = 0;
+        if (shouldFollow) {
+            var browser = getOption("browser", arguments, repo);
+            if (browser == null) {
+                var os = System.getProperty("os.name").toLowerCase();
+                if (os.startsWith("win")) {
+                    browser = "explorer";
+                } else if (os.startsWith("mac")) {
+                    browser = "open";
+                } else {
+                    // Assume GNU/Linux
+                    browser = "xdg-open";
+                }
+            }
+            err = pushAndFollow(remote, branch, isQuiet, browser);
+        } else {
+            err = push(remote, branch, isQuiet);
         }
-        var err = pushAndTrack(remote, repo.currentBranch().get(), isQuiet);
-        if (err != 0) {
-            System.exit(err);
-        }
+        System.exit(err);
     }
 }


### PR DESCRIPTION
Hi all,

please review this patch that adds the `--follow` switch and the `--browser` flag to `git publish`. These flags can be used to automatically open a browser with the link that a remote host replies with in the response to the `git push --set-upstream` command that `git publish` runs. The effect is a "poor mans" `git pr create` for those that can't (or don't want) to have a personal access token on their machine.

For example, running `git publish --follow --browser=firefox` will open the "Open a pull request" page in Firefox.

Testing:
- [x] Manual testing of `git publish --follow --browser=firefox` on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/638/head:pull/638`
`$ git checkout pull/638`
