### PR TITLE
423: Avoid combining messages with different subjects

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
@@ -184,6 +184,9 @@ class ReviewArchive {
     private String parentAuthorPath(ArchiveItem item) {
         var ret = new StringBuilder();
         ret.append(item.author().id());
+        ret.append(":");
+        ret.append(item.subject());
+        ret.append(":");
         while (item.parent().isPresent()) {
             item = item.parent().get();
             ret.append(".");

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -323,6 +323,9 @@ class MailingListBridgeBotTests {
             Repository.materialize(archiveFolder.path(), archive.url(), "master");
             assertTrue(archiveContains(archiveFolder.path(), "Subject: RFR: 1234: This is a pull request"));
 
+            // Add a comment quickly before integration - it should not be combined with the integration message
+            pr.addComment("I will now integrate this PR");
+
             // Now it has been integrated
             var ignoredPr = ignored.pullRequest(pr.id());
             ignoredPr.setBody("This has been integrated");
@@ -335,6 +338,7 @@ class MailingListBridgeBotTests {
 
             // The archive should now contain another entry
             Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            assertTrue(archiveContains(archiveFolder.path(), "Subject: Re: RFR: 1234: This is a pull request"));
             assertTrue(archiveContains(archiveFolder.path(), "Subject: Integrated: 1234: This is a pull request"));
             assertFalse(archiveContains(archiveFolder.path(), "\\[Closed\\]"));
         }


### PR DESCRIPTION
Hi all,

Please review this small change that avoids combining mailinglist messages with different subjects, to enure that integration notices are sent separately.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-423](https://bugs.openjdk.java.net/browse/SKARA-423): Avoid combining messages with different subjects


### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/668/head:pull/668`
`$ git checkout pull/668`
