### PR TITLE
Allow a WorkItem to return follow-up items

### DIFF
--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
@@ -74,14 +74,18 @@ public class BotRunner {
             }
 
             log.log(Level.FINE, "Executing item " + item + " on repository " + scratchPath, TaskPhases.BEGIN);
+            Collection<WorkItem> followUpItems = null;
             try {
-                item.run(scratchPath);
+                followUpItems = item.run(scratchPath);
             } catch (RuntimeException e) {
                 log.severe("Exception during item execution (" + item + "): " + e.getMessage());
                 item.handleRuntimeException(e);
                 log.throwing(item.toString(), "run", e);
             } finally {
                 log.log(Level.FINE, "Item " + item + " is now done", TaskPhases.END);
+            }
+            if (followUpItems != null) {
+                followUpItems.forEach(BotRunner.this::submitOrSchedule);
             }
 
             synchronized (executor) {

--- a/bot/src/main/java/org/openjdk/skara/bot/WorkItem.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/WorkItem.java
@@ -34,8 +34,10 @@ public interface WorkItem {
     boolean concurrentWith(WorkItem other);
 
     /**
-     * Execute the appropriate tasks with the provided scratch folder.
+     * Execute the appropriate tasks with the provided scratch folder. Optionally return follow-up work items
+     * that will be scheduled for execution.
      * @param scratchPath
+     * @return A collection of follow-up work items, allowed to be empty (or null) if none are needed.
      */
     Collection<WorkItem> run(Path scratchPath);
 

--- a/bot/src/main/java/org/openjdk/skara/bot/WorkItem.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/WorkItem.java
@@ -23,9 +23,9 @@
 package org.openjdk.skara.bot;
 
 import java.nio.file.Path;
+import java.util.*;
 
 public interface WorkItem {
-
     /**
      * Return true if this item can run concurrently with <code>other</code>, otherwise false.
      * @param other
@@ -37,7 +37,7 @@ public interface WorkItem {
      * Execute the appropriate tasks with the provided scratch folder.
      * @param scratchPath
      */
-    void run(Path scratchPath);
+    Collection<WorkItem> run(Path scratchPath);
 
     /**
      * The BotRunner will catch <code>RuntimeException</code>s, implementing this method allows a WorkItem to

--- a/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestCloserBot.java
+++ b/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestCloserBot.java
@@ -83,8 +83,9 @@ class PullRequestCloserBotWorkItem implements WorkItem {
     }
 
     @Override
-    public void run(Path scratchPath) {
+    public Collection<WorkItem> run(Path scratchPath) {
         checkWelcomeMessage();
+        return List.of();
     }
 
     @Override

--- a/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestPrunerBot.java
+++ b/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestPrunerBot.java
@@ -76,7 +76,7 @@ class PullRequestPrunerBotWorkItem implements WorkItem {
     private final String noticeMarker = "<!-- PullrequestCloserBot auto close notification -->";
 
     @Override
-    public void run(Path scratchPath) {
+    public Collection<WorkItem> run(Path scratchPath) {
         var comments = pr.comments();
         if (comments.size() > 0) {
             var lastComment = comments.get(comments.size() - 1);
@@ -87,7 +87,7 @@ class PullRequestPrunerBotWorkItem implements WorkItem {
                 log.fine("Posting prune message");
                 pr.addComment(message);
                 pr.setState(PullRequest.State.CLOSED);
-                return;
+                return List.of();
             }
         }
 
@@ -98,6 +98,7 @@ class PullRequestPrunerBotWorkItem implements WorkItem {
 
         log.fine("Posting prune notification message");
         pr.addComment(noticeMarker + "\n\n" + message);
+        return List.of();
     }
 
     @Override

--- a/bots/cli/src/test/java/org/openjdk/skara/bots/cli/LoggingBot.java
+++ b/bots/cli/src/test/java/org/openjdk/skara/bots/cli/LoggingBot.java
@@ -27,7 +27,7 @@ import org.openjdk.skara.json.JSON;
 
 import java.nio.file.Path;
 import java.time.Duration;
-import java.util.List;
+import java.util.*;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 import java.util.logging.*;
@@ -76,7 +76,8 @@ public class LoggingBot implements Bot, WorkItem {
     }
 
     @Override
-    public void run(Path scratchPath) {
+    public Collection<WorkItem> run(Path scratchPath) {
         runnable.accept(logger);
+        return List.of();
     }
 }

--- a/bots/csr/src/main/java/org/openjdk/skara/bots/csr/CSRBot.java
+++ b/bots/csr/src/main/java/org/openjdk/skara/bots/csr/CSRBot.java
@@ -30,9 +30,7 @@ import org.openjdk.skara.issuetracker.IssueProject;
 import org.openjdk.skara.issuetracker.Issue;
 
 import java.nio.file.Path;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.logging.Logger;
 
 class CSRBot implements Bot, WorkItem {
@@ -63,7 +61,7 @@ class CSRBot implements Bot, WorkItem {
     }
 
     @Override
-    public void run(Path scratchPath) {
+    public Collection<WorkItem> run(Path scratchPath) {
         var prs = repo.pullRequests();
         for (var pr : prs) {
             if (!cache.needsUpdate(pr)) {
@@ -132,6 +130,7 @@ class CSRBot implements Bot, WorkItem {
                 }
             }
         }
+        return List.of();
     }
 
     @Override

--- a/bots/forward/src/main/java/org/openjdk/skara/bots/forward/ForwardBot.java
+++ b/bots/forward/src/main/java/org/openjdk/skara/bots/forward/ForwardBot.java
@@ -26,13 +26,11 @@ import org.openjdk.skara.bot.*;
 import org.openjdk.skara.forge.HostedRepository;
 import org.openjdk.skara.vcs.*;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
-import java.nio.file.Files;
+import java.io.*;
 import java.net.URLEncoder;
-import java.util.List;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.*;
+import java.util.*;
 import java.util.logging.Logger;
 
 class ForwardBot implements Bot, WorkItem {
@@ -65,7 +63,7 @@ class ForwardBot implements Bot, WorkItem {
     }
 
     @Override
-    public void run(Path scratchPath) {
+    public Collection<WorkItem> run(Path scratchPath) {
         try {
             var sanitizedUrl =
                 URLEncoder.encode(toHostedRepo.webUrl().toString(), StandardCharsets.UTF_8);
@@ -92,6 +90,7 @@ class ForwardBot implements Bot, WorkItem {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+        return List.of();
     }
 
     @Override

--- a/bots/hgbridge/src/main/java/org/openjdk/skara/bots/hgbridge/JBridgeBot.java
+++ b/bots/hgbridge/src/main/java/org/openjdk/skara/bots/hgbridge/JBridgeBot.java
@@ -29,7 +29,7 @@ import java.io.*;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
-import java.util.List;
+import java.util.*;
 import java.util.logging.Logger;
 
 public class JBridgeBot implements Bot, WorkItem {
@@ -92,7 +92,7 @@ public class JBridgeBot implements Bot, WorkItem {
     }
 
     @Override
-    public void run(Path scratchPath) {
+    public Collection<WorkItem> run(Path scratchPath) {
         log.fine("Running export for " + exporterConfig.source().toString());
 
         try {
@@ -142,5 +142,6 @@ public class JBridgeBot implements Bot, WorkItem {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+        return List.of();
     }
 }

--- a/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
+++ b/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
@@ -284,7 +284,7 @@ class MergeBot implements Bot, WorkItem {
     }
 
     @Override
-    public void run(Path scratchPath) {
+    public Collection<WorkItem> run(Path scratchPath) {
         try {
             var sanitizedUrl =
                 URLEncoder.encode(fork.webUrl().toString(), StandardCharsets.UTF_8);
@@ -630,6 +630,7 @@ class MergeBot implements Bot, WorkItem {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+        return List.of();
     }
 
     @Override

--- a/bots/mirror/src/main/java/org/openjdk/skara/bots/mirror/MirrorBot.java
+++ b/bots/mirror/src/main/java/org/openjdk/skara/bots/mirror/MirrorBot.java
@@ -26,15 +26,13 @@ import org.openjdk.skara.bot.*;
 import org.openjdk.skara.forge.HostedRepository;
 import org.openjdk.skara.vcs.*;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
-import java.nio.file.Files;
+import java.io.*;
 import java.net.URLEncoder;
-import java.util.List;
-import java.util.stream.Collectors;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.*;
+import java.util.*;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 class MirrorBot implements Bot, WorkItem {
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots");;
@@ -66,7 +64,7 @@ class MirrorBot implements Bot, WorkItem {
     }
 
     @Override
-    public void run(Path scratchPath) {
+    public Collection<WorkItem> run(Path scratchPath) {
         try {
             var sanitizedUrl =
                 URLEncoder.encode(to.webUrl().toString(), StandardCharsets.UTF_8);
@@ -104,6 +102,7 @@ class MirrorBot implements Bot, WorkItem {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+        return List.of();
     }
 
     @Override

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveReaderWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveReaderWorkItem.java
@@ -27,6 +27,7 @@ import org.openjdk.skara.mailinglist.MailingList;
 
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.*;
 
 public class ArchiveReaderWorkItem implements WorkItem {
     private final MailingListArchiveReaderBot bot;
@@ -55,11 +56,12 @@ public class ArchiveReaderWorkItem implements WorkItem {
     }
 
     @Override
-    public void run(Path scratchPath) {
+    public Collection<WorkItem> run(Path scratchPath) {
         // Give the bot a chance to act on all found messages
         var conversations = list.conversations(Duration.ofDays(365));
         for (var conversation : conversations) {
             bot.inspect(conversation);
         }
+        return List.of();
     }
 }

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
@@ -232,7 +232,7 @@ class ArchiveWorkItem implements WorkItem {
     }
 
     @Override
-    public void run(Path scratchPath) {
+    public Collection<WorkItem> run(Path scratchPath) {
         var path = scratchPath.resolve("mlbridge");
         var archiveRepo = materializeArchive(path);
         var mboxBasePath = path.resolve(bot.codeRepo().name());
@@ -248,13 +248,13 @@ class ArchiveWorkItem implements WorkItem {
                 for (var readyLabel : bot.readyLabels()) {
                     if (!labels.contains(readyLabel)) {
                         log.fine("PR is not yet ready - missing label '" + readyLabel + "'");
-                        return;
+                        return List.of();
                     }
                 }
             } else {
                 if (!labels.contains("integrated")) {
                     log.fine("Closed PR was not integrated - will not initiate an RFR thread");
-                    return;
+                    return List.of();
                 }
             }
         }
@@ -276,7 +276,7 @@ class ArchiveWorkItem implements WorkItem {
                 if (!commentFound) {
                     log.fine("PR is not yet ready - missing ready comment from '" + readyComment.getKey() +
                                      "containing '" + readyComment.getValue().pattern() + "'");
-                    return;
+                    return List.of();
                 }
             }
         }
@@ -338,7 +338,7 @@ class ArchiveWorkItem implements WorkItem {
                                                       retryConsumer
                                                       );
             if (newMails.isEmpty()) {
-                return;
+                return List.of();
             }
 
             // Push all new mails to the archive repository
@@ -360,6 +360,7 @@ class ArchiveWorkItem implements WorkItem {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+        return List.of();
     }
 
     @Override

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/CommentPosterWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/CommentPosterWorkItem.java
@@ -92,7 +92,7 @@ public class CommentPosterWorkItem implements WorkItem {
     }
 
     @Override
-    public void run(Path scratchPath) {
+    public Collection<WorkItem> run(Path scratchPath) {
         var comments = pr.comments();
 
         var alreadyBridged = new HashSet<EmailAddress>();
@@ -117,6 +117,7 @@ public class CommentPosterWorkItem implements WorkItem {
             log.info("Bridging new message from " + message.author() + " to " + pr);
             postNewMessage(message);
         }
+        return List.of();
     }
 
     @Override

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/PullRequestWorkItem.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/PullRequestWorkItem.java
@@ -24,7 +24,6 @@ package org.openjdk.skara.bots.notify;
 
 import org.openjdk.skara.bot.WorkItem;
 import org.openjdk.skara.forge.PullRequest;
-import org.openjdk.skara.host.HostUser;
 import org.openjdk.skara.json.*;
 import org.openjdk.skara.storage.StorageBuilder;
 import org.openjdk.skara.vcs.Hash;
@@ -32,7 +31,7 @@ import org.openjdk.skara.vcs.openjdk.Issue;
 
 import java.nio.file.Path;
 import java.util.*;
-import java.util.function.*;
+import java.util.function.Consumer;
 import java.util.regex.Pattern;
 import java.util.stream.*;
 
@@ -174,7 +173,7 @@ public class PullRequestWorkItem implements WorkItem {
     }
 
     @Override
-    public void run(Path scratchPath) {
+    public Collection<WorkItem> run(Path scratchPath) {
         var historyPath = scratchPath.resolve("notify").resolve("history");
         var storage = prStateStorageBuilder
                 .serializer(this::serializePrState)
@@ -187,7 +186,7 @@ public class PullRequestWorkItem implements WorkItem {
         var stored = storage.current();
         if (stored.contains(state)) {
             // Already up to date
-            return;
+            return List.of();
         }
 
         // Search for an existing
@@ -216,6 +215,7 @@ public class PullRequestWorkItem implements WorkItem {
         }
 
         storage.put(state);
+        return List.of();
     }
 
     @Override

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryWorkItem.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryWorkItem.java
@@ -255,7 +255,7 @@ public class RepositoryWorkItem implements WorkItem {
     }
 
     @Override
-    public void run(Path scratchPath) {
+    public Collection<WorkItem> run(Path scratchPath) {
         var historyPath = scratchPath.resolve("notify").resolve("history");
         var repositoryPool = new HostedRepositoryPool(storagePath.resolve("seeds"));
 
@@ -293,6 +293,7 @@ public class RepositoryWorkItem implements WorkItem {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+        return List.of();
     }
 
     @Override

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.skara.bots.pr;
 
+import org.openjdk.skara.bot.WorkItem;
 import org.openjdk.skara.forge.*;
 import org.openjdk.skara.host.*;
 import org.openjdk.skara.issuetracker.*;
@@ -132,7 +133,7 @@ class CheckWorkItem extends PullRequestWorkItem {
     }
 
     @Override
-    public void run(Path scratchPath) {
+    public Collection<WorkItem> run(Path scratchPath) {
         // First determine if the current state of the PR has already been checked
         var census = CensusInstance.create(bot.censusRepo(), bot.censusRef(), scratchPath.resolve("census"), pr);
         var comments = pr.comments();
@@ -144,7 +145,7 @@ class CheckWorkItem extends PullRequestWorkItem {
         if (!currentCheckValid(census, comments, activeReviews, labels)) {
             if (labels.contains("integrated")) {
                 log.info("Skipping check of integrated PR");
-                return;
+                return List.of();
             }
 
             try {
@@ -158,5 +159,6 @@ class CheckWorkItem extends PullRequestWorkItem {
                 throw new UncheckedIOException(e);
             }
         }
+        return List.of();
     }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.skara.bots.pr;
 
+import org.openjdk.skara.bot.WorkItem;
 import org.openjdk.skara.forge.*;
 import org.openjdk.skara.vcs.Repository;
 
@@ -47,9 +48,9 @@ public class LabelerWorkItem extends PullRequestWorkItem {
     }
 
     @Override
-    public void run(Path scratchPath) {
+    public Collection<WorkItem> run(Path scratchPath) {
         if (bot.currentLabels().containsKey(pr.headHash())) {
-            return;
+            return List.of();
         }
         try {
             var path = scratchPath.resolve("pr").resolve("labeler").resolve(pr.repository().name());
@@ -75,5 +76,6 @@ public class LabelerWorkItem extends PullRequestWorkItem {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+        return List.of();
     }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -118,7 +118,6 @@ class PullRequestBot implements Bot {
 
                 ret.add(new CheckWorkItem(this, pr, e -> updateCache.invalidate(pr)));
                 ret.add(new CommandWorkItem(this, pr, e -> updateCache.invalidate(pr)));
-                ret.add(new CheckWorkItem(this, pr, e -> updateCache.invalidate(pr)));
                 ret.add(new LabelerWorkItem(this, pr, e -> updateCache.invalidate(pr)));
             }
         }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestWorkItem.java
@@ -28,7 +28,7 @@ import org.openjdk.skara.forge.PullRequest;
 import java.util.function.Consumer;
 
 abstract class PullRequestWorkItem implements WorkItem {
-    private final Consumer<RuntimeException> errorHandler;
+    final Consumer<RuntimeException> errorHandler;
     final PullRequestBot bot;
     final PullRequest pr;
 

--- a/bots/submit/src/main/java/org/openjdk/skara/bots/submit/SubmitBotWorkItem.java
+++ b/bots/submit/src/main/java/org/openjdk/skara/bots/submit/SubmitBotWorkItem.java
@@ -28,7 +28,8 @@ import org.openjdk.skara.vcs.Repository;
 
 import java.io.*;
 import java.nio.file.Path;
-import java.time.*;
+import java.time.ZonedDateTime;
+import java.util.*;
 import java.util.logging.Logger;
 
 public class SubmitBotWorkItem implements WorkItem {
@@ -67,7 +68,7 @@ public class SubmitBotWorkItem implements WorkItem {
     }
 
     @Override
-    public void run(Path scratchPath) {
+    public Collection<WorkItem> run(Path scratchPath) {
         // Is the check already up to date?
         var checks = pr.checks(pr.headHash());
         if (checks.containsKey(executor.checkName())) {
@@ -76,7 +77,7 @@ public class SubmitBotWorkItem implements WorkItem {
                 log.info("Check for hash " + pr.headHash() + " is too old - running again");
             } else {
                 log.fine("Hash " + pr.headHash() + " already has a check - skipping");
-                return;
+                return List.of();
             }
         }
 
@@ -97,5 +98,7 @@ public class SubmitBotWorkItem implements WorkItem {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+
+        return List.of();
     }
 }

--- a/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestWorkItem.java
+++ b/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestWorkItem.java
@@ -22,7 +22,7 @@
  */
 package org.openjdk.skara.bots.tester;
 
-import org.openjdk.skara.bot.*;
+import org.openjdk.skara.bot.WorkItem;
 import org.openjdk.skara.ci.*;
 import org.openjdk.skara.forge.*;
 import org.openjdk.skara.vcs.*;
@@ -31,7 +31,6 @@ import java.io.*;
 import java.net.*;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
-import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.logging.Logger;
 import java.util.stream.*;
@@ -248,12 +247,12 @@ public class TestWorkItem implements WorkItem {
     }
 
     @Override
-    public void run(Path scratchPath) {
+    public Collection<WorkItem> run(Path scratchPath) {
         var state = State.from(pr, approversGroupId);
         var stage = state.stage();
         if (stage == Stage.NA || stage == Stage.ERROR || stage == Stage.PENDING || stage == Stage.FINISHED) {
             // nothing to do
-            return;
+            return List.of();
         }
 
         if (stage == Stage.STARTED) {
@@ -374,7 +373,7 @@ public class TestWorkItem implements WorkItem {
                        "@" + state.requested().author().userName() + " the test " + wording + String.join(",", nonExistingJobs) + " does not exist"
                     );
                     pr.addComment(String.join("\n", lines));
-                    return;
+                    return List.of();
                 }
 
                 jobs = trimmedJobs;
@@ -434,6 +433,7 @@ public class TestWorkItem implements WorkItem {
         } else {
             throw new RuntimeException("Unexpected state " + state);
         }
+        return List.of();
     }
 
     @Override

--- a/bots/topological/src/main/java/org/openjdk/skara/bots/topological/TopologicalBot.java
+++ b/bots/topological/src/main/java/org/openjdk/skara/bots/topological/TopologicalBot.java
@@ -32,8 +32,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Files;
 import java.net.URLEncoder;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -65,7 +64,7 @@ class TopologicalBot implements Bot, WorkItem {
     }
 
     @Override
-    public void run(Path scratchPath) {
+    public Collection<WorkItem> run(Path scratchPath) {
         log.info("Starting topobot run");
         try {
             var sanitizedUrl = URLEncoder.encode(hostedRepo.webUrl().toString(), StandardCharsets.UTF_8);
@@ -121,6 +120,7 @@ class TopologicalBot implements Bot, WorkItem {
             throw new UncheckedIOException(e);
         }
         log.info("Ending topobot run");
+        return List.of();
     }
 
     private static Stream<Branch> dependencies(Repository repo, Hash hash, Path depsFile) throws IOException {

--- a/test/src/main/java/org/openjdk/skara/test/TestBotRunner.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestBotRunner.java
@@ -25,6 +25,7 @@ package org.openjdk.skara.test;
 import org.openjdk.skara.bot.*;
 
 import java.io.IOException;
+import java.util.*;
 import java.util.function.Predicate;
 
 public class TestBotRunner {
@@ -33,14 +34,19 @@ public class TestBotRunner {
     }
 
     public static void runPeriodicItems(Bot bot, Predicate<WorkItem> ignored) throws IOException {
-        for (var item : bot.getPeriodicItems()) {
+        var items = new LinkedList<>(bot.getPeriodicItems());
+        for (var item = items.pollFirst(); item != null; item = items.pollFirst()) {
             if (!ignored.test(item)) {
+                Collection<WorkItem> followUpItems = null;
                 try (var scratchFolder = new TemporaryDirectory()) {
-                    item.run(scratchFolder.path());
+                    followUpItems = item.run(scratchFolder.path());
                 } catch (RuntimeException e) {
                     item.handleRuntimeException(e);
                     // Allow tests to assert on these as well
                     throw e;
+                }
+                if (followUpItems != null) {
+                    items.addAll(followUpItems);
                 }
             }
         }


### PR DESCRIPTION
Hi all,

Please review this change that allows a WorkItem to return follow-up items to schedule after itself has run. Use this to run another CheckWorkItem after a CommandWorkItem successfully has executed commands.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**) ⚠️ Review applies to d76eda50fd10c3b2a0145ce7ed767c6a6b6e10bc


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/648/head:pull/648`
`$ git checkout pull/648`
