### PR TITLE
git-pr: remove --no-commit from git apply

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/pr/Utils.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/Utils.java
@@ -414,7 +414,7 @@ class Utils {
     }
 
     static void apply(Path patch) throws IOException {
-        var pb = new ProcessBuilder("git", "apply", "--no-commit", patch.toString());
+        var pb = new ProcessBuilder("git", "apply", patch.toString());
         pb.inheritIO();
         await(pb.start());
     }


### PR DESCRIPTION
Hi all,

please review this patch that removes `--no-commit` from `git apply` in `pr/Utils.java` (a left-over from some Mercurial experimentation).

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/788/head:pull/788`
`$ git checkout pull/788`
