### PR TITLE
Metadata cache expiration makes the generic expiration in the PR update cache unnecessary

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -157,7 +157,7 @@ class PullRequestBot implements Bot {
         var ret = new LinkedList<WorkItem>();
 
         for (var pr : pullRequests) {
-            if (updateCache.needsUpdate(pr, Duration.ofMinutes(5)) || checkHasExpired(pr)) {
+            if (updateCache.needsUpdate(pr) || checkHasExpired(pr)) {
                 if (!isReady(pr)) {
                     continue;
                 }


### PR DESCRIPTION
There's no need to expire all PRs periodically now that it's possible to determine this depending on PR content.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ⏳ (1/1 running) | ⏳ (1/1 running) | ⏳ (1/1 running) |

### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/866/head:pull/866`
`$ git checkout pull/866`
