### PR TITLE
forge: add method PullRequest.diff

### DIFF
--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
@@ -295,4 +295,9 @@ class InMemoryPullRequest implements PullRequest {
     public URI headUrl() {
         return null;
     }
+
+    @Override
+    public Diff diff() {
+        return null;
+    }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
@@ -23,6 +23,7 @@
 package org.openjdk.skara.forge;
 
 import org.openjdk.skara.issuetracker.Issue;
+import org.openjdk.skara.vcs.Diff;
 import org.openjdk.skara.vcs.Hash;
 
 import java.net.URI;
@@ -119,6 +120,11 @@ public interface PullRequest extends Issue {
      * @return
      */
     URI diffUrl();
+
+    /** Returns a diff of the changes between PR HEAD and target branch.
+     * @return
+     */
+    Diff diff();
 
     /**
      * Creates a new check.

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -27,6 +27,7 @@ import org.openjdk.skara.host.HostUser;
 import org.openjdk.skara.issuetracker.*;
 import org.openjdk.skara.json.*;
 import org.openjdk.skara.network.*;
+import org.openjdk.skara.vcs.Diff;
 import org.openjdk.skara.vcs.Hash;
 
 import java.net.URI;
@@ -661,5 +662,11 @@ public class GitHubPullRequest implements PullRequest {
     @Override
     public URI headUrl() {
         return URI.create(webUrl() + "/commits/" + headHash().hex());
+    }
+
+    @Override
+    public Diff diff() {
+        var files = request.get("pulls/" + json.get("number").toString() + "/files").execute();
+        return host.toDiff(targetHash(), headHash(), files);
     }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -104,13 +104,13 @@ public class GitLabRepository implements HostedRepository {
                         .execute();
 
         var targetRepo = (GitLabRepository) target;
-        return new GitLabMergeRequest(targetRepo, pr, targetRepo.request);
+        return new GitLabMergeRequest(targetRepo, gitLabHost, pr, targetRepo.request);
     }
 
     @Override
     public PullRequest pullRequest(String id) {
         var pr = request.get("merge_requests/" + id).execute();
-        return new GitLabMergeRequest(this, pr, request);
+        return new GitLabMergeRequest(this, gitLabHost, pr, request);
     }
 
     @Override
@@ -118,7 +118,7 @@ public class GitLabRepository implements HostedRepository {
         return request.get("merge_requests")
                       .param("state", "opened")
                       .execute().stream()
-                      .map(value -> new GitLabMergeRequest(this, value, request))
+                      .map(value -> new GitLabMergeRequest(this, gitLabHost, value, request))
                       .collect(Collectors.toList());
     }
 
@@ -128,7 +128,7 @@ public class GitLabRepository implements HostedRepository {
                       .param("order_by", "updated_at")
                       .param("updated_after", updatedAfter.format(DateTimeFormatter.ISO_DATE_TIME))
                       .execute().stream()
-                      .map(value -> new GitLabMergeRequest(this, value, request))
+                      .map(value -> new GitLabMergeRequest(this, gitLabHost, value, request))
                       .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
Hi all,

please review this patch that adds the method `PullRequest.diff` for fetching the diff between a pull request's `HEAD` and target branch.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ⏳ (1/1 running) | ✔️ (1/1 passed) | ⏳ (1/1 running) |

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/882/head:pull/882`
`$ git checkout pull/882`
