### PR TITLE
Set the resolved in build custom field in Jira when resolving an issue (if configured)

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
@@ -47,11 +47,13 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
     private final Map<String, String> fixVersions;
     private final JbsBackport jbsBackport;
     private final boolean prOnly;
+    private final String buildName;
 
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots.notify");
 
     IssueNotifier(IssueProject issueProject, boolean reviewLink, URI reviewIcon, boolean commitLink, URI commitIcon,
-            boolean setFixVersion, Map<String, String> fixVersions, JbsBackport jbsBackport, boolean prOnly) {
+            boolean setFixVersion, Map<String, String> fixVersions, JbsBackport jbsBackport, boolean prOnly,
+                  String buildName) {
         this.issueProject = issueProject;
         this.reviewLink = reviewLink;
         this.reviewIcon = reviewIcon;
@@ -61,6 +63,7 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
         this.fixVersions = fixVersions;
         this.jbsBackport = jbsBackport;
         this.prOnly = prOnly;
+        this.buildName = buildName;
     }
 
     static IssueNotifierBuilder newBuilder() {
@@ -257,6 +260,9 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
                 }
 
                 if (setFixVersion) {
+                    if (buildName != null) {
+                        issue.setProperty("customfield_10006", JSON.of(buildName));
+                    }
                     if (requestedVersion != null) {
                         issue.setProperty("fixVersions", JSON.of(requestedVersion));
                         Backports.labelReleaseStreamDuplicates(issue, "hgupdate-sync");

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierBuilder.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierBuilder.java
@@ -38,6 +38,7 @@ class IssueNotifierBuilder {
     private JbsVault vault = null;
     private String securityLevel = null;
     private boolean prOnly = true;
+    private String buildName = null;
 
     IssueNotifierBuilder issueProject(IssueProject issueProject) {
         this.issueProject = issueProject;
@@ -90,9 +91,14 @@ class IssueNotifierBuilder {
         return this;
     }
 
+    public IssueNotifierBuilder buildName(String buildName) {
+        this.buildName = buildName;
+        return this;
+    }
+
     IssueNotifier build() {
         var jbsBackport = new JbsBackport(issueProject.webUrl(), vault, securityLevel);
         return new IssueNotifier(issueProject, reviewLink, reviewIcon, commitLink, commitIcon,
-                                 setFixVersion, fixVersions, jbsBackport, prOnly);
+                                 setFixVersion, fixVersions, jbsBackport, prOnly, buildName);
     }
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierFactory.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierFactory.java
@@ -45,6 +45,9 @@ public class IssueNotifierFactory implements NotifierFactory {
                                                       .collect(Collectors.toMap(JSONObject.Field::name,
                                                                                 f -> f.value().asString())));
         }
+        if (notifierConfiguration.contains("buildname")) {
+            builder.buildName(notifierConfiguration.get("buildname").asString());
+        }
 
         if (notifierConfiguration.contains("vault")) {
             var vaultConfiguration = notifierConfiguration.get("vault").asObject();

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
@@ -378,7 +378,8 @@ public class IssueNotifierTests {
 
             var issueProject = credentials.getIssueProject();
             var storageFolder = tempFolder.path().resolve("storage");
-            var jbsNotifierConfig = JSON.object().put("fixversions", JSON.object());
+            var jbsNotifierConfig = JSON.object().put("fixversions", JSON.object())
+                                        .put("buildname", "team");
             var notifyBot = testBotBuilder(repo, issueProject, storageFolder, jbsNotifierConfig).create("notify", JSON.object());
 
             // Initialize history
@@ -399,8 +400,9 @@ public class IssueNotifierTests {
             var comment = comments.get(0);
             assertTrue(comment.body().contains(editHash.abbreviate()));
 
-            // As well as a fixVersion
+            // As well as a fixVersion and a resolved in build
             assertEquals(Set.of("0.1"), fixVersions(updatedIssue));
+            assertEquals("team", updatedIssue.properties().get("customfield_10006").asString());
 
             // The issue should be assigned and resolved
             assertEquals(RESOLVED, updatedIssue.state());


### PR DESCRIPTION
When the issue notifier resolves an issue upon commit, it should also set the "Resolved In Build" field, if so configured.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/816/head:pull/816`
`$ git checkout pull/816`
