### PR TITLE
pr: fix merge tests

### DIFF
--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
@@ -1064,7 +1064,7 @@ class MergeTests {
             TestBotRunner.runPeriodicItems(mergeBot);
 
             // There should be a warning
-            assertLastCommentContains(pr, "This pull request contains merges that brings in commits not present");
+            assertLastCommentContains(pr, "This pull request contains merges that bring in commits not present");
         }
     }
 }


### PR DESCRIPTION
Hi all,

please review this small patch that fixes a test after fce40b52 was pushed. I updated the wording right before pushing and forgot to update the test.

Testing:
- [x] `make test` passes on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/694/head:pull/694`
`$ git checkout pull/694`
