### PR TITLE
forge: add commitMetadata method to HostedRepository

### DIFF
--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
@@ -159,4 +159,9 @@ class InMemoryHostedRepository implements HostedRepository {
     @Override
     public void addCommitComment(Hash commit, String body) {
     }
+
+    @Override
+    public Optional<CommitMetadata> commitMetadata(Hash commit) {
+        return Optional.empty();
+    }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
@@ -69,6 +69,7 @@ public interface HostedRepository {
     List<HostedBranch> branches();
     List<CommitComment> commitComments(Hash hash);
     void addCommitComment(Hash hash, String body);
+    Optional<CommitMetadata> commitMetadata(Hash hash);
 
     default PullRequest createPullRequest(HostedRepository target,
                                           String targetRef,

--- a/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
@@ -221,6 +221,15 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
         comments.add(new CommitComment(hash, null, -1, Integer.toString(id), body, host.currentUser(), createdAt, createdAt));
     }
 
+    @Override
+    public Optional<CommitMetadata> commitMetadata(Hash hash) {
+        try {
+            return localRepository.commitMetadata(hash);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
     Repository localRepository() {
         return localRepository;
     }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
@@ -49,6 +49,16 @@ public interface ReadOnlyRepository {
     Optional<Commit> lookup(Branch b) throws IOException;
     Optional<Commit> lookup(Tag t) throws IOException;
     List<CommitMetadata> commitMetadata() throws IOException;
+    default Optional<CommitMetadata> commitMetadata(Hash hash) throws IOException {
+        var l = commitMetadata(range(hash));
+        if (l.size() > 1) {
+            throw new IllegalStateException("More than one commit for hash: " + hash.hex());
+        }
+        if (l.size() == 0) {
+            return Optional.empty();
+        }
+        return Optional.of(l.get(0));
+    }
     List<CommitMetadata> commitMetadata(boolean reverse) throws IOException;
     List<CommitMetadata> commitMetadata(String range) throws IOException;
     List<CommitMetadata> commitMetadata(Hash from, Hash to) throws IOException;


### PR DESCRIPTION
Hi all,

please review this patch that adds the method `CommitMetadata HostedRepository.commitMetadata(Hash h)`. This is useful for getting the metadata for a commit from a `HostedRepository` instance without having to clone it first to a local repository.

Testing:
- [ ] not in this commit, will be part of follow-up patches

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/642/head:pull/642`
`$ git checkout pull/642`
