### PR TITLE
info: remove --mercurial and add --title

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitInfo.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitInfo.java
@@ -69,13 +69,13 @@ public class GitInfo {
 
     public static void main(String[] args) throws IOException {
         var flags = List.of(
-            Switch.shortcut("m")
-                  .fullname("mercurial")
-                  .helptext("Deprecated: force use of mercurial")
-                  .optional(),
             Switch.shortcut("")
                   .fullname("no-decoration")
                   .helptext("Do not prefix lines with any decoration")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("title")
+                  .helptext("Show title of commit message")
                   .optional(),
             Switch.shortcut("")
                   .fullname("issues")
@@ -139,8 +139,7 @@ public class GitInfo {
         }
 
         HttpProxy.setup();
-        var isMercurial = arguments.contains("mercurial");
-        var ref = arguments.at(0).orString(isMercurial ? "tip" : "HEAD");
+        var ref = arguments.at(0).orString("HEAD");
         var cwd = Path.of("").toAbsolutePath();
         var repo = ReadOnlyRepository.get(cwd).orElseThrow(die("error: no repository found at " + cwd.toString()));
         var hash = repo.resolve(ref).orElseThrow(die("error: " + ref + " is not a commit"));


### PR DESCRIPTION
Hi all,

please review this patch removes the unused `--mecurial` flag from `git-info` and also adds the missing `--title` flag (oops!).

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/773/head:pull/773`
`$ git checkout pull/773`
