### PR TITLE
625: Proxy build plugin should work on URLs without scheme

### DIFF
--- a/buildSrc/proxy/src/main/java/org/openjdk/skara/gradle/proxy/ProxyPlugin.java
+++ b/buildSrc/proxy/src/main/java/org/openjdk/skara/gradle/proxy/ProxyPlugin.java
@@ -25,6 +25,7 @@ package org.openjdk.skara.gradle.proxy;
 
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.GradleException;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -33,30 +34,45 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class ProxyPlugin implements Plugin<Project> {
+    private static boolean setProxyHostAndPortBasedOn(String protocol, URI uri) {
+        var port = String.valueOf(uri.getPort() == -1 ? 80 : uri.getPort());
+        if (System.getProperty(protocol + ".proxyHost") == null) {
+            System.setProperty(protocol + ".proxyHost", uri.getHost());
+            System.setProperty(protocol + ".proxyPort", port);
+            return true;
+        }
+
+        return false;
+    }
+
     public void apply(Project project) {
+        var hasSetProxy = false;
         for (var key : List.of("http_proxy", "https_proxy")) {
             var value = System.getenv(key);
             value = value == null ? System.getenv(key.toUpperCase()) : value;
             if (value != null) {
-                var protocol = key.split("_")[0];
+                var protocol = key.split("_")[0].toLowerCase();
                 try {
-                    var uri = new URI(value);
-                    if (System.getProperty(protocol + ".proxyHost") == null && uri.getHost() != null) {
-                        System.setProperty(protocol + ".proxyHost", uri.getHost());
-                        System.setProperty(protocol + ".proxyPort", String.valueOf(uri.getPort()));
+                    if (!value.startsWith("http://") && !value.startsWith("https://")) {
+                        // Try to parse it as a http url - we only care about the host and port
+                        value = "http://" + value;
                     }
+                    var uri = new URI(value);
+                    hasSetProxy |= setProxyHostAndPortBasedOn(protocol, uri);
                 } catch (URISyntaxException e) {
-                    // pass
+                    throw new GradleException("Could not parse " + value + " as an URI", e);
                 }
             }
         }
         var no_proxy = System.getenv("no_proxy");
         no_proxy = no_proxy == null ? System.getenv("NO_PROXY") : no_proxy;
-        if (no_proxy != null && System.getProperty("http.nonProxyHosts") == null) {
-            var hosts = Arrays.stream(no_proxy.split(","))
-                              .map(s -> s.startsWith(".") ? "*" + s : s)
-                              .collect(Collectors.toList());
-            System.setProperty("http.nonProxyHosts", String.join("|", hosts));
+        if (no_proxy != null) {
+            if (System.getProperty("http.nonProxyHosts") == null || hasSetProxy) {
+                var hosts = Arrays.stream(no_proxy.split(","))
+                                  .map(s -> s.startsWith(".") ? "*" + s : s)
+                                  .collect(Collectors.toList());
+                System.setProperty("http.nonProxyHosts", String.join("|", hosts));
+            }
         }
     }
 }


### PR DESCRIPTION
Hi all,

please review this patch that makes the build work with http proxy environment variables that do not have a scheme (i.e. does not have a `http://` prefix).

Testing:
- [x] Manual testing on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-625](https://bugs.openjdk.java.net/browse/SKARA-625): Proxy build plugin should work on URLs without scheme


### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/809/head:pull/809`
`$ git checkout pull/809`
