### PR TITLE
token: handle arguments without scheme and add help message

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitToken.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitToken.java
@@ -77,8 +77,13 @@ public class GitToken {
 
         var command = arguments.at(0).asString();
         var uri = arguments.at(1).via(URI::create);
+        if (uri.getScheme() == null) {
+            uri = URI.create("https://" + uri.toString());
+        }
 
         if (command.equals("store")) {
+            System.out.println("info: if you are prompted for a password, fill in your personal access token,\n" +
+                               "      *not* your login password for " + uri.toString());
             var credentials = GitCredentials.fill(uri.getHost(), uri.getPath(), null, null, uri.getScheme());
             GitCredentials.approve(credentials);
         } else if (command.equals("revoke")) {


### PR DESCRIPTION
Hi all,

please review this patch that makes `git-token` print a more informative message when the user is about to enter the token. Also made sure that `git token store <forge>.com` works by adding `https://` (there are currently no forges that serves over plain HTTP).

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/780/head:pull/780`
`$ git checkout pull/780`
