### PR TITLE
webrev: refactor webrev stats

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
@@ -141,9 +141,10 @@ class ArchiveMessages {
     private static String stats(Repository localRepo, Hash base, Hash head) {
         try {
             var diff = localRepo.diff(base, head);
-            var inserted = diff.added();
-            var deleted = diff.removed();
-            var modified = diff.modified();
+            var diffStats = diff.totalStats();
+            var inserted = diffStats.added();
+            var deleted = diffStats.removed();
+            var modified = diffStats.modified();
             var linesChanged = inserted + deleted + modified;
             var filesChanged = diff.patches().size();
             return String.format("%d line%s in %d file%s changed: %d ins; %d del; %d mod",

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Diff.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Diff.java
@@ -56,7 +56,7 @@ public class Diff {
         return patches;
     }
 
-    public List<PatchStats> stats() {
+    public List<WebrevStats> stats() {
         return patches().stream()
                         .filter(Patch::isTextual)
                         .map(Patch::asTextualPatch)
@@ -64,16 +64,11 @@ public class Diff {
                         .collect(Collectors.toList());
     }
 
-    public int added() {
-        return stats().stream().mapToInt(PatchStats::added).sum();
-    }
-
-    public int modified() {
-        return stats().stream().mapToInt(PatchStats::modified).sum();
-    }
-
-    public int removed() {
-        return stats().stream().mapToInt(PatchStats::removed).sum();
+    public WebrevStats totalStats() {
+        var added = stats().stream().mapToInt(WebrevStats::added).sum();
+        var removed = stats().stream().mapToInt(WebrevStats::removed).sum();
+        var modified = stats().stream().mapToInt(WebrevStats::modified).sum();
+        return new WebrevStats(added, removed, modified);
     }
 
     public void write(BufferedWriter w) throws IOException {

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Hunk.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Hunk.java
@@ -73,17 +73,14 @@ public class Hunk {
         return target;
     }
 
-    public int modified() {
-        return Math.min(source.lines().size(), target.lines().size());
+    public WebrevStats stats() {
+        var modified = Math.min(source.lines().size(), target.lines().size());
+        var added = target.lines().size() - modified;
+        var removed = source.lines().size() - modified;
+        return new WebrevStats(added, removed, modified);
     }
 
-    public int added() {
-        return target.lines().size() - modified();
-    }
 
-    public int removed() {
-        return source.lines().size() - modified();
-    }
 
     public void write(BufferedWriter w) throws IOException {
         w.append("@@ -");

--- a/vcs/src/main/java/org/openjdk/skara/vcs/TextualPatch.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/TextualPatch.java
@@ -49,18 +49,18 @@ public class TextualPatch extends Patch {
         return hunks.isEmpty();
     }
 
-    public PatchStats stats() {
+    public WebrevStats stats() {
         int added = 0;
         int removed = 0;
         int modified = 0;
 
         for (var hunk : hunks()) {
-            added += hunk.added();
-            removed += hunk.removed();
-            modified += hunk.modified();
+            var stats = hunk.stats();
+            added += stats.added();
+            removed += stats.removed();
+            modified += stats.modified();
         }
 
-        var path = target().path().isPresent() ? target().path().get() : source().path().get();
-        return new PatchStats(path, added, removed, modified);
+        return new WebrevStats(added, removed, modified);
     }
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/WebrevStats.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/WebrevStats.java
@@ -20,32 +20,21 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package org.openjdk.skara.webrev;
+package org.openjdk.skara.vcs;
 
-import org.openjdk.skara.vcs.PatchStats;
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.Optional;
 
-class WebrevStats {
+public class WebrevStats {
     private final int added;
     private final int removed;
     private final int modified;
-    private final int total;
 
-    public WebrevStats(PatchStats stats, int total) {
-        this.added = stats.added();
-        this.removed = stats.removed();
-        this.modified = stats.modified();
-        this.total = total;
-    }
-
-    public WebrevStats(int added, int removed, int modified, int total) {
+    public WebrevStats(int added, int removed, int modified) {
         this.added = added;
         this.removed = removed;
         this.modified = modified;
-        this.total = total;
-    }
-
-    public static WebrevStats empty() {
-        return new WebrevStats(0, 0, 0, 0);
     }
 
     public int added() {
@@ -60,21 +49,24 @@ class WebrevStats {
         return modified;
     }
 
-    public int changed() {
-        return added() + removed() + modified();
-    }
-
-    public int unchanged() {
-        return total() - changed();
-    }
-
-    public int total() {
-        return total;
+    @Override
+    public int hashCode() {
+        return Objects.hash(added, removed, modified);
     }
 
     @Override
-    public String toString() {
-        return String.format("%d lines changed; %d ins; %d del; %d mod; %d unchg",
-                             changed(), added(), removed(), modified(), unchanged());
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof WebrevStats)) {
+            return false;
+        }
+
+        var o = (WebrevStats) other;
+        return Objects.equals(added, o.added) &&
+               Objects.equals(removed, o.removed) &&
+               Objects.equals(modified, o.modified);
     }
 }

--- a/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
@@ -290,9 +290,10 @@ public class RepositoryTests {
             assertEquals(Hash.zero(), diff.from());
             assertEquals(hash, diff.to());
 
-            assertEquals(0, diff.removed());
-            assertEquals(0, diff.modified());
-            assertEquals(1, diff.added());
+            var stats = diff.totalStats();
+            assertEquals(0, stats.removed());
+            assertEquals(0, stats.modified());
+            assertEquals(1, stats.added());
 
             var patches = diff.patches();
             assertEquals(1, patches.size());
@@ -368,9 +369,10 @@ public class RepositoryTests {
             assertEquals(hash1, diff.from());
             assertEquals(hash2, diff.to());
 
-            assertEquals(0, diff.removed());
-            assertEquals(0, diff.modified());
-            assertEquals(1, diff.added());
+            var stats = diff.totalStats();
+            assertEquals(0, stats.removed());
+            assertEquals(0, stats.modified());
+            assertEquals(1, stats.added());
 
             var patches = diff.patches();
             assertEquals(1, patches.size());
@@ -446,9 +448,10 @@ public class RepositoryTests {
             assertEquals(hash1, diff.from());
             assertEquals(head.hash(), diff.to());
 
-            assertEquals(2, diff.removed());
-            assertEquals(0, diff.modified());
-            assertEquals(0, diff.added());
+            var stats = diff.totalStats();
+            assertEquals(2, stats.removed());
+            assertEquals(0, stats.modified());
+            assertEquals(0, stats.added());
         }
     }
 
@@ -500,9 +503,10 @@ public class RepositoryTests {
             assertEquals(hash1, diff.from());
             assertEquals(head.hash(), diff.to());
 
-            assertEquals(0, diff.removed());
-            assertEquals(0, diff.modified());
-            assertEquals(2, diff.added());
+            var stats = diff.totalStats();
+            assertEquals(0, stats.removed());
+            assertEquals(0, stats.modified());
+            assertEquals(2, stats.added());
 
             var patches = diff.patches();
             assertEquals(1, patches.size());
@@ -607,9 +611,10 @@ public class RepositoryTests {
             assertEquals(1, diffs.size());
             var diff = diffs.get(0);
 
-            assertEquals(0, diff.removed());
-            assertEquals(0, diff.modified());
-            assertEquals(1, diff.added());
+            var stats = diff.totalStats();
+            assertEquals(0, stats.removed());
+            assertEquals(0, stats.modified());
+            assertEquals(1, stats.added());
 
             var patches = diff.patches();
             assertEquals(1, patches.size());
@@ -899,9 +904,10 @@ public class RepositoryTests {
             assertEquals(1, hunk.target().range().count());
             assertLinesEquals(List.of("One more line"), hunk.target().lines());
 
-            assertEquals(1, hunk.added());
-            assertEquals(0, hunk.removed());
-            assertEquals(0, hunk.modified());
+            var stats = hunk.stats();
+            assertEquals(1, stats.added());
+            assertEquals(0, stats.removed());
+            assertEquals(0, stats.modified());
         }
     }
 
@@ -1016,9 +1022,10 @@ public class RepositoryTests {
             assertEquals(2, hunk1.target().range().count());
             assertLinesEquals(List.of("1", "2"), hunk1.target().lines());
 
-            assertEquals(1, hunk1.added());
-            assertEquals(0, hunk1.removed());
-            assertEquals(1, hunk1.modified());
+            var stats1 = hunk1.stats();
+            assertEquals(1, stats1.added());
+            assertEquals(0, stats1.removed());
+            assertEquals(1, stats1.modified());
 
             var hunk2 = hunks.get(1);
             assertEquals(3, hunk2.source().range().start());
@@ -1029,9 +1036,10 @@ public class RepositoryTests {
             assertEquals(1, hunk2.target().range().count());
             assertLinesEquals(List.of("3"), hunk2.target().lines());
 
-            assertEquals(0, hunk2.added());
-            assertEquals(0, hunk2.removed());
-            assertEquals(1, hunk2.modified());
+            var stats2 = hunk2.stats();
+            assertEquals(0, stats2.added());
+            assertEquals(0, stats2.removed());
+            assertEquals(1, stats2.modified());
         }
     }
 
@@ -1077,9 +1085,10 @@ public class RepositoryTests {
             assertEquals(0, hunk.target().range().count());
             assertLinesEquals(List.of(), hunk.target().lines());
 
-            assertEquals(0, hunk.added());
-            assertEquals(1, hunk.removed());
-            assertEquals(0, hunk.modified());
+            var stats = hunk.stats();
+            assertEquals(0, stats.added());
+            assertEquals(1, stats.removed());
+            assertEquals(0, stats.modified());
         }
     }
 
@@ -1126,9 +1135,10 @@ public class RepositoryTests {
             assertEquals(1, hunk.target().range().count());
             assertLinesEquals(List.of("make"), hunk.target().lines());
 
-            assertEquals(1, hunk.added());
-            assertEquals(0, hunk.removed());
-            assertEquals(0, hunk.modified());
+            var stats = hunk.stats();
+            assertEquals(1, stats.added());
+            assertEquals(0, stats.removed());
+            assertEquals(0, stats.modified());
         }
     }
 
@@ -1172,9 +1182,10 @@ public class RepositoryTests {
             assertEquals(1, hunk.target().range().count());
             assertLinesEquals(List.of("One more line"), hunk.target().lines());
 
-            assertEquals(1, hunk.added());
-            assertEquals(0, hunk.removed());
-            assertEquals(0, hunk.modified());
+            var stats = hunk.stats();
+            assertEquals(1, stats.added());
+            assertEquals(0, stats.removed());
+            assertEquals(0, stats.modified());
         }
     }
 
@@ -1785,7 +1796,7 @@ public class RepositoryTests {
             var commit = commits.get(0);
             var diffs = commit.parentDiffs();
             var diff = diffs.get(0);
-            assertEquals(2, diff.added());
+            assertEquals(2, diff.totalStats().added());
 
             var patches = diff.patches();
             assertEquals(1, patches.size());
@@ -2026,9 +2037,10 @@ public class RepositoryTests {
             Files.writeString(contribute, "2. Run git commit", WRITE, APPEND);
 
             var diff = repo.diff(first, List.of(Path.of("README")));
-            assertEquals(1, diff.added());
-            assertEquals(0, diff.modified());
-            assertEquals(0, diff.removed());
+            var diffStats = diff.totalStats();
+            assertEquals(1, diffStats.added());
+            assertEquals(0, diffStats.modified());
+            assertEquals(0, diffStats.removed());
             var patches = diff.patches();
             assertEquals(1, patches.size());
             var patch = patches.get(0);
@@ -2042,9 +2054,10 @@ public class RepositoryTests {
             var second = repo.commit("Updates to both README and CONTRIBUTE", "duke", "duke@openjdk.org");
 
             diff = repo.diff(first, second, List.of(Path.of("CONTRIBUTE")));
-            assertEquals(1, diff.added());
-            assertEquals(0, diff.modified());
-            assertEquals(0, diff.removed());
+            diffStats = diff.totalStats();
+            assertEquals(1, diffStats.added());
+            assertEquals(0, diffStats.modified());
+            assertEquals(0, diffStats.removed());
             patches = diff.patches();
             assertEquals(1, patches.size());
             patch = patches.get(0);

--- a/vcs/src/test/java/org/openjdk/skara/vcs/openjdk/converter/GitToHgConverterTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/openjdk/converter/GitToHgConverterTests.java
@@ -84,9 +84,11 @@ class GitToHgConverterTests {
                         assertEquals(gitHunk.target().range(), hgHunk.target().range());
                         assertEquals(gitHunk.target().lines(), hgHunk.target().lines());
 
-                        assertEquals(gitHunk.added(), hgHunk.added());
-                        assertEquals(gitHunk.removed(), hgHunk.removed());
-                        assertEquals(gitHunk.modified(), hgHunk.modified());
+                        var hgStats = hgHunk.stats();
+                        var gitStats = gitHunk.stats();
+                        assertEquals(gitStats.added(), hgStats.added());
+                        assertEquals(gitStats.removed(), hgStats.removed());
+                        assertEquals(gitStats.modified(), hgStats.modified());
                     }
                 }
             }

--- a/vcs/src/test/java/org/openjdk/skara/vcs/openjdk/converter/HgToGitConverterTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/openjdk/converter/HgToGitConverterTests.java
@@ -108,9 +108,11 @@ class HgToGitConverterTests {
             assertEquals(hgHunk.target().range(), gitHunk.target().range());
             assertEquals(hgHunk.target().lines(), gitHunk.target().lines());
 
-            assertEquals(hgHunk.added(), gitHunk.added());
-            assertEquals(hgHunk.removed(), gitHunk.removed());
-            assertEquals(hgHunk.modified(), gitHunk.modified());
+            var hgStats = hgHunk.stats();
+            var gitStats = gitHunk.stats();
+            assertEquals(hgStats.added(), gitStats.added());
+            assertEquals(hgStats.removed(), gitStats.removed());
+            assertEquals(hgStats.modified(), gitStats.modified());
         }
     }
 

--- a/webrev/src/main/java/org/openjdk/skara/webrev/AddedFileView.java
+++ b/webrev/src/main/java/org/openjdk/skara/webrev/AddedFileView.java
@@ -38,7 +38,7 @@ class AddedFileView implements FileView {
     private final MetadataFormatter formatter;
     private final List<String> newContent;
     private final byte[] binaryContent;
-    private final WebrevStats stats;
+    private final Stats stats;
 
     public AddedFileView(ReadOnlyRepository repo, Hash base, Hash head, List<CommitMetadata> commits, MetadataFormatter formatter, Patch patch, Path out) throws IOException {
         this.patch = patch;
@@ -66,7 +66,7 @@ class AddedFileView implements FileView {
             } else {
                 newContent = repo.lines(path, head).orElseThrow(IllegalArgumentException::new);
             }
-            stats = new WebrevStats(patch.asTextualPatch().stats(), newContent.size());
+            stats = new Stats(patch.asTextualPatch().stats(), newContent.size());
         } else {
             newContent = null;
             if (head == null) {
@@ -74,12 +74,12 @@ class AddedFileView implements FileView {
             } else {
                 binaryContent = repo.show(path, head).orElseThrow(IllegalArgumentException::new);
             }
-            stats = WebrevStats.empty();
+            stats = Stats.empty();
         }
     }
 
     @Override
-    public WebrevStats stats() {
+    public Stats stats() {
         return stats;
     }
 

--- a/webrev/src/main/java/org/openjdk/skara/webrev/FileView.java
+++ b/webrev/src/main/java/org/openjdk/skara/webrev/FileView.java
@@ -23,7 +23,7 @@
 package org.openjdk.skara.webrev;
 
 interface FileView extends View {
-    WebrevStats stats();
+    Stats stats();
 }
 
 

--- a/webrev/src/main/java/org/openjdk/skara/webrev/IndexView.java
+++ b/webrev/src/main/java/org/openjdk/skara/webrev/IndexView.java
@@ -154,7 +154,7 @@ class IndexView implements View {
                      Hash revision,
                      String revisionURL,
                      Path patchFile,
-                     WebrevStats stats) {
+                     Stats stats) {
         this.files = files;
         map = new HashMap<String, String>(); 
 

--- a/webrev/src/main/java/org/openjdk/skara/webrev/ModifiedFileView.java
+++ b/webrev/src/main/java/org/openjdk/skara/webrev/ModifiedFileView.java
@@ -40,7 +40,7 @@ class ModifiedFileView implements FileView {
     private final List<String> oldContent;
     private final List<String> newContent;
     private final byte[] binaryContent;
-    private final WebrevStats stats;
+    private final Stats stats;
 
     public ModifiedFileView(ReadOnlyRepository repo, Hash base, Hash head, List<CommitMetadata> commits, MetadataFormatter formatter, Patch patch, Path out, Navigation navigation) throws IOException {
         this.patch = patch;
@@ -92,7 +92,7 @@ class ModifiedFileView implements FileView {
                                                        " at revision " + head)
                 );
             }
-            stats = new WebrevStats(patch.asTextualPatch().stats(), newContent.size());
+            stats = new Stats(patch.asTextualPatch().stats(), newContent.size());
         } else {
             oldContent = null;
             newContent = null;
@@ -105,12 +105,12 @@ class ModifiedFileView implements FileView {
                                                        " at revision " + head)
                 );
             }
-            stats = WebrevStats.empty();
+            stats = Stats.empty();
         }
     }
 
     @Override
-    public WebrevStats stats() {
+    public Stats stats() {
         return stats;
     }
 

--- a/webrev/src/main/java/org/openjdk/skara/webrev/RemovedFileView.java
+++ b/webrev/src/main/java/org/openjdk/skara/webrev/RemovedFileView.java
@@ -36,7 +36,7 @@ class RemovedFileView implements FileView {
     private final MetadataFormatter formatter;
     private final List<String> oldContent;
     private final byte[] binaryContent;
-    private final WebrevStats stats;
+    private final Stats stats;
 
     public RemovedFileView(ReadOnlyRepository repo, Hash base, Hash head, List<CommitMetadata> commits, MetadataFormatter formatter, Patch patch, Path out) throws IOException {
         this.patch = patch;
@@ -46,16 +46,16 @@ class RemovedFileView implements FileView {
         if (patch.isTextual()) {
             binaryContent = null;
             oldContent = repo.lines(patch.source().path().get(), base).orElseThrow(IllegalArgumentException::new);
-            stats = new WebrevStats(patch.asTextualPatch().stats(), oldContent.size());
+            stats = new Stats(patch.asTextualPatch().stats(), oldContent.size());
         } else {
             oldContent = null;
             binaryContent = repo.show(patch.source().path().get(), base).orElseThrow(IllegalArgumentException::new);
-            stats = WebrevStats.empty();
+            stats = Stats.empty();
         }
     }
 
     @Override
-    public WebrevStats stats() {
+    public Stats stats() {
         return stats;
     }
 

--- a/webrev/src/main/java/org/openjdk/skara/webrev/Stats.java
+++ b/webrev/src/main/java/org/openjdk/skara/webrev/Stats.java
@@ -20,26 +20,32 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package org.openjdk.skara.vcs;
+package org.openjdk.skara.webrev;
 
-import java.nio.file.Path;
-import java.util.Objects;
+import org.openjdk.skara.vcs.WebrevStats;
 
-public class PatchStats {
-    private final Path path;
+class Stats {
     private final int added;
     private final int removed;
     private final int modified;
+    private final int total;
 
-    public PatchStats(Path path, int added, int removed, int modified) {
-        this.path = path;
+    public Stats(WebrevStats stats, int total) {
+        this.added = stats.added();
+        this.removed = stats.removed();
+        this.modified = stats.modified();
+        this.total = total;
+    }
+
+    public Stats(int added, int removed, int modified, int total) {
         this.added = added;
         this.removed = removed;
         this.modified = modified;
+        this.total = total;
     }
 
-    public Path path() {
-        return path;
+    public static Stats empty() {
+        return new Stats(0, 0, 0, 0);
     }
 
     public int added() {
@@ -54,25 +60,21 @@ public class PatchStats {
         return modified;
     }
 
-    @Override
-    public int hashCode() {
-        return Objects.hash(path, added, removed, modified);
+    public int changed() {
+        return added() + removed() + modified();
+    }
+
+    public int unchanged() {
+        return total() - changed();
+    }
+
+    public int total() {
+        return total;
     }
 
     @Override
-    public boolean equals(Object other) {
-        if (other == this) {
-            return true;
-        }
-
-        if (!(other instanceof PatchStats)) {
-            return false;
-        }
-
-        var o = (PatchStats) other;
-        return Objects.equals(path, o.path) &&
-               Objects.equals(added, o.added) &&
-               Objects.equals(removed, o.removed) &&
-               Objects.equals(modified, o.modified);
+    public String toString() {
+        return String.format("%d lines changed; %d ins; %d del; %d mod; %d unchg",
+                             changed(), added(), removed(), modified(), unchanged());
     }
 }

--- a/webrev/src/main/java/org/openjdk/skara/webrev/Webrev.java
+++ b/webrev/src/main/java/org/openjdk/skara/webrev/Webrev.java
@@ -225,8 +225,8 @@ public class Webrev {
                 }
             }
 
-            var total = fileViews.stream().map(FileView::stats).mapToInt(WebrevStats::total).sum();
-            var stats = new WebrevStats(diff.added(), diff.removed(), diff.modified(), total);
+            var total = fileViews.stream().map(FileView::stats).mapToInt(Stats::total).sum();
+            var stats = new Stats(diff.totalStats(), total);
 
             var issueForWebrev = issue != null && issueLinker != null ? issueLinker.apply(issue) : null;
             var tailEndURL = commitLinker != null ? commitLinker.apply(tailEnd.hex()) : null;


### PR DESCRIPTION
Hi all,

please review this patch that renames some of the stats methods (`added`, `modified`, `removed`) in `Hunk`, `Patch` and `Diff`. I want to rename them to clarify that they are statistics tailored for webrev (which has a rather peculiar notion of what a modified line is).

Testing:
- [x] `make test` passes on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/713/head:pull/713`
`$ git checkout pull/713`
