### PR TITLE
Add support for marking PR body content with an expiration time

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -31,7 +31,7 @@ import org.openjdk.skara.vcs.openjdk.Issue;
 
 import java.io.*;
 import java.nio.file.Path;
-import java.time.ZonedDateTime;
+import java.time.*;
 import java.util.*;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
@@ -198,13 +198,16 @@ class CheckRun {
                     if (iss.isPresent()) {
                         if (!relaxedEquals(iss.get().title(), currentIssue.description())) {
                             var issueString = "[" + iss.get().id() + "](" + iss.get().webUrl() + ")";
-                            ret.add("Title mismatch between PR and JBS for issue " + issueString);
+                            ret.add("Title mismatch between PR and JBS for issue " + issueString +
+                                            ExpirationTracker.expiresAfterMarker(Duration.ofMinutes(1)));
                         }
                     } else {
-                        log.warning("Failed to retrieve information on issue " + currentIssue.id());
+                        log.warning("Failed to retrieve information on issue " + currentIssue.id() +
+                                            ExpirationTracker.expiresAfterMarker(Duration.ofMinutes(10)));
                     }
                 } catch (RuntimeException e) {
-                    log.warning("Temporary failure when trying to retrieve information on issue " + currentIssue.id());
+                    log.warning("Temporary failure when trying to retrieve information on issue " + currentIssue.id() +
+                                        ExpirationTracker.expiresAfterMarker(Duration.ofMinutes(30)));
                 }
             }
         }
@@ -435,16 +438,21 @@ class CheckRun {
                             if (!relaxedEquals(iss.get().title(), currentIssue.description())) {
                                 progressBody.append(" ⚠️ Title mismatch between PR and JBS.");
                             }
+                            progressBody.append(ExpirationTracker.expiresAfterMarker(Duration.ofMinutes(1)));
                             progressBody.append("\n");
                         } else {
                             progressBody.append("⚠️ Failed to retrieve information on issue `");
                             progressBody.append(currentIssue.id());
-                            progressBody.append("`.\n");
+                            progressBody.append("`.");
+                            progressBody.append(ExpirationTracker.expiresAfterMarker(Duration.ofMinutes(10)));
+                            progressBody.append("\n");
                         }
                     } catch (RuntimeException e) {
                         progressBody.append("⚠️ Temporary failure when trying to retrieve information on issue `");
                         progressBody.append(currentIssue.id());
-                        progressBody.append("`.\n");
+                        progressBody.append("`.");
+                        progressBody.append(ExpirationTracker.expiresAfterMarker(Duration.ofMinutes(30)));
+                        progressBody.append("\n");
                     }
                 }
             }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -68,7 +68,7 @@ class CheckWorkItem extends PullRequestWorkItem {
         try {
             var hasExpired = ExpirationTracker.hasExpired(body);
             if (hasExpired) {
-                return Base64.getUrlEncoder().encodeToString(UUID.randomUUID().toString().getBytes(StandardCharsets.UTF_8));
+                return String.valueOf(Math.random());
             }
 
             var approverString = reviews.stream()

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -66,6 +66,11 @@ class CheckWorkItem extends PullRequestWorkItem {
     String getMetadata(CensusInstance censusInstance, String title, String body, List<Comment> comments,
                        List<Review> reviews, Set<String> labels, boolean isDraft) {
         try {
+            var hasExpired = ExpirationTracker.hasExpired(body);
+            if (hasExpired) {
+                return Base64.getUrlEncoder().encodeToString(UUID.randomUUID().toString().getBytes(StandardCharsets.UTF_8));
+            }
+
             var approverString = reviews.stream()
                                         .filter(review -> review.verdict() == Review.Verdict.APPROVED)
                                         .map(review -> encodeReviewer(review.reviewer(), censusInstance) + review.hash().hex())

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ExpirationTracker.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ExpirationTracker.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.pr;
+
+import java.time.*;
+import java.time.format.DateTimeFormatter;
+import java.util.regex.*;
+
+public class ExpirationTracker {
+    private static final String expirationMarker = "<!-- Data expires at: '%s' -->";
+    private static final Pattern expirationPattern = Pattern.compile("<!-- Data expires at: '(.*?)' -->", Pattern.MULTILINE);
+
+    static String expiresAfterMarker(Duration expiresAfter) {
+        return String.format(expirationMarker, ZonedDateTime.now().plus(expiresAfter).format(DateTimeFormatter.ISO_ZONED_DATE_TIME));
+    }
+
+    static boolean hasExpired(String textWithMarkers) {
+        var earliestExpiration = textWithMarkers.lines()
+                                                .map(expirationPattern::matcher)
+                                                .filter(Matcher::find)
+                                                .map(matcher -> matcher.group(1))
+                                                .sorted()
+                                                .findFirst();
+        if (earliestExpiration.isEmpty()) {
+            return false;
+        }
+
+        var expiresAt = ZonedDateTime.parse(earliestExpiration.get(), DateTimeFormatter.ISO_ZONED_DATE_TIME);
+        return expiresAt.isBefore(ZonedDateTime.now());
+    }
+}

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -136,7 +136,7 @@ class PullRequestBot implements Bot {
         var ret = new LinkedList<WorkItem>();
 
         for (var pr : pullRequests) {
-            if (updateCache.needsUpdate(pr, Duration.ofMinutes(5))) {
+            if (ExpirationTracker.hasExpired(pr.body()) || updateCache.needsUpdate(pr, Duration.ofMinutes(5))) {
                 if (!isReady(pr)) {
                     continue;
                 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/TestResults.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/TestResults.java
@@ -24,7 +24,7 @@ package org.openjdk.skara.bots.pr;
 
 import org.openjdk.skara.forge.*;
 
-import java.time.ZonedDateTime;
+import java.time.*;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -158,6 +158,14 @@ public class TestResults {
                     resultsBody.append("`");
                 }
             }
+        }
+
+        var needRefresh = latestChecks.values().stream()
+                .filter(check -> check.status() == CheckStatus.IN_PROGRESS)
+                .findAny();
+        if (needRefresh.isPresent()) {
+            resultsBody.append("\n");
+            resultsBody.append(ExpirationTracker.expiresAfterMarker(Duration.ofSeconds(30)));
         }
 
         return Optional.of(resultsBody.toString());

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ExpirationTrackerTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ExpirationTrackerTests.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.pr;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ExpirationTrackerTests {
+    @Test
+    void valid() {
+        var text = "This is a text. " + ExpirationTracker.expiresAfterMarker(Duration.ofHours(10)) + ". Indeed.";
+        assertFalse(ExpirationTracker.hasExpired(text));
+    }
+
+    @Test
+    void expired() throws InterruptedException {
+        var text = "This is a text. " + ExpirationTracker.expiresAfterMarker(Duration.ofMillis(1)) + ". Indeed.";
+        Thread.sleep(10);
+        assertTrue(ExpirationTracker.hasExpired(text));
+    }
+
+    @Test
+    void multipleValid() {
+        var text = "This is a text. " + ExpirationTracker.expiresAfterMarker(Duration.ofHours(10)) + ". Indeed." +
+                "\n" + ExpirationTracker.expiresAfterMarker(Duration.ofDays(2));
+        assertFalse(ExpirationTracker.hasExpired(text));
+    }
+
+    @Test
+    void mixed() throws InterruptedException {
+        var text = ExpirationTracker.expiresAfterMarker(Duration.ofDays(3)) + "\n" +
+                "This is a text. " + ExpirationTracker.expiresAfterMarker(Duration.ofMillis(1)) + ". Indeed." +
+                "\n" + ExpirationTracker.expiresAfterMarker(Duration.ofDays(2));
+        Thread.sleep(10);
+        assertTrue(ExpirationTracker.hasExpired(text));
+    }
+}

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/TestResultsTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/TestResultsTests.java
@@ -152,11 +152,12 @@ public class TestResultsTests {
         var check2 = CheckBuilder.create("Windows x64 (test)", Hash.zero())
                                  .build();
         var summary = TestResults.summarize(List.of(check1, check2));
-        assertEquals("### Testing\n" +
+        assertTrue(summary.get().strip().startsWith("### Testing\n" +
                              "\n" +
                              "|     | Linux x64 | Windows x64 |\n" +
                              "| --- | ----- | ----- |\n" +
-                             "| Build / test | ✔️ (1/1 passed) | ⏳ (1/1 running) |", summary.get().strip());
+                             "| Build / test | ✔️ (1/1 passed) | ⏳ (1/1 running) |"));
+        assertTrue(summary.get().strip().contains("<!-- Data expires"));
     }
 
     @Test


### PR DESCRIPTION
For information in the PR body that is calculated using data from external sources (like Jira, another personal fork, etc.) we need to perform a periodical refresh, as our normal way of detecting updates cannot be used (the updatedAt field of a pull request).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ⏳ (1/1 running) | ⏳ (1/1 running) | ⏳ (1/1 running) |

### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**) ⚠️ Review applies to cd19ac11a56a9d040719a5194386545620d0c4af


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/862/head:pull/862`
`$ git checkout pull/862`
