### PR TITLE
Fix Dockerfile issues

### DIFF
--- a/bots.dockerfile
+++ b/bots.dockerfile
@@ -60,6 +60,7 @@ ENV LC_ALL en_US.UTF-8
 RUN yum -y install unzip
 
 COPY gradlew ./
+COPY deps.env ./
 
 ENV JAVA_TOOL_OPTIONS=$JAVA_OPTIONS
 RUN sh gradlew --no-daemon --version $GRADLE_OPTIONS
@@ -104,12 +105,12 @@ RUN yum -y install rsync unzip && yum clean all
 
 COPY --from=prerequisites-runtime /bots/git/ /bots/git/
 COPY --from=prerequisites-runtime /bots/hg/ /bots/hg/
-COPY --from=builder /bots-build/bots/cli/build/distributions/cli-unknown-linux.tar.gz /bots/tar/
+COPY --from=builder /bots-build/bots/cli/build/distributions/cli-unknown-linux-x64.tar.gz /bots/tar/
 
 ENV JAVA_TOOL_OPTIONS=$JAVA_OPTIONS
 ENV PATH=/bots/git/bin:/bots/hg/bin:${PATH}
 
-RUN tar xvf /bots/tar/cli-unknown-linux.tar.gz
+RUN tar xvf /bots/tar/cli-unknown-linux-x64.tar.gz
 
 ENTRYPOINT ["/bots/bin/skara-bots"]
 CMD ["--help"]


### PR DESCRIPTION
Hi all,

This PR is trying to fix Dockerfile build issue.

1. adding deps.env file to Docker build env
 
error before this change:

```
Removing intermediate container 72a7b09806df
 ---> 66828863be56
Step 19/52 : COPY gradlew ./
 ---> a3b0c0c94d91
Step 20/52 : ENV JAVA_TOOL_OPTIONS=$JAVA_OPTIONS
 ---> Running in a7296b1bc7c5
Removing intermediate container a7296b1bc7c5
 ---> 9034013f18e5
Step 21/52 : RUN sh gradlew --no-daemon --version $GRADLE_OPTIONS
 ---> Running in 6172925e9a37
gradlew: line 87: ./deps.env: No such file or directory 
```

2. update .tar.gz file name

error before this change:

```
 ---> 550d7ac342a3
Step 46/53 : COPY --from=prerequisites-runtime /bots/git/ /bots/git/
 ---> 6783d09d4559
Step 47/53 : COPY --from=prerequisites-runtime /bots/hg/ /bots/hg/
 ---> e1a17de8e587
Step 48/53 : COPY --from=builder /bots-build/bots/cli/build/distributions/cli-unknown-linux.tar.gz /bots/tar/
COPY failed: stat /var/lib/docker/overlay2/fa560932e1a43ea902ad69deadd9ed76da81c01596e971832cec2906e3c494f0/merged/bots-build/bots/cli/build/distributions/cli-unknown-linux.tar.gz: no such file or directory
```

Thanks,

Junyuan
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/692/head:pull/692`
`$ git checkout pull/692`
