### PR TITLE
forge: add Accept HTTP headers for GitHub search API

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubHost.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubHost.java
@@ -69,7 +69,9 @@ public class GitHubHost implements Forge {
         request = new RestRequest(baseApi, application.authId(), () -> Arrays.asList(
                 "Authorization", "token " + getInstallationToken().orElseThrow(),
                 "Accept", "application/vnd.github.machine-man-preview+json",
-                "Accept", "application/vnd.github.antiope-preview+json"));
+                "Accept", "application/vnd.github.antiope-preview+json",
+                "Accept", "application/vnd.github.cloak-preview+json"
+        ));
 
         var graphQLAPI = URIBuilder.base(uri)
                 .appendSubDomain("api")
@@ -106,7 +108,11 @@ public class GitHubHost implements Forge {
                                 .build();
 
         request = new RestRequest(baseApi, pat.username(), () -> Arrays.asList(
-                "Authorization", "token " + getInstallationToken().orElseThrow()));
+                "Authorization", "token " + getInstallationToken().orElseThrow(),
+                "Accept", "application/vnd.github.machine-man-preview+json",
+                "Accept", "application/vnd.github.antiope-preview+json",
+                "Accept", "application/vnd.github.cloak-preview+json"
+        ));
 
         var graphQLAPI = URIBuilder.base(uri)
                 .appendSubDomain("api")


### PR DESCRIPTION
Hi all,

please review this patch that adds the appropriate HTTP headers for using GitHub's search REST endpoint. I also that the `RestRequest`s created in different constructors specify the same `Accept` headers.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ⏳ (1/1 running) | ⏳ (1/1 running) | ⏳ (1/1 running) |

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/900/head:pull/900`
`$ git checkout pull/900`
