### PR TITLE
329: Add /cc command

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandWorkItem.java
@@ -41,17 +41,19 @@ public class CommandWorkItem extends PullRequestWorkItem {
     private static final Pattern commandReplyPattern = Pattern.compile("<!-- Jmerge command reply message \\((\\S+)\\) -->");
     private static final String selfCommandMarker = "<!-- Valid self-command -->";
 
-    private final static Map<String, CommandHandler> commandHandlers = Map.of(
-            "help", new HelpCommand(),
-            "integrate", new IntegrateCommand(),
-            "sponsor", new SponsorCommand(),
-            "contributor", new ContributorCommand(),
-            "summary", new SummaryCommand(),
-            "issue", new IssueCommand(),
-            "solves", new IssueCommand("solves"),
-            "reviewers", new ReviewersCommand(),
-            "csr", new CSRCommand(),
-            "reviewer", new ReviewerCommand()
+    private static final Map<String, CommandHandler> commandHandlers = Map.ofEntries(
+            Map.entry("help", new HelpCommand()),
+            Map.entry("integrate", new IntegrateCommand()),
+            Map.entry("sponsor", new SponsorCommand()),
+            Map.entry("contributor", new ContributorCommand()),
+            Map.entry("summary", new SummaryCommand()),
+            Map.entry("issue", new IssueCommand()),
+            Map.entry("solves", new IssueCommand("solves")),
+            Map.entry("reviewers", new ReviewersCommand()),
+            Map.entry("csr", new CSRCommand()),
+            Map.entry("reviewer", new ReviewerCommand()),
+            Map.entry("label", new LabelCommand()),
+            Map.entry("cc", new LabelCommand("cc"))
     );
 
     static class HelpCommand implements CommandHandler {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelCommand.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.pr;
+
+import org.openjdk.skara.forge.*;
+import org.openjdk.skara.issuetracker.Comment;
+
+import java.io.*;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.regex.Pattern;
+
+public class LabelCommand implements CommandHandler {
+    private final String commandName;
+
+    private static final Pattern argumentPattern = Pattern.compile("(?:(add|remove)\\s+)?((?:[A-Za-z0-9_-]+[\\s,]*)+)");
+
+    LabelCommand() {
+        this("label");
+    }
+
+    LabelCommand(String commandName) {
+        this.commandName = commandName;
+    }
+
+    private void showHelp(LabelConfiguration labelConfiguration, PrintWriter reply) {
+        reply.println("Usage: `/" + commandName + "` <add|remove> [label[, label, ...]]` where `label` is an additional classification that should " +
+                              "be applied to this PR. These labels are valid:");
+        labelConfiguration.allowed().forEach(label -> reply.println(" * `" + label + "`"));
+    }
+
+    private Set<String> automaticLabels(PullRequestBot bot, PullRequest pr, Path scratchPath) throws IOException {
+        var path = scratchPath.resolve("pr").resolve("labelcommand").resolve(pr.repository().name());
+        var seedPath = bot.seedStorage().orElse(scratchPath.resolve("seeds"));
+        var hostedRepositoryPool = new HostedRepositoryPool(seedPath);
+        var localRepo = PullRequestUtils.materialize(hostedRepositoryPool, pr, path);
+        var files = PullRequestUtils.changedFiles(pr, localRepo);
+        return bot.labelConfiguration().fromChanges(files);
+    }
+
+    @Override
+    public void handle(PullRequestBot bot, PullRequest pr, CensusInstance censusInstance, Path scratchPath, String args, Comment comment, List<Comment> allComments, PrintWriter reply) {
+        if (!comment.author().equals(pr.author()) && (!ProjectPermissions.mayCommit(censusInstance, comment.author()))) {
+            reply.println("Only the PR author and project [Committers](https://openjdk.java.net/bylaws#committer) are allowed to modify labels on a PR.");
+            return;
+        }
+
+        var argumentMatcher = argumentPattern.matcher(args);
+        if (!argumentMatcher.matches()) {
+            showHelp(bot.labelConfiguration(), reply);
+            return;
+        }
+
+        var labels = argumentMatcher.group(2).split("[\\s,]+");
+        for (var label : labels) {
+            if (!bot.labelConfiguration().allowed().contains(label)) {
+                reply.println("The label `" + label + "` is not a valid label. These labels are valid:");
+                bot.labelConfiguration().allowed().forEach(l -> reply.println(" * `" + l + "`"));
+                return;
+            }
+        }
+        if (labels.length == 0) {
+            showHelp(bot.labelConfiguration(), reply);
+            return;
+        }
+        var currentLabels = new HashSet<>(pr.labels());
+        if (argumentMatcher.group(1) == null || argumentMatcher.group(1).equals("add")) {
+            for (var label : labels) {
+                if (!currentLabels.contains(label)) {
+                    pr.addLabel(label);
+                    reply.println("The `" + label + "` label was successfully added.");
+                } else {
+                    reply.println("The `" + label + "` label was already applied.");
+                }
+            }
+        } else if (argumentMatcher.group(1).equals("remove")) {
+            try {
+                var automaticLabels = automaticLabels(bot, pr, scratchPath);
+                for (var label : labels) {
+                    if (currentLabels.contains(label)) {
+                        if (automaticLabels.contains(label)) {
+                            reply.println("The `" + label + "` label was automatically added and cannot be removed.");
+                        } else {
+                            pr.removeLabel(label);
+                            reply.println("The `" + label + "` label was successfully removed.");
+                        }
+                    } else {
+                        reply.println("The `" + label + "` label was not set.");
+                    }
+                }
+            } catch (IOException e) {
+                reply.println("An error occurred when trying to check automatically added labels");
+            }
+        }
+    }
+
+    @Override
+    public String description() {
+        return "add or remove an additional classification label";
+    }
+}

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelConfiguration.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelConfiguration.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.pr;
+
+import java.nio.file.Path;
+import java.util.*;
+import java.util.regex.Pattern;
+
+public class LabelConfiguration {
+    private final Map<String, List<Pattern>> matchers;
+    private final Map<String, List<String>> groups;
+    private final Set<String> extra;
+    private final Set<String> allowed;
+
+    private LabelConfiguration(Map<String, List<Pattern>> matchers, Map<String, List<String>> groups, Set<String> extra) {
+        this.matchers = Collections.unmodifiableMap(matchers);
+        this.groups = Collections.unmodifiableMap(groups);
+        this.extra = Collections.unmodifiableSet(extra);
+
+        var allowed = new HashSet<String>();
+        allowed.addAll(matchers.keySet());
+        allowed.addAll(groups.keySet());
+        allowed.addAll(extra);
+        this.allowed = Collections.unmodifiableSet(allowed);
+    }
+
+    static class LabelConfigurationBuilder {
+        private final Map<String, List<Pattern>> matchers = new HashMap<>();
+        private final Map<String, List<String>> groups = new HashMap<>();
+        private final Set<String> extra = new HashSet<>();
+
+        public LabelConfigurationBuilder addMatchers(String label, List<Pattern> matchers) {
+            this.matchers.put(label, matchers);
+            return this;
+        }
+
+        public LabelConfigurationBuilder addGroup(String label, List<String> members) {
+            groups.put(label, members);
+            return this;
+        }
+
+        public LabelConfigurationBuilder addExtra(String label) {
+            extra.add(label);
+            return this;
+        }
+
+        public LabelConfiguration build() {
+            return new LabelConfiguration(matchers, groups, extra);
+        }
+    }
+
+    static LabelConfigurationBuilder newBuilder() {
+        return new LabelConfigurationBuilder();
+    }
+
+    public Set<String> fromChanges(Set<Path> changes) {
+        var labels = new HashSet<String>();
+        for (var file : changes) {
+            for (var label : matchers.entrySet()) {
+                for (var pattern : label.getValue()) {
+                    var matcher = pattern.matcher(file.toString());
+                    if (matcher.find()) {
+                        labels.add(label.getKey());
+                        break;
+                    }
+                }
+            }
+        }
+
+        // If the current labels matches at least two members of a group, the group is also included
+        for (var group : groups.entrySet()) {
+            var count = 0;
+            for (var groupEntry : group.getValue()) {
+                if (labels.contains(groupEntry)) {
+                    count++;
+                    if (count == 2) {
+                        labels.add(group.getKey());
+                        break;
+                    }
+                }
+            }
+        }
+
+        return labels;
+    }
+
+    public Set<String> allowed() {
+        return allowed;
+    }
+}

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
@@ -42,20 +42,8 @@ public class LabelerWorkItem extends PullRequestWorkItem {
     }
 
     private Set<String> getLabels(Repository localRepo) throws IOException {
-        var labels = new HashSet<String>();
         var files = PullRequestUtils.changedFiles(pr, localRepo);
-        for (var file : files) {
-            for (var label : bot.labelPatterns().entrySet()) {
-                for (var pattern : label.getValue()) {
-                    var matcher = pattern.matcher(file.toString());
-                    if (matcher.find()) {
-                        labels.add(label.getKey());
-                        break;
-                    }
-                }
-            }
-        }
-        return labels;
+        return bot.labelConfiguration().fromChanges(files);
     }
 
     @Override
@@ -70,7 +58,7 @@ public class LabelerWorkItem extends PullRequestWorkItem {
             var localRepo = PullRequestUtils.materialize(hostedRepositoryPool, pr, path);
             var newLabels = getLabels(localRepo);
             var currentLabels = pr.labels().stream()
-                                  .filter(key -> bot.labelPatterns().containsKey(key))
+                                  .filter(key -> bot.labelConfiguration().allowed().contains(key))
                                   .collect(Collectors.toSet());
 
             // Add all labels not already set

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -38,7 +38,7 @@ class PullRequestBot implements Bot {
     private final HostedRepository remoteRepo;
     private final HostedRepository censusRepo;
     private final String censusRef;
-    private final Map<String, List<Pattern>> labelPatterns;
+    private final LabelConfiguration labelConfiguration;
     private final Map<String, String> externalCommands;
     private final Map<String, String> blockingCheckLabels;
     private final Set<String> readyLabels;
@@ -52,14 +52,14 @@ class PullRequestBot implements Bot {
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots.pr");
 
     PullRequestBot(HostedRepository repo, HostedRepository censusRepo, String censusRef,
-                   Map<String, List<Pattern>> labelPatterns, Map<String, String> externalCommands,
+                   LabelConfiguration labelConfiguration, Map<String, String> externalCommands,
                    Map<String, String> blockingCheckLabels, Set<String> readyLabels,
                    Map<String, Pattern> readyComments, IssueProject issueProject, boolean ignoreStaleReviews,
                    Pattern allowedTargetBranches, Path seedStorage) {
         remoteRepo = repo;
         this.censusRepo = censusRepo;
         this.censusRef = censusRef;
-        this.labelPatterns = labelPatterns;
+        this.labelConfiguration = labelConfiguration;
         this.externalCommands = externalCommands;
         this.blockingCheckLabels = blockingCheckLabels;
         this.readyLabels = readyLabels;
@@ -149,8 +149,8 @@ class PullRequestBot implements Bot {
         return censusRef;
     }
 
-    Map<String, List<Pattern>> labelPatterns() {
-        return labelPatterns;
+    LabelConfiguration labelConfiguration() {
+        return labelConfiguration;
     }
 
     Map<String, String> externalCommands() {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
@@ -33,7 +33,7 @@ public class PullRequestBotBuilder {
     private HostedRepository repo;
     private HostedRepository censusRepo;
     private String censusRef = "master";
-    private Map<String, List<Pattern>> labelPatterns = Map.of();
+    private LabelConfiguration labelConfiguration = LabelConfiguration.newBuilder().build();
     private Map<String, String> externalCommands = Map.of();
     private Map<String, String> blockingCheckLabels = Map.of();
     private Set<String> readyLabels = Set.of();
@@ -61,8 +61,8 @@ public class PullRequestBotBuilder {
         return this;
     }
 
-    public PullRequestBotBuilder labelPatterns(Map<String, List<Pattern>> labelPatterns) {
-        this.labelPatterns = labelPatterns;
+    public PullRequestBotBuilder labelConfiguration(LabelConfiguration labelConfiguration) {
+        this.labelConfiguration = labelConfiguration;
         return this;
     }
 
@@ -107,7 +107,7 @@ public class PullRequestBotBuilder {
     }
 
     public PullRequestBot build() {
-        return new PullRequestBot(repo, censusRepo, censusRef, labelPatterns, externalCommands, blockingCheckLabels,
+        return new PullRequestBot(repo, censusRepo, censusRef, labelConfiguration, externalCommands, blockingCheckLabels,
                                   readyLabels, readyComments, issueProject, ignoreStaleReviews, allowedTargetBranches,
                                   seedStorage);
     }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
@@ -62,6 +62,35 @@ public class PullRequestBotFactory implements BotFactory {
                                     .collect(Collectors.toMap(obj -> obj.get("user").asString(),
                                                               obj -> Pattern.compile(obj.get("pattern").asString())));
 
+        var labelConfigurations = new HashMap<String, LabelConfiguration>();
+        for (var labelGroup : specific.get("labels").fields()) {
+            var labelConfiguration = LabelConfiguration.newBuilder();
+            if (labelGroup.value().contains("matchers")) {
+                var matchers = labelGroup.value().get("matchers").fields().stream()
+                                         .collect(Collectors.toMap(JSONObject.Field::name,
+                                                                   field -> field.value().stream()
+                                                                                 .map(JSONValue::asString)
+                                                                                 .map(Pattern::compile)
+                                                                                 .collect(Collectors.toList())));
+                matchers.forEach(labelConfiguration::addMatchers);
+            }
+            if (labelGroup.value().contains("groups")) {
+                var groups = labelGroup.value().get("groups").fields().stream()
+                                       .collect(Collectors.toMap(JSONObject.Field::name,
+                                                                 field -> field.value().stream()
+                                                                               .map(JSONValue::asString)
+                                                                               .collect(Collectors.toList())));
+                groups.forEach(labelConfiguration::addGroup);
+            }
+            if (labelGroup.value().contains("extra")) {
+                var extra = labelGroup.value().get("extra").stream()
+                                      .map(JSONValue::asString)
+                                      .collect(Collectors.toList());
+                extra.forEach(labelConfiguration::addExtra);
+            }
+            labelConfigurations.put(labelGroup.name(), labelConfiguration.build());
+        }
+
         for (var repo : specific.get("repositories").fields()) {
             var censusRepo = configuration.repository(repo.value().get("census").asString());
             var censusRef = configuration.repositoryRef(repo.value().get("census").asString());
@@ -77,15 +106,11 @@ public class PullRequestBotFactory implements BotFactory {
                                            .seedStorage(configuration.storageFolder().resolve("seeds"));
 
             if (repo.value().contains("labels")) {
-                var labelPatterns = new HashMap<String, List<Pattern>>();
-                for (var label : repo.value().get("labels").fields()) {
-                    var patterns = label.value().stream()
-                                        .map(JSONValue::asString)
-                                        .map(Pattern::compile)
-                                        .collect(Collectors.toList());
-                    labelPatterns.put(label.name(), patterns);
+                var labelGroup = repo.value().get("labels").asString();
+                if (!labelConfigurations.containsKey(labelGroup)) {
+                    throw new RuntimeException("Unknown label group: " + labelGroup);
                 }
-                botBuilder.labelPatterns(labelPatterns);
+                botBuilder.labelConfiguration(labelConfigurations.get(labelGroup));
             }
             if (repo.value().contains("issues")) {
                 botBuilder.issueProject(configuration.issueProject(repo.value().get("issues").asString()));

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelConfigurationTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelConfigurationTests.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.pr;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.*;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class LabelConfigurationTests {
+    @Test
+    void simple() {
+        var config = LabelConfiguration.newBuilder()
+                                       .addMatchers("1", List.of(Pattern.compile("cpp$")))
+                                       .addMatchers("2", List.of(Pattern.compile("hpp$")))
+                                       .build();
+
+        assertEquals(Set.of("1", "2"), config.allowed());
+
+        assertEquals(Set.of("1"), config.fromChanges(Set.of(Path.of("a.cpp"))));
+        assertEquals(Set.of("2"), config.fromChanges(Set.of(Path.of("a.hpp"))));
+        assertEquals(Set.of("1", "2"), config.fromChanges(Set.of(Path.of("a.cpp"), Path.of("a.hpp"))));
+    }
+
+    @Test
+    void group() {
+        var config = LabelConfiguration.newBuilder()
+                                       .addMatchers("1", List.of(Pattern.compile("cpp$")))
+                                       .addMatchers("2", List.of(Pattern.compile("hpp$")))
+                                       .addGroup("both", List.of("1", "2"))
+                                       .build();
+
+        assertEquals(Set.of("1", "2", "both"), config.allowed());
+
+        assertEquals(Set.of("1"), config.fromChanges(Set.of(Path.of("a.cpp"))));
+        assertEquals(Set.of("2"), config.fromChanges(Set.of(Path.of("a.hpp"))));
+        assertEquals(Set.of("1", "2", "both"), config.fromChanges(Set.of(Path.of("a.cpp"), Path.of("a.hpp"))));
+    }
+}

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelTests.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.pr;
+
+import org.junit.jupiter.api.*;
+import org.openjdk.skara.test.*;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.util.*;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.openjdk.skara.bots.pr.PullRequestAsserts.assertLastCommentContains;
+
+public class LabelTests {
+    @Test
+    void simple(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var integrator = credentials.getHostedRepository();
+
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addReviewer(integrator.forge().currentUser().id())
+                                           .addCommitter(author.forge().currentUser().id());
+            var labelConfiguration = LabelConfiguration.newBuilder()
+                                                       .addMatchers("1", List.of(Pattern.compile("cpp$")))
+                                                       .addMatchers("2", List.of(Pattern.compile("hpp$")))
+                                                       .addGroup("group", List.of("1", "2"))
+                                                       .addExtra("extra")
+                                                       .build();
+            var prBot = PullRequestBot.newBuilder()
+                                      .repo(integrator)
+                                      .censusRepo(censusBuilder.build())
+                                      .labelConfiguration(labelConfiguration)
+                                      .build();
+
+            // Populate the projects repository
+            var localRepoFolder = tempFolder.path().resolve("localrepo");
+            var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "123: This is a pull request");
+
+            // No arguments
+            pr.addComment("/label");
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // The bot should reply with a help message
+            assertLastCommentContains(pr,"Usage: `/label");
+
+            // Check that the alias works as well
+            pr.addComment("/cc");
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // The bot should reply with a help message
+            assertLastCommentContains(pr,"Usage: `/cc");
+
+            // Invalid label
+            pr.addComment("/label add unknown");
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // The bot should reply with a failure message
+            assertLastCommentContains(pr,"The label `unknown` is not a valid label");
+            assertLastCommentContains(pr,"* `1`");
+            assertLastCommentContains(pr,"* `group`");
+            assertLastCommentContains(pr,"* `extra`");
+
+            // Add a label
+            pr.addComment("/label add 1");
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // The bot should reply with a success message
+            assertLastCommentContains(pr,"The `1` label was successfully added.");
+
+            // One more
+            pr.addComment("/cc group");
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // The bot should reply with a success message
+            assertLastCommentContains(pr,"The `group` label was successfully added.");
+
+            // Drop both
+            pr.addComment("/label remove 1   group");
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // The bot should reply with a success message
+            assertLastCommentContains(pr,"The `1` label was successfully removed.");
+            assertLastCommentContains(pr,"The `group` label was successfully removed.");
+
+            // And once more
+            pr.addComment("/label add 2, extra");
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // The bot should reply with a success message
+            assertLastCommentContains(pr,"The `2` label was successfully added.");
+            assertLastCommentContains(pr,"The `extra` label was successfully added.");
+        }
+    }
+
+    @Test
+    void removeAutoApplied(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var integrator = credentials.getHostedRepository();
+
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addReviewer(integrator.forge().currentUser().id())
+                                           .addCommitter(author.forge().currentUser().id());
+            var labelConfiguration = LabelConfiguration.newBuilder()
+                                                       .addMatchers("1", List.of(Pattern.compile("cpp$")))
+                                                       .addMatchers("2", List.of(Pattern.compile("hpp$")))
+                                                       .addGroup("group", List.of("1", "2"))
+                                                       .addExtra("extra")
+                                                       .build();
+            var prBot = PullRequestBot.newBuilder()
+                                      .repo(integrator)
+                                      .censusRepo(censusBuilder.build())
+                                      .labelConfiguration(labelConfiguration)
+                                      .build();
+
+            // Populate the projects repository
+            var localRepoFolder = tempFolder.path().resolve("localrepo");
+            var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType(), Path.of("test.hpp"));
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "123: This is a pull request");
+
+            // The bot should have applied one label automatically
+            TestBotRunner.runPeriodicItems(prBot);
+            assertEquals(Set.of("2", "rfr"), new HashSet<>(pr.labels()));
+
+            // It will refuse to remove it
+            pr.addComment("/label remove 2");
+            TestBotRunner.runPeriodicItems(prBot);
+            assertLastCommentContains(pr, "The `2` label was automatically added and cannot be removed.");
+
+            // Add another file to trigger a group match
+            Files.writeString(localRepoFolder.resolve("test.cpp"), "Hello there");
+            localRepo.add(Path.of("test.cpp"));
+            editHash = localRepo.commit("Another one", "duke", "duke@openjdk.org");
+            localRepo.push(editHash, author.url(), "edit");
+
+            // The bot should have applied more labels automatically
+            TestBotRunner.runPeriodicItems(prBot);
+            assertEquals(Set.of("1", "2", "group", "rfr"), new HashSet<>(pr.labels()));
+
+            // It will refuse to remove these as well
+            pr.addComment("/label remove group, 1");
+            TestBotRunner.runPeriodicItems(prBot);
+            assertLastCommentContains(pr, "The `1` label was automatically added and cannot be removed.");
+            assertLastCommentContains(pr, "The `group` label was automatically added and cannot be removed.");
+        }
+    }
+
+    @Test
+    void commandAuthor(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var integrator = credentials.getHostedRepository();
+            var other = credentials.getHostedRepository();
+            var committer = credentials.getHostedRepository();
+
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addReviewer(integrator.forge().currentUser().id())
+                                           .addCommitter(committer.forge().currentUser().id())
+                                           .addAuthor(author.forge().currentUser().id())
+                                           .addAuthor(other.forge().currentUser().id());
+            var labelConfiguration = LabelConfiguration.newBuilder()
+                                                       .addMatchers("1", List.of(Pattern.compile("cpp$")))
+                                                       .addMatchers("2", List.of(Pattern.compile("hpp$")))
+                                                       .addGroup("group", List.of("1", "2"))
+                                                       .addExtra("extra")
+                                                       .build();
+            var prBot = PullRequestBot.newBuilder()
+                                      .repo(integrator)
+                                      .censusRepo(censusBuilder.build())
+                                      .labelConfiguration(labelConfiguration)
+                                      .build();
+
+            // Populate the projects repository
+            var localRepoFolder = tempFolder.path().resolve("localrepo");
+            var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "123: This is a pull request");
+
+            // Non committers cannot modify labels
+            var otherPr = other.pullRequest(pr.id());
+            otherPr.addComment("/label extra");
+            TestBotRunner.runPeriodicItems(prBot);
+            assertLastCommentContains(pr, "Only the PR author and project [Committers]");
+
+            // But PR authors can
+            pr.addComment("/label extra");
+            TestBotRunner.runPeriodicItems(prBot);
+            assertLastCommentContains(pr, "The `extra` label was successfully added");
+
+            // As well as other committers
+            var committerPr = committer.pullRequest(pr.id());
+            committerPr.addComment("/label 2");
+            TestBotRunner.runPeriodicItems(prBot);
+            assertLastCommentContains(pr, "The `2` label was successfully added");
+        }
+    }
+}

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelerTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelerTests.java
@@ -41,12 +41,18 @@ class LabelerTests {
             var author = credentials.getHostedRepository();
             var reviewer = credentials.getHostedRepository();
 
-            var labelPatterns = Map.of("test1", List.of(Pattern.compile("a.txt")),
-                                       "test2", List.of(Pattern.compile("b.txt")));
+            var labelConfiguration = LabelConfiguration.newBuilder()
+                                                       .addMatchers("test1", List.of(Pattern.compile("a.txt")))
+                                                       .addMatchers("test2", List.of(Pattern.compile("b.txt")))
+                                                       .build();
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id())
                                            .addReviewer(reviewer.forge().currentUser().id());
-            var labelBot = PullRequestBot.newBuilder().repo(author).censusRepo(censusBuilder.build()).labelPatterns(labelPatterns).build();
+            var labelBot = PullRequestBot.newBuilder()
+                                         .repo(author)
+                                         .censusRepo(censusBuilder.build())
+                                         .labelConfiguration(labelConfiguration)
+                                         .build();
 
             // Populate the projects repository
             var localRepoFolder = tempFolder.path();


### PR DESCRIPTION
Hi all,

Please review this change that introduces the `/label` (aliased as `/cc`) command to add or remove additional labels from a PR. The set of allowed labels are configured for each project. The command may be executed by the PR author as well as other project Committers and above.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-329](https://bugs.openjdk.java.net/browse/SKARA-329): Add /cc command


### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/645/head:pull/645`
`$ git checkout pull/645`
