### PR TITLE
git-pr-create: support --backport option

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrCreate.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrCreate.java
@@ -58,6 +58,11 @@ public class GitPrCreate {
               .describe("MAILING LISTS")
               .helptext("Mailing lists to CC for inital RFR e-mail")
               .optional(),
+        Option.shortcut("")
+              .fullname("backport")
+              .describe("REV")
+              .helptext("Create a backport pull request for the given revision")
+              .optional(),
         Switch.shortcut("")
               .fullname("ignore-workspace")
               .helptext("Ignore local changes in worktree and staging area when creating pull request")
@@ -379,23 +384,33 @@ public class GitPrCreate {
         var project = jbsProjectFromJcheckConf(repo, targetBranch);
         var issue = getIssue(currentBranch, project);
         var file = Files.createTempFile("PULL_REQUEST_", ".md");
-        if (issue.isPresent()) {
-            Files.writeString(file, format(issue.get()) + "\n\n");
-        } else {
-            var commit = commits.get(0);
-            issue = getIssue(commit, project);
+        var toBackport = getOption("backport", "create", arguments);
+        if (toBackport == null) {
             if (issue.isPresent()) {
                 Files.writeString(file, format(issue.get()) + "\n\n");
             } else {
-                var message = CommitMessageParsers.v1.parse(commit.message());
-                Files.writeString(file, message.title() + "\n");
-                if (!message.summaries().isEmpty()) {
-                    Files.write(file, message.summaries(), StandardOpenOption.APPEND);
-                }
-                if (!message.additional().isEmpty()) {
-                    Files.write(file, message.additional(), StandardOpenOption.APPEND);
+                var commit = commits.get(0);
+                issue = getIssue(commit, project);
+                if (issue.isPresent()) {
+                    Files.writeString(file, format(issue.get()) + "\n\n");
+                } else {
+                    var message = CommitMessageParsers.v1.parse(commit.message());
+                    Files.writeString(file, message.title() + "\n");
+                    if (!message.summaries().isEmpty()) {
+                        Files.write(file, message.summaries(), StandardOpenOption.APPEND);
+                    }
+                    if (!message.additional().isEmpty()) {
+                        Files.write(file, message.additional(), StandardOpenOption.APPEND);
+                    }
                 }
             }
+        } else {
+            var hash = repo.resolve(toBackport);
+            if (hash.isEmpty()) {
+                System.err.println("error: could not resolve " + toBackport);
+                System.exit(1);
+            }
+            Files.writeString(file, "Backport " + hash.get().hex() + "\n\n");
         }
 
         appendPaddedHTMLComment(file, "Please enter the pull request message for your changes.");


### PR DESCRIPTION
Hi all,

please review this patch that adds the `--backport=HASH` option to `git pr create` to make it a bit easier to create a "backport style" pull request from the CLI. A backporter can now only has to run:

```
$ git checkout -b backport-8123456
$ git cherry-pick <HASH>
$ git pr create --backport=<HASH>
```

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) |

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/871/head:pull/871`
`$ git checkout pull/871`
