### PR TITLE
git-pr-test: add flags --job and --approve

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrTest.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrTest.java
@@ -41,6 +41,15 @@ public class GitPrTest {
               .describe("NAME")
               .helptext("Name of remote, defaults to 'origin'")
               .optional(),
+        Option.shortcut("j")
+              .fullname("job")
+              .describe("NAME")
+              .helptext("Name of a job")
+              .optional(),
+        Switch.shortcut("")
+              .fullname("approve")
+              .helptext("Approve a test request")
+              .optional(),
         Switch.shortcut("")
               .fullname("verbose")
               .helptext("Turn on verbose output")
@@ -63,7 +72,7 @@ public class GitPrTest {
     );
 
     public static void main(String[] args) throws IOException, InterruptedException {
-        var parser = new ArgumentParser("git-pr", flags, inputs);
+        var parser = new ArgumentParser("git-pr test", flags, inputs);
         var arguments = parse(parser, args);
         var repo = getRepo();
         var uri = getURI(repo, arguments);
@@ -71,7 +80,14 @@ public class GitPrTest {
         var id = pullRequestIdArgument(repo, arguments);
         var pr = getPullRequest(uri, repo, host, id);
         var head = pr.headHash();
-        var testComment = pr.addComment("/test");
+
+        var command = "/test";
+        if (arguments.contains("approve")) {
+            command += " approve";
+        } else if (arguments.contains("job")) {
+            command += arguments.get("job").asString();
+        }
+        var testComment = pr.addComment(command);
 
         var seenTestComment = false;
         for (var i = 0; i < 90; i++) {


### PR DESCRIPTION
Hi all,

please review this patch that adds the `--job` and `--approve` flags to `git pr test`.

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/790/head:pull/790`
`$ git checkout pull/790`
