### PR TITLE
vcs: don't append newlines to tag messages

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -1450,7 +1450,7 @@ public class GitRepository implements Repository {
                 var author = Author.fromString(authorLine);
                 var formatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
                 var date = ZonedDateTime.parse(dateLine, formatter);
-                var message = String.join("\n", lines.subList(4, lines.size()));
+                var message = String.join("\n", lines.subList(4, lines.size() - 1)); // Git adds newline
 
                 return Optional.of(new Tag.Annotated(name, target, author, date, message));
             }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -1368,7 +1368,7 @@ public class HgRepository implements Repository {
                     var rev = parts[0].substring(0, parts[0].length() - 1).trim(); // skip last ':' and ev. whitespace
                     var hash = resolve(rev).orElseThrow(IOException::new);
                     var commit = lookup(hash).orElseThrow(IOException::new);
-                    var message = String.join("\n", commit.message()) + "\n";
+                    var message = String.join("\n", commit.message());
                     return Optional.of(new Tag.Annotated(tagName, target, commit.author(), commit.authored(), message));
                 }
             }

--- a/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
@@ -2077,7 +2077,7 @@ public class RepositoryTests {
             Files.writeString(readme, "Hello\n");
             repo.add(readme);
             var head = repo.commit("Added README", "duke", "duke@openjdk.org");
-            var tag = repo.tag(head, "1.0", "Added tag 1.0 for HEAD\n", "duke", "duke@openjdk.org");
+            var tag = repo.tag(head, "1.0", "Added tag 1.0 for HEAD", "duke", "duke@openjdk.org");
             var annotated = repo.annotate(tag).get();
 
             assertEquals("1.0", annotated.name());
@@ -2088,7 +2088,7 @@ public class RepositoryTests {
             assertEquals(now.getDayOfYear(), annotated.date().getDayOfYear());
             assertEquals(now.getHour(), annotated.date().getHour());
             assertEquals(now.getOffset(), annotated.date().getOffset());
-            assertEquals("Added tag 1.0 for HEAD\n", annotated.message());
+            assertEquals("Added tag 1.0 for HEAD", annotated.message());
         }
     }
 


### PR DESCRIPTION
Hi all,

please review this small patch that ensures that neither git nor hg append any newlines to message used when creating annotated tag objects.

Testing:
- [x] `make test` passes on Linux x64
- [x] Updated two unit tests

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/734/head:pull/734`
`$ git checkout pull/734`
