### PR TITLE
git-pr: add csr sub-command

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CSRCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CSRCommand.java
@@ -34,7 +34,7 @@ public class CSRCommand implements CommandHandler {
     private static final String CSR_LABEL = "csr";
 
     private static void showHelp(PrintWriter writer) {
-        writer.println("usage: `/csr [needed|unneeded]`, requires that the issue the pull request links to an approved [CSR](https://wiki.openjdk.java.net/display/csr/Main) request.");
+        writer.println("usage: `/csr [needed|unneeded]`, requires that the issue the pull request refers to links to an approved [CSR](https://wiki.openjdk.java.net/display/csr/Main) request.");
     }
 
     private static void csrReply(PrintWriter writer) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CSRCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CSRCommand.java
@@ -34,7 +34,7 @@ public class CSRCommand implements CommandHandler {
     private static final String CSR_LABEL = "csr";
 
     private static void showHelp(PrintWriter writer) {
-        writer.println("usage: `/csr [unneeded]`, requires that the issue the pull request links to an approved [CSR](https://wiki.openjdk.java.net/display/csr/Main) request.");
+        writer.println("usage: `/csr [needed|unneeded]`, requires that the issue the pull request links to an approved [CSR](https://wiki.openjdk.java.net/display/csr/Main) request.");
     }
 
     private static void csrReply(PrintWriter writer) {
@@ -64,14 +64,15 @@ public class CSRCommand implements CommandHandler {
 
         var labels = pr.labels();
 
-        if (command.args().trim().toLowerCase().equals("unneeded")) {
+        var cmd = command.args().trim().toLowerCase();
+        if (cmd.equals("unneeded") || cmd.equals("uneeded")) {
             if (labels.contains(CSR_LABEL)) {
                 pr.removeLabel(CSR_LABEL);
             }
             reply.println("determined that a [CSR](https://wiki.openjdk.java.net/display/csr/Main) request " +
                           "is no longer needed for this pull request.");
             return;
-        } else if (!command.args().isEmpty()) {
+        } else if (!cmd.isEmpty() && !cmd.equals("needed")) {
             showHelp(reply);
             return;
         }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CSRTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CSRTests.java
@@ -86,6 +86,16 @@ class CSRTests {
             assertLastCommentContains(pr, "determined that a [CSR](https://wiki.openjdk.java.net/display/csr/Main) request " +
                                           "is no longer needed for this pull request.");
             assertFalse(pr.labels().contains("csr"));
+
+            // Require CSR again with long form
+            prAsReviewer.addComment("/csr needed");
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // The bot should reply with a message that a CSR is needed
+            assertLastCommentContains(pr, "has indicated that a " +
+                                          "[compatibility and specification](https://wiki.openjdk.java.net/display/csr/Main) (CSR) request " +
+                                          "is needed for this pull request.");
+            assertTrue(pr.labels().contains("csr"));
         }
     }
 
@@ -239,7 +249,7 @@ class CSRTests {
             TestBotRunner.runPeriodicItems(prBot);
 
             // Show help
-            assertLastCommentContains(pr, "usage: `/csr [unneeded]`, requires that the issue the pull request links " +
+            assertLastCommentContains(pr, "usage: `/csr [needed|unneeded]`, requires that the issue the pull request links " +
                                           "to an approved [CSR](https://wiki.openjdk.java.net/display/csr/Main) request.");
             assertFalse(pr.labels().contains("csr"));
         }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CSRTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CSRTests.java
@@ -249,7 +249,7 @@ class CSRTests {
             TestBotRunner.runPeriodicItems(prBot);
 
             // Show help
-            assertLastCommentContains(pr, "usage: `/csr [needed|unneeded]`, requires that the issue the pull request links " +
+            assertLastCommentContains(pr, "usage: `/csr [needed|unneeded]`, requires that the issue the pull request refers to links " +
                                           "to an approved [CSR](https://wiki.openjdk.java.net/display/csr/Main) request.");
             assertFalse(pr.labels().contains("csr"));
         }

--- a/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
@@ -84,7 +84,10 @@ public class GitPr {
                            .main(GitPrSummary::main),
                     Command.name("cc")
                            .helptext("add one or more labels")
-                           .main(GitPrCC::main)
+                           .main(GitPrCC::main),
+                    Command.name("csr")
+                           .helptext("require CSR for the pull request")
+                           .main(GitPrCSR::main)
         );
 
         HttpProxy.setup();

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrCSR.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrCSR.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.cli.pr;
+
+import org.openjdk.skara.args.*;
+import org.openjdk.skara.issuetracker.Comment;
+import org.openjdk.skara.forge.PullRequest;
+
+import static org.openjdk.skara.cli.pr.Utils.*;
+
+import java.io.IOException;
+import java.util.*;
+
+public class GitPrCSR {
+    static final List<Flag> flags = List.of(
+        Switch.shortcut("")
+              .fullname("needed")
+              .helptext("This pull request needs an approved CSR before integration")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("unneeded")
+              .helptext("This pull request does not need an approved CSR before integration")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("verbose")
+              .helptext("Turn on verbose output")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("debug")
+              .helptext("Turn on debugging output")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("version")
+              .helptext("Print the version of this tool")
+              .optional()
+    );
+
+    static final List<Input> inputs = List.of(
+        Input.position(0)
+             .describe("ID")
+             .singular()
+             .optional()
+    );
+
+    public static void main(String[] args) throws IOException, InterruptedException {
+        var parser = new ArgumentParser("git-pr csr", flags, inputs);
+        var arguments = parse(parser, args);
+        var repo = getRepo();
+        var uri = getURI(repo, arguments);
+        var host = getForge(uri, repo, arguments);
+        var id = pullRequestIdArgument(repo, arguments);
+        var pr = getPullRequest(uri, repo, host, id);
+
+        if (arguments.contains("needed")) {
+            var comment = pr.addComment("/csr needed");
+            showReply(awaitReplyTo(pr, comment));
+        } else if (arguments.contains("unneeded")) {
+            var comment = pr.addComment("/csr unneeded");
+            showReply(awaitReplyTo(pr, comment));
+        } else {
+            System.err.println("error: must use either --needed or --unneeded");
+            System.exit(1);
+        }
+    }
+}


### PR DESCRIPTION
Hi all,

please review this patch that adds the `git pr csr` sub-command that corresponds to the [`/csr`](https://wiki.openjdk.java.net/display/SKARA/Pull+Request+Commands#PullRequestCommands-/csr) pull request command. A contributor who prefers the command-line can now state that a pull request requires a [CSR](https://wiki.openjdk.java.net/display/csr) by running `git pr csr --needed`.

Testing:
- [x] Manual testing on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - **Reviewer**) ⚠️ Review applies to d11bdb543d6208f1fa8ea0bf7a9de37eb8f90b54


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/702/head:pull/702`
`$ git checkout pull/702`
