### PR TITLE
731: Do not include target hash in cached PR metadata

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -841,8 +841,7 @@ class CheckRun {
             }
 
             // Calculate current metadata to avoid unnecessary future checks
-            var metadata = workItem.getMetadata(title, updatedBody, pr.comments(), activeReviews, newLabels,
-                                                censusInstance, pr.targetHash(), pr.isDraft());
+            var metadata = workItem.getMetadata(censusInstance, title, updatedBody, pr.comments(), activeReviews, newLabels, pr.isDraft());
             checkBuilder.metadata(metadata);
         } catch (Exception e) {
             log.throwing("CommitChecker", "checkStatus", e);

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -482,6 +482,7 @@ class CheckTests {
             localRepo.push(unrelatedHash, author.url(), "master");
 
             // Let the bot see the changes
+            pr.setBody(pr.body() + "recheck");
             TestBotRunner.runPeriodicItems(mergeBot);
 
             // The bot should reply with an ok message
@@ -532,6 +533,7 @@ class CheckTests {
             localRepo.push(conflictingHash, author.url(), "master");
 
             // Let the bot see the changes
+            pr.setBody(pr.body() + "recheck");
             TestBotRunner.runPeriodicItems(mergeBot);
 
             // The bot should not yet post the ready for integration message
@@ -560,6 +562,7 @@ class CheckTests {
             localRepo.push(masterHash, author.url(), "master", true);
 
             // Let the bot see the changes
+            pr.setBody(pr.body() + "recheck");
             TestBotRunner.runPeriodicItems(mergeBot);
 
             // The bot should now post an integration message


### PR DESCRIPTION
Avoid using the target branch hash in check metadata calculation, as the pull request update cache will hide such updates anyway.

Best regards,
Robin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-731](https://bugs.openjdk.java.net/browse/SKARA-731): Do not include target hash in cached PR metadata


### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/850/head:pull/850`
`$ git checkout pull/850`
