### PR TITLE
sync: catch exceptions when creating Forge

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitSync.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitSync.java
@@ -155,7 +155,7 @@ public class GitSync {
                                         .flatMap(r -> r.parent())
                                         .map(p -> p.webUrl().toString())
                                         .orElse(null);
-                        } catch (IllegalArgumentException e) {
+                        } catch (Throwable e) {
                             from = null;
                         }
                     }
@@ -164,7 +164,9 @@ public class GitSync {
         }
 
         if (from == null) {
-            die("Could not find repository to sync from, please specify one with --from");
+            System.err.println("error: could not find repository to sync from, please specify one with --from");
+            System.err.println("       or add a remote named 'upstream'");
+            System.exit(1);
         }
 
         var fromPullPath = remotes.contains(from) ?


### PR DESCRIPTION
Hi all,

please review this patch that makes `git-sync` prints a more informative error message when the `Forge` can't be instantiated when trying to auto-magically figure out the "upstream" repository.

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/779/head:pull/779`
`$ git checkout pull/779`
