### PR TITLE
test-bot: make it configurable to check committer status

### DIFF
--- a/bots/tester/build.gradle
+++ b/bots/tester/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     implementation project(':issuetracker')
     implementation project(':json')
     implementation project(':vcs')
+    implementation project(':jcheck')
 
     testImplementation project(':test')
 }

--- a/bots/tester/src/main/java/module-info.java
+++ b/bots/tester/src/main/java/module-info.java
@@ -24,6 +24,8 @@ module org.openjdk.skara.bots.tester {
     requires org.openjdk.skara.bot;
     requires org.openjdk.skara.vcs;
     requires org.openjdk.skara.ci;
+    requires org.openjdk.skara.census;
+    requires org.openjdk.skara.jcheck;
 
     requires java.logging;
 

--- a/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestBotFactory.java
+++ b/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestBotFactory.java
@@ -51,6 +51,16 @@ public class TestBotFactory implements BotFactory {
         var ret = new ArrayList<Bot>();
         var specific = configuration.specific();
 
+        var censusDir = storage.resolve("census.git");
+        try {
+            Files.createDirectories(censusDir);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        var censusRemote = configuration.repository(specific.get("census").asString());
+        var checkCommitterStatus = specific.contains("role") &&
+                                   specific.get("role").asString().toLowerCase().equals("committer");
+
         var approvers = specific.get("approvers").asString();
         var allowlist = specific.get("allowlist").stream().map(JSONValue::asString).collect(Collectors.toSet());
         var availableJobs = specific.get("availableJobs").stream().map(JSONValue::asString).collect(Collectors.toList());
@@ -59,7 +69,7 @@ public class TestBotFactory implements BotFactory {
         var ci = configuration.continuousIntegration(specific.get("ci").asString());
         for (var repo : specific.get("repositories").asArray()) {
             var hostedRepo = configuration.repository(repo.asString());
-            ret.add(new TestBot(ci, approvers, allowlist, availableJobs, defaultJobs, name, storage, hostedRepo));
+            ret.add(new TestBot(ci, approvers, allowlist, availableJobs, defaultJobs, name, storage, hostedRepo, censusRemote, censusDir, checkCommitterStatus));
         }
 
         return ret;

--- a/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestWorkItem.java
+++ b/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestWorkItem.java
@@ -48,9 +48,10 @@ public class TestWorkItem implements WorkItem {
     private final Path storage;
     private final HostedRepository repository;
     private final PullRequest pr;
+    private final Predicate<HostUser> isCommitter;
 
     TestWorkItem(ContinuousIntegration ci, String approversGroupId, Set<String> allowlist, List<String> availableJobs,
-                 List<String> defaultJobs, String name, Path storage, PullRequest pr) {
+                 List<String> defaultJobs, String name, Path storage, PullRequest pr, Predicate<HostUser> isCommitter) {
         this.ci = ci;
         this.approversGroupId = approversGroupId;
         this.allowlist = allowlist;
@@ -60,6 +61,7 @@ public class TestWorkItem implements WorkItem {
         this.storage = storage;
         this.repository = pr.repository();
         this.pr = pr;
+        this.isCommitter = isCommitter;
     }
 
     @Override
@@ -252,7 +254,7 @@ public class TestWorkItem implements WorkItem {
 
     private boolean validate(HostUser u) {
         var forge = pr.repository().forge();
-        return forge.isMemberOf(approversGroupId, u) || allowlist.contains(u.id());
+        return isCommitter.test(u) && (forge.isMemberOf(approversGroupId, u) || allowlist.contains(u.id()));
     }
 
     @Override

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/TestBotTests.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/TestBotTests.java
@@ -49,7 +49,8 @@ class TestBotTests {
 
             var storage = tmp.path().resolve("storage");
             var ci = new InMemoryContinuousIntegration();
-            var bot = new TestBot(ci, "0", Set.of(), List.of(), List.of(), "", storage, upstreamHostedRepo);
+            var bot = new TestBot(ci, "0", Set.of(), List.of(), List.of(), "",
+                                  storage, upstreamHostedRepo, null, null, false);
             var runner = new TestBotRunner();
 
             runner.runPeriodicItems(bot);

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/TestWorkItemTests.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/TestWorkItemTests.java
@@ -64,7 +64,8 @@ class TestWorkItemTests {
             pr.author = duke;
             pr.comments = List.of();
 
-            var item = new TestWorkItem(ci, approvers, Set.of(), available, defaultJobs, name, storage, pr);
+            var item = new TestWorkItem(ci, approvers, Set.of(), available, defaultJobs, name, storage, pr,
+                                        u -> true);
             item.run(scratch);
 
             var comments = pr.comments();
@@ -99,7 +100,8 @@ class TestWorkItemTests {
             var testApproveComment = new Comment("0", "/test approve", duke, now, now);
             pr.comments = List.of(testApproveComment);
 
-            var item = new TestWorkItem(ci, approvers, Set.of(), available, defaultJobs, name, storage, pr);
+            var item = new TestWorkItem(ci, approvers, Set.of(), available, defaultJobs, name, storage, pr,
+                                        u -> true);
             item.run(scratch);
 
             var comments = pr.comments();
@@ -135,7 +137,8 @@ class TestWorkItemTests {
             var testApproveComment = new Comment("0", "/test cancel", duke, now, now);
             pr.comments = List.of(testApproveComment);
 
-            var item = new TestWorkItem(ci, approvers, Set.of(), available, defaultJobs, name, storage, pr);
+            var item = new TestWorkItem(ci, approvers, Set.of(), available, defaultJobs, name, storage, pr,
+                                        u -> true);
             item.run(scratch);
 
             var comments = pr.comments();
@@ -173,7 +176,8 @@ class TestWorkItemTests {
             var comment = new Comment("0", "/test foobar", duke, now, now);
             pr.comments = new ArrayList<>(List.of(comment));
 
-            var item = new TestWorkItem(ci, approvers, Set.of(), available, defaultJobs, name, storage, pr);
+            var item = new TestWorkItem(ci, approvers, Set.of(), available, defaultJobs, name, storage, pr,
+                                        u -> true);
             item.run(scratch);
 
             var comments = pr.comments();
@@ -220,7 +224,8 @@ class TestWorkItemTests {
             var comment = new Comment("0", "/test foobar", duke, now, now);
             pr.comments = new ArrayList<>(List.of(comment));
 
-            var item = new TestWorkItem(ci, approvers, Set.of(), available, defaultJobs, name, storage, pr);
+            var item = new TestWorkItem(ci, approvers, Set.of(), available, defaultJobs, name, storage, pr,
+                                        u -> true);
 
             // Non-existing test group should result in error
             item.run(scratch);
@@ -301,7 +306,8 @@ class TestWorkItemTests {
             var cancelComment = new Comment("1", "/test cancel", duke, now, now);
             pr.comments = new ArrayList<>(List.of(testComment, cancelComment));
 
-            var item = new TestWorkItem(ci, approvers, Set.of(), available, defaultJobs, name, storage, pr);
+            var item = new TestWorkItem(ci, approvers, Set.of(), available, defaultJobs, name, storage, pr,
+                                        u -> true);
 
             item.run(scratch);
 
@@ -342,7 +348,8 @@ class TestWorkItemTests {
             var comment = new Comment("0", "/test tier1", duke, now, now);
             pr.comments = new ArrayList<>(List.of(comment));
 
-            var item = new TestWorkItem(ci, approvers, Set.of(), available, defaultJobs, name, storage, pr);
+            var item = new TestWorkItem(ci, approvers, Set.of(), available, defaultJobs, name, storage, pr,
+                                        u -> true);
 
             item.run(scratch);
 
@@ -426,7 +433,8 @@ class TestWorkItemTests {
             var comment = new Comment("0", "/test tier1", duke, now, now);
             pr.comments = new ArrayList<>(List.of(comment));
 
-            var item = new TestWorkItem(ci, approvers, Set.of(), available, defaultJobs, name, storage, pr);
+            var item = new TestWorkItem(ci, approvers, Set.of(), available, defaultJobs, name, storage, pr,
+                                        u -> true);
 
             item.run(scratch);
 
@@ -513,7 +521,8 @@ class TestWorkItemTests {
             var comment = new Comment("0", "/test tier1", duke, now, now);
             pr.comments = new ArrayList<>(List.of(comment));
 
-            var item = new TestWorkItem(ci, approvers, Set.of(), available, defaultJobs, name, storage, pr);
+            var item = new TestWorkItem(ci, approvers, Set.of(), available, defaultJobs, name, storage, pr,
+                                        u -> true);
 
             item.run(scratch);
 
@@ -621,7 +630,8 @@ class TestWorkItemTests {
             var comment = new Comment("0", "/test tier1", duke, now, now);
             pr.comments = new ArrayList<>(List.of(comment));
 
-            var item = new TestWorkItem(ci, approvers, Set.of(), available, defaultJobs, name, storage, pr);
+            var item = new TestWorkItem(ci, approvers, Set.of(), available, defaultJobs, name, storage, pr,
+                                        u -> true);
 
             item.run(scratch);
 
@@ -746,7 +756,8 @@ class TestWorkItemTests {
             var comment = new Comment("0", "/test tier1", duke, now, now);
             pr.comments = new ArrayList<>(List.of(comment));
 
-            var item = new TestWorkItem(ci, approvers, Set.of(), available, defaultJobs, name, storage, pr);
+            var item = new TestWorkItem(ci, approvers, Set.of(), available, defaultJobs, name, storage, pr,
+                                        u -> true);
 
             item.run(scratch);
 
@@ -834,7 +845,8 @@ class TestWorkItemTests {
             var comment = new Comment("0", "/test tier1", duke, now, now);
             pr.comments = new ArrayList<>(List.of(comment));
 
-            var item = new TestWorkItem(ci, approvers, Set.of(), available, defaultJobs, name, storage, pr);
+            var item = new TestWorkItem(ci, approvers, Set.of(), available, defaultJobs, name, storage, pr,
+                                        u -> true);
 
             item.run(scratch);
 
@@ -987,7 +999,8 @@ class TestWorkItemTests {
             var comment = new Comment("0", "/test tier1", duke, now, now);
             pr.comments = new ArrayList<>(List.of(comment));
 
-            var item = new TestWorkItem(ci, approvers, Set.of("0"), available, defaultJobs, name, storage, pr);
+            var item = new TestWorkItem(ci, approvers, Set.of("0"), available, defaultJobs, name, storage, pr,
+                                        u -> true);
 
             var expectedJobId = "null-1337-17-0";
             var expectedJob = new InMemoryJob();
@@ -1023,4 +1036,86 @@ class TestWorkItemTests {
                             .contains("0 jobs completed, 1 job running, 7 jobs not yet started"));
         }
     }
+
+    @Test
+    void testCommentFromNonCommitterShouldRequireApproval() throws IOException {
+        try (var tmp = new TemporaryDirectory()) {
+            var ci = new InMemoryContinuousIntegration();
+            var approvers = "0";
+            var available = List.of("tier1", "tier2", "tier3");
+            var defaultJobs = List.of("tier1");
+            var name = "test";
+            var storage = tmp.path().resolve("storage");
+            var scratch = tmp.path().resolve("storage");
+
+            var bot = new HostUser(1, "bot", "openjdk [bot]");
+            var host = new InMemoryHost();
+            host.currentUserDetails = bot;
+
+            var repo = new InMemoryHostedRepository();
+            repo.host = host;
+
+            var pr = new InMemoryPullRequest();
+            pr.repository = repo;
+
+            var duke = new HostUser(0, "duke", "Duke");
+            host.groups = Map.of(approvers, Set.of(duke));
+            pr.author = duke;
+            pr.headHash = new Hash("01234567890123456789012345789012345789");
+
+            var now = ZonedDateTime.now();
+            var comment = new Comment("0", "/test foobar", duke, now, now);
+            pr.comments = new ArrayList<>(List.of(comment));
+
+            var item = new TestWorkItem(ci, approvers, Set.of(), available, defaultJobs, name, storage, pr,
+                                        u -> false);
+
+            // Non-existing test group should result in error
+            item.run(scratch);
+
+            var comments = pr.comments();
+            assertEquals(2, comments.size());
+            assertEquals(comment, comments.get(0));
+
+            var secondComment = comments.get(1);
+            assertEquals(bot, secondComment.author());
+
+            var lines = secondComment.body().split("\n");
+            assertEquals(2, lines.length);
+            assertEquals("<!-- TEST ERROR -->", lines[0]);
+            assertEquals("@duke the test group foobar does not exist", lines[1]);
+
+            // Trying to test again should be fine
+            var thirdComment = new Comment("2", "/test tier1", duke, now, now);
+            pr.comments.add(thirdComment);
+            item.run(scratch);
+
+            comments = pr.comments();
+            assertEquals(4, comments.size());
+            assertEquals(comment, comments.get(0));
+            assertEquals(secondComment, comments.get(1));
+            assertEquals(thirdComment, comments.get(2));
+
+            var fourthComment = comments.get(3);
+            assertEquals(bot, fourthComment.author());
+
+            lines = fourthComment.body().split("\n");
+            assertEquals("<!-- TEST PENDING -->", lines[0]);
+            assertEquals("<!-- 01234567890123456789012345789012345789 -->", lines[1]);
+            assertEquals("<!-- tier1 -->", lines[2]);
+            assertEquals("@duke you need to get approval to run the tests in tier1 for commits up until 01234567",
+                         lines[3]);
+
+            // Nothing should change if we run it yet again
+            item.run(scratch);
+
+            comments = pr.comments();
+            assertEquals(4, comments.size());
+            assertEquals(comment, comments.get(0));
+            assertEquals(secondComment, comments.get(1));
+            assertEquals(thirdComment, comments.get(2));
+            assertEquals(fourthComment, comments.get(3));
+        }
+    }
+
 }


### PR DESCRIPTION
Hi all,

please review this patch that add a configurable validation check to the test bot: check if the requester is Committer in the project.

Testing:
- `make test` on Linux x64
- Added an additional unit test

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Robin Westberg ([rwestberg](@rwestberg) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/761/head:pull/761`
`$ git checkout pull/761`
