### PR TITLE
553: Add informational message when automatic labeling comes up empty

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
@@ -24,6 +24,7 @@ package org.openjdk.skara.bots.pr;
 
 import org.openjdk.skara.bot.WorkItem;
 import org.openjdk.skara.forge.*;
+import org.openjdk.skara.issuetracker.Comment;
 import org.openjdk.skara.vcs.Repository;
 
 import java.io.*;
@@ -33,6 +34,8 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 public class LabelerWorkItem extends PullRequestWorkItem {
+    private static final String initialLabelMessage = "<!-- PullRequestBot initial label help comment -->";
+
     LabelerWorkItem(PullRequestBot bot, PullRequest pr, Consumer<RuntimeException> errorHandler) {
         super(bot, pr, errorHandler);
     }
@@ -45,6 +48,60 @@ public class LabelerWorkItem extends PullRequestWorkItem {
     private Set<String> getLabels(Repository localRepo) throws IOException {
         var files = PullRequestUtils.changedFiles(pr, localRepo);
         return bot.labelConfiguration().label(files);
+    }
+
+    private Optional<Comment> findComment(List<Comment> comments, String marker) {
+        var self = pr.repository().forge().currentUser();
+        return comments.stream()
+                       .filter(comment -> comment.author().equals(self))
+                       .filter(comment -> comment.body().contains(marker))
+                       .findAny();
+    }
+
+    private void updateLabelMessage(List<Comment> comments, List<String> newLabels) {
+        var existing = findComment(comments, initialLabelMessage);
+        if (existing.isPresent()) {
+            // Only add the comment once per PR
+            return;
+        }
+
+        var message = new StringBuilder();
+        message.append("@");
+        message.append(pr.author().userName());
+        message.append(" ");
+
+        if (newLabels.isEmpty()) {
+            message.append("To determine the appropriate audience for reviewing this pull request, one or more ");
+            message.append("labels corresponding to different subsystems will normally be applied automatically. ");
+            message.append("However, no automatic labelling rule matches the changes in this pull request. ");
+            message.append("In order to have an RFR email automatically sent to the correct mailing list, you will ");
+            message.append("need to add one or more labels manually using the `/label add \"label\"` command. ");
+            message.append("The following labels are valid: ");
+            var labels = bot.labelConfiguration().allowed().stream()
+                            .sorted()
+                            .map(label -> "`" + label + "`")
+                            .collect(Collectors.joining(", "));
+            message.append(labels);
+            message.append(".");
+        } else {
+            message.append("The following labels will be automatically applied to this pull request: ");
+            var labels = newLabels.stream()
+                                  .sorted()
+                                  .map(label -> "`" + label + "`")
+                                  .collect(Collectors.joining(", "));
+            message.append("`");
+            message.append(labels);
+            message.append("`. When this pull request is ready to be reviewed, an RFR email will be sent to the ");
+            message.append("corresponding mailing list");
+            if (newLabels.size() > 1) {
+                message.append("s");
+            }
+            message.append(". If you would like to change these labels, use the `/label (add|remove) \"label\"` command.");
+        }
+
+        message.append("\n");
+        message.append(initialLabelMessage);
+        pr.addComment(message.toString());
     }
 
     @Override
@@ -73,10 +130,12 @@ public class LabelerWorkItem extends PullRequestWorkItem {
             }
 
             // Add all labels not already set that are not manually removed
-            newLabels.stream()
+            var labelsToAdd = newLabels.stream()
                      .filter(label -> !currentLabels.contains(label))
                      .filter(label -> !manuallyRemoved.contains(label))
-                     .forEach(pr::addLabel);
+                                       .collect(Collectors.toList());
+            updateLabelMessage(comments, labelsToAdd);
+            labelsToAdd.forEach(pr::addLabel);
 
             // Remove set labels no longer present unless it has been manually added
             currentLabels.stream()

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelTests.java
@@ -162,6 +162,8 @@ public class LabelTests {
             // The bot should have applied one label automatically
             TestBotRunner.runPeriodicItems(prBot);
             assertEquals(Set.of("2", "rfr"), new HashSet<>(pr.labels()));
+            assertLastCommentContains(pr, "The following labels will be automatically applied");
+            assertLastCommentContains(pr, "`2`");
 
             // It will refuse to remove it
             pr.addComment("/label remove 2");
@@ -231,6 +233,8 @@ public class LabelTests {
             // The bot will not add any label automatically
             TestBotRunner.runPeriodicItems(prBot);
             assertEquals(Set.of("1", "rfr"), new HashSet<>(pr.labels()));
+            assertEquals(1, pr.comments().size());
+            assertLastCommentContains(pr, "The `1` label was successfully added.");
 
             // Add another file to trigger a group match
             Files.writeString(localRepoFolder.resolve("test.cpp"), "Hello there");

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelerTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelerTests.java
@@ -33,6 +33,7 @@ import java.util.*;
 import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.openjdk.skara.bots.pr.PullRequestAsserts.assertLastCommentContains;
 
 class LabelerTests {
     @Test
@@ -69,6 +70,8 @@ class LabelerTests {
             // Check the status - only the rfr label should be set
             TestBotRunner.runPeriodicItems(labelBot);
             assertEquals(Set.of("rfr"), new HashSet<>(pr.labels()));
+            assertLastCommentContains(pr, "However, no automatic labelling rule matches the changes in this pull request.");
+            assertLastCommentContains(pr, "The following labels are valid: `test1`, `test2`");
 
             var fileA = localRepoFolder.resolve("a.txt");
             Files.writeString(fileA, "Hello");


### PR DESCRIPTION
Hi all,

Please review this change that makes the automatic labeler emit a helpful message when it either succeeds or fails with its task.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-553](https://bugs.openjdk.java.net/browse/SKARA-553): Add informational message when automatic labeling comes up empty


### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/783/head:pull/783`
`$ git checkout pull/783`
