### PR TITLE
Ensure that the notifier looks at both open and closed PRs

### DIFF
--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
@@ -23,7 +23,8 @@
 package org.openjdk.skara.bots.notify.issue;
 
 import org.junit.jupiter.api.*;
-import org.openjdk.skara.bots.notify.*;
+import org.openjdk.skara.bots.notify.NotifyBot;
+import org.openjdk.skara.issuetracker.Issue;
 import org.openjdk.skara.json.JSON;
 import org.openjdk.skara.test.*;
 
@@ -323,6 +324,7 @@ public class IssueNotifierTests {
             // Simulate integration
             pr.addComment("Pushed as commit " + editHash.hex() + ".");
             pr.addLabel("integrated");
+            pr.setState(Issue.State.CLOSED);
             localRepo.push(editHash, repo.url(), "other");
             TestBotRunner.runPeriodicItems(notifyBot);
 


### PR DESCRIPTION
Hi all,

Please review this small change that ensures that the notifier looks at both open and closed PRs, similar to how the mailing list bridge works.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/659/head:pull/659`
`$ git checkout pull/659`
