### PR TITLE
416: Expose committer date in CommitMetadata

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
@@ -72,7 +72,7 @@ class ReviewArchive {
 
     private boolean hasLegacyIntegrationNotice(Repository localRepo, Commit commit) {
         // Commits before this date are assumed to have been serviced by the old PR notifier
-        return commit.date().isBefore(ZonedDateTime.of(2020, 4, 28, 14, 0, 0, 0, ZoneId.of("UTC")));
+        return commit.authored().isBefore(ZonedDateTime.of(2020, 4, 28, 14, 0, 0, 0, ZoneId.of("UTC")));
     }
 
     private List<ArchiveItem> generateArchiveItems(List<Email> sentEmails, Repository localRepo, URI issueTracker, String issuePrefix, HostUserToEmailAuthor hostUserToEmailAuthor, HostUserToUserName hostUserToUserName, HostUserToRole hostUserToRole, WebrevStorage.WebrevGenerator webrevGenerator, WebrevNotification webrevNotification, String subjectPrefix) throws IOException {

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/CommitFormatters.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/CommitFormatters.java
@@ -38,7 +38,7 @@ public class CommitFormatters {
         if (!commit.author().equals(commit.committer())) {
             printer.println("Committer: " + commit.committer().name() + " <" + commit.committer().email() + ">");
         }
-        printer.println("Date:      " + commit.date().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss +0000")));
+        printer.println("Date:      " + commit.authored().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss +0000")));
         printer.println("URL:       " + repository.webUrl(commit.hash()));
 
         return writer.toString();

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/json/JsonNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/json/JsonNotifier.java
@@ -56,7 +56,7 @@ class JsonNotifier implements Notifier, RepositoryListener {
         }
         ret.put("issue", issueIds);
         ret.put("user", commit.author().name());
-        ret.put("date", commit.date().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss +0000")));
+        ret.put("date", commit.authored().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss +0000")));
 
         return ret;
     }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/slack/SlackNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/slack/SlackNotifier.java
@@ -89,7 +89,7 @@ class SlackNotifier implements Notifier, RepositoryListener, PullRequestListener
                 query.put("text", branch.name() + ": " + commit.hash().abbreviate() + ": " + title + "\n" +
                                   "Author: " + commit.author().name() + "\n" +
                                   "Committer: " + commit.author().name() + "\n" +
-                                  "Date: " + commit.date().format(DateTimeFormatter.RFC_1123_DATE_TIME) + "\n");
+                                  "Date: " + commit.authored().format(DateTimeFormatter.RFC_1123_DATE_TIME) + "\n");
 
                 var attachment = JSON.object();
                 attachment.put("fallback", "Link to commit");

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -304,10 +304,11 @@ public class GitHubRepository implements HostedRepository {
         var commit = o.get("commit").asObject();
         var author = new Author(commit.get("author").get("name").asString(),
                                 commit.get("author").get("email").asString());
+        var authored = ZonedDateTime.parse(commit.get("author").get("date").asString());
         var committer = new Author(commit.get("committer").get("name").asString(),
                                    commit.get("committer").get("email").asString());
-        var date = ZonedDateTime.parse(commit.get("author").get("date").asString());
+        var committed = ZonedDateTime.parse(commit.get("committer").get("date").asString());
         var message = Arrays.asList(commit.get("message").asString().split("\n"));
-        return Optional.of(new CommitMetadata(hash, parents, author, committer, date, message));
+        return Optional.of(new CommitMetadata(hash, parents, author, authored, committer, committed, message));
     }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -337,10 +337,11 @@ public class GitLabRepository implements HostedRepository {
                                       .collect(Collectors.toList());
         var author = new Author(c.get("author_name").asString(),
                                 c.get("author_email").asString());
+        var authored = ZonedDateTime.parse(c.get("authored_date").asString());
         var committer = new Author(c.get("committer_name").asString(),
                                    c.get("committer_email").asString());
-        var date = ZonedDateTime.parse(c.get("authored_date").asString());
+        var committed = ZonedDateTime.parse(c.get("comitted_date").asString());
         var message = Arrays.asList(c.get("message").asString().split("\n"));
-        return Optional.of(new CommitMetadata(hash, parents, author, committer, date, message));
+        return Optional.of(new CommitMetadata(hash, parents, author, authored, committer, committed, message));
     }
 }

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/AuthorCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/AuthorCheckTests.java
@@ -43,11 +43,12 @@ class AuthorCheckTests {
 
     private static Commit commit(Author author) {
         var committer = new Author("Foo", "foo@bar.org");
+        var committed = ZonedDateTime.now();
         var hash = new Hash("0123456789012345678901234567890123456789");
         var parents = List.of(new Hash("12345789012345789012345678901234567890"));
-        var date = ZonedDateTime.now();
+        var authored = ZonedDateTime.now();
         var message = List.of("Initial commit");
-        var metadata = new CommitMetadata(hash, parents, author, committer, date, message);
+        var metadata = new CommitMetadata(hash, parents, author, authored, committer, committed, message);
         return new Commit(metadata, List.of());
     }
 

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/BinaryCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/BinaryCheckTests.java
@@ -59,8 +59,8 @@ class BinaryCheckTests {
         var hash = new Hash("0123456789012345678901234567890123456789");
         var parents = List.of(hash, hash);
         var message = List.of("A commit");
-        var date = ZonedDateTime.now();
-        var metadata = new CommitMetadata(hash, parents, author, author, date, message);
+        var authored = ZonedDateTime.now();
+        var metadata = new CommitMetadata(hash, parents, author, authored, author, authored, message);
         return new Commit(metadata, parentDiffs);
     }
 

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/BlacklistCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/BlacklistCheckTests.java
@@ -42,11 +42,10 @@ class BlacklistCheckTests {
 
     private static Commit commit(Hash hash) {
         var author = new Author("Foo", "foo@bar.org");
-        var committer = author;
         var parents = List.of(new Hash("12345789012345789012345678901234567890"));
-        var date = ZonedDateTime.now();
+        var authored = ZonedDateTime.now();
         var message = List.of("Initial commit");
-        var metadata = new CommitMetadata(hash, parents, author, committer, date, message);
+        var metadata = new CommitMetadata(hash, parents, author, authored, author, authored, message);
         return new Commit(metadata, List.of());
     }
 

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/CommitterCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/CommitterCheckTests.java
@@ -80,7 +80,7 @@ class CommitterCheckTests {
         var parents = List.of(hash, hash);
         var date = ZonedDateTime.now();
         var message = List.of("Merge");
-        var metadata = new CommitMetadata(hash, parents, author, committer, date, message);
+        var metadata = new CommitMetadata(hash, parents, author, date, committer, date, message);
         return new Commit(metadata, List.of());
     }
 
@@ -89,7 +89,7 @@ class CommitterCheckTests {
         var parents = List.of(new Hash("12345789012345789012345678901234567890"));
         var date = ZonedDateTime.now();
         var message = List.of("Initial commit");
-        var metadata = new CommitMetadata(hash, parents, author, committer, date, message);
+        var metadata = new CommitMetadata(hash, parents, author, date, committer, date, message);
         return new Commit(metadata, List.of());
     }
 

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/ExecutableCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/ExecutableCheckTests.java
@@ -60,8 +60,8 @@ class ExecutableCheckTests {
         var hash = new Hash("0123456789012345678901234567890123456789");
         var parents = List.of(hash, hash);
         var message = List.of("A commit");
-        var date = ZonedDateTime.now();
-        var metadata = new CommitMetadata(hash, parents, author, author, date, message);
+        var authored = ZonedDateTime.now();
+        var metadata = new CommitMetadata(hash, parents, author, authored, author, authored, message);
         return new Commit(metadata, parentDiffs);
     }
 

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/HgTagCommitCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/HgTagCommitCheckTests.java
@@ -60,8 +60,8 @@ class HgTagCommitCheckTests {
     private static Commit commit(Hash hash, List<String> message, List<Diff> parentDiffs) {
         var author = new Author("Foo Bar", "foo@bar.org");
         var parents = List.of(new Hash("12345789012345789012345678901234567890"));
-        var date = ZonedDateTime.now();
-        var metadata = new CommitMetadata(hash, parents, author, author, date, message);
+        var authored = ZonedDateTime.now();
+        var metadata = new CommitMetadata(hash, parents, author, authored, author, authored, message);
         return new Commit(metadata, parentDiffs);
     }
 
@@ -70,8 +70,8 @@ class HgTagCommitCheckTests {
         var parents = List.of(new Hash("12345789012345789012345678901234567890"),
                               new Hash("12345789012345789012345678901234567890"));
         var message = List.of("Merge");
-        var date = ZonedDateTime.now();
-        var metadata = new CommitMetadata(Hash.zero(), parents, author, author, date, message);
+        var authored = ZonedDateTime.now();
+        var metadata = new CommitMetadata(Hash.zero(), parents, author, authored, author, authored, message);
         return new Commit(metadata, List.of());
     }
 

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/IssuesCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/IssuesCheckTests.java
@@ -81,8 +81,8 @@ class IssuesCheckTests {
         var author = new Author("foo", "foo@host.org");
         var hash = new Hash("0123456789012345678901234567890123456789");
         var parents = List.of(hash);
-        var date = ZonedDateTime.now();
-        var metadata = new CommitMetadata(hash, parents, author, author, date, message);
+        var authored = ZonedDateTime.now();
+        var metadata = new CommitMetadata(hash, parents, author, authored, author, authored, message);
         return new Commit(metadata, List.of());
     }
 

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/MergeMessageCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/MergeMessageCheckTests.java
@@ -56,8 +56,8 @@ class MergeMessageCheckTests {
         var author = new Author("foo", "foo@host.org");
         var hash = new Hash("0123456789012345678901234567890123456789");
         var parents = List.of(hash, hash);
-        var date = ZonedDateTime.now();
-        var metadata = new CommitMetadata(hash, parents, author, author, date, message);
+        var authored = ZonedDateTime.now();
+        var metadata = new CommitMetadata(hash, parents, author, authored, author, authored, message);
         return new Commit(metadata, List.of());
     }
 

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/MessageCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/MessageCheckTests.java
@@ -56,8 +56,8 @@ class MessageCheckTests {
         var author = new Author("foo", "foo@host.org");
         var hash = new Hash("0123456789012345678901234567890123456789");
         var parents = List.of(hash);
-        var date = ZonedDateTime.now();
-        var metadata = new CommitMetadata(hash, parents, author, author, date, message);
+        var authored = ZonedDateTime.now();
+        var metadata = new CommitMetadata(hash, parents, author, authored, author, authored, message);
         return new Commit(metadata, List.of());
     }
 

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/ProblemListsCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/ProblemListsCheckTests.java
@@ -152,8 +152,8 @@ class ProblemListsCheckTests {
         var author = new Author("foo", "foo@host.org");
         var hash = new Hash(("" + id).repeat(40));
         var parents = List.of(Hash.zero());
-        var date = ZonedDateTime.now();
-        var metadata = new CommitMetadata(hash, parents, author, author, date, List.of(message));
+        var authored = ZonedDateTime.now();
+        var metadata = new CommitMetadata(hash, parents, author, authored, author, authored, List.of(message));
         return new Commit(metadata, List.of());
     }
 

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/ReviewersCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/ReviewersCheckTests.java
@@ -101,13 +101,13 @@ class ReviewersCheckTests {
     private static Commit commit(Author author, List<String> reviewers) {
         var hash = new Hash("0123456789012345678901234567890123456789");
         var parents = List.of(new Hash("12345789012345789012345678901234567890"));
-        var date = ZonedDateTime.now();
+        var authored = ZonedDateTime.now();
         var message = new ArrayList<String>();
         message.addAll(List.of("Initial commit"));
         if (!reviewers.isEmpty()) {
             message.addAll(List.of("", "Reviewed-by: " + String.join(", ", reviewers)));
         }
-        var metadata = new CommitMetadata(hash, parents, author, author, date, message);
+        var metadata = new CommitMetadata(hash, parents, author, authored, author, authored, message);
         return new Commit(metadata, List.of());
     }
 

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/SymlinkCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/SymlinkCheckTests.java
@@ -71,8 +71,8 @@ class SymlinkCheckTests {
         var author = new Author("foo", "foo@localhost");
         var hash = new Hash("0123456789012345678901234567890123456789");
         var parents = List.of(hash);
-        var date = ZonedDateTime.now();
-        var metadata = new CommitMetadata(hash, parents, author, author, date, List.of("Added symlink"));
+        var authored = ZonedDateTime.now();
+        var metadata = new CommitMetadata(hash, parents, author, authored, author, authored, List.of("Added symlink"));
         return new Commit(metadata, diffs);
     }
 

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/WhitespaceCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/WhitespaceCheckTests.java
@@ -66,9 +66,9 @@ class WhitespaceCheckTests {
         var author = new Author("Foo Bar", "foo@bar.org");
         var hash = new Hash("0123456789012345678901234567890123456789");
         var parents = List.of(new Hash("12345789012345789012345678901234567890"));
-        var date = ZonedDateTime.now();
+        var authored = ZonedDateTime.now();
         var message = List.of("Initial commit", "", "Reviewed-by: baz");
-        var metadata = new CommitMetadata(hash, parents, author, author, date, message);
+        var metadata = new CommitMetadata(hash, parents, author, authored, author, authored, message);
         return new Commit(metadata, parentDiffs);
     }
 

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Commit.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Commit.java
@@ -63,8 +63,12 @@ public class Commit {
         return metadata.isInitialCommit();
     }
 
-    public ZonedDateTime date() {
-        return metadata.date();
+    public ZonedDateTime authored() {
+        return metadata.authored();
+    }
+
+    public ZonedDateTime committed() {
+        return metadata.committed();
     }
 
     public boolean isMerge() {

--- a/vcs/src/main/java/org/openjdk/skara/vcs/CommitMetadata.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/CommitMetadata.java
@@ -30,18 +30,21 @@ public class CommitMetadata {
     private final Hash hash;
     private final List<Hash> parents;
     private final Author author;
+    private final ZonedDateTime authored;
     private final Author committer;
-    private final ZonedDateTime date;
+    private final ZonedDateTime committed;
     private final List<String> message;
 
     public CommitMetadata(Hash hash, List<Hash> parents,
-                          Author author, Author committer,
-                          ZonedDateTime date, List<String> message) {
+                          Author author, ZonedDateTime authored,
+                          Author committer, ZonedDateTime committed,
+                          List<String> message) {
         this.hash = hash;
         this.parents = parents;
         this.author = author;
+        this.authored = authored;
         this.committer = committer;
-        this.date = date;
+        this.committed = committed;
         this.message = message;
     }
 
@@ -65,8 +68,12 @@ public class CommitMetadata {
         return parents;
     }
 
-    public ZonedDateTime date() {
-        return date;
+    public ZonedDateTime authored() {
+        return authored;
+    }
+
+    public ZonedDateTime committed() {
+        return committed;
     }
 
     public boolean isInitialCommit() {
@@ -84,14 +91,14 @@ public class CommitMetadata {
     @Override
     public String toString() {
         final var formatter = DateTimeFormatter.RFC_1123_DATE_TIME;
-        final var displayDate = date.format(formatter);
+        final var displayDate = authored.format(formatter);
         return String.format("%s  %-12s  %s  %s",
                              hash().toString(), author(), displayDate, message.get(0));
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(hash, parents, author, committer, date, message);
+        return Objects.hash(hash, parents, author, authored, committer, committed, message);
     }
 
     @Override
@@ -104,8 +111,9 @@ public class CommitMetadata {
         return Objects.equals(hash, other.hash) &&
                Objects.equals(parents, other.parents) &&
                Objects.equals(author, other.author) &&
+               Objects.equals(authored, other.authored) &&
                Objects.equals(committer, other.committer) &&
-               Objects.equals(date, other.date) &&
+               Objects.equals(committed, other.committed) &&
                Objects.equals(message, other.message);
     }
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitCommitMetadata.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitCommitMetadata.java
@@ -39,9 +39,10 @@ class GitCommitMetadata {
     private static final String parentsFormat = "%P";
     private static final String authorNameFormat = "%an";
     private static final String authorEmailFormat = "%ae";
+    private static final String authorDateFormat = "%aI";
     private static final String committerNameFormat = "%cn";
     private static final String committerEmailFormat = "%ce";
-    private static final String timestampFormat = "%aI";
+    private static final String committerDateFormat = "%cI";
 
     private static final String messageDelimiter = "=@=@=@=@=@";
     private static final String messageFormat = "%B" + messageDelimiter;
@@ -51,9 +52,10 @@ class GitCommitMetadata {
                                                     parentsFormat,
                                                     authorNameFormat,
                                                     authorEmailFormat,
+                                                    authorDateFormat,
                                                     committerNameFormat,
                                                     committerEmailFormat,
-                                                    timestampFormat,
+                                                    committerDateFormat,
                                                     messageFormat);
 
     public static CommitMetadata read(UnixStreamReader reader) throws IOException {
@@ -69,20 +71,24 @@ class GitCommitMetadata {
             parents.add(new Hash(parentHash));
         }
 
+        var dateFormatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+
         var authorName = reader.readLine();
         log.finer("authorName: " + authorName);
         var authorEmail = reader.readLine();
         log.finer("authorEmail: " + authorEmail);
         var author = new Author(authorName, authorEmail);
+        var authored = ZonedDateTime.parse(reader.readLine(), dateFormatter);
+        log.finer("authorDate: " + authored);
 
         var committerName = reader.readLine();
         log.finer("committerName: " + committerName);
         var committerEmail = reader.readLine();
         log.finer("committerEmail " + committerName);
         var committer = new Author(committerName, committerEmail);
+        var committed = ZonedDateTime.parse(reader.readLine(), dateFormatter);
+        log.finer("committerDate: " + committed);
 
-        var formatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
-        var date = ZonedDateTime.parse(reader.readLine(), formatter);
 
         var message = new ArrayList<String>();
         var line = reader.readLine();
@@ -96,6 +102,6 @@ class GitCommitMetadata {
             message.add(prefix);
         }
 
-        return new CommitMetadata(hash, parents, author, committer, date, message);
+        return new CommitMetadata(hash, parents, author, authored, committer, committed, message);
     }
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgCommitMetadata.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgCommitMetadata.java
@@ -47,7 +47,7 @@ class HgCommitMetadata {
         var author = Author.fromString(reader.readLine());
 
         var formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd H:m:sZ");
-        var date = ZonedDateTime.parse(reader.readLine(), formatter);
+        var authored = ZonedDateTime.parse(reader.readLine(), formatter);
 
         var messageSize = Integer.parseInt(reader.readLine());
         var messageBuffer = reader.read(messageSize);
@@ -64,6 +64,6 @@ class HgCommitMetadata {
             }
         }
 
-        return new CommitMetadata(hash, parents, author, author, date, message);
+        return new CommitMetadata(hash, parents, author, authored, author, authored, message);
     }
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -1326,7 +1326,7 @@ public class HgRepository implements Repository {
                     var hash = resolve(rev).orElseThrow(IOException::new);
                     var commit = lookup(hash).orElseThrow(IOException::new);
                     var message = String.join("\n", commit.message()) + "\n";
-                    return Optional.of(new Tag.Annotated(tagName, target, commit.author(), commit.date(), message));
+                    return Optional.of(new Tag.Annotated(tagName, target, commit.author(), commit.authored(), message));
                 }
             }
         }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/convert/GitToHgConverter.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/convert/GitToHgConverter.java
@@ -221,14 +221,14 @@ public class GitToHgConverter implements Converter {
             if (parents.size() == 1 && patches0.isEmpty()) {
                 var tmp = Files.createFile(hgRoot.resolve("THIS_IS_A_REALLY_UNIQUE_FILE_NAME_THAT_CANT_POSSIBLY_BE_USED"));
                 hgRepo.add(tmp);
-                hgRepo.commit(hgMessage, hgAuthor, null, commit.date());
+                hgRepo.commit(hgMessage, hgAuthor, null, commit.authored());
                 hgRepo.remove(tmp);
                 hgHash = hgRepo.amend(hgMessage, hgAuthor, null);
             } else {
                 hgHash = hgRepo.commit(hgMessage,
                                        hgAuthor,
                                        null,
-                                       commit.date());
+                                       commit.authored());
             }
             log.fine("Converted hg hash: " + hgHash.hex());
             gitToHg.put(commit.hash(), hgHash);

--- a/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/convert/HgToGitConverter.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/convert/HgToGitConverter.java
@@ -508,8 +508,8 @@ public class HgToGitConverter implements Converter {
                 pipe.print(" <");
                 pipe.print(author.email());
                 pipe.print("> ");
-                var epoch = commit.date().toEpochSecond();
-                var offset = commit.date().format(DateTimeFormatter.ofPattern("xx"));
+                var epoch = commit.authored().toEpochSecond();
+                var offset = commit.authored().format(DateTimeFormatter.ofPattern("xx"));
                 pipe.print(epoch);
                 pipe.print(" ");
                 pipe.println(offset);

--- a/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
@@ -2299,4 +2299,28 @@ public class RepositoryTests {
             assertThrows(IOException.class, () -> Repository.get(dir.path()));
         }
     }
+
+    @Test
+    void testCommitterDate() throws IOException {
+        try (var dir = new TemporaryDirectory()) {
+            var repo = Repository.init(dir.path(), VCS.GIT);
+            var readme = dir.path().resolve("README");
+            Files.write(readme, List.of("Hello, readme!"));
+
+            repo.add(readme);
+            var authored = ZonedDateTime.parse("2020-06-15T14:27:13+02:00");
+            var committed = authored.plusMinutes(10);
+            var head = repo.commit("Add README",
+                                   "author", "author@openjdk.java.net", authored,
+                                   "committer", "committer@openjdk.java.net", committed);
+            var commit = repo.lookup(head).orElseThrow();
+            assertEquals("author", commit.author().name());
+            assertEquals("author@openjdk.java.net", commit.author().email());
+            assertEquals(authored, commit.authored());
+
+            assertEquals("committer", commit.committer().name());
+            assertEquals("committer@openjdk.java.net", commit.committer().email());
+            assertEquals(committed, commit.committed());
+        }
+    }
 }

--- a/vcs/src/test/java/org/openjdk/skara/vcs/openjdk/converter/GitToHgConverterTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/openjdk/converter/GitToHgConverterTests.java
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class GitToHgConverterTests {
     void assertCommitEquals(Commit gitCommit, Commit hgCommit) {
-        assertEquals(gitCommit.date(), hgCommit.date());
+        assertEquals(gitCommit.authored(), hgCommit.authored());
         assertEquals(gitCommit.isInitialCommit(), hgCommit.isInitialCommit());
         assertEquals(gitCommit.isMerge(), hgCommit.isMerge());
         assertEquals(gitCommit.numParents(), hgCommit.numParents());

--- a/vcs/src/test/java/org/openjdk/skara/vcs/openjdk/converter/HgToGitConverterTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/openjdk/converter/HgToGitConverterTests.java
@@ -64,7 +64,7 @@ class HgToGitConverterTests {
             assertEquals(gitCommit.author(), new Author("Foo Bar", "foo@openjdk.java.net"));
             assertEquals(gitCommit.committer(), new Author("Foo Bar", "foo@openjdk.java.net"));
             assertEquals(hgCommit.message(), gitCommit.message());
-            assertEquals(hgCommit.date(), gitCommit.date());
+            assertEquals(hgCommit.authored(), gitCommit.authored());
             assertEquals(hgCommit.isInitialCommit(), gitCommit.isInitialCommit());
             assertEquals(hgCommit.isMerge(), gitCommit.isMerge());
             assertEquals(hgCommit.numParents(), gitCommit.numParents());


### PR DESCRIPTION
Hi all,

please review this patch that removes the `date()` method in `CommitMetadata` and adds `authored()` and `committed()`. For Mercurial commits `authored()` will equal `committed()` since Mercurial does not support different author and committer dates.

Testing:
- [x] `make test` passes on Linux x64
- [x] Added a new unit test

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-416](https://bugs.openjdk.java.net/browse/SKARA-416): Expose committer date in CommitMetadata


### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/664/head:pull/664`
`$ git checkout pull/664`
