### PR TITLE
defpath: normalize error format

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitDefpath.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitDefpath.java
@@ -208,7 +208,7 @@ public class GitDefpath {
         var cwd = Path.of("").toAbsolutePath();
         var repository = Repository.get(cwd);
         if (!repository.isPresent()) {
-            die(String.format("error: %s is not a hg repository", cwd.toString()));
+            die(String.format("error: %s is not a repository", cwd.toString()));
         }
         var repo = repository.get();
 


### PR DESCRIPTION
Hi all,

please review this small patch that makes `git defpath` use the same error message as `git jcheck` and `git webrev` when not finding a local repository.

Testing:
- [x] Manual testing on Linux x64

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/833/head:pull/833`
`$ git checkout pull/833`
