### PR TITLE
674: Allow reviewers command in PR body

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewersCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewersCommand.java
@@ -151,4 +151,9 @@ public class ReviewersCommand implements CommandHandler {
     public String description() {
         return "set the number of additional required reviewers for this PR";
     }
+
+    @Override
+    public boolean allowedInBody() {
+        return true;
+    }
 }


### PR DESCRIPTION
Hi all,

please review this pull request that allows the `/reviewers` pull request command to be used in the PR body.

Testing:
- `make test` passes on Linux x64
- Added one additional unit test

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-674](https://bugs.openjdk.java.net/browse/SKARA-674): Allow reviewers command in PR body


### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/823/head:pull/823`
`$ git checkout pull/823`
