### PR TITLE
623: Label rules filter should take direct group matches into account

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/LabelConfigurationJson.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/LabelConfigurationJson.java
@@ -129,7 +129,7 @@ public class LabelConfigurationJson implements LabelConfiguration {
         }
 
         var ret = new HashSet<>(labels);
-        // If the current labels matches at least two members of a group, use the group instead
+        // If the current labels matches at least two members of a group, use the group
         for (var group : groups.entrySet()) {
             var count = 0;
             for (var groupEntry : group.getValue()) {
@@ -137,12 +137,20 @@ public class LabelConfigurationJson implements LabelConfiguration {
                     count++;
                     if (count == 2) {
                         ret.add(group.getKey());
-                        ret.removeAll(group.getValue());
                         break;
                     }
                 }
             }
         }
+
+        // Finally remove all group members for any group that has been matched (note that a group can
+        // also have individual rules and be matched in the first step).
+        for (var group : groups.entrySet()) {
+            if (ret.contains(group.getKey())) {
+                ret.removeAll(group.getValue());
+            }
+        }
+
         return ret;
     }
 

--- a/forge/src/test/java/org/openjdk/skara/forge/LabelConfigurationTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/LabelConfigurationTests.java
@@ -59,4 +59,20 @@ public class LabelConfigurationTests {
         assertEquals(Set.of("2"), config.label(Set.of(Path.of("a.hpp"))));
         assertEquals(Set.of("both"), config.label(Set.of(Path.of("a.cpp"), Path.of("a.hpp"))));
     }
+
+    @Test
+    void groupAndSingle() {
+        var config = LabelConfigurationJson.builder()
+                                           .addMatchers("1", List.of(Pattern.compile("cpp$")))
+                                           .addMatchers("both", List.of(Pattern.compile("hpp$")))
+                                           .addGroup("both", List.of("1", "2"))
+                                           .build();
+
+        assertEquals(Set.of("1", "both"), config.allowed());
+
+        assertEquals(Set.of("1"), config.label(Set.of(Path.of("a.cpp"))));
+        assertEquals(Set.of("both"), config.label(Set.of(Path.of("a.hpp"))));
+        assertEquals(Set.of("both"), config.label(Set.of(Path.of("a.cpp"), Path.of("a.hpp"))));
+
+    }
 }


### PR DESCRIPTION
When a mailing list rule filter matches a group, any group members should be removed from the list of matches.

Best regards,
Robin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-623](https://bugs.openjdk.java.net/browse/SKARA-623): Label rules filter should take direct group matches into account


### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/839/head:pull/839`
`$ git checkout pull/839`
