### PR TITLE
Ensure that the seed repo fetches everything when refreshing

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepositoryPool.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepositoryPool.java
@@ -84,7 +84,7 @@ public class HostedRepositoryPool {
             }
             try {
                 log.info("Seed is potentially stale, time to fetch the latest upstream changes");
-                seedRepo.fetchAll();
+                seedRepo.fetch(hostedRepository.url(), "+*:*", true);
             } catch (IOException e) {
                 if (!allowStale) {
                     throw e;

--- a/forge/src/test/java/org/openjdk/skara/forge/HostedRepositoryPoolTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/HostedRepositoryPoolTests.java
@@ -92,11 +92,14 @@ public class HostedRepositoryPoolTests {
             var clone = pool.checkout(source, "master", cloneFolder.path());
             assertFalse(CheckableRepository.hasBeenEdited(clone));
 
+            var updatedClone = pool.checkout(source, "master", cloneFolder.path());
+            assertFalse(CheckableRepository.hasBeenEdited(updatedClone));
+
             // Push something else
             var hash = CheckableRepository.appendAndCommit(localRepo);
             localRepo.push(hash, source.url(), "master");
 
-            var updatedClone = pool.checkout(source, "master", cloneFolder.path());
+            updatedClone = pool.checkout(source, "master", cloneFolder.path());
             assertTrue(CheckableRepository.hasBeenEdited(updatedClone));
         }
     }
@@ -118,11 +121,14 @@ public class HostedRepositoryPoolTests {
             var clone = pool.checkout(source, "master", cloneFolder.path());
             assertFalse(CheckableRepository.hasBeenEdited(clone));
 
+            var updatedClone = pool.checkoutAllowStale(source, "master", cloneFolder.path());
+            assertFalse(CheckableRepository.hasBeenEdited(updatedClone));
+
             // Push something else
             var hash = CheckableRepository.appendAndCommit(localRepo);
             localRepo.push(hash, source.url(), "master");
 
-            var updatedClone = pool.checkoutAllowStale(source, "master", cloneFolder.path());
+            updatedClone = pool.checkoutAllowStale(source, "master", cloneFolder.path());
             assertFalse(CheckableRepository.hasBeenEdited(updatedClone));
         }
     }


### PR DESCRIPTION
Ensure that the seed repo fetches everything from the correct upstream when refreshing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) |

### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/881/head:pull/881`
`$ git checkout pull/881`
