### PR TITLE
Show a summary of pre-submit testing results in the PR body (if any)

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/TestResults.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/TestResults.java
@@ -93,7 +93,7 @@ public class TestResults {
         resultsBody.append("|     |");
         platforms.forEach(platform -> resultsBody.append(" ").append(platform).append(" |"));
         resultsBody.append("\n| --- |");
-        platforms.forEach(platform -> resultsBody.append(" :-----: |"));
+        platforms.forEach(platform -> resultsBody.append(" ----- |"));
         for (var flavor : flavors) {
             resultsBody.append("\n| ").append(flavor).append(" |");
             for (var platform : platforms) {
@@ -119,12 +119,14 @@ public class TestResults {
                     int total = failureCount + pendingCount + successCount;
                     if (failureCount > 0) {
                         resultsBody.append(" ❌");
+                        resultsBody.append(" (").append(failureCount).append("/").append(total).append(" failed) |");
                     } else if (pendingCount > 0) {
                         resultsBody.append(" ⏳");
+                        resultsBody.append(" (").append(pendingCount).append("/").append(total).append(" in progress) |");
                     } else {
                         resultsBody.append(" ✔️");
+                        resultsBody.append(" (").append(successCount).append("/").append(total).append(" passed) |");
                     }
-                    resultsBody.append(" (").append(successCount).append("/").append(total).append(") |");
 
                 } else {
                     resultsBody.append("    | ");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/TestResults.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/TestResults.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.pr;
+
+import org.openjdk.skara.forge.*;
+
+import java.time.ZonedDateTime;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class TestResults {
+    private static String platformFromName(String checkName) {
+        var checkFlavorStart = checkName.indexOf("(");
+        if (checkFlavorStart > 0) {
+            return checkName.substring(0, checkFlavorStart - 1).strip();
+        } else {
+            return checkName.strip();
+        }
+    }
+
+    private static String flavorFromName(String checkName) {
+        var checkFlavorStart = checkName.indexOf("(");
+        var checkFlavorEnd = checkName.lastIndexOf(")");
+        if (checkFlavorStart > 0 && checkFlavorEnd > checkFlavorStart) {
+            var flavor = checkName.substring(checkFlavorStart + 1, checkFlavorEnd).strip().toLowerCase();
+            for (int i = 1; i < 10; ++i) {
+                if (flavor.contains("tier" + i)) {
+                    return "Test (tier" + i + ")";
+                }
+            }
+            if (flavor.contains("build")) {
+                return "Build";
+            }
+        }
+        // Fallback value
+        return "Build / test";
+    }
+
+    private static boolean ignoredCheck(String checkName) {
+        var lcName = checkName.toLowerCase();
+        return lcName.contains("jcheck") || lcName.contains("prerequisites") || lcName.contains("post-process");
+    }
+
+    static Optional<String> summarize(List<Check> checks) {
+        // Retain only the latest when there are multiple checks with the same name
+        var latestChecks = checks.stream()
+                                 .filter(check -> !ignoredCheck(check.name()))
+                                 .sorted(Comparator.comparing(Check::startedAt, ZonedDateTime::compareTo))
+                                 .collect(Collectors.toMap(Check::name, Function.identity(), (a, b) -> b, LinkedHashMap::new));
+        if (latestChecks.isEmpty()) {
+            return Optional.empty();
+        }
+
+        var platforms = latestChecks.values().stream()
+                                    .map(check -> platformFromName(check.name()))
+                                    .collect(Collectors.toCollection(TreeSet::new));
+        var flavors = latestChecks.values().stream()
+                                  .map(check -> flavorFromName(check.name()))
+                                  .collect(Collectors.toCollection(TreeSet::new));
+        if (platforms.isEmpty() || flavors.isEmpty()) {
+            return Optional.empty();
+        }
+
+        var platformFlavors = latestChecks.values().stream()
+                                          .collect(Collectors.groupingBy(check -> platformFromName(check.name()))).entrySet().stream()
+                                          .collect(Collectors.toMap(Map.Entry::getKey,
+                                                                    entry -> entry.getValue().stream()
+                                                                                  .collect(Collectors.groupingBy(check -> flavorFromName(check.name())))));
+
+        var resultsBody = new StringBuilder();
+        resultsBody.append("\n\n### Successful test tasks\n\n");
+        resultsBody.append("|     |");
+        platforms.forEach(platform -> resultsBody.append(" ").append(platform).append(" |"));
+        resultsBody.append("\n| --- |");
+        platforms.forEach(platform -> resultsBody.append(" :-----: |"));
+        for (var flavor : flavors) {
+            resultsBody.append("\n| ").append(flavor).append(" |");
+            for (var platform : platforms) {
+                var platformChecks = platformFlavors.get(platform);
+                var flavorChecks = platformChecks.get(flavor);
+                if (flavorChecks != null) {
+                    int failureCount = 0;
+                    int pendingCount = 0;
+                    int successCount = 0;
+                    for (var check : flavorChecks) {
+                        switch (check.status()) {
+                            case IN_PROGRESS:
+                                pendingCount++;
+                                break;
+                            case FAILURE:
+                                failureCount++;
+                                break;
+                            case SUCCESS:
+                                successCount++;
+                                break;
+                        }
+                    }
+                    int total = failureCount + pendingCount + successCount;
+                    if (failureCount > 0) {
+                        resultsBody.append(" ❌");
+                    } else if (pendingCount > 0) {
+                        resultsBody.append(" ⏳");
+                    } else {
+                        resultsBody.append(" ✔️");
+                    }
+                    resultsBody.append(" (").append(successCount).append("/").append(total).append(") |");
+
+                } else {
+                    resultsBody.append("    | ");
+                }
+            }
+        }
+
+        var failedChecks = latestChecks.values().stream()
+                                       .filter(check -> check.status() == CheckStatus.FAILURE)
+                                       .sorted(Comparator.comparing(Check::name))
+                                       .collect(Collectors.toList());
+        if (!failedChecks.isEmpty()) {
+            resultsBody.append("\n\n**Failed test task");
+            if (failedChecks.size() > 1) {
+                resultsBody.append("s");
+            }
+            resultsBody.append("**");
+            for (var failedCheck : failedChecks) {
+                resultsBody.append("\n- ");
+                if (failedCheck.details().isPresent()) {
+                    resultsBody.append("[");
+                    resultsBody.append(failedCheck.name());
+                    resultsBody.append("](");
+                    resultsBody.append(failedCheck.details().get().toString());
+                    resultsBody.append(")");
+                } else {
+                    resultsBody.append("`");
+                    resultsBody.append(failedCheck.name());
+                    resultsBody.append("`");
+                }
+            }
+        }
+
+        return Optional.of(resultsBody.toString());
+    }
+}

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -28,6 +28,7 @@ import org.openjdk.skara.json.JSON;
 import org.openjdk.skara.test.*;
 
 import java.io.IOException;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.nio.file.attribute.PosixFilePermission;
@@ -1679,6 +1680,54 @@ class CheckTests {
             TestBotRunner.runPeriodicItems(mergeBot);
             pr = author.pullRequest(pr.id());
             assertEquals(numComments, pr.comments().size());
+        }
+    }
+
+    @Test
+    void preSubmitInSummary(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var reviewer = credentials.getHostedRepository();
+            var issues = credentials.getIssueProject();
+
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addAuthor(author.forge().currentUser().id())
+                                           .addReviewer(reviewer.forge().currentUser().id());
+            var checkBot = PullRequestBot.newBuilder().repo(author).censusRepo(censusBuilder.build()).issueProject(issues).build();
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(), Path.of("appendable.txt"),
+                                                     Set.of("issues"), null);
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Make a draft PR where we can add some checks
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.url(), "preedit", true);
+            var draftPr = credentials.createPullRequest(author, "master", "preedit", "This is a pull request", true);
+            var check1 = CheckBuilder.create("ps1", editHash).title("PS1");
+            draftPr.createCheck(check1.build());
+            draftPr.updateCheck(check1.complete(true).build());
+            var check2 = CheckBuilder.create("ps2", editHash).title("PS2");
+            draftPr.createCheck(check2.build());
+            draftPr.updateCheck(check2.complete(false).build());
+            var check3 = CheckBuilder.create("ps3", editHash).title("PS3");
+            draftPr.createCheck(check3.build());
+            draftPr.updateCheck(check3.details(URI.create("https://www.example.com")).complete(false).build());
+
+            // Now make an actual PR
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
+
+            // Check the status
+            TestBotRunner.runPeriodicItems(checkBot);
+
+            // The body should contain the issue title
+            assertTrue(pr.body().contains("Pre-submit test results"));
+            assertTrue(pr.body().contains("1 job completed successfully"));
+            assertTrue(pr.body().contains("The job [ps3](https://www.example.com) failed"));
+            assertTrue(pr.body().contains("The job `ps2` failed"));
         }
     }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -1724,10 +1724,11 @@ class CheckTests {
             TestBotRunner.runPeriodicItems(checkBot);
 
             // The body should contain the issue title
-            assertTrue(pr.body().contains("Pre-submit test results"));
-            assertTrue(pr.body().contains("1 job completed successfully"));
-            assertTrue(pr.body().contains("The job [ps3](https://www.example.com) failed"));
-            assertTrue(pr.body().contains("The job `ps2` failed"));
+            assertTrue(pr.body().contains("Successful test task"));
+            assertTrue(pr.body().contains("|     | ps1 | ps2 | ps3 |"));
+            assertTrue(pr.body().contains("**Failed test tasks**"));
+            assertTrue(pr.body().contains("- [ps3](https://www.example.com)"));
+            assertTrue(pr.body().contains("- `ps2`"));
         }
     }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/TestResultsTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/TestResultsTests.java
@@ -38,13 +38,11 @@ public class TestResultsTests {
                                 .complete(true)
                                 .build();
         var summary = TestResults.summarize(List.of(check));
-        assertEquals("\n" +
-                             "\n" +
-                             "### Successful test tasks\n" +
+        assertEquals("### Successful test tasks\n" +
                              "\n" +
                              "|     | Test |\n" +
-                             "| --- | :-----: |\n" +
-                             "| Build / test | ✔️ (1/1) |", summary.get());
+                             "| --- | ----- |\n" +
+                             "| Build / test | ✔️ (1/1 passed) |", summary.get().strip());
     }
 
     @Test
@@ -56,13 +54,11 @@ public class TestResultsTests {
                                  .complete(true)
                                  .build();
         var summary = TestResults.summarize(List.of(check1, check2));
-        assertEquals("\n" +
-                             "\n" +
-                             "### Successful test tasks\n" +
+        assertEquals("### Successful test tasks\n" +
                              "\n" +
                              "|     | Linux x64 | Windows x64 |\n" +
-                             "| --- | :-----: | :-----: |\n" +
-                             "| Build / test | ✔️ (1/1) | ✔️ (1/1) |", summary.get());
+                             "| --- | ----- | ----- |\n" +
+                             "| Build / test | ✔️ (1/1 passed) | ✔️ (1/1 passed) |", summary.get().strip());
     }
 
     @Test
@@ -74,14 +70,12 @@ public class TestResultsTests {
                                  .complete(true)
                                  .build();
         var summary = TestResults.summarize(List.of(check1, check2));
-        assertEquals("\n" +
-                             "\n" +
-                             "### Successful test tasks\n" +
+        assertEquals("### Successful test tasks\n" +
                              "\n" +
                              "|     | Linux x64 |\n" +
-                             "| --- | :-----: |\n" +
-                             "| Build | ✔️ (1/1) |\n" +
-                             "| Test (tier1) | ✔️ (1/1) |", summary.get());
+                             "| --- | ----- |\n" +
+                             "| Build | ✔️ (1/1 passed) |\n" +
+                             "| Test (tier1) | ✔️ (1/1 passed) |", summary.get().strip());
     }
 
     @Test
@@ -99,14 +93,12 @@ public class TestResultsTests {
                                  .complete(true)
                                  .build();
         var summary = TestResults.summarize(List.of(check1, check2, check3, check4));
-        assertEquals("\n" +
-                             "\n" +
-                             "### Successful test tasks\n" +
+        assertEquals("### Successful test tasks\n" +
                              "\n" +
                              "|     | Linux x64 | Windows x64 |\n" +
-                             "| --- | :-----: | :-----: |\n" +
-                             "| Build | ✔️ (1/1) | ✔️ (1/1) |\n" +
-                             "| Test (tier1) | ✔️ (1/1) | ✔️ (1/1) |", summary.get());
+                             "| --- | ----- | ----- |\n" +
+                             "| Build | ✔️ (1/1 passed) | ✔️ (1/1 passed) |\n" +
+                             "| Test (tier1) | ✔️ (1/1 passed) | ✔️ (1/1 passed) |", summary.get().strip());
     }
 
     @Test
@@ -124,14 +116,12 @@ public class TestResultsTests {
                                  .complete(true)
                                  .build();
         var summary = TestResults.summarize(List.of(check1, check2, check3, check4));
-        assertEquals("\n" +
-                             "\n" +
-                             "### Successful test tasks\n" +
+        assertEquals("### Successful test tasks\n" +
                              "\n" +
                              "|     | Linux x64 | Windows x64 | macOS x64 |\n" +
-                             "| --- | :-----: | :-----: | :-----: |\n" +
-                             "| Build | ✔️ (1/1) | ✔️ (1/1) | ✔️ (1/1) |\n" +
-                             "| Test (tier1) | ✔️ (1/1) |    |     | ", summary.get());
+                             "| --- | ----- | ----- | ----- |\n" +
+                             "| Build | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) |\n" +
+                             "| Test (tier1) | ✔️ (1/1 passed) |    |     |", summary.get().strip());
     }
 
     @Test
@@ -144,16 +134,14 @@ public class TestResultsTests {
                                  .details(URI.create("www.example.com"))
                                  .build();
         var summary = TestResults.summarize(List.of(check1, check2));
-        assertEquals("\n" +
-                             "\n" +
-                             "### Successful test tasks\n" +
+        assertEquals("### Successful test tasks\n" +
                              "\n" +
                              "|     | Linux x64 | Windows x64 |\n" +
-                             "| --- | :-----: | :-----: |\n" +
-                             "| Build / test | ✔️ (1/1) | ❌ (0/1) |\n" +
+                             "| --- | ----- | ----- |\n" +
+                             "| Build / test | ✔️ (1/1 passed) | ❌ (1/1 failed) |\n" +
                              "\n" +
                              "**Failed test task**\n" +
-                             "- [Windows x64 (test)](www.example.com)", summary.get());
+                             "- [Windows x64 (test)](www.example.com)", summary.get().strip());
     }
 
     @Test
@@ -164,13 +152,11 @@ public class TestResultsTests {
         var check2 = CheckBuilder.create("Windows x64 (test)", Hash.zero())
                                  .build();
         var summary = TestResults.summarize(List.of(check1, check2));
-        assertEquals("\n" +
-                             "\n" +
-                             "### Successful test tasks\n" +
+        assertEquals("### Successful test tasks\n" +
                              "\n" +
                              "|     | Linux x64 | Windows x64 |\n" +
-                             "| --- | :-----: | :-----: |\n" +
-                             "| Build / test | ✔️ (1/1) | ⏳ (0/1) |", summary.get());
+                             "| --- | ----- | ----- |\n" +
+                             "| Build / test | ✔️ (1/1 passed) | ⏳ (1/1 in progress) |", summary.get().strip());
     }
 
     @Test
@@ -199,13 +185,11 @@ public class TestResultsTests {
                                  .complete(true)
                                  .build();
         var summary = TestResults.summarize(List.of(check1, check2, check3, check4));
-        assertEquals("\n" +
-                             "\n" +
-                             "### Successful test tasks\n" +
+        assertEquals("### Successful test tasks\n" +
                              "\n" +
                              "|     | Linux x64 |\n" +
-                             "| --- | :-----: |\n" +
-                             "| Build | ✔️ (1/1) |\n" +
-                             "| Test (tier1) | ✔️ (1/1) |", summary.get());
+                             "| --- | ----- |\n" +
+                             "| Build | ✔️ (1/1 passed) |\n" +
+                             "| Test (tier1) | ✔️ (1/1 passed) |", summary.get().strip());
     }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/TestResultsTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/TestResultsTests.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.pr;
+
+import org.junit.jupiter.api.Test;
+import org.openjdk.skara.forge.*;
+import org.openjdk.skara.vcs.Hash;
+
+import java.net.URI;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TestResultsTests {
+    @Test
+    void simple() {
+        var check = CheckBuilder.create("Test", Hash.zero())
+                                .complete(true)
+                                .build();
+        var summary = TestResults.summarize(List.of(check));
+        assertEquals("\n" +
+                             "\n" +
+                             "### Successful test tasks\n" +
+                             "\n" +
+                             "|     | Test |\n" +
+                             "| --- | :-----: |\n" +
+                             "| Build / test | ✔️ (1/1) |", summary.get());
+    }
+
+    @Test
+    void multiPlatform() {
+        var check1 = CheckBuilder.create("Linux x64 (test)", Hash.zero())
+                                 .complete(true)
+                                 .build();
+        var check2 = CheckBuilder.create("Windows x64 (test)", Hash.zero())
+                                 .complete(true)
+                                 .build();
+        var summary = TestResults.summarize(List.of(check1, check2));
+        assertEquals("\n" +
+                             "\n" +
+                             "### Successful test tasks\n" +
+                             "\n" +
+                             "|     | Linux x64 | Windows x64 |\n" +
+                             "| --- | :-----: | :-----: |\n" +
+                             "| Build / test | ✔️ (1/1) | ✔️ (1/1) |", summary.get());
+    }
+
+    @Test
+    void multiFlavor() {
+        var check1 = CheckBuilder.create("Linux x64 (Build)", Hash.zero())
+                                 .complete(true)
+                                 .build();
+        var check2 = CheckBuilder.create("Linux x64 (Test tier1)", Hash.zero())
+                                 .complete(true)
+                                 .build();
+        var summary = TestResults.summarize(List.of(check1, check2));
+        assertEquals("\n" +
+                             "\n" +
+                             "### Successful test tasks\n" +
+                             "\n" +
+                             "|     | Linux x64 |\n" +
+                             "| --- | :-----: |\n" +
+                             "| Build | ✔️ (1/1) |\n" +
+                             "| Test (tier1) | ✔️ (1/1) |", summary.get());
+    }
+
+    @Test
+    void multiEverything() {
+        var check1 = CheckBuilder.create("Linux x64 (Build)", Hash.zero())
+                                 .complete(true)
+                                 .build();
+        var check2 = CheckBuilder.create("Linux x64 (Test tier1)", Hash.zero())
+                                 .complete(true)
+                                 .build();
+        var check3 = CheckBuilder.create("Windows x64 (Build)", Hash.zero())
+                                 .complete(true)
+                                 .build();
+        var check4 = CheckBuilder.create("Windows x64 (Test tier1)", Hash.zero())
+                                 .complete(true)
+                                 .build();
+        var summary = TestResults.summarize(List.of(check1, check2, check3, check4));
+        assertEquals("\n" +
+                             "\n" +
+                             "### Successful test tasks\n" +
+                             "\n" +
+                             "|     | Linux x64 | Windows x64 |\n" +
+                             "| --- | :-----: | :-----: |\n" +
+                             "| Build | ✔️ (1/1) | ✔️ (1/1) |\n" +
+                             "| Test (tier1) | ✔️ (1/1) | ✔️ (1/1) |", summary.get());
+    }
+
+    @Test
+    void sparse() {
+        var check1 = CheckBuilder.create("Linux x64 (Build)", Hash.zero())
+                                 .complete(true)
+                                 .build();
+        var check2 = CheckBuilder.create("Linux x64 (Test tier1)", Hash.zero())
+                                 .complete(true)
+                                 .build();
+        var check3 = CheckBuilder.create("Windows x64 (Build)", Hash.zero())
+                                 .complete(true)
+                                 .build();
+        var check4 = CheckBuilder.create("macOS x64 (Build)", Hash.zero())
+                                 .complete(true)
+                                 .build();
+        var summary = TestResults.summarize(List.of(check1, check2, check3, check4));
+        assertEquals("\n" +
+                             "\n" +
+                             "### Successful test tasks\n" +
+                             "\n" +
+                             "|     | Linux x64 | Windows x64 | macOS x64 |\n" +
+                             "| --- | :-----: | :-----: | :-----: |\n" +
+                             "| Build | ✔️ (1/1) | ✔️ (1/1) | ✔️ (1/1) |\n" +
+                             "| Test (tier1) | ✔️ (1/1) |    |     | ", summary.get());
+    }
+
+    @Test
+    void failure() {
+        var check1 = CheckBuilder.create("Linux x64 (test)", Hash.zero())
+                                 .complete(true)
+                                 .build();
+        var check2 = CheckBuilder.create("Windows x64 (test)", Hash.zero())
+                                 .complete(false)
+                                 .details(URI.create("www.example.com"))
+                                 .build();
+        var summary = TestResults.summarize(List.of(check1, check2));
+        assertEquals("\n" +
+                             "\n" +
+                             "### Successful test tasks\n" +
+                             "\n" +
+                             "|     | Linux x64 | Windows x64 |\n" +
+                             "| --- | :-----: | :-----: |\n" +
+                             "| Build / test | ✔️ (1/1) | ❌ (0/1) |\n" +
+                             "\n" +
+                             "**Failed test task**\n" +
+                             "- [Windows x64 (test)](www.example.com)", summary.get());
+    }
+
+    @Test
+    void inProgress() {
+        var check1 = CheckBuilder.create("Linux x64 (test)", Hash.zero())
+                                 .complete(true)
+                                 .build();
+        var check2 = CheckBuilder.create("Windows x64 (test)", Hash.zero())
+                                 .build();
+        var summary = TestResults.summarize(List.of(check1, check2));
+        assertEquals("\n" +
+                             "\n" +
+                             "### Successful test tasks\n" +
+                             "\n" +
+                             "|     | Linux x64 | Windows x64 |\n" +
+                             "| --- | :-----: | :-----: |\n" +
+                             "| Build / test | ✔️ (1/1) | ⏳ (0/1) |", summary.get());
+    }
+
+    @Test
+    void ignored() {
+        var check1 = CheckBuilder.create("jcheck", Hash.zero())
+                                 .complete(true)
+                                 .build();
+        var check2 = CheckBuilder.create("Prerequisites", Hash.zero())
+                                 .build();
+        var summary = TestResults.summarize(List.of(check1, check2));
+        assertTrue(summary.isEmpty());
+    }
+
+    @Test
+    void mixed() {
+        var check1 = CheckBuilder.create("Linux x64 (Build)", Hash.zero())
+                                 .complete(true)
+                                 .build();
+        var check2 = CheckBuilder.create("Linux x64 (Test tier1)", Hash.zero())
+                                 .complete(true)
+                                 .build();
+        var check3 = CheckBuilder.create("Prerequisites", Hash.zero())
+                                 .complete(true)
+                                 .build();
+        var check4 = CheckBuilder.create("Post-process", Hash.zero())
+                                 .complete(true)
+                                 .build();
+        var summary = TestResults.summarize(List.of(check1, check2, check3, check4));
+        assertEquals("\n" +
+                             "\n" +
+                             "### Successful test tasks\n" +
+                             "\n" +
+                             "|     | Linux x64 |\n" +
+                             "| --- | :-----: |\n" +
+                             "| Build | ✔️ (1/1) |\n" +
+                             "| Test (tier1) | ✔️ (1/1) |", summary.get());
+    }
+}

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
@@ -164,4 +164,9 @@ class InMemoryHostedRepository implements HostedRepository {
     public Optional<CommitMetadata> commitMetadata(Hash commit) {
         return Optional.empty();
     }
+
+    @Override
+    public List<Check> allChecks(Hash hash) {
+        return List.of();
+    }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/Check.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/Check.java
@@ -24,6 +24,7 @@ package org.openjdk.skara.forge;
 
 import org.openjdk.skara.vcs.Hash;
 
+import java.net.URI;
 import java.time.ZonedDateTime;
 import java.util.*;
 
@@ -37,8 +38,10 @@ public class Check {
     private final String summary;
     private final List<CheckAnnotation> annotations;
     private final String name;
+    private final URI details;
 
-    Check(String name, Hash hash, CheckStatus status, ZonedDateTime startedAt, ZonedDateTime completedAt, String metadata, String title, String summary, List<CheckAnnotation> annotations) {
+    Check(String name, Hash hash, CheckStatus status, ZonedDateTime startedAt, ZonedDateTime completedAt,
+          String metadata, String title, String summary, List<CheckAnnotation> annotations, URI details) {
         this.name = name;
         this.hash = hash;
         this.status = status;
@@ -48,6 +51,7 @@ public class Check {
         this.title = title;
         this.summary = summary;
         this.annotations = annotations;
+        this.details = details;
     }
 
     public String name() {
@@ -84,5 +88,9 @@ public class Check {
 
     public List<CheckAnnotation> annotations() {
         return annotations;
+    }
+
+    public Optional<URI> details() {
+        return Optional.ofNullable(details);
     }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/CheckBuilder.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/CheckBuilder.java
@@ -24,11 +24,11 @@ package org.openjdk.skara.forge;
 
 import org.openjdk.skara.vcs.Hash;
 
+import java.net.URI;
 import java.time.*;
 import java.util.*;
 
 public class CheckBuilder {
-
     private final String name;
     private final Hash hash;
 
@@ -39,6 +39,7 @@ public class CheckBuilder {
     private ZonedDateTime completedAt;
     private String title;
     private String summary;
+    private URI details;
 
     private CheckBuilder(String name, Hash hash) {
         this.name = name;
@@ -124,7 +125,12 @@ public class CheckBuilder {
         return this;
     }
 
+    public CheckBuilder details(URI details) {
+        this.details = details;
+        return this;
+    }
+
     public Check build() {
-        return new Check(name, hash, status, startedAt, completedAt, metadata, title, summary, annotations);
+        return new Check(name, hash, status, startedAt, completedAt, metadata, title, summary, annotations, details);
     }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
@@ -70,6 +70,7 @@ public interface HostedRepository {
     List<CommitComment> commitComments(Hash hash);
     void addCommitComment(Hash hash, String body);
     Optional<CommitMetadata> commitMetadata(Hash hash);
+    List<Check> allChecks(Hash hash);
 
     default PullRequest createPullRequest(HostedRepository target,
                                           String targetRef,

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -395,6 +395,9 @@ public class GitHubPullRequest implements PullRequest {
                                     checkBuilder.summary(output.get("summary").asString());
                                 }
                             }
+                            if (c.contains("details_url")) {
+                                checkBuilder.details(URI.create(c.get("details_url").asString()));
+                            }
 
                             return checkBuilder.build();
                         }, (a, b) -> b));

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -312,4 +312,54 @@ public class GitHubRepository implements HostedRepository {
         var message = Arrays.asList(commit.get("message").asString().split("\n"));
         return Optional.of(new CommitMetadata(hash, parents, author, authored, committer, committed, message));
     }
+
+    @Override
+    public List<Check> allChecks(Hash hash) {
+        var checks = request.get("commits/" + hash.hex() + "/check-runs").execute();
+
+        return checks.get("check_runs").stream()
+                     .map(c -> {
+                         var checkBuilder = CheckBuilder.create(c.get("name").asString(), new Hash(c.get("head_sha").asString()));
+                         checkBuilder.startedAt(ZonedDateTime.parse(c.get("started_at").asString()));
+
+                         var completed = c.get("status").asString().equals("completed");
+                         if (completed) {
+                             var conclusion = c.get("conclusion").asString();
+                             var completedAt = ZonedDateTime.parse(c.get("completed_at").asString());
+                             switch (conclusion) {
+                                 case "cancelled":
+                                     checkBuilder.cancel(completedAt);
+                                     break;
+                                 case "success":
+                                     checkBuilder.complete(true, completedAt);
+                                     break;
+                                 case "failure":
+                                     // fallthrough
+                                 case "neutral":
+                                     checkBuilder.complete(false, completedAt);
+                                     break;
+                                 default:
+                                     throw new IllegalStateException("Unexpected conclusion: " + conclusion);
+                             }
+                         }
+                         if (c.contains("external_id")) {
+                             checkBuilder.metadata(c.get("external_id").asString());
+                         }
+                         if (c.contains("output")) {
+                             var output = c.get("output").asObject();
+                             if (output.contains("title")) {
+                                 checkBuilder.title(output.get("title").asString());
+                             }
+                             if (output.contains("summary")) {
+                                 checkBuilder.summary(output.get("summary").asString());
+                             }
+                         }
+                         if (c.contains("details_url")) {
+                             checkBuilder.details(URI.create(c.get("details_url").asString()));
+                         }
+
+                         return checkBuilder.build(); }
+                     )
+                     .collect(Collectors.toList());
+    }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -344,4 +344,9 @@ public class GitLabRepository implements HostedRepository {
         var message = Arrays.asList(c.get("message").asString().split("\n"));
         return Optional.of(new CommitMetadata(hash, parents, author, authored, committer, committed, message));
     }
+
+    @Override
+    public List<Check> allChecks(Hash hash) {
+        return List.of();
+    }
 }

--- a/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
@@ -233,6 +233,15 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
         }
     }
 
+    @Override
+    public List<Check> allChecks(Hash hash) {
+        return host.getPullRequests(this).stream()
+                   .map(pr -> (TestPullRequest)pr)
+                   .flatMap(testPr -> testPr.data.checks.stream())
+                   .filter(check -> check.hash().equals(hash))
+                   .collect(Collectors.toList());
+    }
+
     Repository localRepository() {
         return localRepository;
     }

--- a/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
@@ -40,7 +40,7 @@ public class TestPullRequest extends TestIssue implements PullRequest {
     private final TestHostedRepository sourceRepository;
     private final String targetRef;
     private final String sourceRef;
-    private final PullRequestData data;
+    final PullRequestData data;
 
     private TestPullRequest(TestHostedRepository targetRepository, TestHostedRepository sourceRepository, String id, HostUser author, HostUser user, String targetRef, String sourceRef, PullRequestData data) {
         super(targetRepository, id, author, user, data);
@@ -170,7 +170,7 @@ public class TestPullRequest extends TestIssue implements PullRequest {
     @Override
     public void createCheck(Check check) {
         var existing = data.checks.stream()
-                                  .filter(c -> check.name().equals(check.name()))
+                                  .filter(c -> c.name().equals(check.name()))
                                   .findAny();
         existing.ifPresent(data.checks::remove);
         data.checks.add(check);


### PR DESCRIPTION
Now that we are executing pre-submit tests for certain OpenJDK repositories, we can also display a summary of the results in the PR body, to help reviewers determine the test status of a change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**) ⚠️ Review applies to 223de8e3c106cd58331a55f528bb82c0d74439ce


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/855/head:pull/855`
`$ git checkout pull/855`
