### PR TITLE
Avoid potentially moving folders across volume boundaries

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepositoryPool.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepositoryPool.java
@@ -79,16 +79,8 @@ public class HostedRepositoryPool {
         }
 
         private void removeOldClone(Path path, String reason) {
-            if (!Files.exists(seed)) {
-                try {
-                    Files.createDirectories(seed.getParent());
-                } catch (IOException e) {
-                    log.severe("Failed to create seed parent folder: " + seed.getParent());
-                    log.throwing("HostedRepositoryInstance", "preserveOldClone", e);
-                }
-            }
             if (Files.exists(path)) {
-                var preserved = seed.resolveSibling(seed.getFileName().toString() + "-" + reason + "-" + UUID.randomUUID());
+                var preserved = path.resolveSibling(seed.getFileName().toString() + "-" + reason + "-" + UUID.randomUUID());
                 log.severe("Invalid local repository detected (" + reason + ") - preserved in: " + preserved);
                 try {
                     Files.move(path, preserved);


### PR DESCRIPTION
When a checked out repository cannot be cleaned, the folder is moved to a separate location to allow further manual inspection. Avoid moving them across volume boundaries.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/858/head:pull/858`
`$ git checkout pull/858`
