### PR TITLE
Proper name for hgupdate-sync-label

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
@@ -248,7 +248,7 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
                 if (setFixVersion) {
                     if (requestedVersion != null) {
                         issue.setProperty("fixVersions", JSON.of(requestedVersion));
-                        Backports.labelReleaseStreamDuplicates(issue, "hgupdater-sync");
+                        Backports.labelReleaseStreamDuplicates(issue, "hgupdate-sync");
                     }
                 }
             }

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/BackportsTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/BackportsTests.java
@@ -200,13 +200,13 @@ public class BackportsTests {
         }
 
         void assertLabeled(String... labeledVersions) {
-            Backports.labelReleaseStreamDuplicates(issues.get(0), "hgupdater-sync");
+            Backports.labelReleaseStreamDuplicates(issues.get(0), "hgupdate-sync");
 
             var labels = new HashSet<>(Arrays.asList(labeledVersions));
             var labeledIssues = new HashSet<String>();
             for (var issue : issues) {
                 var version = issue.properties().get("fixVersions").get(0).asString();
-                if (issue.labels().contains("hgupdater-sync")) {
+                if (issue.labels().contains("hgupdate-sync")) {
                     labeledIssues.add(version);
                 }
             }

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
@@ -699,10 +699,10 @@ public class IssueNotifierTests {
             localRepo.push(commit, repo.url(), "master");
             TestBotRunner.runPeriodicItems(notifyBot);
 
-            assertEquals(List.of("hgupdater-sync"), issue1.labels());
+            assertEquals(List.of("hgupdate-sync"), issue1.labels());
             assertEquals(List.of(), issue2.labels());
             assertEquals(List.of(), issue3.labels());
-            assertEquals(List.of("hgupdater-sync"), issue4.labels());
+            assertEquals(List.of("hgupdate-sync"), issue4.labels());
         }
     }
 }


### PR DESCRIPTION
Hi all,

Please review this minor change that updates the name of the sync label to the one actually in use.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/795/head:pull/795`
`$ git checkout pull/795`
