### PR TITLE
bridgekeeper: support multiple close messages

### DIFF
--- a/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/BridgekeeperBotFactory.java
+++ b/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/BridgekeeperBotFactory.java
@@ -40,7 +40,11 @@ public class BridgekeeperBotFactory implements BotFactory {
         var specific = configuration.specific();
 
         for (var repo : specific.get("mirrors").asArray()) {
-            var bot = new PullRequestCloserBot(configuration.repository(repo.asString()));
+            var bot = new PullRequestCloserBot(configuration.repository(repo.asString()), PullRequestCloserBot.Type.MIRROR);
+            ret.add(bot);
+        }
+        for (var repo : specific.get("data").asArray()) {
+            var bot = new PullRequestCloserBot(configuration.repository(repo.asString()), PullRequestCloserBot.Type.DATA);
             ret.add(bot);
         }
         var pruned = new HashMap<HostedRepository, Duration>();

--- a/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestCloserBot.java
+++ b/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestCloserBot.java
@@ -35,10 +35,12 @@ class PullRequestCloserBotWorkItem implements WorkItem {
     private final HostedRepository repository;
     private final PullRequest pr;
     private final Consumer<RuntimeException> errorHandler;
+    private final PullRequestCloserBot.Type type;
 
-    PullRequestCloserBotWorkItem(HostedRepository repository, PullRequest pr, Consumer<RuntimeException> errorHandler) {
+    PullRequestCloserBotWorkItem(HostedRepository repository, PullRequest pr, PullRequestCloserBot.Type type, Consumer<RuntimeException> errorHandler) {
         this.pr = pr;
         this.repository = repository;
+        this.type = type;
         this.errorHandler = errorHandler;
     }
 
@@ -52,13 +54,24 @@ class PullRequestCloserBotWorkItem implements WorkItem {
                                     .anyMatch(comment -> comment.body().contains(welcomeMarker));
 
         if (!welcomePosted) {
-            var message = "Welcome to the OpenJDK organization on GitHub!\n\n" +
-                    "This repository is currently a read-only git mirror of the official Mercurial " +
-                    "repository (located at https://hg.openjdk.java.net/). As such, we are not " +
-                    "currently accepting pull requests here. If you would like to contribute to " +
-                    "the OpenJDK project, please see https://openjdk.java.net/contribute/ on how " +
-                    "to proceed.\n\n" +
-                    "This pull request will be automatically closed.";
+            String message = null;
+            if (type == PullRequestCloserBot.Type.MIRROR) {
+                message = "Welcome to the OpenJDK organization on GitHub!\n\n" +
+                "This repository is currently a read-only git mirror of the official Mercurial " +
+                "repository (located at https://hg.openjdk.java.net/). As such, we are not " +
+                "currently accepting pull requests here. If you would like to contribute to " +
+                "the OpenJDK project, please see https://openjdk.java.net/contribute/ on how " +
+                "to proceed.\n\n" +
+                "This pull request will be automatically closed.";
+            } else if (type == PullRequestCloserBot.Type.DATA) {
+                message = "Welcome to the OpenJDK organization on GitHub!\n\n" +
+                "This repository currently holds only automatically generated data and therefore does not accept pull requests." +
+                "This pull request will be automatically closed.";
+            } else {
+                message = "Welcome to the OpenJDK organization on GitHub!\n\n" +
+                "This repository does not currently accept pull requests." +
+                "This pull request will be automatically closed.";
+            }
 
             log.fine("Posting welcome message");
             pr.addComment(welcomeMarker + "\n\n" + message);
@@ -102,10 +115,16 @@ class PullRequestCloserBotWorkItem implements WorkItem {
 public class PullRequestCloserBot implements Bot {
     private final HostedRepository remoteRepo;
     private final PullRequestUpdateCache updateCache;
+    public enum Type {
+        MIRROR,
+        DATA
+    }
+    private final Type type;
 
-    PullRequestCloserBot(HostedRepository repo) {
+    PullRequestCloserBot(HostedRepository repo, Type type) {
         this.remoteRepo = repo;
         this.updateCache = new PullRequestUpdateCache();
+        this.type = type;
     }
 
     @Override
@@ -114,7 +133,7 @@ public class PullRequestCloserBot implements Bot {
 
         for (var pr : remoteRepo.pullRequests()) {
             if (updateCache.needsUpdate(pr)) {
-                var item = new PullRequestCloserBotWorkItem(remoteRepo, pr, e -> updateCache.invalidate(pr));
+                var item = new PullRequestCloserBotWorkItem(remoteRepo, pr, type, e -> updateCache.invalidate(pr));
                 ret.add(item);
             }
         }

--- a/bots/bridgekeeper/src/test/java/org/openjdk/skara/bots/bridgekeeper/PullRequestCloserBotTests.java
+++ b/bots/bridgekeeper/src/test/java/org/openjdk/skara/bots/bridgekeeper/PullRequestCloserBotTests.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.*;
 
 import java.io.IOException;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.openjdk.skara.issuetracker.Issue.State.*;
 
 class PullRequestCloserBotTests {
@@ -38,7 +38,7 @@ class PullRequestCloserBotTests {
         try (var credentials = new HostCredentials(testInfo);
              var tempFolder = new TemporaryDirectory()) {
             var author = credentials.getHostedRepository();
-            var bot = new PullRequestCloserBot(author);
+            var bot = new PullRequestCloserBot(author, PullRequestCloserBot.Type.MIRROR);
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -68,7 +68,7 @@ class PullRequestCloserBotTests {
         try (var credentials = new HostCredentials(testInfo);
              var tempFolder = new TemporaryDirectory()) {
             var author = credentials.getHostedRepository();
-            var bot = new PullRequestCloserBot(author);
+            var bot = new PullRequestCloserBot(author, PullRequestCloserBot.Type.MIRROR);
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -99,6 +99,51 @@ class PullRequestCloserBotTests {
 
             // There should still only be one welcome comment
             assertEquals(1, pr.comments().size());
+
+            // The message should mention mirroring
+            assertTrue(pr.comments().get(0).body().contains("This repository is currently a read-only git mirror"));
+        }
+    }
+
+    @Test
+    void dataMessage(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var bot = new PullRequestCloserBot(author, PullRequestCloserBot.Type.DATA);
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
+
+            // Let the bot see it
+            TestBotRunner.runPeriodicItems(bot);
+
+            // There should now be no open PRs
+            var prs = author.pullRequests();
+            assertEquals(0, prs.size());
+
+            // The author is persistent
+            pr.setState(Issue.State.OPEN);
+            prs = author.pullRequests();
+            assertEquals(1, prs.size());
+
+            // But so is the bot
+            TestBotRunner.runPeriodicItems(bot);
+            prs = author.pullRequests();
+            assertEquals(0, prs.size());
+
+            // There should still only be one welcome comment
+            assertEquals(1, pr.comments().size());
+
+            // The message should mention automatically generated data
+            assertTrue(pr.comments().get(0).body().contains("This repository currently holds only automatically generated data"));
         }
     }
 }


### PR DESCRIPTION
Hi all,

please review this small patch that allows the bridgekeeper bot to close pull requests with different messages depending on the type of repository.   

Testing:
- [x] `make test` passes on Linux x64
- [x] Added an additional unit test

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/720/head:pull/720`
`$ git checkout pull/720`
