### PR TITLE
notify: prefix event handlers with "on*"

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/PullRequestListener.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/PullRequestListener.java
@@ -27,12 +27,12 @@ import org.openjdk.skara.vcs.Hash;
 import org.openjdk.skara.vcs.openjdk.Issue;
 
 public interface PullRequestListener {
-    default void handleNewIssue(PullRequest pr, Issue issue) {
+    default void onNewIssue(PullRequest pr, Issue issue) {
     }
-    default void handleRemovedIssue(PullRequest pr, Issue issue) {
+    default void onRemovedIssue(PullRequest pr, Issue issue) {
     }
-    default void handleNewPullRequest(PullRequest pr) {
+    default void onNewPullRequest(PullRequest pr) {
     }
-    default void handleIntegratedPullRequest(PullRequest pr, Hash hash) {
+    default void onIntegratedPullRequest(PullRequest pr, Hash hash) {
     }
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/PullRequestWorkItem.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/PullRequestWorkItem.java
@@ -157,19 +157,19 @@ public class PullRequestWorkItem implements WorkItem {
     }
 
     private void notifyNewIssue(String issueId) {
-        listeners.forEach(c -> c.handleNewIssue(pr, new Issue(issueId, "")));
+        listeners.forEach(c -> c.onNewIssue(pr, new Issue(issueId, "")));
     }
 
     private void notifyRemovedIssue(String issueId) {
-        listeners.forEach(c -> c.handleRemovedIssue(pr, new Issue(issueId, "")));
+        listeners.forEach(c -> c.onRemovedIssue(pr, new Issue(issueId, "")));
     }
 
     private void notifyNewPr(PullRequest pr) {
-        listeners.forEach(c -> c.handleNewPullRequest(pr));
+        listeners.forEach(c -> c.onNewPullRequest(pr));
     }
 
     private void notifyIntegratedPr(PullRequest pr, Hash hash) {
-        listeners.forEach(c -> c.handleIntegratedPullRequest(pr, hash));
+        listeners.forEach(c -> c.onIntegratedPullRequest(pr, hash));
     }
 
     @Override

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryListener.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryListener.java
@@ -29,13 +29,13 @@ import org.openjdk.skara.vcs.openjdk.OpenJDKTag;
 import java.util.List;
 
 public interface RepositoryListener {
-    default void handleCommits(HostedRepository repository, Repository localRepository, List<Commit> commits, Branch branch) throws NonRetriableException {
+    default void onNewCommits(HostedRepository repository, Repository localRepository, List<Commit> commits, Branch branch) throws NonRetriableException {
     }
-    default void handleOpenJDKTagCommits(HostedRepository repository, Repository localRepository, List<Commit> commits, OpenJDKTag tag, Tag.Annotated annotated) throws NonRetriableException {
+    default void onNewOpenJDKTagCommits(HostedRepository repository, Repository localRepository, List<Commit> commits, OpenJDKTag tag, Tag.Annotated annotated) throws NonRetriableException {
     }
-    default void handleTagCommit(HostedRepository repository, Repository localRepository, Commit commit, Tag tag, Tag.Annotated annotation) throws NonRetriableException {
+    default void onNewTagCommit(HostedRepository repository, Repository localRepository, Commit commit, Tag tag, Tag.Annotated annotation) throws NonRetriableException {
     }
-    default void handleNewBranch(HostedRepository repository, Repository localRepository, List<Commit> commits, Branch parent, Branch branch) throws NonRetriableException {
+    default void onNewBranch(HostedRepository repository, Repository localRepository, List<Commit> commits, Branch parent, Branch branch) throws NonRetriableException {
     }
     String name();
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryWorkItem.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryWorkItem.java
@@ -84,12 +84,12 @@ public class RepositoryWorkItem implements WorkItem {
         }
         var branch = new Branch(ref.name());
         var parent = new Branch(bestParent.getKey().name());
-        listener.handleNewBranch(repository, localRepo, bestParentCommits, parent, branch);
+        listener.onNewBranch(repository, localRepo, bestParentCommits, parent, branch);
     }
 
     private void handleUpdatedRef(Repository localRepo, Reference ref, List<Commit> commits, RepositoryListener listener) throws NonRetriableException {
         var branch = new Branch(ref.name());
-        listener.handleCommits(repository, localRepo, commits, branch);
+        listener.onNewCommits(repository, localRepo, commits, branch);
     }
 
     private List<Throwable> handleRef(Repository localRepo, UpdateHistory history, Reference ref, Collection<Reference> allRefs) throws IOException {
@@ -208,7 +208,7 @@ public class RepositoryWorkItem implements WorkItem {
 
             history.addTags(List.of(tag.tag()), listener.name());
             try {
-                listener.handleOpenJDKTagCommits(repository, localRepo, commits, tag, annotation.orElse(null));
+                listener.onNewOpenJDKTagCommits(repository, localRepo, commits, tag, annotation.orElse(null));
             } catch (NonRetriableException e) {
                 errors.add(e.cause());
             } catch (RuntimeException e) {
@@ -230,7 +230,7 @@ public class RepositoryWorkItem implements WorkItem {
 
             history.addTags(List.of(tag), listener.name());
             try {
-                listener.handleTagCommit(repository, localRepo, commit.get(), tag, annotation.orElse(null));
+                listener.onNewTagCommit(repository, localRepo, commit.get(), tag, annotation.orElse(null));
             } catch (NonRetriableException e) {
                 errors.add(e.cause());
             } catch (RuntimeException e) {

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
@@ -73,7 +73,7 @@ class IssueNotifier implements Notifier, PullRequestListener {
     }
 
     @Override
-    public void handleIntegratedPullRequest(PullRequest pr, Hash hash)  {
+    public void onIntegratedPullRequest(PullRequest pr, Hash hash)  {
         var repository = pr.repository();
         var commit = repository.commitMetadata(hash).orElseThrow(() ->
                 new IllegalStateException("Integrated commit " + hash +
@@ -115,7 +115,7 @@ class IssueNotifier implements Notifier, PullRequestListener {
     }
 
     @Override
-    public void handleNewIssue(PullRequest pr, org.openjdk.skara.vcs.openjdk.Issue issue) {
+    public void onNewIssue(PullRequest pr, org.openjdk.skara.vcs.openjdk.Issue issue) {
         var realIssue = issueProject.issue(issue.shortId());
         if (realIssue.isEmpty()) {
             log.warning("Pull request " + pr + " added unknown issue: " + issue.id());
@@ -135,7 +135,7 @@ class IssueNotifier implements Notifier, PullRequestListener {
     }
 
     @Override
-    public void handleRemovedIssue(PullRequest pr, org.openjdk.skara.vcs.openjdk.Issue issue) {
+    public void onRemovedIssue(PullRequest pr, org.openjdk.skara.vcs.openjdk.Issue issue) {
         var realIssue = issueProject.issue(issue.shortId());
         if (realIssue.isEmpty()) {
             log.warning("Pull request " + pr + " removed unknown issue: " + issue.id());

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/json/JsonNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/json/JsonNotifier.java
@@ -82,7 +82,7 @@ class JsonNotifier implements Notifier, RepositoryListener {
     }
 
     @Override
-    public void handleCommits(HostedRepository repository, Repository localRepository, List<Commit> commits, Branch branch) throws NonRetriableException {
+    public void onNewCommits(HostedRepository repository, Repository localRepository, List<Commit> commits, Branch branch) throws NonRetriableException {
         try (var writer = new JsonWriter(path, repository.name())) {
             for (var commit : commits) {
                 var json = commitToChanges(repository, localRepository, commit, defaultBuild);
@@ -94,7 +94,7 @@ class JsonNotifier implements Notifier, RepositoryListener {
     }
 
     @Override
-    public void handleOpenJDKTagCommits(HostedRepository repository, Repository localRepository, List<Commit> commits, OpenJDKTag tag, Tag.Annotated annotation) throws NonRetriableException {
+    public void onNewOpenJDKTagCommits(HostedRepository repository, Repository localRepository, List<Commit> commits, OpenJDKTag tag, Tag.Annotated annotation) throws NonRetriableException {
         var build = String.format("b%02d", tag.buildNum());
         try (var writer = new JsonWriter(path, repository.name())) {
             var issues = new ArrayList<Issue>();

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/mailinglist/MailingListNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/mailinglist/MailingListNotifier.java
@@ -219,7 +219,7 @@ class MailingListNotifier implements Notifier, RepositoryListener {
     }
 
     @Override
-    public void handleCommits(HostedRepository repository, Repository localRepository, List<Commit> commits, Branch branch) throws NonRetriableException {
+    public void onNewCommits(HostedRepository repository, Repository localRepository, List<Commit> commits, Branch branch) throws NonRetriableException {
         if (mode == Mode.PR) {
             commits = filterPrCommits(repository, localRepository, commits, branch);
         }
@@ -227,12 +227,12 @@ class MailingListNotifier implements Notifier, RepositoryListener {
     }
 
     @Override
-    public void handleOpenJDKTagCommits(HostedRepository repository, Repository localRepository, List<Commit> commits, OpenJDKTag tag, Tag.Annotated annotation) throws NonRetriableException {
+    public void onNewOpenJDKTagCommits(HostedRepository repository, Repository localRepository, List<Commit> commits, OpenJDKTag tag, Tag.Annotated annotation) throws NonRetriableException {
         if (!reportNewTags) {
             return;
         }
         if (!reportNewBuilds) {
-            handleTagCommit(repository, localRepository, commits.get(commits.size() - 1), tag.tag(), annotation);
+            onNewTagCommit(repository, localRepository, commits.get(commits.size() - 1), tag.tag(), annotation);
             return;
         }
         var writer = new StringWriter();
@@ -275,7 +275,7 @@ class MailingListNotifier implements Notifier, RepositoryListener {
     }
 
     @Override
-    public void handleTagCommit(HostedRepository repository, Repository localRepository, Commit commit, Tag tag, Tag.Annotated annotation) throws NonRetriableException {
+    public void onNewTagCommit(HostedRepository repository, Repository localRepository, Commit commit, Tag tag, Tag.Annotated annotation) throws NonRetriableException {
         if (!reportNewTags) {
             return;
         }
@@ -327,7 +327,7 @@ class MailingListNotifier implements Notifier, RepositoryListener {
     }
 
     @Override
-    public void handleNewBranch(HostedRepository repository, Repository localRepository, List<Commit> commits, Branch parent, Branch branch) throws NonRetriableException {
+    public void onNewBranch(HostedRepository repository, Repository localRepository, List<Commit> commits, Branch parent, Branch branch) throws NonRetriableException {
         if (!reportNewBranches) {
             return;
         }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/slack/SlackNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/slack/SlackNotifier.java
@@ -53,7 +53,7 @@ class SlackNotifier implements Notifier, RepositoryListener, PullRequestListener
     }
 
     @Override
-    public void handleNewPullRequest(PullRequest pr) {
+    public void onNewPullRequest(PullRequest pr) {
         if (prWebhook == null) {
             return;
         }
@@ -71,10 +71,10 @@ class SlackNotifier implements Notifier, RepositoryListener, PullRequestListener
     }
 
     @Override
-    public void handleCommits(HostedRepository repository,
-                              Repository localRepository,
-                              List<Commit> commits,
-                              Branch branch) throws NonRetriableException {
+    public void onNewCommits(HostedRepository repository,
+                             Repository localRepository,
+                             List<Commit> commits,
+                             Branch branch) throws NonRetriableException {
         if (commitWebhook == null) {
             return;
         }

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdaterTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdaterTests.java
@@ -50,7 +50,7 @@ public class UpdaterTests {
         }
 
         @Override
-        public void handleCommits(HostedRepository repository, Repository localRepository, List<Commit> commits,
+        public void onNewCommits(HostedRepository repository, Repository localRepository, List<Commit> commits,
                                   Branch branch) throws NonRetriableException {
             updateCount++;
             if (shouldFail) {
@@ -63,19 +63,19 @@ public class UpdaterTests {
         }
 
         @Override
-        public void handleOpenJDKTagCommits(HostedRepository repository, Repository localRepository,
+        public void onNewOpenJDKTagCommits(HostedRepository repository, Repository localRepository,
          List<Commit> commits, OpenJDKTag tag, Tag.Annotated annotated) {
             throw new RuntimeException("unexpected");
         }
 
         @Override
-        public void handleTagCommit(HostedRepository repository, Repository localRepository, Commit commit, Tag tag,
+        public void onNewTagCommit(HostedRepository repository, Repository localRepository, Commit commit, Tag tag,
          Tag.Annotated annotation) {
             throw new RuntimeException("unexpected");
         }
 
         @Override
-        public void handleNewBranch(HostedRepository repository, Repository localRepository, List<Commit> commits,
+        public void onNewBranch(HostedRepository repository, Repository localRepository, List<Commit> commits,
          Branch parent, Branch branch) {
             throw new RuntimeException("unexpected");
         }


### PR DESCRIPTION
Hi all,

please review this refactoring that prefix the event handles in the notify bot with `on` instead of `handle` (I also renamed some handlers for consistency).

Testing:
- [x] `make test` passes on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/653/head:pull/653`
`$ git checkout pull/653`
