### PR TITLE
notify: rename IssueUpdater to IssueNotifier

### DIFF
--- a/bots/notify/build.gradle
+++ b/bots/notify/build.gradle
@@ -29,6 +29,7 @@ module {
         opens 'org.openjdk.skara.bots.notify' to 'org.junit.platform.commons'
         opens 'org.openjdk.skara.bots.notify.mailinglist' to 'org.junit.platform.commons'
         opens 'org.openjdk.skara.bots.notify.json' to 'org.junit.platform.commons'
+        opens 'org.openjdk.skara.bots.notify.issue' to 'org.junit.platform.commons'
     }
 }
 

--- a/bots/notify/src/main/java/module-info.java
+++ b/bots/notify/src/main/java/module-info.java
@@ -36,7 +36,7 @@ module org.openjdk.skara.bots.notify {
 
     uses org.openjdk.skara.bots.notify.NotifierFactory;
     provides org.openjdk.skara.bots.notify.NotifierFactory with
-            org.openjdk.skara.bots.notify.issue.IssueUpdaterFactory,
+            org.openjdk.skara.bots.notify.issue.IssueNotifierFactory,
             org.openjdk.skara.bots.notify.json.JsonNotifierFactory,
             org.openjdk.skara.bots.notify.mailinglist.MailingListNotifierFactory,
             org.openjdk.skara.bots.notify.slack.SlackNotifierFactory;

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
@@ -33,7 +33,7 @@ import java.net.URI;
 import java.util.*;
 import java.util.logging.Logger;
 
-public class IssueUpdater implements PullRequestUpdateConsumer {
+class IssueNotifier implements PullRequestUpdateConsumer {
     private final IssueProject issueProject;
     private final boolean reviewLink;
     private final URI reviewIcon;
@@ -41,7 +41,7 @@ public class IssueUpdater implements PullRequestUpdateConsumer {
     private final URI commitIcon;
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots.notify");
 
-    IssueUpdater(IssueProject issueProject, boolean reviewLink, URI reviewIcon, boolean commitLink, URI commitIcon) {
+    IssueNotifier(IssueProject issueProject, boolean reviewLink, URI reviewIcon, boolean commitLink, URI commitIcon) {
         this.issueProject = issueProject;
         this.reviewLink = reviewLink;
         this.reviewIcon = reviewIcon;
@@ -49,8 +49,8 @@ public class IssueUpdater implements PullRequestUpdateConsumer {
         this.commitIcon = commitIcon;
     }
 
-    public static IssueUpdaterBuilder newBuilder() {
-        return new IssueUpdaterBuilder();
+    static IssueNotifierBuilder newBuilder() {
+        return new IssueNotifierBuilder();
     }
 
     @Override

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierBuilder.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierBuilder.java
@@ -27,39 +27,39 @@ import org.openjdk.skara.issuetracker.IssueProject;
 import java.net.URI;
 import java.util.Map;
 
-public class IssueUpdaterBuilder {
+class IssueNotifierBuilder {
     private IssueProject issueProject;
     private boolean reviewLink = true;
     private URI reviewIcon = null;
     private boolean commitLink = true;
     private URI commitIcon = null;
 
-    public IssueUpdaterBuilder issueProject(IssueProject issueProject) {
+    IssueNotifierBuilder issueProject(IssueProject issueProject) {
         this.issueProject = issueProject;
         return this;
     }
 
-    public IssueUpdaterBuilder reviewLink(boolean reviewLink) {
+    IssueNotifierBuilder reviewLink(boolean reviewLink) {
         this.reviewLink = reviewLink;
         return this;
     }
 
-    public IssueUpdaterBuilder reviewIcon(URI reviewIcon) {
+    IssueNotifierBuilder reviewIcon(URI reviewIcon) {
         this.reviewIcon = reviewIcon;
         return this;
     }
 
-    public IssueUpdaterBuilder commitLink(boolean commitLink) {
+    IssueNotifierBuilder commitLink(boolean commitLink) {
         this.commitLink = commitLink;
         return this;
     }
 
-    public IssueUpdaterBuilder commitIcon(URI commitIcon) {
+    IssueNotifierBuilder commitIcon(URI commitIcon) {
         this.commitIcon = commitIcon;
         return this;
     }
 
-    public IssueUpdater build() {
-        return new IssueUpdater(issueProject, reviewLink, reviewIcon, commitLink, commitIcon);
+    IssueNotifier build() {
+        return new IssueNotifier(issueProject, reviewLink, reviewIcon, commitLink, commitIcon);
     }
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierFactory.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierFactory.java
@@ -6,7 +6,7 @@ import org.openjdk.skara.json.JSONObject;
 
 import java.net.URI;
 
-public class IssueUpdaterFactory implements NotifierFactory {
+public class IssueNotifierFactory implements NotifierFactory {
     @Override
     public String name() {
         return "issue";
@@ -15,27 +15,27 @@ public class IssueUpdaterFactory implements NotifierFactory {
     @Override
     public Notifier create(BotConfiguration botConfiguration, JSONObject notifierConfiguration) {
         var issueProject = botConfiguration.issueProject(notifierConfiguration.get("project").asString());
-        var issueUpdaterBuilder = IssueUpdater.newBuilder()
-                .issueProject(issueProject);
+        var builder = IssueNotifier.newBuilder()
+                                   .issueProject(issueProject);
 
         if (notifierConfiguration.contains("reviews")) {
             if (notifierConfiguration.get("reviews").contains("icon")) {
-                issueUpdaterBuilder.reviewIcon(URI.create(notifierConfiguration.get("reviews").get("icon").asString()));
+                builder.reviewIcon(URI.create(notifierConfiguration.get("reviews").get("icon").asString()));
             }
         }
         if (notifierConfiguration.contains("commits")) {
             if (notifierConfiguration.get("commits").contains("icon")) {
-                issueUpdaterBuilder.commitIcon(URI.create(notifierConfiguration.get("commits").get("icon").asString()));
+                builder.commitIcon(URI.create(notifierConfiguration.get("commits").get("icon").asString()));
             }
         }
 
         if (notifierConfiguration.contains("reviewlink")) {
-            issueUpdaterBuilder.reviewLink(notifierConfiguration.get("reviewlink").asBoolean());
+            builder.reviewLink(notifierConfiguration.get("reviewlink").asBoolean());
         }
         if (notifierConfiguration.contains("commitlink")) {
-            issueUpdaterBuilder.commitLink(notifierConfiguration.get("commitlink").asBoolean());
+            builder.commitLink(notifierConfiguration.get("commitlink").asBoolean());
         }
 
-        return issueUpdaterBuilder.build();
+        return builder.build();
     }
 }

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
@@ -20,10 +20,10 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package org.openjdk.skara.bots.notify;
+package org.openjdk.skara.bots.notify.issue;
 
 import org.junit.jupiter.api.*;
-import org.openjdk.skara.bots.notify.issue.IssueUpdater;
+import org.openjdk.skara.bots.notify.*;
 import org.openjdk.skara.json.JSON;
 import org.openjdk.skara.test.*;
 
@@ -35,7 +35,7 @@ import java.util.regex.Pattern;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.openjdk.skara.bots.notify.UpdaterTests.*;
 
-public class IssueUpdaterTests {
+public class IssueNotifierTests {
     @Test
     void testIssueIdempotence(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
@@ -53,7 +53,7 @@ public class IssueUpdaterTests {
 
             var issueProject = credentials.getIssueProject();
             var commitIcon = URI.create("http://www.example.com/commit.png");
-            var updater = IssueUpdater.newBuilder()
+            var updater = IssueNotifier.newBuilder()
                                       .issueProject(issueProject)
                                       .reviewLink(false)
                                       .commitIcon(commitIcon)
@@ -123,7 +123,7 @@ public class IssueUpdaterTests {
 
             var issueProject = credentials.getIssueProject();
             var reviewIcon = URI.create("http://www.example.com/review.png");
-            var updater = IssueUpdater.newBuilder()
+            var updater = IssueNotifier.newBuilder()
                                       .issueProject(issueProject)
                                       .reviewIcon(reviewIcon)
                                       .commitLink(false)
@@ -224,7 +224,7 @@ public class IssueUpdaterTests {
 
             var issueProject = credentials.getIssueProject();
             var reviewIcon = URI.create("http://www.example.com/review.png");
-            var updater = IssueUpdater.newBuilder()
+            var updater = IssueNotifier.newBuilder()
                                       .issueProject(issueProject)
                                       .reviewLink(false)
                                       .reviewIcon(reviewIcon)
@@ -283,7 +283,7 @@ public class IssueUpdaterTests {
 
             var issueProject = credentials.getIssueProject();
             var reviewIcon = URI.create("http://www.example.com/review.png");
-            var updater = IssueUpdater.newBuilder()
+            var updater = IssueNotifier.newBuilder()
                                       .issueProject(issueProject)
                                       .reviewIcon(reviewIcon)
                                       .commitLink(true)


### PR DESCRIPTION
Hi all,

please review this refactoring that renames `IssueUpdater` to `IssueNotifier`.

Testing:
- [x] `make test` passes on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/650/head:pull/650`
`$ git checkout pull/650`
