### PR TITLE
forge: use correct endpoints for commits in GitLab

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -292,7 +292,7 @@ public class GitLabRepository implements HostedRepository {
 
     @Override
     public List<CommitComment> commitComments(Hash hash) {
-        return request.get("commits/" + hash.hex() + "/comments")
+        return request.get("repository/commits/" + hash.hex() + "/comments")
                       .execute()
                       .stream()
                       .map(JSONValue::asObject)
@@ -318,14 +318,14 @@ public class GitLabRepository implements HostedRepository {
     @Override
     public void addCommitComment(Hash hash, String body) {
         var query = JSON.object().put("note", body);
-        request.post("commits/" + hash.hex() + "/comments")
+        request.post("repository/commits/" + hash.hex() + "/comments")
                .body(query)
                .execute();
     }
 
     @Override
     public Optional<CommitMetadata> commitMetadata(Hash hash) {
-        var c = request.get("commits/" + hash.hex())
+        var c = request.get("repository/commits/" + hash.hex())
                        .onError(r -> Optional.of(JSON.of()))
                        .execute();
         if (c.isNull()) {


### PR DESCRIPTION
Hi all,

please review this patch that uses the correct REST API endpoint for commits for GitLab.

Testing:
- [x] Manual verification of endpoints
- [x] `make test` passes on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/671/head:pull/671`
`$ git checkout pull/671`
