### PR TITLE
637: PR author should be able to use /csr PR command

### DIFF
--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CSRTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CSRTests.java
@@ -84,7 +84,7 @@ class CSRTests {
 
             // The bot should reply with a message that a CSR is no longer needed
             assertLastCommentContains(pr, "determined that a [CSR](https://wiki.openjdk.java.net/display/csr/Main) request " +
-                                          "is no longer needed for this pull request.");
+                                          "is not needed for this pull request.");
             assertFalse(pr.labels().contains("csr"));
 
             // Require CSR again with long form
@@ -212,9 +212,18 @@ class CSRTests {
             pr.addComment("/csr");
             TestBotRunner.runPeriodicItems(prBot);
 
-            // The bot should reply with a message that only reviewers can require a CSR
-            assertLastCommentContains(pr, "only [Reviewers](https://openjdk.java.net/bylaws#reviewer) are allowed require a CSR.");
-            assertFalse(pr.labels().contains("csr"));
+            // The bot should reply with a message that a CSR is needed
+            assertLastCommentContains(pr, "has indicated that a " +
+                                          "[compatibility and specification](https://wiki.openjdk.java.net/display/csr/Main) (CSR) request " +
+                                          "is needed for this pull request.");
+            assertTrue(pr.labels().contains("csr"));
+
+            // Stating that a CSR is not needed should not work
+            pr.addComment("/csr unneeded");
+            TestBotRunner.runPeriodicItems(prBot);
+            assertLastCommentContains(pr, "only [Reviewers]");
+            assertLastCommentContains(pr, "can determine that a CSR is not needed.");
+            assertTrue(pr.labels().contains("csr"));
         }
     }
 


### PR DESCRIPTION
Hi all,

please review this patch that allows pull request authors that are *not* Reviewers to use the `/csr` command. A person who is not a Reviewer should still be allowed to state that a CSR is required (but not that state that a CSR is *not* required).

Testing:
- [x] `make test` passes on Linux x64
- [x] Added a new unit test

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-637](https://bugs.openjdk.java.net/browse/SKARA-637): PR author should be able to use /csr PR command


### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/821/head:pull/821`
`$ git checkout pull/821`
