### PR TITLE
716: Git version check pattern matching is too strict

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitVersion.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitVersion.java
@@ -32,7 +32,7 @@ import java.util.stream.Collectors;
 public class GitVersion {
 
     private static final Pattern versionPattern = Pattern.compile(
-            "git version (?<versionString>.*(?<major>\\d)\\.(?<minor>\\d{2})\\.(?<security>\\d).*)");
+            "git version (?<versionString>.*(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<security>\\d+).*)");
     private static final GitVersion UNKNOWN = new GitVersion("UNKNOWN", -1, -1, -1);
 
     private final String versionString;


### PR DESCRIPTION
Hi,

may I have reviews please for this small fix. On my Ubuntu 16.4 box I run with git 2.7.0 (so far without any problems, but that is another story). Skara wants a newer version and does a version check. That check fails to parse the version number correctly. 

https://bugs.openjdk.java.net/browse/SKARA-716

Tests: tried to run gradlw test on my Linux box but I get test errors - but those errors also appear on a clean repo (see https://mail.openjdk.java.net/pipermail/skara-dev/2020-September/003410.html), I am quite sure they have anything to do with my fix.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-716](https://bugs.openjdk.java.net/browse/SKARA-716): Git version check pattern matching is too strict


### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/838/head:pull/838`
`$ git checkout pull/838`
