### PR TITLE
685: Show a warning if PR author's full name does not match commit author's full name

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -170,9 +170,6 @@ class CheckRun {
             ret.add(error);
         }
 
-        var headHash = pr.headHash();
-        var originalCommits = localRepo.commitMetadata(baseHash, headHash);
-
         for (var blocker : workItem.bot.blockingCheckLabels().entrySet()) {
             if (labels.contains(blocker.getKey())) {
                 ret.add(blocker.getValue());

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
@@ -115,8 +115,18 @@ public class CheckablePullRequest {
                 throw new CommitFailure("Merge PRs can only be created by known OpenJDK authors.");
             }
 
-            var headCommit = localRepo.commitMetadata(pr.headHash().hex() + "^.." + pr.headHash().hex()).get(0);
-            author = headCommit.author();
+            var headHash = pr.headHash();
+            var headCommit = localRepo.lookup(headHash).get();
+            var headAuthor = headCommit.author();
+            var prAuthor = pr.author();
+            if (!prAuthor.fullName().equals(prAuthor.userName())) {
+                if (!headAuthor.name().equals(prAuthor.fullName())) {
+                    throw new CommitFailure("The HEAD commit of this pull request, " + headHash.abbreviate() +
+                                            ", has a different author, `" + headAuthor.name() + "`" +
+                                            ", than the author of this pull request: `" + prAuthor.fullName() + "`");
+                }
+            }
+            author = headAuthor;
         } else {
             author = new Author(contributor.fullName().orElseThrow(), contributor.username() + "@" + censusDomain);
         }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrateTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrateTests.java
@@ -805,7 +805,8 @@ class IntegrateTests {
             localRepo.push(masterHash, author.url(), "master", true);
 
             // Make a change with a corresponding PR with an empty e-mail
-            var editHash = CheckableRepository.appendAndCommit(localRepo, "Content", "A commit", "Duke", "");
+            var authorFullName = author.forge().currentUser().fullName();
+            var editHash = CheckableRepository.appendAndCommit(localRepo, "Content", "A commit", authorFullName, "");
             localRepo.push(editHash, author.url(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/SponsorTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/SponsorTests.java
@@ -58,7 +58,9 @@ class SponsorTests {
             localRepo.push(masterHash, author.url(), "master", true);
 
             // Make a change with a corresponding PR
-            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            var authorFullName = author.forge().currentUser().fullName();
+            var authorEmail = "ta@none.none";
+            var editHash = CheckableRepository.appendAndCommit(localRepo, "This is a new line", "Append commit", authorFullName, authorEmail);
             localRepo.push(editHash, author.url(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
@@ -106,8 +108,8 @@ class SponsorTests {
                 assertEquals("Generated Author 2", headCommit.author().name());
                 assertEquals("integrationauthor2@openjdk.java.net", headCommit.author().email());
             } else {
-                assertEquals("testauthor", headCommit.author().name());
-                assertEquals("ta@none.none", headCommit.author().email());
+                assertEquals(authorFullName, headCommit.author().name());
+                assertEquals(authorEmail, headCommit.author().email());
             }
 
             assertEquals("Generated Reviewer 1", headCommit.committer().name());
@@ -252,7 +254,8 @@ class SponsorTests {
             localRepo.push(masterHash, author.url(), "master", true);
 
             // Make a change with a corresponding PR
-            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            var authorFullName = author.forge().currentUser().fullName();
+            var editHash = CheckableRepository.appendAndCommit(localRepo, "This is a new line", "Append commit", authorFullName, "ta@none.none");
             localRepo.push(editHash, author.url(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
@@ -276,7 +279,7 @@ class SponsorTests {
             assertTrue(pr.labels().contains("sponsor"));
 
             // Push another change
-            var updateHash = CheckableRepository.appendAndCommit(localRepo,"Yet more stuff");
+            var updateHash = CheckableRepository.appendAndCommit(localRepo, "Yet more stuff", "Append commit", authorFullName, "ta@none.none");
             localRepo.push(updateHash, author.url(), "edit");
 
             // Make sure that the push registered
@@ -487,7 +490,8 @@ class SponsorTests {
             localRepo.push(masterHash, author.url(), "master", true);
 
             // Make a change with a corresponding PR
-            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            var authorFullName = author.forge().currentUser().fullName();
+            var editHash = CheckableRepository.appendAndCommit(localRepo, "This is a new line", "Append commit", authorFullName, "ta@none.none");
             localRepo.push(editHash, author.url(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 


### PR DESCRIPTION
Hi all,

please review this patch that adds an error if the author of the pull request does not have an OpenJDK username, has a full name set for their GitHub account and the `HEAD` commit for the pull request uses another full name.

Testing:
- [x] `make test` passes on Linux x64
- [x] Added an additional unit test

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-685](https://bugs.openjdk.java.net/browse/SKARA-685): Show a warning if PR author's full name does not match commit author's full name


### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/840/head:pull/840`
`$ git checkout pull/840`
