### PR TITLE
notify: rename MailingListUpdater to MailingListNotifier

### DIFF
--- a/bots/notify/build.gradle
+++ b/bots/notify/build.gradle
@@ -27,6 +27,7 @@ module {
         requires 'org.junit.jupiter.api'
         requires 'org.openjdk.skara.test'
         opens 'org.openjdk.skara.bots.notify' to 'org.junit.platform.commons'
+        opens 'org.openjdk.skara.bots.notify.mailinglist' to 'org.junit.platform.commons'
     }
 }
 

--- a/bots/notify/src/main/java/module-info.java
+++ b/bots/notify/src/main/java/module-info.java
@@ -38,6 +38,6 @@ module org.openjdk.skara.bots.notify {
     provides org.openjdk.skara.bots.notify.NotifierFactory with
             org.openjdk.skara.bots.notify.issue.IssueUpdaterFactory,
             org.openjdk.skara.bots.notify.json.JsonUpdaterFactory,
-            org.openjdk.skara.bots.notify.mailinglist.MailingListUpdaterFactory,
+            org.openjdk.skara.bots.notify.mailinglist.MailingListNotifierFactory,
             org.openjdk.skara.bots.notify.slack.SlackUpdaterFactory;
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/mailinglist/MailingListNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/mailinglist/MailingListNotifier.java
@@ -35,7 +35,7 @@ import java.util.*;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
-public class MailingListUpdater implements RepositoryUpdateConsumer {
+class MailingListNotifier implements RepositoryUpdateConsumer {
     private final MailingList list;
     private final EmailAddress recipient;
     private final EmailAddress sender;
@@ -54,7 +54,7 @@ public class MailingListUpdater implements RepositoryUpdateConsumer {
         PR
     }
 
-    MailingListUpdater(MailingList list, EmailAddress recipient, EmailAddress sender, EmailAddress author,
+    MailingListNotifier(MailingList list, EmailAddress recipient, EmailAddress sender, EmailAddress author,
                        boolean includeBranch, boolean reportNewTags, boolean reportNewBranches, boolean reportNewBuilds,
                        Mode mode, Map<String, String> headers, Pattern allowedAuthorDomains) {
         this.list = list;
@@ -70,8 +70,8 @@ public class MailingListUpdater implements RepositoryUpdateConsumer {
         this.allowedAuthorDomains = allowedAuthorDomains;
     }
 
-    public static MailingListUpdaterBuilder newBuilder() {
-        return new MailingListUpdaterBuilder();
+    public static MailingListNotifierBuilder newBuilder() {
+        return new MailingListNotifierBuilder();
     }
 
     private String tagAnnotationToText(HostedRepository repository, Tag.Annotated annotation) {

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/mailinglist/MailingListNotifierBuilder.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/mailinglist/MailingListNotifierBuilder.java
@@ -28,7 +28,7 @@ import org.openjdk.skara.mailinglist.MailingList;
 import java.util.Map;
 import java.util.regex.Pattern;
 
-public class MailingListUpdaterBuilder {
+class MailingListNotifierBuilder {
     private MailingList list;
     private EmailAddress recipient;
     private EmailAddress sender;
@@ -37,69 +37,69 @@ public class MailingListUpdaterBuilder {
     private boolean reportNewTags = true;
     private boolean reportNewBranches = true;
     private boolean reportNewBuilds = true;
-    private MailingListUpdater.Mode mode = MailingListUpdater.Mode.ALL;
+    private MailingListNotifier.Mode mode = MailingListNotifier.Mode.ALL;
     private Map<String, String> headers = Map.of();
     private Pattern allowedAuthorDomains = Pattern.compile(".*");
     private boolean repoInSubject = false;
     private Pattern branchInSubject = Pattern.compile("a^"); // Does not match anything
 
-    public MailingListUpdaterBuilder list(MailingList list) {
+    public MailingListNotifierBuilder list(MailingList list) {
         this.list = list;
         return this;
     }
 
-    public MailingListUpdaterBuilder recipient(EmailAddress recipient) {
+    public MailingListNotifierBuilder recipient(EmailAddress recipient) {
         this.recipient = recipient;
         return this;
     }
 
-    public MailingListUpdaterBuilder sender(EmailAddress sender) {
+    public MailingListNotifierBuilder sender(EmailAddress sender) {
         this.sender = sender;
         return this;
     }
 
-    public MailingListUpdaterBuilder author(EmailAddress author) {
+    public MailingListNotifierBuilder author(EmailAddress author) {
         this.author = author;
         return this;
     }
 
-    public MailingListUpdaterBuilder includeBranch(boolean includeBranch) {
+    public MailingListNotifierBuilder includeBranch(boolean includeBranch) {
         this.includeBranch = includeBranch;
         return this;
     }
 
-    public MailingListUpdaterBuilder reportNewTags(boolean reportNewTags) {
+    public MailingListNotifierBuilder reportNewTags(boolean reportNewTags) {
         this.reportNewTags = reportNewTags;
         return this;
     }
 
-    public MailingListUpdaterBuilder reportNewBranches(boolean reportNewBranches) {
+    public MailingListNotifierBuilder reportNewBranches(boolean reportNewBranches) {
         this.reportNewBranches = reportNewBranches;
         return this;
     }
 
-    public MailingListUpdaterBuilder reportNewBuilds(boolean reportNewBuilds) {
+    public MailingListNotifierBuilder reportNewBuilds(boolean reportNewBuilds) {
         this.reportNewBuilds = reportNewBuilds;
         return this;
     }
 
-    public MailingListUpdaterBuilder mode(MailingListUpdater.Mode mode) {
+    public MailingListNotifierBuilder mode(MailingListNotifier.Mode mode) {
         this.mode = mode;
         return this;
     }
 
-    public MailingListUpdaterBuilder headers(Map<String, String> headers) {
+    public MailingListNotifierBuilder headers(Map<String, String> headers) {
         this.headers = headers;
         return this;
     }
 
-    public MailingListUpdaterBuilder allowedAuthorDomains(Pattern allowedAuthorDomains) {
+    public MailingListNotifierBuilder allowedAuthorDomains(Pattern allowedAuthorDomains) {
         this.allowedAuthorDomains = allowedAuthorDomains;
         return this;
     }
 
-    public MailingListUpdater build() {
-        return new MailingListUpdater(list, recipient, sender, author, includeBranch, reportNewTags, reportNewBranches,
+    public MailingListNotifier build() {
+        return new MailingListNotifier(list, recipient, sender, author, includeBranch, reportNewTags, reportNewBranches,
                                       reportNewBuilds, mode, headers, allowedAuthorDomains);
     }
 }

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/mailinglist/MailingListNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/mailinglist/MailingListNotifierTests.java
@@ -20,11 +20,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package org.openjdk.skara.bots.notify;
+package org.openjdk.skara.bots.notify.mailinglist;
 
 import org.junit.jupiter.api.*;
-import org.openjdk.skara.bots.notify.mailinglist.MailingListUpdater;
 import org.openjdk.skara.email.*;
+import org.openjdk.skara.bots.notify.*;
 import org.openjdk.skara.mailinglist.MailingListServerFactory;
 import org.openjdk.skara.test.*;
 
@@ -36,7 +36,7 @@ import java.util.regex.Pattern;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.openjdk.skara.bots.notify.UpdaterTests.*;
 
-public class MailingListUpdaterTests {
+public class MailingListNotifierTests {
     @Test
     void testMailingList(TestInfo testInfo) throws IOException {
         try (var listServer = new TestMailmanServer();
@@ -58,16 +58,16 @@ public class MailingListUpdaterTests {
             var storageFolder = tempFolder.path().resolve("storage");
 
             var sender = EmailAddress.from("duke", "duke@duke.duke");
-            var updater = MailingListUpdater.newBuilder()
-                                            .list(mailmanList)
-                                            .recipient(listAddress)
-                                            .sender(sender)
-                                            .reportNewTags(false)
-                                            .reportNewBranches(false)
-                                            .reportNewBuilds(false)
-                                            .headers(Map.of("extra1", "value1", "extra2", "value2"))
-                                            .allowedAuthorDomains(Pattern.compile("none"))
-                                            .build();
+            var updater = MailingListNotifier.newBuilder()
+                                             .list(mailmanList)
+                                             .recipient(listAddress)
+                                             .sender(sender)
+                                             .reportNewTags(false)
+                                             .reportNewBranches(false)
+                                             .reportNewBuilds(false)
+                                             .headers(Map.of("extra1", "value1", "extra2", "value2"))
+                                             .allowedAuthorDomains(Pattern.compile("none"))
+                                             .build();
             var notifyBot = NotifyBot.newBuilder()
                                      .repository(repo)
                                      .storagePath(storageFolder)
@@ -130,14 +130,14 @@ public class MailingListUpdaterTests {
             var storageFolder = tempFolder.path().resolve("storage");
 
             var sender = EmailAddress.from("duke", "duke@duke.duke");
-            var updater = MailingListUpdater.newBuilder()
-                                            .list(mailmanList)
-                                            .recipient(listAddress)
-                                            .sender(sender)
-                                            .reportNewTags(false)
-                                            .reportNewBranches(false)
-                                            .reportNewBuilds(false)
-                                            .build();
+            var updater = MailingListNotifier.newBuilder()
+                                             .list(mailmanList)
+                                             .recipient(listAddress)
+                                             .sender(sender)
+                                             .reportNewTags(false)
+                                             .reportNewBranches(false)
+                                             .reportNewBuilds(false)
+                                             .build();
             var notifyBot = NotifyBot.newBuilder()
                                      .repository(repo)
                                      .storagePath(storageFolder)
@@ -202,14 +202,14 @@ public class MailingListUpdaterTests {
             var storageFolder = tempFolder.path().resolve("storage");
 
             var sender = EmailAddress.from("duke", "duke@duke.duke");
-            var updater = MailingListUpdater.newBuilder()
-                                            .list(mailmanList)
-                                            .recipient(listAddress)
-                                            .sender(sender)
-                                            .reportNewTags(false)
-                                            .reportNewBranches(false)
-                                            .reportNewBuilds(false)
-                                            .build();
+            var updater = MailingListNotifier.newBuilder()
+                                             .list(mailmanList)
+                                             .recipient(listAddress)
+                                             .sender(sender)
+                                             .reportNewTags(false)
+                                             .reportNewBranches(false)
+                                             .reportNewBuilds(false)
+                                             .build();
             var notifyBot = NotifyBot.newBuilder()
                                      .repository(repo)
                                      .storagePath(storageFolder)
@@ -267,16 +267,16 @@ public class MailingListUpdaterTests {
 
             var sender = EmailAddress.from("duke", "duke@duke.duke");
             var author = EmailAddress.from("author", "author@duke.duke");
-            var updater = MailingListUpdater.newBuilder()
-                                            .list(mailmanList)
-                                            .recipient(listAddress)
-                                            .sender(sender)
-                                            .author(author)
-                                            .includeBranch(true)
-                                            .reportNewTags(false)
-                                            .reportNewBranches(false)
-                                            .reportNewBuilds(false)
-                                            .build();
+            var updater = MailingListNotifier.newBuilder()
+                                             .list(mailmanList)
+                                             .recipient(listAddress)
+                                             .sender(sender)
+                                             .author(author)
+                                             .includeBranch(true)
+                                             .reportNewTags(false)
+                                             .reportNewBranches(false)
+                                             .reportNewBuilds(false)
+                                             .build();
             var notifyBot = NotifyBot.newBuilder()
                                      .repository(repo)
                                      .storagePath(storageFolder)
@@ -365,17 +365,17 @@ public class MailingListUpdaterTests {
 
             var sender = EmailAddress.from("duke", "duke@duke.duke");
             var author = EmailAddress.from("author", "author@duke.duke");
-            var updater = MailingListUpdater.newBuilder()
-                                            .list(mailmanList)
-                                            .recipient(listAddress)
-                                            .sender(sender)
-                                            .author(author)
-                                            .reportNewTags(false)
-                                            .reportNewBranches(false)
-                                            .reportNewBuilds(false)
-                                            .includeBranch(true)
-                                            .mode(MailingListUpdater.Mode.PR)
-                                            .build();
+            var updater = MailingListNotifier.newBuilder()
+                                             .list(mailmanList)
+                                             .recipient(listAddress)
+                                             .sender(sender)
+                                             .author(author)
+                                             .reportNewTags(false)
+                                             .reportNewBranches(false)
+                                             .reportNewBuilds(false)
+                                             .includeBranch(true)
+                                             .mode(MailingListNotifier.Mode.PR)
+                                             .build();
             var notifyBot = NotifyBot.newBuilder()
                                      .repository(repo)
                                      .storagePath(storageFolder)
@@ -450,15 +450,15 @@ public class MailingListUpdaterTests {
             var storageFolder = tempFolder.path().resolve("storage");
 
             var sender = EmailAddress.from("duke", "duke@duke.duke");
-            var updater = MailingListUpdater.newBuilder()
-                                            .list(mailmanList)
-                                            .recipient(listAddress)
-                                            .sender(sender)
-                                            .reportNewTags(false)
-                                            .reportNewBranches(false)
-                                            .reportNewBuilds(false)
-                                            .mode(MailingListUpdater.Mode.PR)
-                                            .build();
+            var updater = MailingListNotifier.newBuilder()
+                                             .list(mailmanList)
+                                             .recipient(listAddress)
+                                             .sender(sender)
+                                             .reportNewTags(false)
+                                             .reportNewBranches(false)
+                                             .reportNewBuilds(false)
+                                             .mode(MailingListNotifier.Mode.PR)
+                                             .build();
             var notifyBot = NotifyBot.newBuilder()
                                      .repository(repo)
                                      .storagePath(storageFolder)
@@ -542,16 +542,16 @@ public class MailingListUpdaterTests {
             var storageFolder = tempFolder.path().resolve("storage");
 
             var sender = EmailAddress.from("duke", "duke@duke.duke");
-            var updater = MailingListUpdater.newBuilder()
-                                            .list(mailmanList)
-                                            .recipient(listAddress)
-                                            .sender(sender)
-                                            .author(null)
-                                            .reportNewTags(false)
-                                            .reportNewBranches(false)
-                                            .reportNewBuilds(false)
-                                            .mode(MailingListUpdater.Mode.PR)
-                                            .build();
+            var updater = MailingListNotifier.newBuilder()
+                                             .list(mailmanList)
+                                             .recipient(listAddress)
+                                             .sender(sender)
+                                             .author(null)
+                                             .reportNewTags(false)
+                                             .reportNewBranches(false)
+                                             .reportNewBuilds(false)
+                                             .mode(MailingListNotifier.Mode.PR)
+                                             .build();
             var notifyBot = NotifyBot.newBuilder()
                                      .repository(repo)
                                      .storagePath(storageFolder)
@@ -637,21 +637,21 @@ public class MailingListUpdaterTests {
             var storageFolder = tempFolder.path().resolve("storage");
 
             var sender = EmailAddress.from("duke", "duke@duke.duke");
-            var updater = MailingListUpdater.newBuilder()
-                                            .list(mailmanList)
-                                            .recipient(listAddress)
-                                            .sender(sender)
-                                            .reportNewBranches(false)
-                                            .headers(Map.of("extra1", "value1", "extra2", "value2"))
-                                            .build();
-            var noTagsUpdater = MailingListUpdater.newBuilder()
-                                                  .list(mailmanList)
-                                                  .recipient(listAddress)
-                                                  .sender(sender)
-                                                  .reportNewTags(false)
-                                                  .reportNewBranches(false)
-                                                  .reportNewBuilds(false)
-                                                  .build();
+            var updater = MailingListNotifier.newBuilder()
+                                             .list(mailmanList)
+                                             .recipient(listAddress)
+                                             .sender(sender)
+                                             .reportNewBranches(false)
+                                             .headers(Map.of("extra1", "value1", "extra2", "value2"))
+                                             .build();
+            var noTagsUpdater = MailingListNotifier.newBuilder()
+                                                   .list(mailmanList)
+                                                   .recipient(listAddress)
+                                                   .sender(sender)
+                                                   .reportNewTags(false)
+                                                   .reportNewBranches(false)
+                                                   .reportNewBuilds(false)
+                                                   .build();
             var notifyBot = NotifyBot.newBuilder()
                                      .repository(repo)
                                      .storagePath(storageFolder)
@@ -754,22 +754,22 @@ public class MailingListUpdaterTests {
             var storageFolder = tempFolder.path().resolve("storage");
 
             var sender = EmailAddress.from("duke", "duke@duke.duke");
-            var updater = MailingListUpdater.newBuilder()
-                                            .list(mailmanList)
-                                            .recipient(listAddress)
-                                            .sender(sender)
-                                            .reportNewBranches(false)
-                                            .reportNewBuilds(false)
-                                            .headers(Map.of("extra1", "value1", "extra2", "value2"))
-                                            .build();
-            var noTagsUpdater = MailingListUpdater.newBuilder()
-                                                  .list(mailmanList)
-                                                  .recipient(listAddress)
-                                                  .sender(sender)
-                                                  .reportNewTags(false)
-                                                  .reportNewBranches(false)
-                                                  .reportNewBuilds(false)
-                                                  .build();
+            var updater = MailingListNotifier.newBuilder()
+                                             .list(mailmanList)
+                                             .recipient(listAddress)
+                                             .sender(sender)
+                                             .reportNewBranches(false)
+                                             .reportNewBuilds(false)
+                                             .headers(Map.of("extra1", "value1", "extra2", "value2"))
+                                             .build();
+            var noTagsUpdater = MailingListNotifier.newBuilder()
+                                                   .list(mailmanList)
+                                                   .recipient(listAddress)
+                                                   .sender(sender)
+                                                   .reportNewTags(false)
+                                                   .reportNewBranches(false)
+                                                   .reportNewBuilds(false)
+                                                   .build();
             var notifyBot = NotifyBot.newBuilder()
                                      .repository(repo)
                                      .storagePath(storageFolder)
@@ -847,14 +847,14 @@ public class MailingListUpdaterTests {
             var storageFolder = tempFolder.path().resolve("storage");
 
             var sender = EmailAddress.from("duke", "duke@duke.duke");
-            var updater = MailingListUpdater.newBuilder()
-                                            .list(mailmanList)
-                                            .recipient(listAddress)
-                                            .sender(sender)
-                                            .reportNewTags(false)
-                                            .reportNewBuilds(false)
-                                            .headers(Map.of("extra1", "value1", "extra2", "value2"))
-                                            .build();
+            var updater = MailingListNotifier.newBuilder()
+                                             .list(mailmanList)
+                                             .recipient(listAddress)
+                                             .sender(sender)
+                                             .reportNewTags(false)
+                                             .reportNewBuilds(false)
+                                             .headers(Map.of("extra1", "value1", "extra2", "value2"))
+                                             .build();
             var notifyBot = NotifyBot.newBuilder()
                                      .repository(repo)
                                      .storagePath(storageFolder)
@@ -927,16 +927,16 @@ public class MailingListUpdaterTests {
             var storageFolder = tempFolder.path().resolve("storage");
 
             var sender = EmailAddress.from("duke", "duke@duke.duke");
-            var updater = MailingListUpdater.newBuilder()
-                                            .list(mailmanList)
-                                            .recipient(listAddress)
-                                            .sender(sender)
-                                            .reportNewTags(false)
-                                            .reportNewBranches(false)
-                                            .reportNewBuilds(false)
-                                            .headers(Map.of("extra1", "value1", "extra2", "value2"))
-                                            .allowedAuthorDomains(Pattern.compile("none"))
-                                            .build();
+            var updater = MailingListNotifier.newBuilder()
+                                             .list(mailmanList)
+                                             .recipient(listAddress)
+                                             .sender(sender)
+                                             .reportNewTags(false)
+                                             .reportNewBranches(false)
+                                             .reportNewBuilds(false)
+                                             .headers(Map.of("extra1", "value1", "extra2", "value2"))
+                                             .allowedAuthorDomains(Pattern.compile("none"))
+                                             .build();
             var notifyBot = NotifyBot.newBuilder()
                                      .repository(repo)
                                      .storagePath(storageFolder)


### PR DESCRIPTION
Hi all,

please review this refactoring that renames `MailingListUpdater` to `MailingListNotifier`. More refactorings will follow after this one for the other notifiers.

Testing:
- [x] `make test` passes on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/646/head:pull/646`
`$ git checkout pull/646`
