### PR TITLE
translate: better helptext for --map

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitTranslate.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitTranslate.java
@@ -42,7 +42,7 @@ public class GitTranslate {
             Option.shortcut("")
                   .fullname("map")
                   .describe("FILE")
-                  .helptext("File with commit info (defaults to .hgcommits)")
+                  .helptext("File with commit mapping (defaults to .hgcommits)")
                   .optional(),
             Option.shortcut("")
                   .fullname("to-hg")


### PR DESCRIPTION
Hi all,

please review this small patch that updates the helptext for `git translate --map`.

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/781/head:pull/781`
`$ git checkout pull/781`
