### PR TITLE
Allow a HostedRepositoryPool to refresh the seed from upstream

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -175,7 +175,10 @@ class CheckWorkItem extends PullRequestWorkItem {
     @Override
     public Collection<WorkItem> run(Path scratchPath) {
         // First determine if the current state of the PR has already been checked
-        var census = CensusInstance.create(bot.censusRepo(), bot.censusRef(), scratchPath.resolve("census"), pr,
+        var seedPath = bot.seedStorage().orElse(scratchPath.resolve("seeds"));
+        var hostedRepositoryPool = new HostedRepositoryPool(seedPath);
+
+        var census = CensusInstance.create(hostedRepositoryPool, bot.censusRepo(), bot.censusRef(), scratchPath.resolve("census"), pr,
                                            bot.confOverrideRepository().orElse(null), bot.confOverrideName(), bot.confOverrideRef());
         var comments = pr.comments();
         var allReviews = pr.reviews();
@@ -244,8 +247,6 @@ class CheckWorkItem extends PullRequestWorkItem {
             }
 
             try {
-                var seedPath = bot.seedStorage().orElse(scratchPath.resolve("seeds"));
-                var hostedRepositoryPool = new HostedRepositoryPool(seedPath);
                 var localRepoPath = scratchPath.resolve("pr").resolve("check").resolve(pr.repository().name());
                 var localRepo = PullRequestUtils.materialize(hostedRepositoryPool, pr, localRepoPath);
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandWorkItem.java
@@ -23,8 +23,7 @@
 package org.openjdk.skara.bots.pr;
 
 import org.openjdk.skara.bot.WorkItem;
-import org.openjdk.skara.forge.PullRequest;
-import org.openjdk.skara.forge.PullRequestBody;
+import org.openjdk.skara.forge.*;
 import org.openjdk.skara.host.HostUser;
 import org.openjdk.skara.issuetracker.Comment;
 
@@ -222,7 +221,10 @@ public class CommandWorkItem extends PullRequestWorkItem {
             return List.of(new LabelerWorkItem(bot, updatedPR, errorHandler));
         }
 
-        var census = CensusInstance.create(bot.censusRepo(), bot.censusRef(), scratchPath.resolve("census"), pr,
+        var seedPath = bot.seedStorage().orElse(scratchPath.resolve("seeds"));
+        var hostedRepositoryPool = new HostedRepositoryPool(seedPath);
+
+        var census = CensusInstance.create(hostedRepositoryPool, bot.censusRepo(), bot.censusRef(), scratchPath.resolve("census"), pr,
                                            bot.confOverrideRepository().orElse(null), bot.confOverrideName(), bot.confOverrideRef());
         var command = nextCommand.get();
         log.info("Processing command: " + command.id() + " - " + command.name());

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -50,10 +50,12 @@ class CheckTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id())
                                            .addReviewer(reviewer.forge().currentUser().id());
+            var seedFolder = tempFolder.path().resolve("seed");
             var checkBot = PullRequestBot.newBuilder()
                                          .repo(author)
                                          .censusRepo(censusBuilder.build())
                                          .censusLink("https://census.com/{{contributor}}-profile")
+                                         .seedStorage(seedFolder)
                                          .build();
 
             // Populate the projects repository

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepositoryPool.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepositoryPool.java
@@ -66,6 +66,7 @@ public class HostedRepositoryPool {
                 try {
                     Files.move(tmpSeedFolder, seed);
                     log.info("Seeded repository " + hostedRepository.name() + " into " + seed);
+                    return;
                 } catch (IOException e) {
                     log.info("Failed to populate seed folder " + seed + " - perhaps due to a benign race. Ignoring..");
                     clearDirectory(tmpSeedFolder);


### PR DESCRIPTION
Add support for periodically refreshing the seed repository used with the HostedRepositoryPool remote repository cache. Also allow the refresh to fail (and instead just use the latest cache) which can be used for operations that can tolerate a delayed update (for example, determining the project name from the jcheck configuration file which rarely changes).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ⏳ (1/1 running) | ✔️ (1/1 passed) | ⏳ (1/1 running) |

### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**) ⚠️ Review applies to 11b658e2a9535e408d05c97166479cf175e44470


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/874/head:pull/874`
`$ git checkout pull/874`
