### PR TITLE
648: `git sync` requires ssh to be specified when setting 'to' repo on set-up

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitSync.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitSync.java
@@ -170,7 +170,7 @@ public class GitSync {
         }
 
         var fromPullPath = remotes.contains(from) ?
-            Remote.toURI(repo.pullPath(from)) : URI.create(from);
+            Remote.toURI(repo.pullPath(from)) : Remote.toURI(from);
 
         String to = null;
         if (arguments.contains("to")) {
@@ -193,7 +193,7 @@ public class GitSync {
         }
 
         var toPushPath = remotes.contains(to) ?
-            Remote.toURI(repo.pullPath(to)) : URI.create(to);
+            Remote.toURI(repo.pullPath(to)) : Remote.toURI(to);
 
         var toScheme = toPushPath.getScheme();
         if (toScheme.equals("https") || toScheme.equals("http")) {

--- a/cli/src/main/java/org/openjdk/skara/cli/Remote.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/Remote.java
@@ -85,6 +85,10 @@ public class Remote {
     }
 
     public static URI toURI(String remotePath) throws IOException {
+        return toURI(remotePath, false);
+    }
+
+    public static URI toURI(String remotePath, boolean canonicalize) throws IOException {
         if (remotePath.startsWith("git+")) {
             remotePath = remotePath.substring("git+".length());
         }
@@ -101,7 +105,7 @@ public class Remote {
         if (indexOfColon != -1) {
             if (indexOfSlash == -1 || indexOfColon < indexOfSlash) {
                 var uri = URI.create("ssh://" + remotePath.replace(":", "/"));
-                return sshCanonicalize(uri);
+                return canonicalize ? sshCanonicalize(uri) : uri;
             }
         }
 


### PR DESCRIPTION
Hi all,

please review this patch that makes `git-sync` work better with git-style SSH paths.

Testing:
- [x] Manual testing on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-648](https://bugs.openjdk.java.net/browse/SKARA-648): `git sync` requires ssh to be specified when setting 'to' repo on set-up


### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/827/head:pull/827`
`$ git checkout pull/827`
