### PR TITLE
vcs: support explicit fast-forward merging

### DIFF
--- a/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
+++ b/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
@@ -477,7 +477,7 @@ class MergeBot implements Bot, WorkItem {
                 var remoteBranch = new Branch(repo.upstreamFor(toBranch).orElseThrow(() ->
                     new IllegalStateException("Could not get remote branch name for " + toBranch.name())
                 ));
-                repo.merge(remoteBranch); // should always be a fast-forward merge
+                repo.merge(remoteBranch, Repository.FastForward.ONLY);
                 if (!repo.isClean()) {
                     throw new RuntimeException("Local repository isn't clean after fast-forward merge - has the fork diverged unexpectedly?");
                 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
@@ -116,9 +116,25 @@ public interface Repository extends ReadOnlyRepository {
     void prune(Branch branch, String remote) throws IOException;
     void delete(Branch b) throws IOException;
     void rebase(Hash hash, String committerName, String committerEmail) throws IOException;
-    void merge(Hash hash) throws IOException;
-    void merge(Branch branch) throws IOException;
-    void merge(Hash hash, String strategy) throws IOException;
+
+    enum FastForward {
+        ONLY,
+        DISABLE,
+        AUTO
+    }
+
+    default void merge(Hash hash) throws IOException {
+        merge(hash, FastForward.AUTO);
+    }
+    void merge(Hash hash, FastForward ff) throws IOException;
+    default void merge(Branch branch) throws IOException {
+        merge(branch, FastForward.AUTO);
+    }
+    void merge(Branch branch, FastForward ff) throws IOException;
+    default void merge(Hash hash, String strategy) throws IOException {
+        merge(hash, strategy, FastForward.AUTO);
+    }
+    void merge(Hash hash, String strategy, FastForward ff) throws IOException;
     void abortMerge() throws IOException;
     void addRemote(String name, String path) throws IOException;
     void setPaths(String remote, String pullPath, String pushPath) throws IOException;

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -1093,28 +1093,40 @@ public class GitRepository implements Repository {
     }
 
     @Override
-    public void merge(Hash h) throws IOException {
-        merge(h.hex(), null);
+    public void merge(Hash h, FastForward ff) throws IOException {
+        merge(h.hex(), null, ff);
     }
 
     @Override
-    public void merge(Branch b) throws IOException {
-        merge(b.name(), null);
+    public void merge(Branch b, FastForward ff) throws IOException {
+        merge(b.name(), null, ff);
     }
 
     @Override
-    public void merge(Hash h, String strategy) throws IOException {
-        merge(h.hex(), strategy);
+    public void merge(Hash h, String strategy, FastForward ff) throws IOException {
+        merge(h.hex(), strategy, ff);
     }
 
-    private void merge(String ref, String strategy) throws IOException {
+    private void merge(String ref, String strategy, FastForward ff) throws IOException {
         var cmd = new ArrayList<String>();
         cmd.addAll(List.of("git", "-c", "user.name=unused", "-c", "user.email=unused",
                            "merge", "--no-commit"));
+
+        if (ff == FastForward.AUTO) {
+            cmd.add("--ff");
+        } else if (ff == FastForward.DISABLE) {
+            cmd.add("--no-ff");
+        } else if (ff == FastForward.ONLY) {
+            cmd.add("--ff-only");
+        } else {
+            throw new IllegalArgumentException("Unexpected fast forward value: " + ff);
+        }
+
         if (strategy != null) {
             cmd.add("-s");
             cmd.add(strategy);
         }
+
         cmd.add(ref);
         try (var p = capture(cmd)) {
             await(p);


### PR DESCRIPTION
Hi all,

please review this patch that makes it explicit for `Repository.merge` whether a fast-forward merge should be attempted or not.

Testing:
- [x] `make test` passes on Linux x64
- [x] Added two new unit tests

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/731/head:pull/731`
`$ git checkout pull/731`
