### PR TITLE
jcheck: allow configurable census URL

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitJCheck.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitJCheck.java
@@ -241,6 +241,16 @@ public class GitJCheck {
 
         var endpoint = getOption("census", arguments);
         if (endpoint == null) {
+            try {
+                var conf = JCheckConfiguration.from(repo, repo.head());
+                if (conf.isPresent()) {
+                    endpoint = conf.get().census().url().toString();
+                }
+            } catch (IOException e) {
+                // pass
+            }
+        }
+        if (endpoint == null) {
             endpoint = "https://openjdk.java.net/census.xml";
         }
         var census = endpoint.startsWith("http://") || endpoint.startsWith("https://") ?

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/CensusConfiguration.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/CensusConfiguration.java
@@ -23,17 +23,20 @@
 package org.openjdk.skara.jcheck;
 
 import org.openjdk.skara.ini.Section;
+import java.net.URI;
 
 public class CensusConfiguration {
     private static final CensusConfiguration DEFAULT =
-        new CensusConfiguration(0, "localhost");
+        new CensusConfiguration(0, "localhost", URI.create("https://openjdk.java.net/census.xml"));
 
     private final int version;
     private final String domain;
+    private final URI url;
 
-    CensusConfiguration(int version, String domain) {
+    CensusConfiguration(int version, String domain, URI url) {
         this.version = version;
         this.domain = domain;
+        this.url = url;
     }
 
     public int version() {
@@ -42,6 +45,10 @@ public class CensusConfiguration {
 
     public String domain() {
         return domain;
+    }
+
+    public URI url() {
+        return url;
     }
 
     static String name() {
@@ -55,6 +62,7 @@ public class CensusConfiguration {
 
         var version = s.get("version", DEFAULT.version());
         var domain = s.get("domain", DEFAULT.domain());
-        return new CensusConfiguration(version, domain);
+        var url = s.get("url", DEFAULT.url().toString());
+        return new CensusConfiguration(version, domain, URI.create(url));
     }
 }


### PR DESCRIPTION
Hi all,

please review this patch that makes it possible to configure a URL to the census.xml in a .jcheck/configuration file.

Testing:
- [x] Manual testing on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/785/head:pull/785`
`$ git checkout pull/785`
