### PR TITLE
445: The issue notifier should not process commits for downstream projects

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierBuilder.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierBuilder.java
@@ -37,6 +37,7 @@ class IssueNotifierBuilder {
     private Map<String, String> fixVersions = null;
     private JbsVault vault = null;
     private String securityLevel = null;
+    private boolean prOnly = true;
 
     IssueNotifierBuilder issueProject(IssueProject issueProject) {
         this.issueProject = issueProject;
@@ -64,6 +65,7 @@ class IssueNotifierBuilder {
     }
 
     public IssueNotifierBuilder setFixVersion(boolean setFixVersion) {
+        prOnly = false;
         this.setFixVersion = setFixVersion;
         return this;
     }
@@ -83,9 +85,14 @@ class IssueNotifierBuilder {
         return this;
     }
 
+    public IssueNotifierBuilder prOnly(boolean prOnly) {
+        this.prOnly = prOnly;
+        return this;
+    }
+
     IssueNotifier build() {
         var jbsBackport = new JbsBackport(issueProject.webUrl(), vault, securityLevel);
         return new IssueNotifier(issueProject, reviewLink, reviewIcon, commitLink, commitIcon,
-                                 setFixVersion, fixVersions, jbsBackport);
+                                 setFixVersion, fixVersions, jbsBackport, prOnly);
     }
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierFactory.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierFactory.java
@@ -63,6 +63,10 @@ public class IssueNotifierFactory implements NotifierFactory {
             builder.securityLevel(notifierConfiguration.get("security").asString());
         }
 
+        if (notifierConfiguration.contains("pronly")) {
+            builder.prOnly(notifierConfiguration.get("pronly").asBoolean());
+        }
+
         return builder.build();
     }
 }


### PR DESCRIPTION
Hi all,

Please review this change that makes it possible to avoid posting comments in issues merged into downstream projects.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-445](https://bugs.openjdk.java.net/browse/SKARA-445): The issue notifier should not process commits for downstream projects


### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/688/head:pull/688`
`$ git checkout pull/688`
