### PR TITLE
Store target hash before potentially fetching the ref

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -45,6 +45,7 @@ public class GitHubPullRequest implements PullRequest {
     private final Logger log = Logger.getLogger("org.openjdk.skara.host");
 
     private List<String> labels = null;
+    private Hash targetHash = null;
 
     GitHubPullRequest(GitHubRepository repository, JSONValue jsonValue, RestRequest request) {
         this.host = (GitHubHost)repository.forge();
@@ -257,12 +258,19 @@ public class GitHubPullRequest implements PullRequest {
 
     @Override
     public String targetRef() {
-        return json.get("base").get("ref").asString();
+        var targetRef = json.get("base").get("ref").asString();
+        if (targetHash == null) {
+            // Read this value before returning, to ensure that future fetches of this ref contains the hash
+            targetHash = repository.branchHash(targetRef);
+        }
+        return targetRef;
     }
 
     @Override
     public Hash targetHash() {
-        return repository.branchHash(targetRef());
+        // Ensure that the field is populated
+        targetRef();
+        return targetHash;
     }
 
     @Override


### PR DESCRIPTION
Hi all,

Please review this change that determines the hash of the target ref for a PR before returning the ref. This ensures that subsequently fetching the ref contains the hash (barring concurrent force pushes to the target ref, which should never happen).

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/742/head:pull/742`
`$ git checkout pull/742`
