### PR TITLE
forge: use commit object in GitHubRepository.commitMetadata

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -292,21 +292,22 @@ public class GitHubRepository implements HostedRepository {
 
     @Override
     public Optional<CommitMetadata> commitMetadata(Hash hash) {
-        var c = request.get("commits/" + hash.hex())
+        var o = request.get("commits/" + hash.hex())
                        .onError(r -> Optional.of(JSON.of()))
                        .execute();
-        if (c.isNull()) {
+        if (o.isNull()) {
             return Optional.empty();
         }
-        var parents = c.get("parents").stream()
+        var parents = o.get("parents").stream()
                                       .map(p -> new Hash(p.get("sha").asString()))
                                       .collect(Collectors.toList());
-        var author = new Author(c.get("author").get("name").asString(),
-                                c.get("author").get("email").asString());
-        var committer = new Author(c.get("committer").get("name").asString(),
-                                   c.get("committer").get("email").asString());
-        var date = ZonedDateTime.parse(c.get("author").get("date").asString());
-        var message = Arrays.asList(c.get("message").asString().split("\n"));
+        var commit = o.get("commit").asObject();
+        var author = new Author(commit.get("author").get("name").asString(),
+                                commit.get("author").get("email").asString());
+        var committer = new Author(commit.get("committer").get("name").asString(),
+                                   commit.get("committer").get("email").asString());
+        var date = ZonedDateTime.parse(commit.get("author").get("date").asString());
+        var message = Arrays.asList(commit.get("message").asString().split("\n"));
         return Optional.of(new CommitMetadata(hash, parents, author, committer, date, message));
     }
 }


### PR DESCRIPTION
Hi all,

please review this patch that properly parses the JSON reply from the `/commits` endpoint on GitHub.

Testing:
- [ ] None, but this time I'm sure I got it right :smile: 

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/661/head:pull/661`
`$ git checkout pull/661`
