### PR TITLE
vcs: allow capital letters in e-mails

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/CommitMessageSyntax.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/CommitMessageSyntax.java
@@ -26,7 +26,7 @@ import java.util.regex.Pattern;
 
 public class CommitMessageSyntax {
         private static final String OPENJDK_USERNAME_REGEX = "[-.a-z0-9]+";
-        public static final String EMAIL_ADDR_REGEX = "[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]+";
+        public static final String EMAIL_ADDR_REGEX = "[A-Za-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]+";
         public static final String REAL_NAME_REGEX = "[^<>@]+";
         private static final String REAL_NAME_AND_EMAIL_ATTR_REGEX = REAL_NAME_REGEX + " +<" + EMAIL_ADDR_REGEX + ">";
         private static final String ATTR_REGEX = "(?:(?:" + EMAIL_ADDR_REGEX + ")|(?:" + REAL_NAME_AND_EMAIL_ATTR_REGEX + "))";

--- a/vcs/src/test/java/org/openjdk/skara/vcs/openjdk/CommitMessageParsersTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/openjdk/CommitMessageParsersTests.java
@@ -242,4 +242,22 @@ public class CommitMessageParsersTests {
         assertEquals(List.of(), message.summaries());
         assertEquals(List.of(), message.additional());
     }
+
+    @Test
+    void capitalLetterInEmail() {
+        var text = List.of("01234567: An issue",
+                           "",
+                           "Co-authored-by: Just An Example <JustAn@example.com>",
+                           "Reviewed-by: ab, cd, ef");
+
+        var message = CommitMessageParsers.v1.parse(text);
+
+        assertEquals("01234567: An issue", message.title());
+        assertEquals(List.of(new Issue("01234567", "An issue")), message.issues());
+        assertEquals(List.of("ab", "cd", "ef"), message.reviewers());
+        assertEquals(List.of(new Author("Just An Example", "JustAn@example.com")),
+                     message.contributors());
+        assertEquals(List.of(), message.summaries());
+        assertEquals(List.of(), message.additional());
+    }
 }


### PR DESCRIPTION
Hi all,

please review this patch that allows e-mail addresses for the "Co-authored-by" lines to have capital letters for the name part.

Testing:
- [x] Added a unit test
- [x] `make test` passes on Linux x64

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/852/head:pull/852`
`$ git checkout pull/852`
