### PR TITLE
Ignore cancelled checks when summarizing results

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/TestResults.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/TestResults.java
@@ -66,6 +66,7 @@ public class TestResults {
     private static Collection<Check> latestChecks(List<Check> checks) {
         var latestChecks = checks.stream()
                                  .filter(check -> !ignoredCheck(check.name()))
+                                 .filter(check -> check.status() != CheckStatus.CANCELLED)
                                  .sorted(Comparator.comparing(Check::startedAt, ZonedDateTime::compareTo))
                                  .collect(Collectors.toMap(Check::name, Function.identity(), (a, b) -> b, LinkedHashMap::new));
         return latestChecks.values();

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/TestResultsTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/TestResultsTests.java
@@ -173,6 +173,20 @@ public class TestResultsTests {
     }
 
     @Test
+    void ignoredAndCancelled() {
+        var check1 = CheckBuilder.create("Prerequisites", Hash.zero())
+                                 .complete(true)
+                                 .build();
+        var check2 = CheckBuilder.create("Post-process artifacts", Hash.zero())
+                                 .build();
+        var check3 = CheckBuilder.create("Linux x64", Hash.zero())
+                                 .cancel()
+                                 .build();
+        var summary = TestResults.summarize(List.of(check1, check2, check3));
+        assertTrue(summary.isEmpty());
+    }
+
+    @Test
     void mixed() {
         var check1 = CheckBuilder.create("Linux x64 (Build)", Hash.zero())
                                  .complete(true)


### PR DESCRIPTION
Cancelled (or skipped) checks can lead to empty lines in the summary, so just ignore those.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) |

### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/870/head:pull/870`
`$ git checkout pull/870`
