### PR TITLE
forge: refactor HostUser constructor to static methods

### DIFF
--- a/bots/checkout/src/test/java/org/openjdk/skara/bots/checkout/CheckoutBotTests.java
+++ b/bots/checkout/src/test/java/org/openjdk/skara/bots/checkout/CheckoutBotTests.java
@@ -58,7 +58,7 @@ class CheckoutBotTests {
     @Test
     void simpleConversion(TestInfo testInfo) throws IOException {
         try (var tmp = new TemporaryDirectory()) {
-            var host = TestHost.createNew(List.of(new HostUser(0, "duke", "J. Duke")));
+            var host = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));
             var marksLocalDir = tmp.path().resolve("marks.git");
             Files.createDirectories(marksLocalDir);
             var marksLocalRepo = Repository.init(marksLocalDir, VCS.GIT);
@@ -90,7 +90,7 @@ class CheckoutBotTests {
     @Test
     void update(TestInfo testInfo) throws IOException {
         try (var tmp = new TemporaryDirectory()) {
-            var host = TestHost.createNew(List.of(new HostUser(0, "duke", "J. Duke")));
+            var host = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));
             var marksLocalDir = tmp.path().resolve("marks.git");
             Files.createDirectories(marksLocalDir);
             var marksLocalRepo = Repository.init(marksLocalDir, VCS.GIT);

--- a/bots/forward/src/test/java/org/openjdk/skara/bots/forward/ForwardBotTests.java
+++ b/bots/forward/src/test/java/org/openjdk/skara/bots/forward/ForwardBotTests.java
@@ -41,7 +41,7 @@ class ForwardBotTests {
     @Test
     void mirrorMasterBranches(TestInfo testInfo) throws IOException {
         try (var temp = new TemporaryDirectory()) {
-            var host = TestHost.createNew(List.of(new HostUser(0, "duke", "J. Duke")));
+            var host = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));
 
             var fromDir = temp.path().resolve("from.git");
             var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
@@ -78,7 +78,7 @@ class ForwardBotTests {
     @Test
     void mirrorDifferentBranches(TestInfo testInfo) throws IOException {
         try (var temp = new TemporaryDirectory()) {
-            var host = TestHost.createNew(List.of(new HostUser(0, "duke", "J. Duke")));
+            var host = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));
 
             var fromDir = temp.path().resolve("from.git");
             var fromLocalRepo = Repository.init(fromDir, VCS.GIT);

--- a/bots/hgbridge/src/test/java/org/openjdk/skara/bots/hgbridge/BridgeBotTests.java
+++ b/bots/hgbridge/src/test/java/org/openjdk/skara/bots/hgbridge/BridgeBotTests.java
@@ -68,7 +68,7 @@ class BridgeBotTests {
             this.source(source);
             this.destinations(List.of(destination));
 
-            var host = TestHost.createNew(List.of(new HostUser(0, "duke", "J. Duke")));
+            var host = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));
             var marksLocalRepo = Repository.init(marksRepoPath.resolve("marks.git"), VCS.GIT);
 
             var initialFile = marksLocalRepo.root().resolve("init.txt");

--- a/bots/merge/src/test/java/org/openjdk/skara/bots/merge/MergeBotTests.java
+++ b/bots/merge/src/test/java/org/openjdk/skara/bots/merge/MergeBotTests.java
@@ -42,7 +42,7 @@ class MergeBotTests {
     @Test
     void mergeMasterBranch(TestInfo testInfo) throws IOException {
         try (var temp = new TemporaryDirectory()) {
-            var host = TestHost.createNew(List.of(new HostUser(0, "duke", "J. Duke")));
+            var host = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));
 
             var fromDir = temp.path().resolve("from.git");
             var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
@@ -117,7 +117,7 @@ class MergeBotTests {
     @Test
     void successfulDependency(TestInfo testInfo) throws IOException {
         try (var temp = new TemporaryDirectory(false)) {
-            var host = TestHost.createNew(List.of(new HostUser(0, "duke", "J. Duke")));
+            var host = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));
 
             var fromDir = temp.path().resolve("from.git");
             var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
@@ -206,7 +206,7 @@ class MergeBotTests {
     @Test
     void failedDependency(TestInfo testInfo) throws IOException {
         try (var temp = new TemporaryDirectory(false)) {
-            var host = TestHost.createNew(List.of(new HostUser(0, "duke", "J. Duke")));
+            var host = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));
 
             var fromDir = temp.path().resolve("from.git");
             var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
@@ -298,7 +298,7 @@ class MergeBotTests {
     @Test
     void failingMergeTest(TestInfo testInfo) throws IOException {
         try (var temp = new TemporaryDirectory()) {
-            var host = TestHost.createNew(List.of(new HostUser(0, "duke", "J. Duke")));
+            var host = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));
 
             var fromDir = temp.path().resolve("from.git");
             var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
@@ -369,7 +369,7 @@ class MergeBotTests {
     @Test
     void failingPrerequisite(TestInfo testInfo) throws IOException {
         try (var temp = new TemporaryDirectory()) {
-            var host = TestHost.createNew(List.of(new HostUser(0, "duke", "J. Duke")));
+            var host = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));
 
             var fromDir = temp.path().resolve("from.git");
             var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
@@ -438,7 +438,7 @@ class MergeBotTests {
             var fromLocalRepo2 = Repository.init(fromDir2, VCS.GIT);
             var fromHostedRepo2 = new TestHostedRepository(host, "test-2", fromLocalRepo2);
 
-            var host2 = TestHost.createNew(List.of(new HostUser(0, "duke", "J. Duke")));
+            var host2 = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));
             var toDir2 = temp.path().resolve("to2.git");
             var toLocalRepo2 = Repository.init(toDir2, VCS.GIT);
             var toGitConfig2 = toDir2.resolve(".git").resolve("config");
@@ -501,7 +501,7 @@ class MergeBotTests {
     @Test
     void failingMergeShouldResultInOnlyOnePR(TestInfo testInfo) throws IOException {
         try (var temp = new TemporaryDirectory()) {
-            var host = TestHost.createNew(List.of(new HostUser(0, "duke", "J. Duke")));
+            var host = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));
 
             var fromDir = temp.path().resolve("from.git");
             var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
@@ -572,7 +572,7 @@ class MergeBotTests {
     @Test
     void resolvedMergeConflictShouldResultInIntegrateCommand(TestInfo testInfo) throws IOException {
         try (var temp = new TemporaryDirectory()) {
-            var host = TestHost.createNew(List.of(new HostUser(0, "duke", "J. Duke")));
+            var host = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));
 
             var fromDir = temp.path().resolve("from.git");
             var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
@@ -684,7 +684,7 @@ class MergeBotTests {
     @Test
     void testMergeHourly(TestInfo testInfo) throws IOException {
         try (var temp = new TemporaryDirectory()) {
-            var host = TestHost.createNew(List.of(new HostUser(0, "duke", "J. Duke")));
+            var host = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));
 
             var fromDir = temp.path().resolve("from.git");
             var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
@@ -799,7 +799,7 @@ class MergeBotTests {
     @Test
     void testMergeDaily(TestInfo testInfo) throws IOException {
         try (var temp = new TemporaryDirectory()) {
-            var host = TestHost.createNew(List.of(new HostUser(0, "duke", "J. Duke")));
+            var host = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));
 
             var fromDir = temp.path().resolve("from.git");
             var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
@@ -920,7 +920,7 @@ class MergeBotTests {
     @Test
     void testMergeWeekly(TestInfo testInfo) throws IOException {
         try (var temp = new TemporaryDirectory()) {
-            var host = TestHost.createNew(List.of(new HostUser(0, "duke", "J. Duke")));
+            var host = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));
 
             var fromDir = temp.path().resolve("from.git");
             var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
@@ -1041,7 +1041,7 @@ class MergeBotTests {
     @Test
     void testMergeMonthly(TestInfo testInfo) throws IOException {
         try (var temp = new TemporaryDirectory()) {
-            var host = TestHost.createNew(List.of(new HostUser(0, "duke", "J. Duke")));
+            var host = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));
 
             var fromDir = temp.path().resolve("from.git");
             var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
@@ -1162,7 +1162,7 @@ class MergeBotTests {
     @Test
     void testMergeYearly(TestInfo testInfo) throws IOException {
         try (var temp = new TemporaryDirectory()) {
-            var host = TestHost.createNew(List.of(new HostUser(0, "duke", "J. Duke")));
+            var host = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));
 
             var fromDir = temp.path().resolve("from.git");
             var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
@@ -1289,7 +1289,7 @@ class MergeBotTests {
     @Test
     void mergeAfterDivergedStorage(TestInfo testInfo) throws IOException {
         try (var temp = new TemporaryDirectory()) {
-            var host = TestHost.createNew(List.of(new HostUser(0, "duke", "J. Duke")));
+            var host = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));
 
             var fromDir = temp.path().resolve("from.git");
             var fromLocalRepo = Repository.init(fromDir, VCS.GIT);

--- a/bots/mirror/src/test/java/org/openjdk/skara/bots/mirror/MirrorBotTests.java
+++ b/bots/mirror/src/test/java/org/openjdk/skara/bots/mirror/MirrorBotTests.java
@@ -40,7 +40,7 @@ class MirrorBotTests {
     @Test
     void mirrorMasterBranch(TestInfo testInfo) throws IOException {
         try (var temp = new TemporaryDirectory()) {
-            var host = TestHost.createNew(List.of(new HostUser(0, "duke", "J. Duke")));
+            var host = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));
 
             var fromDir = temp.path().resolve("from.git");
             var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
@@ -77,7 +77,7 @@ class MirrorBotTests {
     @Test
     void mirrorMultipleBranches(TestInfo testInfo) throws IOException {
         try (var temp = new TemporaryDirectory()) {
-            var host = TestHost.createNew(List.of(new HostUser(0, "duke", "J. Duke")));
+            var host = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));
 
             var fromDir = temp.path().resolve("from.git");
             var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
@@ -123,7 +123,7 @@ class MirrorBotTests {
     @Test
     void mirrorMultipleTags(TestInfo testInfo) throws IOException {
         try (var temp = new TemporaryDirectory()) {
-            var host = TestHost.createNew(List.of(new HostUser(0, "duke", "J. Duke")));
+            var host = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));
 
             var fromDir = temp.path().resolve("from.git");
             var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
@@ -168,7 +168,7 @@ class MirrorBotTests {
     @Test
     void mirrorRemovingBranch(TestInfo testInfo) throws IOException {
         try (var temp = new TemporaryDirectory()) {
-            var host = TestHost.createNew(List.of(new HostUser(0, "duke", "J. Duke")));
+            var host = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));
 
             var fromDir = temp.path().resolve("from.git");
             var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
@@ -223,7 +223,7 @@ class MirrorBotTests {
     @Test
     void mirrorSelectedBranches(TestInfo testInfo) throws IOException {
         try (var temp = new TemporaryDirectory()) {
-            var host = TestHost.createNew(List.of(new HostUser(0, "duke", "J. Duke")));
+            var host = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));
 
             var fromDir = temp.path().resolve("from.git");
             var fromLocalRepo = Repository.init(fromDir, VCS.GIT);

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/VetoTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/VetoTests.java
@@ -37,9 +37,9 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class VetoTests {
     private static HostUser createUser(int id) {
-        return new HostUser(id,
-                            String.format("noname_%d", id),
-                            String.format("No Name %d", id));
+        return HostUser.create(id,
+                               String.format("noname_%d", id),
+                               String.format("No Name %d", id));
     }
 
     private static class Comments {

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHost.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHost.java
@@ -29,7 +29,7 @@ import org.openjdk.skara.vcs.Hash;
 import java.util.*;
 
 class InMemoryHost implements Forge {
-    HostUser currentUserDetails = new HostUser(0, "openjdk", "openjdk [bot]");
+    HostUser currentUserDetails = HostUser.create(0, "openjdk", "openjdk [bot]");
     Map<String, Set<HostUser>> groups;
 
     @Override

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/StateTests.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/StateTests.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class StateTests {
     @Test
     void noCommentsShouldEqualNA() {
-        var bot = new HostUser(1, "bot", "openjdk [bot]");
+        var bot = HostUser.create(1, "bot", "openjdk [bot]");
         var host = new InMemoryHost();
         host.currentUserDetails = bot;
 
@@ -44,7 +44,7 @@ class StateTests {
         var pr = new InMemoryPullRequest();
         pr.repository = repo;
 
-        var duke = new HostUser(0, "duke", "Duke");
+        var duke = HostUser.create(0, "duke", "Duke");
         pr.author = duke;
         pr.comments = List.of();
 
@@ -57,7 +57,7 @@ class StateTests {
 
     @Test
     void testCommentFromNotApprovedUserShouldEqualRequested() {
-        var bot = new HostUser(1, "bot", "openjdk [bot]");
+        var bot = HostUser.create(1, "bot", "openjdk [bot]");
 
         var host = new InMemoryHost();
         host.currentUserDetails = bot;
@@ -68,7 +68,7 @@ class StateTests {
         var pr = new InMemoryPullRequest();
         pr.repository = repo;
 
-        var duke = new HostUser(0, "duke", "Duke");
+        var duke = HostUser.create(0, "duke", "Duke");
         pr.author = duke;
 
         var now = ZonedDateTime.now();
@@ -87,7 +87,7 @@ class StateTests {
 
     @Test
     void testCommentFromApprovedUserShouldEqualApproved() {
-        var bot = new HostUser(1, "bot", "openjdk [bot]");
+        var bot = HostUser.create(1, "bot", "openjdk [bot]");
 
         var host = new InMemoryHost();
         host.currentUserDetails = bot;
@@ -98,7 +98,7 @@ class StateTests {
         var pr = new InMemoryPullRequest();
         pr.repository = repo;
 
-        var duke = new HostUser(0, "duke", "Duke");
+        var duke = HostUser.create(0, "duke", "Duke");
         pr.author = duke;
 
         var now = ZonedDateTime.now();
@@ -117,7 +117,7 @@ class StateTests {
 
     @Test
     void testApprovalNeededCommentShouldResultInPending() {
-        var bot = new HostUser(1, "bot", "openjdk [bot]");
+        var bot = HostUser.create(1, "bot", "openjdk [bot]");
 
         var host = new InMemoryHost();
         host.currentUserDetails = bot;
@@ -128,7 +128,7 @@ class StateTests {
         var pr = new InMemoryPullRequest();
         pr.repository = repo;
 
-        var duke = new HostUser(0, "duke", "Duke");
+        var duke = HostUser.create(0, "duke", "Duke");
         pr.author = duke;
 
         var now = ZonedDateTime.now();
@@ -152,7 +152,7 @@ class StateTests {
 
     @Test
     void testStartedCommentShouldResultInRunning() {
-        var bot = new HostUser(1, "bot", "openjdk [bot]");
+        var bot = HostUser.create(1, "bot", "openjdk [bot]");
 
         var host = new InMemoryHost();
         host.currentUserDetails = bot;
@@ -163,7 +163,7 @@ class StateTests {
         var pr = new InMemoryPullRequest();
         pr.repository = repo;
 
-        var duke = new HostUser(0, "duke", "Duke");
+        var duke = HostUser.create(0, "duke", "Duke");
         pr.author = duke;
 
         var now = ZonedDateTime.now();
@@ -176,7 +176,7 @@ class StateTests {
         );
         var pendingComment = new Comment("1", String.join("\n", pendingBody), bot, now, now);
 
-        var member = new HostUser(2, "foo", "Foo Bar");
+        var member = HostUser.create(2, "foo", "Foo Bar");
         var approveComment = new Comment("2", "/test approve", member, now, now);
 
         var startedBody = List.of(
@@ -200,7 +200,7 @@ class StateTests {
 
     @Test
     void cancelCommentFromAuthorShouldEqualCancelled() {
-        var bot = new HostUser(1, "bot", "openjdk [bot]");
+        var bot = HostUser.create(1, "bot", "openjdk [bot]");
 
         var host = new InMemoryHost();
         host.currentUserDetails = bot;
@@ -211,7 +211,7 @@ class StateTests {
         var pr = new InMemoryPullRequest();
         pr.repository = repo;
 
-        var duke = new HostUser(0, "duke", "Duke");
+        var duke = HostUser.create(0, "duke", "Duke");
         pr.author = duke;
 
         var now = ZonedDateTime.now();
@@ -232,7 +232,7 @@ class StateTests {
 
     @Test
     void cancelCommentFromAnotherUserShouldHaveNoEffect() {
-        var bot = new HostUser(1, "bot", "openjdk [bot]");
+        var bot = HostUser.create(1, "bot", "openjdk [bot]");
 
         var host = new InMemoryHost();
         host.currentUserDetails = bot;
@@ -243,10 +243,10 @@ class StateTests {
         var pr = new InMemoryPullRequest();
         pr.repository = repo;
 
-        var duke = new HostUser(0, "duke", "Duke");
+        var duke = HostUser.create(0, "duke", "Duke");
         pr.author = duke;
 
-        var user = new HostUser(0, "foo", "Foo Bar");
+        var user = HostUser.create(0, "foo", "Foo Bar");
 
         var now = ZonedDateTime.now();
         var testComment = new Comment("0", "/test tier1", duke, now, now);
@@ -266,7 +266,7 @@ class StateTests {
 
     @Test
     void multipleTestCommentsShouldOnlyCareAboutLast() {
-        var bot = new HostUser(1, "bot", "openjdk [bot]");
+        var bot = HostUser.create(1, "bot", "openjdk [bot]");
 
         var host = new InMemoryHost();
         host.currentUserDetails = bot;
@@ -277,7 +277,7 @@ class StateTests {
         var pr = new InMemoryPullRequest();
         pr.repository = repo;
 
-        var duke = new HostUser(0, "duke", "Duke");
+        var duke = HostUser.create(0, "duke", "Duke");
         pr.author = duke;
 
         var now = ZonedDateTime.now();
@@ -299,7 +299,7 @@ class StateTests {
 
     @Test
     void errorAfterRequestedShouldBeError() {
-        var bot = new HostUser(1, "bot", "openjdk [bot]");
+        var bot = HostUser.create(1, "bot", "openjdk [bot]");
 
         var host = new InMemoryHost();
         host.currentUserDetails = bot;
@@ -310,7 +310,7 @@ class StateTests {
         var pr = new InMemoryPullRequest();
         pr.repository = repo;
 
-        var duke = new HostUser(0, "duke", "Duke");
+        var duke = HostUser.create(0, "duke", "Duke");
         pr.author = duke;
 
         var now = ZonedDateTime.now();
@@ -335,7 +335,7 @@ class StateTests {
 
     @Test
     void testFinishedCommentShouldResultInFinished() {
-        var bot = new HostUser(1, "bot", "openjdk [bot]");
+        var bot = HostUser.create(1, "bot", "openjdk [bot]");
 
         var host = new InMemoryHost();
         host.currentUserDetails = bot;
@@ -346,7 +346,7 @@ class StateTests {
         var pr = new InMemoryPullRequest();
         pr.repository = repo;
 
-        var duke = new HostUser(0, "duke", "Duke");
+        var duke = HostUser.create(0, "duke", "Duke");
         pr.author = duke;
 
         var now = ZonedDateTime.now();
@@ -359,7 +359,7 @@ class StateTests {
         );
         var pendingComment = new Comment("1", String.join("\n", pendingBody), bot, now, now);
 
-        var member = new HostUser(2, "foo", "Foo Bar");
+        var member = HostUser.create(2, "foo", "Foo Bar");
         var approveComment = new Comment("2", "/test approve", member, now, now);
 
         var startedBody = List.of(

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/TestWorkItemTests.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/TestWorkItemTests.java
@@ -50,7 +50,7 @@ class TestWorkItemTests {
             var storage = tmp.path().resolve("storage");
             var scratch = tmp.path().resolve("storage");
 
-            var bot = new HostUser(1, "bot", "openjdk [bot]");
+            var bot = HostUser.create(1, "bot", "openjdk [bot]");
             var host = new InMemoryHost();
             host.currentUserDetails = bot;
 
@@ -60,7 +60,7 @@ class TestWorkItemTests {
             var pr = new InMemoryPullRequest();
             pr.repository = repo;
 
-            var duke = new HostUser(0, "duke", "Duke");
+            var duke = HostUser.create(0, "duke", "Duke");
             pr.author = duke;
             pr.comments = List.of();
 
@@ -84,7 +84,7 @@ class TestWorkItemTests {
             var storage = tmp.path().resolve("storage");
             var scratch = tmp.path().resolve("storage");
 
-            var bot = new HostUser(1, "bot", "openjdk [bot]");
+            var bot = HostUser.create(1, "bot", "openjdk [bot]");
             var host = new InMemoryHost();
             host.currentUserDetails = bot;
 
@@ -94,7 +94,7 @@ class TestWorkItemTests {
             var pr = new InMemoryPullRequest();
             pr.repository = repo;
 
-            var duke = new HostUser(0, "duke", "Duke");
+            var duke = HostUser.create(0, "duke", "Duke");
             var now = ZonedDateTime.now();
             pr.author = duke;
             var testApproveComment = new Comment("0", "/test approve", duke, now, now);
@@ -121,7 +121,7 @@ class TestWorkItemTests {
             var storage = tmp.path().resolve("storage");
             var scratch = tmp.path().resolve("storage");
 
-            var bot = new HostUser(1, "bot", "openjdk [bot]");
+            var bot = HostUser.create(1, "bot", "openjdk [bot]");
             var host = new InMemoryHost();
             host.currentUserDetails = bot;
 
@@ -131,7 +131,7 @@ class TestWorkItemTests {
             var pr = new InMemoryPullRequest();
             pr.repository = repo;
 
-            var duke = new HostUser(0, "duke", "Duke");
+            var duke = HostUser.create(0, "duke", "Duke");
             var now = ZonedDateTime.now();
             pr.author = duke;
             var testApproveComment = new Comment("0", "/test cancel", duke, now, now);
@@ -158,7 +158,7 @@ class TestWorkItemTests {
             var storage = tmp.path().resolve("storage");
             var scratch = tmp.path().resolve("storage");
 
-            var bot = new HostUser(1, "bot", "openjdk [bot]");
+            var bot = HostUser.create(1, "bot", "openjdk [bot]");
             var host = new InMemoryHost();
             host.currentUserDetails = bot;
             host.groups = Map.of("0", Set.of());
@@ -169,7 +169,7 @@ class TestWorkItemTests {
             var pr = new InMemoryPullRequest();
             pr.repository = repo;
 
-            var duke = new HostUser(0, "duke", "Duke");
+            var duke = HostUser.create(0, "duke", "Duke");
             pr.author = duke;
 
             var now = ZonedDateTime.now();
@@ -205,7 +205,7 @@ class TestWorkItemTests {
             var storage = tmp.path().resolve("storage");
             var scratch = tmp.path().resolve("storage");
 
-            var bot = new HostUser(1, "bot", "openjdk [bot]");
+            var bot = HostUser.create(1, "bot", "openjdk [bot]");
             var host = new InMemoryHost();
             host.currentUserDetails = bot;
             host.groups = Map.of("0", Set.of());
@@ -216,7 +216,7 @@ class TestWorkItemTests {
             var pr = new InMemoryPullRequest();
             pr.repository = repo;
 
-            var duke = new HostUser(0, "duke", "Duke");
+            var duke = HostUser.create(0, "duke", "Duke");
             pr.author = duke;
             pr.headHash = new Hash("01234567890123456789012345789012345789");
 
@@ -286,7 +286,7 @@ class TestWorkItemTests {
             var storage = tmp.path().resolve("storage");
             var scratch = tmp.path().resolve("storage");
 
-            var bot = new HostUser(1, "bot", "openjdk [bot]");
+            var bot = HostUser.create(1, "bot", "openjdk [bot]");
             var host = new InMemoryHost();
             host.currentUserDetails = bot;
             host.groups = Map.of("0", Set.of());
@@ -297,7 +297,7 @@ class TestWorkItemTests {
             var pr = new InMemoryPullRequest();
             pr.repository = repo;
 
-            var duke = new HostUser(0, "duke", "Duke");
+            var duke = HostUser.create(0, "duke", "Duke");
             pr.author = duke;
             pr.headHash = new Hash("01234567890123456789012345789012345789");
 
@@ -329,7 +329,7 @@ class TestWorkItemTests {
             var storage = tmp.path().resolve("storage");
             var scratch = tmp.path().resolve("storage");
 
-            var bot = new HostUser(1, "bot", "openjdk [bot]");
+            var bot = HostUser.create(1, "bot", "openjdk [bot]");
             var host = new InMemoryHost();
             host.currentUserDetails = bot;
             host.groups = Map.of(approvers, Set.of());
@@ -340,7 +340,7 @@ class TestWorkItemTests {
             var pr = new InMemoryPullRequest();
             pr.repository = repo;
 
-            var duke = new HostUser(0, "duke", "Duke");
+            var duke = HostUser.create(0, "duke", "Duke");
             pr.author = duke;
             pr.headHash = new Hash("01234567890123456789012345789012345789");
 
@@ -387,7 +387,7 @@ class TestWorkItemTests {
             assertEquals(cancelComment, comments.get(2));
 
             // Approving the test should not start a job, it has already been cancelled
-            var member = new HostUser(3, "foo", "Foo Bar");
+            var member = HostUser.create(3, "foo", "Foo Bar");
             host.groups = Map.of(approvers, Set.of(member));
             var approveComment = new Comment("3", "/test approve", member, now, now);
             pr.comments.add(approveComment);
@@ -414,7 +414,7 @@ class TestWorkItemTests {
             var storage = tmp.path().resolve("storage");
             var scratch = tmp.path().resolve("storage");
 
-            var bot = new HostUser(1, "bot", "openjdk [bot]");
+            var bot = HostUser.create(1, "bot", "openjdk [bot]");
             var host = new InMemoryHost();
             host.currentUserDetails = bot;
             host.groups = Map.of(approvers, Set.of());
@@ -425,7 +425,7 @@ class TestWorkItemTests {
             var pr = new InMemoryPullRequest();
             pr.repository = repo;
 
-            var duke = new HostUser(0, "duke", "Duke");
+            var duke = HostUser.create(0, "duke", "Duke");
             pr.author = duke;
             pr.headHash = new Hash("01234567890123456789012345789012345789");
 
@@ -460,7 +460,7 @@ class TestWorkItemTests {
             assertEquals(secondComment, comments.get(1));
 
             // Approve the request
-            var member = new HostUser(2, "foo", "Foo Bar");
+            var member = HostUser.create(2, "foo", "Foo Bar");
             host.groups = Map.of(approvers, Set.of(member));
             var approveComment = new Comment("2", "/test approve", member, now, now);
             pr.comments.add(approveComment);
@@ -498,7 +498,7 @@ class TestWorkItemTests {
             var storage = tmp.path().resolve("storage");
             var scratch = tmp.path().resolve("storage");
 
-            var bot = new HostUser(1, "bot", "openjdk [bot]");
+            var bot = HostUser.create(1, "bot", "openjdk [bot]");
             var host = new InMemoryHost();
             host.currentUserDetails = bot;
             host.groups = Map.of(approvers, Set.of());
@@ -513,7 +513,7 @@ class TestWorkItemTests {
             pr.repository = repo;
             pr.id = "17";
 
-            var duke = new HostUser(0, "duke", "Duke");
+            var duke = HostUser.create(0, "duke", "Duke");
             pr.author = duke;
             pr.headHash = head;
 
@@ -548,7 +548,7 @@ class TestWorkItemTests {
             assertEquals(secondComment, comments.get(1));
 
             // Approve the request
-            var member = new HostUser(2, "foo", "Foo Bar");
+            var member = HostUser.create(2, "foo", "Foo Bar");
             host.groups = Map.of(approvers, Set.of(member));
             var approveComment = new Comment("2", "/test approve", member, now, now);
             pr.comments.add(approveComment);
@@ -607,7 +607,7 @@ class TestWorkItemTests {
             var storage = tmp.path().resolve("storage");
             var scratch = tmp.path().resolve("storage");
 
-            var bot = new HostUser(1, "bot", "openjdk [bot]");
+            var bot = HostUser.create(1, "bot", "openjdk [bot]");
             var host = new InMemoryHost();
             host.currentUserDetails = bot;
             host.groups = Map.of(approvers, Set.of());
@@ -623,7 +623,7 @@ class TestWorkItemTests {
             pr.id = "17";
             pr.headHash = head;
 
-            var duke = new HostUser(0, "duke", "Duke");
+            var duke = HostUser.create(0, "duke", "Duke");
             pr.author = duke;
 
             var now = ZonedDateTime.now();
@@ -657,7 +657,7 @@ class TestWorkItemTests {
             assertEquals(secondComment, comments.get(1));
 
             // Approve the request
-            var member = new HostUser(2, "foo", "Foo Bar");
+            var member = HostUser.create(2, "foo", "Foo Bar");
             host.groups = Map.of(approvers, Set.of(member));
             var approveComment = new Comment("2", "/test approve", member, now, now);
             pr.comments.add(approveComment);
@@ -733,7 +733,7 @@ class TestWorkItemTests {
             var storage = tmp.path().resolve("storage");
             var scratch = tmp.path().resolve("storage");
 
-            var bot = new HostUser(1, "bot", "openjdk [bot]");
+            var bot = HostUser.create(1, "bot", "openjdk [bot]");
             var host = new InMemoryHost();
             host.currentUserDetails = bot;
             host.groups = Map.of(approvers, Set.of());
@@ -749,7 +749,7 @@ class TestWorkItemTests {
             pr.id = "17";
             pr.headHash = head;
 
-            var duke = new HostUser(0, "duke", "Duke");
+            var duke = HostUser.create(0, "duke", "Duke");
             pr.author = duke;
 
             var now = ZonedDateTime.now();
@@ -783,7 +783,7 @@ class TestWorkItemTests {
             assertEquals(secondComment, comments.get(1));
 
             // Approve the request
-            var member = new HostUser(2, "foo", "Foo Bar");
+            var member = HostUser.create(2, "foo", "Foo Bar");
             host.groups = Map.of(approvers, Set.of(member));
             var approveComment = new Comment("2", "/test approve", member, now, now);
             pr.comments.add(approveComment);
@@ -822,7 +822,7 @@ class TestWorkItemTests {
             var storage = tmp.path().resolve("storage");
             var scratch = tmp.path().resolve("storage");
 
-            var bot = new HostUser(1, "bot", "openjdk [bot]");
+            var bot = HostUser.create(1, "bot", "openjdk [bot]");
             var host = new InMemoryHost();
             host.currentUserDetails = bot;
             host.groups = Map.of(approvers, Set.of());
@@ -838,7 +838,7 @@ class TestWorkItemTests {
             pr.id = "17";
             pr.headHash = head;
 
-            var duke = new HostUser(0, "duke", "Duke");
+            var duke = HostUser.create(0, "duke", "Duke");
             pr.author = duke;
 
             var now = ZonedDateTime.now();
@@ -872,7 +872,7 @@ class TestWorkItemTests {
             assertEquals(secondComment, comments.get(1));
 
             // Approve the request
-            var member = new HostUser(2, "foo", "Foo Bar");
+            var member = HostUser.create(2, "foo", "Foo Bar");
             host.groups = Map.of(approvers, Set.of(member));
             var approveComment = new Comment("2", "/test approve", member, now, now);
             pr.comments.add(approveComment);
@@ -976,7 +976,7 @@ class TestWorkItemTests {
             var storage = tmp.path().resolve("storage");
             var scratch = tmp.path().resolve("storage");
 
-            var bot = new HostUser(1, "bot", "openjdk [bot]");
+            var bot = HostUser.create(1, "bot", "openjdk [bot]");
             var host = new InMemoryHost();
             host.currentUserDetails = bot;
             host.groups = Map.of(approvers, Set.of());
@@ -991,7 +991,7 @@ class TestWorkItemTests {
             pr.repository = repo;
             pr.id = "17";
 
-            var duke = new HostUser(0, "duke", "Duke");
+            var duke = HostUser.create(0, "duke", "Duke");
             pr.author = duke;
             pr.headHash = head;
 
@@ -1048,7 +1048,7 @@ class TestWorkItemTests {
             var storage = tmp.path().resolve("storage");
             var scratch = tmp.path().resolve("storage");
 
-            var bot = new HostUser(1, "bot", "openjdk [bot]");
+            var bot = HostUser.create(1, "bot", "openjdk [bot]");
             var host = new InMemoryHost();
             host.currentUserDetails = bot;
 
@@ -1058,7 +1058,7 @@ class TestWorkItemTests {
             var pr = new InMemoryPullRequest();
             pr.repository = repo;
 
-            var duke = new HostUser(0, "duke", "Duke");
+            var duke = HostUser.create(0, "duke", "Duke");
             host.groups = Map.of(approvers, Set.of(duke));
             pr.author = duke;
             pr.headHash = new Hash("01234567890123456789012345789012345789");
@@ -1129,7 +1129,7 @@ class TestWorkItemTests {
             var storage = tmp.path().resolve("storage");
             var scratch = tmp.path().resolve("storage");
 
-            var bot = new HostUser(1, "bot", "openjdk [bot]");
+            var bot = HostUser.create(1, "bot", "openjdk [bot]");
             var host = new InMemoryHost();
             host.currentUserDetails = bot;
 
@@ -1139,7 +1139,7 @@ class TestWorkItemTests {
             var pr = new InMemoryPullRequest();
             pr.repository = repo;
 
-            var duke = new HostUser(0, "duke", "Duke");
+            var duke = HostUser.create(0, "duke", "Duke");
             host.groups = Map.of(approvers, Set.of(duke));
             pr.author = duke;
             pr.headHash = new Hash("01234567890123456789012345789012345789");

--- a/bots/topological/src/test/java/org/openjdk/skara/bots/topological/TopologicalBotTests.java
+++ b/bots/topological/src/test/java/org/openjdk/skara/bots/topological/TopologicalBotTests.java
@@ -43,7 +43,7 @@ class TopologicalBotTests {
     @Test
     void testTopoMerge() throws IOException {
         try (var temp = new TemporaryDirectory()) {
-            var host = TestHost.createNew(List.of(new HostUser(0, "duke", "J. Duke")));
+            var host = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));
 
             var fromDir = temp.path().resolve("from.git");
             var repo = Repository.init(fromDir, VCS.GIT);
@@ -113,7 +113,7 @@ class TopologicalBotTests {
     @Test
     void testTopoMergeFailure() throws IOException {
         try (var temp = new TemporaryDirectory()) {
-            var host = TestHost.createNew(List.of(new HostUser(0, "duke", "J. Duke")));
+            var host = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));
 
             var fromDir = temp.path().resolve("from.git");
             var repo = Repository.init(fromDir, VCS.GIT);

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubHost.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubHost.java
@@ -204,8 +204,8 @@ public class GitHubHost implements Forge {
     }
 
     HostUser parseUserObject(JSONValue json) {
-        return new HostUser(json.get("id").asInt(), json.get("login").asString(),
-                            () -> getFullName(json.get("login").asString()));
+        return HostUser.create(json.get("id").asInt(), json.get("login").asString(),
+                               () -> getFullName(json.get("login").asString()));
     }
 
     @Override
@@ -284,7 +284,7 @@ public class GitHubHost implements Forge {
             name = login;
         }
         var email = details.get("email").asString();
-        return new HostUser(id, login, name, email);
+        return HostUser.create(id, login, name, email);
     }
 
     @Override

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabHost.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabHost.java
@@ -149,7 +149,7 @@ public class GitLabHost implements Forge {
         var username = o.get("username").asString();
         var name = o.get("name").asString();
         var email = o.get("email").asString();
-        return new HostUser(id, username, name, email);
+        return HostUser.create(id, username, name, email);
     }
 
     @Override

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -194,9 +194,9 @@ public class GitLabMergeRequest implements PullRequest {
                                         line,
                                         note.get("id").toString(),
                                         note.get("body").asString(),
-                                        new HostUser(note.get("author").get("id").asInt(),
-                                                     note.get("author").get("username").asString(),
-                                                     note.get("author").get("name").asString()),
+                                        HostUser.create(note.get("author").get("id").asInt(),
+                                                        note.get("author").get("username").asString(),
+                                                        note.get("author").get("name").asString()),
                                         ZonedDateTime.parse(note.get("created_at").asString()),
                                         ZonedDateTime.parse(note.get("updated_at").asString()));
         return comment;
@@ -340,9 +340,9 @@ public class GitLabMergeRequest implements PullRequest {
     private Comment parseComment(JSONValue comment) {
         var ret = new Comment(comment.get("id").toString(),
                               comment.get("body").asString(),
-                              new HostUser(comment.get("author").get("id").asInt(),
-                                           comment.get("author").get("username").asString(),
-                                           comment.get("author").get("name").asString()),
+                              HostUser.create(comment.get("author").get("id").asInt(),
+                                              comment.get("author").get("username").asString(),
+                                              comment.get("author").get("name").asString()),
                               ZonedDateTime.parse(comment.get("created_at").asString()),
                               ZonedDateTime.parse(comment.get("updated_at").asString()));
         return ret;

--- a/host/src/main/java/org/openjdk/skara/host/HostUser.java
+++ b/host/src/main/java/org/openjdk/skara/host/HostUser.java
@@ -33,39 +33,48 @@ public class HostUser {
     private String name;
     private String email;
 
-    public HostUser(String id, String username, Supplier<String> nameSupplier, String email) {
-        this.id = id;
+    private HostUser(String id, String username, String name) {
+        this.id = id ;
+        this.username = username;
+        this.nameSupplier = null;
+        this.name = name;
+        this.email = null;
+    }
+
+    private HostUser(String id, String username, Supplier<String> nameSupplier) {
+        this.id = id ;
         this.username = username;
         this.nameSupplier = nameSupplier;
+        this.name = null;
+        this.email = null;
+    }
+
+    private HostUser(String id, String username, String name, String email) {
+        this.id = id ;
+        this.username = username;
+        this.nameSupplier = null;
+        this.name = name;
         this.email = email;
     }
 
-    public HostUser(String id, String username, Supplier<String> nameSupplier) {
-        this(id, username, nameSupplier, null);
+    public static HostUser create(int id, String username, Supplier<String> nameSupplier) {
+        return new HostUser(String.valueOf(id), username, nameSupplier);
     }
 
-    public HostUser(String id, String username, String name) {
-        this(id, username, () -> name);
+    public static HostUser create(int id, String username, String name, String email) {
+        return new HostUser(String.valueOf(id), username, name, email);
     }
 
-    public HostUser(String id, String username, String name, String email) {
-        this(id, username, () -> name, email);
+    public static HostUser create(String id, String username, String name, String email) {
+        return new HostUser(id, username, name, email);
     }
 
-    public HostUser(int id, String username, String name) {
-        this(String.valueOf(id), username, name);
+    public static HostUser create(String id, String username, String name) {
+        return new HostUser(id, username, name);
     }
 
-    public HostUser(int id, String username, String name, String email) {
-        this(String.valueOf(id), username, name, email);
-    }
-
-    public HostUser(int id, String username, Supplier<String> nameSupplier) {
-        this(String.valueOf(id), username, nameSupplier);
-    }
-
-    public HostUser(int id, String username, Supplier<String> nameSupplier, String email) {
-        this(String.valueOf(id), username, nameSupplier, email);
+    public static HostUser create(int id, String username, String name) {
+        return new HostUser(String.valueOf(id), username, name);
     }
 
     @Override

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraHost.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraHost.java
@@ -104,9 +104,9 @@ public class JiraHost implements IssueTracker {
             return Optional.empty();
         }
 
-        var user = new HostUser(data.get("name").asString(),
-                                data.get("name").asString(),
-                                data.get("displayName").asString());
+        var user = HostUser.create(data.get("name").asString(),
+                                   data.get("name").asString(),
+                                   data.get("displayName").asString());
         return Optional.of(user);
     }
 
@@ -114,10 +114,10 @@ public class JiraHost implements IssueTracker {
     public HostUser currentUser() {
         if (currentUser == null) {
             var data = request.get("myself").execute();
-            currentUser = new HostUser(data.get("name").asString(),
-                                       data.get("name").asString(),
-                                       data.get("displayName").asString(),
-                                       data.get("emailAddress").asString());
+            currentUser = HostUser.create(data.get("name").asString(),
+                                          data.get("name").asString(),
+                                          data.get("displayName").asString(),
+                                          data.get("emailAddress").asString());
         }
         return currentUser;
     }

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraIssue.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraIssue.java
@@ -65,9 +65,9 @@ public class JiraIssue implements Issue {
 
     @Override
     public HostUser author() {
-        return new HostUser(json.get("fields").get("creator").get("key").asString(),
-                            json.get("fields").get("creator").get("name").asString(),
-                            json.get("fields").get("creator").get("displayName").asString());
+        return HostUser.create(json.get("fields").get("creator").get("key").asString(),
+                               json.get("fields").get("creator").get("name").asString(),
+                               json.get("fields").get("creator").get("displayName").asString());
     }
 
     @Override
@@ -111,9 +111,9 @@ public class JiraIssue implements Issue {
     private Comment parseComment(JSONValue json) {
         return new Comment(json.get("id").asString(),
                            json.get("body").asString(),
-                           new HostUser(json.get("author").get("name").asString(),
-                                        json.get("author").get("name").asString(),
-                                        json.get("author").get("displayName").asString()),
+                           HostUser.create(json.get("author").get("name").asString(),
+                                           json.get("author").get("name").asString(),
+                                           json.get("author").get("displayName").asString()),
                            ZonedDateTime.parse(json.get("created").asString(), dateFormat),
                            ZonedDateTime.parse(json.get("updated").asString(), dateFormat));
     }
@@ -275,9 +275,9 @@ public class JiraIssue implements Issue {
             return List.of();
         }
 
-        var user = new HostUser(assignee.get("name").asString(),
-                                assignee.get("name").asString(),
-                                assignee.get("displayName").asString());
+        var user = HostUser.create(assignee.get("name").asString(),
+                                   assignee.get("name").asString(),
+                                   assignee.get("displayName").asString());
         return List.of(user);
     }
 

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraProject.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraProject.java
@@ -434,9 +434,9 @@ public class JiraProject implements IssueProject {
             return Optional.empty();
         }
         var data = user.asArray().get(0);
-        return Optional.of(new HostUser(data.get("name").asString(),
-                                        data.get("name").asString(),
-                                        data.get("displayName").asString(),
-                                        data.get("emailAddress").asString()));
+        return Optional.of(HostUser.create(data.get("name").asString(),
+                                           data.get("name").asString(),
+                                           data.get("displayName").asString(),
+                                           data.get("emailAddress").asString()));
     }
 }

--- a/test/src/main/java/org/openjdk/skara/test/CensusBuilder.java
+++ b/test/src/main/java/org/openjdk/skara/test/CensusBuilder.java
@@ -207,7 +207,7 @@ public class CensusBuilder {
 
     public HostedRepository build() {
         try {
-            var host = TestHost.createNew(List.of(new HostUser(1, "cu", "Census User")));
+            var host = TestHost.createNew(List.of(HostUser.create(1, "cu", "Census User")));
             var repository = host.repository("census").orElseThrow();
             var folder = Files.createTempDirectory("censusbuilder");
             var localRepository = Repository.init(folder, VCS.GIT);

--- a/test/src/main/java/org/openjdk/skara/test/HostCredentials.java
+++ b/test/src/main/java/org/openjdk/skara/test/HostCredentials.java
@@ -184,10 +184,10 @@ public class HostCredentials implements AutoCloseable {
     private static class TestCredentials implements Credentials {
         private final List<TestHost> hosts = new ArrayList<>();
         private final List<HostUser> users = List.of(
-                new HostUser(1, "user1", "User Number 1"),
-                new HostUser(2, "user2", "User Number 2"),
-                new HostUser(3, "user3", "User Number 3"),
-                new HostUser(4, "user4", "User Number 4")
+                HostUser.create(1, "user1", "User Number 1"),
+                HostUser.create(2, "user2", "User Number 2"),
+                HostUser.create(3, "user3", "User Number 3"),
+                HostUser.create(4, "user4", "User Number 4")
         );
 
         private TestHost createHost(int userIndex) {


### PR DESCRIPTION
Hi all,

please review this patch that refactors `HostUser` to get have private constructors and instead use public static creator functions. This is in preparation for a refactoring to using a "builder" for the `HostUser` class.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ⏳ (1/1 running) | ⏳ (1/1 running) | ⏳ (1/1 running) |

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/889/head:pull/889`
`$ git checkout pull/889`
