### PR TITLE
Fix typo in property name for GitLab commitMetadata

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -340,7 +340,7 @@ public class GitLabRepository implements HostedRepository {
         var authored = ZonedDateTime.parse(c.get("authored_date").asString());
         var committer = new Author(c.get("committer_name").asString(),
                                    c.get("committer_email").asString());
-        var committed = ZonedDateTime.parse(c.get("comitted_date").asString());
+        var committed = ZonedDateTime.parse(c.get("committed_date").asString());
         var message = Arrays.asList(c.get("message").asString().split("\n"));
         return Optional.of(new CommitMetadata(hash, parents, author, authored, committer, committed, message));
     }


### PR DESCRIPTION
Hi all,

Please review this minor fix that corrects a property name in the GitLab commitMetadata function.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/673/head:pull/673`
`$ git checkout pull/673`
