### PR TITLE
SKARA-461: Do a git version check

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitSkara.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitSkara.java
@@ -24,6 +24,7 @@ package org.openjdk.skara.cli;
 
 import org.openjdk.skara.args.Main;
 import org.openjdk.skara.vcs.Repository;
+import org.openjdk.skara.vcs.git.GitVersion;
 import org.openjdk.skara.vcs.openjdk.CommitMessageParsers;
 import org.openjdk.skara.version.Version;
 
@@ -171,6 +172,19 @@ public class GitSkara {
         }
     }
 
+    private static void checkGitVersion() {
+        try {
+            GitVersion version = GitVersion.get();
+            if (!version.isKnownSupported()) {
+                System.err.println("WARNING: Your git version is: " + version + "," +
+                        " which is not a known supported version." +
+                        " Please consider upgrading to a more recent version.");
+            }
+        } catch (IOException e) {
+            System.err.println("Could not check git version: " + e.getMessage());
+        }
+    }
+
     public static void main(String[] args) throws Exception {
         commands.put("jcheck", GitJCheck::main);
         commands.put("webrev", GitWebrev::main);
@@ -190,6 +204,8 @@ public class GitSkara {
         commands.put("update", GitSkara::update);
         commands.put("help", GitSkara::usage);
         commands.put("version", GitSkara::version);
+
+        checkGitVersion();
 
         var isEmpty = args.length == 0;
         var command = isEmpty ? "help" : args[0];

--- a/vcs/build.gradle
+++ b/vcs/build.gradle
@@ -28,6 +28,7 @@ module {
         requires 'org.junit.jupiter.api'
         requires 'org.junit.jupiter.params'
         opens 'org.openjdk.skara.vcs' to 'org.junit.platform.commons'
+        opens 'org.openjdk.skara.vcs.git' to 'org.junit.platform.commons'
         opens 'org.openjdk.skara.vcs.openjdk' to 'org.junit.platform.commons'
         opens 'org.openjdk.skara.vcs.openjdk.converter' to 'org.junit.platform.commons'
     }

--- a/vcs/src/main/java/module-info.java
+++ b/vcs/src/main/java/module-info.java
@@ -26,6 +26,7 @@ module org.openjdk.skara.vcs {
     requires org.openjdk.skara.encoding;
 
     exports org.openjdk.skara.vcs;
+    exports org.openjdk.skara.vcs.git;
     exports org.openjdk.skara.vcs.openjdk;
     exports org.openjdk.skara.vcs.openjdk.convert;
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitVersion.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitVersion.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.vcs.git;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Objects;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class GitVersion {
+
+    private static final Pattern versionPattern = Pattern.compile(
+            "git version (?<versionString>.*(?<major>\\d)\\.(?<minor>\\d{2})\\.(?<security>\\d).*)");
+    private static final GitVersion UNKNOWN = new GitVersion("UNKNOWN", -1, -1, -1);
+
+    private final String versionString;
+    private final int major;
+    private final int minor;
+    private final int security;
+
+    private GitVersion(String versionString, int major, int minor, int security) {
+        this.versionString = versionString;
+        this.major = major;
+        this.minor = minor;
+        this.security = security;
+    }
+
+    public static GitVersion parse(String version) {
+        var matcher = versionPattern.matcher(version);
+        if (!matcher.find()) {
+            return UNKNOWN;
+        }
+
+        return new GitVersion(
+            matcher.group("versionString"),
+            Integer.parseInt(matcher.group("major")),
+            Integer.parseInt(matcher.group("minor")),
+            Integer.parseInt(matcher.group("security"))
+        );
+    }
+
+    public static GitVersion get() throws IOException {
+        var p = new ProcessBuilder().command("git", "--version").start();
+        try {
+            var code = p.waitFor();
+            if (code != 0) throw new IOException("git --version exited with code: " + code);
+            try (var lines = new BufferedReader(new InputStreamReader(p.getInputStream())).lines()) {
+                var linesList = lines.collect(Collectors.toList());
+                for (var line : linesList) {
+                    var version = parse(line);
+                    if (version != UNKNOWN) {
+                        return version;
+                    }
+                }
+            }
+            return UNKNOWN;
+        } catch (InterruptedException e) {
+            throw new IOException(e);
+        }
+    }
+
+    public boolean isKnownSupported() {
+        if (major < 2) {
+            return false;
+        }
+
+        switch (minor) {
+//            case 17:
+//            case 19:
+//                return security >= 4;
+//
+//            case 18:
+//            case 20:
+            case 22: // we require 2.22 since we use --combined-all-paths option of git log
+            case 25:
+                return security >= 3;
+
+//            case 21:
+            case 23:
+            case 24:
+                return security >= 2;
+
+            default: {
+                if (minor >= 26) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    public boolean isUnknown() {
+        return this == UNKNOWN;
+    }
+
+    public int major() {
+        return major;
+    }
+
+    public int minor() {
+        return minor;
+    }
+
+    public int security() {
+        return security;
+    }
+
+    @Override
+    public String toString() {
+        return versionString;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        GitVersion that = (GitVersion) o;
+        return Objects.equals(versionString, that.versionString);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(versionString);
+    }
+}

--- a/vcs/src/test/java/org/openjdk/skara/vcs/git/GitVersionTest.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/git/GitVersionTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.vcs.git;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+public class GitVersionTest {
+
+    static Stream<Arguments> supportedVersions() {
+        return Stream.of(
+            arguments("git version 2.22.3", 2, 22, 3),
+            arguments("git version 2.23.2", 2, 23, 2),
+            arguments("git version 2.24.2", 2, 24, 2),
+            arguments("git version 2.25.3", 2, 25, 3),
+            arguments("git version 2.26.1", 2, 26, 1),
+
+            arguments("git version 2.27.0.windows.1", 2, 27, 0)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("supportedVersions")
+    void testSupportedVersions(String versionsString, int major, int minor, int security) {
+        GitVersion version = GitVersion.parse(versionsString);
+
+        assertEquals(version.major(), major);
+        assertEquals(version.minor(), minor);
+        assertEquals(version.security(), security);
+
+        assertFalse(version.isUnknown());
+        assertTrue(version.isKnownSupported());
+    }
+
+    static Stream<Arguments> unsupportedVersions() {
+        return Stream.of(
+            arguments("git version 2.17.4", 2, 17, 4),
+            arguments("git version 2.18.3", 2, 18, 3),
+            arguments("git version 2.19.4", 2, 19, 4),
+            arguments("git version 2.20.3", 2, 20, 3),
+            arguments("git version 2.21.2", 2, 21, 2),
+            arguments("git version 2.21.1 (Apple Git-122.3) ", 2, 21, 1) // doesn't contain security fix
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("unsupportedVersions")
+    void testUnsupportedVersions(String versionsString, int major, int minor, int security) {
+        GitVersion version = GitVersion.parse(versionsString);
+
+        assertEquals(version.major(), major);
+        assertEquals(version.minor(), minor);
+        assertEquals(version.security(), security);
+
+        assertFalse(version.isUnknown());
+        assertFalse(version.isKnownSupported());
+    }
+
+    static Stream<Arguments> unknownVersions() {
+        return Stream.of(
+            arguments("asdfxzxcv")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("unknownVersions")
+    void testUnsupportedVersions(String versionsString) {
+        GitVersion version = GitVersion.parse(versionsString);
+
+        assertTrue(version.isUnknown());
+        assertFalse(version.isKnownSupported());
+    }
+
+}


### PR DESCRIPTION
Hi,

This PR adds a git version check to the `git skara` CLI. This will print a warning if the git version is not a known working version. Since outdated versions can lead to IOExceptions due to e.g. unsupported git CLI options, hopefully the warning message will help to inform users about their use of an unsupported git version, and a potential way to solve the problem i.e. upgrading to a more recent version.

Currently at least git 2.22 is required since we use the `--combined-all-paths` option of git log (see GitCommits), which was added in 2.22.

Thanks,
Jorn
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-461](https://bugs.openjdk.java.net/browse/SKARA-461): Do a git version check


### Reviewers
 * Kevin Rushforth ([kcr](@kevinrushforth) - no project role)
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/707/head:pull/707`
`$ git checkout pull/707`
