### PR TITLE
428: git-jcheck does not work on repositories without default or maser branch

### DIFF
--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/JCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/JCheck.java
@@ -258,10 +258,12 @@ public class JCheck {
             return new Issues(new ArrayList<Issue>().iterator(), null);
         }
 
-        var master = repository.resolve(repository.defaultBranch().name())
-                               .orElseThrow(() -> new IllegalStateException("Default branch not found"));
+        var master = repository.resolve(repository.defaultBranch().name());
+        var head = repository.head();
 
-        var conf = parseConfiguration(repository, master, List.of());
+        var conf = master.isPresent() ?
+            parseConfiguration(repository, master.get(), List.of()) :
+            parseConfiguration(repository, head, List.of());
         var branchRegex = conf.isPresent() ? conf.get().repository().branches() : ".*";
         var tagRegex = conf.isPresent() ? conf.get().repository().tags() : ".*";
 


### PR DESCRIPTION
Hi all,

please review this small patch that makes `JCheck` work on repositories _without_ a remotee `HEAD` ref being present (i.e. `refs/remotes/origin/HEAD`) and _without_ a `master` ref being present (i.e. `refs/heads/master`). In such a case `JCheck` will now fall back to configuration values for allowed tags and branches as specified in the configuration file at `HEAD` (`HEAD` is always present).

Testing:
- [x] `make test` passes on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/676/head:pull/676`
`$ git checkout pull/676`
