### PR TITLE
Set or update the resolved in build field when new tags arrive

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/BuildCompare.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/BuildCompare.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 20202, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.notify.issue;
+
+import java.util.regex.Pattern;
+
+public class BuildCompare {
+    private static final Pattern buildPattern = Pattern.compile("^b(\\d+)");
+
+    // Return the number from a numbered build (e.g., 'b12' -> 12), or -1 if not a numbered build.
+    private static int buildNumber(String build) {
+        var buildMatcher = buildPattern.matcher(build);
+        if (buildMatcher.matches()) {
+            return Integer.parseInt(buildMatcher.group(1));
+        } else {
+            return -1;
+        }
+    }
+
+    // Notable values for rib are 'team', 'master', and numbered builds
+    // (b22).  'team' should not overwrite any value; 'master' should only
+    // overwrite 'team'; numbered builds (b22) should only be overwritten by
+    // lower numbered builds.
+    // The last condition is due to the use of duplicate bugids in jdk update
+    // releases.  A fix could be made in jdk7u10-b02, and also (due to an
+    // escalation or some other urgent need) be fixed in jdk7u8-b04.  At some
+    // later date when jdk7u8 is merged into, say, jdk7u10-b10, without the
+    // last condition the Resolved in Build field would be changed from b02
+    // to b10.
+    public static boolean shouldReplace(String newBuild, String oldBuild) {
+        if (oldBuild == null) {
+            return true;
+        }
+        if (newBuild.equals(oldBuild)) {
+            return false;
+        }
+        if (newBuild.equals("team")) {
+            return false;
+        }
+        if (newBuild.startsWith("ma")) {
+            return oldBuild.equals("team");
+        }
+
+        var oldBuildNumber = buildNumber(oldBuild);
+        var newBuildNumber = buildNumber(newBuild);
+
+        return oldBuildNumber < 0 || (newBuildNumber >= 0 && newBuildNumber < oldBuildNumber);
+    }
+}

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/BuildCompare.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/BuildCompare.java
@@ -37,7 +37,7 @@ public class BuildCompare {
         }
     }
 
-    // Notable values for rib are 'team', 'master', and numbered builds
+    // Notable values for "Resolved in Build" are 'team', 'master', and numbered builds
     // (b22).  'team' should not overwrite any value; 'master' should only
     // overwrite 'team'; numbered builds (b22) should only be overwritten by
     // lower numbered builds.

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
@@ -26,12 +26,13 @@ import org.openjdk.skara.bots.notify.*;
 import org.openjdk.skara.email.EmailAddress;
 import org.openjdk.skara.forge.*;
 import org.openjdk.skara.issuetracker.*;
+import org.openjdk.skara.issuetracker.Issue;
 import org.openjdk.skara.jcheck.JCheckConfiguration;
 import org.openjdk.skara.json.JSON;
 import org.openjdk.skara.vcs.*;
-import org.openjdk.skara.vcs.openjdk.CommitMessageParsers;
+import org.openjdk.skara.vcs.openjdk.*;
 
-import java.io.IOException;
+import java.io.*;
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.*;
@@ -104,7 +105,7 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
     @Override
     public void attachTo(Emitter e) {
         e.registerPullRequestListener(this);
-        if (!prOnly) {
+        if (!prOnly || buildName != null) {
             e.registerRepositoryListener(this);
         }
     }
@@ -260,13 +261,96 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
                 }
 
                 if (setFixVersion) {
-                    if (buildName != null) {
-                        issue.setProperty("customfield_10006", JSON.of(buildName));
-                    }
                     if (requestedVersion != null) {
+                        if (buildName != null) {
+                            // Check if the build name should be updated
+                            var oldBuild = issue.properties().getOrDefault("customfield_10006", JSON.of());
+                            if (BuildCompare.shouldReplace(buildName, oldBuild.asString())) {
+                                issue.setProperty("customfield_10006", JSON.of(buildName));
+                            } else {
+                                log.info("Not replacing build " + oldBuild.asString() + " with " + buildName + " for issue " + issue.id());
+                            }
+                        }
                         issue.setProperty("fixVersions", JSON.of(requestedVersion));
                         Backports.labelReleaseStreamDuplicates(issue, "hgupdate-sync");
                     }
+                }
+            }
+        }
+    }
+
+    @Override
+    public void onNewOpenJDKTagCommits(HostedRepository repository, Repository localRepository, List<Commit> commits, OpenJDKTag tag, Tag.Annotated annotated) throws NonRetriableException {
+        if (!setFixVersion) {
+            return;
+        }
+        if (buildName == null) {
+            return;
+        }
+
+        for (var commit : commits) {
+            var commitMessage = CommitMessageParsers.v1.parse(commit);
+            for (var commitIssue : commitMessage.issues()) {
+                var optionalIssue = issueProject.issue(commitIssue.shortId());
+                if (optionalIssue.isEmpty()) {
+                    log.severe("Cannot update RIB for issue " + commitIssue.id()
+                                       + " - issue not found in issue project");
+                    continue;
+                }
+                var issue = optionalIssue.get();
+
+                // Determine which branch this tag belongs to
+                String tagBranch = null;
+                try {
+                    for (var branch : repository.branches()) {
+                        var hash = localRepository.resolve(tag.tag()).orElseThrow();
+                        if (localRepository.isAncestor(hash, branch.hash())) {
+                            if (tagBranch == null) {
+                                tagBranch = branch.name();
+                            } else {
+                                throw new RuntimeException("Tag " + tag.tag().name() + " found in both " + tagBranch + " and " + branch.name());
+                            }
+                        }
+                    }
+                    if (tagBranch == null) {
+                        throw new RuntimeException("Cannot find any branch containing the tag " + tag.tag().name());
+                    }
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+
+                // The actual issue to be updated can change depending on the fix version
+                var requestedVersion = fixVersions != null ? fixVersions.getOrDefault(tagBranch, null) : null;
+                if (requestedVersion == null) {
+                    try {
+                        var conf = localRepository.lines(Path.of(".jcheck/conf"), commit.hash());
+                        if (conf.isPresent()) {
+                            var parsed = JCheckConfiguration.parse(conf.get());
+                            var version = parsed.general().version();
+                            requestedVersion = version.orElse(null);
+                        }
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+                if (requestedVersion == null) {
+                    throw new RuntimeException("Failed to determine requested fixVersion for " + issue.id());
+                }
+                var fixVersion = JdkVersion.parse(requestedVersion);
+                var existing = Backports.findIssue(issue, fixVersion);
+                if (existing.isEmpty()) {
+                    throw new RuntimeException("Cannot find a properly resolved issue for: " + issue.id());
+                } else {
+                    issue = existing.get();
+                }
+
+                // Check if the build name should be updated
+                var oldBuild = issue.properties().getOrDefault("customfield_10006", JSON.of());
+                var newBuild = "b" + tag.buildNum();
+                if (BuildCompare.shouldReplace(newBuild, oldBuild.asString())) {
+                    issue.setProperty("customfield_10006", JSON.of(newBuild));
+                } else {
+                    log.info("Not replacing build " + oldBuild.asString() + " with " + newBuild + " for issue " + issue.id());
                 }
             }
         }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
@@ -293,7 +293,7 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
             for (var commitIssue : commitMessage.issues()) {
                 var optionalIssue = issueProject.issue(commitIssue.shortId());
                 if (optionalIssue.isEmpty()) {
-                    log.severe("Cannot update RIB for issue " + commitIssue.id()
+                    log.severe("Cannot update \"Resolved in Build\" for issue " + commitIssue.id()
                                        + " - issue not found in issue project");
                     continue;
                 }

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/BuildCompareTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/BuildCompareTests.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.notify.issue;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class BuildCompareTests {
+    @Test
+    void simple() {
+        assertTrue(BuildCompare.shouldReplace("main", "team"));
+        assertFalse(BuildCompare.shouldReplace("team", "main"));
+
+        assertTrue(BuildCompare.shouldReplace("b03", "team"));
+        assertTrue(BuildCompare.shouldReplace("b03", "main"));
+        assertTrue(BuildCompare.shouldReplace("b03", "b04"));
+
+        assertFalse(BuildCompare.shouldReplace("team", "b03"));
+        assertFalse(BuildCompare.shouldReplace("main", "b03"));
+        assertFalse(BuildCompare.shouldReplace("b04", "b03"));
+
+        assertTrue(BuildCompare.shouldReplace("team", null));
+        assertTrue(BuildCompare.shouldReplace("main", null));
+        assertTrue(BuildCompare.shouldReplace("b05", null));
+
+        assertFalse(BuildCompare.shouldReplace("team", "team"));
+        assertFalse(BuildCompare.shouldReplace("main", "main"));
+        assertFalse(BuildCompare.shouldReplace("b12", "b12"));
+    }
+}

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
@@ -428,7 +428,7 @@ public class IssueNotifierTests {
                                         .put("buildname", "team");
             var notifyBot = testBotBuilder(repo, issueProject, storageFolder, jbsNotifierConfig).create("notify", JSON.object());
             var jbsNotifierConfig2 = JSON.object().put("fixversions", JSON.object())
-                                        .put("buildname", "main");
+                                        .put("buildname", "master");
             var notifyBot2 = testBotBuilder(repo, issueProject, storageFolder, jbsNotifierConfig2).create("notify", JSON.object());
             var jbsNotifierConfig3 = JSON.object().put("fixversions", JSON.object())
                                          .put("buildname", "b04");
@@ -475,7 +475,7 @@ public class IssueNotifierTests {
             TestBotRunner.runPeriodicItems(notifyBot2);
 
             updatedIssue = issueProject.issue(issue.id()).orElseThrow();
-            assertEquals("main", updatedIssue.properties().get("customfield_10006").asString());
+            assertEquals("master", updatedIssue.properties().get("customfield_10006").asString());
 
             // Restore the history to simulate looking at another repository
             localRepo.fetch(repo.url(), "history");
@@ -586,7 +586,7 @@ public class IssueNotifierTests {
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // Create an issue and commit a fix
-            var authorEmailAddress = issueProject.issueTracker().currentUser().userName() + "@otherjdk.org";
+            var authorEmailAddress = issueProject.issueTracker().currentUser().email().orElse(issueProject.issueTracker().currentUser().userName() + "@otherjdk.org");
             var issue = issueProject.createIssue("This is an issue", List.of("Indeed"), Map.of("issuetype", JSON.of("Enhancement")));
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", issue.id() + ": Fix that issue", "Duke", authorEmailAddress);
             localRepo.push(editHash, repo.url(), "master");
@@ -744,7 +744,7 @@ public class IssueNotifierTests {
 
             var storageFolder = tempFolder.path().resolve("storage");
             var issueProject = credentials.getIssueProject();
-            var jbsNotifierConfig = JSON.object().put("fixversions", JSON.object().put("master", "12u14"));
+            var jbsNotifierConfig = JSON.object().put("fixversions", JSON.object().put("master", "12.0.1"));
             var notifyBot = testBotBuilder(repo, issueProject, storageFolder, jbsNotifierConfig).create("notify", JSON.object());
 
             // Initialize history
@@ -752,14 +752,14 @@ public class IssueNotifierTests {
 
             // Create an issue and commit a fix
             var issue = issueProject.createIssue("This is an issue", List.of("Indeed"), Map.of("issuetype", JSON.of("Enhancement")));
-            issue.setProperty("fixVersions", JSON.array().add("12-pool").add("tbd13").add("unknown"));
+            issue.setProperty("fixVersions", JSON.array().add("12-pool").add("tbd_major").add("unknown"));
 
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", issue.id() + ": Fix that issue");
             localRepo.push(editHash, repo.url(), "master");
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The fixVersion should have been updated
-            assertEquals(Set.of("12u14"), fixVersions(issue));
+            assertEquals(Set.of("12.0.1"), fixVersions(issue));
         }
     }
 
@@ -775,7 +775,7 @@ public class IssueNotifierTests {
 
             var storageFolder = tempFolder.path().resolve("storage");
             var issueProject = credentials.getIssueProject();
-            var jbsNotifierConfig = JSON.object().put("fixversions", JSON.object().put("master", "12u14"));
+            var jbsNotifierConfig = JSON.object().put("fixversions", JSON.object().put("master", "12.0.1"));
             var notifyBot = testBotBuilder(repo, issueProject, storageFolder, jbsNotifierConfig).create("notify", JSON.object());
 
             // Initialize history
@@ -783,14 +783,14 @@ public class IssueNotifierTests {
 
             // Create an issue and commit a fix
             var issue = issueProject.createIssue("This is an issue", List.of("Indeed"), Map.of("issuetype", JSON.of("Enhancement")));
-            issue.setProperty("fixVersions", JSON.array().add("12-pool").add("tbd13").add("unknown"));
+            issue.setProperty("fixVersions", JSON.array().add("12-pool").add("tbd_major").add("unknown"));
 
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", issue.id() + ": Fix that issue");
             localRepo.push(editHash, repo.url(), "master");
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The fixVersion should have been updated
-            assertEquals(Set.of("12u14"), fixVersions(issue));
+            assertEquals(Set.of("12.0.1"), fixVersions(issue));
         }
     }
 

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
@@ -28,6 +28,7 @@ import org.openjdk.skara.forge.HostedRepository;
 import org.openjdk.skara.issuetracker.*;
 import org.openjdk.skara.json.*;
 import org.openjdk.skara.test.*;
+import org.openjdk.skara.vcs.Branch;
 
 import java.io.IOException;
 import java.net.URI;
@@ -407,6 +408,161 @@ public class IssueNotifierTests {
             // The issue should be assigned and resolved
             assertEquals(RESOLVED, updatedIssue.state());
             assertEquals(List.of(issueProject.issueTracker().currentUser()), updatedIssue.assignees());
+        }
+    }
+
+    @Test
+    void testIssueBuildAfterMerge(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+
+            var repo = credentials.getHostedRepository();
+            var repoFolder = tempFolder.path().resolve("repo");
+            var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
+            credentials.commitLock(localRepo);
+            localRepo.pushAll(repo.url());
+
+            var issueProject = credentials.getIssueProject();
+            var storageFolder = tempFolder.path().resolve("storage");
+            var jbsNotifierConfig = JSON.object().put("fixversions", JSON.object())
+                                        .put("buildname", "team");
+            var notifyBot = testBotBuilder(repo, issueProject, storageFolder, jbsNotifierConfig).create("notify", JSON.object());
+            var jbsNotifierConfig2 = JSON.object().put("fixversions", JSON.object())
+                                        .put("buildname", "main");
+            var notifyBot2 = testBotBuilder(repo, issueProject, storageFolder, jbsNotifierConfig2).create("notify", JSON.object());
+            var jbsNotifierConfig3 = JSON.object().put("fixversions", JSON.object())
+                                         .put("buildname", "b04");
+            var notifyBot3 = testBotBuilder(repo, issueProject, storageFolder, jbsNotifierConfig3).create("notify", JSON.object());
+            var jbsNotifierConfig4 = JSON.object().put("fixversions", JSON.object())
+                                         .put("buildname", "b02");
+            var notifyBot4 = testBotBuilder(repo, issueProject, storageFolder, jbsNotifierConfig4).create("notify", JSON.object());
+            var jbsNotifierConfig5 = JSON.object().put("fixversions", JSON.object())
+                                         .put("buildname", "b03");
+            var notifyBot5 = testBotBuilder(repo, issueProject, storageFolder, jbsNotifierConfig5).create("notify", JSON.object());
+
+            // Initialize history
+            TestBotRunner.runPeriodicItems(notifyBot);
+            var blankHistory = repo.branchHash("history");
+
+            // Create an issue and commit a fix
+            var authorEmailAddress = issueProject.issueTracker().currentUser().userName() + "@openjdk.org";
+            var issue = issueProject.createIssue("This is an issue", List.of("Indeed"), Map.of("issuetype", JSON.of("Enhancement")));
+            var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", issue.id() + ": Fix that issue", "Duke", authorEmailAddress);
+            localRepo.push(editHash, repo.url(), "master");
+            TestBotRunner.runPeriodicItems(notifyBot);
+
+            // The changeset should be reflected in a comment
+            var updatedIssue = issueProject.issue(issue.id()).orElseThrow();
+
+            var comments = updatedIssue.comments();
+            assertEquals(1, comments.size());
+            var comment = comments.get(0);
+            assertTrue(comment.body().contains(editHash.abbreviate()));
+
+            // As well as a fixVersion and a resolved in build
+            assertEquals(Set.of("0.1"), fixVersions(updatedIssue));
+            assertEquals("team", updatedIssue.properties().get("customfield_10006").asString());
+
+            // The issue should be assigned and resolved
+            assertEquals(RESOLVED, updatedIssue.state());
+            assertEquals(List.of(issueProject.issueTracker().currentUser()), updatedIssue.assignees());
+
+            // Restore the history to simulate looking at another repository
+            localRepo.fetch(repo.url(), "history");
+            localRepo.push(blankHistory, repo.url(), "history", true);
+
+            // When the second notifier sees it, it should upgrade the build name
+            TestBotRunner.runPeriodicItems(notifyBot2);
+
+            updatedIssue = issueProject.issue(issue.id()).orElseThrow();
+            assertEquals("main", updatedIssue.properties().get("customfield_10006").asString());
+
+            // Restore the history to simulate looking at another repository
+            localRepo.fetch(repo.url(), "history");
+            localRepo.push(blankHistory, repo.url(), "history", true);
+
+            // When the third notifier sees it, it should switch to a build number
+            TestBotRunner.runPeriodicItems(notifyBot3);
+
+            updatedIssue = issueProject.issue(issue.id()).orElseThrow();
+            assertEquals("b04", updatedIssue.properties().get("customfield_10006").asString());
+
+            // Restore the history to simulate looking at another repository
+            localRepo.fetch(repo.url(), "history");
+            localRepo.push(blankHistory, repo.url(), "history", true);
+
+            // When the fourth notifier sees it, it should switch to a lower build number
+            TestBotRunner.runPeriodicItems(notifyBot4);
+
+            updatedIssue = issueProject.issue(issue.id()).orElseThrow();
+            assertEquals("b02", updatedIssue.properties().get("customfield_10006").asString());
+
+            // Restore the history to simulate looking at another repository
+            localRepo.fetch(repo.url(), "history");
+            localRepo.push(blankHistory, repo.url(), "history", true);
+
+            // When the fifth notifier sees it, it should NOT switch to a higher build number
+            TestBotRunner.runPeriodicItems(notifyBot5);
+
+            updatedIssue = issueProject.issue(issue.id()).orElseThrow();
+            assertEquals("b02", updatedIssue.properties().get("customfield_10006").asString());
+        }
+    }
+
+    @Test
+    void testIssueBuildAfterTag(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+
+            var repo = credentials.getHostedRepository();
+            var repoFolder = tempFolder.path().resolve("repo");
+            var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
+            credentials.commitLock(localRepo);
+            localRepo.pushAll(repo.url());
+
+            var issueProject = credentials.getIssueProject();
+            var storageFolder = tempFolder.path().resolve("storage");
+            var jbsNotifierConfig = JSON.object().put("fixversions", JSON.object())
+                                        .put("buildname", "team");
+            var notifyBot = testBotBuilder(repo, issueProject, storageFolder, jbsNotifierConfig).create("notify", JSON.object());
+
+            // Initialize history
+            var current = localRepo.resolve("master").orElseThrow();
+            localRepo.tag(current, "jdk-16+9", "First tag", "duke", "duke@openjdk.org");
+            localRepo.push(new Branch(repo.url().toString()), "--tags", false);
+            TestBotRunner.runPeriodicItems(notifyBot);
+
+            // Create an issue and commit a fix
+            var authorEmailAddress = issueProject.issueTracker().currentUser().userName() + "@openjdk.org";
+            var issue = issueProject.createIssue("This is an issue", List.of("Indeed"), Map.of("issuetype", JSON.of("Enhancement")));
+            var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", issue.id() + ": Fix that issue", "Duke", authorEmailAddress);
+            localRepo.push(editHash, repo.url(), "master");
+            TestBotRunner.runPeriodicItems(notifyBot);
+
+            // The changeset should be reflected in a comment
+            var updatedIssue = issueProject.issue(issue.id()).orElseThrow();
+
+            var comments = updatedIssue.comments();
+            assertEquals(1, comments.size());
+            var comment = comments.get(0);
+            assertTrue(comment.body().contains(editHash.abbreviate()));
+
+            // As well as a fixVersion and a resolved in build
+            assertEquals(Set.of("0.1"), fixVersions(updatedIssue));
+            assertEquals("team", updatedIssue.properties().get("customfield_10006").asString());
+
+            // The issue should be assigned and resolved
+            assertEquals(RESOLVED, updatedIssue.state());
+            assertEquals(List.of(issueProject.issueTracker().currentUser()), updatedIssue.assignees());
+
+            // Tag it
+            localRepo.tag(editHash, "jdk-16+10", "Second tag", "duke", "duke@openjdk.org");
+            localRepo.push(new Branch(repo.url().toString()), "--tags", false);
+            TestBotRunner.runPeriodicItems(notifyBot);
+
+            // The build should now be updated
+            updatedIssue = issueProject.issue(issue.id()).orElseThrow();
+            assertEquals("b10", updatedIssue.properties().get("customfield_10006").asString());
         }
     }
 

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraHost.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraHost.java
@@ -36,6 +36,8 @@ public class JiraHost implements IssueTracker {
     private final String securityLevel;
     private final RestRequest request;
 
+    private HostUser currentUser;
+
     JiraHost(URI uri) {
         this.uri = uri;
         this.visibilityRole = null;
@@ -110,11 +112,14 @@ public class JiraHost implements IssueTracker {
 
     @Override
     public HostUser currentUser() {
-        var data = request.get("myself").execute();
-        var user = new HostUser(data.get("name").asString(),
-                                data.get("name").asString(),
-                                data.get("displayName").asString());
-        return user;
+        if (currentUser == null) {
+            var data = request.get("myself").execute();
+            currentUser = new HostUser(data.get("name").asString(),
+                                       data.get("name").asString(),
+                                       data.get("displayName").asString(),
+                                       data.get("emailAddress").asString());
+        }
+        return currentUser;
     }
 
     @Override

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraIssue.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraIssue.java
@@ -534,7 +534,8 @@ public class JiraIssue implements Issue {
             log.warning("Ignoring unknown property: " + name);
             return;
         }
-        var query = JSON.object().put("fields", JSON.object().put(name, encoded.get()));
+        var customEncoded = jiraProject.encodeCustomFields(name, encoded.get(), properties(), id());
+        var query = JSON.object().put("fields", JSON.object().put(name, customEncoded));
         request.put("").body(query).execute();
     }
 


### PR DESCRIPTION
When the issue notifier is configured to set a build name when resolving issues, it should also update that name when an OpenJDK-formatted tag is seen in the repository.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**) ⚠️ Review applies to c31aaab4b266b230282d3627ef0bfaefe82cd093


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/817/head:pull/817`
`$ git checkout pull/817`
