### PR TITLE
Use a separate watchdog thread for the WorkItem scheduler

### DIFF
--- a/bot/src/main/java/org/openjdk/skara/bot/BotWatchdog.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotWatchdog.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bot;
+
+import java.time.Duration;
+
+public class BotWatchdog {
+    private final Thread watchThread;
+    private final long maxWaitMillis;
+    private volatile boolean hasBeenPinged = false;
+
+    private void threadMain() {
+        while (true) {
+            try {
+                Thread.sleep(maxWaitMillis);
+                if (!hasBeenPinged) {
+                    System.out.println("No watchdog ping detected - exiting...");
+                    System.exit(1);
+                }
+                hasBeenPinged = false;
+            } catch (InterruptedException ignored) {
+            }
+        }
+    }
+
+    BotWatchdog(Duration maxWait) {
+        maxWaitMillis = maxWait.toMillis();
+        watchThread = new Thread(this::threadMain);
+        watchThread.setName("BotWatchdog");
+        watchThread.setDaemon(true);
+        watchThread.start();
+    }
+
+    public void ping() {
+        hasBeenPinged = true;
+    }
+}


### PR DESCRIPTION
Use a separate watchdog thread to be able to detect if our ForkJoinPool stops executing tasks (which we've seen happen a few times). Not much to do in that case, just let the process restart.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) |

### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/894/head:pull/894`
`$ git checkout pull/894`
