### PR TITLE
690: Merge commit message is not Merge jdk, but: Merge jdk

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
@@ -128,7 +128,16 @@ class PullRequestCheckIssueVisitor implements IssueVisitor {
     @Override
     public void visit(MergeMessageIssue e) {
         var message = String.join("\n", e.commit().message());
-        addFailureMessage(e.check(), "Merge commit message is not " + e.expected() + ", but: " + message);
+        var desc = "Merge commit message is not `" + e.expected() + "`, but:";
+        if (e.commit().message().size() == 1) {
+            desc += " `" + message + "`";
+        } else {
+            desc += "\n" +
+                    "```\n" +
+                    message +
+                    "```";
+        }
+        addFailureMessage(e.check(), desc);
     }
 
     @Override


### PR DESCRIPTION
Hi all,

please review this patch that makes it more clear what the expected and current commit messages are when showing the error for `MergeMessageCheck`.

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-690](https://bugs.openjdk.java.net/browse/SKARA-690): Merge commit message is not Merge jdk, but: Merge jdk


### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**) ⚠️ Review applies to fc746103f146fa35f5a7e7f15ce5701ead530704


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/831/head:pull/831`
`$ git checkout pull/831`
