### PR TITLE
notify: rename PullRequestIssues to PullRequestState

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/NotifyBot.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/NotifyBot.java
@@ -38,7 +38,7 @@ public class NotifyBot implements Bot {
     private final Pattern branches;
     private final StorageBuilder<UpdatedTag> tagStorageBuilder;
     private final StorageBuilder<UpdatedBranch> branchStorageBuilder;
-    private final StorageBuilder<PullRequestIssues> prIssuesStorageBuilder;
+    private final StorageBuilder<PullRequestState> prStateStorageBuilder;
     private final List<RepositoryUpdateConsumer> updaters;
     private final List<PullRequestUpdateConsumer> prUpdaters;
     private final PullRequestUpdateCache updateCache;
@@ -46,7 +46,7 @@ public class NotifyBot implements Bot {
     private final Map<String, Pattern> readyComments;
 
     NotifyBot(HostedRepository repository, Path storagePath, Pattern branches, StorageBuilder<UpdatedTag> tagStorageBuilder,
-              StorageBuilder<UpdatedBranch> branchStorageBuilder, StorageBuilder<PullRequestIssues> prIssuesStorageBuilder,
+              StorageBuilder<UpdatedBranch> branchStorageBuilder, StorageBuilder<PullRequestState> prStateStorageBuilder,
               List<RepositoryUpdateConsumer> updaters, List<PullRequestUpdateConsumer> prUpdaters,
               Set<String> readyLabels, Map<String, Pattern> readyComments) {
         this.repository = repository;
@@ -54,7 +54,7 @@ public class NotifyBot implements Bot {
         this.branches = branches;
         this.tagStorageBuilder = tagStorageBuilder;
         this.branchStorageBuilder = branchStorageBuilder;
-        this.prIssuesStorageBuilder = prIssuesStorageBuilder;
+        this.prStateStorageBuilder = prStateStorageBuilder;
         this.updaters = updaters;
         this.prUpdaters = prUpdaters;
         this.updateCache = new PullRequestUpdateCache();
@@ -112,7 +112,7 @@ public class NotifyBot implements Bot {
                 if (!isReady(pr)) {
                     continue;
                 }
-                ret.add(new PullRequestWorkItem(pr, prIssuesStorageBuilder, prUpdaters, e -> updateCache.invalidate(pr)));
+                ret.add(new PullRequestWorkItem(pr, prStateStorageBuilder, prUpdaters, e -> updateCache.invalidate(pr)));
             }
         }
 

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/NotifyBotBuilder.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/NotifyBotBuilder.java
@@ -35,7 +35,7 @@ public class NotifyBotBuilder {
     private Pattern branches;
     private StorageBuilder<UpdatedTag> tagStorageBuilder;
     private StorageBuilder<UpdatedBranch> branchStorageBuilder;
-    private StorageBuilder<PullRequestIssues> prIssuesStorageBuilder;
+    private StorageBuilder<PullRequestState> prStateStorageBuilder;
     private List<RepositoryUpdateConsumer> updaters = List.of();
     private List<PullRequestUpdateConsumer> prUpdaters = List.of();
     private Set<String> readyLabels = Set.of();
@@ -66,8 +66,8 @@ public class NotifyBotBuilder {
         return this;
     }
 
-    public NotifyBotBuilder prIssuesStorageBuilder(StorageBuilder<PullRequestIssues> prIssuesStorageBuilder) {
-        this.prIssuesStorageBuilder = prIssuesStorageBuilder;
+    public NotifyBotBuilder prStateStorageBuilder(StorageBuilder<PullRequestState> prStateStorageBuilder) {
+        this.prStateStorageBuilder = prStateStorageBuilder;
         return this;
     }
 
@@ -92,6 +92,6 @@ public class NotifyBotBuilder {
     }
 
     public NotifyBot build() {
-        return new NotifyBot(repository, storagePath, branches, tagStorageBuilder, branchStorageBuilder, prIssuesStorageBuilder, updaters, prUpdaters, readyLabels, readyComments);
+        return new NotifyBot(repository, storagePath, branches, tagStorageBuilder, branchStorageBuilder, prStateStorageBuilder, updaters, prUpdaters, readyLabels, readyComments);
     }
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/NotifyBotFactory.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/NotifyBotFactory.java
@@ -122,7 +122,7 @@ public class NotifyBotFactory implements BotFactory {
                     .remoteRepository(databaseRepo, databaseRef, databaseName, databaseEmail, "Added tag for " + repoName);
             var branchStorageBuilder = new StorageBuilder<UpdatedBranch>(baseName + ".branches.txt")
                     .remoteRepository(databaseRepo, databaseRef, databaseName, databaseEmail, "Added branch hash for " + repoName);
-            var issueStorageBuilder = new StorageBuilder<PullRequestIssues>(baseName + ".prissues.txt")
+            var prStateStorageBuilder = new StorageBuilder<PullRequestState>(baseName + ".prissues.txt")
                     .remoteRepository(databaseRepo, databaseRef, databaseName, databaseEmail, "Added pull request issue info for " + repoName);
             var bot = NotifyBot.newBuilder()
                                .repository(configuration.repository(repoName))
@@ -130,7 +130,7 @@ public class NotifyBotFactory implements BotFactory {
                                .branches(branchPattern)
                                .tagStorageBuilder(tagStorageBuilder)
                                .branchStorageBuilder(branchStorageBuilder)
-                               .prIssuesStorageBuilder(issueStorageBuilder)
+                               .prStateStorageBuilder(prStateStorageBuilder)
                                .updaters(updaters)
                                .prUpdaters(prUpdaters)
                                .readyLabels(readyLabels)

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/PullRequestState.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/PullRequestState.java
@@ -26,16 +26,16 @@ import org.openjdk.skara.forge.PullRequest;
 
 import java.util.*;
 
-public class PullRequestIssues {
+class PullRequestState {
     private final String prId;
     private final Set<String> issueIds;
 
-    PullRequestIssues(PullRequest pr, Set<String> issueIds) {
+    PullRequestState(PullRequest pr, Set<String> issueIds) {
         this.prId = pr.repository().id() + ":" + pr.id();
         this.issueIds = issueIds;
     }
 
-    PullRequestIssues(String prId, Set<String> issueIds) {
+    PullRequestState(String prId, Set<String> issueIds) {
         this.prId = prId;
         this.issueIds = issueIds;
     }
@@ -50,7 +50,7 @@ public class PullRequestIssues {
 
     @Override
     public String toString() {
-        return "PullRequestIssues{" +
+        return "PullRequestState{" +
                 "prId='" + prId + '\'' +
                 ", issueIds=" + issueIds +
                 '}';
@@ -64,7 +64,7 @@ public class PullRequestIssues {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        PullRequestIssues that = (PullRequestIssues) o;
+        var that = (PullRequestState) o;
         return prId.equals(that.prId) &&
                 issueIds.equals(that.issueIds);
     }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/PullRequestWorkItem.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/PullRequestWorkItem.java
@@ -36,33 +36,33 @@ import java.util.stream.*;
 
 public class PullRequestWorkItem implements WorkItem {
     private final PullRequest pr;
-    private final StorageBuilder<PullRequestIssues> prIssuesStorageBuilder;
+    private final StorageBuilder<PullRequestState> prStateStorageBuilder;
     private final List<PullRequestUpdateConsumer> pullRequestUpdateConsumers;
     private final Consumer<RuntimeException> errorHandler;
 
-    PullRequestWorkItem(PullRequest pr, StorageBuilder<PullRequestIssues> prIssuesStorageBuilder, List<PullRequestUpdateConsumer> pullRequestUpdateConsumers, Consumer<RuntimeException> errorHandler) {
+    PullRequestWorkItem(PullRequest pr, StorageBuilder<PullRequestState> prStateStorageBuilder, List<PullRequestUpdateConsumer> pullRequestUpdateConsumers, Consumer<RuntimeException> errorHandler) {
         this.pr = pr;
-        this.prIssuesStorageBuilder = prIssuesStorageBuilder;
+        this.prStateStorageBuilder = prStateStorageBuilder;
         this.pullRequestUpdateConsumers = pullRequestUpdateConsumers;
         this.errorHandler = errorHandler;
     }
 
-    private Set<PullRequestIssues> loadPrIssues(String current) {
+    private Set<PullRequestState> deserializePrState(String current) {
         if (current.isBlank()) {
             return Set.of();
         }
         var data = JSON.parse(current);
         return data.stream()
                    .map(JSONValue::asObject)
-                   .map(obj -> new PullRequestIssues(obj.get("pr").asString(), obj.get("issues").stream()
-                                                                                  .map(JSONValue::asString)
-                                                                                  .collect(Collectors.toSet())))
+                   .map(obj -> new PullRequestState(obj.get("pr").asString(), obj.get("issues").stream()
+                                                                                 .map(JSONValue::asString)
+                                                                                 .collect(Collectors.toSet())))
                    .collect(Collectors.toSet());
     }
 
-    private String serializePrIssues(Collection<PullRequestIssues> added, Set<PullRequestIssues> existing) {
+    private String serializePrState(Collection<PullRequestState> added, Set<PullRequestState> existing) {
         var addedPrs = added.stream()
-                            .map(PullRequestIssues::prId)
+                            .map(PullRequestState::prId)
                             .collect(Collectors.toSet());
         var nonReplaced = existing.stream()
                                   .filter(item -> !addedPrs.contains(item.prId()))
@@ -70,7 +70,7 @@ public class PullRequestWorkItem implements WorkItem {
 
         var entries = Stream.concat(nonReplaced.stream(),
                                     added.stream())
-                            .sorted(Comparator.comparing(PullRequestIssues::prId))
+                            .sorted(Comparator.comparing(PullRequestState::prId))
                             .map(pr -> JSON.object().put("pr", pr.prId()).put("issues", new JSONArray(
                                     pr.issueIds().stream()
                                       .map(JSON::of)
@@ -124,13 +124,13 @@ public class PullRequestWorkItem implements WorkItem {
     @Override
     public void run(Path scratchPath) {
         var historyPath = scratchPath.resolve("notify").resolve("history");
-        var storage = prIssuesStorageBuilder
-                .serializer(this::serializePrIssues)
-                .deserializer(this::loadPrIssues)
+        var storage = prStateStorageBuilder
+                .serializer(this::serializePrState)
+                .deserializer(this::deserializePrState)
                 .materialize(historyPath);
 
         var issues = parseIssues();
-        var prIssues = new PullRequestIssues(pr, issues);
+        var prIssues = new PullRequestState(pr, issues);
         var current = storage.current();
         if (current.contains(prIssues)) {
             // Already up to date

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/IssueUpdaterTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/IssueUpdaterTests.java
@@ -48,7 +48,7 @@ public class IssueUpdaterTests {
 
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
-            var prIssuesStorage = createPullRequestIssuesStorage(repo);
+            var prStateStorage = createPullRequestStateStorage(repo);
             var storageFolder = tempFolder.path().resolve("storage");
 
             var issueProject = credentials.getIssueProject();
@@ -64,7 +64,7 @@ public class IssueUpdaterTests {
                                      .branches(Pattern.compile("master"))
                                      .tagStorageBuilder(tagStorage)
                                      .branchStorageBuilder(branchStorage)
-                                     .prIssuesStorageBuilder(prIssuesStorage)
+                                     .prStateStorageBuilder(prStateStorage)
                                      .updaters(List.of(updater))
                                      .build();
 
@@ -116,7 +116,7 @@ public class IssueUpdaterTests {
 
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
-            var prIssuesStorage = createPullRequestIssuesStorage(repo);
+            var prStateStorage = createPullRequestStateStorage(repo);
             var storageFolder = tempFolder.path().resolve("storage");
 
             var issueProject = credentials.getIssueProject();
@@ -132,7 +132,7 @@ public class IssueUpdaterTests {
                                      .branches(Pattern.compile("master"))
                                      .tagStorageBuilder(tagStorage)
                                      .branchStorageBuilder(branchStorage)
-                                     .prIssuesStorageBuilder(prIssuesStorage)
+                                     .prStateStorageBuilder(prStateStorage)
                                      .prUpdaters(List.of(updater))
                                      .readyLabels(Set.of("rfr"))
                                      .readyComments(Map.of(reviewer.forge().currentUser().userName(), Pattern.compile("This is now ready")))
@@ -217,7 +217,7 @@ public class IssueUpdaterTests {
 
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
-            var prIssuesStorage = createPullRequestIssuesStorage(repo);
+            var prStateStorage = createPullRequestStateStorage(repo);
             var storageFolder = tempFolder.path().resolve("storage");
 
             var issueProject = credentials.getIssueProject();
@@ -234,7 +234,7 @@ public class IssueUpdaterTests {
                                      .branches(Pattern.compile("master"))
                                      .tagStorageBuilder(tagStorage)
                                      .branchStorageBuilder(branchStorage)
-                                     .prIssuesStorageBuilder(prIssuesStorage)
+                                     .prStateStorageBuilder(prStateStorage)
                                      .prUpdaters(List.of(updater)).readyLabels(Set.of("rfr"))
                                      .readyComments(Map.of(reviewer.forge().currentUser().userName(), Pattern.compile("This is now ready")))
                                      .build();
@@ -276,7 +276,7 @@ public class IssueUpdaterTests {
 
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
-            var prIssuesStorage = createPullRequestIssuesStorage(repo);
+            var prStateStorage = createPullRequestStateStorage(repo);
             var storageFolder = tempFolder.path().resolve("storage");
 
             var issueProject = credentials.getIssueProject();
@@ -293,7 +293,7 @@ public class IssueUpdaterTests {
                                      .branches(Pattern.compile(".*"))
                                      .tagStorageBuilder(tagStorage)
                                      .branchStorageBuilder(branchStorage)
-                                     .prIssuesStorageBuilder(prIssuesStorage)
+                                     .prStateStorageBuilder(prStateStorage)
                                      .updaters(List.of(updater))
                                      .prUpdaters(List.of(updater))
                                      .build();

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/JsonUpdaterTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/JsonUpdaterTests.java
@@ -57,7 +57,7 @@ public class JsonUpdaterTests {
 
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
-            var prIssuesStorage = createPullRequestIssuesStorage(repo);
+            var prStateStorage = createPullRequestStateStorage(repo);
             var jsonFolder = tempFolder.path().resolve("json");
             Files.createDirectory(jsonFolder);
             var storageFolder = tempFolder.path().resolve("storage");
@@ -69,7 +69,7 @@ public class JsonUpdaterTests {
                                      .branches(Pattern.compile("master"))
                                      .tagStorageBuilder(tagStorage)
                                      .branchStorageBuilder(branchStorage)
-                                     .prIssuesStorageBuilder(prIssuesStorage)
+                                     .prStateStorageBuilder(prStateStorage)
                                      .updaters(List.of(updater))
                                      .build();
 
@@ -105,7 +105,7 @@ public class JsonUpdaterTests {
 
             var tagStorage = UpdaterTests.createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
-            var prIssuesStorage = createPullRequestIssuesStorage(repo);
+            var prStateStorage = createPullRequestStateStorage(repo);
             var jsonFolder = tempFolder.path().resolve("json");
             Files.createDirectory(jsonFolder);
             var storageFolder =tempFolder.path().resolve("storage");
@@ -117,7 +117,7 @@ public class JsonUpdaterTests {
                                      .branches(Pattern.compile("master"))
                                      .tagStorageBuilder(tagStorage)
                                      .branchStorageBuilder(branchStorage)
-                                     .prIssuesStorageBuilder(prIssuesStorage)
+                                     .prStateStorageBuilder(prStateStorage)
                                      .updaters(List.of(updater))
                                      .build();
 

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/MailingListUpdaterTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/MailingListUpdaterTests.java
@@ -54,7 +54,7 @@ public class MailingListUpdaterTests {
             var mailmanList = mailmanServer.getList(listAddress.address());
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
-            var prIssuesStorage = createPullRequestIssuesStorage(repo);
+            var prStateStorage = createPullRequestStateStorage(repo);
             var storageFolder = tempFolder.path().resolve("storage");
 
             var sender = EmailAddress.from("duke", "duke@duke.duke");
@@ -74,7 +74,7 @@ public class MailingListUpdaterTests {
                                      .branches(Pattern.compile("master"))
                                      .tagStorageBuilder(tagStorage)
                                      .branchStorageBuilder(branchStorage)
-                                     .prIssuesStorageBuilder(prIssuesStorage)
+                                     .prStateStorageBuilder(prStateStorage)
                                      .updaters(List.of(updater))
                                      .build();
 
@@ -126,7 +126,7 @@ public class MailingListUpdaterTests {
             var mailmanList = mailmanServer.getList(listAddress.address());
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
-            var prIssuesStorage = createPullRequestIssuesStorage(repo);
+            var prStateStorage = createPullRequestStateStorage(repo);
             var storageFolder = tempFolder.path().resolve("storage");
 
             var sender = EmailAddress.from("duke", "duke@duke.duke");
@@ -144,7 +144,7 @@ public class MailingListUpdaterTests {
                                      .branches(Pattern.compile("master"))
                                      .tagStorageBuilder(tagStorage)
                                      .branchStorageBuilder(branchStorage)
-                                     .prIssuesStorageBuilder(prIssuesStorage)
+                                     .prStateStorageBuilder(prStateStorage)
                                      .updaters(List.of(updater))
                                      .build();
 
@@ -198,7 +198,7 @@ public class MailingListUpdaterTests {
             var mailmanList = mailmanServer.getList(listAddress.address());
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
-            var prIssuesStorage = createPullRequestIssuesStorage(repo);
+            var prStateStorage = createPullRequestStateStorage(repo);
             var storageFolder = tempFolder.path().resolve("storage");
 
             var sender = EmailAddress.from("duke", "duke@duke.duke");
@@ -216,7 +216,7 @@ public class MailingListUpdaterTests {
                                      .branches(Pattern.compile("master"))
                                      .tagStorageBuilder(tagStorage)
                                      .branchStorageBuilder(branchStorage)
-                                     .prIssuesStorageBuilder(prIssuesStorage)
+                                     .prStateStorageBuilder(prStateStorage)
                                      .updaters(List.of(updater))
                                      .build();
 
@@ -262,7 +262,7 @@ public class MailingListUpdaterTests {
             var mailmanList = mailmanServer.getList(listAddress.address());
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
-            var prIssuesStorage = createPullRequestIssuesStorage(repo);
+            var prStateStorage = createPullRequestStateStorage(repo);
             var storageFolder = tempFolder.path().resolve("storage");
 
             var sender = EmailAddress.from("duke", "duke@duke.duke");
@@ -283,7 +283,7 @@ public class MailingListUpdaterTests {
                                      .branches(Pattern.compile("master|another"))
                                      .tagStorageBuilder(tagStorage)
                                      .branchStorageBuilder(branchStorage)
-                                     .prIssuesStorageBuilder(prIssuesStorage)
+                                     .prStateStorageBuilder(prStateStorage)
                                      .updaters(List.of(updater))
                                      .build();
 
@@ -360,7 +360,7 @@ public class MailingListUpdaterTests {
             var mailmanList = mailmanServer.getList(listAddress.address());
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
-            var prIssuesStorage = createPullRequestIssuesStorage(repo);
+            var prStateStorage = createPullRequestStateStorage(repo);
             var storageFolder = tempFolder.path().resolve("storage");
 
             var sender = EmailAddress.from("duke", "duke@duke.duke");
@@ -382,7 +382,7 @@ public class MailingListUpdaterTests {
                                      .branches(Pattern.compile("master|other"))
                                      .tagStorageBuilder(tagStorage)
                                      .branchStorageBuilder(branchStorage)
-                                     .prIssuesStorageBuilder(prIssuesStorage)
+                                     .prStateStorageBuilder(prStateStorage)
                                      .updaters(List.of(updater))
                                      .build();
 
@@ -446,7 +446,7 @@ public class MailingListUpdaterTests {
             var mailmanList = mailmanServer.getList(listAddress.address());
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
-            var prIssuesStorage = createPullRequestIssuesStorage(repo);
+            var prStateStorage = createPullRequestStateStorage(repo);
             var storageFolder = tempFolder.path().resolve("storage");
 
             var sender = EmailAddress.from("duke", "duke@duke.duke");
@@ -465,7 +465,7 @@ public class MailingListUpdaterTests {
                                      .branches(Pattern.compile("master"))
                                      .tagStorageBuilder(tagStorage)
                                      .branchStorageBuilder(branchStorage)
-                                     .prIssuesStorageBuilder(prIssuesStorage)
+                                     .prStateStorageBuilder(prStateStorage)
                                      .updaters(List.of(updater))
                                      .build();
 
@@ -538,7 +538,7 @@ public class MailingListUpdaterTests {
             var mailmanList = mailmanServer.getList(listAddress.address());
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
-            var prIssuesStorage = createPullRequestIssuesStorage(repo);
+            var prStateStorage = createPullRequestStateStorage(repo);
             var storageFolder = tempFolder.path().resolve("storage");
 
             var sender = EmailAddress.from("duke", "duke@duke.duke");
@@ -558,7 +558,7 @@ public class MailingListUpdaterTests {
                                      .branches(Pattern.compile("master|other"))
                                      .tagStorageBuilder(tagStorage)
                                      .branchStorageBuilder(branchStorage)
-                                     .prIssuesStorageBuilder(prIssuesStorage)
+                                     .prStateStorageBuilder(prStateStorage)
                                      .updaters(List.of(updater))
                                      .build();
 
@@ -633,7 +633,7 @@ public class MailingListUpdaterTests {
             var mailmanList = mailmanServer.getList(listAddress.address());
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
-            var prIssuesStorage = createPullRequestIssuesStorage(repo);
+            var prStateStorage = createPullRequestStateStorage(repo);
             var storageFolder = tempFolder.path().resolve("storage");
 
             var sender = EmailAddress.from("duke", "duke@duke.duke");
@@ -658,7 +658,7 @@ public class MailingListUpdaterTests {
                                      .branches(Pattern.compile("master"))
                                      .tagStorageBuilder(tagStorage)
                                      .branchStorageBuilder(branchStorage)
-                                     .prIssuesStorageBuilder(prIssuesStorage)
+                                     .prStateStorageBuilder(prStateStorage)
                                      .updaters(List.of(updater, noTagsUpdater))
                                      .build();
 
@@ -750,7 +750,7 @@ public class MailingListUpdaterTests {
             var mailmanList = mailmanServer.getList(listAddress.address());
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
-            var prIssuesStorage = createPullRequestIssuesStorage(repo);
+            var prStateStorage = createPullRequestStateStorage(repo);
             var storageFolder = tempFolder.path().resolve("storage");
 
             var sender = EmailAddress.from("duke", "duke@duke.duke");
@@ -776,7 +776,7 @@ public class MailingListUpdaterTests {
                                      .branches(Pattern.compile("master"))
                                      .tagStorageBuilder(tagStorage)
                                      .branchStorageBuilder(branchStorage)
-                                     .prIssuesStorageBuilder(prIssuesStorage)
+                                     .prStateStorageBuilder(prStateStorage)
                                      .updaters(List.of(updater, noTagsUpdater))
                                      .build();
 
@@ -843,7 +843,7 @@ public class MailingListUpdaterTests {
             var mailmanList = mailmanServer.getList(listAddress.address());
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
-            var prIssuesStorage = createPullRequestIssuesStorage(repo);
+            var prStateStorage = createPullRequestStateStorage(repo);
             var storageFolder = tempFolder.path().resolve("storage");
 
             var sender = EmailAddress.from("duke", "duke@duke.duke");
@@ -861,7 +861,7 @@ public class MailingListUpdaterTests {
                                      .branches(Pattern.compile("master|newbranch."))
                                      .tagStorageBuilder(tagStorage)
                                      .branchStorageBuilder(branchStorage)
-                                     .prIssuesStorageBuilder(prIssuesStorage)
+                                     .prStateStorageBuilder(prStateStorage)
                                      .updaters(List.of(updater))
                                      .build();
 
@@ -923,7 +923,7 @@ public class MailingListUpdaterTests {
             var mailmanList = mailmanServer.getList(listAddress.address());
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
-            var prIssuesStorage = createPullRequestIssuesStorage(repo);
+            var prStateStorage = createPullRequestStateStorage(repo);
             var storageFolder = tempFolder.path().resolve("storage");
 
             var sender = EmailAddress.from("duke", "duke@duke.duke");
@@ -943,7 +943,7 @@ public class MailingListUpdaterTests {
                                      .branches(Pattern.compile("master"))
                                      .tagStorageBuilder(tagStorage)
                                      .branchStorageBuilder(branchStorage)
-                                     .prIssuesStorageBuilder(prIssuesStorage)
+                                     .prStateStorageBuilder(prStateStorage)
                                      .updaters(List.of(updater))
                                      .build();
 

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdaterTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdaterTests.java
@@ -47,8 +47,8 @@ public class UpdaterTests {
                 .remoteRepository(repository, "history", "Duke", "duke@openjdk.java.net", "Updated branches");
     }
 
-    public static StorageBuilder<PullRequestIssues> createPullRequestIssuesStorage(HostedRepository repository) {
-        return new StorageBuilder<PullRequestIssues>("prissues.txt")
+    public static StorageBuilder<PullRequestState> createPullRequestStateStorage(HostedRepository repository) {
+        return new StorageBuilder<PullRequestState>("prissues.txt")
                 .remoteRepository(repository, "history", "Duke", "duke@openjdk.java.net", "Updated prissues");
     }
 
@@ -112,7 +112,7 @@ public class UpdaterTests {
 
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
-            var prIssuesStorage = createPullRequestIssuesStorage(repo);
+            var prStateStorage = createPullRequestStateStorage(repo);
             var storageFolder = tempFolder.path().resolve("storage");
 
             var idempotent = new TestRepositoryUpdateConsumer("i", true);
@@ -123,7 +123,7 @@ public class UpdaterTests {
                                      .branches(Pattern.compile("master"))
                                      .tagStorageBuilder(tagStorage)
                                      .branchStorageBuilder(branchStorage)
-                                     .prIssuesStorageBuilder(prIssuesStorage)
+                                     .prStateStorageBuilder(prStateStorage)
                                      .updaters(List.of(idempotent, nonIdempotent))
                                      .build();
 


### PR DESCRIPTION
Hi all,

please review this patch that just renames `PullRequestIssues` to `PullRequestState`. This patch is just a pure refactoring, future patches will add additional fields to `PullRequestState`. I also tried to update all variable and method names that referred to e.g. `prIssues`. Finally I made the class `PullRequestState` package-private.

Testing:
- [x] `make test` passes on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/640/head:pull/640`
`$ git checkout pull/640`
