### PR TITLE
437: Skara should invalidate approved reviews if the target branch changes

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -57,7 +57,8 @@ public class GitHubRepository implements HostedRepository {
                 "Accept", "application/vnd.github.machine-man-preview+json",
                 "Accept", "application/vnd.github.antiope-preview+json",
                 "Accept", "application/vnd.github.shadow-cat-preview+json",
-                "Accept", "application/vnd.github.comfort-fade-preview+json"));
+                "Accept", "application/vnd.github.comfort-fade-preview+json",
+                "Accept", "application/vnd.github.mockingbird-preview+json"));
             var token = gitHubHost.getInstallationToken();
             if (token.isPresent()) {
                 headers.add("Authorization");


### PR DESCRIPTION
Hi all,

Please review this change that disregards pull request reviews done before changing the target branch, as that is not what's reviewed. Tested manually on GitHub.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-437](https://bugs.openjdk.java.net/browse/SKARA-437): Skara should invalidate approved reviews if the target branch changes


### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/689/head:pull/689`
`$ git checkout pull/689`
