### PR TITLE
hg: allow tags without email

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -650,7 +650,9 @@ public class HgRepository implements Repository {
 
     @Override
     public Tag tag(Hash hash, String name, String message, String authorName, String authorEmail) throws IOException {
-        var user = authorName + " <" + authorEmail + ">";
+        var user = authorEmail != null ?
+            authorName + " <" + authorEmail + ">" :
+            authorName;
         try (var p = capture("hg", "tag",
                              "--message", message,
                              "--user", user,

--- a/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
@@ -2409,4 +2409,19 @@ public class RepositoryTests {
             assertEquals(Path.of("README.new"), p1.target().path().get());
         }
     }
+
+    @Test
+    void testMercurialTagWithoutEmail() throws IOException, InterruptedException {
+        try (var dir = new TemporaryDirectory()) {
+            var repo = Repository.init(dir.path(), VCS.HG);
+            var readme = dir.path().resolve("README");
+            Files.write(readme, List.of("Hello, readme!"));
+            repo.add(readme);
+            var head = repo.commit("Add README", "author", "author@openjdk.java.net");
+            var tag = repo.tag(head, "1.0", "Add tag 1.0", "duke", null);
+            var annotated = repo.annotate(tag).orElseThrow();
+            assertEquals("duke", annotated.author().name());
+            assertNull(annotated.author().email());
+        }
+    }
 }


### PR DESCRIPTION
Hi all,

please review this patch which allows `HgRepository.tag` to allow a `null` argument for `authorEmail`. Mercurial does not require e-mails for authors, so neither should `HgRepository`.

Testing:
- [x] `make test` passes on Linux x64
- [x] Added a new unit test

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/729/head:pull/729`
`$ git checkout pull/729`
