### PR TITLE
A GitLab merge request source repo may have an ID but still be inaccessible (due to permissions)

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -273,8 +273,13 @@ public class GitLabMergeRequest implements PullRequest {
         if (json.get("source_project_id").isNull()) {
             return Optional.empty();
         } else {
-            return Optional.of(new GitLabRepository((GitLabHost) repository.forge(),
-                                                    json.get("source_project_id").asInt()));
+            var projectId = json.get("source_project_id").asInt();
+            var project = ((GitLabHost) repository.forge()).getProjectInfo(projectId);
+            if (project.isEmpty()) {
+                return Optional.empty();
+            } else {
+                return Optional.of(new GitLabRepository((GitLabHost) repository.forge(), project.get()));
+            }
         }
     }
 

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -44,14 +44,14 @@ public class GitLabRepository implements HostedRepository {
     private final Pattern mergeRequestPattern;
 
     public GitLabRepository(GitLabHost gitLabHost, String projectName) {
-        this(gitLabHost, gitLabHost.getProjectInfo(projectName));
+        this(gitLabHost, gitLabHost.getProjectInfo(projectName).orElseThrow(() -> new RuntimeException("Project not found: " + projectName)));
     }
 
     public GitLabRepository(GitLabHost gitLabHost, int id) {
-        this(gitLabHost, gitLabHost.getProjectInfo(id));
+        this(gitLabHost, gitLabHost.getProjectInfo(id).orElseThrow(() -> new RuntimeException("Project not found by id: " + id)));
     }
 
-    private GitLabRepository(GitLabHost gitLabHost, JSONValue json) {
+    GitLabRepository(GitLabHost gitLabHost, JSONValue json) {
         this.gitLabHost = gitLabHost;
         this.json = json;
         this.projectName = json.get("path_with_namespace").asString();


### PR DESCRIPTION
Hi all,

Please review this change that ensures that the source repository of a GitLab merge request is accessible before attempting to use it.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/762/head:pull/762`
`$ git checkout pull/762`
