### PR TITLE
vcs: support setting dates for tags

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
@@ -111,7 +111,10 @@ public interface Repository extends ReadOnlyRepository {
                String authorEmail,
                String committerName,
                String committerEmail) throws IOException;
-    Tag tag(Hash hash, String tagName, String message, String authorName, String authorEmail) throws IOException;
+    default Tag tag(Hash hash, String tagName, String message, String authorName, String authorEmail) throws IOException {
+        return tag(hash, tagName, message, authorName, authorEmail, null);
+    }
+    Tag tag(Hash hash, String tagName, String message, String authorName, String authorEmail, ZonedDateTime date) throws IOException;
     Branch branch(Hash hash, String branchName) throws IOException;
     void prune(Branch branch, String remote) throws IOException;
     void delete(Branch b) throws IOException;

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -761,13 +761,17 @@ public class GitRepository implements Repository {
     }
 
     @Override
-    public Tag tag(Hash hash, String name, String message, String authorName, String authorEmail) throws IOException {
+    public Tag tag(Hash hash, String name, String message, String authorName, String authorEmail, ZonedDateTime date) throws IOException {
         var cmd = Process.capture("git", "tag", "--annotate", "--message=" + message, name, hash.hex())
                          .workdir(dir)
                          .environ("GIT_AUTHOR_NAME", authorName)
                          .environ("GIT_AUTHOR_EMAIL", authorEmail)
                          .environ("GIT_COMMITTER_NAME", authorName)
                          .environ("GIT_COMMITTER_EMAIL", authorEmail);
+        if (date != null) {
+            cmd = cmd.environ("GIT_AUTHOR_DATE", date.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+            cmd = cmd.environ("GIT_COMMITTER_DATE", date.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+        }
         try (var p = cmd.execute()) {
             await(p);
         }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -660,15 +660,21 @@ public class HgRepository implements Repository {
     }
 
     @Override
-    public Tag tag(Hash hash, String name, String message, String authorName, String authorEmail) throws IOException {
+    public Tag tag(Hash hash, String name, String message, String authorName, String authorEmail, ZonedDateTime date) throws IOException {
         var user = authorEmail != null ?
             authorName + " <" + authorEmail + ">" :
             authorName;
-        try (var p = capture("hg", "tag",
-                             "--message", message,
-                             "--user", user,
-                             "--rev", hash.hex(),
-                             name)) {
+        var cmd = new ArrayList<String>();
+        cmd.addAll(List.of("hg", "tag",
+                           "--message", message,
+                           "--user", user,
+                           "--rev", hash.hex()));
+        if (date != null) {
+            cmd.add("--date");
+            cmd.add(date.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+        }
+        cmd.add(name);
+        try (var p = capture(cmd)) {
             await(p);
         }
 

--- a/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
@@ -2596,4 +2596,23 @@ public class RepositoryTests {
             assertTrue(paths.contains(readme));
         }
     }
+
+    @ParameterizedTest
+    @EnumSource(VCS.class)
+    void testTimestampOnTags(VCS vcs) throws IOException {
+        try (var dir = new TemporaryDirectory()) {
+            var r = Repository.init(dir.path(), vcs);
+
+            var readme = dir.path().resolve("README");
+            Files.write(readme, List.of("Hello, readme!"));
+
+            r.add(readme);
+            var hash = r.commit("Add README", "duke", "duke@openjdk.java.net");
+            var date = ZonedDateTime.parse("2007-12-03T10:15:30+01:00");
+            var tag = r.tag(hash, "1.0", "Added tag 1.0", "duke", "duke@openjdk.org", date);
+            var annotated = r.annotate(tag);
+            assertTrue(annotated.isPresent());
+            assertEquals(date, annotated.get().date());
+        }
+    }
 }


### PR DESCRIPTION
Hi all,

please review this patch that allows setting the date for tag objects.

Testing:
- [x] `make test` passes on Linux x64
- [x] Added a new unit test

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/735/head:pull/735`
`$ git checkout pull/735`
