### PR TITLE
vcs: lower rename detection to 90%

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitCommits.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitCommits.java
@@ -60,8 +60,8 @@ class GitCommits implements Commits, AutoCloseable {
         var cmd = new ArrayList<String>();
         cmd.addAll(List.of("git", "log", "--format=" + format,
                                          "--patch",
-                                         "--find-renames=99%",
-                                         "--find-copies=99%",
+                                         "--find-renames=90%",
+                                         "--find-copies=90%",
                                          "--find-copies-harder",
                                          "--topo-order",
                                          "--binary",

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -971,8 +971,8 @@ public class GitRepository implements Repository {
     public List<StatusEntry> status(Hash from, Hash to) throws IOException {
         var cmd = new ArrayList<String>();
         cmd.addAll(List.of("git", "diff", "--raw",
-                                          "--find-renames=99%",
-                                          "--find-copies=99%",
+                                          "--find-renames=90%",
+                                          "--find-copies=90%",
                                           "--find-copies-harder",
                                           "--no-abbrev",
                                           "--no-color"));
@@ -1015,8 +1015,8 @@ public class GitRepository implements Repository {
     @Override
     public Diff diff(Hash from, Hash to, List<Path> files) throws IOException {
         var cmd = new ArrayList<>(List.of("git", "diff", "--patch",
-                                                         "--find-renames=99%",
-                                                         "--find-copies=99%",
+                                                         "--find-renames=90%",
+                                                         "--find-copies=90%",
                                                          "--find-copies-harder",
                                                          "--binary",
                                                          "--raw",


### PR DESCRIPTION
Hi all,

please review this small patch that lowers rename and copy detection for `GitRepository` to `90%`. The default value of `50%` is too small for most OpenJDK patches given that the copyright + license header can easily be 19 lines. `99%` turned out to be a bit too strict for generating good looking webrevs, so lets take it down to `90%` and see how it goes.

Testing:
- [x] `make test` passes on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/714/head:pull/714`
`$ git checkout pull/714`
