### PR TITLE
vcs: add method ReadOnlyRepository.follow

### DIFF
--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/TestRepository.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/TestRepository.java
@@ -321,4 +321,12 @@ class TestRepository implements ReadOnlyRepository {
     public String rangeExclusive(Hash from, Hash to) {
         return null;
     }
+
+    public List<CommitMetadata> follow(Path path) {
+        return List.of();
+    }
+
+    public List<CommitMetadata> follow(Path path, Hash from, Hash to) {
+        return List.of();
+    }
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
@@ -120,6 +120,8 @@ public interface ReadOnlyRepository {
         return diff(head, files, DEFAULT_SIMILARITY);
     }
 
+    List<CommitMetadata> follow(Path path) throws IOException;
+    List<CommitMetadata> follow(Path path, Hash base, Hash head) throws IOException;
     Diff diff(Hash head, List<Path> files, int similarity) throws IOException;
     List<String> config(String key) throws IOException;
     Repository copyTo(Path destination) throws IOException;


### PR DESCRIPTION
Hi all,

please review this patch that adds the method `ReadOnlyRepository.follow` for getting all commits that changed a particular file.

Testing:
- [x] `make test` passes on Linux x64
- [x] Added a new unit test

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**) ⚠️ Review applies to 56466073a2fcb47d7e9a8312c421030c5bb117c3


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/740/head:pull/740`
`$ git checkout pull/740`
