### PR TITLE
notify: add handleIntegratedPullRequest callback

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/PullRequestUpdateConsumer.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/PullRequestUpdateConsumer.java
@@ -23,6 +23,7 @@
 package org.openjdk.skara.bots.notify;
 
 import org.openjdk.skara.forge.PullRequest;
+import org.openjdk.skara.vcs.Hash;
 import org.openjdk.skara.vcs.openjdk.Issue;
 
 public interface PullRequestUpdateConsumer extends Notifier {
@@ -31,5 +32,7 @@ public interface PullRequestUpdateConsumer extends Notifier {
     default void handleRemovedIssue(PullRequest pr, Issue issue) {
     }
     default void handleNewPullRequest(PullRequest pr) {
+    }
+    default void handleIntegratedPullRequest(PullRequest pr, Hash hash) {
     }
 }

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/IssueUpdaterTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/IssueUpdaterTests.java
@@ -65,7 +65,8 @@ public class IssueUpdaterTests {
                                      .tagStorageBuilder(tagStorage)
                                      .branchStorageBuilder(branchStorage)
                                      .prStateStorageBuilder(prStateStorage)
-                                     .updaters(List.of(updater))
+                                     .prUpdaters(List.of(updater))
+                                     .integratorId(repo.forge().currentUser().id())
                                      .build();
 
             // Initialize history
@@ -80,6 +81,7 @@ public class IssueUpdaterTests {
             localRepo.push(editHash, repo.url(), "master");
             var pr = credentials.createPullRequest(repo, "master", "master", issue.id() + ": Fix that issue");
             pr.setBody("\n\n### Issue\n * [" + issue.id() + "](http://www.test.test/): The issue");
+            pr.addLabel("integrated");
             pr.addComment("Pushed as commit " + editHash.hex() + ".");
             TestBotRunner.runPeriodicItems(notifyBot);
 
@@ -294,8 +296,8 @@ public class IssueUpdaterTests {
                                      .tagStorageBuilder(tagStorage)
                                      .branchStorageBuilder(branchStorage)
                                      .prStateStorageBuilder(prStateStorage)
-                                     .updaters(List.of(updater))
                                      .prUpdaters(List.of(updater))
+                                     .integratorId(repo.forge().currentUser().id())
                                      .build();
 
             // Initialize history
@@ -318,6 +320,7 @@ public class IssueUpdaterTests {
 
             // Simulate integration
             pr.addComment("Pushed as commit " + editHash.hex() + ".");
+            pr.addLabel("integrated");
             localRepo.push(editHash, repo.url(), "other");
             TestBotRunner.runPeriodicItems(notifyBot);
 

--- a/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/CommitMessageParser.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/CommitMessageParser.java
@@ -23,6 +23,7 @@
 package org.openjdk.skara.vcs.openjdk;
 
 import org.openjdk.skara.vcs.Commit;
+import org.openjdk.skara.vcs.CommitMetadata;
 
 import java.util.List;
 
@@ -31,5 +32,8 @@ public interface CommitMessageParser {
     CommitMessage parse(List<String> lines);
     default CommitMessage parse(Commit c) {
         return parse(c.message());
+    }
+    default CommitMessage parse(CommitMetadata metadata) {
+        return parse(metadata.message());
     }
 }


### PR DESCRIPTION
Hi all,

please review this patch that adds the `handleIntegratedPullRequest` callback to `PullRequestUpdateConsumer`. I have also updated `IssueUpdater` to make use of this new callback, as well as updated the unit tests for `IssueUpdater`.

Testing:
- [x] `make test` passes on Linux x64
- [x] Updated two unit tests

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/643/head:pull/643`
`$ git checkout pull/643`
