### PR TITLE
Ensure that seeded checkouts can be preserved

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepositoryPool.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepositoryPool.java
@@ -160,8 +160,7 @@ public class HostedRepositoryPool {
         try {
             localClone.checkout(new Branch(ref), true);
         } catch (IOException e) {
-            var preserveUnchecked = hostedRepositoryInstance.seed.resolveSibling(
-                    hostedRepositoryInstance.seed.getFileName().toString() + "-unchecked-" + UUID.randomUUID());
+            var preserveUnchecked = path.resolveSibling(hostedRepositoryInstance.seed.getFileName().toString() + "-unchecked-" + UUID.randomUUID());
             log.severe("Uncheckoutable local repository detected - preserved in: " + preserveUnchecked);
             Files.move(localClone.root(), preserveUnchecked);
             localClone = hostedRepositoryInstance.materializeClone(path, allowStale);

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepositoryPool.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepositoryPool.java
@@ -74,20 +74,16 @@ public class HostedRepositoryPool {
             }
 
             var seedRepo = Repository.get(seed).orElseThrow(() -> new IOException("Existing seed is corrupt?"));
-            if (allowStale) {
-                try {
-                    var lastFetch = Files.getLastModifiedTime(seed.resolve("FETCH_HEAD"));
-                    if (lastFetch.toInstant().isAfter(Instant.now().minus(Duration.ofMinutes(1)))) {
-                        log.info("Seed should be up to date, skipping fetch");
-                        return;
-                    }
-                } catch (IOException ignored) {
+            try {
+                var lastFetch = Files.getLastModifiedTime(seed.resolve("FETCH_HEAD"));
+                if (lastFetch.toInstant().isAfter(Instant.now().minus(Duration.ofMinutes(1)))) {
+                    log.info("Seed should be up to date, skipping fetch");
+                    return;
                 }
-                log.info("Seed is potentially stale, time to fetch the latest upstream changes");
-            } else {
-                log.info("Fetching latest upstream changes into the seed");
+            } catch (IOException ignored) {
             }
             try {
+                log.info("Seed is potentially stale, time to fetch the latest upstream changes");
                 seedRepo.fetchAll();
             } catch (IOException e) {
                 if (!allowStale) {

--- a/forge/src/test/java/org/openjdk/skara/forge/HostedRepositoryPoolTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/HostedRepositoryPoolTests.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.forge;
+
+import org.junit.jupiter.api.*;
+import org.openjdk.skara.test.*;
+import org.openjdk.skara.vcs.*;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class HostedRepositoryPoolTests {
+    @Test
+    void simple(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var sourceFolder = new TemporaryDirectory();
+             var seedFolder = new TemporaryDirectory();
+             var cloneFolder = new TemporaryDirectory()) {
+            var source = credentials.getHostedRepository();
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(sourceFolder.path(), source.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            localRepo.push(masterHash, source.url(), "master", true);
+
+            // Push something else
+            var hash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(hash, source.url(), "master");
+
+            var pool = new HostedRepositoryPool(seedFolder.path());
+            var clone = pool.checkout(source, hash.hex(), cloneFolder.path());
+            assertTrue(CheckableRepository.hasBeenEdited(clone));
+        }
+    }
+
+    @Test
+    void emptyExisting(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var sourceFolder = new TemporaryDirectory();
+             var seedFolder = new TemporaryDirectory();
+             var cloneFolder = new TemporaryDirectory()) {
+            var source = credentials.getHostedRepository();
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(sourceFolder.path(), source.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            localRepo.push(masterHash, source.url(), "master", true);
+
+            var pool = new HostedRepositoryPool(seedFolder.path());
+            var empty = Repository.init(cloneFolder.path(), VCS.GIT);
+            assertThrows(IOException.class, () -> empty.checkout(new Branch("master"), true));
+            var clone = pool.checkout(source, "master", cloneFolder.path());
+            assertFalse(CheckableRepository.hasBeenEdited(clone));
+        }
+    }
+}


### PR DESCRIPTION
Preserving a seeded clone that fails checkout should not move files across volume boundaries. Also ensure that seeds are only updated periodically.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ⏳ (1/1 running) | ✔️ (1/1 passed) | ⏳ (1/1 running) |

### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/877/head:pull/877`
`$ git checkout pull/877`
