### PR TITLE
pr: only warn about differing author names

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
@@ -115,18 +115,8 @@ public class CheckablePullRequest {
                 throw new CommitFailure("Merge PRs can only be created by known OpenJDK authors.");
             }
 
-            var headHash = pr.headHash();
-            var headCommit = localRepo.lookup(headHash).get();
-            var headAuthor = headCommit.author();
-            var prAuthor = pr.author();
-            if (!prAuthor.fullName().equals(prAuthor.userName())) {
-                if (!headAuthor.name().equals(prAuthor.fullName())) {
-                    throw new CommitFailure("The HEAD commit of this pull request, " + headHash.abbreviate() +
-                                            ", has a different author, `" + headAuthor.name() + "`" +
-                                            ", than the author of this pull request: `" + prAuthor.fullName() + "`");
-                }
-            }
-            author = headAuthor;
+            var head = localRepo.lookup(pr.headHash()).get();
+            author = head.author();
         } else {
             author = new Author(contributor.fullName().orElseThrow(), contributor.username() + "@" + censusDomain);
         }

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
@@ -290,4 +290,9 @@ class InMemoryPullRequest implements PullRequest {
     public Optional<ZonedDateTime> labelAddedAt(String label) {
         return null;
     }
+
+    @Override
+    public URI headUrl() {
+        return null;
+    }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
@@ -74,6 +74,12 @@ public interface PullRequest extends Issue {
     Hash headHash();
 
     /**
+     * URI to the current head of the request.
+     * @return
+     */
+    URI headUrl();
+
+    /**
      * Returns the name of the ref used for fetching the pull request.
      * @return
      */

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -654,4 +654,9 @@ public class GitHubPullRequest implements PullRequest {
                       .map(o -> ZonedDateTime.parse(o.get("created_at").asString()))
                       .findFirst();
     }
+
+    @Override
+    public URI headUrl() {
+        return URI.create(webUrl() + "/commits/" + headHash().hex());
+    }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -731,4 +731,9 @@ public class GitLabMergeRequest implements PullRequest {
                       .map(o -> ZonedDateTime.parse(o.get("created_at").asString()))
                       .findFirst();
     }
+
+    @Override
+    public URI headUrl() {
+        return URI.create(webUrl() + "/diffs?commit_id=" + headHash().hex());
+    }
 }

--- a/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
@@ -227,4 +227,9 @@ public class TestPullRequest extends TestIssue implements PullRequest {
     public Optional<ZonedDateTime> labelAddedAt(String label) {
         return Optional.ofNullable(data.labels.get(label));
     }
+
+    @Override
+    public URI headUrl() {
+        return URI.create(webUrl().toString() + "/commits/" + headHash().hex());
+    }
 }


### PR DESCRIPTION
Hi all,

please review this patch that slightly updates the pull request full name checking to only write a warning instead of failing jcheck. This patch also provides clear instructions in the warning comment for how to create a new commit with the desired full name.

Testing:
- [x] Updated the existing unit test
- [x] `make test` passes on Linux x64

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/849/head:pull/849`
`$ git checkout pull/849`
