### PR TITLE
git-info: add --upstream flag

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitInfo.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitInfo.java
@@ -106,6 +106,10 @@ public class GitInfo {
                   .helptext("Show contributors")
                   .optional(),
             Switch.shortcut("")
+                  .fullname("upstream")
+                  .helptext("Show upstream commit hash")
+                  .optional(),
+            Switch.shortcut("")
                   .fullname("verbose")
                   .helptext("Turn on verbose output")
                   .optional(),
@@ -159,9 +163,10 @@ public class GitInfo {
         var showSummary = getSwitch("summary", arguments, repo);
         var showIssues = getSwitch("issues", arguments, repo);
         var showTitle = getSwitch("title", arguments, repo);
+        var showUpstream = getSwitch("upstream", arguments, repo);
 
         if (!showSponsor && !showAuthors && !showReviewers &&
-            !showReview && !showSummary && !showIssues && !showTitle) {
+            !showReview && !showSummary && !showIssues && !showTitle && !showUpstream) {
             // no switches or configuration provided, show everything by default
             showSponsor = true;
             showAuthors = true;
@@ -170,6 +175,7 @@ public class GitInfo {
             showSummary = true;
             showIssues = true;
             showTitle = true;
+            showUpstream = true;
         }
 
         var message = useMercurial ?
@@ -224,6 +230,12 @@ public class GitInfo {
             System.out.println(decoration + String.join(", ", message.reviewers()));
         }
 
+        if (showUpstream) {
+            if (message.original().isPresent()) {
+                var decoration = useDecoration ? "Upstream: " : "";
+                System.out.println(decoration + message.original().get().hex());
+            }
+        }
 
         if (showReview) {
             var decoration = useDecoration? "Review: " : "";


### PR DESCRIPTION
Hi all,

please review this patch that adds the `--upstream` flag to `git-info` to show the hash for the original (upstream) commit that that provided commit was backported from. For example, if commit `B` has been backported from commit `A`, then a user can run:

```
$ git info --upstream B
A
```

Testing:
- [x] Manual testing on Linux x64

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ⏳ (1/1 running) | ✔️ (1/1 passed) | ⏳ (1/1 running) |

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/883/head:pull/883`
`$ git checkout pull/883`
