### PR TITLE
hg: implement ReadOnlyRepository.isAncestor

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -697,7 +697,7 @@ public class HgRepository implements Repository {
 
     @Override
     public boolean isAncestor(Hash ancestor, Hash descendant) throws IOException {
-        throw new RuntimeException("Not implemented yet");
+        return mergeBase(ancestor, descendant).equals(ancestor);
     }
 
     @Override


### PR DESCRIPTION
Hi all,

please review this patch that implements `ReadOnlyRepository.isAncestor` for `HgRepository`.

Testing:
- [x] `make test` passes on Linux x64
- [x] Added a new unit test

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/730/head:pull/730`
`$ git checkout pull/730`
