### PR TITLE
git-pr: add reviewer sub-command

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
@@ -75,7 +75,10 @@ public class GitPr {
                            .main(GitPrInfo::main),
                     Command.name("issue")
                            .helptext("add, remove or create issues")
-                           .main(GitPrIssue::main)
+                           .main(GitPrIssue::main),
+                    Command.name("reviewer")
+                           .helptext("add or remove reviewers")
+                           .main(GitPrReviewer::main)
         );
 
         HttpProxy.setup();

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrReviewer.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrReviewer.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.cli.pr;
+
+import org.openjdk.skara.args.*;
+import org.openjdk.skara.issuetracker.Comment;
+import org.openjdk.skara.forge.PullRequest;
+
+import static org.openjdk.skara.cli.pr.Utils.*;
+
+import java.io.IOException;
+import java.util.*;
+
+public class GitPrReviewer {
+    static final List<Flag> flags = List.of(
+        Option.shortcut("")
+              .fullname("add")
+              .describe("USERNAME")
+              .helptext("Consider pull request reviewed by this user")
+              .optional(),
+        Option.shortcut("")
+              .fullname("remove")
+              .describe("USERNAME")
+              .helptext("Do not consider pull request reviewed by this user")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("verbose")
+              .helptext("Turn on verbose output")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("debug")
+              .helptext("Turn on debugging output")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("version")
+              .helptext("Print the version of this tool")
+              .optional()
+    );
+
+    static final List<Input> inputs = List.of(
+        Input.position(0)
+             .describe("ID")
+             .singular()
+             .optional()
+    );
+
+    public static void main(String[] args) throws IOException, InterruptedException {
+        var parser = new ArgumentParser("git-pr reviewer", flags, inputs);
+        var arguments = parse(parser, args);
+        var repo = getRepo();
+        var uri = getURI(repo, arguments);
+        var host = getForge(uri, repo, arguments);
+        var id = pullRequestIdArgument(repo, arguments);
+        var pr = getPullRequest(uri, repo, host, id);
+
+        if (arguments.contains("add")) {
+            var username = arguments.get("add").asString();
+            var comment = pr.addComment("/reviewer add" + " " + username);
+            showReply(awaitReplyTo(pr, comment));
+        } else if (arguments.contains("remove")) {
+            var username = arguments.get("remove").asString();
+            var comment = pr.addComment("/reviewer remove" + " " + username);
+            showReply(awaitReplyTo(pr, comment));
+        } else {
+            System.err.println("error: must use either --add or --remove");
+            System.exit(1);
+        }
+    }
+}


### PR DESCRIPTION
Hi all,

please review this patch that adds the `git pr reviewer` sub-command which corresponds to the [`/reviewer`](https://wiki.openjdk.java.net/display/SKARA/Pull+Request+Commands#PullRequestCommands-/reviewer) pull request command. A pull request author can now run `git pr reviewr --add=ehelin` to mark me as a reviewer of a pull request (note that not all OpenJDK projects allow authors to add reviewers).

Testing:
- Manual testing on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/697/head:pull/697`
`$ git checkout pull/697`
