### PR TITLE
pr: improve message for unexpected merge commits

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -703,7 +703,7 @@ class CheckRun {
         }
 
         var message = "⚠️  @" + pr.author().userName() +
-                      " This pull request contains merges that brings in commits not present in the target repository." +
+                      " This pull request contains merges that bring in commits not present in the target repository." +
                       " Since this is not a \"merge style\" pull request, these changes will be squashed when this pull request in integrated." +
                       " If this is your intention, then please ignore this message. If you want to preserve the commit structure, you must change" +
                       " the title of this pull request to `Merge <project>:<branch>` where `<project>` is the name of another project in the" +

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -702,12 +702,13 @@ class CheckRun {
             return;
         }
 
-        var message = "@" + pr.author().userName() + " This pull request looks like it contains a merge commit that " +
-                "brings in commits from outside of this repository. If you want these commits to be preserved " +
-                "when you integrate, you will need to make a 'merge-style' pull request. To do this, change the " +
-                "title of this pull request to `Merge <project>:<branch>`, where `<project>` is the name of another " +
-                "project in the OpenJDK organization. For example: `Merge jdk:master`." +
-                "\n" + mergeCommitWarningMarker;
+        var message = "⚠️  @" + pr.author().userName() +
+                      " This pull request contains merges that brings in commits not present in the target repository." +
+                      " Since this is not a \"merge style\" pull request, these changes will be squashed when this pull request in integrated." +
+                      " If this is your intention, then please ignore this message. If you want to preserve the commit structure, you must change" +
+                      " the title of this pull request to `Merge <project>:<branch>` where `<project>` is the name of another project in the" +
+                      " [OpenJDK organization](https://github.com/openjdk) (for example `Merge jdk:master`).\n" +
+                      mergeCommitWarningMarker;
         pr.addComment(message);
     }
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
@@ -1064,7 +1064,7 @@ class MergeTests {
             TestBotRunner.runPeriodicItems(mergeBot);
 
             // There should be a warning
-            assertLastCommentContains(pr, "This pull request looks like it contains a merge commit");
+            assertLastCommentContains(pr, "This pull request contains merges that brings in commits not present");
         }
     }
 }


### PR DESCRIPTION
Hi all,

please review this patch that improves the warning when a pull request contains a merge request that brings in commits not present in the target repository. This indicates that the user might wanted to do a "merge style" pull request, but can also arise in other scenarios.

Testing:
- [x] `make test` passes on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**) ⚠️ Review applies to a4b94acb91292bf187447c980836ddd1eca370b3
 * Kevin Rushforth ([kcr](@kevinrushforth) - no project role) ⚠️ Review applies to a4b94acb91292bf187447c980836ddd1eca370b3


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/693/head:pull/693`
`$ git checkout pull/693`
