### PR TITLE
SKARA-611: PR generated an email on jdk-dev

### DIFF
--- a/config/mailinglist/rules/jdk.json
+++ b/config/mailinglist/rules/jdk.json
@@ -771,12 +771,6 @@
             "hotspot-gc",
             "hotspot-runtime",
             "hotspot-jfr"
-        ],
-        "jdk": [
-            "hotspot",
-            "core-libs",
-            "compiler",
-            "2d"
         ]
     }
 }


### PR DESCRIPTION
This came up as https://github.com/openjdk/jdk/pull/49 generated a mailing list notification on jdk-dev. Removing jdk-dev mailing list aggregation as this mailing list should not be used for PRs.

./gradlew test
BUILD SUCCESSFUL in 23m 19s
138 actionable tasks: 138 executed

on mac.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-611](https://bugs.openjdk.java.net/browse/SKARA-611): PR generated an email on jdk-dev


### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/804/head:pull/804`
`$ git checkout pull/804`
