### PR TITLE
git-pr: add summary sub-command

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
@@ -78,7 +78,10 @@ public class GitPr {
                            .main(GitPrIssue::main),
                     Command.name("reviewer")
                            .helptext("add or remove reviewers")
-                           .main(GitPrReviewer::main)
+                           .main(GitPrReviewer::main),
+                    Command.name("summary")
+                           .helptext("add a summary to the commit message for the pull request")
+                           .main(GitPrSummary::main)
         );
 
         HttpProxy.setup();

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrSummary.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrSummary.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.cli.pr;
+
+import org.openjdk.skara.args.*;
+
+import static org.openjdk.skara.cli.pr.Utils.*;
+
+import java.io.IOException;
+import java.util.List;
+import java.nio.file.Files;
+
+public class GitPrSummary {
+    static final List<Flag> flags = List.of(
+        Switch.shortcut("")
+              .fullname("verbose")
+              .helptext("Turn on verbose output")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("debug")
+              .helptext("Turn on debugging output")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("version")
+              .helptext("Print the version of this tool")
+              .optional()
+    );
+
+    static final List<Input> inputs = List.of(
+        Input.position(0)
+             .describe("ID")
+             .singular()
+             .optional()
+    );
+
+    public static void main(String[] args) throws IOException, InterruptedException {
+        var parser = new ArgumentParser("git-pr summary", flags, inputs);
+        var arguments = parse(parser, args);
+        var repo = getRepo();
+        var uri = getURI(repo, arguments);
+        var host = getForge(uri, repo, arguments);
+        var id = pullRequestIdArgument(repo, arguments);
+        var pr = getPullRequest(uri, repo, host, id);
+
+        var file = Files.createTempFile("SUMMARY", ".txt");
+        var success = spawnEditor(repo, file);
+        if (!success) {
+            System.err.println("error: editor exited with non-zero status code, aborting");
+            System.exit(1);
+        }
+        var lines = Files.readAllLines(file);
+        if (lines.stream().allMatch(String::isEmpty)) {
+            System.err.println("error: no summary present, aborting");
+            System.exit(1);
+        }
+        var comment = lines.size() == 1 ?
+            pr.addComment("/summary " + lines.get(0)) :
+            pr.addComment("/summary\n" + String.join("\n", lines));
+    }
+}

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrSummary.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrSummary.java
@@ -33,6 +33,10 @@ import java.nio.file.Files;
 public class GitPrSummary {
     static final List<Flag> flags = List.of(
         Switch.shortcut("")
+              .fullname("remove")
+              .helptext("Remove an existing summary")
+              .optional(),
+        Switch.shortcut("")
               .fullname("verbose")
               .helptext("Turn on verbose output")
               .optional(),
@@ -61,6 +65,11 @@ public class GitPrSummary {
         var host = getForge(uri, repo, arguments);
         var id = pullRequestIdArgument(repo, arguments);
         var pr = getPullRequest(uri, repo, host, id);
+
+        if (arguments.contains("remove")) {
+            showReply(awaitReplyTo(pr, pr.addComment("/summary")));
+            return;
+        }
 
         var file = Files.createTempFile("SUMMARY", ".txt");
         var success = spawnEditor(repo, file);

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrSummary.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrSummary.java
@@ -76,5 +76,6 @@ public class GitPrSummary {
         var comment = lines.size() == 1 ?
             pr.addComment("/summary " + lines.get(0)) :
             pr.addComment("/summary\n" + String.join("\n", lines));
+        showReply(awaitReplyTo(pr, comment));
     }
 }


### PR DESCRIPTION
Hi all,

please review this patch that adds the `git pr summary` sub-command which corresponds to the [`/summary`](https://wiki.openjdk.java.net/display/SKARA/Pull+Request+Commands#PullRequestCommands-/summary) pull request command. Contributors who prefer to use the command-line can now run `git pr summary` which will open their configured editor for writing a summary.

Testing:
- [x] Manual testing on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - **Reviewer**) ⚠️ Review applies to 56e36cf154f9d679593883ff36eeadf323a47a3e


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/700/head:pull/700`
`$ git checkout pull/700`
