### PR TITLE
634: Refresh PR data between commands in CommandWorkItem 

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandWorkItem.java
@@ -223,8 +223,11 @@ public class CommandWorkItem extends PullRequestWorkItem {
         log.info("Processing command: " + command.id() + " - " + command.name());
         processCommand(pr, census, scratchPath.resolve("pr").resolve("command"), command, comments);
 
+        // Must re-fetch PR after running the command, the command might have updated the PR
+        var updatedPR = pr.repository().pullRequest(pr.id());
+
         // Run another check to reflect potential changes from commands
-        return List.of(new CheckWorkItem(bot, pr, errorHandler));
+        return List.of(new CheckWorkItem(bot, updatedPR, errorHandler));
     }
 
     @Override

--- a/test/src/main/java/org/openjdk/skara/test/HostCredentials.java
+++ b/test/src/main/java/org/openjdk/skara/test/HostCredentials.java
@@ -354,14 +354,22 @@ public class HostCredentials implements AutoCloseable {
         return credentials.getIssueProject(host);
     }
 
-    public PullRequest createPullRequest(HostedRepository hostedRepository, String targetRef, String sourceRef, String title, boolean draft) {
-        var pr = hostedRepository.createPullRequest(hostedRepository, targetRef, sourceRef, title, List.of("PR body"), draft);
+    public PullRequest createPullRequest(HostedRepository hostedRepository, String targetRef, String sourceRef, String title, List<String> body, boolean draft) {
+        var pr = hostedRepository.createPullRequest(hostedRepository, targetRef, sourceRef, title, body, draft);
         pullRequestsToBeClosed.add(pr);
         return pr;
     }
 
+    public PullRequest createPullRequest(HostedRepository hostedRepository, String targetRef, String sourceRef, String title, boolean draft) {
+        return createPullRequest(hostedRepository, targetRef, sourceRef, title, List.of("PR body"), draft);
+    }
+
+    public PullRequest createPullRequest(HostedRepository hostedRepository, String targetRef, String sourceRef, String title, List<String> body) {
+        return createPullRequest(hostedRepository, targetRef, sourceRef, title, body, false);
+    }
+
     public PullRequest createPullRequest(HostedRepository hostedRepository, String targetRef, String sourceRef, String title) {
-        return createPullRequest(hostedRepository, targetRef, sourceRef, title, false);
+        return createPullRequest(hostedRepository, targetRef, sourceRef, title, List.of("PR body"), false);
     }
 
     public Issue createIssue(IssueProject issueProject, String title) {


### PR DESCRIPTION
Hi all,

please review this patch that ensures that the pull request data is re-fetched between commands are being run (since commands can affect the PR state).

Testing:
- [x] `make test` passes on Linux x64
- [x] Added a new unit test

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-634](https://bugs.openjdk.java.net/browse/SKARA-634): Refresh PR data between commands in CommandWorkItem 


### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/813/head:pull/813`
`$ git checkout pull/813`
