### PR TITLE
checkout-bot: remote leading slash from path

### DIFF
--- a/bots/checkout/src/main/java/org/openjdk/skara/bots/checkout/CheckoutBotFactory.java
+++ b/bots/checkout/src/main/java/org/openjdk/skara/bots/checkout/CheckoutBotFactory.java
@@ -55,7 +55,7 @@ public class CheckoutBotFactory implements BotFactory {
             var fromBranch = new Branch(from.substring(lastColon + 1));
             var to = Path.of(repo.get("to").asString());
 
-            var repoName = fromURI.getPath();
+            var repoName = fromURI.getPath().substring(1); // Remove leading '/'
             var markStorage = MarkStorage.create(marksRepo, marksUser, repoName);
 
             bots.add(new CheckoutBot(fromURI, fromBranch, to, storage, markStorage));


### PR DESCRIPTION
Hi all,

please review this patch that removes the leading slash from the path to the marks file for the checkout bot.

Testing:
- `make test` passes on Linux x64
- Manual testing on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/759/head:pull/759`
`$ git checkout pull/759`
