### PR TITLE
420: Expand JBS issues in PR titles

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -35,6 +35,7 @@ import java.nio.file.Path;
 import java.util.*;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.*;
 
 class CheckRun {
@@ -59,6 +60,7 @@ class CheckRun {
     private static final String emptyPrBodyMarker = "<!--\nReplace this text with a description of your pull request (also remove the surrounding HTML comment markers).\n" +
             "If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.\n-->";
     private final Set<String> newLabels;
+    static final Pattern ISSUE_ID_PATTERN = Pattern.compile("^(?:[A-Za-z][A-Za-z0-9]+-)?([0-9]+)$");
 
     private CheckRun(CheckWorkItem workItem, PullRequest pr, Repository localRepo, List<Comment> comments,
                      List<Review> allReviews, List<Review> activeReviews, Set<String> labels,
@@ -457,6 +459,27 @@ class CheckRun {
         return newBody;
     }
 
+    private String updateTitle() {
+        var title = pr.title();
+        var m = ISSUE_ID_PATTERN.matcher(title);
+        var project = issueProject();
+
+        var newTitle = title;
+        if (m.matches() && project != null) {
+            var id = m.group(1);
+            var issue = project.issue(id);
+            if (issue.isPresent()) {
+                newTitle = id + ": " + issue.get().title();
+            }
+        }
+
+        if (!title.equals(newTitle)) {
+            pr.setTitle(newTitle);
+        }
+
+        return newTitle;
+    }
+
     private String verdictToString(Review.Verdict verdict) {
         switch (verdict) {
             case APPROVED:
@@ -716,6 +739,7 @@ class CheckRun {
             // Calculate and update the status message if needed
             var statusMessage = getStatusMessage(comments, activeReviews, visitor, additionalErrors);
             var updatedBody = updateStatusMessage(statusMessage);
+            var title = updateTitle();
 
             // Post / update approval messages (only needed if the review itself can't contain a body)
             if (!pr.repository().forge().supportsReviewBody()) {
@@ -756,7 +780,7 @@ class CheckRun {
             }
 
             // Calculate current metadata to avoid unnecessary future checks
-            var metadata = workItem.getMetadata(pr.title(), updatedBody, pr.comments(), activeReviews, newLabels,
+            var metadata = workItem.getMetadata(title, updatedBody, pr.comments(), activeReviews, newLabels,
                                                 censusInstance, pr.targetHash(), pr.isDraft());
             checkBuilder.metadata(metadata);
         } catch (Exception e) {

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -1448,4 +1448,84 @@ class CheckTests {
                                              "   - Bug\n"));
         }
     }
+
+    @Test
+    void expandTitleWithNumericIssueId(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var reviewer = credentials.getHostedRepository();
+            var issues = credentials.getIssueProject();
+
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addAuthor(author.forge().currentUser().id())
+                                           .addReviewer(reviewer.forge().currentUser().id());
+            var checkBot = PullRequestBot.newBuilder()
+                                         .repo(author)
+                                         .censusRepo(censusBuilder.build())
+                                         .issueProject(issues)
+                                         .build();
+
+            var bug = issues.createIssue("My first bug", List.of("A bug"), Map.of());
+            var numericId = bug.id().split("-")[1];
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Make a change with a corresponding PR
+            var bugHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(bugHash, author.url(), "bug", true);
+            var bugPR = credentials.createPullRequest(author, "master", "bug", numericId, true);
+            assertEquals(numericId, bugPR.title());
+
+            // Check the status (should expand title)
+            TestBotRunner.runPeriodicItems(checkBot);
+
+            // Verify that the title is expanded
+            bugPR = author.pullRequest(bugPR.id());
+            assertEquals(numericId + ": " + bug.title(), bugPR.title());
+        }
+    }
+
+    @Test
+    void expandTitleWithIssueId(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var reviewer = credentials.getHostedRepository();
+            var issues = credentials.getIssueProject();
+
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addAuthor(author.forge().currentUser().id())
+                                           .addReviewer(reviewer.forge().currentUser().id());
+            var checkBot = PullRequestBot.newBuilder()
+                                         .repo(author)
+                                         .censusRepo(censusBuilder.build())
+                                         .issueProject(issues)
+                                         .build();
+
+            var bug = issues.createIssue("My first bug", List.of("A bug"), Map.of());
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Make a change with a corresponding PR
+            var bugHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(bugHash, author.url(), "bug", true);
+            var bugPR = credentials.createPullRequest(author, "master", "bug", bug.id(), true);
+            assertEquals(bug.id(), bugPR.title());
+
+            // Check the status (should expand title)
+            TestBotRunner.runPeriodicItems(checkBot);
+
+            // Verify that the title is expanded
+            bugPR = author.pullRequest(bugPR.id());
+            var numericId = bug.id().split("-")[1];
+            assertEquals(numericId + ": " + bug.title(), bugPR.title());
+        }
+    }
 }


### PR DESCRIPTION
Hi all,

please review this small patch that automatically expands issue ids in pull request titles to the "id: title" format. For example if a pull request for the [skara](https://github.com/openjdk/skara) repository has the title `420`, then the pull request title will be automatically set to `420: Expand JBS issues in PR titles`. I have been fairly conservative in what we expand, we only expand titles exactly matching `PROJECT-ID` or `ID`, i.e. `SKARA-420` or `420`.

Testing:
- [x] Added two new unit tests
- [x] `make test` passes on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-420](https://bugs.openjdk.java.net/browse/SKARA-420): Expand JBS issues in PR titles


### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/672/head:pull/672`
`$ git checkout pull/672`
