### PR TITLE
vcs: add method Repository.deleteUntrackedFiles

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
@@ -147,6 +147,7 @@ public interface Repository extends ReadOnlyRepository {
     }
     void addSubmodule(String pullPath, Path path) throws IOException;
     void updateSubmodule(Path path) throws IOException;
+    void deleteUntrackedFiles() throws IOException;
     default void updateSubmodule(Submodule s) throws IOException {
         updateSubmodule(s.path());
     }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -366,6 +366,17 @@ public class GitRepository implements Repository {
     }
 
     @Override
+    public void deleteUntrackedFiles() throws IOException {
+        var root = root();
+        try (var p = capture("git", "ls-files", "--full-name", "--other")) {
+            var res = await(p);
+            for (var line : res.stdout()) {
+                Files.delete(root.resolve(line));
+            }
+        }
+    }
+
+    @Override
     public void reset(Hash target, boolean hard) throws IOException {
         var cmd = new ArrayList<>(List.of("git", "reset"));
         if (hard) {

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -359,6 +359,17 @@ public class HgRepository implements Repository {
     }
 
     @Override
+    public void deleteUntrackedFiles() throws IOException {
+        var root = root();
+        try (var p = capture("hg", "status", "--unknown", "--no-status")) {
+            var res = await(p);
+            for (var line : res.stdout()) {
+                Files.delete(root.resolve(line));
+            }
+        }
+    }
+
+    @Override
     public void clean() throws IOException {
         try (var p = capture("hg", "merge", "--abort")) {
             p.await();

--- a/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
@@ -2571,4 +2571,29 @@ public class RepositoryTests {
             assertEquals(2, r.commits().asList().size());
         }
     }
+
+    @ParameterizedTest
+    @EnumSource(VCS.class)
+    void testDeleteUntrackedFiles(VCS vcs) throws IOException {
+        try (var dir = new TemporaryDirectory()) {
+            var r = Repository.init(dir.path(), vcs);
+
+            var readme = dir.path().resolve("README");
+            Files.write(readme, List.of("Hello, readme!"));
+
+            r.add(readme);
+            var hash1 = r.commit("Add README", "duke", "duke@openjdk.java.net");
+            var untracked = dir.path().resolve("UNTRACKED");
+            Files.write(untracked, List.of("Hello, untracked!"));
+
+            var paths = Files.list(r.root()).collect(Collectors.toList());
+            assertTrue(paths.contains(untracked));
+            assertTrue(paths.contains(readme));
+
+            r.deleteUntrackedFiles();
+            paths = Files.list(r.root()).collect(Collectors.toList());
+            assertFalse(paths.contains(untracked));
+            assertTrue(paths.contains(readme));
+        }
+    }
 }


### PR DESCRIPTION
Hi all,

please review this patch that adds a new method to `Repository` - `deleteUntrackedFiles`. As the name suggests, the new method deletes all untracked files in a repository. This is useful when you want to clean up a repository after for example a `revert`.

Testing:
- [x] `make test` passes on Linux x64
- [x] Added a new unit test

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/732/head:pull/732`
`$ git checkout pull/732`
