### PR TITLE
720: Incorrect usage instructions for label command

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
@@ -73,33 +73,39 @@ public class LabelerWorkItem extends PullRequestWorkItem {
         if (newLabels.isEmpty()) {
             message.append("To determine the appropriate audience for reviewing this pull request, one or more ");
             message.append("labels corresponding to different subsystems will normally be applied automatically. ");
-            message.append("However, no automatic labelling rule matches the changes in this pull request.\n\n");
-            message.append("In order to have an RFR email automatically sent to the correct mailing list, you will ");
-            message.append("need to add one or more labels manually using the `/label add \"label\"` command. ");
-            message.append("The following labels are valid: ");
-            var labels = bot.labelConfiguration().allowed().stream()
-                            .sorted()
-                            .map(label -> "`" + label + "`")
-                            .collect(Collectors.joining(" "));
-            message.append(labels);
-            message.append(".");
+            message.append("However, no automatic labelling rule matches the changes in this pull request. ");
+            message.append("In order to have an \"RFR\" email sent to the correct mailing list, you will ");
+            message.append("need to add one or more applicable labels manually using the ");
+            message.append("[/label](https://wiki.openjdk.java.net/display/SKARA/Pull+Request+Commands#PullRequestCommands-/label)");
+            message.append(" pull request command.\n\n");
+            message.append("<details>\n");
+            message.append("<summary>Applicable Labels</summary>\n");
+            message.append("<br>\n");
+            message.append("\n");
+            bot.labelConfiguration().allowed()
+                                    .stream()
+                                    .sorted()
+                                    .forEach(label -> message.append("- `" + label + "`\n"));
+            message.append("\n");
+            message.append("</details>");
         } else {
             message.append("The following label");
             if (newLabels.size() > 1) {
                 message.append("s");
             }
-            message.append(" will be automatically applied to this pull request: ");
-            var labels = newLabels.stream()
-                                  .sorted()
-                                  .map(label -> "`" + label + "`")
-                                  .collect(Collectors.joining(" "));
-            message.append(labels);
-            message.append(".\n\nWhen this pull request is ready to be reviewed, an RFR email will be sent to the ");
+            message.append(" will be automatically applied to this pull request:\n\n");
+            newLabels.stream()
+                     .sorted()
+                     .forEach(label -> message.append("- `" + label + "`\n"));
+            message.append("\n");
+            message.append("When this pull request is ready to be reviewed, an \"RFR\" email will be sent to the ");
             message.append("corresponding mailing list");
             if (newLabels.size() > 1) {
                 message.append("s");
             }
-            message.append(". If you would like to change these labels, use the `/label (add|remove) \"label\"` command.");
+            message.append(". If you would like to change these labels, use the ");
+            message.append("[/label](https://wiki.openjdk.java.net/display/SKARA/Pull+Request+Commands#PullRequestCommands-/label)");
+            message.append(" pull request command.");
         }
 
         message.append("\n");

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelerTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelerTests.java
@@ -71,7 +71,11 @@ class LabelerTests {
             TestBotRunner.runPeriodicItems(labelBot);
             assertEquals(Set.of("rfr"), new HashSet<>(pr.labels()));
             assertLastCommentContains(pr, "However, no automatic labelling rule matches the changes in this pull request.");
-            assertLastCommentContains(pr, "The following labels are valid: `test1` `test2`");
+            assertLastCommentContains(pr, "<details>");
+            assertLastCommentContains(pr, "<summary>Applicable Labels</summary>");
+            assertLastCommentContains(pr, "- `test1`");
+            assertLastCommentContains(pr, "- `test2`");
+            assertLastCommentContains(pr, "</details>");
 
             var fileA = localRepoFolder.resolve("a.txt");
             Files.writeString(fileA, "Hello");


### PR DESCRIPTION
Hi all,

please review this patch that improves the messages from the bots wrt to applied labels. For automatically applied labels we now list the labels more prominently. This is done to bring more attention to lists that will be CC:d. When no labels are automatically found then the message has been made a bit shorter by using a dropdown for revealing applicable labels. Both messages now link to the `/label` pull request command documentation instead of describing it in the messages.

Testing:
- [x] Updated a unit test
- [x] `make test` passes on Linux x64

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-720](https://bugs.openjdk.java.net/browse/SKARA-720): Incorrect usage instructions for label command


### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/842/head:pull/842`
`$ git checkout pull/842`
