### PR TITLE
Remove mention of /integrate from the start of the pre-integration message.

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -517,7 +517,7 @@ class CheckRun {
             var hasContributingFile =
                 !localRepo.files(pr.targetHash(), Path.of("CONTRIBUTING.md")).isEmpty();
             if (hasContributingFile) {
-                message.append(". When the change also fulfills all ");
+                message.append(". In addition to the automated checks, the change must also fulfill all ");
                 message.append("[project specific requirements](https://github.com/");
                 message.append(pr.repository().name());
                 message.append("/blob/");
@@ -528,8 +528,8 @@ class CheckRun {
             throw new UncheckedIOException(e);
         }
 
-        message.append(", type `/integrate` in a new comment to proceed. After integration, ");
-        message.append("the commit message will be:\n");
+        message.append("\n\n");
+        message.append("After integration, the commit message will be:\n");
         message.append("```\n");
         message.append(commitMessage);
         message.append("\n```\n");


### PR DESCRIPTION
Hi,

In response to some of the discussion on: https://github.com/openjdk/jdk/pull/26 I suggest changing the pre-integration comment to remove the mention of `/integrate` at the start, where it reads:

    type `/integrate` in a new comment to proceed

Since `/integrate` is also mentioned at the end of the same message (with a clearer description of what it does [1](https://github.com/openjdk/skara/blob/master/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java#L603-L610)), this is an attempt to encourage users to read till the end of the message before typing `/integrate`.

Thanks,
Jorn
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/801/head:pull/801`
`$ git checkout pull/801`
