### PR TITLE
git: commitMetadata should return commits in topo order

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -204,6 +204,7 @@ public class GitRepository implements Repository {
         var args = new ArrayList<String>();
         args.addAll(List.of("git", "rev-list",
                                    "--format=" + GitCommitMetadata.FORMAT,
+                                   "--topo-order",
                                    "--no-abbrev",
                                    "--no-color",
                                    range));


### PR DESCRIPTION
Hi all,

please review this small patch that makes `GitRepository.commitMetadata` return commits topological order (i.e. all parents first, then the parent). This is already done by `GitRepository.commits`.

Testing:
- [x] `make test` passes on Linux x64
- [ ] Did not add a new unit test since it is hard to force commits to be returned in non-topological order

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/727/head:pull/727`
`$ git checkout pull/727`
