### PR TITLE
265: Mail bot shows wrong source line for inline review comments

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
@@ -334,7 +334,7 @@ class ArchiveMessages {
             body.append(reviewComment.path()).append(" line ").append(reviewComment.line()).append(":\n\n");
             try {
                 var contents = pr.repository().fileContents(reviewComment.path(), reviewComment.hash().hex()).lines().collect(Collectors.toList());
-                for (int i = Math.max(0, reviewComment.line() - 2); i < Math.min(contents.size(), reviewComment.line() + 1); ++i) {
+                for (int i = Math.max(0, reviewComment.line() - 3); i < Math.min(contents.size(), reviewComment.line()); ++i) {
                     body.append("> ").append(i + 1).append(": ").append(contents.get(i)).append("\n");
                 }
                 body.append("\n");

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -1337,11 +1337,10 @@ class MailingListBridgeBotTests {
             TestBotRunner.runPeriodicItems(mlBot);
             listServer.processIncoming();
 
-            // The archive should only contain context around line 2
+            // The archive should only contain context up to and including Line 2
             Repository.materialize(archiveFolder.path(), archive.url(), "master");
             assertTrue(archiveContains(archiveFolder.path(), "^> 2: Line 1$"));
-            assertTrue(archiveContains(archiveFolder.path(), "^> 3: Line 2$"));
-            assertFalse(archiveContains(archiveFolder.path(), "^> 4: Line 3$"));
+            assertFalse(archiveContains(archiveFolder.path(), "^> 3: Line 2$"));
         }
     }
 


### PR DESCRIPTION
Hi all,

Please review this small change that adjusts the quoted source lines in review comments, to have the line the comment is made about be the last one.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-265](https://bugs.openjdk.java.net/browse/SKARA-265): Mail bot shows wrong source line for inline review comments


### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/757/head:pull/757`
`$ git checkout pull/757`
