### PR TITLE
webrev: not all commits changes files

### DIFF
--- a/webrev/src/main/java/org/openjdk/skara/webrev/Webrev.java
+++ b/webrev/src/main/java/org/openjdk/skara/webrev/Webrev.java
@@ -296,7 +296,7 @@ public class Webrev {
                     JSON.object().put("message", String.join("\n", commit.message()))
                 );
                 var filesArray = JSON.array();
-                for (var path : pathsPerCommit.get(commit.hash())) {
+                for (var path : pathsPerCommit.getOrDefault(commit.hash(), List.of())) {
                     filesArray.add(JSON.object().put("filename", path.toString()));
                 }
                 c.put("files", filesArray);


### PR DESCRIPTION
Hi all,

please review this small patch that updates webrev's JSON generator to handle commits that don't change any files. This can happen for example with trivial merges (since we use the `-c` flag to `git log`).

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/754/head:pull/754`
`$ git checkout pull/754`
