### PR TITLE
vcs: introduce "Backport-of" trailer

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/CommitMessage.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/CommitMessage.java
@@ -23,8 +23,10 @@
 package org.openjdk.skara.vcs.openjdk;
 
 import org.openjdk.skara.vcs.Author;
+import org.openjdk.skara.vcs.Hash;
 
 import java.util.List;
+import java.util.Optional;
 
 public class CommitMessage {
     private final String title;
@@ -32,6 +34,7 @@ public class CommitMessage {
     private final List<String> reviewers;
     private final List<Author> contributors;
     private final List<String> summaries;
+    private final Hash original;
     private final List<String> additional;
 
     public CommitMessage(String title,
@@ -39,12 +42,14 @@ public class CommitMessage {
                          List<String> reviewers,
                          List<Author> contributors,
                          List<String> summaries,
+                         Hash original,
                          List<String> additional) {
         this.title = title;
         this.issues = issues;
         this.reviewers = reviewers;
         this.contributors = contributors;
         this.summaries = summaries;
+        this.original = original;
         this.additional = additional;
     }
 
@@ -70,6 +75,10 @@ public class CommitMessage {
 
     public List<String> summaries() {
         return summaries;
+    }
+
+    public Optional<Hash> original() {
+        return Optional.ofNullable(original);
     }
 
     public List<String> additional() {

--- a/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/CommitMessageBuilder.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/CommitMessageBuilder.java
@@ -23,12 +23,14 @@
 package org.openjdk.skara.vcs.openjdk;
 
 import org.openjdk.skara.vcs.Author;
+import org.openjdk.skara.vcs.Hash;
 
 import java.util.*;
 import java.util.stream.Collectors;
 
 public class CommitMessageBuilder {
     private String title = null;
+    private Hash original = null;
     private List<Issue> issues = new ArrayList<>();
     private List<String> summaries = new ArrayList<>();
     private List<String> reviewers = new ArrayList<>();
@@ -105,13 +107,18 @@ public class CommitMessageBuilder {
         return this;
     }
 
+    public CommitMessageBuilder original(Hash original) {
+        this.original = original;
+        return this;
+    }
+
     public CommitMessageBuilder contributor(Author contributor) {
         contributors.add(contributor);
         return this;
     }
 
     public CommitMessage create() {
-        return new CommitMessage(title, issues, reviewers, contributors, summaries, List.of());
+        return new CommitMessage(title, issues, reviewers, contributors, summaries, original, List.of());
     }
 
     public List<String> format(CommitMessageFormatter formatter) {

--- a/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/CommitMessageFormatters.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/CommitMessageFormatters.java
@@ -79,7 +79,8 @@ public class CommitMessageFormatters {
                 }
             }
 
-            if ((message.reviewers().size() + message.contributors().size()) > 0) {
+            if (((message.reviewers().size() + message.contributors().size()) > 0) ||
+                 message.original().isPresent()) {
                 lines.add("");
                 if (message.contributors().size() > 0) {
                     for (var contributor : message.contributors()) {
@@ -88,6 +89,9 @@ public class CommitMessageFormatters {
                 }
                 if (message.reviewers().size() > 0) {
                     lines.add("Reviewed-by: " + String.join(", ", message.reviewers()));
+                }
+                if (message.original().isPresent()) {
+                    lines.add("Backport-of: " + message.original().get().hex());
                 }
             }
 

--- a/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/CommitMessageSyntax.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/CommitMessageSyntax.java
@@ -36,4 +36,5 @@ public class CommitMessageSyntax {
         public static final Pattern REVIEWED_BY_PATTERN = Pattern.compile("Reviewed-by: ((?:" + OPENJDK_USERNAME_REGEX + ")(?:, " + OPENJDK_USERNAME_REGEX + ")*)$");
         public static final Pattern CONTRIBUTED_BY_PATTERN = Pattern.compile("Contributed-by: (" + ATTR_REGEX + "(?:, " + ATTR_REGEX + ")*)$");
         public static final Pattern CO_AUTHOR_PATTERN = Pattern.compile("Co-authored-by: ((?:" + REAL_NAME_AND_EMAIL_ATTR_REGEX + ")(?:, " + REAL_NAME_AND_EMAIL_ATTR_REGEX + ")*)$");
+        public static final Pattern BACKPORT_OF_PATTERN = Pattern.compile("^Backport-of: ([0-9a-z]{40})$");
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/convert/ConverterCommitMessageParser.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/convert/ConverterCommitMessageParser.java
@@ -78,6 +78,6 @@ public class ConverterCommitMessageParser implements CommitMessageParser {
             additional.add(line);
         }
 
-        return new CommitMessage(null, issues, reviewers, contributors, summaries, additional);
+        return new CommitMessage(null, issues, reviewers, contributors, summaries, null, additional);
     }
 }

--- a/vcs/src/test/java/org/openjdk/skara/vcs/openjdk/CommitMessageFormattersTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/openjdk/CommitMessageFormattersTests.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.openjdk.skara.vcs.Author;
+import org.openjdk.skara.vcs.Hash;
 
 public class CommitMessageFormattersTests {
     private CommitMessageFormatter v0() {
@@ -145,6 +146,24 @@ public class CommitMessageFormattersTests {
                              "Co-authored-by: Baz Bar <baz@bar.org>",
                              "Co-authored-by: Foo Bar <foo@bar.org>",
                              "Reviewed-by: foo"),
+                     lines);
+    }
+
+    @Test
+    void formatVersion1WithOriginal() {
+        var lines = CommitMessage.title("01234567: A bug")
+                                 .summary("A summary")
+                                 .reviewer("foo")
+                                 .contributors(new Author("Baz Bar", "baz@bar.org"))
+                                 .original(new Hash("0123456789012345678901234567890123456789"))
+                                 .format(v1());
+        assertEquals(List.of("01234567: A bug",
+                             "",
+                             "A summary",
+                             "",
+                             "Co-authored-by: Baz Bar <baz@bar.org>",
+                             "Reviewed-by: foo",
+                             "Backport-of: 0123456789012345678901234567890123456789"),
                      lines);
     }
 }

--- a/vcs/src/test/java/org/openjdk/skara/vcs/openjdk/CommitMessageParsersTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/openjdk/CommitMessageParsersTests.java
@@ -23,11 +23,13 @@
 package org.openjdk.skara.vcs.openjdk;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.openjdk.skara.vcs.Author;
+import org.openjdk.skara.vcs.Hash;
 
 public class CommitMessageParsersTests {
     @Test
@@ -259,5 +261,40 @@ public class CommitMessageParsersTests {
                      message.contributors());
         assertEquals(List.of(), message.summaries());
         assertEquals(List.of(), message.additional());
+    }
+
+    @Test
+    void backportOfTrailer() {
+        var text = List.of("01234567: An issue",
+                           "",
+                           "Reviewed-by: ab",
+                           "Backport-of: 0123456789012345678901234567890123456789");
+
+        var message = CommitMessageParsers.v1.parse(text);
+
+        assertEquals("01234567: An issue", message.title());
+        assertEquals(List.of(new Issue("01234567", "An issue")), message.issues());
+        assertEquals(List.of("ab"), message.reviewers());
+        assertEquals(List.of(), message.contributors());
+        assertEquals(List.of(), message.summaries());
+        assertEquals(List.of(), message.additional());
+        assertEquals(Optional.of(new Hash("0123456789012345678901234567890123456789")), message.original());
+    }
+
+    @Test
+    void onlyBackportOfTrailer() {
+        var text = List.of("01234567: An issue",
+                           "",
+                           "Backport-of: 0123456789012345678901234567890123456789");
+
+        var message = CommitMessageParsers.v1.parse(text);
+
+        assertEquals("01234567: An issue", message.title());
+        assertEquals(List.of(new Issue("01234567", "An issue")), message.issues());
+        assertEquals(List.of(), message.reviewers());
+        assertEquals(List.of(), message.contributors());
+        assertEquals(List.of(), message.summaries());
+        assertEquals(List.of(), message.additional());
+        assertEquals(Optional.of(new Hash("0123456789012345678901234567890123456789")), message.original());
     }
 }


### PR DESCRIPTION
Hi all,

please review this pull request that adds support for the "Backport-of" trailer to commit messages.

Testing:
- [x] Added three new unit tests
- [x] `make test` passes on Linux x64

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Successful test tasks

|     | linux | mac | win |
| --- | ----- | ----- | ----- |
| Build / test | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) |

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/856/head:pull/856`
`$ git checkout pull/856`
