### PR TITLE
storage: cache deserialized values in FileStorage

### DIFF
--- a/storage/src/main/java/org/openjdk/skara/storage/FileStorage.java
+++ b/storage/src/main/java/org/openjdk/skara/storage/FileStorage.java
@@ -29,7 +29,9 @@ import java.util.*;
 
 class FileStorage<T> implements Storage<T> {
     private final Path file;
+    private String old;
     private String current;
+    private Set<T> deserialized;
     private StorageSerializer<T> serializer;
     private StorageDeserializer<T> deserializer;
 
@@ -48,7 +50,11 @@ class FileStorage<T> implements Storage<T> {
                 current = "";
             }
         }
-        return Collections.unmodifiableSet(deserializer.deserialize(current));
+        if (old != current) {
+            deserialized = Collections.unmodifiableSet(deserializer.deserialize(current));
+            old = current;
+        }
+        return deserialized;
     }
 
     @Override


### PR DESCRIPTION
Hi all,

please review this patch that adds caching of the deserialized value to `FileStorage`. There is no point in deserializing the same `String` over and over again, the deserialized value will remain the same.

Testing:
- [x] Added a new unit test
- [x] `make test` passes on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/656/head:pull/656`
`$ git checkout pull/656`
