### PR TITLE
notify: rename SlackUpdater to SlackNotifier

### DIFF
--- a/bots/notify/src/main/java/module-info.java
+++ b/bots/notify/src/main/java/module-info.java
@@ -39,5 +39,5 @@ module org.openjdk.skara.bots.notify {
             org.openjdk.skara.bots.notify.issue.IssueUpdaterFactory,
             org.openjdk.skara.bots.notify.json.JsonNotifierFactory,
             org.openjdk.skara.bots.notify.mailinglist.MailingListNotifierFactory,
-            org.openjdk.skara.bots.notify.slack.SlackUpdaterFactory;
+            org.openjdk.skara.bots.notify.slack.SlackNotifierFactory;
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/slack/SlackNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/slack/SlackNotifier.java
@@ -35,12 +35,12 @@ import java.net.URI;
 import java.util.List;
 import java.time.format.DateTimeFormatter;
 
-public class SlackUpdater implements RepositoryUpdateConsumer, PullRequestUpdateConsumer {
+class SlackNotifier implements RepositoryUpdateConsumer, PullRequestUpdateConsumer {
     private final RestRequest prWebhook;
     private final RestRequest commitWebhook;
     private final String username;
 
-    public SlackUpdater(URI prWebhook, URI commitWebhook, String username) {
+    SlackNotifier(URI prWebhook, URI commitWebhook, String username) {
         this.prWebhook = prWebhook != null ? new RestRequest(prWebhook) : null;
         this.commitWebhook = commitWebhook != null ? new RestRequest(commitWebhook) : null;
         this.username = username;

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/slack/SlackNotifierFactory.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/slack/SlackNotifierFactory.java
@@ -29,7 +29,7 @@ import org.openjdk.skara.network.URIBuilder;
 
 import java.net.URI;
 
-public class SlackUpdaterFactory implements NotifierFactory {
+public class SlackNotifierFactory implements NotifierFactory {
     @Override
     public String name() {
         return "slack";
@@ -46,7 +46,6 @@ public class SlackUpdaterFactory implements NotifierFactory {
             commitWebhook = URIBuilder.base(notifierConfiguration.get("commit").asString()).build();
         }
         var username = notifierConfiguration.get("username").asString();
-        var updater = new SlackUpdater(prWebhook, commitWebhook, username);
-        return updater;
+        return new SlackNotifier(prWebhook, commitWebhook, username);
     }
 }


### PR DESCRIPTION
Hi all,

please review this refactoring that renames `SlackUpdater` to `SlackNotifier`.

Testing:
- [x] `make test` passes

Thanks,
Erik