### PR TITLE
342: Pull request bot should warn on merge commits with non-target branch parent

### DIFF
--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
@@ -38,6 +38,7 @@ import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.openjdk.skara.bots.pr.PullRequestAsserts.assertLastCommentContains;
 
 class MergeTests {
     @Test
@@ -998,6 +999,72 @@ class MergeTests {
 
             var check = pr.checks(mergeHash).get("jcheck");
             assertEquals("- Could not determine the source for this merge. A Merge PR title must be specified on the format: Merge `project`:`branch` to allow verification of the merge contents.", check.summary().orElseThrow());
+        }
+    }
+
+    @Test
+    void foreignCommitWarning(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+
+            var author = credentials.getHostedRepository();
+            var integrator = credentials.getHostedRepository();
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addCommitter(author.forge().currentUser().id())
+                                           .addReviewer(integrator.forge().currentUser().id());
+            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
+
+            // Populate the projects repository
+            var localRepoFolder = tempFolder.path().resolve("localrepo");
+            var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Make more changes in another branch
+            var otherHash1 = CheckableRepository.appendAndCommit(localRepo, "First change in other",
+                                                                 "First other\n\nReviewed-by: integrationreviewer2");
+            localRepo.push(otherHash1, author.url(), "other", true);
+            var otherHash2 = CheckableRepository.appendAndCommit(localRepo, "Second change in other",
+                                                                 "Second other\n\nReviewed-by: integrationreviewer2");
+            localRepo.push(otherHash2, author.url(), "other");
+
+            // Go back to the original master
+            localRepo.checkout(masterHash, true);
+
+            // Make a change with a corresponding PR
+            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated", StandardCharsets.UTF_8);
+            localRepo.add(unrelated);
+            var updatedMaster = localRepo.commit( "Unrelated", "some", "some@one");
+            localRepo.push(updatedMaster, author.url(), "master");
+
+            // Go back to the original master again
+            localRepo.checkout(masterHash, true);
+            var editChange = Files.writeString(localRepo.root().resolve("edit.txt"), "Edit", StandardCharsets.UTF_8);
+            localRepo.add(editChange);
+            var editHash = localRepo.commit( "Edit", "some", "some@one");
+
+            // Merge the latest commit from master
+            localRepo.merge(updatedMaster);
+            var masterMergeHash = localRepo.commit("Master merge commit", "some", "some@one");
+            localRepo.push(masterMergeHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "1234: A change");
+
+            // Let the bot check the status
+            TestBotRunner.runPeriodicItems(mergeBot);
+
+            // Merging latest master should not trigger a warning
+            assertEquals(0, pr.comments().size());
+
+            localRepo.merge(otherHash2);
+            var mergeHash = localRepo.commit("Merge commit", "some", "some@one");
+            localRepo.push(mergeHash, author.url(), "edit", true);
+
+            // Let the bot check the status
+            TestBotRunner.runPeriodicItems(mergeBot);
+
+            // There should be a warning
+            assertLastCommentContains(pr, "This pull request looks like it contains a merge commit");
         }
     }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequestUtils.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequestUtils.java
@@ -181,4 +181,19 @@ public class PullRequestUtils {
                       .map(Contributor::username)
                       .collect(Collectors.toCollection(LinkedHashSet::new));
     }
+
+    public static boolean containsForeignMerge(PullRequest pr, Repository localRepo) throws IOException {
+        var baseHash = baseHash(pr, localRepo);
+        var commits = localRepo.commitMetadata(baseHash, pr.headHash());
+        var mergeParents = commits.stream()
+                                  .filter(CommitMetadata::isMerge)
+                                  .flatMap(commit -> commit.parents().stream().skip(1))
+                                  .collect(Collectors.toList());
+        for (var mergeParent : mergeParents) {
+            if (!localRepo.isAncestor(baseHash, mergeParent)) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequestUtils.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequestUtils.java
@@ -190,7 +190,7 @@ public class PullRequestUtils {
                                   .flatMap(commit -> commit.parents().stream().skip(1))
                                   .collect(Collectors.toList());
         for (var mergeParent : mergeParents) {
-            if (!localRepo.isAncestor(baseHash, mergeParent)) {
+            if (!localRepo.mergeBase(pr.targetHash(), mergeParent).equals(mergeParent)) {
                 return true;
             }
         }


### PR DESCRIPTION
Hi all,

Please review this change that checks if a PR contains merges from outside the current project, and suggests using a merge-style PR.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-342](https://bugs.openjdk.java.net/browse/SKARA-342): Pull request bot should warn on merge commits with non-target branch parent


### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/679/head:pull/679`
`$ git checkout pull/679`
