### PR TITLE
forge: use /app/installations/ endpoint for GitHub access tokens

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubApplication.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubApplication.java
@@ -176,7 +176,7 @@ public class GitHubApplication {
     }
 
     private String generateInstallationToken() throws Token.GeneratorError {
-        var tokens = URIBuilder.base(apiBase).setPath("/installations/" + id + "/access_tokens").build();
+        var tokens = URIBuilder.base(apiBase).setPath("/app/installations/" + id + "/access_tokens").build();
 
         try {
             var response = client.send(


### PR DESCRIPTION
Hi all,

please review this small patch that changes the REST endpoint for creating GitHub access tokens from `/installations/:installation_id/access_tokens` to `/app/installations/:installation_id/access_tokens`. GitHub [announced in April](https://developer.github.com/changes/2020-04-15-replacing-create-installation-access-token-endpoint/) that they are deprecating the `/installations/:installation_id/access_tokens` endpoint and that applications should migrate to the `/app/installations/:installation_id/access_tokens` endpoint which features identical semantics.

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/703/head:pull/703`
`$ git checkout pull/703`
