### PR TITLE
vcs: improve git->hg converter

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/convert/GitToHgConverter.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/convert/GitToHgConverter.java
@@ -198,7 +198,7 @@ public class GitToHgConverter implements Converter {
                 var date = annotated.get().date();
                 hgRepo.tag(hgHash, name, msg, user, null, date);
             } else {
-                hgRepo.tag(hgHash, name, "Added tag " + name + " for " + hgHash.abbreviate(), "duke", null, null); 
+                hgRepo.tag(hgHash, name, "Added tag " + name + " for " + hgHash.abbreviate(), "duke", null, null);
             }
             var hgTagCommitHash = hgRepo.head();
             var last = marks.get(marks.size() - 1);

--- a/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/convert/Mark.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/convert/Mark.java
@@ -24,12 +24,14 @@ package org.openjdk.skara.vcs.openjdk.convert;
 
 import org.openjdk.skara.vcs.Hash;
 import java.util.Objects;
+import java.util.Optional;
 import static java.util.Objects.equals;
 
 public class Mark implements Comparable<Mark> {
     private final int key;
     private final Hash hg;
     private final Hash git;
+    private final Hash tag;
 
     public Mark(int key, Hash hg, Hash git) {
         if (key == 0) {
@@ -38,6 +40,17 @@ public class Mark implements Comparable<Mark> {
         this.key = key;
         this.hg = hg;
         this.git = git;
+        this.tag = null;
+    }
+
+    public Mark(int key, Hash hg, Hash git, Hash tag) {
+        if (key == 0) {
+            throw new IllegalArgumentException("A mark cannot be 0");
+        }
+        this.key = key;
+        this.hg = hg;
+        this.git = git;
+        this.tag = tag;
     }
 
     public int key() {
@@ -52,6 +65,10 @@ public class Mark implements Comparable<Mark> {
         return git;
     }
 
+    public Optional<Hash> tag() {
+        return Optional.ofNullable(tag);
+    }
+
     @Override
     public int compareTo(Mark o) {
         return Integer.compare(key, o.key);
@@ -59,7 +76,7 @@ public class Mark implements Comparable<Mark> {
 
     @Override
     public int hashCode() {
-        return Objects.hash(key, hg, git);
+        return Objects.hash(key, hg, git, tag);
     }
 
     @Override
@@ -72,7 +89,8 @@ public class Mark implements Comparable<Mark> {
             var m = (Mark) o;
             return Objects.equals(key, m.key) &&
                    Objects.equals(hg, m.hg) &&
-                   Objects.equals(git, m.git);
+                   Objects.equals(git, m.git) &&
+                   Objects.equals(tag, m.tag);
         }
 
         return false;

--- a/vcs/src/test/java/org/openjdk/skara/vcs/openjdk/converter/GitToHgConverterTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/openjdk/converter/GitToHgConverterTests.java
@@ -43,7 +43,6 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class GitToHgConverterTests {
     void assertCommitEquals(ReadOnlyRepository gitRepo, Commit gitCommit, ReadOnlyRepository hgRepo, Commit hgCommit) throws IOException {
-        System.out.println("git commit: " + gitCommit.hash() + ", hg commit: " + hgCommit.hash());
         assertEquals(gitCommit.authored(), hgCommit.authored());
         assertEquals(gitCommit.isInitialCommit(), hgCommit.isInitialCommit());
         assertEquals(gitCommit.isMerge(), hgCommit.isMerge());


### PR DESCRIPTION
Hi all,

please review this patch that significantly improves the `GitToHgConverter`. The new converter handles all OpenJDK Git repositories and also handles additional Git tags. I also improved the testing by quite a bit, the verification is much more strict and I added a bunch of more tests. I also added some `@Disabled` tests (since they require an internet connection), but they are still useful for running locally when working on the converter.

Testing:
- [x] `make test` passes on Linux x64
- [x] Added a number of new unit tests

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**) ⚠️ Review applies to b957495aae1fb6989f568b000b4b7bc96226e735


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/736/head:pull/736`
`$ git checkout pull/736`
