### PR TITLE
notifier: add commit comment notifier

### DIFF
--- a/bots/notify/build.gradle
+++ b/bots/notify/build.gradle
@@ -30,6 +30,7 @@ module {
         opens 'org.openjdk.skara.bots.notify.mailinglist' to 'org.junit.platform.commons'
         opens 'org.openjdk.skara.bots.notify.json' to 'org.junit.platform.commons'
         opens 'org.openjdk.skara.bots.notify.issue' to 'org.junit.platform.commons'
+        opens 'org.openjdk.skara.bots.notify.comment' to 'org.junit.platform.commons'
     }
 }
 

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/comment/CommitCommentNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/comment/CommitCommentNotifier.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.notify.comment;
+
+import org.openjdk.skara.bots.notify.*;
+import org.openjdk.skara.forge.*;
+import org.openjdk.skara.issuetracker.*;
+import org.openjdk.skara.vcs.*;
+import org.openjdk.skara.vcs.openjdk.CommitMessageParsers;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+class CommitCommentNotifier implements Notifier, PullRequestListener {
+    private final IssueProject issueProject;
+
+    CommitCommentNotifier(IssueProject issueProject) {
+        this.issueProject = issueProject;
+    }
+
+    private List<Issue> issues(CommitMetadata metadata) {
+        var commitMessage = CommitMessageParsers.v1.parse(metadata);
+        return commitMessage.issues()
+                            .stream()
+                            .map(i -> issueProject.issue(i.shortId()))
+                            .filter(Optional::isPresent)
+                            .map(Optional::get)
+                            .collect(Collectors.toList());
+    }
+
+    @Override
+    public void attachTo(Emitter e) {
+        e.registerPullRequestListener(this);
+    }
+
+    @Override
+    public void onIntegratedPullRequest(PullRequest pr, Hash hash)  {
+        var repository = pr.repository();
+        var commit = repository.commitMetadata(hash).orElseThrow(() ->
+                new IllegalStateException("Integrated commit " + hash +
+                                          " not present in repository " + repository.webUrl())
+        );
+        var comment = new ArrayList<String>();
+        comment.addAll(List.of(
+            "<!-- COMMIT COMMENT NOTIFICATION -->",
+            "### Review",
+            "",
+            "- [" + pr.repository().name() + "/" + pr.id() + "](" + pr.webUrl() + ")"
+        ));
+        var issues = issues(commit);
+        if (issues.size() > 0) {
+            comment.add("");
+            comment.add("### Issues");
+            comment.add("");
+            for (var issue : issues) {
+                comment.add("- [" + issue.id() + "](" + issue.webUrl() + ")");
+            }
+        }
+        repository.addCommitComment(hash, String.join("\n", comment));
+    }
+}

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/comment/CommitCommentNotifierFactory.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/comment/CommitCommentNotifierFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.notify.comment;
+
+import org.openjdk.skara.bot.BotConfiguration;
+import org.openjdk.skara.bots.notify.*;
+import org.openjdk.skara.json.JSONObject;
+
+import java.net.URI;
+
+public class CommitCommentNotifierFactory implements NotifierFactory {
+    @Override
+    public String name() {
+        return "comment";
+    }
+
+    @Override
+    public Notifier create(BotConfiguration botConfiguration, JSONObject notifierConfiguration) {
+        var issueProject = botConfiguration.issueProject(notifierConfiguration.get("project").asString());
+        return new CommitCommentNotifier(issueProject);
+    }
+}

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/comment/CommitCommentNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/comment/CommitCommentNotifierTests.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.notify.comment;
+
+import org.junit.jupiter.api.*;
+import org.openjdk.skara.bots.notify.*;
+import org.openjdk.skara.json.JSON;
+import org.openjdk.skara.test.*;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.*;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.openjdk.skara.bots.notify.TestUtils.*;
+
+public class CommitCommentNotifierTests {
+    @Test
+    void testCommitComment(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var repo = credentials.getHostedRepository();
+            var repoFolder = tempFolder.path().resolve("repo");
+            var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
+            credentials.commitLock(localRepo);
+            localRepo.pushAll(repo.url());
+
+            var tagStorage = createTagStorage(repo);
+            var branchStorage = createBranchStorage(repo);
+            var prStateStorage = createPullRequestStateStorage(repo);
+            var storageFolder = tempFolder.path().resolve("storage");
+
+            var issueProject = credentials.getIssueProject();
+            var notifyBot = NotifyBot.newBuilder()
+                                     .repository(repo)
+                                     .storagePath(storageFolder)
+                                     .branches(Pattern.compile("master"))
+                                     .tagStorageBuilder(tagStorage)
+                                     .branchStorageBuilder(branchStorage)
+                                     .prStateStorageBuilder(prStateStorage)
+                                     .integratorId(repo.forge().currentUser().id())
+                                     .build();
+            var notifier = new CommitCommentNotifier(issueProject);
+            notifier.attachTo(notifyBot);
+
+            // Initialize history
+            TestBotRunner.runPeriodicItems(notifyBot);
+
+            // Save the state
+            var historyState = localRepo.fetch(repo.url(), "history");
+
+            // Commit a fix
+            var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", "Fix an issue");
+            localRepo.push(editHash, repo.url(), "master");
+            var pr = credentials.createPullRequest(repo, "master", "master", "Fix an issue");
+            pr.setBody("I made a fix");
+            pr.addLabel("integrated");
+            pr.addComment("Pushed as commit " + editHash.hex() + ".");
+            TestBotRunner.runPeriodicItems(notifyBot);
+
+            // Check commit comment
+            var comments = repo.commitComments(editHash);
+            assertEquals(1, comments.size());
+            var comment = comments.get(0);
+            assertEquals(editHash, comment.commit());
+            assertEquals(repo.forge().currentUser(), comment.author());
+            assertEquals(Optional.empty(), comment.path());
+            assertEquals(Optional.empty(), comment.line());
+
+            var lines = comment.body().split("\n");
+            assertEquals(4, lines.length);
+            assertEquals("<!-- COMMIT COMMENT NOTIFICATION -->", lines[0]);
+            assertEquals("### Review", lines[1]);
+            assertEquals("", lines[2]);
+            assertEquals("- [" + repo.name() + "/" + pr.id() + "](" + pr.webUrl() + ")", lines[3]);
+        }
+    }
+
+    @Test
+    void testCommitCommentWithIssues(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var repo = credentials.getHostedRepository();
+            var repoFolder = tempFolder.path().resolve("repo");
+            var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
+            credentials.commitLock(localRepo);
+            localRepo.pushAll(repo.url());
+
+            var tagStorage = createTagStorage(repo);
+            var branchStorage = createBranchStorage(repo);
+            var prStateStorage = createPullRequestStateStorage(repo);
+            var storageFolder = tempFolder.path().resolve("storage");
+
+            var issueProject = credentials.getIssueProject();
+            var issue = issueProject.createIssue("A title",
+                                                 List.of("A description"),
+                                                 Map.of("issuetype", JSON.of("Enhancement")));
+            var commitMessageTitle = issue.id() + ": A title";
+            var editHash = CheckableRepository.appendAndCommit(localRepo, "Change", commitMessageTitle);
+
+            var notifyBot = NotifyBot.newBuilder()
+                                     .repository(repo)
+                                     .storagePath(storageFolder)
+                                     .branches(Pattern.compile("master"))
+                                     .tagStorageBuilder(tagStorage)
+                                     .branchStorageBuilder(branchStorage)
+                                     .prStateStorageBuilder(prStateStorage)
+                                     .integratorId(repo.forge().currentUser().id())
+                                     .build();
+            var notifier = new CommitCommentNotifier(issueProject);
+            notifier.attachTo(notifyBot);
+
+            // Initialize history
+            TestBotRunner.runPeriodicItems(notifyBot);
+
+            // Save the state
+            var historyState = localRepo.fetch(repo.url(), "history");
+
+            // Commit a fix
+            localRepo.push(editHash, repo.url(), "master");
+            var pr = credentials.createPullRequest(repo, "master", "master", commitMessageTitle);
+            pr.setBody("\n\n### Issue\n * [" + issue.id() + "](http://www.test.test/): The issue");
+            pr.addLabel("integrated");
+            pr.addComment("Pushed as commit " + editHash.hex() + ".");
+            TestBotRunner.runPeriodicItems(notifyBot);
+
+            // Check commit comment
+            var comments = repo.commitComments(editHash);
+            assertEquals(1, comments.size());
+            var comment = comments.get(0);
+            assertEquals(editHash, comment.commit());
+            assertEquals(repo.forge().currentUser(), comment.author());
+            assertEquals(Optional.empty(), comment.path());
+            assertEquals(Optional.empty(), comment.line());
+
+            var lines = comment.body().split("\n");
+            assertEquals(8, lines.length);
+            assertEquals("<!-- COMMIT COMMENT NOTIFICATION -->", lines[0]);
+            assertEquals("### Review", lines[1]);
+            assertEquals("", lines[2]);
+            assertEquals("- [" + repo.name() + "/" + pr.id() + "](" + pr.webUrl() + ")", lines[3]);
+            assertEquals("", lines[4]);
+            assertEquals("### Issues", lines[5]);
+            assertEquals("", lines[6]);
+            assertEquals("- [" + issue.id() + "](" + issue.webUrl() + ")", lines[7]);
+        }
+    }
+}

--- a/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
@@ -217,7 +217,10 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
         nextCommitCommentId += 1;
         var createdAt = ZonedDateTime.now();
 
-        var comments = commitComments.putIfAbsent(hash, new ArrayList<CommitComment>());
+        if (!commitComments.containsKey(hash)) {
+            commitComments.put(hash, new ArrayList<CommitComment>());
+        }
+        var comments = commitComments.get(hash);
         comments.add(new CommitComment(hash, null, -1, Integer.toString(id), body, host.currentUser(), createdAt, createdAt));
     }
 


### PR DESCRIPTION
Hi all,

please review this patch that adds a new notifier - the commit comment notifier. The notifier is simple, it will add a comment to a pushed commit with links to the pull request and to fixed issues. This allows people to browse the history online and use the links in the comment to directly go to the review and/or issues (this already possible via CLI with the `git info` command).

Testing:
- [x] Added two new unit tests
- [x] `make test` passes on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/644/head:pull/644`
`$ git checkout pull/644`
