### PR TITLE
fork: fix helptext for --reference

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitFork.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitFork.java
@@ -141,7 +141,7 @@ public class GitFork {
             Option.shortcut("")
                   .fullname("reference")
                   .describe("DIR")
-                  .helptext("Same as git clone's flag 'reference-if-able'")
+                  .helptext("Same as git clone's flags 'reference-if-able' + 'dissociate'")
                   .optional(),
             Option.shortcut("")
                   .fullname("depth")


### PR DESCRIPTION
Hi all,

please review this patch updates the helptext for the flag `--reference` of `git-fork` to say that `git-fork` will always use `--reference-if-able` together with `--dissociate` when cloning (for safety reasons).

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/774/head:pull/774`
`$ git checkout pull/774`
