### PR TITLE
mlbridge: use consistent conf for webrevs

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotFactory.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotFactory.java
@@ -113,14 +113,14 @@ public class MailingListBridgeBotFactory implements BotFactory {
             var folder = repoConfig.contains("folder") ? repoConfig.get("folder").asString() : configuration.repositoryName(repo);
 
             var webrevGenerateHTML = true;
-            if (repoConfig.contains("webrev") &&
-                repoConfig.get("webrev").contains("html") &&
-                repoConfig.get("webrev").get("html").asBoolean() == false) {
+            if (repoConfig.contains("webrevs") &&
+                repoConfig.get("webrevs").contains("html") &&
+                repoConfig.get("webrevs").get("html").asBoolean() == false) {
                 webrevGenerateHTML = false;
             }
-            var webrevGenerateJSON = repoConfig.contains("webrev") &&
-                                     repoConfig.get("webrev").contains("json") &&
-                                     repoConfig.get("webrev").get("json").asBoolean();
+            var webrevGenerateJSON = repoConfig.contains("webrevs") &&
+                                     repoConfig.get("webrevs").contains("json") &&
+                                     repoConfig.get("webrevs").get("json").asBoolean();
 
             var botBuilder = MailingListBridgeBot.newBuilder().from(from)
                                                  .repo(configuration.repository(repo))


### PR DESCRIPTION
Hi all,

please review this small patch that makes the configuration for the mlbridge bot use consistent spelling for the "webrevs" fields.

Testing:
- [x] `make test` on Linux x64 passes

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/724/head:pull/724`
`$ git checkout pull/724`
