### PR TITLE
mlbridge: configure webrev ref explicitly

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotFactory.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotFactory.java
@@ -81,7 +81,7 @@ public class MailingListBridgeBotFactory implements BotFactory {
 
         var webrevHTMLRepo = configuration.repository(specific.get("webrevs").get("repository").get("html").asString());
         var webrevJSONRepo = configuration.repository(specific.get("webrevs").get("repository").get("json").asString());
-        var webrevRef = configuration.repositoryRef(specific.get("webrevs").get("repository").asString());
+        var webrevRef = specific.get("webrevs").get("ref").asString();
         var webrevWeb = specific.get("webrevs").get("web").asString();
 
         var archiveRepo = configuration.repository(specific.get("archive").asString());


### PR DESCRIPTION
Hi all,

please review this small patch makes the configuration for the ref used for storing webrevs explicit. Now that mlbridge supports two different kinds of webrevs, the ref applies to both repositories and must therefore be configured separately.

Testing:
- [x] `make test` passes on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/721/head:pull/721`
`$ git checkout pull/721`
