### PR TITLE
427: Allow bridging PR updates to multiple recipients

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBot.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBot.java
@@ -40,7 +40,7 @@ public class MailingListBridgeBot implements Bot {
     private final String archiveRef;
     private final HostedRepository censusRepo;
     private final String censusRef;
-    private final EmailAddress listAddress;
+    private final List<MailingListConfiguration> lists;
     private final Set<String> ignoredUsers;
     private final Set<Pattern> ignoredComments;
     private final URI listArchive;
@@ -64,7 +64,7 @@ public class MailingListBridgeBot implements Bot {
     private ZonedDateTime lastFullUpdate;
 
     MailingListBridgeBot(EmailAddress from, HostedRepository repo, HostedRepository archive, String archiveRef,
-                         HostedRepository censusRepo, String censusRef, EmailAddress list,
+                         HostedRepository censusRepo, String censusRef, List<MailingListConfiguration> lists,
                          Set<String> ignoredUsers, Set<Pattern> ignoredComments, URI listArchive, String smtpServer,
                          HostedRepository webrevStorageRepository, String webrevStorageRef,
                          Path webrevStorageBase, URI webrevStorageBaseUri, Set<String> readyLabels,
@@ -77,7 +77,7 @@ public class MailingListBridgeBot implements Bot {
         this.archiveRef = archiveRef;
         this.censusRepo = censusRepo;
         this.censusRef = censusRef;
-        listAddress = list;
+        this.lists = lists;
         this.ignoredUsers = ignoredUsers;
         this.ignoredComments = ignoredComments;
         this.listArchive = listArchive;
@@ -126,8 +126,8 @@ public class MailingListBridgeBot implements Bot {
         return emailAddress;
     }
 
-    EmailAddress listAddress() {
-        return listAddress;
+    List<MailingListConfiguration> lists() {
+        return lists;
     }
 
     Duration sendInterval() {

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotBuilder.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotBuilder.java
@@ -38,7 +38,7 @@ public class MailingListBridgeBotBuilder {
     private String archiveRef = "master";
     private HostedRepository censusRepo;
     private String censusRef = "master";
-    private EmailAddress list;
+    private List<MailingListConfiguration> lists;
     private Set<String> ignoredUsers = Set.of();
     private Set<Pattern> ignoredComments = Set.of();
     private URI listArchive;
@@ -90,8 +90,8 @@ public class MailingListBridgeBotBuilder {
         return this;
     }
 
-    public MailingListBridgeBotBuilder list(EmailAddress list) {
-        this.list = list;
+    public MailingListBridgeBotBuilder lists(List<MailingListConfiguration> lists) {
+        this.lists = lists;
         return this;
     }
 
@@ -181,7 +181,7 @@ public class MailingListBridgeBotBuilder {
     }
 
     public MailingListBridgeBot build() {
-        return new MailingListBridgeBot(from, repo, archive, archiveRef, censusRepo, censusRef, list,
+        return new MailingListBridgeBot(from, repo, archive, archiveRef, censusRepo, censusRef, lists,
                                         ignoredUsers, ignoredComments, listArchive, smtpServer,
                                         webrevStorageRepository, webrevStorageRef, webrevStorageBase, webrevStorageBaseUri,
                                         readyLabels, readyComments, issueTracker, headers, sendInterval, cooldown,

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListConfiguration.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListConfiguration.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.mlbridge;
+
+import org.openjdk.skara.email.EmailAddress;
+
+import java.util.*;
+
+class MailingListConfiguration {
+    private EmailAddress list;
+    private Set<String> labels;
+
+    MailingListConfiguration(EmailAddress list, Set<String> labels) {
+        this.list = list;
+        this.labels = labels;
+    }
+
+    EmailAddress list() {
+        return list;
+    }
+
+    Set<String> labels() {
+        return labels;
+    }
+}

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBotTests.java
@@ -38,11 +38,11 @@ import java.util.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 class MailingListArchiveReaderBotTests {
-    private void addReply(Conversation conversation, MailingList mailingList, PullRequest pr, String reply) {
+    private void addReply(Conversation conversation, EmailAddress recipient, MailingList mailingList, PullRequest pr, String reply) {
         var first = conversation.first();
         var references = first.id().toString();
         var email = Email.create(EmailAddress.from("Commenter", "c@test.test"), "Re: RFR: " + pr.title(), reply)
-                         .recipient(first.author())
+                         .recipient(recipient)
                          .id(EmailAddress.from(UUID.randomUUID() + "@id.id"))
                          .header("In-Reply-To", first.id().toString())
                          .header("References", references)
@@ -50,8 +50,8 @@ class MailingListArchiveReaderBotTests {
         mailingList.post(email);
     }
 
-    private void addReply(Conversation conversation, MailingList mailingList, PullRequest pr) {
-        addReply(conversation, mailingList, pr, "Looks good");
+    private void addReply(Conversation conversation, EmailAddress recipient, MailingList mailingList, PullRequest pr) {
+        addReply(conversation, recipient, mailingList, pr, "Looks good");
     }
 
     @Test
@@ -72,7 +72,7 @@ class MailingListArchiveReaderBotTests {
                                             .repo(author)
                                             .archive(archive)
                                             .censusRepo(censusBuilder.build())
-                                            .list(listAddress)
+                                            .lists(List.of(new MailingListConfiguration(listAddress, Set.of())))
                                             .ignoredUsers(Set.of(ignored.forge().currentUser().userName()))
                                             .listArchive(listServer.getArchive())
                                             .smtpServer(listServer.getSMTP())
@@ -113,7 +113,7 @@ class MailingListArchiveReaderBotTests {
             // Post a reply directly to the list
             var conversations = mailmanList.conversations(Duration.ofDays(1));
             assertEquals(1, conversations.size());
-            addReply(conversations.get(0), mailmanList, pr);
+            addReply(conversations.get(0), listAddress, mailmanList, pr);
             listServer.processIncoming();
 
             // Another archive reader pass - has to be done twice
@@ -147,7 +147,7 @@ class MailingListArchiveReaderBotTests {
                                             .repo(author)
                                             .archive(archive)
                                             .censusRepo(censusBuilder.build())
-                                            .list(listAddress)
+                                            .lists(List.of(new MailingListConfiguration(listAddress, Set.of())))
                                             .ignoredUsers(Set.of(ignored.forge().currentUser().userName()))
                                             .listArchive(listServer.getArchive())
                                             .smtpServer(listServer.getSMTP())
@@ -185,7 +185,7 @@ class MailingListArchiveReaderBotTests {
             // Post a reply directly to the list
             var conversations = mailmanList.conversations(Duration.ofDays(1));
             assertEquals(1, conversations.size());
-            addReply(conversations.get(0), mailmanList, pr);
+            addReply(conversations.get(0), listAddress, mailmanList, pr);
             listServer.processIncoming();
 
             // Another archive reader pass - has to be done twice
@@ -224,7 +224,7 @@ class MailingListArchiveReaderBotTests {
                                             .repo(author)
                                             .archive(archive)
                                             .censusRepo(censusBuilder.build())
-                                            .list(listAddress)
+                                            .lists(List.of(new MailingListConfiguration(listAddress, Set.of())))
                                             .ignoredUsers(Set.of(ignored.forge().currentUser().userName()))
                                             .listArchive(listServer.getArchive())
                                             .smtpServer(listServer.getSMTP())
@@ -267,7 +267,7 @@ class MailingListArchiveReaderBotTests {
             assertEquals(1, conversations.size());
 
             var replyBody = "This line is about 30 bytes long\n".repeat(1000 * 10);
-            addReply(conversations.get(0), mailmanList, pr, replyBody);
+            addReply(conversations.get(0), listAddress, mailmanList, pr, replyBody);
             listServer.processIncoming();
 
             // Another archive reader pass - has to be done twice

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -122,7 +122,7 @@ class MailingListBridgeBotTests {
                                             .repo(author)
                                             .archive(archive)
                                             .censusRepo(censusBuilder.build())
-                                            .list(listAddress)
+                                            .lists(List.of(new MailingListConfiguration(listAddress, Set.of())))
                                             .ignoredUsers(Set.of(ignored.forge().currentUser().userName()))
                                             .ignoredComments(Set.of())
                                             .listArchive(listServer.getArchive())
@@ -290,7 +290,7 @@ class MailingListBridgeBotTests {
                                             .repo(author)
                                             .archive(archive)
                                             .censusRepo(censusBuilder.build())
-                                            .list(listAddress)
+                                            .lists(List.of(new MailingListConfiguration(listAddress, Set.of())))
                                             .ignoredUsers(Set.of(ignored.forge().currentUser().userName()))
                                             .listArchive(listServer.getArchive())
                                             .smtpServer(listServer.getSMTP())
@@ -356,20 +356,20 @@ class MailingListBridgeBotTests {
                     .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
             var mlBot = MailingListBridgeBot.newBuilder()
-                    .from(from)
-                    .repo(author)
-                    .archive(archive)
-                    .censusRepo(censusBuilder.build())
-                    .list(listAddress)
-                    .ignoredUsers(Set.of(ignored.forge().currentUser().userName()))
-                    .listArchive(listServer.getArchive())
-                    .smtpServer(listServer.getSMTP())
-                    .webrevStorageRepository(archive)
-                    .webrevStorageRef("webrev")
-                    .webrevStorageBase(Path.of("test"))
-                    .webrevStorageBaseUri(webrevServer.uri())
-                    .issueTracker(URIBuilder.base("http://issues.test/browse/").build())
-                    .build();
+                                            .from(from)
+                                            .repo(author)
+                                            .archive(archive)
+                                            .censusRepo(censusBuilder.build())
+                                            .lists(List.of(new MailingListConfiguration(listAddress, Set.of())))
+                                            .ignoredUsers(Set.of(ignored.forge().currentUser().userName()))
+                                            .listArchive(listServer.getArchive())
+                                            .smtpServer(listServer.getSMTP())
+                                            .webrevStorageRepository(archive)
+                                            .webrevStorageRef("webrev")
+                                            .webrevStorageBase(Path.of("test"))
+                                            .webrevStorageBaseUri(webrevServer.uri())
+                                            .issueTracker(URIBuilder.base("http://issues.test/browse/").build())
+                                            .build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -434,7 +434,7 @@ class MailingListBridgeBotTests {
                                             .repo(author)
                                             .archive(archive)
                                             .censusRepo(censusBuilder.build())
-                                            .list(listAddress)
+                                            .lists(List.of(new MailingListConfiguration(listAddress, Set.of())))
                                             .ignoredUsers(Set.of(ignored.forge().currentUser().userName()))
                                             .listArchive(listServer.getArchive())
                                             .smtpServer(listServer.getSMTP())
@@ -513,7 +513,7 @@ class MailingListBridgeBotTests {
                                             .repo(author)
                                             .archive(archive)
                                             .censusRepo(censusBuilder.build())
-                                            .list(listAddress)
+                                            .lists(List.of(new MailingListConfiguration(listAddress, Set.of())))
                                             .ignoredUsers(Set.of(ignored.forge().currentUser().userName()))
                                             .listArchive(listServer.getArchive())
                                             .smtpServer(listServer.getSMTP())
@@ -590,7 +590,7 @@ class MailingListBridgeBotTests {
                                             .repo(author)
                                             .archive(archive)
                                             .censusRepo(censusBuilder.build())
-                                            .list(listAddress)
+                                            .lists(List.of(new MailingListConfiguration(listAddress, Set.of())))
                                             .ignoredUsers(Set.of(ignored.forge().currentUser().userName()))
                                             .listArchive(listServer.getArchive())
                                             .smtpServer(listServer.getSMTP())
@@ -673,7 +673,7 @@ class MailingListBridgeBotTests {
                                             .repo(author)
                                             .archive(archive)
                                             .censusRepo(censusBuilder.build())
-                                            .list(listAddress)
+                                            .lists(List.of(new MailingListConfiguration(listAddress, Set.of())))
                                             .ignoredUsers(Set.of(ignored.forge().currentUser().userName()))
                                             .listArchive(listServer.getArchive())
                                             .smtpServer(listServer.getSMTP())
@@ -727,7 +727,7 @@ class MailingListBridgeBotTests {
                                             .repo(author)
                                             .archive(archive)
                                             .censusRepo(censusBuilder.build())
-                                            .list(listAddress)
+                                            .lists(List.of(new MailingListConfiguration(listAddress, Set.of())))
                                             .ignoredUsers(Set.of(ignored.forge().currentUser().userName()))
                                             .listArchive(listServer.getArchive())
                                             .smtpServer(listServer.getSMTP())
@@ -822,7 +822,7 @@ class MailingListBridgeBotTests {
                                             .repo(author)
                                             .archive(archive)
                                             .censusRepo(censusBuilder.build())
-                                            .list(listAddress)
+                                            .lists(List.of(new MailingListConfiguration(listAddress, Set.of())))
                                             .listArchive(listServer.getArchive())
                                             .smtpServer(listServer.getSMTP())
                                             .webrevStorageRepository(archive)
@@ -917,7 +917,7 @@ class MailingListBridgeBotTests {
                                             .repo(author)
                                             .archive(archive)
                                             .censusRepo(censusBuilder.build())
-                                            .list(listAddress)
+                                            .lists(List.of(new MailingListConfiguration(listAddress, Set.of())))
                                             .listArchive(listServer.getArchive())
                                             .smtpServer(listServer.getSMTP())
                                             .webrevStorageRepository(archive)
@@ -1046,7 +1046,7 @@ class MailingListBridgeBotTests {
                                             .repo(author)
                                             .archive(archive)
                                             .censusRepo(censusBuilder.build())
-                                            .list(listAddress)
+                                            .lists(List.of(new MailingListConfiguration(listAddress, Set.of())))
                                             .listArchive(listServer.getArchive())
                                             .smtpServer(listServer.getSMTP())
                                             .webrevStorageRepository(archive)
@@ -1109,7 +1109,7 @@ class MailingListBridgeBotTests {
                                             .repo(author)
                                             .archive(archive)
                                             .censusRepo(censusBuilder.build())
-                                            .list(listAddress)
+                                            .lists(List.of(new MailingListConfiguration(listAddress, Set.of())))
                                             .listArchive(listServer.getArchive())
                                             .smtpServer(listServer.getSMTP())
                                             .webrevStorageRepository(archive)
@@ -1173,7 +1173,7 @@ class MailingListBridgeBotTests {
                                             .repo(author)
                                             .archive(archive)
                                             .censusRepo(censusBuilder.build())
-                                            .list(listAddress)
+                                            .lists(List.of(new MailingListConfiguration(listAddress, Set.of())))
                                             .listArchive(listServer.getArchive())
                                             .smtpServer(listServer.getSMTP())
                                             .webrevStorageRepository(archive)
@@ -1238,7 +1238,7 @@ class MailingListBridgeBotTests {
                                             .repo(author)
                                             .archive(archive)
                                             .censusRepo(censusBuilder.build())
-                                            .list(listAddress)
+                                            .lists(List.of(new MailingListConfiguration(listAddress, Set.of())))
                                             .listArchive(listServer.getArchive())
                                             .smtpServer(listServer.getSMTP())
                                             .webrevStorageRepository(archive)
@@ -1301,7 +1301,7 @@ class MailingListBridgeBotTests {
                                             .repo(author)
                                             .archive(archive)
                                             .censusRepo(censusBuilder.build())
-                                            .list(listAddress)
+                                            .lists(List.of(new MailingListConfiguration(listAddress, Set.of())))
                                             .listArchive(listServer.getArchive())
                                             .smtpServer(listServer.getSMTP())
                                             .webrevStorageRepository(archive)
@@ -1358,7 +1358,7 @@ class MailingListBridgeBotTests {
                                             .repo(author)
                                             .archive(archive)
                                             .censusRepo(censusBuilder.build())
-                                            .list(listAddress)
+                                            .lists(List.of(new MailingListConfiguration(listAddress, Set.of())))
                                             .listArchive(listServer.getArchive())
                                             .smtpServer(listServer.getSMTP())
                                             .webrevStorageRepository(archive)
@@ -1434,7 +1434,7 @@ class MailingListBridgeBotTests {
                                             .repo(author)
                                             .archive(archive)
                                             .censusRepo(censusBuilder.build())
-                                            .list(listAddress)
+                                            .lists(List.of(new MailingListConfiguration(listAddress, Set.of())))
                                             .listArchive(listServer.getArchive())
                                             .smtpServer(listServer.getSMTP())
                                             .webrevStorageRepository(archive)
@@ -1500,7 +1500,7 @@ class MailingListBridgeBotTests {
                                             .repo(author)
                                             .archive(archive)
                                             .censusRepo(censusBuilder.build())
-                                            .list(listAddress)
+                                            .lists(List.of(new MailingListConfiguration(listAddress, Set.of())))
                                             .listArchive(listServer.getArchive())
                                             .smtpServer(listServer.getSMTP())
                                             .webrevStorageRepository(archive)
@@ -1630,7 +1630,7 @@ class MailingListBridgeBotTests {
                                             .repo(author)
                                             .archive(archive)
                                             .censusRepo(censusBuilder.build())
-                                            .list(listAddress)
+                                            .lists(List.of(new MailingListConfiguration(listAddress, Set.of())))
                                             .listArchive(listServer.getArchive())
                                             .smtpServer(listServer.getSMTP())
                                             .webrevStorageRepository(archive)
@@ -1727,7 +1727,7 @@ class MailingListBridgeBotTests {
                                             .archive(archive)
                                             .archiveRef("archive")
                                             .censusRepo(censusBuilder.build())
-                                            .list(listAddress)
+                                            .lists(List.of(new MailingListConfiguration(listAddress, Set.of())))
                                             .listArchive(listServer.getArchive())
                                             .smtpServer(listServer.getSMTP())
                                             .webrevStorageRepository(archive)
@@ -1817,7 +1817,7 @@ class MailingListBridgeBotTests {
                                             .archive(archive)
                                             .archiveRef("archive")
                                             .censusRepo(censusBuilder.build())
-                                            .list(listAddress)
+                                            .lists(List.of(new MailingListConfiguration(listAddress, Set.of())))
                                             .listArchive(listServer.getArchive())
                                             .smtpServer(listServer.getSMTP())
                                             .webrevStorageRepository(archive)
@@ -1903,7 +1903,7 @@ class MailingListBridgeBotTests {
                                             .archive(archive)
                                             .archiveRef("archive")
                                             .censusRepo(censusBuilder.build())
-                                            .list(listAddress)
+                                            .lists(List.of(new MailingListConfiguration(listAddress, Set.of())))
                                             .listArchive(listServer.getArchive())
                                             .smtpServer(listServer.getSMTP())
                                             .webrevStorageRepository(archive)
@@ -1975,7 +1975,7 @@ class MailingListBridgeBotTests {
                                             .archive(archive)
                                             .archiveRef("archive")
                                             .censusRepo(censusBuilder.build())
-                                            .list(listAddress)
+                                            .lists(List.of(new MailingListConfiguration(listAddress, Set.of())))
                                             .listArchive(listServer.getArchive())
                                             .smtpServer(listServer.getSMTP())
                                             .webrevStorageRepository(archive)
@@ -2045,7 +2045,7 @@ class MailingListBridgeBotTests {
                                             .repo(author)
                                             .archive(archive)
                                             .censusRepo(censusBuilder.build())
-                                            .list(listAddress)
+                                            .lists(List.of(new MailingListConfiguration(listAddress, Set.of())))
                                             .ignoredUsers(Set.of(ignored.forge().currentUser().userName()))
                                             .listArchive(listServer.getArchive())
                                             .smtpServer(listServer.getSMTP())
@@ -2126,7 +2126,7 @@ class MailingListBridgeBotTests {
                                             .repo(author)
                                             .archive(archive)
                                             .censusRepo(censusBuilder.build())
-                                            .list(listAddress)
+                                            .lists(List.of(new MailingListConfiguration(listAddress, Set.of())))
                                             .listArchive(listServer.getArchive())
                                             .smtpServer(listServer.getSMTP())
                                             .webrevStorageRepository(archive)
@@ -2215,7 +2215,7 @@ class MailingListBridgeBotTests {
                                             .repo(author)
                                             .archive(archive)
                                             .censusRepo(censusBuilder.build())
-                                            .list(listAddress)
+                                            .lists(List.of(new MailingListConfiguration(listAddress, Set.of())))
                                             .ignoredUsers(Set.of(ignored.forge().currentUser().userName()))
                                             .ignoredComments(Set.of(Pattern.compile("ignore this comment", Pattern.MULTILINE | Pattern.DOTALL)))
                                             .listArchive(listServer.getArchive())
@@ -2282,7 +2282,7 @@ class MailingListBridgeBotTests {
                                             .repo(author)
                                             .archive(archive)
                                             .censusRepo(censusBuilder.build())
-                                            .list(listAddress)
+                                            .lists(List.of(new MailingListConfiguration(listAddress, Set.of())))
                                             .listArchive(listServer.getArchive())
                                             .smtpServer(listServer.getSMTP())
                                             .webrevStorageRepository(archive)
@@ -2343,7 +2343,7 @@ class MailingListBridgeBotTests {
                                                    .ignoredUsers(Set.of(bot.forge().currentUser().userName()))
                                                    .archive(archive)
                                                    .censusRepo(censusBuilder.build())
-                                                   .list(listAddress)
+                                                   .lists(List.of(new MailingListConfiguration(listAddress, Set.of())))
                                                    .listArchive(listServer.getArchive())
                                                    .smtpServer(listServer.getSMTP())
                                                    .webrevStorageRepository(archive)
@@ -2408,7 +2408,7 @@ class MailingListBridgeBotTests {
                                                    .ignoredUsers(Set.of(bot.forge().currentUser().userName()))
                                                    .archive(archive)
                                                    .censusRepo(censusBuilder.build())
-                                                   .list(listAddress)
+                                                   .lists(List.of(new MailingListConfiguration(listAddress, Set.of())))
                                                    .listArchive(listServer.getArchive())
                                                    .smtpServer(listServer.getSMTP())
                                                    .webrevStorageRepository(archive)
@@ -2475,7 +2475,7 @@ class MailingListBridgeBotTests {
                                                    .ignoredUsers(Set.of(bot.forge().currentUser().userName()))
                                                    .archive(archive)
                                                    .censusRepo(censusBuilder.build())
-                                                   .list(listAddress)
+                                                   .lists(List.of(new MailingListConfiguration(listAddress, Set.of())))
                                                    .listArchive(listServer.getArchive())
                                                    .smtpServer(listServer.getSMTP())
                                                    .webrevStorageRepository(archive)
@@ -2564,7 +2564,7 @@ class MailingListBridgeBotTests {
                                             .repo(author)
                                             .archive(archive)
                                             .censusRepo(censusBuilder.build())
-                                            .list(listAddress)
+                                            .lists(List.of(new MailingListConfiguration(listAddress, Set.of())))
                                             .listArchive(listServer.getArchive())
                                             .smtpServer(listServer.getSMTP())
                                             .webrevStorageRepository(archive)
@@ -2621,7 +2621,7 @@ class MailingListBridgeBotTests {
                                             .repo(author)
                                             .archive(archive)
                                             .censusRepo(censusBuilder.build())
-                                            .list(listAddress)
+                                            .lists(List.of(new MailingListConfiguration(listAddress, Set.of())))
                                             .listArchive(listServer.getArchive())
                                             .smtpServer(listServer.getSMTP())
                                             .webrevStorageRepository(archive)
@@ -2678,7 +2678,7 @@ class MailingListBridgeBotTests {
                                             .repo(author)
                                             .archive(archive)
                                             .censusRepo(censusBuilder.build())
-                                            .list(listAddress)
+                                            .lists(List.of(new MailingListConfiguration(listAddress, Set.of())))
                                             .listArchive(listServer.getArchive())
                                             .smtpServer(listServer.getSMTP())
                                             .webrevStorageRepository(archive)
@@ -2739,7 +2739,7 @@ class MailingListBridgeBotTests {
                                                    .ignoredUsers(Set.of(bot.forge().currentUser().userName()))
                                                    .archive(archive)
                                                    .censusRepo(censusBuilder.build())
-                                                   .list(listAddress)
+                                                   .lists(List.of(new MailingListConfiguration(listAddress, Set.of())))
                                                    .listArchive(listServer.getArchive())
                                                    .smtpServer(listServer.getSMTP())
                                                    .webrevStorageRepository(archive)
@@ -2808,6 +2808,84 @@ class MailingListBridgeBotTests {
             // Check the archive
             Repository.materialize(archiveFolder.path(), archive.url(), "master");
             assertTrue(archiveContains(archiveFolder.path(), "Update number - " + counter + " -"));
+        }
+    }
+
+    @Test
+    void multipleRecipients(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory();
+             var archiveFolder = new TemporaryDirectory();
+             var listServer = new TestMailmanServer();
+             var webrevServer = new TestWebrevServer()) {
+            var author = credentials.getHostedRepository();
+            var archive = credentials.getHostedRepository();
+            var listAddress1 = EmailAddress.parse(listServer.createList("test1"));
+            var listAddress2 = EmailAddress.parse(listServer.createList("test2"));
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addAuthor(author.forge().currentUser().id());
+            var from = EmailAddress.from("test", "test@test.mail");
+            var mlBot = MailingListBridgeBot.newBuilder()
+                                            .from(from)
+                                            .repo(author)
+                                            .archive(archive)
+                                            .censusRepo(censusBuilder.build())
+                                            .lists(List.of(new MailingListConfiguration(listAddress1, Set.of("list1")),
+                                                           new MailingListConfiguration(listAddress2, Set.of("list2"))))
+                                            .listArchive(listServer.getArchive())
+                                            .smtpServer(listServer.getSMTP())
+                                            .webrevStorageRepository(archive)
+                                            .webrevStorageRef("webrev")
+                                            .webrevStorageBase(Path.of("test"))
+                                            .webrevStorageBaseUri(webrevServer.uri())
+                                            .issueTracker(URIBuilder.base("http://issues.test/browse/").build())
+                                            .build();
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, archive.url(), "webrev", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo, "A simple change",
+                                                               "Change msg\n\nWith several lines");
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(archive, "master", "edit", "1234: This is a pull request");
+            pr.setBody("This is a PR");
+            pr.addLabel("list1");
+
+            // Run an archive pass
+            TestBotRunner.runPeriodicItems(mlBot);
+            listServer.processIncoming();
+
+            // The mail should have been sent to list1
+            var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
+            var mailmanList = mailmanServer.getList(listAddress1.address());
+            var conversations = mailmanList.conversations(Duration.ofDays(1));
+            assertEquals(1, conversations.size());
+            var mail = conversations.get(0).first();
+            assertEquals("RFR: 1234: This is a pull request", mail.subject());
+            assertEquals(pr.author().fullName(), mail.author().fullName().orElseThrow());
+            assertEquals(noreplyAddress(archive), mail.author().address());
+            assertEquals(listAddress1, mail.sender());
+            assertEquals(List.of(listAddress1), mail.recipients());
+
+            // Add another label and comment
+            pr.addLabel("list2");
+            pr.addComment("Looks good!");
+            TestBotRunner.runPeriodicItems(mlBot);
+            listServer.processIncoming();
+
+            // This one should have been sent to list1 and list2
+            conversations = mailmanList.conversations(Duration.ofDays(1));
+            assertEquals(1, conversations.size());
+            var reply = conversations.get(0).replies(conversations.get(0).first()).get(0);
+            assertEquals("RFR: 1234: This is a pull request", reply.subject());
+            assertEquals(pr.author().fullName(), reply.author().fullName().orElseThrow());
+            assertEquals(noreplyAddress(archive), reply.author().address());
+            assertEquals(listAddress1, reply.sender());
+            assertEquals(List.of(listAddress1, listAddress2), reply.recipients());
         }
     }
 }

--- a/email/src/main/java/org/openjdk/skara/email/Email.java
+++ b/email/src/main/java/org/openjdk/skara/email/Email.java
@@ -97,6 +97,7 @@ public class Email {
         if (message.headers.containsKey("To")) {
             recipients = Arrays.stream(message.headers.get("To").split(","))
                                .map(MimeText::decode)
+                               .map(String::strip)
                                .map(EmailAddress::parse)
                                .collect(Collectors.toList());
         } else {

--- a/email/src/test/java/org/openjdk/skara/email/SMTPTests.java
+++ b/email/src/test/java/org/openjdk/skara/email/SMTPTests.java
@@ -22,13 +22,13 @@
  */
 package org.openjdk.skara.email;
 
-import org.openjdk.skara.test.SMTPServer;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.*;
+import org.openjdk.skara.test.SMTPServer;
 
 import java.io.IOException;
 import java.time.Duration;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -40,7 +40,7 @@ class SMTPTests {
             var recipient = EmailAddress.from("Dest", "dest@dest.email");
             var sentMail = Email.create(sender, "Subject", "Body").recipient(recipient).build();
 
-            SMTP.send(server.address(), recipient, sentMail);
+            SMTP.send(server.address(), sentMail);
             var email = server.receive(Duration.ofSeconds(10));
             assertEquals(sentMail, email);
         }
@@ -58,7 +58,7 @@ class SMTPTests {
                                 .header("Something", "Other")
                                 .build();
 
-            SMTP.send(server.address(), recipient, sentMail);
+            SMTP.send(server.address(), sentMail);
             var email = server.receive(Duration.ofSeconds(10));
             assertEquals(sentMail, email);
         }
@@ -75,7 +75,7 @@ class SMTPTests {
                                 .header("Something", "Öthè®")
                                 .build();
 
-            SMTP.send(server.address(), recipient, sentMail);
+            SMTP.send(server.address(), sentMail);
             var email = server.receive(Duration.ofSeconds(10));
             assertEquals(sentMail, email);
         }
@@ -88,7 +88,7 @@ class SMTPTests {
             var recipient = EmailAddress.from("Dest", "dest@dest.email");
             var sentMail = Email.create(sender, "Subject", "Body").recipient(recipient).build();
 
-            assertThrows(RuntimeException.class, () -> SMTP.send(server.address(), recipient, sentMail, Duration.ZERO));
+            assertThrows(RuntimeException.class, () -> SMTP.send(server.address(), sentMail, Duration.ZERO));
         }
     }
 
@@ -99,7 +99,23 @@ class SMTPTests {
             var recipient = EmailAddress.from("Dest", "dest@dest.email");
             var sentMail = Email.create(sender, "Subject", "Body\n.\nMore text").recipient(recipient).build();
 
-            SMTP.send(server.address(), recipient, sentMail);
+            SMTP.send(server.address(), sentMail);
+            var email = server.receive(Duration.ofSeconds(10));
+            assertEquals(sentMail, email);
+        }
+    }
+
+    @Test
+    void multipleRecipients() throws IOException {
+        try (var server = new SMTPServer()) {
+            var sender = EmailAddress.from("Test", "test@test.email");
+            var recipient1 = EmailAddress.from("Dest1", "dest1@dest.email");
+            var recipient2 = EmailAddress.from("Dest2", "dest2@dest.email");
+            var sentMail = Email.create(sender, "Subject", "Body")
+                                .recipients(List.of(recipient1, recipient2))
+                                .build();
+
+            SMTP.send(server.address(), sentMail);
             var email = server.receive(Duration.ofSeconds(10));
             assertEquals(sentMail, email);
         }

--- a/mailinglist/src/main/java/org/openjdk/skara/mailinglist/mailman/MailmanList.java
+++ b/mailinglist/src/main/java/org/openjdk/skara/mailinglist/mailman/MailmanList.java
@@ -56,7 +56,7 @@ public class MailmanList implements MailingList {
 
     @Override
     public void post(Email email) {
-        server.sendMessage(listAddress, email);
+        server.sendMessage(email);
     }
 
     private List<ZonedDateTime> getMonthRange(Duration maxAge) {

--- a/mailinglist/src/main/java/org/openjdk/skara/mailinglist/mailman/MailmanServer.java
+++ b/mailinglist/src/main/java/org/openjdk/skara/mailinglist/mailman/MailmanServer.java
@@ -50,7 +50,7 @@ public class MailmanServer implements MailingListServer {
         return URIBuilder.base(archive).appendPath(listName + "/" + dateStr + ".txt").build();
     }
 
-    void sendMessage(EmailAddress recipientList, Email message) {
+    void sendMessage(Email message) {
         while (lastSend.plus(sendInterval).isAfter(Instant.now())) {
             try {
                 Thread.sleep(sendInterval.dividedBy(10).toMillis());
@@ -59,7 +59,7 @@ public class MailmanServer implements MailingListServer {
         }
         lastSend = Instant.now();
         try {
-            SMTP.send(smtpServer, recipientList, message);
+            SMTP.send(smtpServer, message);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }


### PR DESCRIPTION
Hi all,

Please review this change that allows the mailing list bridge bot to send mails to multiple recipient lists, depending on PR labels and configuration.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-427](https://bugs.openjdk.java.net/browse/SKARA-427): Allow bridging PR updates to multiple recipients


### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/667/head:pull/667`
`$ git checkout pull/667`
