### PR TITLE
pr: add config option for 24h hint

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
@@ -104,6 +104,13 @@ public class PullRequestBotFactory implements BotFactory {
                                          .collect(Collectors.toSet());
                 botBuilder.twoReviewersLabels(labels);
             }
+            if (repo.value().contains("24h")) {
+                var labels = repo.value().get("24h")
+                                         .stream()
+                                         .map(label -> label.asString())
+                                         .collect(Collectors.toSet());
+                botBuilder.twentyFourHoursLabels(labels);
+            }
             if (repo.value().contains("issues")) {
                 botBuilder.issueProject(configuration.issueProject(repo.value().get("issues").asString()));
             }


### PR DESCRIPTION
Hi all,

please review this patch that adds a config option for the pr bot for the 24h hint in the integration message.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ⏳ (1/1 running) | ⏳ (1/1 running) | ⏳ (1/1 running) |

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/873/head:pull/873`
`$ git checkout pull/873`
