### PR TITLE
694: Checking invalid email gives an exception

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -139,24 +139,6 @@ class CheckRun {
                  .collect(Collectors.toList());
     }
 
-    // For unknown contributors, check that all commits have the same name and email
-    private boolean checkCommitAuthor(List<CommitMetadata> commits) throws IOException {
-        var author = censusInstance.namespace().get(pr.author().id());
-        if (author != null) {
-            return true;
-        }
-
-        var names = new HashSet<String>();
-        var emails = new HashSet<String>();
-
-        for (var commit : commits) {
-            names.add(commit.author().name());
-            emails.add(commit.author().email());
-        }
-
-        return ((names.size() == 1) && emails.size() == 1);
-    }
-
     // Additional bot-specific checks that are not handled by JCheck
     private List<String> botSpecificChecks(Hash finalHash) throws IOException {
         var ret = new ArrayList<String>();
@@ -190,13 +172,6 @@ class CheckRun {
 
         var headHash = pr.headHash();
         var originalCommits = localRepo.commitMetadata(baseHash, headHash);
-
-        if (!checkCommitAuthor(originalCommits)) {
-            var error = "For contributors who are not existing OpenJDK Authors, commit attribution will be taken from " +
-                    "the commits in the PR. However, the commits in this PR have inconsistent user names and/or " +
-                    "email addresses. Please amend the commits.";
-            ret.add(error);
-        }
 
         for (var blocker : workItem.bot.blockingCheckLabels().entrySet()) {
             if (labels.contains(blocker.getKey())) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
@@ -115,7 +115,6 @@ public class CheckablePullRequest {
                 throw new CommitFailure("Merge PRs can only be created by known OpenJDK authors.");
             }
 
-            // Use the information contained in the head commit - jcheck has verified that it contains sane values
             var headCommit = localRepo.commitMetadata(pr.headHash().hex() + "^.." + pr.headHash().hex()).get(0);
             author = headCommit.author();
         } else {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
@@ -162,12 +162,16 @@ class PullRequestCheckIssueVisitor implements IssueVisitor {
 
     @Override
     public void visit(AuthorNameIssue issue) {
-        throw new IllegalStateException("Invalid author name: " + issue.commit().author());
+        // We only get here for contributors without an OpenJDK username
+        addFailureMessage(issue.check(), "Pull request's HEAD commit must contain a full name");
+        readyForReview = false;
     }
 
     @Override
     public void visit(AuthorEmailIssue issue) {
-        throw new IllegalStateException("Invalid author email: " + issue.commit().author());
+        // We only get here for contributors without an OpenJDK username
+        addFailureMessage(issue.check(), "Pull request's HEAD commit must contain a valid e-mail");
+        readyForReview = false;
     }
 
     @Override

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrateTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrateTests.java
@@ -783,4 +783,45 @@ class IntegrateTests {
             assertTrue(lastComment.body().contains("CONTRIBUTING.md"));
         }
     }
+
+    @Test
+    void contributorMissingEmail(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory();
+             var pushedFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var reviewer = credentials.getHostedRepository();
+            var committer = credentials.getHostedRepository();
+
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addCommitter(committer.forge().currentUser().id())
+                                           .addReviewer(reviewer.forge().currentUser().id());
+            var mergeBot = PullRequestBot.newBuilder().repo(reviewer).censusRepo(censusBuilder.build()).build();
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Make a change with a corresponding PR with an empty e-mail
+            var editHash = CheckableRepository.appendAndCommit(localRepo, "Content", "A commit", "Duke", "");
+            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
+
+            // Run the bot
+            TestBotRunner.runPeriodicItems(mergeBot);
+
+            // The bot should respond with a failure about missing e-mail
+            pr = author.pullRequest(pr.id());
+            assertFalse(pr.labels().contains("ready"));
+            var checks = pr.checks(pr.headHash());
+            assertTrue(checks.containsKey("jcheck"));
+            var jcheck = checks.get("jcheck");
+            assertEquals(CheckStatus.FAILURE, jcheck.status());
+            assertTrue(jcheck.summary().isPresent());
+            var summary = jcheck.summary().get();
+            assertTrue(summary.contains("Pull request's HEAD commit must contain a valid e-mail"));
+        }
+    }
 }


### PR DESCRIPTION
Hi all,

please review this patch that ensures that contributors who do not have an OpenJDK username specify a valid name and e-mail for a pull request's `HEAD` commit.

Testing:
- Added a new unit test
- `make test` passes on Linux x64

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-694](https://bugs.openjdk.java.net/browse/SKARA-694): Checking invalid email gives an exception


### Reviewers
 * [Tim Bell](https://openjdk.java.net/census#tbell) (@tbell29552 - **Reviewer**) ⚠️ Review applies to c392626c83aa1e14a510b3a136523d3d64aaa8bd
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/837/head:pull/837`
`$ git checkout pull/837`
