### PR TITLE
jcheck: use census from .jcheck/conf by default

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -732,7 +732,7 @@ class CheckRun {
                 additionalErrors = List.of(e.getMessage());
                 localHash = baseHash;
             }
-            PullRequestCheckIssueVisitor visitor = checkablePullRequest.createVisitor(localHash, censusInstance);
+            PullRequestCheckIssueVisitor visitor = checkablePullRequest.createVisitor(localHash);
             if (!localHash.equals(baseHash)) {
                 // Determine current status
                 var additionalConfiguration = AdditionalConfiguration.get(localRepo, localHash, pr.repository().forge().currentUser(), comments);

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
@@ -146,8 +146,8 @@ public class CheckablePullRequest {
         }
     }
 
-    PullRequestCheckIssueVisitor createVisitor(Hash localHash, CensusInstance censusInstance) throws IOException {
-        var checks = JCheck.checksFor(localRepo, censusInstance.census(), pr.targetHash());
+    PullRequestCheckIssueVisitor createVisitor(Hash localHash) throws IOException {
+        var checks = JCheck.checksFor(localRepo, pr.targetHash());
         return new PullRequestCheckIssueVisitor(checks);
     }
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
@@ -126,7 +126,7 @@ public class IntegrateCommand implements CommandHandler {
 
             var localHash = checkablePr.commit(rebasedHash.get(), censusInstance.namespace(), censusInstance.configuration().census().domain(), null);
 
-            var issues = checkablePr.createVisitor(localHash, censusInstance);
+            var issues = checkablePr.createVisitor(localHash);
             var additionalConfiguration = AdditionalConfiguration.get(localRepo, localHash, pr.repository().forge().currentUser(), allComments);
             checkablePr.executeChecks(localHash, censusInstance, issues, additionalConfiguration);
             if (!issues.messages().isEmpty()) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
@@ -112,7 +112,7 @@ public class SponsorCommand implements CommandHandler {
             var localHash = checkablePr.commit(rebasedHash.get(), censusInstance.namespace(), censusInstance.configuration().census().domain(),
                     command.user().id());
 
-            var issues = checkablePr.createVisitor(localHash, censusInstance);
+            var issues = checkablePr.createVisitor(localHash);
             var additionalConfiguration = AdditionalConfiguration.get(localRepo, localHash, pr.repository().forge().currentUser(), allComments);
             checkablePr.executeChecks(localHash, censusInstance, issues, additionalConfiguration);
             if (!issues.messages().isEmpty()) {

--- a/cli/src/main/java/org/openjdk/skara/cli/GitJCheck.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitJCheck.java
@@ -201,22 +201,9 @@ public class GitJCheck {
         }
 
         var endpoint = getOption("census", arguments);
-        if (endpoint == null) {
-            try {
-                var conf = JCheckConfiguration.from(repo, repo.head());
-                if (conf.isPresent()) {
-                    endpoint = conf.get().census().url().toString();
-                }
-            } catch (IOException e) {
-                // pass
-            }
-        }
-        if (endpoint == null) {
-            endpoint = "https://openjdk.java.net/census.xml";
-        }
-        var census = endpoint.startsWith("http://") || endpoint.startsWith("https://") ?
-            Census.from(URI.create(endpoint)) :
-            Census.parse(Path.of(endpoint));
+        var census = endpoint == null ? null :
+            endpoint.startsWith("http://") || endpoint.startsWith("https://") ?
+                Census.from(URI.create(endpoint)) : Census.parse(Path.of(endpoint));
 
         var ignore = new HashSet<String>();
         var ignoreOption = getOption("ignore", arguments);

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/AuthorCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/AuthorCheck.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.skara.jcheck;
 
+import org.openjdk.skara.census.Census;
 import org.openjdk.skara.vcs.Commit;
 import org.openjdk.skara.vcs.openjdk.CommitMessage;
 
@@ -32,7 +33,7 @@ public class AuthorCheck extends CommitCheck {
     private final Logger log = Logger.getLogger("org.openjdk.skara.jcheck.author");
 
     @Override
-    Iterator<Issue> check(Commit commit, CommitMessage message, JCheckConfiguration conf) {
+    Iterator<Issue> check(Commit commit, CommitMessage message, JCheckConfiguration conf, Census census) {
         var metadata = CommitIssue.metadata(commit, message, conf, this);
 
         var author = commit.author();

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/BinaryCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/BinaryCheck.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.skara.jcheck;
 
+import org.openjdk.skara.census.Census;
 import org.openjdk.skara.vcs.Commit;
 import org.openjdk.skara.vcs.openjdk.CommitMessage;
 
@@ -33,7 +34,7 @@ public class BinaryCheck extends CommitCheck {
     private final Logger log = Logger.getLogger("org.openjdk.skara.jcheck.binary");
 
     @Override
-    Iterator<Issue> check(Commit commit, CommitMessage message, JCheckConfiguration conf) {
+    Iterator<Issue> check(Commit commit, CommitMessage message, JCheckConfiguration conf, Census census) {
         var metadata = CommitIssue.metadata(commit, message, conf, this);
 
         var issues = new ArrayList<Issue>();

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/CommitCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/CommitCheck.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.skara.jcheck;
 
+import org.openjdk.skara.census.Census;
 import org.openjdk.skara.vcs.openjdk.CommitMessage;
 import org.openjdk.skara.vcs.Commit;
 
@@ -29,7 +30,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 
 abstract class CommitCheck implements Check {
-    abstract Iterator<Issue> check(Commit commit, CommitMessage message, JCheckConfiguration conf);
+    abstract Iterator<Issue> check(Commit commit, CommitMessage message, JCheckConfiguration conf, Census census);
 
     protected Iterator<Issue> iterator(Issue... issues) {
         return Arrays.asList(issues).iterator();

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/CommitterCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/CommitterCheck.java
@@ -33,13 +33,8 @@ import java.util.logging.Logger;
 
 public class CommitterCheck extends CommitCheck {
     private final Logger log = Logger.getLogger("org.openjdk.skara.jcheck.committer");
-    private final Census census;
 
-    CommitterCheck(Census census) {
-        this.census = census;
-    }
-
-    private boolean hasRole(Project project, String role, String username, int version) {
+    private boolean hasRole(Census census, Project project, String role, String username, int version) {
         switch (role) {
             case "lead":
                 return project.isLead(username, version);
@@ -58,7 +53,7 @@ public class CommitterCheck extends CommitCheck {
 
 
     @Override
-    Iterator<Issue> check(Commit commit, CommitMessage message, JCheckConfiguration conf) {
+    Iterator<Issue> check(Commit commit, CommitMessage message, JCheckConfiguration conf, Census census) {
         var issues = new ArrayList<Issue>();
         var project = census.project(conf.general().project());
         var version = conf.census().version();
@@ -81,7 +76,7 @@ public class CommitterCheck extends CommitCheck {
                 committer.name() : committer.email().split("@")[0];
             var allowedToMerge = conf.checks().committer().allowedToMerge();
             if (!commit.isMerge() || !allowedToMerge.contains(username)) {
-                if (!hasRole(project, role, username, version)) {
+                if (!hasRole(census, project, role, username, version)) {
                     log.finer("issue: committer does not have role " + role);
                     issues.add(new CommitterIssue(project, metadata));
                 }

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/DuplicateIssuesCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/DuplicateIssuesCheck.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.skara.jcheck;
 
+import org.openjdk.skara.census.Census;
 import org.openjdk.skara.vcs.Commit;
 import org.openjdk.skara.vcs.Hash;
 import org.openjdk.skara.vcs.ReadOnlyRepository;
@@ -60,7 +61,7 @@ public class DuplicateIssuesCheck extends CommitCheck {
     }
 
     @Override
-    Iterator<org.openjdk.skara.jcheck.Issue> check(Commit commit, CommitMessage message, JCheckConfiguration conf) {
+    Iterator<org.openjdk.skara.jcheck.Issue> check(Commit commit, CommitMessage message, JCheckConfiguration conf, Census census) {
         try {
             if (issuesToHashes == null) {
                 populateIssuesToHashesMap();

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/ExecutableCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/ExecutableCheck.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.skara.jcheck;
 
+import org.openjdk.skara.census.Census;
 import org.openjdk.skara.vcs.Commit;
 import org.openjdk.skara.vcs.openjdk.CommitMessage;
 
@@ -33,7 +34,7 @@ public class ExecutableCheck extends CommitCheck {
     private final Logger log = Logger.getLogger("org.openjdk.skara.jcheck.executable");
 
     @Override
-    Iterator<Issue> check(Commit commit, CommitMessage message, JCheckConfiguration conf) {
+    Iterator<Issue> check(Commit commit, CommitMessage message, JCheckConfiguration conf, Census census) {
         var metadata = CommitIssue.metadata(commit, message, conf, this);
 
         var issues = new ArrayList<Issue>();

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/HgTagCommitCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/HgTagCommitCheck.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.skara.jcheck;
 
+import org.openjdk.skara.census.Census;
 import org.openjdk.skara.vcs.Commit;
 import org.openjdk.skara.vcs.openjdk.CommitMessage;
 
@@ -38,7 +39,7 @@ public class HgTagCommitCheck extends CommitCheck {
     }
 
     @Override
-    Iterator<Issue> check(Commit commit, CommitMessage message, JCheckConfiguration conf) {
+    Iterator<Issue> check(Commit commit, CommitMessage message, JCheckConfiguration conf, Census census) {
         if (commit.isMerge() || !utils.addsHgTag(commit)) {
             return iterator();
         }

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/IssuesCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/IssuesCheck.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.skara.jcheck;
 
+import org.openjdk.skara.census.Census;
 import org.openjdk.skara.vcs.Commit;
 import org.openjdk.skara.vcs.openjdk.CommitMessage;
 
@@ -38,7 +39,7 @@ public class IssuesCheck extends CommitCheck {
     }
 
     @Override
-    Iterator<Issue> check(Commit commit, CommitMessage message, JCheckConfiguration conf) {
+    Iterator<Issue> check(Commit commit, CommitMessage message, JCheckConfiguration conf, Census census) {
         if (commit.isMerge() || utils.addsHgTag(commit)) {
             return iterator();
         }

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/MergeMessageCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/MergeMessageCheck.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.skara.jcheck;
 
+import org.openjdk.skara.census.Census;
 import org.openjdk.skara.vcs.Commit;
 import org.openjdk.skara.vcs.openjdk.CommitMessage;
 
@@ -32,7 +33,7 @@ import java.util.regex.Pattern;
 public class MergeMessageCheck extends CommitCheck {
     private final Logger log = Logger.getLogger("org.openjdk.skara.jcheck.merge");
     @Override
-    Iterator<Issue> check(Commit commit, CommitMessage message, JCheckConfiguration conf) {
+    Iterator<Issue> check(Commit commit, CommitMessage message, JCheckConfiguration conf, Census census) {
         if (!commit.isMerge()) {
             return iterator();
         }

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/MessageCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/MessageCheck.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.skara.jcheck;
 
+import org.openjdk.skara.census.Census;
 import org.openjdk.skara.vcs.Commit;
 import org.openjdk.skara.vcs.openjdk.CommitMessage;
 
@@ -38,7 +39,7 @@ public class MessageCheck extends CommitCheck {
     }
 
     @Override
-    Iterator<Issue> check(Commit commit, CommitMessage message, JCheckConfiguration conf) {
+    Iterator<Issue> check(Commit commit, CommitMessage message, JCheckConfiguration conf, Census census) {
         var issues = new ArrayList<Issue>();
         if (commit.isMerge() || utils.addsHgTag(commit)) {
             return issues.iterator();

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/ProblemListsCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/ProblemListsCheck.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.skara.jcheck;
 
+import org.openjdk.skara.census.Census;
 import org.openjdk.skara.vcs.Commit;
 import org.openjdk.skara.vcs.FileEntry;
 import org.openjdk.skara.vcs.Hash;
@@ -66,7 +67,7 @@ public class ProblemListsCheck extends CommitCheck {
     }
 
     @Override
-    Iterator<Issue> check(Commit commit, CommitMessage message, JCheckConfiguration conf) {
+    Iterator<Issue> check(Commit commit, CommitMessage message, JCheckConfiguration conf, Census census) {
         var problemListed = new HashMap<String, List<Path>>();
         var checkConf = conf.checks().problemlists();
         var dirs = checkConf.dirs();

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/ReviewersCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/ReviewersCheck.java
@@ -37,11 +37,9 @@ import java.util.logging.Logger;
 
 public class ReviewersCheck extends CommitCheck {
     private final Logger log = Logger.getLogger("org.openjdk.skara.jcheck.reviewers");
-    private final Census census;
     private final Utilities utils;
 
-    ReviewersCheck(Census census, Utilities utils) {
-        this.census = census;
+    ReviewersCheck(Utilities utils) {
         this.utils = utils;
     }
 
@@ -67,7 +65,7 @@ public class ReviewersCheck extends CommitCheck {
     }
 
     @Override
-    Iterator<Issue> check(Commit commit, CommitMessage message, JCheckConfiguration conf) {
+    Iterator<Issue> check(Commit commit, CommitMessage message, JCheckConfiguration conf, Census census) {
         if (commit.isMerge() || utils.addsHgTag(commit)) {
             return iterator();
         }

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/SymlinkCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/SymlinkCheck.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.skara.jcheck;
 
+import org.openjdk.skara.census.Census;
 import org.openjdk.skara.vcs.Commit;
 import org.openjdk.skara.vcs.openjdk.CommitMessage;
 
@@ -33,7 +34,7 @@ public class SymlinkCheck extends CommitCheck {
     private final Logger log = Logger.getLogger("org.openjdk.skara.jcheck.symlink");
 
     @Override
-    Iterator<Issue> check(Commit commit, CommitMessage message, JCheckConfiguration conf) {
+    Iterator<Issue> check(Commit commit, CommitMessage message, JCheckConfiguration conf, Census census) {
         var metadata = CommitIssue.metadata(commit, message, conf, this);
 
         var issues = new ArrayList<Issue>();

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/WhitespaceCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/WhitespaceCheck.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.skara.jcheck;
 
+import org.openjdk.skara.census.Census;
 import org.openjdk.skara.vcs.Commit;
 import org.openjdk.skara.vcs.openjdk.CommitMessage;
 
@@ -36,7 +37,7 @@ public class WhitespaceCheck extends CommitCheck {
     private final Logger log = Logger.getLogger("org.openjdk.skara.jcheck.whitespace");
 
     @Override
-    Iterator<Issue> check(Commit commit, CommitMessage message, JCheckConfiguration conf) {
+    Iterator<Issue> check(Commit commit, CommitMessage message, JCheckConfiguration conf, Census census) {
         var metadata = CommitIssue.metadata(commit, message, conf, this);
         var issues = new ArrayList<Issue>();
         var pattern = Pattern.compile(conf.checks().whitespace().files());

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/AuthorCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/AuthorCheckTests.java
@@ -69,7 +69,7 @@ class AuthorCheckTests {
         var author = new Author("Foo", "foo@localhost");
         var commit = commit(author);
         var check = new AuthorCheck();
-        var issues = toList(check.check(commit, message(commit), conf));
+        var issues = toList(check.check(commit, message(commit), conf, null));
         assertEquals(0, issues.size());
     }
 
@@ -79,7 +79,7 @@ class AuthorCheckTests {
         var commit = commit(author);
         var message = message(commit);
         var check = new AuthorCheck();
-        var issues = toList(check.check(commit, message, conf));
+        var issues = toList(check.check(commit, message, conf, null));
 
         assertEquals(1, issues.size());
         assertTrue(issues.get(0) instanceof AuthorNameIssue);
@@ -96,7 +96,7 @@ class AuthorCheckTests {
         var commit = commit(author);
         var message = message(commit);
         var check = new AuthorCheck();
-        var issues = toList(check.check(commit, message, conf));
+        var issues = toList(check.check(commit, message, conf, null));
 
         assertEquals(1, issues.size());
         assertTrue(issues.get(0) instanceof AuthorNameIssue);
@@ -113,7 +113,7 @@ class AuthorCheckTests {
         var commit = commit(author);
         var message = message(commit);
         var check = new AuthorCheck();
-        var issues = toList(check.check(commit, message, conf));
+        var issues = toList(check.check(commit, message, conf, null));
 
         assertEquals(1, issues.size());
         assertTrue(issues.get(0) instanceof AuthorEmailIssue);
@@ -130,7 +130,7 @@ class AuthorCheckTests {
         var commit = commit(author);
         var message = message(commit);
         var check = new AuthorCheck();
-        var issues = toList(check.check(commit, message, conf));
+        var issues = toList(check.check(commit, message, conf, null));
 
         assertEquals(1, issues.size());
         assertTrue(issues.get(0) instanceof AuthorEmailIssue);

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/BinaryCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/BinaryCheckTests.java
@@ -81,7 +81,7 @@ class BinaryCheckTests {
         var commit = commit(textualParentDiffs("README", "100644"));
         var message = message(commit);
         var check = new BinaryCheck();
-        var issues = toList(check.check(commit, message, conf));
+        var issues = toList(check.check(commit, message, conf, null));
         assertEquals(0, issues.size());
     }
 
@@ -95,7 +95,7 @@ class BinaryCheckTests {
         var commit = commit(List.of(diff));
         var message = message(commit);
         var check = new BinaryCheck();
-        var issues = toList(check.check(commit, message, conf));
+        var issues = toList(check.check(commit, message, conf, null));
         assertEquals(1, issues.size());
         assertTrue(issues.get(0) instanceof BinaryIssue);
         var issue = (BinaryIssue) issues.get(0);

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/CommitterCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/CommitterCheckTests.java
@@ -117,8 +117,8 @@ class CommitterCheckTests {
     void authorIsLeadShouldPass() throws IOException {
         var author = new Author("Foo", "foo@localhost");
         var commit = commit(author, author);
-        var check = new CommitterCheck(census());
-        var issues = toList(check.check(commit, message(commit), conf()));
+        var check = new CommitterCheck();
+        var issues = toList(check.check(commit, message(commit), conf(), census()));
         assertEquals(0, issues.size());
     }
 
@@ -126,8 +126,8 @@ class CommitterCheckTests {
     void authorIsCommitterShouldPass() throws IOException {
         var author = new Author("Bar", "bar@localhost");
         var commit = commit(author, author);
-        var check = new CommitterCheck(census());
-        var issues = toList(check.check(commit, message(commit), conf()));
+        var check = new CommitterCheck();
+        var issues = toList(check.check(commit, message(commit), conf(), census()));
         assertEquals(0, issues.size());
     }
 
@@ -136,8 +136,8 @@ class CommitterCheckTests {
         var author = new Author("Baz", "baz@localhost");
         var commit = commit(author, author);
         var message = message(commit);
-        var check = new CommitterCheck(census());
-        var issues = toList(check.check(commit, message, conf()));
+        var check = new CommitterCheck();
+        var issues = toList(check.check(commit, message, conf(), census()));
 
         assertEquals(1, issues.size());
         var issue = issues.get(0);
@@ -156,8 +156,8 @@ class CommitterCheckTests {
         var committer = new Author("Bar", "bar@host.org");
         var commit = commit(author, committer);
         var message = message(commit);
-        var check = new CommitterCheck(census());
-        var issues = toList(check.check(commit, message, conf()));
+        var check = new CommitterCheck();
+        var issues = toList(check.check(commit, message, conf(), census()));
 
         assertEquals(1, issues.size());
         var issue = issues.get(0);
@@ -176,8 +176,8 @@ class CommitterCheckTests {
         var committer = new Author("bar", "bar@localhost");
         var commit = commit(author, committer);
         var message = message(commit);
-        var check = new CommitterCheck(census());
-        var issues = toList(check.check(commit, message, conf()));
+        var check = new CommitterCheck();
+        var issues = toList(check.check(commit, message, conf(), census()));
         assertEquals(0, issues.size());
     }
 
@@ -187,8 +187,8 @@ class CommitterCheckTests {
         var committer = new Author("Baz", "baz@localhost");
         var commit = commit(author, committer);
         var message = message(commit);
-        var check = new CommitterCheck(census());
-        var issues = toList(check.check(commit, message, conf()));
+        var check = new CommitterCheck();
+        var issues = toList(check.check(commit, message, conf(), census()));
 
         assertEquals(1, issues.size());
         var issue = issues.get(0);
@@ -207,8 +207,8 @@ class CommitterCheckTests {
         var committer = new Author("", "baz@localhost");
         var commit = commit(author, committer);
         var message = message(commit);
-        var check = new CommitterCheck(census());
-        var issues = toList(check.check(commit, message, conf()));
+        var check = new CommitterCheck();
+        var issues = toList(check.check(commit, message, conf(), census()));
 
         assertEquals(2, issues.size());
         assertTrue(issues.get(0) instanceof CommitterNameIssue);
@@ -225,8 +225,8 @@ class CommitterCheckTests {
         var committer = new Author("Baz", "");
         var commit = commit(author, committer);
         var message = message(commit);
-        var check = new CommitterCheck(census());
-        var issues = toList(check.check(commit, message, conf()));
+        var check = new CommitterCheck();
+        var issues = toList(check.check(commit, message, conf(), census()));
 
         assertEquals(2, issues.size());
         assertTrue(issues.get(0) instanceof CommitterEmailIssue);
@@ -243,17 +243,17 @@ class CommitterCheckTests {
         var committer = new Author("baz", "baz@localhost");
         var commit = mergeCommit(author, committer);
         var message = message(commit);
-        var check = new CommitterCheck(census());
-        var issues = toList(check.check(commit, message, conf()));
+        var check = new CommitterCheck();
+        var issues = toList(check.check(commit, message, conf(), census()));
 
         assertEquals(1, issues.size());
         assertTrue(issues.get(0) instanceof CommitterIssue);
 
-        check = new CommitterCheck(census());
+        check = new CommitterCheck();
         var text = new ArrayList<>(CONFIGURATION);
         text.addAll(List.of("[checks \"committer\"]", "allowed-to-merge=baz"));
         var conf = JCheckConfiguration.parse(text);
-        issues = toList(check.check(commit, message, conf));
+        issues = toList(check.check(commit, message, conf, census()));
         assertEquals(List.of(), issues);
     }
 
@@ -263,11 +263,11 @@ class CommitterCheckTests {
         var committer = new Author("baz", "baz@localhost");
         var commit = commit(author, committer);
         var message = message(commit);
-        var check = new CommitterCheck(census());
+        var check = new CommitterCheck();
         var text = new ArrayList<>(CONFIGURATION);
         text.addAll(List.of("[checks \"committer\"]", "allowed-to-merge=baz"));
         var conf = JCheckConfiguration.parse(text);
-        var issues = toList(check.check(commit, message, conf));
+        var issues = toList(check.check(commit, message, conf, census()));
 
         assertEquals(1, issues.size());
         assertTrue(issues.get(0) instanceof CommitterIssue);

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/DuplicateIssuesCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/DuplicateIssuesCheckTests.java
@@ -77,7 +77,7 @@ class DuplicateIssuesCheckTests {
             var check = new DuplicateIssuesCheck(r);
 
             var commit = r.lookup(third).orElseThrow();
-            var issues = toList(check.check(commit, message(commit), conf()));
+            var issues = toList(check.check(commit, message(commit), conf(), null));
             assertEquals(List.of(), issues);
         }
     }
@@ -103,7 +103,7 @@ class DuplicateIssuesCheckTests {
             var check = new DuplicateIssuesCheck(r);
 
             var commit = r.lookup(third).orElseThrow();
-            var issues = toList(check.check(commit, message(commit), conf()));
+            var issues = toList(check.check(commit, message(commit), conf(), null));
             assertEquals(2, issues.size());
             assertTrue(issues.get(0) instanceof DuplicateIssuesIssue);
             var issue = (DuplicateIssuesIssue) issues.get(0);
@@ -132,7 +132,7 @@ class DuplicateIssuesCheckTests {
 
             var check = new DuplicateIssuesCheck(r);
             var commit = r.lookup(third).orElseThrow();
-            var issues = toList(check.check(commit, message(commit), conf()));
+            var issues = toList(check.check(commit, message(commit), conf(), null));
             assertEquals(1, issues.size());
             assertTrue(issues.get(0) instanceof DuplicateIssuesIssue);
             var issue = (DuplicateIssuesIssue) issues.get(0);

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/ExecutableCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/ExecutableCheckTests.java
@@ -82,7 +82,7 @@ class ExecutableCheckTests {
         var commit = commit(parentDiffs("README", "100644"));
         var message = message(commit);
         var check = new ExecutableCheck();
-        var issues = toList(check.check(commit, message, conf));
+        var issues = toList(check.check(commit, message, conf, null));
         assertEquals(0, issues.size());
     }
 
@@ -91,7 +91,7 @@ class ExecutableCheckTests {
         var commit = commit(parentDiffs("README", "100755"));
         var message = message(commit);
         var check = new ExecutableCheck();
-        var issues = toList(check.check(commit, message, conf));
+        var issues = toList(check.check(commit, message, conf, null));
         assertEquals(1, issues.size());
         assertTrue(issues.get(0) instanceof ExecutableIssue);
         var issue = (ExecutableIssue) issues.get(0);

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/HgTagCommitCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/HgTagCommitCheckTests.java
@@ -96,7 +96,7 @@ class HgTagCommitCheckTests {
         var lines = List.of("Added tag " + tag + " for changeset " + targetHash);
         var commit = commit(new Hash(commitHash), lines, diffs);
         var check = new HgTagCommitCheck(new Utilities());
-        var issues = toList(check.check(commit, message(commit), conf));
+        var issues = toList(check.check(commit, message(commit), conf, null));
         assertEquals(0, issues.size());
     }
 
@@ -104,7 +104,7 @@ class HgTagCommitCheckTests {
     void commitThatDoesNotAddTagShouldPass() {
         var commit = commit(Hash.zero(), List.of(), List.of());
         var check = new HgTagCommitCheck(new Utilities());
-        var issues = toList(check.check(commit, message(commit), conf));
+        var issues = toList(check.check(commit, message(commit), conf, null));
         assertEquals(0, issues.size());
     }
 
@@ -112,7 +112,7 @@ class HgTagCommitCheckTests {
     void mergeCommitShouldPass() {
         var commit = mergeCommit();
         var check = new HgTagCommitCheck(new Utilities());
-        var issues = toList(check.check(commit, message(commit), conf));
+        var issues = toList(check.check(commit, message(commit), conf, null));
         assertEquals(0, issues.size());
     }
 
@@ -125,7 +125,7 @@ class HgTagCommitCheckTests {
         var lines = List.of("Added tag " + tag + " for changeset " + targetHash, "Another line");
         var commit = commit(new Hash(commitHash), lines, diffs);
         var check = new HgTagCommitCheck(new Utilities());
-        var issues = toList(check.check(commit, message(commit), conf));
+        var issues = toList(check.check(commit, message(commit), conf, null));
 
         assertEquals(1, issues.size());
         assertTrue(issues.get(0) instanceof HgTagCommitIssue);
@@ -145,7 +145,7 @@ class HgTagCommitCheckTests {
         var lines = List.of("I want tag " + tag + " for commit " + targetHash);
         var commit = commit(new Hash(commitHash), lines, diffs);
         var check = new HgTagCommitCheck(new Utilities());
-        var issues = toList(check.check(commit, message(commit), conf));
+        var issues = toList(check.check(commit, message(commit), conf, null));
 
         assertEquals(1, issues.size());
         assertTrue(issues.get(0) instanceof HgTagCommitIssue);
@@ -179,7 +179,7 @@ class HgTagCommitCheckTests {
         var commit = commit(new Hash(commitHash), lines, diffs);
 
         var check = new HgTagCommitCheck(new Utilities());
-        var issues = toList(check.check(commit, message(commit), conf));
+        var issues = toList(check.check(commit, message(commit), conf, null));
 
         assertEquals(1, issues.size());
         assertTrue(issues.get(0) instanceof HgTagCommitIssue);
@@ -210,7 +210,7 @@ class HgTagCommitCheckTests {
         var commit = commit(new Hash(commitHash), lines, diffs);
 
         var check = new HgTagCommitCheck(new Utilities());
-        var issues = toList(check.check(commit, message(commit), conf));
+        var issues = toList(check.check(commit, message(commit), conf, null));
 
         assertEquals(1, issues.size());
         assertTrue(issues.get(0) instanceof HgTagCommitIssue);
@@ -230,7 +230,7 @@ class HgTagCommitCheckTests {
         var lines = List.of("Added tag skara-11+23 for changeset " + targetHash);
         var commit = commit(new Hash(commitHash), lines, diffs);
         var check = new HgTagCommitCheck(new Utilities());
-        var issues = toList(check.check(commit, message(commit), conf));
+        var issues = toList(check.check(commit, message(commit), conf, null));
 
         assertEquals(1, issues.size());
         assertTrue(issues.get(0) instanceof HgTagCommitIssue);

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/IssuesCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/IssuesCheckTests.java
@@ -103,7 +103,7 @@ class IssuesCheckTests {
         var commit = commit(List.of("Bugfix"));
         var message = message(commit);
         var check = new IssuesCheck(utils);
-        var issues = toList(check.check(commit, message, conf()));
+        var issues = toList(check.check(commit, message, conf(), null));
 
         assertEquals(1, issues.size());
         assertTrue(issues.get(0) instanceof IssuesIssue);
@@ -118,7 +118,7 @@ class IssuesCheckTests {
     void singleIssueReferenceShouldPass() {
         var commit = commit(List.of("1234570: A bug"));
         var check = new IssuesCheck(utils);
-        var issues = toList(check.check(commit, message(commit), conf()));
+        var issues = toList(check.check(commit, message(commit), conf(), null));
         assertEquals(0, issues.size());
     }
 
@@ -127,7 +127,7 @@ class IssuesCheckTests {
         var commit = commit(List.of("1234570: A bug", "1234567: Another bug"));
         var message = message(commit);
         var check = new IssuesCheck(utils);
-        var issues = toList(check.check(commit, message, conf()));
+        var issues = toList(check.check(commit, message, conf(), null));
         assertEquals(0, issues.size());
     }
 
@@ -136,7 +136,7 @@ class IssuesCheckTests {
         var commit = commit(List.of("0123456: A bug"));
         var message = message(commit);
         var check = new IssuesCheck(utils);
-        var issues = toList(check.check(commit, message, conf()));
+        var issues = toList(check.check(commit, message, conf(), null));
 
         assertEquals(0, issues.size());
     }
@@ -146,7 +146,7 @@ class IssuesCheckTests {
         var commit = commit(List.of("123456: A bug"));
         var message = message(commit);
         var check = new IssuesCheck(utils);
-        var issues = toList(check.check(commit, message, conf()));
+        var issues = toList(check.check(commit, message, conf(), null));
 
         assertEquals(0, issues.size());
     }
@@ -156,7 +156,7 @@ class IssuesCheckTests {
         var commit = commit(List.of("12345678: A bug"));
         var message = message(commit);
         var check = new IssuesCheck(utils);
-        var issues = toList(check.check(commit, message, conf()));
+        var issues = toList(check.check(commit, message, conf(), null));
 
         assertEquals(0, issues.size());
     }
@@ -166,7 +166,7 @@ class IssuesCheckTests {
         var commit = commit(List.of("JDK-7654321: A bug"));
         var message = message(commit);
         var check = new IssuesCheck(utils);
-        var issues = toList(check.check(commit, message, conf()));
+        var issues = toList(check.check(commit, message, conf(), null));
 
         assertEquals(0, issues.size());
     }
@@ -176,7 +176,7 @@ class IssuesCheckTests {
         var commit = commit(List.of("PROJ-1234567: A bug"));
         var message = message(commit);
         var check = new IssuesCheck(utils);
-        var issues = toList(check.check(commit, message, conf2()));
+        var issues = toList(check.check(commit, message, conf2(), null));
 
         assertEquals(0, issues.size());
     }
@@ -186,7 +186,7 @@ class IssuesCheckTests {
         var commit = commit(List.of("1234567: A bug"));
         var message = message(commit);
         var check = new IssuesCheck(utils);
-        var issues = toList(check.check(commit, message, conf2()));
+        var issues = toList(check.check(commit, message, conf2(), null));
 
         assertEquals(1, issues.size());
         assertTrue(issues.get(0) instanceof IssuesIssue);
@@ -202,7 +202,7 @@ class IssuesCheckTests {
         var commit = commit(List.of("JDK-1234567: A bug"));
         var message = message(commit);
         var check = new IssuesCheck(utils);
-        var issues = toList(check.check(commit, message, conf2()));
+        var issues = toList(check.check(commit, message, conf2(), null));
 
         assertEquals(1, issues.size());
         assertTrue(issues.get(0) instanceof IssuesIssue);
@@ -217,7 +217,7 @@ class IssuesCheckTests {
     void singleIssueReferenceConf3ShouldPass() {
         var commit = commit(List.of("1234570: A bug"));
         var check = new IssuesCheck(utils);
-        var issues = toList(check.check(commit, message(commit), conf3()));
+        var issues = toList(check.check(commit, message(commit), conf3(), null));
         assertEquals(0, issues.size());
     }
 
@@ -226,7 +226,7 @@ class IssuesCheckTests {
         var commit = commit(List.of("1234570: A bug", "1234567: Another bug"));
         var message = message(commit);
         var check = new IssuesCheck(utils);
-        var issues = toList(check.check(commit, message, conf3()));
+        var issues = toList(check.check(commit, message, conf3(), null));
         assertEquals(0, issues.size());
     }
 
@@ -235,7 +235,7 @@ class IssuesCheckTests {
         var commit = commit(List.of("0123456: A bug"));
         var message = message(commit);
         var check = new IssuesCheck(utils);
-        var issues = toList(check.check(commit, message, conf3()));
+        var issues = toList(check.check(commit, message, conf3(), null));
 
         assertEquals(1, issues.size());
         assertTrue(issues.get(0) instanceof IssuesIssue);
@@ -251,7 +251,7 @@ class IssuesCheckTests {
         var commit = commit(List.of("9876543: A bug"));
         var message = message(commit);
         var check = new IssuesCheck(utils);
-        var issues = toList(check.check(commit, message, conf3()));
+        var issues = toList(check.check(commit, message, conf3(), null));
 
         assertEquals(1, issues.size());
         assertTrue(issues.get(0) instanceof IssuesIssue);
@@ -267,7 +267,7 @@ class IssuesCheckTests {
         var commit = commit(List.of("123456: A bug"));
         var message = message(commit);
         var check = new IssuesCheck(utils);
-        var issues = toList(check.check(commit, message, conf3()));
+        var issues = toList(check.check(commit, message, conf3(), null));
 
         assertEquals(1, issues.size());
         assertTrue(issues.get(0) instanceof IssuesIssue);
@@ -283,7 +283,7 @@ class IssuesCheckTests {
         var commit = commit(List.of("12345678: A bug"));
         var message = message(commit);
         var check = new IssuesCheck(utils);
-        var issues = toList(check.check(commit, message, conf3()));
+        var issues = toList(check.check(commit, message, conf3(), null));
 
         assertEquals(1, issues.size());
         assertTrue(issues.get(0) instanceof IssuesIssue);
@@ -299,7 +299,7 @@ class IssuesCheckTests {
         var commit = commit(List.of("JDK-7654321: A bug"));
         var message = message(commit);
         var check = new IssuesCheck(utils);
-        var issues = toList(check.check(commit, message, conf3()));
+        var issues = toList(check.check(commit, message, conf3(), null));
 
         assertEquals(1, issues.size());
         assertTrue(issues.get(0) instanceof IssuesIssue);
@@ -315,7 +315,7 @@ class IssuesCheckTests {
         var commit = commit(List.of("12345: A bug", "1234567: Another bug"));
         var message = message(commit);
         var check = new IssuesCheck(utils);
-        var issues = toList(check.check(commit, message, conf3()));
+        var issues = toList(check.check(commit, message, conf3(), null));
 
         assertEquals(1, issues.size());
         assertTrue(issues.get(0) instanceof IssuesIssue);
@@ -331,7 +331,7 @@ class IssuesCheckTests {
         var commit = commit(List.of("1234567: A bug", "012: Another bug"));
         var message = message(commit);
         var check = new IssuesCheck(utils);
-        var issues = toList(check.check(commit, message, conf3()));
+        var issues = toList(check.check(commit, message, conf3(), null));
 
         assertEquals(1, issues.size());
         assertTrue(issues.get(0) instanceof IssuesIssue);

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/JCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/JCheckTests.java
@@ -260,12 +260,7 @@ class JCheckTests {
             repo.add(readme);
             var first = repo.commit("Add README", "duke", "duke@openjdk.java.net");
 
-            var censusPath = dir.path().resolve("census");
-            Files.createDirectories(censusPath);
-            CensusCreator.populateCensusDirectory(censusPath);
-            var census = Census.parse(censusPath);
-
-            var checks = JCheck.checksFor(repo, census, first);
+            var checks = JCheck.checksFor(repo, first);
             var checkNames = checks.stream()
                                    .map(Check::name)
                                    .collect(Collectors.toSet());

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/MergeMessageCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/MergeMessageCheckTests.java
@@ -78,7 +78,7 @@ class MergeMessageCheckTests {
         var commit = commit(List.of("Merge"));
         var message = message(commit);
         var check = new MergeMessageCheck();
-        var issues = toList(check.check(commit, message, conf()));
+        var issues = toList(check.check(commit, message, conf(), null));
         assertEquals(0, issues.size());
     }
 
@@ -87,7 +87,7 @@ class MergeMessageCheckTests {
         var commit = commit(List.of("Work"));
         var message = message(commit);
         var check = new MergeMessageCheck();
-        var issues = toList(check.check(commit, message, conf()));
+        var issues = toList(check.check(commit, message, conf(), null));
 
         assertEquals(1, issues.size());
         assertTrue(issues.get(0) instanceof MergeMessageIssue);
@@ -98,7 +98,7 @@ class MergeMessageCheckTests {
         var commit = commit(List.of("Merge", "", "This is a summary"));
         var message = message(commit);
         var check = new MergeMessageCheck();
-        var issues = toList(check.check(commit, message, conf()));
+        var issues = toList(check.check(commit, message, conf(), null));
 
         assertEquals(1, issues.size());
         assertTrue(issues.get(0) instanceof MergeMessageIssue);
@@ -111,7 +111,7 @@ class MergeMessageCheckTests {
         var check = new MergeMessageCheck();
         var conf = new ArrayList<>(CONFIGURATION);
         conf.set(conf.size() - 1, "message = Merge \\'[a-z]+\\' into \\'[a-z]+\\'");
-        var issues = toList(check.check(commit, message, JCheckConfiguration.parse(conf)));
+        var issues = toList(check.check(commit, message, JCheckConfiguration.parse(conf), null));
 
         assertEquals(List.of(), issues);
     }

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/MessageCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/MessageCheckTests.java
@@ -77,7 +77,7 @@ class MessageCheckTests {
     void titleOnlyMessageShouldPass() {
         var commit = commit(List.of("Bugfix"));
         var check = new MessageCheck(utils);
-        var issues = toList(check.check(commit, message(commit), conf()));
+        var issues = toList(check.check(commit, message(commit), conf(), null));
         assertEquals(0, issues.size());
     }
 
@@ -86,7 +86,7 @@ class MessageCheckTests {
         var commit = commit(new ArrayList<String>());
         var message = message(commit);
         var check = new MessageCheck(utils);
-        var issues = toList(check.check(commit, message, conf()));
+        var issues = toList(check.check(commit, message, conf(), null));
 
         assertEquals(1, issues.size());
         assertTrue(issues.get(0) instanceof MessageIssue);
@@ -102,7 +102,7 @@ class MessageCheckTests {
         var commit = commit(List.of("Bugfix", "Additional"));
         var message = message(commit);
         var check = new MessageCheck(utils);
-        var issues = toList(check.check(commit, message, conf()));
+        var issues = toList(check.check(commit, message, conf(), null));
 
         assertEquals(1, issues.size());
         assertTrue(issues.get(0) instanceof MessageIssue);
@@ -118,7 +118,7 @@ class MessageCheckTests {
         var commit = commit(List.of("\tBugfix"));
         var message = message(commit);
         var check = new MessageCheck(utils);
-        var issues = toList(check.check(commit, message, conf()));
+        var issues = toList(check.check(commit, message, conf(), null));
 
         assertEquals(1, issues.size());
         assertTrue(issues.get(0) instanceof MessageWhitespaceIssue);
@@ -132,7 +132,7 @@ class MessageCheckTests {
         var commit = commit(List.of("Bugfix\r"));
         var message = message(commit);
         var check = new MessageCheck(utils);
-        var issues = toList(check.check(commit, message, conf()));
+        var issues = toList(check.check(commit, message, conf(), null));
 
         assertEquals(1, issues.size());
         assertTrue(issues.get(0) instanceof MessageWhitespaceIssue);
@@ -146,7 +146,7 @@ class MessageCheckTests {
         var commit = commit(List.of("Bugfix "));
         var message = message(commit);
         var check = new MessageCheck(utils);
-        var issues = toList(check.check(commit, message, conf()));
+        var issues = toList(check.check(commit, message, conf(), null));
 
         assertEquals(1, issues.size());
         assertTrue(issues.get(0) instanceof MessageWhitespaceIssue);

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/ProblemListsCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/ProblemListsCheckTests.java
@@ -174,7 +174,7 @@ class ProblemListsCheckTests {
         var commit = commit(0, "Bugfix");
         var message = message(commit);
         var check = new ProblemListsCheck(REPOSITORY);
-        var issues = toList(check.check(commit, message, conf));
+        var issues = toList(check.check(commit, message, conf, null));
 
         assertEquals(0, issues.size());
     }
@@ -184,7 +184,7 @@ class ProblemListsCheckTests {
         var commit = commit(0, "4: Bugfix");
         var message = message(commit);
         var check = new ProblemListsCheck(REPOSITORY);
-        var issues = toList(check.check(commit, message, conf));
+        var issues = toList(check.check(commit, message, conf, null));
 
         assertEquals(0, issues.size());
     }
@@ -194,7 +194,7 @@ class ProblemListsCheckTests {
         var commit = commit(0, "PROJ-1: Bugfix");
         var message = message(commit);
         var check = new ProblemListsCheck(REPOSITORY);
-        var issues = toList(check.check(commit, message, conf));
+        var issues = toList(check.check(commit, message, conf, null));
 
         assertEquals(0, issues.size());
     }
@@ -204,7 +204,7 @@ class ProblemListsCheckTests {
         var commit = commit(0, "4: Bugfix", "5: Bugfix2");
         var message = message(commit);
         var check = new ProblemListsCheck(REPOSITORY);
-        var issues = toList(check.check(commit, message, conf));
+        var issues = toList(check.check(commit, message, conf, null));
 
         assertEquals(0, issues.size());
     }
@@ -214,7 +214,7 @@ class ProblemListsCheckTests {
         var commit = commit(0, "3: Bugfix");
         var message = message(commit);
         var check = new ProblemListsCheck(REPOSITORY);
-        var issues = toList(check.check(commit, message, conf));
+        var issues = toList(check.check(commit, message, conf, null));
 
         assertEquals(1, issues.size());
         assertTrue(issues.get(0) instanceof ProblemListsIssue);
@@ -228,7 +228,7 @@ class ProblemListsCheckTests {
         var commit = commit(1, "1: Bugfix");
         var message = message(commit);
         var check = new ProblemListsCheck(REPOSITORY);
-        var issues = toList(check.check(commit, message, conf));
+        var issues = toList(check.check(commit, message, conf, null));
 
         assertEquals(0, issues.size());
     }
@@ -240,7 +240,7 @@ class ProblemListsCheckTests {
         {
             var commit = commit(1, "2: Bugfix");
             var message = message(commit);
-            var issues = toList(check.check(commit, message, conf));
+            var issues = toList(check.check(commit, message, conf, null));
 
             assertEquals(1, issues.size());
             assertTrue(issues.get(0) instanceof ProblemListsIssue);
@@ -253,7 +253,7 @@ class ProblemListsCheckTests {
         {
             var commit = commit(2, "2: Bugfix");
             var message = message(commit);
-            var issues = toList(check.check(commit, message, conf));
+            var issues = toList(check.check(commit, message, conf, null));
 
             assertEquals(1, issues.size());
             assertTrue(issues.get(0) instanceof ProblemListsIssue);
@@ -269,7 +269,7 @@ class ProblemListsCheckTests {
         var commit = commit(0, "2: Bugfix", "3: Bugfix2");
         var message = message(commit);
         var check = new ProblemListsCheck(REPOSITORY);
-        var issues = toList(check.check(commit, message, conf));
+        var issues = toList(check.check(commit, message, conf, null));
 
         assertEquals(2, issues.size());
         // assume that issues are in the same order as messages
@@ -288,7 +288,7 @@ class ProblemListsCheckTests {
         var commit = commit(0, "4: Bugfix", "3: Bugfix2");
         var message = message(commit);
         var check = new ProblemListsCheck(REPOSITORY);
-        var issues = toList(check.check(commit, message, conf));
+        var issues = toList(check.check(commit, message, conf, null));
 
         assertEquals(1, issues.size());
         // assume that issues are in the same order as messages
@@ -303,7 +303,7 @@ class ProblemListsCheckTests {
         var commit = commit(0, "PROJ-4: Bugfix");
         var message = message(commit);
         var check = new ProblemListsCheck(REPOSITORY);
-        var issues = toList(check.check(commit, message, conf2));
+        var issues = toList(check.check(commit, message, conf2, null));
 
         assertEquals(0, issues.size());
     }
@@ -313,7 +313,7 @@ class ProblemListsCheckTests {
         var commit = commit(0, "1: Bugfix");
         var message = message(commit);
         var check = new ProblemListsCheck(REPOSITORY);
-        var issues = toList(check.check(commit, message, conf2));
+        var issues = toList(check.check(commit, message, conf2, null));
 
         assertEquals(0, issues.size());
     }
@@ -323,7 +323,7 @@ class ProblemListsCheckTests {
         var commit = commit(0, "PROJ-3: Bugfix");
         var message = message(commit);
         var check = new ProblemListsCheck(REPOSITORY);
-        var issues = toList(check.check(commit, message, conf2));
+        var issues = toList(check.check(commit, message, conf2, null));
 
         assertEquals(1, issues.size());
         assertTrue(issues.get(0) instanceof ProblemListsIssue);
@@ -337,7 +337,7 @@ class ProblemListsCheckTests {
         var commit = commit(1, "PROJ-1: Bugfix");
         var message = message(commit);
         var check = new ProblemListsCheck(REPOSITORY);
-        var issues = toList(check.check(commit, message, conf2));
+        var issues = toList(check.check(commit, message, conf2, null));
 
         assertEquals(0, issues.size());
     }
@@ -349,7 +349,7 @@ class ProblemListsCheckTests {
         {
             var commit = commit(1, "2: Bugfix");
             var message = message(commit);
-            var issues = toList(check.check(commit, message, conf3));
+            var issues = toList(check.check(commit, message, conf3, null));
 
             assertEquals(1, issues.size());
             assertTrue(issues.get(0) instanceof ProblemListsIssue);
@@ -365,7 +365,7 @@ class ProblemListsCheckTests {
         {
             var commit = commit(2, "2: Bugfix");
             var message = message(commit);
-            var issues = toList(check.check(commit, message, conf3));
+            var issues = toList(check.check(commit, message, conf3, null));
 
             assertEquals(1, issues.size());
             assertTrue(issues.get(0) instanceof ProblemListsIssue);
@@ -385,7 +385,7 @@ class ProblemListsCheckTests {
 
         var commit = commit(0, "PROJ-2: Bugfix");
         var message = message(commit);
-        var issues = toList(check.check(commit, message, conf4));
+        var issues = toList(check.check(commit, message, conf4, null));
 
         assertEquals(1, issues.size());
         assertTrue(issues.get(0) instanceof ProblemListsIssue);

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/ReviewersCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/ReviewersCheckTests.java
@@ -159,24 +159,24 @@ class ReviewersCheckTests {
     @Test
     void singleReviewerShouldPass() throws IOException {
         var commit = commit(List.of("bar"));
-        var check = new ReviewersCheck(census(), utils);
-        var issues = toList(check.check(commit, message(commit), conf(1)));
+        var check = new ReviewersCheck(utils);
+        var issues = toList(check.check(commit, message(commit), conf(1), census()));
         assertEquals(0, issues.size());
     }
 
     @Test
     void leadAsReviewerShouldPass() throws IOException {
         var commit = commit(List.of("foo"));
-        var check = new ReviewersCheck(census(), utils);
-        var issues = toList(check.check(commit, message(commit), conf(1)));
+        var check = new ReviewersCheck(utils);
+        var issues = toList(check.check(commit, message(commit), conf(1), census()));
         assertEquals(0, issues.size());
     }
 
     @Test
     void committerAsReviewerShouldFail() throws IOException {
         var commit = commit(List.of("baz"));
-        var check = new ReviewersCheck(census(), utils);
-        var issues = toList(check.check(commit, message(commit), conf(1)));
+        var check = new ReviewersCheck(utils);
+        var issues = toList(check.check(commit, message(commit), conf(1), census()));
 
         assertEquals(1, issues.size());
         assertTrue(issues.get(0) instanceof TooFewReviewersIssue);
@@ -192,8 +192,8 @@ class ReviewersCheckTests {
     @Test
     void authorAsReviewerShouldFail() throws IOException {
         var commit = commit(List.of("qux"));
-        var check = new ReviewersCheck(census(), utils);
-        var issues = toList(check.check(commit, message(commit), conf(1)));
+        var check = new ReviewersCheck(utils);
+        var issues = toList(check.check(commit, message(commit), conf(1), census()));
 
         assertEquals(1, issues.size());
         assertTrue(issues.get(0) instanceof TooFewReviewersIssue);
@@ -209,8 +209,8 @@ class ReviewersCheckTests {
     @Test
     void noReviewersShouldFail() throws IOException {
         var commit = commit(List.of());
-        var check = new ReviewersCheck(census(), utils);
-        var issues = toList(check.check(commit, message(commit), conf(1)));
+        var check = new ReviewersCheck(utils);
+        var issues = toList(check.check(commit, message(commit), conf(1), census()));
 
         assertEquals(1, issues.size());
         assertTrue(issues.get(0) instanceof TooFewReviewersIssue);
@@ -226,8 +226,8 @@ class ReviewersCheckTests {
     @Test
     void multipleInvalidReviewersShouldFail() throws IOException {
         var commit = commit(List.of("qux", "baz"));
-        var check = new ReviewersCheck(census(), utils);
-        var issues = toList(check.check(commit, message(commit), conf(1)));
+        var check = new ReviewersCheck(utils);
+        var issues = toList(check.check(commit, message(commit), conf(1), census()));
 
         assertEquals(1, issues.size());
         assertTrue(issues.get(0) instanceof TooFewReviewersIssue);
@@ -243,8 +243,8 @@ class ReviewersCheckTests {
     @Test
     void uknownReviewersShouldFail() throws IOException {
         var commit = commit(List.of("unknown", "user"));
-        var check = new ReviewersCheck(census(), utils);
-        var issues = toList(check.check(commit, message(commit), conf(1)));
+        var check = new ReviewersCheck(utils);
+        var issues = toList(check.check(commit, message(commit), conf(1), census()));
 
         assertEquals(1, issues.size());
         assertTrue(issues.get(0) instanceof InvalidReviewersIssue);
@@ -258,8 +258,8 @@ class ReviewersCheckTests {
     @Test
     void oneReviewerAndMultipleInvalidReviewersShouldPass() throws IOException {
         var commit = commit(List.of("bar", "baz", "qux"));
-        var check = new ReviewersCheck(census(), utils);
-        var issues = toList(check.check(commit, message(commit), conf(1)));
+        var check = new ReviewersCheck(utils);
+        var issues = toList(check.check(commit, message(commit), conf(1), census()));
 
         assertEquals(0, issues.size());
     }
@@ -267,8 +267,8 @@ class ReviewersCheckTests {
     @Test
     void oneReviewerAndUknownReviewerShouldFail() throws IOException {
         var commit = commit(List.of("bar", "unknown"));
-        var check = new ReviewersCheck(census(), utils);
-        var issues = toList(check.check(commit, message(commit), conf(1)));
+        var check = new ReviewersCheck(utils);
+        var issues = toList(check.check(commit, message(commit), conf(1), census()));
 
         assertEquals(1, issues.size());
         assertTrue(issues.get(0) instanceof InvalidReviewersIssue);
@@ -282,8 +282,8 @@ class ReviewersCheckTests {
     @Test
     void zeroReviewersConfigurationShouldPass() throws IOException {
         var commit = commit(new ArrayList<String>());
-        var check = new ReviewersCheck(census(), utils);
-        var issues = toList(check.check(commit, message(commit), conf(0)));
+        var check = new ReviewersCheck(utils);
+        var issues = toList(check.check(commit, message(commit), conf(0), census()));
 
         assertEquals(0, issues.size());
     }
@@ -291,8 +291,8 @@ class ReviewersCheckTests {
     @Test
     void selfReviewShouldNotPass() throws IOException {
         var commit = commit(new Author("bar", "bar@localhost"), List.of("bar"));
-        var check = new ReviewersCheck(census(), utils);
-        var issues = toList(check.check(commit, message(commit), conf(1)));
+        var check = new ReviewersCheck(utils);
+        var issues = toList(check.check(commit, message(commit), conf(1), census()));
 
         assertEquals(1, issues.size());
         assertTrue(issues.get(0) instanceof SelfReviewIssue);
@@ -306,8 +306,8 @@ class ReviewersCheckTests {
     void ignoredReviewersShouldBeExcluded() throws IOException {
         var ignored = List.of("foo", "bar");
         var commit = commit(ignored);
-        var check = new ReviewersCheck(census(), utils);
-        var issues = toList(check.check(commit, message(commit), conf(1, ignored)));
+        var check = new ReviewersCheck(utils);
+        var issues = toList(check.check(commit, message(commit), conf(1, ignored), census()));
 
         assertEquals(1, issues.size());
         assertTrue(issues.get(0) instanceof TooFewReviewersIssue);
@@ -316,8 +316,8 @@ class ReviewersCheckTests {
     @Test
     void requiringCommitterAndReviwerShouldPass() throws IOException {
         var commit = commit(List.of("bar", "baz"));
-        var check = new ReviewersCheck(census(), utils);
-        var issues = toList(check.check(commit, message(commit), conf(1, 1)));
+        var check = new ReviewersCheck(utils);
+        var issues = toList(check.check(commit, message(commit), conf(1, 1), census()));
 
         assertEquals(0, issues.size());
     }
@@ -325,8 +325,8 @@ class ReviewersCheckTests {
     @Test
     void missingRoleShouldFail() throws IOException {
         var commit = commit(List.of("bar", "qux"));
-        var check = new ReviewersCheck(census(), utils);
-        var issues = toList(check.check(commit, message(commit), conf(1, 1)));
+        var check = new ReviewersCheck(utils);
+        var issues = toList(check.check(commit, message(commit), conf(1, 1), census()));
 
         assertEquals(1, issues.size());
         assertTrue(issues.get(0) instanceof TooFewReviewersIssue);
@@ -342,8 +342,8 @@ class ReviewersCheckTests {
     @Test
     void relaxedRoleShouldPass() throws IOException {
         var commit = commit(List.of("bar", "qux"));
-        var check = new ReviewersCheck(census(), utils);
-        var issues = toList(check.check(commit, message(commit), conf(0, 1, 1)));
+        var check = new ReviewersCheck(utils);
+        var issues = toList(check.check(commit, message(commit), conf(0, 1, 1), census()));
 
         assertEquals(0, issues.size());
     }
@@ -351,8 +351,8 @@ class ReviewersCheckTests {
     @Test
     void relaxedRoleAndMissingRoleShouldFail() throws IOException {
         var commit = commit(List.of("bar", "contributor"));
-        var check = new ReviewersCheck(census(), utils);
-        var issues = toList(check.check(commit, message(commit), conf(0, 1, 1)));
+        var check = new ReviewersCheck(utils);
+        var issues = toList(check.check(commit, message(commit), conf(0, 1, 1), census()));
 
         assertEquals(1, issues.size());
         assertTrue(issues.get(0) instanceof TooFewReviewersIssue);
@@ -368,22 +368,22 @@ class ReviewersCheckTests {
     @Test
     void legacyConfigurationShouldWork() throws IOException {
         var commit = commit(List.of("bar"));
-        var check = new ReviewersCheck(census(), utils);
+        var check = new ReviewersCheck(utils);
         var legacyConf = new ArrayList<>(CONFIGURATION);
         legacyConf.add("minimum = 1");
         legacyConf.add("role = reviewer");
-        var issues = toList(check.check(commit, message(commit), JCheckConfiguration.parse(legacyConf)));
+        var issues = toList(check.check(commit, message(commit), JCheckConfiguration.parse(legacyConf), census()));
         assertEquals(0, issues.size());
     }
 
     @Test
     void legacyConfigurationShouldAcceptRole() throws IOException {
         var commit = commit(List.of("baz"));
-        var check = new ReviewersCheck(census(), utils);
+        var check = new ReviewersCheck(utils);
         var legacyConf = new ArrayList<>(CONFIGURATION);
         legacyConf.add("minimum = 1");
         legacyConf.add("role = reviewer");
-        var issues = toList(check.check(commit, message(commit), JCheckConfiguration.parse(legacyConf)));
+        var issues = toList(check.check(commit, message(commit), JCheckConfiguration.parse(legacyConf), census()));
 
         assertEquals(1, issues.size());
         assertTrue(issues.get(0) instanceof TooFewReviewersIssue);
@@ -399,24 +399,24 @@ class ReviewersCheckTests {
     @Test
     void legacyConfigurationShouldAcceptCommitterRole() throws IOException {
         var commit = commit(List.of("foo"));
-        var check = new ReviewersCheck(census(), utils);
+        var check = new ReviewersCheck(utils);
         var legacyConf = new ArrayList<>(CONFIGURATION);
         legacyConf.add("minimum = 1");
         legacyConf.add("role = committer");
 
-        var issues = toList(check.check(commit, message(commit), JCheckConfiguration.parse(legacyConf)));
+        var issues = toList(check.check(commit, message(commit), JCheckConfiguration.parse(legacyConf), census()));
         assertEquals(0, issues.size());
 
         commit = commit(List.of("bar"));
-        issues = toList(check.check(commit, message(commit), JCheckConfiguration.parse(legacyConf)));
+        issues = toList(check.check(commit, message(commit), JCheckConfiguration.parse(legacyConf), census()));
         assertEquals(0, issues.size());
 
         commit = commit(List.of("baz"));
-        issues = toList(check.check(commit, message(commit), JCheckConfiguration.parse(legacyConf)));
+        issues = toList(check.check(commit, message(commit), JCheckConfiguration.parse(legacyConf), census()));
         assertEquals(0, issues.size());
 
         commit = commit(List.of("qux"));
-        issues = toList(check.check(commit, message(commit), JCheckConfiguration.parse(legacyConf)));
+        issues = toList(check.check(commit, message(commit), JCheckConfiguration.parse(legacyConf), census()));
         assertEquals(1, issues.size());
         assertTrue(issues.get(0) instanceof TooFewReviewersIssue);
         var issue = (TooFewReviewersIssue) issues.get(0);
@@ -431,23 +431,23 @@ class ReviewersCheckTests {
     @Test
     void modernConfigurationShouldAcceptCommitterRole() throws IOException {
         var commit = commit(List.of("foo"));
-        var check = new ReviewersCheck(census(), utils);
+        var check = new ReviewersCheck(utils);
         var modernConf = new ArrayList<>(CONFIGURATION);
         modernConf.add("committers = 1");
 
-        var issues = toList(check.check(commit, message(commit), JCheckConfiguration.parse(modernConf)));
+        var issues = toList(check.check(commit, message(commit), JCheckConfiguration.parse(modernConf), census()));
         assertEquals(0, issues.size());
 
         commit = commit(List.of("bar"));
-        issues = toList(check.check(commit, message(commit), JCheckConfiguration.parse(modernConf)));
+        issues = toList(check.check(commit, message(commit), JCheckConfiguration.parse(modernConf), census()));
         assertEquals(0, issues.size());
 
         commit = commit(List.of("baz"));
-        issues = toList(check.check(commit, message(commit), JCheckConfiguration.parse(modernConf)));
+        issues = toList(check.check(commit, message(commit), JCheckConfiguration.parse(modernConf), census()));
         assertEquals(0, issues.size());
 
         commit = commit(List.of("qux"));
-        issues = toList(check.check(commit, message(commit), JCheckConfiguration.parse(modernConf)));
+        issues = toList(check.check(commit, message(commit), JCheckConfiguration.parse(modernConf), census()));
         assertEquals(1, issues.size());
         assertTrue(issues.get(0) instanceof TooFewReviewersIssue);
         var issue = (TooFewReviewersIssue) issues.get(0);
@@ -462,32 +462,32 @@ class ReviewersCheckTests {
     @Test
     void oldJDKConfigurationShouldRequireContributor() throws IOException {
         var commit = commit(List.of("foo"));
-        var check = new ReviewersCheck(census(), utils);
+        var check = new ReviewersCheck(utils);
         var oldJDKConf = new ArrayList<String>();
         oldJDKConf.add("project=jdk");
         oldJDKConf.add("bugids=dup");
 
-        var issues = toList(check.check(commit, message(commit), JCheckConfiguration.parse(oldJDKConf)));
+        var issues = toList(check.check(commit, message(commit), JCheckConfiguration.parse(oldJDKConf), census()));
         assertEquals(0, issues.size());
 
         commit = commit(List.of("bar"));
-        issues = toList(check.check(commit, message(commit), JCheckConfiguration.parse(oldJDKConf)));
+        issues = toList(check.check(commit, message(commit), JCheckConfiguration.parse(oldJDKConf), census()));
         assertEquals(0, issues.size());
 
         commit = commit(List.of("baz"));
-        issues = toList(check.check(commit, message(commit), JCheckConfiguration.parse(oldJDKConf)));
+        issues = toList(check.check(commit, message(commit), JCheckConfiguration.parse(oldJDKConf), census()));
         assertEquals(0, issues.size());
 
         commit = commit(List.of("qux"));
-        issues = toList(check.check(commit, message(commit), JCheckConfiguration.parse(oldJDKConf)));
+        issues = toList(check.check(commit, message(commit), JCheckConfiguration.parse(oldJDKConf), census()));
         assertEquals(0, issues.size());
 
         commit = commit(List.of("contributor"));
-        issues = toList(check.check(commit, message(commit), JCheckConfiguration.parse(oldJDKConf)));
+        issues = toList(check.check(commit, message(commit), JCheckConfiguration.parse(oldJDKConf), census()));
         assertEquals(0, issues.size());
 
         commit = commit(List.of());
-        issues = toList(check.check(commit, message(commit), JCheckConfiguration.parse(oldJDKConf)));
+        issues = toList(check.check(commit, message(commit), JCheckConfiguration.parse(oldJDKConf), census()));
         assertEquals(1, issues.size());
         assertTrue(issues.get(0) instanceof TooFewReviewersIssue);
         var issue = (TooFewReviewersIssue) issues.get(0);
@@ -499,7 +499,7 @@ class ReviewersCheckTests {
         assertEquals(check, issue.check());
 
         commit = commit(List.of("unknown"));
-        issues = toList(check.check(commit, message(commit), JCheckConfiguration.parse(oldJDKConf)));
+        issues = toList(check.check(commit, message(commit), JCheckConfiguration.parse(oldJDKConf), census()));
         assertEquals(1, issues.size());
         assertTrue(issues.get(0) instanceof InvalidReviewersIssue);
         var invalidIssue = (InvalidReviewersIssue) issues.get(0);

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/SymlinkCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/SymlinkCheckTests.java
@@ -101,7 +101,7 @@ class SymlinkCheckTests {
         var commit = commitWithSymlink("symlink");
         var message = message(commit);
         var check = new SymlinkCheck();
-        var issues = toList(check.check(commit, message, conf()));
+        var issues = toList(check.check(commit, message, conf(), null));
 
         assertEquals(1, issues.size());
         assertTrue(issues.get(0) instanceof SymlinkIssue);
@@ -114,7 +114,7 @@ class SymlinkCheckTests {
         var commit = commitWithRegularFile("README.txt", "Hello, world");
         var message = message(commit);
         var check = new SymlinkCheck();
-        var issues = toList(check.check(commit, message, conf()));
+        var issues = toList(check.check(commit, message, conf(), null));
         assertEquals(List.of(), issues);
     }
 }

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/WhitespaceCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/WhitespaceCheckTests.java
@@ -89,7 +89,7 @@ class WhitespaceCheckTests {
         var commit = commit(parentDiffs("README.md", "An additional line"));
         var conf = configuration("README\\.md");
         var check = new WhitespaceCheck();
-        var issues = toList(check.check(commit, message(commit), conf));
+        var issues = toList(check.check(commit, message(commit), conf, null));
 
         assertEquals(0, issues.size());
     }
@@ -102,7 +102,7 @@ class WhitespaceCheckTests {
         var conf = configuration("README\\.md");
         var message = message(commit);
         var check = new WhitespaceCheck();
-        var issues = toList(check.check(commit, message, conf));
+        var issues = toList(check.check(commit, message, conf, null));
 
         assertEquals(1, issues.size());
         assertTrue(issues.get(0) instanceof WhitespaceIssue);
@@ -126,7 +126,7 @@ class WhitespaceCheckTests {
         var conf = configuration("README\\.md");
         var message = message(commit);
         var check = new WhitespaceCheck();
-        var issues = toList(check.check(commit, message, conf));
+        var issues = toList(check.check(commit, message, conf, null));
 
         assertEquals(1, issues.size());
         assertTrue(issues.get(0) instanceof WhitespaceIssue);
@@ -150,7 +150,7 @@ class WhitespaceCheckTests {
         var conf = configuration("README\\.md");
         var message = message(commit);
         var check = new WhitespaceCheck();
-        var issues = toList(check.check(commit, message, conf));
+        var issues = toList(check.check(commit, message, conf, null));
 
         assertEquals(1, issues.size());
         assertTrue(issues.get(0) instanceof WhitespaceIssue);


### PR DESCRIPTION
Hi all,

please review this patch that makes jcheck by default use the census file pointed to by .jcheck/conf (an overriding census can also be supplied). A whole bunch of trivial updates to tests were needed due to `CommitCheck.check` now taking a `Census` parameter.

Testing:
- [x] `make test` passes on Linux x64
- [x] `make images` passes on Linux x64
- [x] Manual testing on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/818/head:pull/818`
`$ git checkout pull/818`
