### PR TITLE
git-pr-create: be explicit about CC:d mailing lists

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
@@ -44,7 +44,7 @@ public class LabelerWorkItem extends PullRequestWorkItem {
 
     private Set<String> getLabels(Repository localRepo) throws IOException {
         var files = PullRequestUtils.changedFiles(pr, localRepo);
-        return bot.labelConfiguration().fromChanges(files);
+        return bot.labelConfiguration().label(files);
     }
 
     @Override

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
@@ -23,6 +23,7 @@
 package org.openjdk.skara.bots.pr;
 
 import org.openjdk.skara.forge.HostedRepository;
+import org.openjdk.skara.forge.LabelConfiguration;
 import org.openjdk.skara.issuetracker.IssueProject;
 
 import java.nio.file.Path;
@@ -33,7 +34,7 @@ public class PullRequestBotBuilder {
     private HostedRepository repo;
     private HostedRepository censusRepo;
     private String censusRef = "master";
-    private LabelConfiguration labelConfiguration = LabelConfiguration.newBuilder().build();
+    private LabelConfiguration labelConfiguration = LabelConfiguration.builder().build();
     private Map<String, String> externalCommands = Map.of();
     private Map<String, String> blockingCheckLabels = Map.of();
     private Set<String> readyLabels = Set.of();

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
@@ -23,6 +23,7 @@
 package org.openjdk.skara.bots.pr;
 
 import org.openjdk.skara.bot.*;
+import org.openjdk.skara.forge.LabelConfiguration;
 import org.openjdk.skara.json.*;
 
 import java.util.*;
@@ -64,31 +65,8 @@ public class PullRequestBotFactory implements BotFactory {
 
         var labelConfigurations = new HashMap<String, LabelConfiguration>();
         for (var labelGroup : specific.get("labels").fields()) {
-            var labelConfiguration = LabelConfiguration.newBuilder();
-            if (labelGroup.value().contains("matchers")) {
-                var matchers = labelGroup.value().get("matchers").fields().stream()
-                                         .collect(Collectors.toMap(JSONObject.Field::name,
-                                                                   field -> field.value().stream()
-                                                                                 .map(JSONValue::asString)
-                                                                                 .map(Pattern::compile)
-                                                                                 .collect(Collectors.toList())));
-                matchers.forEach(labelConfiguration::addMatchers);
-            }
-            if (labelGroup.value().contains("groups")) {
-                var groups = labelGroup.value().get("groups").fields().stream()
-                                       .collect(Collectors.toMap(JSONObject.Field::name,
-                                                                 field -> field.value().stream()
-                                                                               .map(JSONValue::asString)
-                                                                               .collect(Collectors.toList())));
-                groups.forEach(labelConfiguration::addGroup);
-            }
-            if (labelGroup.value().contains("extra")) {
-                var extra = labelGroup.value().get("extra").stream()
-                                      .map(JSONValue::asString)
-                                      .collect(Collectors.toList());
-                extra.forEach(labelConfiguration::addExtra);
-            }
-            labelConfigurations.put(labelGroup.name(), labelConfiguration.build());
+            labelConfigurations.put(labelGroup.name(),
+                                    LabelConfiguration.fromJSON(labelGroup.value()));
         }
 
         for (var repo : specific.get("repositories").fields()) {

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelTests.java
@@ -203,7 +203,7 @@ public class LabelTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addReviewer(integrator.forge().currentUser().id())
                                            .addCommitter(author.forge().currentUser().id());
-            var labelConfiguration = LabelConfiguration.newBuilder()
+            var labelConfiguration = LabelConfiguration.builder()
                                                        .addMatchers("1", List.of(Pattern.compile("cpp$")))
                                                        .addMatchers("2", List.of(Pattern.compile("hpp$")))
                                                        .addGroup("group", List.of("1", "2"))

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelTests.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.skara.bots.pr;
 
+import org.openjdk.skara.forge.LabelConfiguration;
 import org.junit.jupiter.api.*;
 import org.openjdk.skara.test.*;
 
@@ -44,7 +45,7 @@ public class LabelTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addReviewer(integrator.forge().currentUser().id())
                                            .addCommitter(author.forge().currentUser().id());
-            var labelConfiguration = LabelConfiguration.newBuilder()
+            var labelConfiguration = LabelConfiguration.builder()
                                                        .addMatchers("1", List.of(Pattern.compile("cpp$")))
                                                        .addMatchers("2", List.of(Pattern.compile("hpp$")))
                                                        .addGroup("group", List.of("1", "2"))
@@ -134,7 +135,7 @@ public class LabelTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addReviewer(integrator.forge().currentUser().id())
                                            .addCommitter(author.forge().currentUser().id());
-            var labelConfiguration = LabelConfiguration.newBuilder()
+            var labelConfiguration = LabelConfiguration.builder()
                                                        .addMatchers("1", List.of(Pattern.compile("cpp$")))
                                                        .addMatchers("2", List.of(Pattern.compile("hpp$")))
                                                        .addGroup("group", List.of("1", "2"))
@@ -264,7 +265,7 @@ public class LabelTests {
                                            .addCommitter(committer.forge().currentUser().id())
                                            .addAuthor(author.forge().currentUser().id())
                                            .addAuthor(other.forge().currentUser().id());
-            var labelConfiguration = LabelConfiguration.newBuilder()
+            var labelConfiguration = LabelConfiguration.builder()
                                                        .addMatchers("1", List.of(Pattern.compile("cpp$")))
                                                        .addMatchers("2", List.of(Pattern.compile("hpp$")))
                                                        .addGroup("group", List.of("1", "2"))

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelerTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelerTests.java
@@ -23,6 +23,7 @@
 package org.openjdk.skara.bots.pr;
 
 import org.openjdk.skara.test.*;
+import org.openjdk.skara.forge.LabelConfiguration;
 
 import org.junit.jupiter.api.*;
 
@@ -41,7 +42,7 @@ class LabelerTests {
             var author = credentials.getHostedRepository();
             var reviewer = credentials.getHostedRepository();
 
-            var labelConfiguration = LabelConfiguration.newBuilder()
+            var labelConfiguration = LabelConfiguration.builder()
                                                        .addMatchers("test1", List.of(Pattern.compile("a.txt")))
                                                        .addMatchers("test2", List.of(Pattern.compile("b.txt")))
                                                        .build();

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrCreate.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrCreate.java
@@ -26,17 +26,18 @@ import org.openjdk.skara.args.*;
 import org.openjdk.skara.cli.GitPublish;
 import org.openjdk.skara.cli.GitJCheck;
 import org.openjdk.skara.vcs.Branch;
+import org.openjdk.skara.vcs.ReadOnlyRepository;
 import org.openjdk.skara.vcs.openjdk.CommitMessageParsers;
+import org.openjdk.skara.forge.Forge;
+import org.openjdk.skara.forge.LabelConfiguration;
+import org.openjdk.skara.json.JSON;
 
 import static org.openjdk.skara.cli.pr.Utils.*;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public class GitPrCreate {
@@ -59,7 +60,7 @@ public class GitPrCreate {
         Option.shortcut("")
               .fullname("cc")
               .describe("MAILING LISTS")
-              .helptext("CC additional mailing lists for inital RFR e-mail")
+              .helptext("Mailing lists to CC for inital RFR e-mail")
               .optional(),
         Switch.shortcut("")
               .fullname("ignore-workspace")
@@ -101,6 +102,33 @@ public class GitPrCreate {
              .singular()
              .optional()
     );
+
+
+    private static LabelConfiguration labelConfiguration(Forge forge, String project) throws IOException {
+        var group = project.split("/")[0];
+        var skaraRemoteRepo = forge.repository(group + "/skara").orElseThrow(() ->
+            new IOException("error: could not resolve Skara repository")
+        );
+        var rules = skaraRemoteRepo.fileContents("config/mailinglist/rules/jdk.json", "master");
+        var json = JSON.parse(rules);
+        return LabelConfiguration.fromJSON(json);
+    }
+
+    private static Set<String> suggestedLabels(ReadOnlyRepository repo, Forge forge, String project, String targetRef, String headRef) throws IOException {
+        var config = labelConfiguration(forge, project);
+        var baseHash = repo.resolve(targetRef).orElseThrow(() ->
+            new IOException("error: cannot resolve " + targetRef)
+        );
+        var headHash = repo.resolve(headRef).orElseThrow(() ->
+            new IOException("error: cannot resolve " + headRef)
+        );
+        var status = repo.status(baseHash, headHash);
+        var files = status.stream()
+                          .filter(e -> !e.status().isDeleted())
+                          .map(e -> e.target().path().get())
+                          .collect(Collectors.toSet());
+        return config.label(files);
+    }
 
     public static void main(String[] args) throws IOException, InterruptedException {
         var parser = new ArgumentParser("git-pr", flags, inputs);
@@ -274,6 +302,84 @@ public class GitPrCreate {
             }
         }
 
+        var mailingLists = new ArrayList<String>();
+        var parentProject = projectName(parentRepo.url());
+        var isTargetingJDKRepo = parentProject.endsWith("jdk");
+        var cc = getOption("cc", "create", arguments);
+        var isCCManual = cc != null && !cc.equals("auto");
+        if (!isTargetingJDKRepo && isCCManual) {
+            System.out.println("error: you cannot manually CC additional mailing lists for " + parentProject);
+            System.exit(1);
+        }
+        if (isTargetingJDKRepo) {
+            if (isCCManual) {
+                var config = labelConfiguration(host, parentProject);
+                var lists = cc.split(",");
+                for (var input : lists) {
+                    var label = input;
+                    if (label.endsWith("@openjdk.java.net")) {
+                        label = input.split("@")[0];
+                    }
+                    if (label.endsWith("-dev")) {
+                        label = label.replace("-dev", "");
+                    }
+                    if (!config.isAllowed(label) && !config.isAllowed(label + "-dev")) {
+                        System.out.println("error: the mailing list \"" + label +
+                                           "-dev@openjdk.java.net\" is not applicable, aborting.");
+                        System.exit(1);
+                    }
+                }
+                System.out.println("You have chosen the following mailing lists to be CC:d for the \"RFR\" e-mail:");
+                for (var input : lists) {
+                    String list = null;
+                    if (input.endsWith("@openjdk.java.net")) {
+                        list = input;
+                    } else if (input.endsWith("-dev")) {
+                        list = input + "@openjdk.java.net";
+                    } else  {
+                        list = input + "-dev@openjdk.java.net";
+                    }
+                    System.out.println("- " + list);
+                    mailingLists.add(list);
+                }
+            } else {
+                var suggested = suggestedLabels(repo, host, parentProject, targetBranch, headRef);
+                System.out.println("The following mailing lists will be CC:d for the \"RFR\" e-mail:");
+                for (var label : suggested) {
+                    String list = null;
+                    if (label.endsWith("-dev")) {
+                        list = label + "@openjdk.java.net";
+                    } else {
+                        list = label + "-dev@openjdk.java.net";
+                    }
+                    if (cc == null) {
+                        System.out.println("- " + list);
+                    }
+                    mailingLists.add(list);
+                }
+            }
+            if (cc == null || !cc.equals("auto")) {
+                System.out.println("");
+                System.out.print("Do you want to proceed with this mailing list selection? [Y/n]: ");
+                var scanner = new Scanner(System.in);
+                var answer = scanner.nextLine().toLowerCase();
+                while (!(answer.equals("y") || answer.equals("n") || answer.isEmpty())) {
+                    System.out.print("Please answer with 'y', 'n' or empty for the default choice: ");
+                    answer = scanner.nextLine().toLowerCase();
+                }
+                if (!(answer.isEmpty() || answer.equals("y"))) {
+                    System.out.println("");
+                    System.out.println("error: user not satisfied with mailing list selection, aborting.");
+                    if (cc == null) {
+                        System.out.println("       To specify mailing lists manually, use the --cc option.");
+                    } else if (cc.equals("auto")) {
+                        System.out.println("       You have set --cc=auto, you can use --cc to specify mailing lists manually");
+                    }
+                    System.exit(1);
+                }
+            }
+        }
+
         var project = jbsProjectFromJcheckConf(repo, targetBranch);
         var issue = getIssue(currentBranch, project);
         var file = Files.createTempFile("PULL_REQUEST_", ".md");
@@ -332,6 +438,13 @@ public class GitPrCreate {
         }
         appendPaddedHTMLComment(file, "Repository: " + parentRepo.webUrl());
         appendPaddedHTMLComment(file, "Branch:     " + targetBranch);
+        if (!mailingLists.isEmpty()) {
+            appendPaddedHTMLComment(file, "");
+            appendPaddedHTMLComment(file, "The following mailing lists will be CC:d for the \"RFR\" e-mail:");
+            for (var list : mailingLists) {
+                appendPaddedHTMLComment(file, "- " + list);
+            }
+        }
 
         var success = spawnEditor(repo, file);
         if (!success) {
@@ -360,9 +473,11 @@ public class GitPrCreate {
             System.exit(1);
         }
 
-        if (arguments.contains("cc")) {
-            var lists = arguments.get("cc").asString().trim();
-            body.add("/cc " + lists);
+        if (isCCManual && !mailingLists.isEmpty()) {
+            var arg = mailingLists.stream()
+                                  .map(l -> l.split("@")[0].replace("-dev", ""))
+                                  .collect(Collectors.joining(","));
+            body.add("/cc " + arg);
         }
 
         var isDraft = getSwitch("draft", "create", arguments);

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrCreate.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrCreate.java
@@ -56,6 +56,11 @@ public class GitPrCreate {
               .describe("NAME")
               .helptext("Name of target branch, defaults to 'master'")
               .optional(),
+        Option.shortcut("")
+              .fullname("cc")
+              .describe("MAILING LISTS")
+              .helptext("CC additional mailing lists for inital RFR e-mail")
+              .optional(),
         Switch.shortcut("")
               .fullname("ignore-workspace")
               .helptext("Ignore local changes in worktree and staging area when creating pull request")
@@ -353,6 +358,11 @@ public class GitPrCreate {
         } else {
             System.err.println("error: cannot create pull request with empty body, aborting");
             System.exit(1);
+        }
+
+        if (arguments.contains("cc")) {
+            var lists = arguments.get("cc").asString().trim();
+            body.add("/cc " + lists);
         }
 
         var isDraft = getSwitch("draft", "create", arguments);

--- a/forge/src/test/java/org/openjdk/skara/forge/LabelConfigurationTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/LabelConfigurationTests.java
@@ -20,7 +20,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package org.openjdk.skara.bots.pr;
+package org.openjdk.skara.forge;
 
 import org.junit.jupiter.api.Test;
 
@@ -33,21 +33,21 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class LabelConfigurationTests {
     @Test
     void simple() {
-        var config = LabelConfiguration.newBuilder()
+        var config = LabelConfiguration.builder()
                                        .addMatchers("1", List.of(Pattern.compile("cpp$")))
                                        .addMatchers("2", List.of(Pattern.compile("hpp$")))
                                        .build();
 
         assertEquals(Set.of("1", "2"), config.allowed());
 
-        assertEquals(Set.of("1"), config.fromChanges(Set.of(Path.of("a.cpp"))));
-        assertEquals(Set.of("2"), config.fromChanges(Set.of(Path.of("a.hpp"))));
-        assertEquals(Set.of("1", "2"), config.fromChanges(Set.of(Path.of("a.cpp"), Path.of("a.hpp"))));
+        assertEquals(Set.of("1"), config.label(Set.of(Path.of("a.cpp"))));
+        assertEquals(Set.of("2"), config.label(Set.of(Path.of("a.hpp"))));
+        assertEquals(Set.of("1", "2"), config.label(Set.of(Path.of("a.cpp"), Path.of("a.hpp"))));
     }
 
     @Test
     void group() {
-        var config = LabelConfiguration.newBuilder()
+        var config = LabelConfiguration.builder()
                                        .addMatchers("1", List.of(Pattern.compile("cpp$")))
                                        .addMatchers("2", List.of(Pattern.compile("hpp$")))
                                        .addGroup("both", List.of("1", "2"))
@@ -55,8 +55,8 @@ public class LabelConfigurationTests {
 
         assertEquals(Set.of("1", "2", "both"), config.allowed());
 
-        assertEquals(Set.of("1"), config.fromChanges(Set.of(Path.of("a.cpp"))));
-        assertEquals(Set.of("2"), config.fromChanges(Set.of(Path.of("a.hpp"))));
-        assertEquals(Set.of("both"), config.fromChanges(Set.of(Path.of("a.cpp"), Path.of("a.hpp"))));
+        assertEquals(Set.of("1"), config.labels(Set.of(Path.of("a.cpp"))));
+        assertEquals(Set.of("2"), config.labels(Set.of(Path.of("a.hpp"))));
+        assertEquals(Set.of("both"), config.labels(Set.of(Path.of("a.cpp"), Path.of("a.hpp"))));
     }
 }

--- a/forge/src/test/java/org/openjdk/skara/forge/LabelConfigurationTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/LabelConfigurationTests.java
@@ -55,8 +55,8 @@ public class LabelConfigurationTests {
 
         assertEquals(Set.of("1", "2", "both"), config.allowed());
 
-        assertEquals(Set.of("1"), config.labels(Set.of(Path.of("a.cpp"))));
-        assertEquals(Set.of("2"), config.labels(Set.of(Path.of("a.hpp"))));
-        assertEquals(Set.of("both"), config.labels(Set.of(Path.of("a.cpp"), Path.of("a.hpp"))));
+        assertEquals(Set.of("1"), config.label(Set.of(Path.of("a.cpp"))));
+        assertEquals(Set.of("2"), config.label(Set.of(Path.of("a.hpp"))));
+        assertEquals(Set.of("both"), config.label(Set.of(Path.of("a.cpp"), Path.of("a.hpp"))));
     }
 }


### PR DESCRIPTION
Hi all,

please review this patch that makes `git pr create` much more explicit about the
mailing lists that will be CC:d for the "RFR" email generated from a pull
request. A user can now manually specify the mailing lists with `--cc` flag, for
example:

```
$ git pr create --cc=hotspot-dev,build-dev
```

Furthermore, `git pr create` will now also prompt the user for confirmation
about the selected mailing lists before proceeding:

```
$ git pr create --cc=hotspot-dev,build-dev
You have chosen the following mailing lists to be CC:d for the "RFR" e-mail:
- hotspot-dev@openjdk.java.net
- build-dev@openjdk.java.net

Do you want to proceed with this mailing list selection? [Y/n]:
```

If a user does not specify `--cc`, then `git pr create` will display the mailing
lists that were inferred based on the changes in the pull request:

```
The following mailing lists will be CC:d for the "RFR" e-mail:
- build-dev@openjdk.java.net

Do you want to proceed with this mailing list selection? [Y/n]:
```

If a user specify `--cc=auto` then no prompt will be shown and inferred mailing
lists will be used.

Additionally, the selected mailing lists will also be shown in the users
`$EDITOR` when the user writes the pull request message. For example:

```
  <!-- Please enter the pull request message for your changes.                -->
  <!-- The first line will be considered the title, use a blank line to       -->
  <!-- separate the title from the body. Pull requests are required to have   -->
  <!-- a title and a body. An empty message aborts the pull request.          -->
  <!-- These HTML comment lines will be removed automatically.                -->
  <!--                                                                        -->
  <!-- Commits to be included from branch 'update-readme':                    -->
  <!-- - 13be5f30: Update the README                                          -->
  <!--   M  README.md                                                         -->
  <!--                                                                        -->
  <!-- Repository: https://github.com/openjdk/jdk                             -->
  <!-- Branch:     master                                                     -->
  <!--                                                                        -->
  <!-- The following mailing lists will be CC:d for the "RFR" e-mail:         -->
  <!-- - jdk-dev@openjdk.java.net                                             -->
```

As with all flags to Skara's CLI commands, a default value can be configured for
the `--cc` flag. This means that users that so wish can opt in to always use the
inferred mailing lists by running:

```
$ git config --global pr.create.cc auto
```

Testing:
- [x] Manual testing on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**) ⚠️ Review applies to f88fd37948d1bf36c02f2e107cb851a52d0bc13f


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/750/head:pull/750`
`$ git checkout pull/750`
