### PR TITLE
Keep checking for incoming test results for a while

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -415,6 +415,17 @@ class CheckRun {
                 progressBody.append(resultSummary.get());
                 var expiration = TestResults.expiresIn(checks);
                 expiration.ifPresent(this::setExpiration);
+            } else {
+                try {
+                    var headCommit = localRepo.commitMetadata(pr.headHash());
+                    if (headCommit.isPresent()) {
+                        // If the commit is recent, perhaps test results will appear soon
+                        if (headCommit.get().committed().isAfter(ZonedDateTime.now().minus(Duration.ofDays(1)))) {
+                            setExpiration(Duration.ofMinutes(10));
+                        }
+                    }
+                } catch (IOException ignored) {
+                }
             }
         }
 


### PR DESCRIPTION
When a PR is updated with additional commits, test results may not yet be available when the summary is created. Keep checking for a while in case they are just about to be triggered.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) |

### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/872/head:pull/872`
`$ git checkout pull/872`
