### PR TITLE
git-pr: use correct argument in git-pr issue

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrIssue.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrIssue.java
@@ -92,7 +92,7 @@ public class GitPrIssue {
             var comment = pr.addComment("/issue add" + " " + issueId);
             showReply(awaitReplyTo(pr, comment));
         } else if (arguments.contains("remove")) {
-            var issueId = arguments.get("add").asString();
+            var issueId = arguments.get("remove").asString();
             var comment = pr.addComment("/issue remove" + " " + issueId);
             showReply(awaitReplyTo(pr, comment));
         } else if (arguments.contains("create")) {


### PR DESCRIPTION
Hi all,

please review this small patch that fixes `git pr issue --remove` to use the correct argument (`--remove`, not `--add`).

Testing:
- Manual testing on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/696/head:pull/696`
`$ git checkout pull/696`
