### PR TITLE
430: /summary command does not support multi-line summaries

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SummaryCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SummaryCommand.java
@@ -27,32 +27,45 @@ import org.openjdk.skara.issuetracker.Comment;
 
 import java.io.PrintWriter;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.List;
 
 public class SummaryCommand implements CommandHandler {
     @Override
     public void handle(PullRequestBot bot, PullRequest pr, CensusInstance censusInstance, Path scratchPath, String args, Comment comment, List<Comment> allComments, PrintWriter reply) {
         if (!comment.author().equals(pr.author())) {
-            reply.println("Only the author (@" + pr.author().userName() + ") is allowed to issue the `summary` command.");
+            reply.println("Only the author (@" + pr.author().userName() + ") is allowed to issue the `/summary` command.");
             return;
         }
 
         var currentSummary = Summary.summary(pr.repository().forge().currentUser(), allComments);
 
         if (args.isBlank()) {
-            if (currentSummary.isPresent()) {
-                reply.println("Removing existing summary");
-                reply.println(Summary.setSummaryMarker(""));
+            var lines = Arrays.asList(comment.body().split("\n"));
+            if (lines.size() == 1) {
+                if (currentSummary.isPresent()) {
+                    reply.println("Removing existing summary");
+                    reply.println(Summary.setSummaryMarker(""));
+                } else {
+                    reply.println("To set a summary, use the syntax `/summary <summary text>`");
+                }
             } else {
-                reply.println("To set a summary, use the syntax `/summary <summary text>`");
+                // A multi-line summary
+                var summary = String.join("\n", lines.subList(1, lines.size()));
+                var action = currentSummary.isPresent() ? "Updating existing" : "Setting";
+                reply.println(action + " summary to:\n" +
+                              "\n" +
+                              "```\n" +
+                              summary +
+                              "\n```");
+                reply.println(Summary.setSummaryMarker(summary));
             }
         } else {
-            if (currentSummary.isPresent()) {
-                reply.println("Updating existing summary to `" + args.strip() + "`");
-            } else {
-                reply.println("Setting summary to `" + args.strip() + "`");
-            }
-            reply.println(Summary.setSummaryMarker(args.strip()));
+            // A single-line summary
+            var summary = args.strip();
+            var action = currentSummary.isPresent() ? "Updating existing" : "Setting";
+            reply.println(action + " summary to `" + summary + "`");
+            reply.println(Summary.setSummaryMarker(summary));
         }
     }
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/SummaryTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/SummaryTests.java
@@ -133,6 +133,7 @@ class SummaryTests {
             assertEquals("Third time is surely the charm", summaryLine);
         }
     }
+
     @Test
     void invalidCommandAuthor(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
@@ -166,6 +167,92 @@ class SummaryTests {
                           .filter(comment -> comment.body().contains("Only the author"))
                           .count();
             assertEquals(1, error);
+        }
+    }
+
+    @Test
+    void multiline(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var integrator = credentials.getHostedRepository();
+
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addReviewer(integrator.forge().currentUser().id())
+                                           .addCommitter(author.forge().currentUser().id());
+            var prBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
+
+            // Populate the projects repository
+            var localRepoFolder = tempFolder.path().resolve("localrepo");
+            var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
+
+            // Try setting a summary when none has been set yet
+            pr.addComment("/summary");
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // The bot should reply with a help message
+            assertLastCommentContains(pr,"To set a summary");
+
+            // Add a multi-line summary
+            pr.addComment("/summary\nFirst line\nSecond line");
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // The bot should reply with a success message
+            assertLastCommentContains(pr,
+                "Setting summary to:\n" +
+                "\n" +
+                "```\n" +
+                "First line\n" +
+                "Second line\n" +
+                "```");
+
+            // Remove it again
+            pr.addComment("/summary");
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // The bot should reply with a success message
+            assertLastCommentContains(pr,"Removing existing");
+
+            // Now add one again
+            pr.addComment("/summary\nL1\nL2");
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // The bot should reply with a success message
+            assertLastCommentContains(pr,
+                "Setting summary to:\n" +
+                "\n" +
+                "```\n" +
+                "L1\n" +
+                "L2\n" +
+                "```");
+
+            // Now update it
+            pr.addComment("/summary\n1L\n2L");
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // The bot should reply with a success message
+            assertLastCommentContains(pr,
+                "Updating existing summary to:\n" +
+                "\n" +
+                "```\n" +
+                "1L\n" +
+                "2L\n" +
+                "```");
+
+            // Finllay update it to a single line summary
+            pr.addComment("/summary single line");
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // The bot should reply with a success message
+            assertLastCommentContains(pr, "Updating existing summary to `single line`");
         }
     }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/SummaryTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/SummaryTests.java
@@ -247,7 +247,7 @@ class SummaryTests {
                 "2L\n" +
                 "```");
 
-            // Finllay update it to a single line summary
+            // Finally update it to a single line summary
             pr.addComment("/summary single line");
             TestBotRunner.runPeriodicItems(prBot);
 


### PR DESCRIPTION
Hi all,

please review this patch that makes the `/summary` pull request command accept multi-line summaries. As described on the [Skara wiki](https://wiki.openjdk.java.net/display/SKARA/Pull+Request+Commands#PullRequestCommands-/summary) the `/summary` command should this, since the commit message format allow for this.

Testing:
- [x] Added a new unit test
- [x] `make test` passes on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-430](https://bugs.openjdk.java.net/browse/SKARA-430): /summary command does not support multi-line summaries


### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**) ⚠️ Review applies to c0ca352e75a5e66694fa5843ca204e60a9d8650d


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/678/head:pull/678`
`$ git checkout pull/678`
