### PR TITLE
Treat bad whitespace in commit message gracefully

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
@@ -201,8 +201,8 @@ class PullRequestCheckIssueVisitor implements IssueVisitor {
 
     @Override
     public void visit(MessageWhitespaceIssue issue) {
-        var message = String.join("\n", issue.commit().message());
-        throw new IllegalStateException("Commit message contains bad whitespace: " + message);
+        addFailureMessage(issue.check(), "The commit message contains bad whitespace");
+        readyForReview = false;
     }
 
     @Override

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
@@ -206,8 +206,10 @@ class PullRequestCheckIssueVisitor implements IssueVisitor {
             desc = "trailing whitespace";
         } else if (issue.kind() == MessageWhitespaceIssue.Whitespace.CR) {
             desc = "a carriage return";
-        } else {
+        } else if (issue.kind() == MessageWhitespaceIssue.Whitespace.TAB) {
             desc = "a tab";
+        } else {
+            desc = "an unknown kind of whitespace (" + issue.kind().name() + ")";
         }
         addFailureMessage(issue.check(), "The commit message contains " + desc + " on line " + issue.line());
         readyForReview = false;

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
@@ -201,7 +201,15 @@ class PullRequestCheckIssueVisitor implements IssueVisitor {
 
     @Override
     public void visit(MessageWhitespaceIssue issue) {
-        addFailureMessage(issue.check(), "The commit message contains bad whitespace");
+        String desc;
+        if (issue.kind() == MessageWhitespaceIssue.Whitespace.TRAILING) {
+            desc = "trailing whitespace";
+        } else if (issue.kind() == MessageWhitespaceIssue.Whitespace.CR) {
+            desc = "a carriage return";
+        } else {
+            desc = "a tab";
+        }
+        addFailureMessage(issue.check(), "The commit message contains " + desc + " on line " + issue.line());
         readyForReview = false;
     }
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SummaryCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SummaryCommand.java
@@ -28,6 +28,7 @@ import org.openjdk.skara.issuetracker.Comment;
 import java.io.PrintWriter;
 import java.nio.file.Path;
 import java.util.*;
+import java.util.stream.Collectors;
 
 public class SummaryCommand implements CommandHandler {
     @Override
@@ -46,7 +47,9 @@ public class SummaryCommand implements CommandHandler {
                 reply.println("To set a summary, use the syntax `/summary <summary text>`");
             }
         } else {
-            var summary = command.args().strip();
+            var summary = command.args().lines()
+                                 .map(String::strip)
+                                 .collect(Collectors.joining("\n"));
             var action = currentSummary.isPresent() ? "Updating existing" : "Setting";
             if (summary.contains("\n")) {
                 reply.println(action + " summary to:\n" +


### PR DESCRIPTION
The check "message" should handle the error gracefully instead of throwing. Also trim individual lines in multi-line summaries to help avoid this problem in the first place.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/814/head:pull/814`
`$ git checkout pull/814`
