### PR TITLE
Ensure that spurious newlines added by the hosted provider does not give different metadata checksums

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -80,8 +80,8 @@ class CheckWorkItem extends PullRequestWorkItem {
                                     .sorted()
                                     .collect(Collectors.joining());
             var digest = MessageDigest.getInstance("SHA-256");
-            digest.update(title.getBytes(StandardCharsets.UTF_8));
-            digest.update(body.getBytes(StandardCharsets.UTF_8));
+            digest.update(title.strip().getBytes(StandardCharsets.UTF_8));
+            digest.update(body.strip().getBytes(StandardCharsets.UTF_8));
             digest.update(approverString.getBytes(StandardCharsets.UTF_8));
             digest.update(commentString.getBytes(StandardCharsets.UTF_8));
             digest.update(labelString.getBytes(StandardCharsets.UTF_8));


### PR DESCRIPTION
At least for GitLab, the body of a pull request can be amended server side with additional newlines. Ensure that this does not affect the metadata calculation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/857/head:pull/857`
`$ git checkout pull/857`
