### PR TITLE
657: Integrate command uses "merge request" in failure message

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
@@ -72,7 +72,7 @@ public class IntegrateCommand implements CommandHandler {
 
         var problem = checkProblem(pr.checks(pr.headHash()), "jcheck", pr);
         if (problem.isPresent()) {
-            reply.print("Your merge request cannot be fulfilled at this time, as ");
+            reply.print("Your integration request cannot be fulfilled at this time, as ");
             reply.println(problem.get());
             return;
         }
@@ -130,7 +130,7 @@ public class IntegrateCommand implements CommandHandler {
             var additionalConfiguration = AdditionalConfiguration.get(localRepo, localHash, pr.repository().forge().currentUser(), allComments);
             checkablePr.executeChecks(localHash, censusInstance, issues, additionalConfiguration);
             if (!issues.messages().isEmpty()) {
-                reply.print("Your merge request cannot be fulfilled at this time, as ");
+                reply.print("Your integration request cannot be fulfilled at this time, as ");
                 reply.println("your changes failed the final jcheck:");
                 issues.messages().stream()
                       .map(line -> " * " + line)

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
@@ -116,7 +116,7 @@ public class SponsorCommand implements CommandHandler {
             var additionalConfiguration = AdditionalConfiguration.get(localRepo, localHash, pr.repository().forge().currentUser(), allComments);
             checkablePr.executeChecks(localHash, censusInstance, issues, additionalConfiguration);
             if (!issues.messages().isEmpty()) {
-                reply.print("Your merge request cannot be fulfilled at this time, as ");
+                reply.print("Your integration request cannot be fulfilled at this time, as ");
                 reply.println("your changes failed the final jcheck:");
                 issues.messages().stream()
                       .map(line -> " * " + line)

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrateTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrateTests.java
@@ -193,7 +193,7 @@ class IntegrateTests {
 
             // The bot should reply with an error message
             var error = pr.comments().stream()
-                          .filter(comment -> comment.body().contains("merge request cannot be fulfilled at this time"))
+                          .filter(comment -> comment.body().contains("integration request cannot be fulfilled at this time"))
                           .filter(comment -> comment.body().contains("status check"))
                           .filter(comment -> comment.body().contains("has not been performed on commit"))
                           .count();
@@ -236,7 +236,7 @@ class IntegrateTests {
 
             // The bot should reply with an error message
             var error = pr.comments().stream()
-                          .filter(comment -> comment.body().contains("merge request cannot be fulfilled at this time"))
+                          .filter(comment -> comment.body().contains("integration request cannot be fulfilled at this time"))
                           .filter(comment -> comment.body().contains("failed the final jcheck"))
                           .count();
             assertEquals(1, error, pr.comments().stream().map(Comment::body).collect(Collectors.joining("\n---\n")));
@@ -270,7 +270,7 @@ class IntegrateTests {
 
             // The bot should reply with an error message
             var error = pr.comments().stream()
-                          .filter(comment -> comment.body().contains("merge request cannot be fulfilled at this time"))
+                          .filter(comment -> comment.body().contains("integration request cannot be fulfilled at this time"))
                           .filter(comment -> comment.body().contains("status check"))
                           .filter(comment -> comment.body().contains("did not complete successfully"))
                           .count();
@@ -320,7 +320,7 @@ class IntegrateTests {
 
             // The bot should reply with an error message
             var error = pr.comments().stream()
-                          .filter(comment -> comment.body().contains("merge request cannot be fulfilled at this time"))
+                          .filter(comment -> comment.body().contains("integration request cannot be fulfilled at this time"))
                           .filter(comment -> comment.body().contains("status check"))
                           .filter(comment -> comment.body().contains("has not been performed on commit"))
                           .count();

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/SponsorTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/SponsorTests.java
@@ -524,7 +524,7 @@ class SponsorTests {
 
             // The bot should reply with an error message
             var error = pr.comments().stream()
-                          .filter(comment -> comment.body().contains("merge request cannot be fulfilled at this time"))
+                          .filter(comment -> comment.body().contains("integration request cannot be fulfilled at this time"))
                           .filter(comment -> comment.body().contains("failed the final jcheck"))
                           .count();
             assertEquals(1, error);


### PR DESCRIPTION
Hi all,

please review this patch that uses the wording "integration request" instead of "merge request" in failure messages for the `/integrate` pull request command.

Testing:
- [x] `make test` passes on Linux x64
- [x] Updated unit tests

Thanks,
Erik
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-657](https://bugs.openjdk.java.net/browse/SKARA-657): Integrate command uses "merge request" in failure message


### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/835/head:pull/835`
`$ git checkout pull/835`
