### PR TITLE
vcs: lookup does not handle non-existing commits

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -179,8 +179,19 @@ public class GitRepository implements Repository {
         return new GitCommits(dir, range, reverse, n);
     }
 
+    private boolean exists(Hash h) throws IOException {
+        try (var p = capture("git", "cat-file", "-e", h.hex())) {
+            var res = p.await();
+            return res.status() == 0;
+        }
+    }
+
     @Override
     public Optional<Commit> lookup(Hash h) throws IOException {
+        if (!exists(h)) {
+            return Optional.empty();
+        }
+
         var commits = commits(h.hex(), 1).asList();
         if (commits.size() != 1) {
             return Optional.empty();

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -235,8 +235,18 @@ public class HgRepository implements Repository {
         return new HgCommits(dir, range, ext, reverse, n);
     }
 
+    private boolean exists(Hash h) throws IOException {
+        try (var p = capture("hg", "log", "--rev=" + h.hex(), "--template={node}\n")) {
+            var res = p.await();
+            return res.status() == 0;
+        }
+    }
+
     @Override
     public Optional<Commit> lookup(Hash h) throws IOException {
+        if (!exists(h)) {
+            return Optional.empty();
+        }
         var commits = commits(h.hex()).asList();
         if (commits.size() != 1) {
             return Optional.empty();

--- a/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
@@ -2726,4 +2726,21 @@ public class RepositoryTests {
             }
         }
     }
+
+    @ParameterizedTest
+    @EnumSource(VCS.class)
+    void testNonExistingLookup(VCS vcs) throws IOException {
+        try (var dir = new TemporaryDirectory()) {
+            var r = Repository.init(dir.path(), vcs);
+            assertTrue(r.isClean());
+
+            var readme = dir.path().resolve("README.md");
+            Files.writeString(readme, "Hello world\n");
+            r.add(readme);
+            var hash = r.commit("Added readme", "duke", "duke@openjdk.java.net");
+
+            var nonExisting = r.lookup(new Hash("0123456789012345678901234567890123456789"));
+            assertEquals(Optional.empty(), nonExisting);
+        }
+    }
 }


### PR DESCRIPTION
Hi all,

please review this patch that makes `ReadOnlyRepository.lookup` handle hashes that do not exist in the repository. I also added a unit test for this scenario.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ⏳ (1/1 running) | ✔️ (1/1 passed) | ⏳ (1/1 running) |

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/898/head:pull/898`
`$ git checkout pull/898`
