### PR TITLE
notify: create test utils

### DIFF
--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/TestUtils.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/TestUtils.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.notify;
+
+import org.openjdk.skara.forge.HostedRepository;
+import org.openjdk.skara.storage.StorageBuilder;
+
+public class TestUtils {
+    public static StorageBuilder<UpdatedTag> createTagStorage(HostedRepository repository) {
+        return new StorageBuilder<UpdatedTag>("tags.txt")
+                .remoteRepository(repository, "history", "Duke", "duke@openjdk.java.net", "Updated tags");
+    }
+
+    public static StorageBuilder<UpdatedBranch> createBranchStorage(HostedRepository repository) {
+        return new StorageBuilder<UpdatedBranch>("branches.txt")
+                .remoteRepository(repository, "history", "Duke", "duke@openjdk.java.net", "Updated branches");
+    }
+
+    public static StorageBuilder<PullRequestState> createPullRequestStateStorage(HostedRepository repository) {
+        return new StorageBuilder<PullRequestState>("prissues.txt")
+                .remoteRepository(repository, "history", "Duke", "duke@openjdk.java.net", "Updated prissues");
+    }
+}

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdaterTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdaterTests.java
@@ -35,23 +35,9 @@ import java.util.List;
 import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.openjdk.skara.bots.notify.TestUtils.*;
 
 public class UpdaterTests {
-    public static StorageBuilder<UpdatedTag> createTagStorage(HostedRepository repository) {
-        return new StorageBuilder<UpdatedTag>("tags.txt")
-                .remoteRepository(repository, "history", "Duke", "duke@openjdk.java.net", "Updated tags");
-    }
-
-    public static StorageBuilder<UpdatedBranch> createBranchStorage(HostedRepository repository) {
-        return new StorageBuilder<UpdatedBranch>("branches.txt")
-                .remoteRepository(repository, "history", "Duke", "duke@openjdk.java.net", "Updated branches");
-    }
-
-    public static StorageBuilder<PullRequestState> createPullRequestStateStorage(HostedRepository repository) {
-        return new StorageBuilder<PullRequestState>("prissues.txt")
-                .remoteRepository(repository, "history", "Duke", "duke@openjdk.java.net", "Updated prissues");
-    }
-
     private static class TestRepositoryListener implements Notifier, RepositoryListener {
         private final String name;
         private final boolean idempotent;

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
@@ -33,7 +33,7 @@ import java.util.*;
 import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.openjdk.skara.bots.notify.UpdaterTests.*;
+import static org.openjdk.skara.bots.notify.TestUtils.*;
 
 public class IssueNotifierTests {
     @Test

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/json/JsonNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/json/JsonNotifierTests.java
@@ -35,7 +35,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.openjdk.skara.bots.notify.UpdaterTests.*;
+import static org.openjdk.skara.bots.notify.TestUtils.*;
 
 public class JsonNotifierTests {
     private List<Path> findJsonFiles(Path folder, String partialName) throws IOException {
@@ -104,7 +104,7 @@ public class JsonNotifierTests {
             localRepo.tag(masterHash, "jdk-12+1", "Added tag 1", "Duke", "duke@openjdk.java.net");
             localRepo.pushAll(repo.url());
 
-            var tagStorage = UpdaterTests.createTagStorage(repo);
+            var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
             var prStateStorage = createPullRequestStateStorage(repo);
             var jsonFolder = tempFolder.path().resolve("json");

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/mailinglist/MailingListNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/mailinglist/MailingListNotifierTests.java
@@ -34,7 +34,7 @@ import java.util.*;
 import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.openjdk.skara.bots.notify.UpdaterTests.*;
+import static org.openjdk.skara.bots.notify.TestUtils.*;
 
 public class MailingListNotifierTests {
     @Test


### PR DESCRIPTION
Hi all,

please review this patch that moves some static utility functions out from a unit test and into a proper `TestUtils` class.

Testing:
- [x] `make test` passes on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/652/head:pull/652`
`$ git checkout pull/652`
