### PR TITLE
548: PR is marked as being ready for integration before the CSR is approved

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -759,7 +759,10 @@ class CheckRun {
             var amendedHash = checkablePullRequest.amendManualReviewers(localHash, censusInstance.namespace());
             var commit = localRepo.lookup(amendedHash).orElseThrow();
             var commitMessage = String.join("\n", commit.message());
-            var readyForIntegration = visitor.messages().isEmpty() && additionalErrors.isEmpty();
+            var readyForIntegration = visitor.messages().isEmpty() &&
+                                      additionalErrors.isEmpty() &&
+                                      labels.stream().noneMatch(l -> workItem.bot.blockingReadyLabels().contains(l));
+
             updateMergeReadyComment(readyForIntegration, commitMessage, comments, activeReviews, rebasePossible);
             if (readyForIntegration && rebasePossible) {
                 newLabels.add("ready");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -172,9 +172,12 @@ class PullRequestBot implements Bot {
         return blockingCheckLabels;
     }
 
+    Set<String> blockingReadyLabels() {
+        return Set.of("csr");
+    }
+
     Map<String, String> blockingIntegrationLabels() {
-        return Map.of("rejected", "The change is currently blocked from integration by a rejection.",
-                      "csr", "The change is currently blocked from integration by a pending CSR.");
+        return Map.of("rejected", "The change is currently blocked from integration by a rejection.");
     }
 
     Set<String> readyLabels() {


### PR DESCRIPTION
Hi all,

please review this patch that makes the "csr" label be a blocker for a pull request becoming "ready". The "csr" label used to block integration, but it is more friendly for authors and reviewers if the integration message doesn't appear :smile: 

Testing:
- [x] `make test` passes on Linux x64
- [x] Added a new unit test

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-548](https://bugs.openjdk.java.net/browse/SKARA-548): PR is marked as being ready for integration before the CSR is approved


### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/834/head:pull/834`
`$ git checkout pull/834`
