### PR TITLE
442: Remove debug logging

### DIFF
--- a/mailinglist/src/main/java/org/openjdk/skara/mailinglist/mboxfile/MboxFileList.java
+++ b/mailinglist/src/main/java/org/openjdk/skara/mailinglist/mboxfile/MboxFileList.java
@@ -90,7 +90,6 @@ public class MboxFileList implements MailingList {
             mbox = Files.readString(file, StandardCharsets.UTF_8);
         } catch (IOException e) {
             log.info("Failed to open mbox file");
-            log.throwing("MboxFileList", "conversations", e);
             return new LinkedList<>();
         }
         var cutoff = Instant.now().minus(maxAge);


### PR DESCRIPTION
Remove the stacktrace log for a caught exception that is expected, and just clutters the log.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-442](https://bugs.openjdk.java.net/browse/SKARA-442): Remove debug logging


### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/686/head:pull/686`
`$ git checkout pull/686`
