### PR TITLE
tester: allow configurable allowlist

### DIFF
--- a/bots/tester/src/main/java/org/openjdk/skara/bots/tester/State.java
+++ b/bots/tester/src/main/java/org/openjdk/skara/bots/tester/State.java
@@ -23,7 +23,10 @@
 package org.openjdk.skara.bots.tester;
 
 import org.openjdk.skara.forge.PullRequest;
+import org.openjdk.skara.host.HostUser;
 import org.openjdk.skara.issuetracker.Comment;
+
+import java.util.function.Predicate;
 
 class State {
     private final Stage stage;
@@ -77,7 +80,7 @@ class State {
         return finished;
     }
 
-    static State from(PullRequest pr, String approverGroupId) {
+    static State from(PullRequest pr, Predicate<HostUser> validate) {
         Comment requested = null;
         Comment pending = null;
         Comment approval = null;
@@ -127,7 +130,7 @@ class State {
                     }
                 } else if (body.equals("/test approve")) {
                     approval = comment;
-                    if (host.isMemberOf(approverGroupId, author)) {
+                    if (validate.test(author)) {
                         isApproved = true;
                     }
                 } else if (body.equals("/test cancel")) {
@@ -135,7 +138,7 @@ class State {
                         cancelled = comment;
                     }
                 } else if (body.startsWith("/test")) {
-                    if (host.isMemberOf(approverGroupId, author)) {
+                    if (validate.test(author)) {
                         isApproved = true;
                     }
                 }

--- a/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestBot.java
+++ b/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestBot.java
@@ -47,6 +47,7 @@ public class TestBot implements Bot {
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots");;
     private final ContinuousIntegration ci;
     private final String approversGroupId;
+    private final Set<String> allowlist;
     private final List<String> availableJobs;
     private final List<String> defaultJobs;
     private final String name;
@@ -57,6 +58,7 @@ public class TestBot implements Bot {
 
     TestBot(ContinuousIntegration ci,
             String approversGroupId,
+            Set<String> allowlist,
             List<String> availableJobs,
             List<String> defaultJobs,
             String name,
@@ -64,6 +66,7 @@ public class TestBot implements Bot {
             HostedRepository repo) {
         this.ci = ci;
         this.approversGroupId = approversGroupId;
+        this.allowlist = allowlist;
         this.availableJobs = availableJobs;
         this.defaultJobs = defaultJobs;
         this.name = name;
@@ -83,6 +86,7 @@ public class TestBot implements Bot {
             if (cache.needsUpdate(pr)) {
                 ret.add(new TestWorkItem(ci,
                                          approversGroupId,
+                                         allowlist,
                                          availableJobs,
                                          defaultJobs,
                                          name,
@@ -121,6 +125,7 @@ public class TestBot implements Bot {
                     if (shouldUpdate) {
                         ret.add(new TestWorkItem(ci,
                                                  approversGroupId,
+                                                 allowlist,
                                                  availableJobs,
                                                  defaultJobs,
                                                  name,

--- a/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestBotFactory.java
+++ b/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestBotFactory.java
@@ -52,13 +52,14 @@ public class TestBotFactory implements BotFactory {
         var specific = configuration.specific();
 
         var approvers = specific.get("approvers").asString();
+        var allowlist = specific.get("allowlist").stream().map(JSONValue::asString).collect(Collectors.toSet());
         var availableJobs = specific.get("availableJobs").stream().map(JSONValue::asString).collect(Collectors.toList());
         var defaultJobs = specific.get("defaultJobs").stream().map(JSONValue::asString).collect(Collectors.toList());
         var name = specific.get("name").asString();
         var ci = configuration.continuousIntegration(specific.get("ci").asString());
         for (var repo : specific.get("repositories").asArray()) {
             var hostedRepo = configuration.repository(repo.asString());
-            ret.add(new TestBot(ci, approvers, availableJobs, defaultJobs, name, storage, hostedRepo));
+            ret.add(new TestBot(ci, approvers, allowlist, availableJobs, defaultJobs, name, storage, hostedRepo));
         }
 
         return ret;

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/StateTests.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/StateTests.java
@@ -48,7 +48,7 @@ class StateTests {
         pr.author = duke;
         pr.comments = List.of();
 
-        var state = State.from(pr, "0");
+        var state = State.from(pr, u -> host.isMemberOf("0", u));
         assertEquals(Stage.NA, state.stage());
         assertEquals(null, state.requested());
         assertEquals(null, state.pending());
@@ -78,7 +78,7 @@ class StateTests {
         var approvers = "0";
         host.groups = Map.of(approvers, Set.of());
 
-        var state = State.from(pr, approvers);
+        var state = State.from(pr, u -> host.isMemberOf(approvers, u));
         assertEquals(Stage.REQUESTED, state.stage());
         assertEquals(comment, state.requested());
         assertEquals(null, state.pending());
@@ -108,7 +108,7 @@ class StateTests {
         var approvers = "0";
         host.groups = Map.of(approvers, Set.of(duke));
 
-        var state = State.from(pr, approvers);
+        var state = State.from(pr, u -> host.isMemberOf(approvers, u));
         assertEquals(Stage.APPROVED, state.stage());
         assertEquals(comment, state.requested());
         assertEquals(null, state.pending());
@@ -143,7 +143,7 @@ class StateTests {
         pr.comments = List.of(testComment, pendingComment);
         host.groups = Map.of("0", Set.of());
 
-        var state = State.from(pr, "0");
+        var state = State.from(pr, u -> host.isMemberOf("0", u));
         assertEquals(Stage.PENDING, state.stage());
         assertEquals(testComment, state.requested());
         assertEquals(pendingComment, state.pending());
@@ -191,7 +191,7 @@ class StateTests {
         var approvers = "0";
         host.groups = Map.of(approvers, Set.of(member));
 
-        var state = State.from(pr, approvers);
+        var state = State.from(pr, u -> host.isMemberOf(approvers, u));
         assertEquals(Stage.STARTED, state.stage());
         assertEquals(testComment, state.requested());
         assertEquals(pendingComment, state.pending());
@@ -222,7 +222,7 @@ class StateTests {
         var approvers = "0";
         host.groups = Map.of(approvers, Set.of());
 
-        var state = State.from(pr, approvers);
+        var state = State.from(pr, u -> host.isMemberOf(approvers, u));
         assertEquals(Stage.CANCELLED, state.stage());
         assertEquals(testComment, state.requested());
         assertEquals(cancelComment, state.cancelled());
@@ -256,7 +256,7 @@ class StateTests {
         var approvers = "0";
         host.groups = Map.of(approvers, Set.of());
 
-        var state = State.from(pr, approvers);
+        var state = State.from(pr, u -> host.isMemberOf(approvers, u));
         assertEquals(Stage.REQUESTED, state.stage());
         assertEquals(testComment, state.requested());
         assertEquals(null, state.cancelled());
@@ -289,7 +289,7 @@ class StateTests {
         var approvers = "0";
         host.groups = Map.of(approvers, Set.of());
 
-        var state = State.from(pr, approvers);
+        var state = State.from(pr, u -> host.isMemberOf(approvers, u));
         assertEquals(Stage.REQUESTED, state.stage());
         assertEquals(test3Comment, state.requested());
         assertEquals(null, state.cancelled());
@@ -326,7 +326,7 @@ class StateTests {
         var approvers = "0";
         host.groups = Map.of(approvers, Set.of());
 
-        var state = State.from(pr, approvers);
+        var state = State.from(pr, u -> host.isMemberOf(approvers, u));
         assertEquals(Stage.ERROR, state.stage());
         assertEquals(testComment, state.requested());
         assertEquals(null, state.pending());
@@ -381,7 +381,7 @@ class StateTests {
         var approvers = "0";
         host.groups = Map.of(approvers, Set.of(member));
 
-        var state = State.from(pr, approvers);
+        var state = State.from(pr, u -> host.isMemberOf(approvers, u));
         assertEquals(Stage.FINISHED, state.stage());
         assertEquals(testComment, state.requested());
         assertEquals(pendingComment, state.pending());

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/TestBotTests.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/TestBotTests.java
@@ -49,7 +49,7 @@ class TestBotTests {
 
             var storage = tmp.path().resolve("storage");
             var ci = new InMemoryContinuousIntegration();
-            var bot = new TestBot(ci, "0", List.of(), List.of(), "", storage, upstreamHostedRepo);
+            var bot = new TestBot(ci, "0", Set.of(), List.of(), List.of(), "", storage, upstreamHostedRepo);
             var runner = new TestBotRunner();
 
             runner.runPeriodicItems(bot);


### PR DESCRIPTION
Hi all,

please review that patch that enables a configurable allowlist for the tester bot. I also added a unit test for the new functionality.

Testing:
- [x] `make test` passes on Linux x64
- [x] Added a new unit test

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/753/head:pull/753`
`$ git checkout pull/753`
