### PR TITLE
webrev: add logging

### DIFF
--- a/webrev/src/main/java/module-info.java
+++ b/webrev/src/main/java/module-info.java
@@ -23,6 +23,7 @@
 module org.openjdk.skara.webrev {
     requires org.openjdk.skara.vcs;
     requires java.net.http;
+    requires java.logging;
 
     exports org.openjdk.skara.webrev;
 }

--- a/webrev/src/main/java/org/openjdk/skara/webrev/ModifiedFileView.java
+++ b/webrev/src/main/java/org/openjdk/skara/webrev/ModifiedFileView.java
@@ -50,20 +50,25 @@ class ModifiedFileView implements FileView {
         this.formatter = formatter;
         if (patch.isTextual()) {
             binaryContent = null;
-            oldContent = repo.lines(patch.source().path().get(), base).orElseThrow(() -> {
-                throw new IllegalArgumentException("Could not get content for file " +
-                                                   patch.source().path().get() +
-                                                   " at revision " + base);
-            });
+            var sourcePath = patch.source().path().orElseThrow(() ->
+                new IllegalArgumentException("Could not get source path for file with hash " +
+                                                   patch.source().hash() + " with target path" +
+                                                   patch.target().path().get())
+            );
+
+            oldContent = repo.lines(sourcePath, base).orElseThrow(() ->
+                new IllegalArgumentException("Could not get content for file " +
+                                                   sourcePath + " at revision " + base)
+            );
             if (head == null) {
                 var path = repo.root().resolve(patch.target().path().get());
                 if (patch.target().type().get().isVCSLink()) {
                     var tip = repo.head();
-                    var content = repo.lines(patch.target().path().get(), tip).orElseThrow(() -> {
-                        throw new IllegalArgumentException("Could not get content for file " +
+                    var content = repo.lines(patch.target().path().get(), tip).orElseThrow(() ->
+                        new IllegalArgumentException("Could not get content for file " +
                                                            patch.target().path().get() +
-                                                           " at revision " + tip);
-                    });
+                                                           " at revision " + tip)
+                    );
                     newContent = List.of(content.get(0) + "-dirty");
                 } else {
                     List<String> lines = null;
@@ -81,11 +86,11 @@ class ModifiedFileView implements FileView {
                     newContent = lines;
                 }
             } else {
-                newContent = repo.lines(patch.target().path().get(), head).orElseThrow(() -> {
-                    throw new IllegalArgumentException("Could not get content for file " +
+                newContent = repo.lines(patch.target().path().get(), head).orElseThrow(() ->
+                    new IllegalArgumentException("Could not get content for file " +
                                                        patch.target().path().get() +
-                                                       " at revision " + head);
-                });
+                                                       " at revision " + head)
+                );
             }
             stats = new WebrevStats(patch.asTextualPatch().stats(), newContent.size());
         } else {
@@ -94,11 +99,11 @@ class ModifiedFileView implements FileView {
             if (head == null) {
                 binaryContent = Files.readAllBytes(repo.root().resolve(patch.target().path().get()));
             } else {
-                binaryContent = repo.show(patch.target().path().get(), head).orElseThrow(() -> {
-                    throw new IllegalArgumentException("Could not get content for file " +
+                binaryContent = repo.show(patch.target().path().get(), head).orElseThrow(() ->
+                    new IllegalArgumentException("Could not get content for file " +
                                                        patch.target().path().get() +
-                                                       " at revision " + head);
-                });
+                                                       " at revision " + head)
+                );
             }
             stats = WebrevStats.empty();
         }

--- a/webrev/src/main/java/org/openjdk/skara/webrev/Webrev.java
+++ b/webrev/src/main/java/org/openjdk/skara/webrev/Webrev.java
@@ -29,6 +29,8 @@ import java.net.URISyntaxException;
 import java.nio.channels.FileChannel;
 import java.nio.file.*;
 import java.util.*;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import java.util.function.Function;
 
 import static java.nio.file.StandardOpenOption.*;
@@ -41,6 +43,8 @@ public class Webrev {
     private static final String CSS = "style.css";
 
     private static final String INDEX = "index.html";
+
+    private static final Logger log = Logger.getLogger("org.openjdk.skara.webrev");
 
     public static final Set<String> STATIC_FILES =
         Set.of(ANCNAV_HTML, ANCNAV_JS, ICON, CSS, INDEX);
@@ -198,6 +202,11 @@ public class Webrev {
             }
 
             var headHash = head == null ? repository.head() : head;
+            var filesDesc = files.isEmpty() ? "" :
+                            " for files " +
+                            String.join(", ", files.stream().map(Path::toString).collect(Collectors.toList()));
+            log.fine("Generating webrev from " + tailEnd + " to " + headHash + filesDesc);
+
             var fileViews = new ArrayList<FileView>();
             var formatter = new MetadataFormatter(issueLinker);
             for (var patch : patches) {

--- a/webrev/src/main/java/org/openjdk/skara/webrev/Webrev.java
+++ b/webrev/src/main/java/org/openjdk/skara/webrev/Webrev.java
@@ -204,7 +204,7 @@ public class Webrev {
             var headHash = head == null ? repository.head() : head;
             var filesDesc = files.isEmpty() ? "" :
                             " for files " +
-                            String.join(", ", files.stream().map(Path::toString).collect(Collectors.toList()));
+                            files.stream().map(Path::toString).collect(Collectors.joining(", "));
             log.fine("Generating webrev from " + tailEnd + " to " + headHash + filesDesc);
 
             var fileViews = new ArrayList<FileView>();


### PR DESCRIPTION
Hi all,

please review this small patch that add some additional logging to `Webrev` and dereferences `Optional`s a bit more carefully in `ModifiedFileView`.

Testing:
- [x] `make test` passes on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - **Reviewer**) ⚠️ Review applies to df7bb77cdf08cb4c2f23999455ebcb0b0dda5636


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/674/head:pull/674`
`$ git checkout pull/674`
