### PR TITLE
Upgrade the notifier database lazily

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/PullRequestWorkItem.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/PullRequestWorkItem.java
@@ -82,14 +82,7 @@ public class PullRequestWorkItem implements WorkItem {
 
                        // Storage might be missing commit information
                        if (!obj.contains("commit")) {
-                           var prId = id.split(":")[1];
-                           var currentPR = pr.repository().pullRequest(prId);
-                           var hash = resultingCommitHashFor(currentPR);
-                           if (hash == null) {
-                               obj.putNull("commit");
-                           } else {
-                               obj.put("commit", hash.hex());
-                           }
+                           obj.put("commit", Hash.zero().hex());
                        }
 
                        var commit = obj.get("commit").isNull() ?
@@ -116,11 +109,16 @@ public class PullRequestWorkItem implements WorkItem {
                                                              .stream()
                                                              .map(JSON::of)
                                                              .collect(Collectors.toList()));
-                                var commit = pr.commitId().isPresent()?
-                                    JSON.of(pr.commitId().get().hex()) : JSON.of();
-                                return JSON.object().put("pr", pr.prId())
-                                                    .put("issues",issues)
-                                                    .put("commit", commit);
+                                var ret = JSON.object().put("pr", pr.prId())
+                                              .put("issues",issues);
+                                if (pr.commitId().isPresent()) {
+                                    if (!pr.commitId().get().equals(Hash.zero())) {
+                                        ret.put("commit", JSON.of(pr.commitId().get().hex()));
+                                    }
+                                } else {
+                                    ret.putNull("commit");
+                                }
+                                return ret;
                             })
                             .map(JSONObject::toString)
                             .collect(Collectors.toList());
@@ -194,6 +192,12 @@ public class PullRequestWorkItem implements WorkItem {
                 .filter(ss -> ss.prId().equals(state.prId()))
                 .findAny();
         if (storedState.isPresent()) {
+            // The stored entry could be old and be missing commit information - if so, upgrade it
+            if (storedState.get().commitId().isPresent() && storedState.get().commitId().get().equals(Hash.zero())) {
+                var hash = resultingCommitHashFor(pr);
+                storedState = Optional.of(new PullRequestState(pr, issues, hash));
+            }
+
             var storedIssues = storedState.get().issueIds();
             storedIssues.stream()
                         .filter(issue -> !issues.contains(issue))


### PR DESCRIPTION
Hi all,

Please review this change that updates the notifier database for pull requests only for active PRs.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/657/head:pull/657`
`$ git checkout pull/657`
