### PR TITLE
git-pr-fetch: remove --branch option

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrFetch.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrFetch.java
@@ -41,11 +41,6 @@ public class GitPrFetch {
               .describe("NAME")
               .helptext("Name of remote, defaults to 'origin'")
               .optional(),
-        Option.shortcut("b")
-              .fullname("branch")
-              .describe("NAME")
-              .helptext("Name of target branch, defaults to 'master'")
-              .optional(),
         Switch.shortcut("")
               .fullname("no-token")
               .helptext("Do not use a personal access token (PAT)")
@@ -81,11 +76,6 @@ public class GitPrFetch {
         var pr = getPullRequest(uri, repo, host, id);
 
         var fetchHead = repo.fetch(pr.repository().webUrl(), pr.fetchRef());
-        var branchName = getOption("branch", "fetch", arguments);
-        if (branchName != null) {
-            repo.branch(fetchHead, branchName);
-        } else {
-            System.out.println(fetchHead.hex());
-        }
+        System.out.println(fetchHead.hex());
     }
 }


### PR DESCRIPTION
Hi all,

please review this patch that removes the `--branch` option from `git pr fetch` to make `git pr fetch` align better with `git fetch`.

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/793/head:pull/793`
`$ git checkout pull/793`
