### PR TITLE
forge: add builder for HostUser

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubHost.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubHost.java
@@ -193,19 +193,17 @@ public class GitHubHost implements Forge {
         return Optional.empty();
     }
 
-    private String getFullName(String username) {
-        var details = user(username);
-        return details.get().fullName();
-    }
-
     // Most GitHub API's return user information in this format
     HostUser parseUserField(JSONValue json) {
         return parseUserObject(json.get("user"));
     }
 
     HostUser parseUserObject(JSONValue json) {
-        return HostUser.create(json.get("id").asInt(), json.get("login").asString(),
-                               () -> getFullName(json.get("login").asString()));
+        return HostUser.builder()
+                       .id(json.get("id").asInt())
+                       .username(json.get("login").asString())
+                       .supplier(() -> user(json.get("login").asString()).orElseThrow())
+                       .build();
     }
 
     @Override
@@ -284,7 +282,12 @@ public class GitHubHost implements Forge {
             name = login;
         }
         var email = details.get("email").asString();
-        return HostUser.create(id, login, name, email);
+        return HostUser.builder()
+                       .id(id)
+                       .username(login)
+                       .fullName(name)
+                       .email(email)
+                       .build();
     }
 
     @Override

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabHost.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabHost.java
@@ -149,7 +149,12 @@ public class GitLabHost implements Forge {
         var username = o.get("username").asString();
         var name = o.get("name").asString();
         var email = o.get("email").asString();
-        return HostUser.create(id, username, name, email);
+        return HostUser.builder()
+                       .id(id)
+                       .username(username)
+                       .fullName(name)
+                       .email(email)
+                       .build();
     }
 
     @Override

--- a/host/src/main/java/org/openjdk/skara/host/HostUser.java
+++ b/host/src/main/java/org/openjdk/skara/host/HostUser.java
@@ -27,67 +27,85 @@ import java.util.Optional;
 import java.util.function.Supplier;
 
 public class HostUser {
-    private final String id;
-    private final String username;
-    private final Supplier<String> nameSupplier;
-    private String name;
+    private String id;
+    private String username;
+    private String fullName;
     private String email;
+    private final Supplier<HostUser> supplier;
 
-    private HostUser(String id, String username, String name) {
-        this.id = id ;
-        this.username = username;
-        this.nameSupplier = null;
-        this.name = name;
-        this.email = null;
+    public static class Builder {
+        private String id;
+        private String username;
+        private String fullName;
+        private String email;
+        private Supplier<HostUser> supplier;
+
+        public Builder id(int id) {
+            this.id = String.valueOf(id);
+            return this;
+        }
+
+        public Builder id(String id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder username(String username) {
+            this.username = username;
+            return this;
+        }
+
+        public Builder fullName(String fullName) {
+            this.fullName = fullName;
+            return this;
+        }
+
+        public Builder email(String email) {
+            this.email = email;
+            return this;
+        }
+
+        public Builder supplier(Supplier<HostUser> supplier) {
+            this.supplier = supplier;
+            return this;
+        }
+
+        public HostUser build() {
+            return new HostUser(id, username, fullName, email, supplier);
+        }
     }
 
-    private HostUser(String id, String username, Supplier<String> nameSupplier) {
-        this.id = id ;
+    private HostUser(String id, String username, String fullName, String email, Supplier<HostUser> supplier) {
+        this.id = id;
         this.username = username;
-        this.nameSupplier = nameSupplier;
-        this.name = null;
-        this.email = null;
-    }
-
-    private HostUser(String id, String username, String name, String email) {
-        this.id = id ;
-        this.username = username;
-        this.nameSupplier = null;
-        this.name = name;
+        this.fullName = fullName;
         this.email = email;
+        this.supplier = supplier;
     }
 
-    public static HostUser create(int id, String username, Supplier<String> nameSupplier) {
-        return new HostUser(String.valueOf(id), username, nameSupplier);
+    public static Builder builder() {
+        return new Builder();
     }
 
-    public static HostUser create(int id, String username, String name, String email) {
-        return new HostUser(String.valueOf(id), username, name, email);
+    public static HostUser create(String id, String username, String fullName) {
+        return builder().id(id).username(username).fullName(fullName).build();
     }
 
-    public static HostUser create(String id, String username, String name, String email) {
-        return new HostUser(id, username, name, email);
-    }
-
-    public static HostUser create(String id, String username, String name) {
-        return new HostUser(id, username, name);
-    }
-
-    public static HostUser create(int id, String username, String name) {
-        return new HostUser(String.valueOf(id), username, name);
+    public static HostUser create(int id, String username, String fullName) {
+        return builder().id(id).username(username).fullName(fullName).build();
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) {
+    public boolean equals(Object other) {
+        if (this == other) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (other == null || getClass() != other.getClass()) {
             return false;
         }
-        HostUser that = (HostUser) o;
-        return id.equals(that.id) &&
-                Objects.equals(username, that.username);
+        HostUser o = (HostUser) other;
+        return Objects.equals(id(), o.id()) &&
+               Objects.equals(username(), o.username());
     }
 
     @Override
@@ -95,22 +113,39 @@ public class HostUser {
         return Objects.hash(id, username);
     }
 
+    private void update() {
+        var result = supplier.get();
+        id = result.id;
+        username = result.username;
+        fullName = result.fullName;
+        email = result.email;
+    }
+
     public String id() {
+        if (id == null) {
+            update();
+        }
         return id;
     }
 
     public String username() {
+        if (username == null) {
+            update();
+        }
         return username;
     }
 
     public String fullName() {
-        if (name == null) {
-            name = nameSupplier.get();
+        if (fullName == null) {
+            update();
         }
-        return name;
+        return fullName;
     }
 
     public Optional<String> email() {
+        if (id == null || username == null || fullName == null) {
+            update();
+        }
         return Optional.ofNullable(email);
     }
 
@@ -119,7 +154,7 @@ public class HostUser {
         return "HostUserDetails{" +
                 "id=" + id +
                 ", username='" + username + '\'' +
-                ", name='" + name + '\'' +
+                ", fullName='" + fullName + '\'' +
                 '}';
     }
 }

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraHost.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraHost.java
@@ -114,10 +114,12 @@ public class JiraHost implements IssueTracker {
     public HostUser currentUser() {
         if (currentUser == null) {
             var data = request.get("myself").execute();
-            currentUser = HostUser.create(data.get("name").asString(),
-                                          data.get("name").asString(),
-                                          data.get("displayName").asString(),
-                                          data.get("emailAddress").asString());
+            currentUser = HostUser.builder()
+                                  .id(data.get("name").asString())
+                                  .username(data.get("name").asString())
+                                  .fullName(data.get("displayName").asString())
+                                  .email(data.get("emailAddress").asString())
+                                  .build();
         }
         return currentUser;
     }

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraProject.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraProject.java
@@ -434,9 +434,12 @@ public class JiraProject implements IssueProject {
             return Optional.empty();
         }
         var data = user.asArray().get(0);
-        return Optional.of(HostUser.create(data.get("name").asString(),
-                                           data.get("name").asString(),
-                                           data.get("displayName").asString(),
-                                           data.get("emailAddress").asString()));
+        var hostUser = HostUser.builder()
+                              .id(data.get("name").asString())
+                              .username(data.get("name").asString())
+                              .fullName(data.get("displayName").asString())
+                              .email(data.get("emailAddress").asString())
+                              .build();
+        return Optional.of(hostUser);
     }
 }


### PR DESCRIPTION
Hi all,

please review this patch that adds "builder" for the class `HostUser`. The builder also generalizes the concept of fetching missing information for a `HostUser` so that any username, id and full name now can fetched lazily.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ❌ (1/1 failed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) |

**Failed test task**
- [Linux x64](https://github.com/edvbld/skara/runs/1275224191)

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/890/head:pull/890`
`$ git checkout pull/890`
