### PR TITLE
598: Add test-request label when test request needs approval

### DIFF
--- a/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestWorkItem.java
+++ b/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestWorkItem.java
@@ -38,6 +38,7 @@ import java.util.stream.*;
 import java.util.function.Predicate;
 
 public class TestWorkItem implements WorkItem {
+    private final static String TEST_REQUEST_LABEL = "test-request";
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots");;
     private final ContinuousIntegration ci;
     private final String approversGroupId;
@@ -353,10 +354,15 @@ public class TestWorkItem implements WorkItem {
                         String.join(",", trimmedJobs) + " for commits up until " + head.abbreviate()
                 );
                 pr.addComment(String.join("\n", lines));
+                pr.addLabel(TEST_REQUEST_LABEL);
             }
         } else if (stage == Stage.APPROVED) {
             Hash head = null;
             List<String> jobs = null;
+
+            if (pr.labels().contains(TEST_REQUEST_LABEL)) {
+                pr.removeLabel(TEST_REQUEST_LABEL);
+            }
 
             if (state.pending() != null) {
                 var comment = state.pending();

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
@@ -40,6 +40,7 @@ class InMemoryPullRequest implements PullRequest {
     Hash headHash;
     String id;
     Map<String, Map<String, Check>> checks = new HashMap<>();
+    Set<String> labels = new TreeSet<>();
 
     @Override
     public HostedRepository repository() {
@@ -209,15 +210,17 @@ class InMemoryPullRequest implements PullRequest {
 
     @Override
     public void addLabel(String label) {
+        labels.add(label);
     }
 
     @Override
     public void removeLabel(String label) {
+        labels.remove(label);
     }
 
     @Override
     public List<String> labels() {
-        return null;
+        return new ArrayList<String>(labels);
     }
 
     @Override

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/TestWorkItemTests.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/TestWorkItemTests.java
@@ -1118,4 +1118,86 @@ class TestWorkItemTests {
         }
     }
 
+    @Test
+    void pendingTestShouldHaveTestRequestLabel() throws IOException {
+        try (var tmp = new TemporaryDirectory()) {
+            var ci = new InMemoryContinuousIntegration();
+            var approvers = "0";
+            var available = List.of("tier1", "tier2", "tier3");
+            var defaultJobs = List.of("tier1");
+            var name = "test";
+            var storage = tmp.path().resolve("storage");
+            var scratch = tmp.path().resolve("storage");
+
+            var bot = new HostUser(1, "bot", "openjdk [bot]");
+            var host = new InMemoryHost();
+            host.currentUserDetails = bot;
+
+            var repo = new InMemoryHostedRepository();
+            repo.host = host;
+
+            var pr = new InMemoryPullRequest();
+            pr.repository = repo;
+
+            var duke = new HostUser(0, "duke", "Duke");
+            host.groups = Map.of(approvers, Set.of(duke));
+            pr.author = duke;
+            pr.headHash = new Hash("01234567890123456789012345789012345789");
+
+            var now = ZonedDateTime.now();
+            var comment = new Comment("0", "/test foobar", duke, now, now);
+            pr.comments = new ArrayList<>(List.of(comment));
+
+            var item = new TestWorkItem(ci, approvers, Set.of(), available, defaultJobs, name, storage, pr,
+                                        u -> false);
+
+            // Non-existing test group should result in error
+            item.run(scratch);
+
+            var comments = pr.comments();
+            assertEquals(2, comments.size());
+            assertEquals(comment, comments.get(0));
+
+            var secondComment = comments.get(1);
+            assertEquals(bot, secondComment.author());
+
+            var lines = secondComment.body().split("\n");
+            assertEquals(2, lines.length);
+            assertEquals("<!-- TEST ERROR -->", lines[0]);
+            assertEquals("@duke the test group foobar does not exist", lines[1]);
+
+            // Trying to test again should be fine
+            var thirdComment = new Comment("2", "/test tier1", duke, now, now);
+            pr.comments.add(thirdComment);
+            item.run(scratch);
+
+            comments = pr.comments();
+            assertEquals(4, comments.size());
+            assertEquals(comment, comments.get(0));
+            assertEquals(secondComment, comments.get(1));
+            assertEquals(thirdComment, comments.get(2));
+
+            var fourthComment = comments.get(3);
+            assertEquals(bot, fourthComment.author());
+
+            lines = fourthComment.body().split("\n");
+            assertEquals("<!-- TEST PENDING -->", lines[0]);
+            assertEquals("<!-- 01234567890123456789012345789012345789 -->", lines[1]);
+            assertEquals("<!-- tier1 -->", lines[2]);
+            assertEquals("@duke you need to get approval to run the tests in tier1 for commits up until 01234567",
+                         lines[3]);
+
+            assertEquals(List.of("test-request"), pr.labels());
+
+            // Nothing should change if we run it yet again
+            item.run(scratch);
+
+            comments = pr.comments();
+            assertEquals(4, comments.size());
+            assertEquals(comment, comments.get(0));
+            assertEquals(secondComment, comments.get(1));
+            assertEquals(thirdComment, comments.get(2));
+            assertEquals(fourthComment, comments.get(3));
+        }
+    }
 }


### PR DESCRIPTION
Hi all,

please review this patch that adds a label for test requests.

Testing:
- [x] `make test` passes on Linux x64
- [x] Added a new unit tests

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-598](https://bugs.openjdk.java.net/browse/SKARA-598): Add test-request label when test request needs approval


### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/812/head:pull/812`
`$ git checkout pull/812`
