### PR TITLE
checkout bot: use full path for marks files

### DIFF
--- a/bots/checkout/src/main/java/org/openjdk/skara/bots/checkout/CheckoutBotFactory.java
+++ b/bots/checkout/src/main/java/org/openjdk/skara/bots/checkout/CheckoutBotFactory.java
@@ -55,7 +55,7 @@ public class CheckoutBotFactory implements BotFactory {
             var fromBranch = new Branch(from.substring(lastColon + 1));
             var to = Path.of(repo.get("to").asString());
 
-            var repoName = Path.of(fromURI.getPath()).getFileName().toString();
+            var repoName = fromURI.getPath();
             var markStorage = MarkStorage.create(marksRepo, marksUser, repoName);
 
             bots.add(new CheckoutBot(fromURI, fromBranch, to, storage, markStorage));

--- a/bots/checkout/src/main/java/org/openjdk/skara/bots/checkout/MarkStorage.java
+++ b/bots/checkout/src/main/java/org/openjdk/skara/bots/checkout/MarkStorage.java
@@ -84,7 +84,7 @@ class MarkStorage {
     }
 
     static StorageBuilder<Mark> create(HostedRepository repo, Author user, String name) {
-        return new StorageBuilder<Mark>(name + ".marks.txt")
+        return new StorageBuilder<Mark>(name + "/marks.txt")
             .remoteRepository(repo, "master", user.name(), user.email(), "Updated marks for " + name)
             .serializer(MarkStorage::serialize)
             .deserializer(MarkStorage::deserialize);

--- a/storage/src/main/java/org/openjdk/skara/storage/HostedRepositoryStorage.java
+++ b/storage/src/main/java/org/openjdk/skara/storage/HostedRepositoryStorage.java
@@ -69,6 +69,8 @@ class HostedRepositoryStorage<T> implements Storage<T> {
                 } catch (IOException ignored) {
                     // The remote ref may not yet exist
                     Repository localRepository = Repository.init(localStorage, repository.repositoryType());
+                    var file = localStorage.resolve(fileName);
+                    Files.createDirectories(file.getParent());
                     var storage = Files.writeString(localStorage.resolve(fileName), "");
                     localRepository.add(storage);
                     var firstCommit = localRepository.commit(message, authorName, authorEmail);


### PR DESCRIPTION
Hi all,

please review this small fix that makes the checkout bot use the full path of the from repo as the name for the marks file. I also had to update `HostedRepositoryStorage` to cope with files in directories.

Testing:
- [x] `make test` passes on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/745/head:pull/745`
`$ git checkout pull/745`
