### PR TITLE
vcs: make follow work with merge commits

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -305,6 +305,9 @@ public class GitRepository implements Repository {
         var delimiter = "#@!_-=&";
         var cmd = new ArrayList<String>();
         cmd.addAll(List.of("git", "log",
+                                  "-c",
+                                  "--no-patch",
+                                  "--full-history",
                                   "--follow",
                                   "--format=" + delimiter + "\n" + GitCommitMetadata.FORMAT,
                                   "--topo-order",


### PR DESCRIPTION
Hi all,

please review this patch that makes `ReadOnlyRepository.follow` work with merge commits for Git repositories. I also added an additional unit test to verify the functionality.

Testing:
- [x] `make test` passes on Linux x64
- [x] Added a new unit test

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/752/head:pull/752`
`$ git checkout pull/752`
