### PR TITLE
649: SKARA will not build/install without termcap

### DIFF
--- a/gradlew
+++ b/gradlew
@@ -188,6 +188,7 @@ if [ "${OS}" = "Linux" ]; then
     export LC_ALL=en_US.UTF-8
     export LANG=en_US.UTF-8
     export LANGUAGE=en_US.UTF-8
+    export TERM=${TERM:-dumb}
 fi
 
 exec "${GRADLE_LAUNCHER}" "$@"


### PR DESCRIPTION
Hi all,

please review this small patch that makes us fall back to `TERM=dumb` if `TERM` is not specified when building on Linux.

Testing:
- [x] `make` works on Linux x64 with and without `TERM` defined

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-649](https://bugs.openjdk.java.net/browse/SKARA-649): SKARA will not build/install without termcap


### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/830/head:pull/830`
`$ git checkout pull/830`
