### PR TITLE
660: Add blank line prior to PR body HTML comment

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -467,7 +467,7 @@ class CheckRun {
         if (originalBody.isBlank()) {
             originalBody = emptyPrBodyMarker;
         }
-        var newBody = originalBody + "\n" + progressMarker + "\n" + message;
+        var newBody = originalBody + "\n\n" + progressMarker + "\n" + message;
 
         // TODO? Retrieve the body again here to lower the chance of concurrent updates
         pr.setBody(newBody);

--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequestBody.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequestBody.java
@@ -106,6 +106,6 @@ public class PullRequestBody {
             }
         }
 
-        return new PullRequestBody(bodyText.toString(), issues, contributors);
+        return new PullRequestBody(bodyText.toString().trim(), issues, contributors);
     }
 }


### PR DESCRIPTION
Hi all,

please review this patch that adds a newline (a blank line) prior to the bots `<!--- Anything below this ... -->` message. This is needed to avoid bad interactions with GitHub's Markdown parser for some of the more esoteric Markdown features of GitHub Flavored Markdown.

Testing:
- [x] `make test` passes on Linux x64
- [x] `make images` passes on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-660](https://bugs.openjdk.java.net/browse/SKARA-660): Add blank line prior to PR body HTML comment


### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/824/head:pull/824`
`$ git checkout pull/824`
