### PR TITLE
jcheck: conditionally check backport reviewers

### DIFF
--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/ReviewersCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/ReviewersCheck.java
@@ -135,12 +135,15 @@ public class ReviewersCheck extends CommitCheck {
             }
         }
 
-        for (var role : missing.keySet()) {
-            int required = requirements.get(role);
-            int n = missing.get(role);
-            if (n > 0) {
-                log.finer("issue: too few reviewers with role " + role + " found");
-                return iterator(new TooFewReviewersIssue(required - n, required, role, metadata));
+        var isBackport = message.original().isPresent();
+        if (!isBackport || conf.checks().reviewers().shouldCheckBackports()) {
+            for (var role : missing.keySet()) {
+                int required = requirements.get(role);
+                int n = missing.get(role);
+                if (n > 0) {
+                    log.finer("issue: too few reviewers with role " + role + " found");
+                    return iterator(new TooFewReviewersIssue(required - n, required, role, metadata));
+                }
             }
         }
 

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/ReviewersConfiguration.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/ReviewersConfiguration.java
@@ -28,7 +28,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class ReviewersConfiguration {
-    static final ReviewersConfiguration DEFAULT = new ReviewersConfiguration(0, 1, 0, 0, 0, List.of("duke"));
+    static final ReviewersConfiguration DEFAULT = new ReviewersConfiguration(0, 1, 0, 0, 0, List.of("duke"), false);
 
     private final int lead;
     private final int reviewers;
@@ -36,14 +36,16 @@ public class ReviewersConfiguration {
     private final int authors;
     private final int contributors;
     private final List<String> ignore;
+    private final boolean shouldCheckBackports;
 
-    ReviewersConfiguration(int lead, int reviewers, int committers, int authors, int contributors, List<String> ignore) {
+    ReviewersConfiguration(int lead, int reviewers, int committers, int authors, int contributors, List<String> ignore, boolean shouldCheckBackports) {
         this.lead = lead;
         this.reviewers = reviewers;
         this.committers = committers;
         this.authors = authors;
         this.contributors = contributors;
         this.ignore = ignore;
+        this.shouldCheckBackports = shouldCheckBackports;
     }
 
     public int lead() {
@@ -68,6 +70,10 @@ public class ReviewersConfiguration {
 
     public List<String> ignore() {
         return ignore;
+    }
+
+    public boolean shouldCheckBackports() {
+        return shouldCheckBackports;
     }
 
     static String name() {
@@ -115,7 +121,8 @@ public class ReviewersConfiguration {
         }
 
         var ignore = s.get("ignore", DEFAULT.ignore());
+        var shouldCheckBackports = s.get("backports", "ignore").equals("check");
 
-        return new ReviewersConfiguration(lead, reviewers, committers, authors, contributors, ignore);
+        return new ReviewersConfiguration(lead, reviewers, committers, authors, contributors, ignore, shouldCheckBackports);
     }
 }


### PR DESCRIPTION
Hi all,

please review this patch that makes it possible to configure whether reviewers are required or not for backport commits. The `reviewers` check now supports the configuration `backports=check` or `backports=ignore` with `backports=ignore` being the default. We will still check for invalid reviewers and self-reviews, it is just the "number of reviewers" that can be disabled for backport commits.

Testing:
- [x] Added three new unit tests
- [x] `make test` passes on Linux x64

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) |

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/884/head:pull/884`
`$ git checkout pull/884`
