### PR TITLE
update-sync labels should be applied to all-bar-one records

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/Backports.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/Backports.java
@@ -313,13 +313,12 @@ public class Backports {
         allIssues.addAll(related);
 
         for (var streamIssues : groupByReleaseStream(allIssues)) {
-            // First entry should not have the label
-            var first = streamIssues.get(0);
-            if (first.labels().contains(label)) {
-                first.removeLabel(label);
-            }
-
-            // But all the following ones should
+            // The first issue may have the label if it was part of another
+            // stream. (e.g. feature release has 14 & 15 where update release
+            // has 15, 15.0.1 & 15.0.2. In this case the label should be
+            // applied to 15, which is the first releases in the 15u stream)
+            // This means we ignore the first issue for the purposes of adding
+            // the label.
             if (streamIssues.size() > 1) {
                 var rest = streamIssues.subList(1, streamIssues.size());
                 for (var i : rest) {


### PR DESCRIPTION
This modification fixes the situation where a backport record may be a member
of two distinct streams and has its hgupdate-sync label removed as a result.

E.g. with backport records for 14, 15, 14.0.1, 15.0.1 no label would be
applied to 15. The current logic gives precedence to the fact that it is the
first release in the 15-updates stream and ignores the fact that it is not
the first release in the feature stream. The label added by the feature stream
is removed when evaluating the 15-updates stream. This should not be the case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - no project role)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/848/head:pull/848`
`$ git checkout pull/848`
