### PR TITLE
672: Support pulling tags in checkout bot

### DIFF
--- a/bots/checkout/src/main/java/org/openjdk/skara/bots/checkout/CheckoutBot.java
+++ b/bots/checkout/src/main/java/org/openjdk/skara/bots/checkout/CheckoutBot.java
@@ -96,7 +96,7 @@ public class CheckoutBot implements Bot, WorkItem {
                     new IllegalStateException("Git repository vanished from " + fromDir));
             }
             fromRepo.checkout(branch);
-            fromRepo.pull("origin", branch.name());
+            fromRepo.pull("origin", branch.name(), true);
 
             var repoName = Path.of(from.getPath()).getFileName().toString();
             var marksDir = scratch.resolve("checkout").resolve("marks").resolve(repoName);

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
@@ -66,9 +66,22 @@ public interface Repository extends ReadOnlyRepository {
     default void remove(Path... files) throws IOException {
         remove(Arrays.asList(files));
     }
-    void pull() throws IOException;
-    void pull(String remote) throws IOException;
-    void pull(String remote, String refspec) throws IOException;
+
+    void pull(boolean includeTags) throws IOException;
+    default void pull() throws IOException {
+        pull(false);
+    }
+
+    void pull(String remote, boolean includeTags) throws IOException;
+    default void pull(String remote) throws IOException {
+        pull(remote, false);
+    }
+
+    void pull(String remote, String refspec, boolean includeTags) throws IOException;
+    default void pull(String remote, String refspec) throws IOException {
+        pull(remote, refspec, false);
+    }
+
     void addremove() throws IOException;
     void config(String section, String key, String value, boolean global) throws IOException;
     default void config(String section, String key, String value) throws IOException {

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -1311,22 +1311,27 @@ public class GitRepository implements Repository {
     }
 
     @Override
-    public void pull() throws IOException {
-        pull(null, null);
+    public void pull(boolean includeTags) throws IOException {
+        pull(null, null, includeTags);
     }
 
     @Override
-    public void pull(String remote) throws IOException {
-        pull(remote, null);
+    public void pull(String remote, boolean includeTags) throws IOException {
+        pull(remote, null, includeTags);
     }
 
 
     @Override
-    public void pull(String remote, String refspec) throws IOException {
+    public void pull(String remote, String refspec, boolean includeTags) throws IOException {
         var cmd = new ArrayList<String>();
         cmd.add("git");
         cmd.add("pull");
         cmd.add("--recurse-submodules");
+        if (includeTags) {
+            cmd.add("--tags");
+        } else {
+            cmd.add("--no-tags");
+        }
         if (remote != null) {
             cmd.add(remote);
         }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -1251,17 +1251,18 @@ public class HgRepository implements Repository {
     }
 
     @Override
-    public void pull() throws IOException {
-        pull(null, null);
+    public void pull(boolean includeTags) throws IOException {
+        pull(null, null, includeTags);
     }
 
     @Override
-    public void pull(String remote) throws IOException {
-        pull(remote, null);
+    public void pull(String remote, boolean includeTags) throws IOException {
+        pull(remote, null, includeTags);
     }
 
     @Override
-    public void pull(String remote, String refspec) throws IOException {
+    public void pull(String remote, String refspec, boolean includeTags) throws IOException {
+        // ignore includeTags, hg always pulls tags
         var cmd = new ArrayList<String>();
         cmd.addAll(List.of("hg", "pull", "--update"));
         if (refspec != null) {


### PR DESCRIPTION
Hi all,

please review this patch that allows the checkout bot to support pulling tags. To achieve this I updated `Repository.pull` to take an explicit `includeTags` argument.

Testing:
- [x] `make test` passes on Linux x64
- [x] Added a new unit test

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-672](https://bugs.openjdk.java.net/browse/SKARA-672): Support pulling tags in checkout bot


### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/819/head:pull/819`
`$ git checkout pull/819`
