### PR TITLE
build: update to JDK 14.0.2

### DIFF
--- a/deps.env
+++ b/deps.env
@@ -1,11 +1,11 @@
-JDK_LINUX_X64_URL="https://download.java.net/java/GA/jdk14.0.1/664493ef4a6946b186ff29eb326336a2/7/GPL/openjdk-14.0.1_linux-x64_bin.tar.gz"
-JDK_LINUX_X64_SHA256="22ce248e0bd69f23028625bede9d1b3080935b68d011eaaf9e241f84d6b9c4cc"
+JDK_LINUX_X64_URL="https://download.java.net/java/GA/jdk14.0.2/205943a0976c4ed48cb16f1043c5c647/12/GPL/openjdk-14.0.2_linux-x64_bin.tar.gz"
+JDK_LINUX_X64_SHA256="91310200f072045dc6cef2c8c23e7e6387b37c46e9de49623ce0fa461a24623d"
 
-JDK_MACOS_X64_URL="https://download.java.net/java/GA/jdk14.0.1/664493ef4a6946b186ff29eb326336a2/7/GPL/openjdk-14.0.1_osx-x64_bin.tar.gz"
-JDK_MACOS_X64_SHA256="d8aa6806e6cc99724395563bf02fc6907a7c801f4caef85b96ad44927193da07"
+JDK_MACOS_X64_URL="https://download.java.net/java/GA/jdk14.0.2/205943a0976c4ed48cb16f1043c5c647/12/GPL/openjdk-14.0.2_osx-x64_bin.tar.gz"
+JDK_MACOS_X64_SHA256="386a96eeef63bf94b450809d69ceaa1c9e32a97230e0a120c1b41786b743ae84"
 
-JDK_WINDOWS_X64_URL="https://download.java.net/java/GA/jdk14.0.1/664493ef4a6946b186ff29eb326336a2/7/GPL/openjdk-14.0.1_windows-x64_bin.zip"
-JDK_WINDOWS_X64_SHA256="26255f3f2fe7168ec0dce9d9f3825649c18540ba86279a7506c7f17dd3e537f9"
+JDK_WINDOWS_X64_URL="https://download.java.net/java/GA/jdk14.0.2/205943a0976c4ed48cb16f1043c5c647/12/GPL/openjdk-14.0.2_windows-x64_bin.zip"
+JDK_WINDOWS_X64_SHA256="20600c0bda9d1db9d20dbe1ab656a5f9175ffb990ef3df6af5d994673e4d8ff9"
 
 GRADLE_URL="https://services.gradle.org/distributions/gradle-6.6-bin.zip"
 GRADLE_SHA256="e6f83508f0970452f56197f610d13c5f593baaf43c0e3c6a571e5967be754025"


### PR DESCRIPTION
Hi all,

please review this small patch that updates the JDK to version 14.0.2.

Testing:
- [x] `make test` passes on Linux x64
- [x] `make images` passes on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/723/head:pull/723`
`$ git checkout pull/723`
