### PR TITLE
684: Pull request command parser parses too much

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandWorkItem.java
@@ -24,6 +24,7 @@ package org.openjdk.skara.bots.pr;
 
 import org.openjdk.skara.bot.WorkItem;
 import org.openjdk.skara.forge.PullRequest;
+import org.openjdk.skara.forge.PullRequestBody;
 import org.openjdk.skara.host.HostUser;
 import org.openjdk.skara.issuetracker.Comment;
 
@@ -160,7 +161,8 @@ public class CommandWorkItem extends PullRequestWorkItem {
 
     private Optional<CommandInvocation> nextCommand(PullRequest pr, List<Comment> comments) {
         var self = pr.repository().forge().currentUser();
-        var allCommands = Stream.concat(extractCommands(pr.body(), "body", pr.author()).stream(),
+        var body = PullRequestBody.parse(pr).bodyText();
+        var allCommands = Stream.concat(extractCommands(body, "body", pr.author()).stream(),
                                         comments.stream()
                                                 .filter(comment -> !comment.author().equals(self) || comment.body().endsWith(selfCommandMarker))
                                                 .flatMap(c -> extractCommands(c.body(), c.id(), c.author()).stream()))

--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequestBody.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequestBody.java
@@ -31,8 +31,6 @@ public class PullRequestBody {
     private final List<URI> issues;
     private final List<String> contributors;
 
-    private static final Pattern cutoffPattern = Pattern.compile("^<!-- Anything below this marker will be .*? -->$");
-
     private PullRequestBody(String bodyText, List<URI> issues, List<String> contributors) {
         this.bodyText = bodyText;
         this.issues = issues;


### PR DESCRIPTION
Hi all,

please review this patch that ensures that `extractCommands` in `CommandWorkItem` only parses the parts of the PR body that the user has written (i.e. scrub the automatic message from the bots).

Testing:
- [x] `make test` passes on Linux x64
- Added a new unit test

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-684](https://bugs.openjdk.java.net/browse/SKARA-684): Pull request command parser parses too much


### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/825/head:pull/825`
`$ git checkout pull/825`
