### PR TITLE
git-webrev: add flags --base and --head

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitWebrev.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitWebrev.java
@@ -95,7 +95,7 @@ public class GitWebrev {
             Option.shortcut("r")
                   .fullname("rev")
                   .describe("REV")
-                  .helptext("Compare against a specified revision")
+                  .helptext("Compare against a specified base revision (alias for --base)")
                   .optional(),
             Option.shortcut("o")
                   .fullname("output")
@@ -126,6 +126,16 @@ public class GitWebrev {
                   .fullname("remote")
                   .describe("NAME")
                   .helptext("Use remote to calculate outgoing changes")
+                  .optional(),
+            Option.shortcut("")
+                  .fullname("base")
+                  .describe("REV")
+                  .helptext("Use specified revision as base for comparison")
+                  .optional(),
+            Option.shortcut("")
+                  .fullname("head")
+                  .describe("REV")
+                  .helptext("Use specified revision as head for comparison")
                   .optional(),
             Switch.shortcut("b")
                   .fullname("")
@@ -224,8 +234,21 @@ public class GitWebrev {
             }
         }
 
+        if (arguments.contains("base") && arguments.contains("rev")) {
+            System.err.println("error: cannot combine --base and --rev options");
+            System.exit(1);
+        }
+        if (arguments.contains("head") && arguments.contains("rev")) {
+            System.err.println("error: cannot combine --head and --rev options");
+            System.exit(1);
+        }
+        if (arguments.contains("head") && !arguments.contains("base")) {
+            System.err.println("error: cannot use --head without using --base");
+            System.exit(1);
+        }
+
         var rev = arguments.contains("rev") ? resolve(repo, arguments.get("rev").asString()) : null;
-        if (rev == null) {
+        if (rev == null && !(arguments.contains("base") && arguments.contains("head"))) {
             if (isMercurial) {
                 resolve(repo, noOutgoing ? "tip" : "min(outgoing())^");
             } else {
@@ -278,6 +301,9 @@ public class GitWebrev {
                 }
             }
         }
+
+        var base = arguments.contains("base") ? resolve(repo, arguments.get("base").asString()) : rev;
+        var head = arguments.contains("head") ? resolve(repo, arguments.get("head").asString()) : null;
 
         var issue = arguments.contains("cr") ? arguments.get("cr").asString() : null;
         if (issue != null) {
@@ -366,7 +392,7 @@ public class GitWebrev {
               .issue(issue)
               .version(version)
               .files(files)
-              .generate(rev);
+              .generate(base, head);
     }
 
     private static void apply(String[] args) throws Exception {


### PR DESCRIPTION
Hi all,

please review this patch that adds two new flags to `git-webrev` - `--base` and `--head`. The flag `--base` behaves like `-r, --rev`, that is determines the base commit to compare against. The flag `--head` determines the commit to use a `HEAD` for the comparison, that is the most recent commit for the comparison. The two flags `--base` and `--head` allows a user to create a webrev between two arbitrary commits (without forcing to check out the head commit first).

Testing:
- Manual testing on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**) ⚠️ Review applies to 8532968993e1c7358f4cb92a6020eae9cd10d1f0


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/716/head:pull/716`
`$ git checkout pull/716`
