### PR TITLE
git-pr: add cc sub-command

### DIFF
--- a/args/src/main/java/org/openjdk/skara/args/Arguments.java
+++ b/args/src/main/java/org/openjdk/skara/args/Arguments.java
@@ -23,6 +23,7 @@
 package org.openjdk.skara.args;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 public class Arguments {
     private final List<String> positionals;
@@ -39,6 +40,12 @@ public class Arguments {
                 names.put(flag.shortcut(), flag);
             }
         }
+    }
+
+    public List<Argument> inputs() {
+        return positionals.stream()
+                          .map(Argument::new)
+                          .collect(Collectors.toList());
     }
 
     public Argument at(int pos) {

--- a/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
@@ -78,7 +78,10 @@ public class GitPr {
                            .main(GitPrIssue::main),
                     Command.name("reviewer")
                            .helptext("add or remove reviewers")
-                           .main(GitPrReviewer::main)
+                           .main(GitPrReviewer::main),
+                    Command.name("cc")
+                           .helptext("add one or more labels")
+                           .main(GitPrCC::main)
         );
 
         HttpProxy.setup();

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrCC.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrCC.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.cli.pr;
+
+import org.openjdk.skara.args.*;
+import org.openjdk.skara.issuetracker.Comment;
+import org.openjdk.skara.forge.PullRequest;
+
+import static org.openjdk.skara.cli.pr.Utils.*;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class GitPrCC {
+    static final List<Flag> flags = List.of(
+        Switch.shortcut("")
+              .fullname("verbose")
+              .helptext("Turn on verbose output")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("debug")
+              .helptext("Turn on debugging output")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("version")
+              .helptext("Print the version of this tool")
+              .optional()
+    );
+
+    static final List<Input> inputs = List.of(
+        Input.position(0)
+             .describe("ARG")
+             .trailing()
+             .required()
+    );
+
+    public static void main(String[] args) throws IOException, InterruptedException {
+        var parser = new ArgumentParser("git-pr cc", flags, inputs);
+        var arguments = parse(parser, args);
+        var repo = getRepo();
+        var uri = getURI(repo, arguments);
+        var host = getForge(uri, repo, arguments);
+        var prId = arguments.at(0).asString().matches("[0-9]+") ?
+            arguments.at(0).asString() : null;
+        var pr = getPullRequest(uri, repo, host, prId);
+
+        var labelsStartIndex = prId == null ? 0 : 1;
+        var labels = arguments.inputs()
+                              .stream()
+                              .skip(labelsStartIndex)
+                              .map(Argument::asString)
+                              .collect(Collectors.joining(" "));
+        var comment = pr.addComment("/cc " + labels);
+        showReply(awaitReplyTo(pr, comment));
+    }
+}


### PR DESCRIPTION
Hi all,

please review this patch that adds the `git pr cc` sub-command which corresponds to the [`/cc`](https://wiki.openjdk.java.net/display/SKARA/Pull+Request+Commands#PullRequestCommands-/cc) pull request command. Contributors preferring the command-line can now run for example `git pr cc build-dev hotspot-dev`.

Testing:
- [x] Manual testing on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/699/head:pull/699`
`$ git checkout pull/699`
