### PR TITLE
683: Stats entry in automatic integration email swaps insertions and deletions

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
@@ -405,7 +405,7 @@ class ArchiveMessages {
             result.append("Committer: ").append(commit.committer().name()).append(" <").append(commit.committer().email()).append(">\n");
         }
         result.append("URL:       ").append(pr.repository().webUrl(commit.hash())).append("\n");
-        result.append("Stats:     ").append(stats(localRepo, commit.hash(), commit.parents().get(0))).append("\n");
+        result.append("Stats:     ").append(stats(localRepo, commit.parents().get(0), commit.hash())).append("\n");
         result.append("\n");
         result.append(String.join("\n", commit.message()));
 


### PR DESCRIPTION
Hi all,

please review this small patch that fixes the "Stats:" line for integration notifications :smile: 

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-683](https://bugs.openjdk.java.net/browse/SKARA-683): Stats entry in automatic integration email swaps insertions and deletions


### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/829/head:pull/829`
`$ git checkout pull/829`
