### PR TITLE
pr: hint about two reviewers for some labels

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -500,6 +500,14 @@ class CheckRun {
             throw new UncheckedIOException(e);
         }
 
+        if (labels.stream().anyMatch(label -> workItem.bot.twoReviewersLabels().contains(label))) {
+            message.append("\n\n");
+            message.append(":mag: One or more changes in this pull request modifies files in areas of ");
+            message.append("the source code that often require two reviewers. Please consider if this is ");
+            message.append("the case for this pull request, and if so, await a second reviewer to approve ");
+            message.append("this pull request before you integrate it.");
+        }
+
         message.append("\n\n");
         message.append("After integration, the commit message for the final commit will be:\n");
         message.append("```\n");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -44,6 +44,7 @@ class PullRequestBot implements Bot {
     private final Map<String, String> externalCommands;
     private final Map<String, String> blockingCheckLabels;
     private final Set<String> readyLabels;
+    private final Set<String> twoReviewersLabels;
     private final Map<String, Pattern> readyComments;
     private final IssueProject issueProject;
     private final boolean ignoreStaleReviews;
@@ -61,10 +62,10 @@ class PullRequestBot implements Bot {
     PullRequestBot(HostedRepository repo, HostedRepository censusRepo, String censusRef,
                    LabelConfiguration labelConfiguration, Map<String, String> externalCommands,
                    Map<String, String> blockingCheckLabels, Set<String> readyLabels,
-                   Map<String, Pattern> readyComments, IssueProject issueProject, boolean ignoreStaleReviews,
-                   Set<String> allowedIssueTypes, Pattern allowedTargetBranches, Path seedStorage,
-                   HostedRepository confOverrideRepo, String confOverrideName, String confOverrideRef,
-                   String censusLink) {
+                   Set<String> twoReviewersLabels, Map<String, Pattern> readyComments, IssueProject issueProject,
+                   boolean ignoreStaleReviews, Set<String> allowedIssueTypes, Pattern allowedTargetBranches,
+                   Path seedStorage, HostedRepository confOverrideRepo, String confOverrideName,
+                   String confOverrideRef, String censusLink) {
         remoteRepo = repo;
         this.censusRepo = censusRepo;
         this.censusRef = censusRef;
@@ -72,6 +73,7 @@ class PullRequestBot implements Bot {
         this.externalCommands = externalCommands;
         this.blockingCheckLabels = blockingCheckLabels;
         this.readyLabels = readyLabels;
+        this.twoReviewersLabels = twoReviewersLabels;
         this.issueProject = issueProject;
         this.readyComments = readyComments;
         this.ignoreStaleReviews = ignoreStaleReviews;
@@ -182,6 +184,10 @@ class PullRequestBot implements Bot {
 
     Set<String> readyLabels() {
         return readyLabels;
+    }
+
+    Set<String> twoReviewersLabels() {
+        return twoReviewersLabels;
     }
 
     Map<String, Pattern> readyComments() {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
@@ -39,6 +39,7 @@ public class PullRequestBotBuilder {
     private Map<String, String> externalCommands = Map.of();
     private Map<String, String> blockingCheckLabels = Map.of();
     private Set<String> readyLabels = Set.of();
+    private Set<String> twoReviewersLabels = Set.of();
     private Map<String, Pattern> readyComments = Map.of();
     private IssueProject issueProject = null;
     private boolean ignoreStaleReviews = false;
@@ -85,6 +86,11 @@ public class PullRequestBotBuilder {
 
     public PullRequestBotBuilder readyLabels(Set<String> readyLabels) {
         this.readyLabels = readyLabels;
+        return this;
+    }
+
+    public PullRequestBotBuilder twoReviewersLabels(Set<String> twoReviewersLabels) {
+        this.twoReviewersLabels = twoReviewersLabels;
         return this;
     }
 
@@ -140,7 +146,7 @@ public class PullRequestBotBuilder {
 
     public PullRequestBot build() {
         return new PullRequestBot(repo, censusRepo, censusRef, labelConfiguration, externalCommands,
-                                  blockingCheckLabels, readyLabels, readyComments, issueProject,
+                                  blockingCheckLabels, readyLabels, twoReviewersLabels, readyComments, issueProject,
                                   ignoreStaleReviews, allowedIssueTypes, allowedTargetBranches,
                                   seedStorage, confOverrideRepo, confOverrideName, confOverrideRef,
                                   censusLink);

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
@@ -97,6 +97,13 @@ public class PullRequestBotFactory implements BotFactory {
                 }
                 botBuilder.labelConfiguration(labelConfigurations.get(labelGroup));
             }
+            if (repo.value().contains("two-reviewers")) {
+                var labels = repo.value().get("two-reviewers")
+                                         .stream()
+                                         .map(label -> label.asString())
+                                         .collect(Collectors.toSet());
+                botBuilder.twoReviewersLabels(labels);
+            }
             if (repo.value().contains("issues")) {
                 botBuilder.issueProject(configuration.issueProject(repo.value().get("issues").asString()));
             }


### PR DESCRIPTION
Hi all,

please review this patch that makes it possible to configure per repository whether certain labels should cause a hint in the integration message about two reviewers to be displayed.

Testing:
- [x] Added a new unit test
- [x] `make test` passes on Linux x64

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**) ⚠️ Review applies to 036ae7bdfd2717aaa3d3d805aefd4d83674273f7


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/844/head:pull/844`
`$ git checkout pull/844`
