### PR TITLE
mlbridge: drop prefix "webrev" from webrev paths

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
@@ -222,7 +222,7 @@ class WebrevStorage {
         try {
             var localStorage = Repository.materialize(scratchPath, storage.url(),
                                                       "+" + storageRef + ":mlbridge_webrevs");
-            var relativeFolder = baseFolder.resolve(String.format("%s/webrev.%s", pr.id(), identifier));
+            var relativeFolder = baseFolder.resolve(String.format("%s/%s", pr.id(), identifier));
             var outputFolder = scratchPath.resolve(relativeFolder);
             // If a previous operation was interrupted there may be content here already - overwrite if so
             if (Files.exists(outputFolder)) {

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -194,7 +194,7 @@ class MailingListBridgeBotTests {
             assertTrue(archiveContains(archiveFolder.path(), "Changes:"));
             assertTrue(archiveContains(archiveFolder.path(), "Webrev:"));
             assertTrue(archiveContains(archiveFolder.path(), webrevServer.uri().toString()));
-            assertTrue(archiveContains(archiveFolder.path(), "webrev.00"));
+            assertTrue(archiveContains(archiveFolder.path(), pr.id() + "/00"));
             assertTrue(archiveContains(archiveFolder.path(), "Issue:"));
             assertTrue(archiveContains(archiveFolder.path(), "http://issues.test/browse/TSTPRJ-1234"));
             assertTrue(archiveContains(archiveFolder.path(), "Fetch:"));
@@ -1553,8 +1553,8 @@ class MailingListBridgeBotTests {
             // The archive should reference the updated push
             Repository.materialize(archiveFolder.path(), archive.url(), "master");
             assertTrue(archiveContains(archiveFolder.path(), "has updated the pull request incrementally"));
-            assertTrue(archiveContains(archiveFolder.path(), "full.*/" + pr.id() + "/webrev.01"));
-            assertTrue(archiveContains(archiveFolder.path(), "inc.*/" + pr.id() + "/webrev.00-01"));
+            assertTrue(archiveContains(archiveFolder.path(), "full.*/" + pr.id() + "/01"));
+            assertTrue(archiveContains(archiveFolder.path(), "inc.*/" + pr.id() + "/00-01"));
             assertTrue(archiveContains(archiveFolder.path(), "Patch"));
             assertTrue(archiveContains(archiveFolder.path(), "Fetch"));
             assertTrue(archiveContains(archiveFolder.path(), "Fixing"));
@@ -1682,7 +1682,7 @@ class MailingListBridgeBotTests {
             // The archive should reference the rebased push
             Repository.materialize(archiveFolder.path(), archive.url(), "master");
             assertTrue(archiveContains(archiveFolder.path(), "has updated the pull request with a new target base"));
-            assertTrue(archiveContains(archiveFolder.path(), pr.id() + "/webrev.01"));
+            assertTrue(archiveContains(archiveFolder.path(), pr.id() + "/01"));
             assertFalse(archiveContains(archiveFolder.path(), "Incremental"));
             assertTrue(archiveContains(archiveFolder.path(), "Patch"));
             assertTrue(archiveContains(archiveFolder.path(), "Fetch"));
@@ -1794,8 +1794,8 @@ class MailingListBridgeBotTests {
             Repository.materialize(archiveFolder.path(), archive.url(), "archive");
             assertTrue(archiveContains(archiveFolder.path(), "has updated the pull request with a new target base"));
             assertTrue(archiveContains(archiveFolder.path(), "excludes"));
-            assertTrue(archiveContains(archiveFolder.path(), pr.id() + "/webrev.01"));
-            assertTrue(archiveContains(archiveFolder.path(), pr.id() + "/webrev.00-01"));
+            assertTrue(archiveContains(archiveFolder.path(), pr.id() + "/01"));
+            assertTrue(archiveContains(archiveFolder.path(), pr.id() + "/00-01"));
             assertTrue(archiveContains(archiveFolder.path(), "Original msg"));
             assertTrue(archiveContains(archiveFolder.path(), "More updates"));
         }
@@ -1876,7 +1876,7 @@ class MailingListBridgeBotTests {
             // The archive should contain a merge style webrev
             Repository.materialize(archiveFolder.path(), archive.url(), "archive");
             assertTrue(archiveContains(archiveFolder.path(), "The webrevs contain the adjustments done while merging with regards to each parent branch:"));
-            assertTrue(archiveContains(archiveFolder.path(), pr.id() + "/webrev.00.0"));
+            assertTrue(archiveContains(archiveFolder.path(), pr.id() + "/00.0"));
             assertTrue(archiveContains(archiveFolder.path(), "3 lines in 2 files changed: 1 ins; 1 del; 1 mod"));
 
             // The PR should contain a webrev comment
@@ -1949,7 +1949,7 @@ class MailingListBridgeBotTests {
             // The archive should contain a merge style webrev
             Repository.materialize(archiveFolder.path(), archive.url(), "archive");
             assertTrue(archiveContains(archiveFolder.path(), "The webrev contains the conflicts with master:"));
-            assertTrue(archiveContains(archiveFolder.path(), pr.id() + "/webrev.00.conflicts"));
+            assertTrue(archiveContains(archiveFolder.path(), pr.id() + "/00.conflicts"));
             assertTrue(archiveContains(archiveFolder.path(), "2 lines in 2 files changed: 2 ins; 0 del; 0 mod"));
 
             // The PR should contain a webrev comment
@@ -2090,7 +2090,7 @@ class MailingListBridgeBotTests {
                                          .filter(comment -> comment.body().contains(editHash.hex()))
                                          .collect(Collectors.toList());
             assertEquals(1, webrevComments.size());
-            assertEquals(1, countSubstrings(webrevComments.get(0).body(), "webrev.00"));
+            assertEquals(1, countSubstrings(webrevComments.get(0).body(), pr.id() + "/00"));
 
             // Pretend the archive didn't work out
             archiveRepo.push(masterHash, archive.url(), "master", true);
@@ -2106,7 +2106,7 @@ class MailingListBridgeBotTests {
                                      .filter(comment -> comment.body().contains(editHash.hex()))
                                      .collect(Collectors.toList());
             assertEquals(1, webrevComments.size());
-            assertEquals(1, countSubstrings(webrevComments.get(0).body(), "webrev.00"));
+            assertEquals(1, countSubstrings(webrevComments.get(0).body(), pr.id() + "/00"));
         }
     }
 
@@ -2454,7 +2454,7 @@ class MailingListBridgeBotTests {
 
             // Check the archive
             Repository.materialize(archiveFolder.path(), archive.url(), "master");
-            assertTrue(archiveContains(archiveFolder.path(), "webrev.01"));
+            assertTrue(archiveContains(archiveFolder.path(), pr.id() + "/01"));
         }
     }
 

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/WebrevStorageTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/WebrevStorageTests.java
@@ -76,12 +76,12 @@ class WebrevStorageTests {
 
             // Update the local repository and check that the webrev has been generated
             Repository.materialize(repoFolder, archive.url(), "webrev");
-            assertTrue(Files.exists(repoFolder.resolve("test/" + pr.id() + "/webrev.00/index.html")));
+            assertTrue(Files.exists(repoFolder.resolve("test/" + pr.id() + "/00/index.html")));
 
             // Create it again - it will overwrite the previous one
             generator.generate(masterHash, editHash, "00", WebrevDescription.Type.FULL);
             Repository.materialize(repoFolder, archive.url(), "webrev");
-            assertTrue(Files.exists(repoFolder.resolve("test/" + pr.id() + "/webrev.00/index.html")));
+            assertTrue(Files.exists(repoFolder.resolve("test/" + pr.id() + "/00/index.html")));
         }
     }
 
@@ -125,9 +125,9 @@ class WebrevStorageTests {
 
             // Update the local repository and check that the webrev has been generated
             Repository.materialize(repoFolder, archive.url(), "webrev");
-            assertTrue(Files.exists(repoFolder.resolve("test/" + pr.id() + "/webrev.00/index.html")));
-            assertTrue(Files.size(repoFolder.resolve("test/" + pr.id() + "/webrev.00/large.txt")) > 0);
-            assertTrue(Files.size(repoFolder.resolve("test/" + pr.id() + "/webrev.00/large.txt")) < 1000);
+            assertTrue(Files.exists(repoFolder.resolve("test/" + pr.id() + "/00/index.html")));
+            assertTrue(Files.size(repoFolder.resolve("test/" + pr.id() + "/00/large.txt")) > 0);
+            assertTrue(Files.size(repoFolder.resolve("test/" + pr.id() + "/00/large.txt")) < 1000);
         }
     }
 }


### PR DESCRIPTION
Hi all,

please review this patch that drops the "webrev" prefix from the last part of the path for URLs to automatically generated webrevs. For example, the current path looks like `https://webrevs.openjdk.java.net/skara/704/webrev.00`, they will now look like `https://webrevs.openjdk.java.net/skara/704/00`. This is partly done in preparation for uploading JSON versions of webrevs.

Testing:
- [x] `make test` passes on Linux x64
- [x] Updated a number of unit tests

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/718/head:pull/718`
`$ git checkout pull/718`
