### PR TITLE
pr: always re-fetch PR for returned work items

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -188,6 +188,9 @@ class CheckWorkItem extends PullRequestWorkItem {
                 throw new UncheckedIOException(e);
             }
         }
-        return List.of(new CommandWorkItem(bot, pr, errorHandler));
+
+        // Must re-fetch PR after executing CheckRun
+        var updatedPR = pr.repository().pullRequest(pr.id());
+        return List.of(new CommandWorkItem(bot, updatedPR, errorHandler));
     }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandWorkItem.java
@@ -216,7 +216,10 @@ public class CommandWorkItem extends PullRequestWorkItem {
         if (nextCommand.isEmpty()) {
             log.info("No new non-external PR commands found, stopping further processing");
             // When all commands are processed, it's time to check labels
-            return List.of(new LabelerWorkItem(bot, pr, errorHandler));
+            // Must re-fetch PR after running the command, the command might have updated the PR
+            var updatedPR = pr.repository().pullRequest(pr.id());
+
+            return List.of(new LabelerWorkItem(bot, updatedPR, errorHandler));
         }
 
         var census = CensusInstance.create(bot.censusRepo(), bot.censusRef(), scratchPath.resolve("census"), pr,


### PR DESCRIPTION
Hi all,

please review this patch that ensures that we always re-fetch a pull request before returning new work items. This is to ensure that the returned work items never work on stale data.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/841/head:pull/841`
`$ git checkout pull/841`
