### PR TITLE
git-trees: fix usage message

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitTrees.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitTrees.java
@@ -122,8 +122,11 @@ public class GitTrees {
             System.exit(0);
         }
 
-        if (args.length == 1 && args[0].equals("-h")) {
-            System.out.println("git-trees version: " + Version.fromManifest().orElse("unknown"));
+        if (args.length == 1 && (args[0].equals("-h") || args[0].equals("--help"))) {
+            System.out.println("usage: git-trees [options] <COMMAND>");
+            System.out.println("\t-m, --mercurial\tDeprecated: force use of mercurial");
+            System.out.println("\t-h, --help     \tShow this help text");
+            System.out.println("\t    --version  \tPrint the version of this tool");
             System.exit(0);
         }
 


### PR DESCRIPTION
Hi all,

please review this small patch that fixes the usage message for `git-trees`.

Testing:
- [x] Manual testing on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/704/head:pull/704`
`$ git checkout pull/704`
