### PR TITLE
hg: use --template instead of ext.py for metadata

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -273,18 +273,16 @@ public class HgRepository implements Repository {
 
     @Override
     public List<CommitMetadata> commitMetadata(String range, List<Path> paths, boolean reverse) throws IOException {
-        var ext = Files.createTempFile("ext", ".py");
-        copyResource(EXT_PY, ext);
-
-        var args = new ArrayList<String>();
-        args.addAll(List.of("hg", "--config", "extensions.dump=" + ext.toAbsolutePath().toString(), "metadata"));
+        var cmd = new ArrayList<String>();
+        cmd.addAll(List.of("hg", "log", "--template", HgCommitMetadata.TEMPLATE));
         range = range == null ? "tip:0" : range;
         var revset = reverse ? "reverse(" + range + ")" : range;
-        args.add(revset);
+        cmd.add("--rev");
+        cmd.add(revset);
         if (paths != null && !paths.isEmpty()) {
-            args.add(paths.stream().map(Path::toString).collect(Collectors.joining("\t")));
+            cmd.addAll(paths.stream().map(Path::toString).collect(Collectors.toList()));
         }
-        var p = start(args);
+        var p = start(cmd);
         var reader = new UnixStreamReader(p.getInputStream());
         var result = new ArrayList<CommitMetadata>();
 


### PR DESCRIPTION
Hi all,

please review this patch that makes `HgRepository.commitMetadata` use `--template` instead of `ext.py` for generating the metadata.

Testing:
- [x] `make test` passes on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**) ⚠️ Review applies to 4b359a5ad8be2508b752af4858470331b6b009af


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/739/head:pull/739`
`$ git checkout pull/739`
