### PR TITLE
publish: rename --follow to --browse

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitPublish.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitPublish.java
@@ -144,7 +144,7 @@ public class GitPublish {
                   .optional(),
             Switch.shortcut("")
                   .fullname("browse")
-                  .helptext("Open link returend by remote in web browser")
+                  .helptext("Open link returned by remote in web browser")
                   .optional(),
             Switch.shortcut("")
                   .fullname("verbose")

--- a/cli/src/main/java/org/openjdk/skara/cli/GitPublish.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitPublish.java
@@ -143,8 +143,8 @@ public class GitPublish {
                   .helptext("Silence all output")
                   .optional(),
             Switch.shortcut("")
-                  .fullname("follow")
-                  .helptext("Open link provided by remote")
+                  .fullname("browse")
+                  .helptext("Open link returend by remote in web browser")
                   .optional(),
             Switch.shortcut("")
                   .fullname("verbose")
@@ -212,9 +212,9 @@ public class GitPublish {
 
         var branch = repo.currentBranch().get();
         var isQuiet = getSwitch("quiet", arguments, repo);
-        var shouldFollow = getSwitch("follow", arguments, repo);
+        var shouldBrowse = getSwitch("browse", arguments, repo);
         int err = 0;
-        if (shouldFollow) {
+        if (shouldBrowse) {
             var browser = getOption("browser", arguments, repo);
             if (browser == null) {
                 var os = System.getProperty("os.name").toLowerCase();


### PR DESCRIPTION
Hi all,

please rename this patch that renames the flag `--follow` to `--browse` for `git-publish` to make its meaning more clear.

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**) ⚠️ Review applies to 1142a800d7de2fb3aa6b4ce0bfba48f05e82daaf


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/775/head:pull/775`
`$ git checkout pull/775`
