### PR TITLE
447: Sponsoring should only require committer status

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
@@ -40,7 +40,7 @@ public class SponsorCommand implements CommandHandler {
             reply.println("This change does not need sponsoring - the author is allowed to integrate it.");
             return;
         }
-        if (!censusInstance.isReviewer(command.user())) {
+        if (!censusInstance.isCommitter(command.user())) {
             reply.println("Only [Committers](https://openjdk.java.net/bylaws#committer) are allowed to sponsor changes.");
             return;
         }


### PR DESCRIPTION
Hi all,

please review this small patch that ensures that Committers can sponsor patches.

Testing:
- [x] `make test` passes on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-447](https://bugs.openjdk.java.net/browse/SKARA-447): Sponsoring should only require committer status


### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/691/head:pull/691`
`$ git checkout pull/691`
