### PR TITLE
build: update to Gradle 6.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ external Git source code hosting providers are available:
 ## Building
 
 [JDK 14](http://jdk.java.net/14/) or later and [Gradle](https://gradle.org/)
-6.4.1 or later is required for building. To build the project on macOS or
+6.6 or later is required for building. To build the project on macOS or
 GNU/Linux x64, just run the following command from the source tree root:
 
 ```bash
@@ -84,7 +84,7 @@ If you don't want the build to automatically download any dependencies, then
 you must ensure that you have installed the following software locally:
 
 - JDK 14 or later
-- Gradle 6.4.1 or later
+- Gradle 6.6 or later
 
 To create a build then run the command:
 

--- a/deps.env
+++ b/deps.env
@@ -7,5 +7,5 @@ JDK_MACOS_X64_SHA256="d8aa6806e6cc99724395563bf02fc6907a7c801f4caef85b96ad449271
 JDK_WINDOWS_X64_URL="https://download.java.net/java/GA/jdk14.0.1/664493ef4a6946b186ff29eb326336a2/7/GPL/openjdk-14.0.1_windows-x64_bin.zip"
 JDK_WINDOWS_X64_SHA256="26255f3f2fe7168ec0dce9d9f3825649c18540ba86279a7506c7f17dd3e537f9"
 
-GRADLE_URL="https://services.gradle.org/distributions/gradle-6.4.1-bin.zip"
-GRADLE_SHA256="e58cdff0cee6d9b422dcd08ebeb3177bc44eaa09bd9a2e838ff74c408fe1cbcd"
+GRADLE_URL="https://services.gradle.org/distributions/gradle-6.6-bin.zip"
+GRADLE_SHA256="e6f83508f0970452f56197f610d13c5f593baaf43c0e3c6a571e5967be754025"


### PR DESCRIPTION
Hi all,

please review this patch that updates Gradle to version 6.6.

Testing:
- [x] `make test` passes on Linux x64
- [x] `make images` passes on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/722/head:pull/722`
`$ git checkout pull/722`
