### PR TITLE
Avoid checking closed PRs, handle the "skipped" state of a GitHub check

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -25,7 +25,7 @@ package org.openjdk.skara.bots.pr;
 import org.openjdk.skara.bot.*;
 import org.openjdk.skara.census.Contributor;
 import org.openjdk.skara.forge.*;
-import org.openjdk.skara.issuetracker.IssueProject;
+import org.openjdk.skara.issuetracker.*;
 import org.openjdk.skara.json.JSONValue;
 import org.openjdk.skara.vcs.Hash;
 
@@ -157,6 +157,9 @@ class PullRequestBot implements Bot {
         var ret = new LinkedList<WorkItem>();
 
         for (var pr : pullRequests) {
+            if (pr.state() != Issue.State.OPEN) {
+                continue;
+            }
             if (updateCache.needsUpdate(pr, Duration.ofMinutes(5)) || checkHasExpired(pr)) {
                 if (!isReady(pr)) {
                     continue;

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -317,6 +317,7 @@ public class GitHubRepository implements HostedRepository {
                              var completedAt = ZonedDateTime.parse(c.get("completed_at").asString());
                              switch (conclusion) {
                                  case "cancelled":
+                                 case "skipped":
                                      checkBuilder.cancel(completedAt);
                                      break;
                                  case "success":


### PR DESCRIPTION
This small fix avoids a few problems with the latest check updates.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ⏳ (1/1 running) | ⏳ (1/1 running) | ⏳ (1/1 running) |

### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**) ⚠️ Review applies to 80889ae66a78d5175ac64c059eeb1fdce17b5b8b


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/865/head:pull/865`
`$ git checkout pull/865`
