### PR TITLE
599: Unverified reviews should not count towards jcheck

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -757,7 +757,8 @@ class CheckRun {
                 updateReviewedMessages(comments, allReviews);
             }
 
-            var commit = localRepo.lookup(localHash).orElseThrow();
+            var amendedHash = checkablePullRequest.amendManualReviewers(localHash, censusInstance.namespace());
+            var commit = localRepo.lookup(amendedHash).orElseThrow();
             var commitMessage = String.join("\n", commit.message());
             var readyForIntegration = visitor.messages().isEmpty() && additionalErrors.isEmpty();
             updateMergeReadyComment(readyForIntegration, commitMessage, comments, activeReviews, rebasePossible);

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
@@ -151,14 +151,15 @@ public class IntegrateCommand implements CommandHandler {
 
             // Rebase and push it!
             if (!localHash.equals(pr.targetHash())) {
+                var amendedHash = checkablePr.amendManualReviewers(localHash, censusInstance.namespace());
                 var finalRebaseMessage = rebaseMessage.toString();
                 if (!finalRebaseMessage.isBlank()) {
                     reply.println(rebaseMessage.toString());
                 }
-                reply.println("Pushed as commit " + localHash.hex() + ".");
+                reply.println("Pushed as commit " + amendedHash.hex() + ".");
                 reply.println();
                 reply.println(":bulb: You may see a message that your pull request was closed with unmerged commits. This can be safely ignored.");
-                localRepo.push(localHash, pr.repository().url(), pr.targetRef());
+                localRepo.push(amendedHash, pr.repository().url(), pr.targetRef());
                 pr.setState(PullRequest.State.CLOSED);
                 pr.addLabel("integrated");
                 pr.removeLabel("ready");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
@@ -125,14 +125,15 @@ public class SponsorCommand implements CommandHandler {
             }
 
             if (!localHash.equals(pr.targetHash())) {
+                var amendedHash = checkablePr.amendManualReviewers(localHash, censusInstance.namespace());
                 var finalRebaseMessage = rebaseMessage.toString();
                 if (!finalRebaseMessage.isBlank()) {
                     reply.println(rebaseMessage.toString());
                 }
-                reply.println("Pushed as commit " + localHash.hex() + ".");
+                reply.println("Pushed as commit " + amendedHash.hex() + ".");
                 reply.println();
                 reply.println(":bulb: You may see a message that your pull request was closed with unmerged commits. This can be safely ignored.");
-                localRepo.push(localHash, pr.repository().url(), pr.targetRef());
+                localRepo.push(amendedHash, pr.repository().url(), pr.targetRef());
                 pr.setState(PullRequest.State.CLOSED);
                 pr.addLabel("integrated");
                 pr.removeLabel("sponsor");


### PR DESCRIPTION
The usage of the `/reviewer add` command has apparently been a bit confusing. This change renames the `add` sub command to `credit` instead to clarify the intent better. Such manually credited reviewers will also not count towards the "formal" review requirements as specified by the jcheck configuration.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-599](https://bugs.openjdk.java.net/browse/SKARA-599): Unverified reviews should not count towards jcheck


### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/807/head:pull/807`
`$ git checkout pull/807`
