### PR TITLE
vcs: better regex for real names

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/CommitMessageParsers.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/CommitMessageParsers.java
@@ -115,9 +115,10 @@ public class CommitMessageParsers {
             while (i < lines.size() && lines.get(i).equals("")) {
                 i++;
 
-                if (matcher(CO_AUTHOR_PATTERN, lines, i) != null ||
-                    matcher(REVIEWED_BY_PATTERN, lines, i) != null) {
+                if (lines.get(i).startsWith("Co-authored-by:") ||
+                    lines.get(i).startsWith("Reviewed-by:")) {
                     // "trailers" section
+
                     while ((m = matcher(CO_AUTHOR_PATTERN, lines, i)) != null) {
                         for (var author : m.group(1).split(", ")) {
                             coAuthors.add(Author.fromString(author));

--- a/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/CommitMessageSyntax.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/CommitMessageSyntax.java
@@ -27,7 +27,7 @@ import java.util.regex.Pattern;
 public class CommitMessageSyntax {
         private static final String OPENJDK_USERNAME_REGEX = "[-.a-z0-9]+";
         public static final String EMAIL_ADDR_REGEX = "[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]+";
-        public static final String REAL_NAME_REGEX = "[-_a-zA-Z0-9][-_ a-zA-Z0-9'.]+";
+        public static final String REAL_NAME_REGEX = "[^<>@]+";
         private static final String REAL_NAME_AND_EMAIL_ATTR_REGEX = REAL_NAME_REGEX + " +<" + EMAIL_ADDR_REGEX + ">";
         private static final String ATTR_REGEX = "(?:(?:" + EMAIL_ADDR_REGEX + ")|(?:" + REAL_NAME_AND_EMAIL_ATTR_REGEX + "))";
 

--- a/vcs/src/test/java/org/openjdk/skara/vcs/openjdk/CommitMessageParsersTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/openjdk/CommitMessageParsersTests.java
@@ -224,4 +224,22 @@ public class CommitMessageParsersTests {
         assertEquals(List.of(), message.summaries());
         assertEquals(List.of("Unknown-trailer: bar"), message.additional());
     }
+
+    @Test
+    void internationalCoAuthors() {
+        var text = List.of("01234567: An issue",
+                           "",
+                           "Co-authored-by: Föö Bår <foo@bar.com>",
+                           "Co-authored-by: Bår Bäz <bar@baz.com>",
+                           "Reviewed-by: ab, cd, ef");
+        var message = CommitMessageParsers.v1.parse(text);
+
+        assertEquals("01234567: An issue", message.title());
+        assertEquals(List.of(new Issue("01234567", "An issue")), message.issues());
+        assertEquals(List.of("ab", "cd", "ef"), message.reviewers());
+        assertEquals(List.of(new Author("Föö Bår", "foo@bar.com"), new Author("Bår Bäz", "bar@baz.com")),
+                     message.contributors());
+        assertEquals(List.of(), message.summaries());
+        assertEquals(List.of(), message.additional());
+    }
 }


### PR DESCRIPTION
Hi all,

please review this patch that makes the real name regular expression in the commit message parser accept essentially all characters except the one used in e-mail addresses.

Testing:
- [x] Added a new unit test
- [x] `make test` passes on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/815/head:pull/815`
`$ git checkout pull/815`
