### PR TITLE
vcs: proper source paths for merge commits

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitCombinedDiffParser.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitCombinedDiffParser.java
@@ -147,7 +147,9 @@ class GitCombinedDiffParser {
 
     private List<PatchHeader> parseCombinedRawLine(String line) {
         var headers = new ArrayList<PatchHeader>(numParents);
-        var words = line.substring(2).split("\\s");
+        var parts = line.substring(numParents).split("\\t");
+        var metadata = parts[0];
+        var words = metadata.split(" ");
 
         int index = 0;
         int end = index + numParents;
@@ -175,16 +177,21 @@ class GitCombinedDiffParser {
             statuses.add(Status.from(statusWord.charAt(i)));
         }
 
-        index++;
-        var dstPath = Path.of(words[index]);
-        if (words.length != (index + 1)) {
-            throw new IllegalStateException("Unexpected characters at end of raw line: " + line);
+
+        var srcPaths = new ArrayList<Path>(numParents);
+        index = 1;
+        end = index + numParents;
+        while (index < end) {
+            srcPaths.add(Path.of(parts[index]));
+            index++;
         }
+
+        var dstPath = Path.of(parts[index]);
 
         for (int i = 0; i < numParents; i++) {
             var status = statuses.get(i);
             var srcType = srcTypes.get(i);
-            var srcPath = status.isModified() ?  dstPath : null;
+            var srcPath = status.isAdded() ? null : srcPaths.get(i);
             var srcHash = srcHashes.get(i);
             headers.add(new PatchHeader(srcPath, srcType, srcHash,  dstPath, dstType, dstHash, status));
         }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitCommits.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitCommits.java
@@ -66,6 +66,7 @@ class GitCommits implements Commits, AutoCloseable {
                                          "--topo-order",
                                          "--binary",
                                          "-c",
+                                         "--combined-all-paths",
                                          "--raw",
                                          "--no-abbrev",
                                          "--unified=0",


### PR DESCRIPTION
Hi all,

please review this patch that fixes an issue with parsing Git merge commits. Without the `--combined-all-paths` the "RAW" diff format of `git diff --combined` will only print the resulting (target) path for a rename. This mean that `patch.source().path()` would `Optional.empty()` for such a patch. This patch fixes this by passing the `--combined-all-paths` flag to `git log` and updating the `GitCombinedDiffParser`.

Testing:
- [x] Added a new unit test
- [x] `make test` passes on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/675/head:pull/675`
`$ git checkout pull/675`
