### PR TITLE
vcs: do not hard-code VCS default branch names

### DIFF
--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunnerConfiguration.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunnerConfiguration.java
@@ -28,6 +28,7 @@ import org.openjdk.skara.host.Credential;
 import org.openjdk.skara.issuetracker.*;
 import org.openjdk.skara.json.JSONObject;
 import org.openjdk.skara.network.URIBuilder;
+import org.openjdk.skara.vcs.Branch;
 import org.openjdk.skara.vcs.VCS;
 
 import java.io.*;
@@ -198,7 +199,7 @@ public class BotRunnerConfiguration {
         }
 
         if (ret.ref == null) {
-            ret.ref = ret.repository.repositoryType() == VCS.GIT ? "master" : "default";
+            ret.ref = Branch.defaultFor(ret.repository.repositoryType()).name();
         }
 
         return ret;

--- a/bots/censussync/src/main/java/org/openjdk/skara/bots/censussync/CensusSyncBot.java
+++ b/bots/censussync/src/main/java/org/openjdk/skara/bots/censussync/CensusSyncBot.java
@@ -82,7 +82,7 @@ public class CensusSyncBot implements Bot, WorkItem {
     public Collection<WorkItem> run(Path scratch) {
         try {
             var fromDir = scratch.resolve("from.git");
-            var fromRepo = Repository.materialize(fromDir, from.url(), "master");
+            var fromRepo = Repository.materialize(fromDir, from.url(), Branch.defaultFor(VCS.GIT).name());
             if (last != null && last.equals(fromRepo.head())) {
                 // Nothing to do
                 return List.of();
@@ -91,7 +91,7 @@ public class CensusSyncBot implements Bot, WorkItem {
             var census = Census.parse(fromDir);
 
             var toDir = scratch.resolve("to.git");
-            var toRepo = Repository.materialize(toDir, to.url(), "master");
+            var toRepo = Repository.materialize(toDir, to.url(), Branch.defaultFor(VCS.GIT).name());
 
             var censusXML = toRepo.root().resolve("census.xml");
             if (!Files.exists(censusXML)) {
@@ -135,7 +135,7 @@ public class CensusSyncBot implements Bot, WorkItem {
             }
             toRepo.add(censusXML);
             var head = toRepo.commit("Updated census.xml", "duke", "duke@openjdk.org");
-            toRepo.push(head, to.url(), "master", false);
+            toRepo.push(head, to.url(), Branch.defaultFor(VCS.GIT).name(), false);
             last = fromRepo.head();
         } catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/bots/checkout/src/main/java/org/openjdk/skara/bots/checkout/MarkStorage.java
+++ b/bots/checkout/src/main/java/org/openjdk/skara/bots/checkout/MarkStorage.java
@@ -24,8 +24,7 @@
 package org.openjdk.skara.bots.checkout;
 
 import org.openjdk.skara.forge.HostedRepository;
-import org.openjdk.skara.vcs.Author;
-import org.openjdk.skara.vcs.Hash;
+import org.openjdk.skara.vcs.*;
 import org.openjdk.skara.vcs.openjdk.convert.Mark;
 import org.openjdk.skara.storage.StorageBuilder;
 
@@ -85,7 +84,7 @@ class MarkStorage {
 
     static StorageBuilder<Mark> create(HostedRepository repo, Author user, String name) {
         return new StorageBuilder<Mark>(name + "/marks.txt")
-            .remoteRepository(repo, "master", user.name(), user.email(), "Updated marks for " + name)
+            .remoteRepository(repo, Branch.defaultFor(VCS.GIT).name(), user.name(), user.email(), "Updated marks for " + name)
             .serializer(MarkStorage::serialize)
             .deserializer(MarkStorage::deserialize);
     }

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotBuilder.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotBuilder.java
@@ -22,6 +22,8 @@
  */
 package org.openjdk.skara.bots.mlbridge;
 
+import org.openjdk.skara.vcs.Branch;
+import org.openjdk.skara.vcs.VCS;
 import org.openjdk.skara.email.EmailAddress;
 import org.openjdk.skara.forge.HostedRepository;
 
@@ -35,9 +37,9 @@ public class MailingListBridgeBotBuilder {
     private EmailAddress from;
     private HostedRepository repo;
     private HostedRepository archive;
-    private String archiveRef = "master";
+    private String archiveRef = Branch.defaultFor(VCS.GIT).name();
     private HostedRepository censusRepo;
-    private String censusRef = "master";
+    private String censusRef = Branch.defaultFor(VCS.GIT).name();
     private List<MailingListConfiguration> lists;
     private Set<String> ignoredUsers = Set.of();
     private Set<Pattern> ignoredComments = Set.of();

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/NotifyBotFactory.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/NotifyBotFactory.java
@@ -22,6 +22,8 @@
  */
 package org.openjdk.skara.bots.notify;
 
+import org.openjdk.skara.vcs.Branch;
+import org.openjdk.skara.vcs.VCS;
 import org.openjdk.skara.bot.*;
 import org.openjdk.skara.json.*;
 import org.openjdk.skara.storage.StorageBuilder;
@@ -81,7 +83,7 @@ public class NotifyBotFactory implements BotFactory {
 
         for (var repo : specific.get("repositories").fields()) {
             var repoName = repo.name();
-            var branchPattern = Pattern.compile("^master$");
+            var branchPattern = Pattern.compile("^" + Branch.defaultFor(VCS.GIT).name() + "$");
             if (repo.value().contains("branches")) {
                 branchPattern = Pattern.compile(repo.value().get("branches").asString());
             }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -695,12 +695,13 @@ class CheckRun {
             return;
         }
 
+        var defaultBranch = Branch.defaultFor(VCS.GIT);
         var message = "⚠️  @" + pr.author().userName() +
                       " This pull request contains merges that bring in commits not present in the target repository." +
                       " Since this is not a \"merge style\" pull request, these changes will be squashed when this pull request in integrated." +
                       " If this is your intention, then please ignore this message. If you want to preserve the commit structure, you must change" +
                       " the title of this pull request to `Merge <project>:<branch>` where `<project>` is the name of another project in the" +
-                      " [OpenJDK organization](https://github.com/openjdk) (for example `Merge jdk:master`).\n" +
+                      " [OpenJDK organization](https://github.com/openjdk) (for example `Merge jdk:" + defaultBranch + "`).\n" +
                       mergeCommitWarningMarker;
         pr.addComment(message);
     }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
@@ -22,6 +22,8 @@
  */
 package org.openjdk.skara.bots.pr;
 
+import org.openjdk.skara.vcs.Branch;
+import org.openjdk.skara.vcs.VCS;
 import org.openjdk.skara.forge.*;
 import org.openjdk.skara.issuetracker.IssueProject;
 
@@ -32,7 +34,7 @@ import java.util.regex.Pattern;
 public class PullRequestBotBuilder {
     private HostedRepository repo;
     private HostedRepository censusRepo;
-    private String censusRef = "master";
+    private String censusRef = Branch.defaultFor(VCS.GIT).name();
     private LabelConfiguration labelConfiguration = LabelConfigurationJson.builder().build();
     private Map<String, String> externalCommands = Map.of();
     private Map<String, String> blockingCheckLabels = Map.of();
@@ -45,7 +47,7 @@ public class PullRequestBotBuilder {
     private Path seedStorage = null;
     private HostedRepository confOverrideRepo = null;
     private String confOverrideName = ".conf/jcheck";
-    private String confOverrideRef = "master";
+    private String confOverrideRef = Branch.defaultFor(VCS.GIT).name();
     private String censusLink = null;
 
     PullRequestBotBuilder() {

--- a/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestBot.java
+++ b/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestBot.java
@@ -28,7 +28,7 @@ import org.openjdk.skara.bot.*;
 import org.openjdk.skara.forge.*;
 import org.openjdk.skara.census.Census;
 import org.openjdk.skara.jcheck.JCheckConfiguration;
-import org.openjdk.skara.vcs.Repository;
+import org.openjdk.skara.vcs.*;
 import org.openjdk.skara.host.HostUser;
 
 import java.io.*;
@@ -95,10 +95,10 @@ public class TestBot implements Bot {
         Predicate<HostUser> isCommitter = null;
         if (checkCommitterStatus) {
             try {
-                var censusRepo = Repository.materialize(censusDir, censusRemote.url(), "master");
+                var censusRepo = Repository.materialize(censusDir, censusRemote.url(), Branch.defaultFor(VCS.GIT).name());
                 var census = Census.parse(censusDir);
                 var namespace = census.namespace(repo.namespace());
-                var jcheckConf = repo.fileContents(".jcheck/conf", "master");
+                var jcheckConf = repo.fileContents(".jcheck/conf", Branch.defaultFor(VCS.GIT).name());
                 var jcheck = JCheckConfiguration.parse(jcheckConf.lines().collect(Collectors.toList()));
                 var project = census.project(jcheck.general().project());
                 isCommitter = u -> {

--- a/cli/src/main/java/org/openjdk/skara/cli/debug/GitVerifyImport.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/debug/GitVerifyImport.java
@@ -74,7 +74,7 @@ public class GitVerifyImport {
         var gitBranches = git.branches()
                              .stream()
                              .map(Branch::name)
-                             .map(b -> b.equals("master") ? "default" : b)
+                             .map(b -> b.equals(Branch.defaultFor(VCS.GIT).name()) ? Branch.defaultFor(VCS.HG).name() : b)
                              .collect(Collectors.toSet());
         if (!hgBranches.equals(gitBranches)) {
             if (isVerbose) {
@@ -225,7 +225,7 @@ public class GitVerifyImport {
         var tags = verifyTags(hg, git);
 
         for (var branch : branches) {
-            verifyFiles(hg, branch, git, branch.equals("default") ? "master" : branch);
+            verifyFiles(hg, branch, git, branch.equals(Branch.defaultFor(VCS.HG).name()) ? Branch.defaultFor(VCS.GIT).name() : branch);
         }
 
         for (var tag : tags) {

--- a/cli/src/main/java/org/openjdk/skara/cli/debug/HgOpenJDKImport.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/debug/HgOpenJDKImport.java
@@ -89,7 +89,7 @@ public class HgOpenJDKImport {
             var gitRepo = ReadOnlyRepository.get(gitDir)
                                             .orElseThrow(error("%s is not a git repository", gitDir));
 
-            var converter = new GitToHgConverter(new Branch("master"));
+            var converter = new GitToHgConverter(Branch.defaultFor(VCS.GIT));
             try {
                 var shamap = hgRepo.root().resolve(".hg").resolve("shamap");
                 var marks = new ArrayList<Mark>();

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrCreate.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrCreate.java
@@ -51,7 +51,7 @@ public class GitPrCreate {
         Option.shortcut("b")
               .fullname("branch")
               .describe("NAME")
-              .helptext("Name of target branch, defaults to 'master'")
+              .helptext("Name of target branch, defaults to '" + Branch.defaultFor(VCS.GIT) + "'")
               .optional(),
         Option.shortcut("")
               .fullname("cc")
@@ -105,7 +105,7 @@ public class GitPrCreate {
         var skaraRemoteRepo = forge.repository(group + "/skara").orElseThrow(() ->
             new IOException("error: could not resolve Skara repository")
         );
-        var rules = skaraRemoteRepo.fileContents("config/mailinglist/rules/jdk.json", "master");
+        var rules = skaraRemoteRepo.fileContents("config/mailinglist/rules/jdk.json", Branch.defaultFor(VCS.GIT).name());
         var json = JSON.parse(rules);
         return LabelConfigurationJson.from(json);
     }

--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequestUtils.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequestUtils.java
@@ -76,9 +76,9 @@ public class PullRequestUtils {
                 return hash.get();
             }
 
-            // Only valid option now is a repository - we default the ref to "master"
+            // Only valid option now is a repository - use default ref
             repoName = source;
-            ref = "master";
+            ref = Branch.defaultFor(VCS.GIT).name();
         } else {
             repoName = source.split(":", 2)[0];
             ref = source.split(":", 2)[1];

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/JCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/JCheck.java
@@ -258,11 +258,11 @@ public class JCheck {
             return new Issues(new ArrayList<Issue>().iterator(), null);
         }
 
-        var master = repository.resolve(repository.defaultBranch().name());
+        var defaultHead = repository.resolve(repository.defaultBranch().name());
         var head = repository.head();
 
-        var conf = master.isPresent() ?
-            parseConfiguration(repository, master.get(), List.of()) :
+        var conf = defaultHead.isPresent() ?
+            parseConfiguration(repository, defaultHead.get(), List.of()) :
             parseConfiguration(repository, head, List.of());
         var branchRegex = conf.isPresent() ? conf.get().repository().branches() : ".*";
         var tagRegex = conf.isPresent() ? conf.get().repository().tags() : ".*";

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/JCheckConfiguration.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/JCheckConfiguration.java
@@ -166,8 +166,9 @@ public class JCheckConfiguration {
     }
 
     public static Optional<JCheckConfiguration> from(ReadOnlyRepository r) throws IOException {
-        var master = r.resolve("master")
-                      .orElseThrow(() -> new IOException("Cannot resolve 'master' branch"));
-        return from(r, master, Path.of(".jcheck", "conf"));
+        var defaultBranch = r.defaultBranch();
+        var defaultHead = r.resolve(defaultBranch)
+                      .orElseThrow(() -> new IOException("Cannot resolve '" + defaultBranch + "' branch"));
+        return from(r, defaultHead, Path.of(".jcheck", "conf"));
     }
 }

--- a/test/src/main/java/org/openjdk/skara/test/CensusBuilder.java
+++ b/test/src/main/java/org/openjdk/skara/test/CensusBuilder.java
@@ -221,7 +221,7 @@ public class CensusBuilder {
 
             localRepository.add(folder);
             var hash = localRepository.commit("Generated census", "Census User", "cu@test.test");
-            localRepository.push(hash, repository.url(), "master", true);
+            localRepository.push(hash, repository.url(), Branch.defaultFor(VCS.GIT).name(), true);
             return repository;
 
         } catch (IOException e) {

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Branch.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Branch.java
@@ -23,6 +23,9 @@
 package org.openjdk.skara.vcs;
 
 public class Branch {
+    private static final Branch defaultGit = new Branch("master");
+    private static final Branch defaultHg = new Branch("default");
+
     private final String name;
 
     public Branch(String name) {
@@ -31,6 +34,16 @@ public class Branch {
 
     public String name() {
         return this.name;
+    }
+
+    public static Branch defaultFor(VCS vcs) {
+        if (vcs == VCS.GIT) {
+            return defaultGit;
+        }
+        if (vcs == VCS.HG) {
+            return defaultHg;
+        }
+        throw new IllegalArgumentException("Unsupported VCS: " + vcs);
     }
 
     @Override

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -894,7 +894,7 @@ public class GitRepository implements Repository {
                 var ref = res.stdout().get(0).substring("origin/".length());
                 return new Branch(ref);
             } else {
-                return new Branch("master");
+                return Branch.defaultFor(VCS.GIT);
             }
         }
     }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -773,7 +773,7 @@ public class HgRepository implements Repository {
 
     @Override
     public Branch defaultBranch() throws IOException {
-        return new Branch("default");
+        return Branch.defaultFor(VCS.HG);
     }
 
     @Override

--- a/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/convert/GitToHgConverter.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/convert/GitToHgConverter.java
@@ -39,7 +39,7 @@ public class GitToHgConverter implements Converter {
     private final List<Mark> marks = new ArrayList<Mark>();
 
     public GitToHgConverter() {
-        this(new Branch("master"));
+        this(Branch.defaultFor(VCS.GIT));
     }
 
     public GitToHgConverter(Branch branch) {

--- a/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/convert/HgToGitConverter.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/convert/HgToGitConverter.java
@@ -136,8 +136,8 @@ public class HgToGitConverter implements Converter {
     }
 
     private static Branch convertBranch(Branch branch) {
-        if (branch.name().equals("default")) {
-            return new Branch("master");
+        if (branch.equals(Branch.defaultFor(VCS.HG))) {
+            return Branch.defaultFor(VCS.GIT);
         }
 
         return branch;


### PR DESCRIPTION
Hi all,

please review this patch that ensures that we don't hard-code the name of the default branches for various version control system throughout the Skara source code. Skara has from the beginning been very strict about abstracting away VCS implementation details, but the name of the default branches has managed to find its way into multiple corners of the source code.

Testing:
- [x] `make test` passes on Linux x64
- [x] `make images` passes on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**) ⚠️ Review applies to 6b2063aa75e52f89bf3a96d56d19222cec505de4


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/806/head:pull/806`
`$ git checkout pull/806`
