### PR TITLE
pr: add hint about 24h exposure for PRs with certain labels

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -32,6 +32,7 @@ import org.openjdk.skara.vcs.openjdk.Issue;
 import java.io.*;
 import java.nio.file.Path;
 import java.util.*;
+import java.time.ZonedDateTime;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.stream.*;
@@ -551,6 +552,16 @@ class CheckRun {
             message.append("the source code that often require two reviewers. Please consider if this is ");
             message.append("the case for this pull request, and if so, await a second reviewer to approve ");
             message.append("this pull request before you integrate it.");
+        }
+
+        if (labels.stream().anyMatch(label -> workItem.bot.twentyFourHoursLabels().contains(label))) {
+            var rfrAt = pr.labelAddedAt("rfr");
+            if (rfrAt.isPresent() && ZonedDateTime.now().minusHours(24).isBefore(rfrAt.get())) {
+                message.append("\n\n");
+                message.append(":earth_americas: Applicable reviewers for one or more changes in this pull request are spread across ");
+                message.append("multiple different time zones. Please consider waiting with integrating this pull request until it has ");
+                message.append("been out for review for at least 24 hours to give all reviewers a chance to review the pull request.");
+            }
         }
 
         message.append("\n\n");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -45,6 +45,7 @@ class PullRequestBot implements Bot {
     private final Map<String, String> blockingCheckLabels;
     private final Set<String> readyLabels;
     private final Set<String> twoReviewersLabels;
+    private final Set<String> twentyFourHoursLabels;
     private final Map<String, Pattern> readyComments;
     private final IssueProject issueProject;
     private final boolean ignoreStaleReviews;
@@ -62,7 +63,8 @@ class PullRequestBot implements Bot {
     PullRequestBot(HostedRepository repo, HostedRepository censusRepo, String censusRef,
                    LabelConfiguration labelConfiguration, Map<String, String> externalCommands,
                    Map<String, String> blockingCheckLabels, Set<String> readyLabels,
-                   Set<String> twoReviewersLabels, Map<String, Pattern> readyComments, IssueProject issueProject,
+                   Set<String> twoReviewersLabels, Set<String> twentyFourHoursLabels,
+                   Map<String, Pattern> readyComments, IssueProject issueProject,
                    boolean ignoreStaleReviews, Set<String> allowedIssueTypes, Pattern allowedTargetBranches,
                    Path seedStorage, HostedRepository confOverrideRepo, String confOverrideName,
                    String confOverrideRef, String censusLink) {
@@ -74,6 +76,7 @@ class PullRequestBot implements Bot {
         this.blockingCheckLabels = blockingCheckLabels;
         this.readyLabels = readyLabels;
         this.twoReviewersLabels = twoReviewersLabels;
+        this.twentyFourHoursLabels = twentyFourHoursLabels;
         this.issueProject = issueProject;
         this.readyComments = readyComments;
         this.ignoreStaleReviews = ignoreStaleReviews;
@@ -176,6 +179,10 @@ class PullRequestBot implements Bot {
 
     Set<String> twoReviewersLabels() {
         return twoReviewersLabels;
+    }
+
+    Set<String> twentyFourHoursLabels() {
+        return twentyFourHoursLabels;
     }
 
     IssueProject issueProject() {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
@@ -40,6 +40,7 @@ public class PullRequestBotBuilder {
     private Map<String, String> blockingCheckLabels = Map.of();
     private Set<String> readyLabels = Set.of();
     private Set<String> twoReviewersLabels = Set.of();
+    private Set<String> twentyFourHoursLabels = Set.of();
     private Map<String, Pattern> readyComments = Map.of();
     private IssueProject issueProject = null;
     private boolean ignoreStaleReviews = false;
@@ -91,6 +92,11 @@ public class PullRequestBotBuilder {
 
     public PullRequestBotBuilder twoReviewersLabels(Set<String> twoReviewersLabels) {
         this.twoReviewersLabels = twoReviewersLabels;
+        return this;
+    }
+
+    public PullRequestBotBuilder twentyFourHoursLabels(Set<String> twentyFourHoursLabels) {
+        this.twentyFourHoursLabels = twentyFourHoursLabels;
         return this;
     }
 
@@ -146,9 +152,9 @@ public class PullRequestBotBuilder {
 
     public PullRequestBot build() {
         return new PullRequestBot(repo, censusRepo, censusRef, labelConfiguration, externalCommands,
-                                  blockingCheckLabels, readyLabels, twoReviewersLabels, readyComments, issueProject,
-                                  ignoreStaleReviews, allowedIssueTypes, allowedTargetBranches,
-                                  seedStorage, confOverrideRepo, confOverrideName, confOverrideRef,
-                                  censusLink);
+                                  blockingCheckLabels, readyLabels, twoReviewersLabels, twentyFourHoursLabels,
+                                  readyComments, issueProject, ignoreStaleReviews, allowedIssueTypes,
+                                  allowedTargetBranches, seedStorage, confOverrideRepo, confOverrideName,
+                                  confOverrideRef, censusLink);
     }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelTests.java
@@ -410,4 +410,59 @@ public class LabelTests {
             assertLastCommentContains(pr,"in areas of the source code that often require two reviewers.");
         }
     }
+
+    @Test
+    void twentyFourHoursLabel(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var integrator = credentials.getHostedRepository();
+
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addReviewer(integrator.forge().currentUser().id())
+                                           .addCommitter(author.forge().currentUser().id());
+            var labelConfiguration = LabelConfigurationJson.builder()
+                                                       .addMatchers("1", List.of(Pattern.compile("cpp$")))
+                                                       .addMatchers("2", List.of(Pattern.compile("hpp$")))
+                                                       .addGroup("group", List.of("1", "2"))
+                                                       .addExtra("extra")
+                                                       .build();
+            var prBot = PullRequestBot.newBuilder()
+                                      .repo(integrator)
+                                      .censusRepo(censusBuilder.build())
+                                      .twentyFourHoursLabels(Set.of("1"))
+                                      .labelConfiguration(labelConfiguration)
+                                      .build();
+
+            // Populate the projects repository
+            var localRepoFolder = tempFolder.path().resolve("localrepo");
+            var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "123: This is a pull request");
+
+            // Add a label with 24h hint
+            pr.addComment("/label add 1");
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // The bot should reply with a success message
+            assertLastCommentContains(pr,"The `1` label was successfully added.");
+
+            // Review the PR
+            var prAsReviewer = integrator.pullRequest(pr.id());
+            prAsReviewer.addReview(Review.Verdict.APPROVED, "Looks good!");
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // The bot should reply with a integration message
+            assertLastCommentContains(pr,"This change now passes all *automated* pre-integration checks");
+            assertLastCommentContains(pr,":earth_americas: Applicable reviewers for one or more changes ");
+            assertLastCommentContains(pr,"in this pull request are spread across multiple different time zones.");
+            assertLastCommentContains(pr,"been out for review for at least 24 hours");
+        }
+    }
 }

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
@@ -285,4 +285,9 @@ class InMemoryPullRequest implements PullRequest {
     public URI diffUrl() {
         return null;
     }
+
+    @Override
+    public Optional<ZonedDateTime> labelAddedAt(String label) {
+        return null;
+    }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
@@ -26,6 +26,7 @@ import org.openjdk.skara.issuetracker.Issue;
 import org.openjdk.skara.vcs.Hash;
 
 import java.net.URI;
+import java.time.ZonedDateTime;
 import java.util.*;
 
 public interface PullRequest extends Issue {
@@ -141,4 +142,6 @@ public interface PullRequest extends Issue {
      */
     boolean isDraft();
     void makeNotDraft();
+
+    Optional<ZonedDateTime> labelAddedAt(String label);
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -641,4 +641,17 @@ public class GitHubPullRequest implements PullRequest {
     public URI diffUrl() {
         return URI.create(webUrl() + ".diff");
     }
+
+    @Override
+    public Optional<ZonedDateTime> labelAddedAt(String label) {
+        return request.get("issues/" + json.get("number").toString() + "/timeline")
+                      .execute()
+                      .stream()
+                      .map(JSONValue::asObject)
+                      .filter(obj -> obj.contains("event"))
+                      .filter(obj -> obj.get("event").asString().equals("labeled"))
+                      .filter(obj -> obj.get("label").get("name").asString().equals(label))
+                      .map(o -> ZonedDateTime.parse(o.get("created_at").asString()))
+                      .findFirst();
+    }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -718,4 +718,17 @@ public class GitLabMergeRequest implements PullRequest {
     public URI diffUrl() {
         return URI.create(webUrl() + ".diff");
     }
+
+    @Override
+    public Optional<ZonedDateTime> labelAddedAt(String label) {
+        return request.get("resource_label_events")
+                      .execute()
+                      .stream()
+                      .map(JSONValue::asObject)
+                      .filter(obj -> obj.contains("action"))
+                      .filter(obj -> obj.get("action").asString().equals("add"))
+                      .filter(obj -> obj.get("label").get("name").asString().equals(label))
+                      .map(o -> ZonedDateTime.parse(o.get("created_at").asString()))
+                      .findFirst();
+    }
 }

--- a/test/src/main/java/org/openjdk/skara/test/IssueData.java
+++ b/test/src/main/java/org/openjdk/skara/test/IssueData.java
@@ -34,7 +34,7 @@ class IssueData {
     String body = "";
     String title = "";
     final List<Comment> comments = new ArrayList<>();
-    final Set<String> labels = new HashSet<>();
+    final Map<String, ZonedDateTime> labels = new HashMap<>();
     final List<HostUser> assignees = new ArrayList<>();
     final List<Link> links = new ArrayList<>();
     final Map<String, JSONValue> properties = new HashMap<>();

--- a/test/src/main/java/org/openjdk/skara/test/TestIssue.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestIssue.java
@@ -151,8 +151,9 @@ public class TestIssue implements Issue {
 
     @Override
     public void addLabel(String label) {
-        data.labels.add(label);
-        data.lastUpdate = ZonedDateTime.now();
+        var now = ZonedDateTime.now();
+        data.labels.put(label, now);
+        data.lastUpdate = now;
     }
 
     @Override
@@ -163,7 +164,7 @@ public class TestIssue implements Issue {
 
     @Override
     public List<String> labels() {
-        return new ArrayList<>(data.labels);
+        return new ArrayList<>(data.labels.keySet());
     }
 
     @Override

--- a/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
@@ -222,4 +222,9 @@ public class TestPullRequest extends TestIssue implements PullRequest {
     public URI diffUrl() {
         return URI.create(webUrl().toString() + ".diff");
     }
+
+    @Override
+    public Optional<ZonedDateTime> labelAddedAt(String label) {
+        return Optional.ofNullable(data.labels.get(label));
+    }
 }


### PR DESCRIPTION
Hi all,

please review this patch that allows the PR bot to show a hint in the integration message that the PR should perhaps bit out for review for at least 24 hours if the PR has certain label(s).

Testing:
- [x] Added a unit test
- [x] `make test` passes on Linux x64

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/846/head:pull/846`
`$ git checkout pull/846`
