### PR TITLE
forge: rename HostedCommitMetadata to HostedCommit

### DIFF
--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHost.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHost.java
@@ -68,7 +68,7 @@ class InMemoryHost implements Forge {
     }
 
     @Override
-    public Optional<HostedCommitMetadata> search(Hash hash) {
+    public Optional<HostedCommit> search(Hash hash) {
         return Optional.empty();
     }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/Forge.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/Forge.java
@@ -34,7 +34,7 @@ public interface Forge extends Host {
     String name();
     Optional<HostedRepository> repository(String name);
     boolean supportsReviewBody();
-    Optional<HostedCommitMetadata> search(Hash hash);
+    Optional<HostedCommit> search(Hash hash);
 
     static Forge from(String name, URI uri, Credential credential, JSONObject configuration) {
         var factory = ForgeFactory.getForgeFactories().stream()

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedCommit.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedCommit.java
@@ -29,12 +29,14 @@ import java.util.*;
 import java.time.*;
 import java.time.format.*;
 
-public class HostedCommitMetadata {
+public class HostedCommit {
     private final CommitMetadata metadata;
+    private final List<Diff> parentDiffs;
     private final URI url;
 
-    public HostedCommitMetadata(CommitMetadata metadata, URI url) {
+    public HostedCommit(CommitMetadata metadata, List<Diff> parentDiffs, URI url) {
         this.metadata = metadata;
+        this.parentDiffs = parentDiffs;
         this.url = url;
     }
 
@@ -78,6 +80,10 @@ public class HostedCommitMetadata {
         return metadata.numParents();
     }
 
+    public List<Diff> parentDiffs() {
+        return parentDiffs;
+    }
+
     public URI url() {
         return url;
     }
@@ -94,12 +100,13 @@ public class HostedCommitMetadata {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof HostedCommitMetadata)) {
+        if (!(o instanceof HostedCommit)) {
             return false;
         }
 
-        var other = (HostedCommitMetadata) o;
+        var other = (HostedCommit) o;
         return Objects.equals(metadata, other.metadata) &&
+               Objects.equals(parentDiffs, other.parentDiffs) &&
                Objects.equals(url, other.url);
     }
 }

--- a/test/src/main/java/org/openjdk/skara/test/TestHost.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHost.java
@@ -155,14 +155,14 @@ public class TestHost implements Forge, IssueTracker {
     }
 
     @Override
-    public Optional<HostedCommitMetadata> search(Hash hash) {
+    public Optional<HostedCommit> search(Hash hash) {
         for (var key : data.repositories.keySet()) {
             var repo = data.repositories.get(key);
             try {
                 var commit = repo.lookup(hash);
                 if (commit.isPresent()) {
                     var url = URI.create("file://" + repo.root() + "/commits/" + hash.hex());
-                    return Optional.of(new HostedCommitMetadata(commit.get().metadata(), url));
+                    return Optional.of(new HostedCommit(commit.get().metadata(), commit.get().parentDiffs(), url));
                 }
             } catch (IOException e) {
                 return Optional.empty();


### PR DESCRIPTION
Hi all,

please review this patch that refactors `HostedCommitMetadata` to `HostedCommit`. The changes are primarily in fetching the diff for the commit in addition to the metadata already being fetched.

Thanks,
Erik