### PR TITLE
git-pr-approve: allow configurable message

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrApprove.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrApprove.java
@@ -42,6 +42,11 @@ public class GitPrApprove {
               .describe("NAME")
               .helptext("Name of remote, defaults to 'origin'")
               .optional(),
+        Option.shortcut("m")
+              .fullname("message")
+              .describe("TEXT")
+              .helptext("Message to author as part of approval (e.g. \"Looks good!\")")
+              .optional(),
         Switch.shortcut("")
               .fullname("verbose")
               .helptext("Turn on verbose output")
@@ -71,6 +76,10 @@ public class GitPrApprove {
         var host = getForge(uri, repo, arguments);
         var id = pullRequestIdArgument(repo, arguments);
         var pr = getPullRequest(uri, repo, host, id);
-        pr.addReview(Review.Verdict.APPROVED, "Looks good!");
+
+        var message = arguments.contains("message") ?
+            arguments.get("message").asString() :
+            null;
+        pr.addReview(Review.Verdict.APPROVED, message);
     }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -141,7 +141,9 @@ public class GitHubPullRequest implements PullRequest {
                 query.put("event", "COMMENT");
                 break;
         }
-        query.put("body", body);
+        if (body != null && !body.isEmpty()) {
+            query.put("body", body);
+        }
         query.put("commit_id", headHash().hex());
         query.put("comments", JSON.array());
         request.post("pulls/" + json.get("number").toString() + "/reviews")


### PR DESCRIPTION
Hi all,

please review this patch that allows a configurable message for `git-pr approve` via the `-m, --message` flag.

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/789/head:pull/789`
`$ git checkout pull/789`
