### PR TITLE
610: Add support for other issue tracker email addresses than @openjdk.org

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
@@ -77,14 +77,25 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
         var authorEmail = EmailAddress.from(commit.author().email());
         if (authorEmail.domain().equals("openjdk.org")) {
             return Optional.of(authorEmail.localPart());
+        } else {
+            var user = issueProject.findUser(authorEmail.address());
+            if (user.isPresent()) {
+                return Optional.of(user.get().userName());
+            }
         }
 
         var committerEmail = EmailAddress.from(commit.committer().email());
-        if (!committerEmail.domain().equals("openjdk.org")) {
+        if (committerEmail.domain().equals("openjdk.org")) {
+            return Optional.of(committerEmail.localPart());
+        } else {
+            var user = issueProject.findUser(committerEmail.address());
+            if (user.isPresent()) {
+                return Optional.of(user.get().userName());
+            }
+
             log.severe("Cannot determine issue tracker user name from committer email: " + committerEmail);
             return Optional.empty();
         }
-        return Optional.of(committerEmail.localPart());
     }
 
     @Override

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/IssueProject.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/IssueProject.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.skara.issuetracker;
 
+import org.openjdk.skara.host.HostUser;
 import org.openjdk.skara.json.JSONValue;
 
 import java.net.URI;
@@ -34,4 +35,5 @@ public interface IssueProject {
     Optional<Issue> issue(String id);
     List<Issue> issues();
     String name();
+    Optional<HostUser> findUser(String findBy);
 }

--- a/test/src/main/java/org/openjdk/skara/test/TestHost.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHost.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.skara.test;
 
+import org.openjdk.skara.email.EmailAddress;
 import org.openjdk.skara.forge.*;
 import org.openjdk.skara.host.*;
 import org.openjdk.skara.issuetracker.*;
@@ -126,6 +127,14 @@ public class TestHost implements Forge, IssueTracker {
     public Optional<HostUser> user(String username) {
         return data.users.stream()
                          .filter(user -> user.userName().equals(username))
+                         .findAny();
+    }
+
+    Optional<HostUser> findUser(String findBy) {
+        var findByLocalPart = EmailAddress.parse(findBy).localPart();
+        return data.users.stream()
+                         .filter(user -> user.userName().equals(findBy) ||
+                                 user.userName().equals(findByLocalPart))
                          .findAny();
     }
 

--- a/test/src/main/java/org/openjdk/skara/test/TestIssueProject.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestIssueProject.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.skara.test;
 
+import org.openjdk.skara.host.HostUser;
 import org.openjdk.skara.issuetracker.*;
 import org.openjdk.skara.json.JSONValue;
 import org.openjdk.skara.network.URIBuilder;
@@ -74,5 +75,10 @@ public class TestIssueProject implements IssueProject {
     @Override
     public String name() {
         return projectName.toUpperCase();
+    }
+
+    @Override
+    public Optional<HostUser> findUser(String findBy) {
+        return host.findUser(findBy);
     }
 }


### PR DESCRIPTION
It should be possible to find Jira users based on committer email addresses that are written as `@openjdk.org` in case they exist.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-610](https://bugs.openjdk.java.net/browse/SKARA-610): Add support for other issue tracker email addresses than @openjdk.org


### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/802/head:pull/802`
`$ git checkout pull/802`
