### PR TITLE
456: Read value of resolved in build properly when considering backports

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/Backports.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/Backports.java
@@ -72,8 +72,8 @@ public class Backports {
             log.warning("Issue " + issue.id() + " has multiple valid fixVersions - ignoring");
             return Optional.empty();
         }
-        if (issue.properties().containsKey("customfield_10006") && !issue.properties().get("customfield_10006").isNull()) {
-            return Optional.of(JdkVersion.parse(versionString.get(0), issue.properties().get("customfield_10006").asString()));
+        if (issue.properties().containsKey("customfield_10006") && issue.properties().get("customfield_10006").isObject()) {
+            return Optional.of(JdkVersion.parse(versionString.get(0), issue.properties().get("customfield_10006").get("value").asString()));
         } else {
             return Optional.of(JdkVersion.parse(versionString.get(0)));
         }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/Backports.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/Backports.java
@@ -72,7 +72,7 @@ public class Backports {
             log.warning("Issue " + issue.id() + " has multiple valid fixVersions - ignoring");
             return Optional.empty();
         }
-        if (issue.properties().containsKey("customfield_10006")) {
+        if (issue.properties().containsKey("customfield_10006") && !issue.properties().get("customfield_10006").isNull()) {
             return Optional.of(JdkVersion.parse(versionString.get(0), issue.properties().get("customfield_10006").asString()));
         } else {
             return Optional.of(JdkVersion.parse(versionString.get(0)));

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/BackportsTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/BackportsTests.java
@@ -175,7 +175,7 @@ public class BackportsTests {
             }
             issue.setProperty("fixVersions", JSON.array().add(version));
             if (!resolvedInBuild.isEmpty()) {
-                issue.setProperty("customfield_10006", JSON.of(resolvedInBuild));
+                issue.setProperty("customfield_10006", JSON.object().put("value", resolvedInBuild));
             }
         }
 


### PR DESCRIPTION
Hi all,

Please review this small change that makes sure that the JBS custom field "resolved in build" is read properly.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-456](https://bugs.openjdk.java.net/browse/SKARA-456): Read value of resolved in build properly when considering backports


### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/706/head:pull/706`
`$ git checkout pull/706`
