### PR TITLE
git-pr: git pr sponsor should sponsor

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
@@ -66,7 +66,7 @@ public class GitPr {
                     .main(GitPrSet::main),
             Command.name("sponsor")
                     .helptext("sponsor a pull request")
-                    .main(GitPrSet::main),
+                    .main(GitPrSponsor::main),
             Command.name("test")
                     .helptext("test a pull request")
                     .main(GitPrTest::main),


### PR DESCRIPTION
Hi all,

please review this patch that makes `git pr sponsor` actually run `GitPrSponsor::main`, _not_ `GitPrSet::main`.

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/791/head:pull/791`
`$ git checkout pull/791`
