### PR TITLE
prbot: Allow overriding jcheck configuration

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -78,7 +78,10 @@ class CheckRun {
         this.ignoreStaleReviews = ignoreStaleReviews;
 
         baseHash = PullRequestUtils.baseHash(pr, localRepo);
-        checkablePullRequest = new CheckablePullRequest(pr, localRepo, ignoreStaleReviews);
+        checkablePullRequest = new CheckablePullRequest(pr, localRepo, ignoreStaleReviews,
+                                                        workItem.bot.confOverrideRepository().orElse(null),
+                                                        workItem.bot.confOverrideName(),
+                                                        workItem.bot.confOverrideRef());
     }
 
     static void execute(CheckWorkItem workItem, PullRequest pr, Repository localRepo, List<Comment> comments,

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -135,7 +135,8 @@ class CheckWorkItem extends PullRequestWorkItem {
     @Override
     public Collection<WorkItem> run(Path scratchPath) {
         // First determine if the current state of the PR has already been checked
-        var census = CensusInstance.create(bot.censusRepo(), bot.censusRef(), scratchPath.resolve("census"), pr);
+        var census = CensusInstance.create(bot.censusRepo(), bot.censusRef(), scratchPath.resolve("census"), pr,
+                                           bot.confOverrideRepository().orElse(null), bot.confOverrideName(), bot.confOverrideRef());
         var comments = pr.comments();
         var allReviews = pr.reviews();
         var labels = new HashSet<>(pr.labels());

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandWorkItem.java
@@ -217,7 +217,8 @@ public class CommandWorkItem extends PullRequestWorkItem {
             return List.of(new LabelerWorkItem(bot, pr, errorHandler));
         }
 
-        var census = CensusInstance.create(bot.censusRepo(), bot.censusRef(), scratchPath.resolve("census"), pr);
+        var census = CensusInstance.create(bot.censusRepo(), bot.censusRef(), scratchPath.resolve("census"), pr,
+                                           bot.confOverrideRepository().orElse(null), bot.confOverrideName(), bot.confOverrideRef());
         var command = nextCommand.get();
         log.info("Processing command: " + command.id() + " - " + command.name());
         processCommand(pr, census, scratchPath.resolve("pr").resolve("command"), command, comments);

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
@@ -100,7 +100,10 @@ public class IntegrateCommand implements CommandHandler {
             var seedPath = bot.seedStorage().orElse(scratchPath.resolve("seeds"));
             var hostedRepositoryPool = new HostedRepositoryPool(seedPath);
             var localRepo = PullRequestUtils.materialize(hostedRepositoryPool, pr, path);
-            var checkablePr = new CheckablePullRequest(pr, localRepo, bot.ignoreStaleReviews());
+            var checkablePr = new CheckablePullRequest(pr, localRepo, bot.ignoreStaleReviews(),
+                                                       bot.confOverrideRepository().orElse(null),
+                                                       bot.confOverrideName(),
+                                                       bot.confOverrideRef());
 
             // Validate the target hash if requested
             var rebaseMessage = new StringWriter();

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -48,6 +48,9 @@ class PullRequestBot implements Bot {
     private final Set<String> allowedIssueTypes;
     private final Pattern allowedTargetBranches;
     private final Path seedStorage;
+    private final HostedRepository confOverrideRepo;
+    private final String confOverrideName;
+    private final String confOverrideRef;
     private final ConcurrentMap<Hash, Boolean> currentLabels;
     private final PullRequestUpdateCache updateCache;
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots.pr");
@@ -56,7 +59,8 @@ class PullRequestBot implements Bot {
                    LabelConfiguration labelConfiguration, Map<String, String> externalCommands,
                    Map<String, String> blockingCheckLabels, Set<String> readyLabels,
                    Map<String, Pattern> readyComments, IssueProject issueProject, boolean ignoreStaleReviews,
-                   Set<String> allowedIssueTypes, Pattern allowedTargetBranches, Path seedStorage) {
+                   Set<String> allowedIssueTypes, Pattern allowedTargetBranches, Path seedStorage,
+                   HostedRepository confOverrideRepo, String confOverrideName, String confOverrideRef) {
         remoteRepo = repo;
         this.censusRepo = censusRepo;
         this.censusRef = censusRef;
@@ -70,6 +74,9 @@ class PullRequestBot implements Bot {
         this.allowedIssueTypes = allowedIssueTypes;
         this.allowedTargetBranches = allowedTargetBranches;
         this.seedStorage = seedStorage;
+        this.confOverrideRepo = confOverrideRepo;
+        this.confOverrideName = confOverrideName;
+        this.confOverrideRef = confOverrideRef;
 
         this.currentLabels = new ConcurrentHashMap<>();
         this.updateCache = new PullRequestUpdateCache();
@@ -195,5 +202,17 @@ class PullRequestBot implements Bot {
 
     Optional<Path> seedStorage() {
         return Optional.ofNullable(seedStorage);
+    }
+
+    Optional<HostedRepository> confOverrideRepository() {
+        return Optional.ofNullable(confOverrideRepo);
+    }
+
+    String confOverrideName() {
+        return confOverrideName;
+    }
+
+    String confOverrideRef() {
+        return confOverrideRef;
     }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
@@ -22,8 +22,7 @@
  */
 package org.openjdk.skara.bots.pr;
 
-import org.openjdk.skara.forge.HostedRepository;
-import org.openjdk.skara.forge.LabelConfiguration;
+import org.openjdk.skara.forge.*;
 import org.openjdk.skara.issuetracker.IssueProject;
 
 import java.nio.file.Path;
@@ -44,6 +43,9 @@ public class PullRequestBotBuilder {
     private Set<String> allowedIssueTypes = null;
     private Pattern allowedTargetBranches = Pattern.compile(".*");
     private Path seedStorage = null;
+    private HostedRepository confOverrideRepo = null;
+    private String confOverrideName = ".conf/jcheck";
+    private String confOverrideRef = "master";
 
     PullRequestBotBuilder() {
     }
@@ -113,10 +115,25 @@ public class PullRequestBotBuilder {
         return this;
     }
 
+    public PullRequestBotBuilder confOverrideRepo(HostedRepository confOverrideRepo) {
+        this.confOverrideRepo = confOverrideRepo;
+        return this;
+    }
+
+    public PullRequestBotBuilder confOverrideName(String confOverrideName) {
+        this.confOverrideName = confOverrideName;
+        return this;
+    }
+
+    public PullRequestBotBuilder confOverrideRef(String confOverrideRef) {
+        this.confOverrideRef = confOverrideRef;
+        return this;
+    }
+
     public PullRequestBot build() {
         return new PullRequestBot(repo, censusRepo, censusRef, labelConfiguration, externalCommands,
                                   blockingCheckLabels, readyLabels, readyComments, issueProject,
                                   ignoreStaleReviews, allowedIssueTypes, allowedTargetBranches,
-                                  seedStorage);
+                                  seedStorage, confOverrideRepo, confOverrideName, confOverrideRef);
     }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
@@ -105,6 +105,13 @@ public class PullRequestBotFactory implements BotFactory {
             if (repo.value().contains("targetbranches")) {
                 botBuilder.allowedTargetBranches(repo.value().get("targetbranches").asString());
             }
+            if (repo.value().contains("jcheck")) {
+                botBuilder.confOverrideRepo(configuration.repository(repo.value().get("jcheck").get("repo").asString()));
+                botBuilder.confOverrideRef(configuration.repositoryRef(repo.value().get("jcheck").get("repo").asString()));
+                if (repo.value().get("jcheck").contains("name")) {
+                    botBuilder.confOverrideName(repo.value().get("jcheck").get("name").asString());
+                }
+            }
 
             ret.add(botBuilder.build());
         }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
@@ -85,7 +85,10 @@ public class SponsorCommand implements CommandHandler {
             var seedPath = bot.seedStorage().orElse(scratchPath.resolve("seeds"));
             var hostedRepositoryPool = new HostedRepositoryPool(seedPath);
             var localRepo = PullRequestUtils.materialize(hostedRepositoryPool, pr, path);
-            var checkablePr = new CheckablePullRequest(pr, localRepo, bot.ignoreStaleReviews());
+            var checkablePr = new CheckablePullRequest(pr, localRepo, bot.ignoreStaleReviews(),
+                                                       bot.confOverrideRepository().orElse(null),
+                                                       bot.confOverrideName(),
+                                                       bot.confOverrideRef());
 
             // Validate the target hash if requested
             var rebaseMessage = new StringWriter();

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/JCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/JCheckTests.java
@@ -342,7 +342,8 @@ class JCheckTests {
 
             // Check the last commit without reviewers with the initial .jcheck/conf. Should fail
             // due to missing reviewers.
-            try (var issues = JCheck.check(repo, census, CommitMessageParsers.v1, secondCommit, initialCommit.hash(), List.of())) {
+            var conf = JCheck.parseConfiguration(repo, initialCommit.hash(), List.of()).orElseThrow();
+            try (var issues = JCheck.check(repo, census, CommitMessageParsers.v1, secondCommit, conf)) {
                 for (var issue : issues) {
                     issue.accept(visitor);
                 }


### PR DESCRIPTION
Hi all,

Please review this change that allows the pull request bot to use a jcheck configuration file from a separate repository, overriding the one (if any) present in the checked repository.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/755/head:pull/755`
`$ git checkout pull/755`
