### PR TITLE
git-pr-checkout: better helptext

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrCheckout.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrCheckout.java
@@ -44,7 +44,7 @@ public class GitPrCheckout {
         Option.shortcut("b")
               .fullname("branch")
               .describe("NAME")
-              .helptext("Name of target branch, defaults to 'master'")
+              .helptext("Create a new branched named NAME")
               .optional(),
         Switch.shortcut("")
               .fullname("no-token")


### PR DESCRIPTION
Hi all,

please review this patch that slightly updates the helptext for the `-b, --branch` flag for `git pr checkout` to make it align more with Git's helptext for the `-b, --branch` option to `git checkout`.

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/792/head:pull/792`
`$ git checkout pull/792`
