### PR TITLE
cli: skara debug import-git should always save marks

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/SkaraDebug.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/SkaraDebug.java
@@ -39,7 +39,7 @@ public class SkaraDebug {
                        .main(GitOpenJDKImport::main),
                 Command.name("import-git")
                        .helptext("import git repository")
-                       .main(GitOpenJDKImport::main),
+                       .main(HgOpenJDKImport::main),
                 Command.name("verify-import")
                        .helptext("verify imported repository")
                        .main(GitVerifyImport::main),


### PR DESCRIPTION
Hi all,

please review this patch that makes `git skara debug import-git` always save the marks that were created as part of a conversion, even though the conversion might have failed. This allows for incremental git imports.

Testing:
- [x] Manual testing on Linux x64

Thanks,
Erik