### PR TITLE
cli: add new command hg-export

### DIFF
--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -62,7 +62,8 @@ images {
         'git-publish': 'org.openjdk.skara.cli/org.openjdk.skara.cli.GitPublish',
         'git-proxy': 'org.openjdk.skara.cli/org.openjdk.skara.cli.GitProxy',
         'git-trees': 'org.openjdk.skara.cli/org.openjdk.skara.cli.GitTrees',
-        'git-expand': 'org.openjdk.skara.cli/org.openjdk.skara.cli.GitExpand'
+        'git-expand': 'org.openjdk.skara.cli/org.openjdk.skara.cli.GitExpand',
+        'git-hg-export': 'org.openjdk.skara.cli/org.openjdk.skara.cli.GitHgExport'
     ]
 
     ext.modules = ['jdk.crypto.ec']

--- a/cli/src/main/java/org/openjdk/skara/cli/GitHgExport.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitHgExport.java
@@ -92,7 +92,7 @@ public class GitHgExport {
         var c = commit.get();
         var committer = c.committer();
         if (committer.email() == null || !committer.email().endsWith("@openjdk.org")) {
-            die("commiter is not an OpenJDK committer");
+            die("committer is not an OpenJDK committer");
         }
         var username = committer.email().split("@")[0];
         var date = c.committed();

--- a/cli/src/main/java/org/openjdk/skara/cli/GitHgExport.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitHgExport.java
@@ -100,7 +100,7 @@ public class GitHgExport {
 
         System.out.println("# HG changeset patch");
         System.out.println("# User " + username);
-        System.out.println("# Date " + date.toEpochSecond() + " " + (-1 * date.getOffset().getTotalSeconds())); 
+        System.out.println("# Date " + date.toEpochSecond() + " " + (-1 * date.getOffset().getTotalSeconds()));
         System.out.println("#      " + date.format(dateFormatter));
 
         var message = CommitMessageParsers.v1.parse(c);

--- a/cli/src/main/java/org/openjdk/skara/cli/GitHgExport.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitHgExport.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.cli;
+
+import org.openjdk.skara.args.*;
+import org.openjdk.skara.vcs.*;
+import org.openjdk.skara.vcs.openjdk.*;
+import org.openjdk.skara.version.Version;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.logging.Level;
+import java.time.format.DateTimeFormatter;
+
+public class GitHgExport {
+    private static void die(String msg) {
+        System.err.println("error: " + msg);
+        System.exit(1);
+    }
+
+    public static void main(String[] args) throws IOException, InterruptedException {
+        var flags = List.of(
+            Switch.shortcut("")
+                  .fullname("verbose")
+                  .helptext("Turn on verbose output")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("debug")
+                  .helptext("Turn on debugging output")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("version")
+                  .helptext("Print the version of this tool")
+                  .optional());
+
+        var inputs = List.of(
+            Input.position(0)
+                 .describe("REV")
+                 .singular()
+                 .required()
+        );
+
+        var parser = new ArgumentParser("git-hg-export", flags, inputs);
+        var arguments = parser.parse(args);
+
+        if (arguments.contains("version")) {
+            System.out.println("git-hg-export version: " + Version.fromManifest().orElse("unknown"));
+            System.exit(0);
+        }
+
+        if (arguments.contains("verbose") || arguments.contains("debug")) {
+            var level = arguments.contains("debug") ? Level.FINER : Level.FINE;
+            Logging.setup(level);
+        }
+
+        var ref = arguments.at(0).orString("HEAD");
+        var cwd = Path.of("").toAbsolutePath();
+        var repo = ReadOnlyRepository.get(cwd);
+        if (repo.isEmpty()) {
+            die("no repository present at: " + cwd);
+        }
+        var hash = repo.get().resolve(ref);
+        if (hash.isEmpty()) {
+            die(ref + " does not refer to a commit");
+        }
+        var commit = repo.get().lookup(hash.get());
+        if (commit.isEmpty()) {
+            die("internal error - could not lookup " + hash.get());
+        }
+
+        var c = commit.get();
+        var committer = c.committer();
+        if (committer.email() == null || !committer.email().endsWith("@openjdk.org")) {
+            die("commiter is not an OpenJDK committer");
+        }
+        var username = committer.email().split("@")[0];
+        var date = c.committed();
+        var dateFormatter = DateTimeFormatter.ofPattern("EE MMM HH:mm:ss yyyy xx");
+
+        System.out.println("# HG changeset patch");
+        System.out.println("# User " + username);
+        System.out.println("# Date " + date.toEpochSecond() + " " + (-1 * date.getOffset().getTotalSeconds())); 
+        System.out.println("#      " + date.format(dateFormatter));
+
+        var message = CommitMessageParsers.v1.parse(c);
+        if (!c.author().equals(committer)) {
+            message.addContributor(c.author());
+        }
+        for (var line : CommitMessageFormatters.v0.format(message)) {
+            System.out.println(line);
+        }
+        System.out.println("");
+        var pb = new ProcessBuilder("git", "diff", "--patch",
+                                                   "--binary",
+                                                   "--no-color",
+                                                   "--find-renames=99%",
+                                                   "--find-copies=99%",
+                                                   "--find-copies-harder",
+                                                   repo.get().range(c.hash()));
+        pb.inheritIO();
+        System.exit(pb.start().waitFor());
+    }
+}

--- a/cli/src/main/java/org/openjdk/skara/cli/GitSkara.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitSkara.java
@@ -200,6 +200,7 @@ public class GitSkara {
         commands.put("publish", GitPublish::main);
         commands.put("proxy", GitProxy::main);
         commands.put("trees", GitTrees::main);
+        commands.put("hg-export", GitHgExport::main);
 
         commands.put("update", GitSkara::update);
         commands.put("help", GitSkara::usage);

--- a/skara.gitconfig
+++ b/skara.gitconfig
@@ -35,6 +35,7 @@
         publish = ! git skara publish
         proxy = ! git skara proxy
         trees = ! git skara trees
+        hg-export = ! git skara hg-export
 
         tcommit = trees commit
         tconfig = trees config

--- a/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/CommitMessage.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/CommitMessage.java
@@ -64,6 +64,10 @@ public class CommitMessage {
         return contributors;
     }
 
+    public void addContributor(Author contributor) {
+        contributors.add(contributor);
+    }
+
     public List<String> summaries() {
         return summaries;
     }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/CommitMessageFormatters.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/CommitMessageFormatters.java
@@ -30,9 +30,6 @@ import java.util.stream.Collectors;
 public class CommitMessageFormatters {
     public static class V0 implements CommitMessageFormatter {
         public List<String> format(CommitMessage message) {
-            if (message.title() != null) {
-                throw new IllegalArgumentException("Can't format title, must use issues as title");
-            }
             if (message.issues().isEmpty()) {
                 throw new IllegalArgumentException("Must supply at least one issue");
             }


### PR DESCRIPTION
Hi all,

please review this patch that adds the new command `git hg-export`. The `git hg-export` command prints information about a Git commit in the format expected by `hg import` (i.e. it is very similar to the `hg export --git` command). This command is primarily useful for backporting changes from a Git repository to a Mercurial repository as a backporter can now run:

```
$ git clone https://git.openjdk.java.net/jdk
$ cd jdk
$ git hg-export <REV> | hg -R /path/to/hg/repo/for/jdk11u-dev import -
```

The command `git hg-export` will output the commit message in the format used by the OpenJDK Mercurial repositories. The command will also output the correct author and date.

Testing:
- [x] Manual testing of `git hg-export` on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**) ⚠️ Review applies to 3ae5e536cd57a87d3c5775aebfe3d922cc94eb11


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/712/head:pull/712`
`$ git checkout pull/712`
