### PR TITLE
webrev: follow files for commits.json

### DIFF
--- a/webrev/src/main/java/org/openjdk/skara/webrev/Webrev.java
+++ b/webrev/src/main/java/org/openjdk/skara/webrev/Webrev.java
@@ -278,7 +278,7 @@ public class Webrev {
                     file.put("patch", sb.toString());
                 }
                 files.add(file);
-                var commits = repository.commitMetadata(tailEnd, head, List.of(filename));
+                var commits = repository.follow(filename, tailEnd, head);
                 for (var commit : commits) {
                     if (!pathsPerCommit.containsKey(commit.hash())) {
                         pathsPerCommit.put(commit.hash(), new ArrayList<Path>());


### PR DESCRIPTION
Hi all,

please review this patch that updates `Webrev.generateJSON` to use `ReadOnlyRepository.follow` for getting commit metadata.

Testing:
- [x] `make test` passes on Linux x64
- [x] Manual testing on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/741/head:pull/741`
`$ git checkout pull/741`
