### PR TITLE
git-webrev: add --similarity flag

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitWebrev.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitWebrev.java
@@ -127,6 +127,11 @@ public class GitWebrev {
                   .describe("NAME")
                   .helptext("Use remote to calculate outgoing changes")
                   .optional(),
+            Option.shortcut("s")
+                  .fullname("similarity")
+                  .describe("SIMILARITY")
+                  .helptext("Guess renamed files by similarity (0 - 100)")
+                  .optional(),
             Switch.shortcut("b")
                   .fullname("")
                   .helptext("Do not ignore changes in whitespace (always true)")
@@ -352,6 +357,22 @@ public class GitWebrev {
             }
         }
 
+        var similarity = 90;
+        try {
+            var similarityArg = arg("similarity", arguments, repo);
+            if (similarityArg != null) {
+                var value = Integer.parseInt(similarityArg);
+                if (value < 0 || value > 100) {
+                    System.err.println("error: --similarity must be a number between 0 and 100");
+                    System.exit(1);
+                }
+                similarity = value;
+            }
+        } catch (NumberFormatException e) {
+                System.err.println("error: --similarity must be a number between 0 and 100");
+                System.exit(1);
+        }
+
         var jbs = "https://bugs.openjdk.java.net/browse/";
         var issueParts = issue != null ? issue.split("-") : new String[0];
         var jbsProject = issueParts.length == 2 && KNOWN_JBS_PROJECTS.contains(issueParts[0])?
@@ -366,6 +387,7 @@ public class GitWebrev {
               .issue(issue)
               .version(version)
               .files(files)
+              .similarity(similarity)
               .generate(rev);
     }
 

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/TestRepository.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/TestRepository.java
@@ -234,19 +234,19 @@ class TestRepository implements ReadOnlyRepository {
     public void dump(FileEntry entry, Path to) throws IOException {
     }
 
-    public Diff diff(Hash base, Hash head) throws IOException {
+    public Diff diff(Hash base, Hash head, int similarity) throws IOException {
         return null;
     }
 
-    public Diff diff(Hash base, Hash head, List<Path> files) throws IOException {
+    public Diff diff(Hash base, Hash head, List<Path> files, int similarity) throws IOException {
         return null;
     }
 
-    public Diff diff(Hash head) throws IOException {
+    public Diff diff(Hash head, int similarity) throws IOException {
         return null;
     }
 
-    public Diff diff(Hash head, List<Path> files) throws IOException {
+    public Diff diff(Hash head, List<Path> files, int similarity) throws IOException {
         return null;
     }
 

--- a/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
@@ -102,10 +102,25 @@ public interface ReadOnlyRepository {
     void dump(FileEntry entry, Path to) throws IOException;
     List<StatusEntry> status(Hash from, Hash to) throws IOException;
     List<StatusEntry> status() throws IOException;
-    Diff diff(Hash base, Hash head) throws IOException;
-    Diff diff(Hash base, Hash head, List<Path> files) throws IOException;
-    Diff diff(Hash head) throws IOException;
-    Diff diff(Hash head, List<Path> files) throws IOException;
+
+    static final int DEFAULT_SIMILARITY = 90;
+    default Diff diff(Hash base, Hash head) throws IOException {
+        return diff(base, head, DEFAULT_SIMILARITY);
+    }
+    Diff diff(Hash base, Hash head, int similarity) throws IOException;
+    default Diff diff(Hash base, Hash head, List<Path> files) throws IOException {
+        return diff(base, head, files, DEFAULT_SIMILARITY);
+    }
+    Diff diff(Hash base, Hash head, List<Path> files, int similarity) throws IOException;
+    default Diff diff(Hash head) throws IOException {
+        return diff(head, DEFAULT_SIMILARITY);
+    }
+    Diff diff(Hash head, int similarity) throws IOException;
+    default Diff diff(Hash head, List<Path> files) throws IOException {
+        return diff(head, files, DEFAULT_SIMILARITY);
+    }
+
+    Diff diff(Hash head, List<Path> files, int similarity) throws IOException;
     List<String> config(String key) throws IOException;
     Repository copyTo(Path destination) throws IOException;
     String pullPath(String remote) throws IOException;

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -998,25 +998,28 @@ public class GitRepository implements Repository {
     }
 
     @Override
-    public Diff diff(Hash from) throws IOException {
-        return diff(from, List.of());
+    public Diff diff(Hash from, int similarity) throws IOException {
+        return diff(from, List.of(), similarity);
     }
 
     @Override
-    public Diff diff(Hash from, List<Path> files) throws IOException {
-        return diff(from, null, files);
+    public Diff diff(Hash from, List<Path> files, int similarity) throws IOException {
+        return diff(from, null, files, similarity);
     }
 
     @Override
-    public Diff diff(Hash from, Hash to) throws IOException {
-        return diff(from, to, List.of());
+    public Diff diff(Hash from, Hash to, int similarity) throws IOException {
+        return diff(from, to, List.of(), similarity);
     }
 
     @Override
-    public Diff diff(Hash from, Hash to, List<Path> files) throws IOException {
+    public Diff diff(Hash from, Hash to, List<Path> files, int similarity) throws IOException {
+        if (similarity < 0 || similarity > 100) {
+            throw new IllegalArgumentException("similarity must be between 0 and 100, is: "  + similarity);
+        }
         var cmd = new ArrayList<>(List.of("git", "diff", "--patch",
-                                                         "--find-renames=90%",
-                                                         "--find-copies=90%",
+                                                         "--find-renames=" + similarity + "%",
+                                                         "--find-copies=" + similarity + "%",
                                                          "--find-copies-harder",
                                                          "--binary",
                                                          "--raw",

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -846,22 +846,22 @@ public class HgRepository implements Repository {
     }
 
     @Override
-    public Diff diff(Hash from) throws IOException {
+    public Diff diff(Hash from, int similarity) throws IOException {
         return diff(from, List.of());
     }
 
     @Override
-    public Diff diff(Hash from, List<Path> files) throws IOException {
+    public Diff diff(Hash from, List<Path> files, int similarity) throws IOException {
         return diff(from, null, files);
     }
 
     @Override
-    public Diff diff(Hash from, Hash to) throws IOException {
+    public Diff diff(Hash from, Hash to, int similarity) throws IOException {
         return diff(from, to, List.of());
     }
 
     @Override
-    public Diff diff(Hash from, Hash to, List<Path> files) throws IOException {
+    public Diff diff(Hash from, Hash to, List<Path> files, int similarity) throws IOException {
         var ext = Files.createTempFile("ext", ".py");
         copyResource(EXT_PY, ext);
 

--- a/webrev/src/main/java/org/openjdk/skara/webrev/Webrev.java
+++ b/webrev/src/main/java/org/openjdk/skara/webrev/Webrev.java
@@ -74,6 +74,7 @@ public class Webrev {
         private Function<String, String> commitLinker;
         private String version;
         private List<Path> files = List.of();
+        private int similarity = 90;
 
         Builder(ReadOnlyRepository repository, Path output) {
             this.repository = repository;
@@ -130,14 +131,19 @@ public class Webrev {
             return this;
         }
 
+        public Builder similarity(int similarity) {
+            this.similarity = similarity;
+            return this;
+        }
+
         public void generate(Hash tailEnd) throws IOException {
             generate(tailEnd, null);
         }
 
         public void generate(Hash tailEnd, Hash head) throws IOException {
             var diff = head == null ?
-                    repository.diff(tailEnd, files) :
-                    repository.diff(tailEnd, head, files);
+                    repository.diff(tailEnd, files, similarity) :
+                    repository.diff(tailEnd, head, files, similarity);
             generate(diff, tailEnd, head);
         }
 


### PR DESCRIPTION
Hi all,

please review this patch that adds the `--similarity` flag to `git-webrev`. The `--similarity` flag allows users to manually tune the threshold for when a file should be considered renamed or copied.

Testing:
- Manual testing on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/715/head:pull/715`
`$ git checkout pull/715`
