### PR TITLE
439: Improve command filtering when bridging mails

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
@@ -36,7 +36,7 @@ import java.time.*;
 import java.util.*;
 import java.util.function.*;
 import java.util.logging.Logger;
-import java.util.regex.Pattern;
+import java.util.regex.*;
 import java.util.stream.Collectors;
 
 class ArchiveWorkItem implements WorkItem {
@@ -104,7 +104,7 @@ class ArchiveWorkItem implements WorkItem {
         }
     }
 
-    private final static Pattern commandPattern = Pattern.compile("^/.*$");
+    private final static Pattern commandPattern = Pattern.compile("^\\s*/([A-Za-z]+).*$");
 
     private boolean ignoreComment(HostUser author, String body) {
         if (pr.repository().forge().currentUser().equals(author)) {
@@ -113,8 +113,11 @@ class ArchiveWorkItem implements WorkItem {
         if (bot.ignoredUsers().contains(author.userName())) {
             return true;
         }
-        var commandMatcher = commandPattern.matcher(body);
-        if (commandMatcher.matches()) {
+        // Check if this comment only contains command lines
+        var commandOnly = body.strip().lines()
+                              .map(commandPattern::matcher)
+                              .allMatch(Matcher::matches);
+        if (body.strip().lines().count() > 0 && commandOnly) {
             return true;
         }
         for (var ignoredCommentPattern : bot.ignoredComments()) {

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -1466,7 +1466,10 @@ class MailingListBridgeBotTests {
             // Make a bunch of comments
             pr.addComment("Plain comment\n<!-- this is a comment -->");
             pr.addReviewComment(masterHash, editHash, reviewFile.toString(), 2, "Review comment <!-- this is a comment -->\n");
+            pr.addComment("  /cc others");
             pr.addComment("/integrate stuff");
+            pr.addComment("the command is /hello there");
+            pr.addComment("but this will be parsed\n/newline command");
             TestBotRunner.runPeriodicItems(mlBot);
 
             // Run an archive pass
@@ -1483,6 +1486,10 @@ class MailingListBridgeBotTests {
             assertTrue(archiveContains(archiveFolder.path(), "Plain comment"));
             assertTrue(archiveContains(archiveFolder.path(), "Review comment"));
             assertFalse(archiveContains(archiveFolder.path(), "/integrate"));
+            assertFalse(archiveContains(archiveFolder.path(), "/cc"));
+            assertTrue(archiveContains(archiveFolder.path(), "/hello there"));
+            assertTrue(archiveContains(archiveFolder.path(), "but this will be parsed"));
+            assertFalse(archiveContains(archiveFolder.path(), "/newline"));
         }
     }
 


### PR DESCRIPTION
Hi all,

Please review this change that improves the command comment filtering done by the mailinglist bridge bot, to match more closely what the pull request bot would consider as commands.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-439](https://bugs.openjdk.java.net/browse/SKARA-439): Improve command filtering when bridging mails


### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/756/head:pull/756`
`$ git checkout pull/756`
