### PR TITLE
545: Support additional forms of labels for the /cc command

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelCommand.java
@@ -33,7 +33,8 @@ import java.util.regex.Pattern;
 public class LabelCommand implements CommandHandler {
     private final String commandName;
 
-    private static final Pattern argumentPattern = Pattern.compile("(?:(add|remove)\\s+)?((?:[A-Za-z0-9_-]+[\\s,]*)+)");
+    private static final Pattern argumentPattern = Pattern.compile("(?:(add|remove)\\s+)?((?:[A-Za-z0-9_@.-]+[\\s,]*)+)");
+    private static final Pattern ignoredSuffixes = Pattern.compile("^(.*)(?:-dev(?:@openjdk.java.net)?)$");
 
     LabelCommand() {
         this("label");
@@ -63,7 +64,13 @@ public class LabelCommand implements CommandHandler {
         }
 
         var labels = argumentMatcher.group(2).split("[\\s,]+");
-        for (var label : labels) {
+        for (int i = 0; i < labels.length; ++i) {
+            var label = labels[i];
+            var ignoredSuffixMatcher = ignoredSuffixes.matcher(label);
+            if (ignoredSuffixMatcher.matches()) {
+                label = ignoredSuffixMatcher.group(1);
+                labels[i] = label;
+            }
             if (!bot.labelConfiguration().allowed().contains(label)) {
                 reply.println("The label `" + label + "` is not a valid label. These labels are valid:");
                 bot.labelConfiguration().allowed().forEach(l -> reply.println(" * `" + l + "`"));

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelTests.java
@@ -307,4 +307,54 @@ public class LabelTests {
             assertLastCommentContains(pr, "The `2` label was successfully added");
         }
     }
+
+    @Test
+    void stripSuffix(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var integrator = credentials.getHostedRepository();
+
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addReviewer(integrator.forge().currentUser().id())
+                                           .addCommitter(author.forge().currentUser().id());
+            var labelConfiguration = LabelConfiguration.builder()
+                                                       .addMatchers("1", List.of(Pattern.compile("cpp$")))
+                                                       .addMatchers("2", List.of(Pattern.compile("hpp$")))
+                                                       .addGroup("group", List.of("1", "2"))
+                                                       .addExtra("extra")
+                                                       .build();
+            var prBot = PullRequestBot.newBuilder()
+                                      .repo(integrator)
+                                      .censusRepo(censusBuilder.build())
+                                      .labelConfiguration(labelConfiguration)
+                                      .build();
+
+            // Populate the projects repository
+            var localRepoFolder = tempFolder.path().resolve("localrepo");
+            var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "123: This is a pull request");
+
+            // Add a label with -dev suffix
+            pr.addComment("/label add 1-dev");
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // The bot should reply with a success message
+            assertLastCommentContains(pr,"The `1` label was successfully added.");
+
+            // One more
+            pr.addComment("/cc group-dev@openjdk.java.net");
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // The bot should reply with a success message
+            assertLastCommentContains(pr,"The `group` label was successfully added.");
+        }
+    }
 }


### PR DESCRIPTION
Hi all,

Please review this small change that makes the `/cc` command a bit more intuitive.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-545](https://bugs.openjdk.java.net/browse/SKARA-545): Support additional forms of labels for the /cc command


### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/766/head:pull/766`
`$ git checkout pull/766`
