### PR TITLE
Avoid posting Jira link comments multiple times

### DIFF
--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraIssue.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraIssue.java
@@ -388,6 +388,15 @@ public class JiraIssue implements Issue {
     }
 
     private void addWebLinkAsComment(Link link) {
+        var alreadyPosted = comments().stream()
+                                      .map(this::parseWebLinkComment)
+                                      .filter(Optional::isPresent)
+                                      .map(Optional::get)
+                                      .anyMatch(l -> l.uri().equals(link.uri()) && l.title().equals(link.title()));
+        if (alreadyPosted) {
+            return;
+        }
+
         var body = new StringBuilder();
         body.append("Remote link: ").append(link.title().orElseThrow()).append("\n");
         body.append("URL: ").append(link.uri().orElseThrow().toString()).append("\n");


### PR DESCRIPTION
Hi all,

Please review this change that avoids potentially posting the same Jira link comment multiple times.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/784/head:pull/784`
`$ git checkout pull/784`
