### PR TITLE
467: git pr create assumes .jcheck/conf file

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/pr/Utils.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/Utils.java
@@ -227,12 +227,20 @@ class Utils {
         return issues;
     }
 
-    static String jbsProjectFromJcheckConf(Repository repo, String targetBranch) throws IOException {
+    static Optional<String> jbsProjectFromJcheckConf(Repository repo, String targetBranch) throws IOException {
         var conf = JCheckConfiguration.from(repo, repo.resolve(targetBranch).orElseThrow(() ->
             new IOException("Could not resolve '" + targetBranch + "' branch")
         ));
 
-        return conf.get().general().jbs();
+        if (conf.isEmpty()) {
+            return Optional.empty();
+        }
+
+        return Optional.ofNullable(conf.get().general().jbs());
+    }
+
+    static Optional<Issue> getIssue(Commit commit, Optional<String> project) throws IOException {
+        return project.isEmpty() ? Optional.empty() : getIssue(commit, project.get());
     }
 
     static Optional<Issue> getIssue(Commit commit, String project) throws IOException {
@@ -245,6 +253,10 @@ class Utils {
             return getIssue(issue.id(), project);
         }
         return Optional.empty();
+    }
+
+    static Optional<Issue> getIssue(Branch b, Optional<String> project) throws IOException {
+        return project.isEmpty() ? Optional.empty() : getIssue(b, project.get());
     }
 
     static Optional<Issue> getIssue(Branch b, String project) throws IOException {


### PR DESCRIPTION
Hi all,

please review this patch that makes `git pr create` work for repositories without an `.jcheck/conf` file.

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-467](https://bugs.openjdk.java.net/browse/SKARA-467): git pr create assumes .jcheck/conf file


### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/711/head:pull/711`
`$ git checkout pull/711`
