### PR TITLE
Add support for paginated fields

### DIFF
--- a/network/src/test/java/org/openjdk/skara/network/RestRequestTests.java
+++ b/network/src/test/java/org/openjdk/skara/network/RestRequestTests.java
@@ -175,6 +175,21 @@ class RestRequestTests {
     }
 
     @Test
+    void fieldPagination() throws IOException {
+        var page1 = "{ \"a\": 1, \"b\": [ 1, 2, 3 ] }";
+        var page2 = "{ \"a\": 1, \"b\": [ 4, 5, 6 ] }";
+        try (var receiver = new RestReceiver(List.of(page1, page2))) {
+            var request = new RestRequest(receiver.getEndpoint());
+            var result = request.post("/test").execute();
+            assertEquals(1, result.get("a").asInt());
+            assertEquals(6, result.get("b").asArray().size());
+            assertEquals(1, result.get("b").asArray().get(0).asInt());
+            assertEquals(4, result.get("b").asArray().get(3).asInt());
+            assertEquals(6, result.get("b").asArray().get(5).asInt());
+        }
+    }
+
+    @Test
     void retryOnTransientErrors() throws IOException {
         try (var receiver = new RestReceiver()) {
             receiver.setTruncatedResponseCount(1);


### PR DESCRIPTION
Hi all,

Please review this change that add support for automatic decoding of paginated results where the pagination is done on a field in the result object, instead of across the entire result.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/681/head:pull/681`
`$ git checkout pull/681`
