### PR TITLE
publish: only exit on error

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitPublish.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitPublish.java
@@ -231,6 +231,9 @@ public class GitPublish {
         } else {
             err = push(remote, branch, isQuiet);
         }
-        System.exit(err);
+
+        if (err != 0) {
+            System.exit(err);
+        }
     }
 }


### PR DESCRIPTION
Hi all,

please review this small patch that ensures that `GitPublish.main` only calls `System.exit` on error. This is needed because `GitPrCreate.main` calls `GitPublish.main`, so `GitPublish.main` cannot unconditionally call `System.exit`.

Testing:
- [x] Manual testing of `git publish`

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/655/head:pull/655`
`$ git checkout pull/655`
