### PR TITLE
fork: align --setup-pre-push-hook with jcheck

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitFork.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitFork.java
@@ -153,10 +153,9 @@ public class GitFork {
                   .describe("DATE")
                   .helptext("Same as git clones flag 'shallow-since'")
                   .optional(),
-            Option.shortcut("")
-                  .fullname("setup-pre-push-hooks")
-                  .describe("CHECKS")
-                  .helptext("Setups pre-push hooks for [branches,commits]")
+            Switch.shortcut("")
+                  .fullname("setup-pre-push-hook")
+                  .helptext("Setup a pre-push hook that runs git-jcheck")
                   .optional(),
             Option.shortcut("")
                   .fullname("host")
@@ -382,9 +381,9 @@ public class GitFork {
                     GitSync.sync(repo, new String[]{"--from", "upstream", "--to", "origin", "--fast-forward"});
                 }
 
-                var setupPrePushHooksOption = getOption("setup-pre-push-hooks", subsection, arguments);
+                var setupPrePushHooksOption = getOption("setup-pre-push-hook", subsection, arguments);
                 if (setupPrePushHooksOption != null) {
-                    var res = GitJCheck.run(repo, new String[]{"--setup-pre-push-hooks", setupPrePushHooksOption });
+                    var res = GitJCheck.run(repo, new String[]{"--setup-pre-push-hook", setupPrePushHooksOption });
                     if (res != 0) {
                         System.exit(res);
                     }


### PR DESCRIPTION
Hi all,

please review this patch that aligns the `--setup-pre-push-hook` for `git-fork` with the same option in `git-jcheck`.

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/771/head:pull/771`
`$ git checkout pull/771`
