### PR TITLE
549: Links to users under Reviewers lead to a 404 page

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -263,11 +263,25 @@ class CheckRun {
         var namespace = censusInstance.namespace();
         var contributor = namespace.get(reviewer.id());
         if (contributor == null) {
-            return reviewer.userName() + " (no known " + namespace.name() + " user name / role)";
+            return "@" + reviewer.userName() + " (no known " + namespace.name() + " user name / role)";
         } else {
-            var userNameLink = "[" + contributor.username() + "](@" + reviewer.userName() + ")";
-            return contributor.fullName().orElse(contributor.username()) + " (" + userNameLink + " - " +
-                    getRole(contributor.username()) + ")";
+            var ret = new StringBuilder();
+            var censusLink = workItem.bot.censusLink(contributor);
+            if (censusLink.isPresent()) {
+                ret.append("[");
+            }
+            ret.append(contributor.fullName().orElse(contributor.username()));
+            if (censusLink.isPresent()) {
+                ret.append("](");
+                ret.append(censusLink.get().toString());
+                ret.append("]");
+            }
+            ret.append(" (@");
+            ret.append(reviewer.userName());
+            ret.append(" - ");
+            ret.append(getRole(contributor.username()));
+            ret.append(")");
+            return ret.toString();
         }
     }
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -23,11 +23,13 @@
 package org.openjdk.skara.bots.pr;
 
 import org.openjdk.skara.bot.*;
+import org.openjdk.skara.census.Contributor;
 import org.openjdk.skara.forge.*;
 import org.openjdk.skara.issuetracker.IssueProject;
 import org.openjdk.skara.json.JSONValue;
 import org.openjdk.skara.vcs.Hash;
 
+import java.net.URI;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.*;
@@ -51,6 +53,7 @@ class PullRequestBot implements Bot {
     private final HostedRepository confOverrideRepo;
     private final String confOverrideName;
     private final String confOverrideRef;
+    private final String censusLink;
     private final ConcurrentMap<Hash, Boolean> currentLabels;
     private final PullRequestUpdateCache updateCache;
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots.pr");
@@ -60,7 +63,8 @@ class PullRequestBot implements Bot {
                    Map<String, String> blockingCheckLabels, Set<String> readyLabels,
                    Map<String, Pattern> readyComments, IssueProject issueProject, boolean ignoreStaleReviews,
                    Set<String> allowedIssueTypes, Pattern allowedTargetBranches, Path seedStorage,
-                   HostedRepository confOverrideRepo, String confOverrideName, String confOverrideRef) {
+                   HostedRepository confOverrideRepo, String confOverrideName, String confOverrideRef,
+                   String censusLink) {
         remoteRepo = repo;
         this.censusRepo = censusRepo;
         this.censusRef = censusRef;
@@ -77,6 +81,7 @@ class PullRequestBot implements Bot {
         this.confOverrideRepo = confOverrideRepo;
         this.confOverrideName = confOverrideName;
         this.confOverrideRef = confOverrideRef;
+        this.censusLink = censusLink;
 
         this.currentLabels = new ConcurrentHashMap<>();
         this.updateCache = new PullRequestUpdateCache();
@@ -214,5 +219,12 @@ class PullRequestBot implements Bot {
 
     String confOverrideRef() {
         return confOverrideRef;
+    }
+
+    Optional<URI> censusLink(Contributor contributor) {
+        if (censusLink == null) {
+            return Optional.empty();
+        }
+        return Optional.of(URI.create(censusLink.replace("{{contributor}}", contributor.username())));
     }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
@@ -46,6 +46,7 @@ public class PullRequestBotBuilder {
     private HostedRepository confOverrideRepo = null;
     private String confOverrideName = ".conf/jcheck";
     private String confOverrideRef = "master";
+    private String censusLink = null;
 
     PullRequestBotBuilder() {
     }
@@ -130,10 +131,16 @@ public class PullRequestBotBuilder {
         return this;
     }
 
+    public PullRequestBotBuilder censusLink(String censusLink) {
+        this.censusLink = censusLink;
+        return this;
+    }
+
     public PullRequestBot build() {
         return new PullRequestBot(repo, censusRepo, censusRef, labelConfiguration, externalCommands,
                                   blockingCheckLabels, readyLabels, readyComments, issueProject,
                                   ignoreStaleReviews, allowedIssueTypes, allowedTargetBranches,
-                                  seedStorage, confOverrideRepo, confOverrideName, confOverrideRef);
+                                  seedStorage, confOverrideRepo, confOverrideName, confOverrideRef,
+                                  censusLink);
     }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
@@ -72,7 +72,6 @@ public class PullRequestBotFactory implements BotFactory {
         for (var repo : specific.get("repositories").fields()) {
             var censusRepo = configuration.repository(repo.value().get("census").asString());
             var censusRef = configuration.repositoryRef(repo.value().get("census").asString());
-
             var botBuilder = PullRequestBot.newBuilder()
                                            .repo(configuration.repository(repo.name()))
                                            .censusRepo(censusRepo)
@@ -111,6 +110,9 @@ public class PullRequestBotFactory implements BotFactory {
                 if (repo.value().get("jcheck").contains("name")) {
                     botBuilder.confOverrideName(repo.value().get("jcheck").get("name").asString());
                 }
+            }
+            if (repo.value().contains("censuslink")) {
+                botBuilder.censusLink(repo.value().get("censuslink").asString());
             }
 
             ret.add(botBuilder.build());

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -48,7 +48,11 @@ class CheckTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id())
                                            .addReviewer(reviewer.forge().currentUser().id());
-            var checkBot = PullRequestBot.newBuilder().repo(author).censusRepo(censusBuilder.build()).build();
+            var checkBot = PullRequestBot.newBuilder()
+                                         .repo(author)
+                                         .censusRepo(censusBuilder.build())
+                                         .censusLink("https://census.com/{{contributor}}-profile")
+                                         .build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -88,6 +92,7 @@ class CheckTests {
 
             // The PR should now be ready
             assertTrue(pr.labels().contains("ready"));
+            assertTrue(pr.body().contains("https://census.com/integrationreviewer2-profile"));
         }
     }
 
@@ -244,6 +249,10 @@ class CheckTests {
             assertEquals(1, authorPr.body().split("Generated Reviewer", -1).length - 1);
             assertTrue(authorPr.reviews().size() >= 2);
             assertFalse(authorPr.body().contains("Note"));
+
+            // No census link is set
+            var reviewerString = "Generated Reviewer 2 (@" + reviewer.forge().currentUser().userName() + " - **Reviewer**)";
+            assertTrue(authorPr.body().contains(reviewerString));
         }
     }
 


### PR DESCRIPTION
Hi all,

Please review this change that improves the formatting of user names / link listed under Reviewers in the PR body. With proper configuration, it will look something like this:

 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-549](https://bugs.openjdk.java.net/browse/SKARA-549): Links to users under Reviewers lead to a 404 page


### Reviewers
 * Erik Helin ([ehelin](@edvbld) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/763/head:pull/763`
`$ git checkout pull/763`
