### PR TITLE
756: Fix action platform names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       run: sh gradlew test --info --stacktrace
 
   mac:
-    name: Windows x64
+    name: macOS x64
     runs-on: 'macos-10.15'
     steps:
     - uses: actions/checkout@v1
@@ -22,7 +22,7 @@ jobs:
       run: sh gradlew test --info --stacktrace
 
   win:
-    name: macOS x64
+    name: Windows x64
     runs-on: 'windows-2019'
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
The latest update to the GitHub Actions file accidentally swapped windows and mac.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) |

### Issue
 * [SKARA-756](https://bugs.openjdk.java.net/browse/SKARA-756): Fix action platform names<!-- Data expires at: '2020-10-07T08:25:20.203146Z[UTC]' -->


### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/863/head:pull/863`
`$ git checkout pull/863`
