### PR TITLE
forge: refactor HostedRepository.commitMetadata to commit

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/comment/CommitCommentNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/comment/CommitCommentNotifier.java
@@ -56,7 +56,7 @@ class CommitCommentNotifier implements Notifier, PullRequestListener {
     @Override
     public void onIntegratedPullRequest(PullRequest pr, Hash hash)  {
         var repository = pr.repository();
-        var commit = repository.commitMetadata(hash).orElseThrow(() ->
+        var commit = repository.commit(hash).orElseThrow(() ->
                 new IllegalStateException("Integrated commit " + hash +
                                           " not present in repository " + repository.webUrl())
         );
@@ -67,7 +67,7 @@ class CommitCommentNotifier implements Notifier, PullRequestListener {
             "",
             "- [" + pr.repository().name() + "/" + pr.id() + "](" + pr.webUrl() + ")"
         ));
-        var issues = issues(commit);
+        var issues = issues(commit.metadata());
         if (issues.size() > 0) {
             comment.add("");
             comment.add("### Issues");

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
@@ -72,12 +72,6 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
     }
 
     private Optional<String> findIssueUsername(Commit commit) {
-        return findIssueUsername(new CommitMetadata(commit.hash(), commit.parents(), commit.author(),
-                                                    commit.authored(), commit.committer(), commit.committed(),
-                                                    commit.message()));
-    }
-
-    private Optional<String> findIssueUsername(CommitMetadata commit) {
         var authorEmail = EmailAddress.from(commit.author().email());
         if (authorEmail.domain().equals("openjdk.org")) {
             return Optional.of(authorEmail.localPart());
@@ -113,7 +107,7 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
     @Override
     public void onIntegratedPullRequest(PullRequest pr, Hash hash)  {
         var repository = pr.repository();
-        var commit = repository.commitMetadata(hash).orElseThrow(() ->
+        var commit = repository.commit(hash).orElseThrow(() ->
                 new IllegalStateException("Integrated commit " + hash +
                                           " not present in repository " + repository.webUrl())
         );

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -835,7 +835,7 @@ class CheckRun {
             return;
         }
 
-        var head = pr.repository().commitMetadata(pr.headHash()).orElseThrow(
+        var head = pr.repository().commit(pr.headHash()).orElseThrow(
             () -> new IllegalStateException("Cannot lookup HEAD hash for PR " + pr.id())
         );
         if (!pr.author().fullName().equals(pr.author().username()) &&

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
@@ -161,7 +161,7 @@ class InMemoryHostedRepository implements HostedRepository {
     }
 
     @Override
-    public Optional<CommitMetadata> commitMetadata(Hash commit) {
+    public Optional<HostedCommit> commit(Hash commit) {
         return Optional.empty();
     }
 

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
@@ -70,7 +70,7 @@ public interface HostedRepository {
     List<CommitComment> commitComments(Hash hash);
     List<CommitComment> recentCommitComments();
     void addCommitComment(Hash hash, String body);
-    Optional<CommitMetadata> commitMetadata(Hash hash);
+    Optional<HostedCommit> commit(Hash hash);
     List<Check> allChecks(Hash hash);
 
     default PullRequest createPullRequest(HostedRepository target,

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -701,6 +701,6 @@ public class GitHubPullRequest implements PullRequest {
     @Override
     public Diff diff() {
         var files = request.get("pulls/" + json.get("number").toString() + "/files").execute();
-        return host.toDiff(targetHash(), headHash(), files);
+        return repository.toDiff(targetHash(), headHash(), files);
     }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -750,6 +750,6 @@ public class GitLabMergeRequest implements PullRequest {
     @Override
     public Diff diff() {
         var changes = request.get("changes").execute();
-        return host.toDiff(targetHash(), headHash(), changes.get("changes"));
+        return repository.toDiff(targetHash(), headHash(), changes.get("changes"));
     }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -388,12 +388,70 @@ public class GitLabRepository implements HostedRepository {
                .execute();
     }
 
+    private CommitMetadata toCommitMetadata(JSONValue o) {
+        var hash = new Hash(o.get("id").asString());
+        var parents = o.get("parent_ids").stream()
+                                      .map(JSONValue::asString)
+                                      .map(Hash::new)
+                                      .collect(Collectors.toList());
+        var author = new Author(o.get("author_name").asString(),
+                                o.get("author_email").asString());
+        var authored = ZonedDateTime.parse(o.get("authored_date").asString());
+        var committer = new Author(o.get("committer_name").asString(),
+                                   o.get("committer_email").asString());
+        var committed = ZonedDateTime.parse(o.get("committed_date").asString());
+        var message = Arrays.asList(o.get("message").asString().split("\n"));
+        return new CommitMetadata(hash, parents, author, authored, committer, committed, message);
+    }
+
+    Diff toDiff(Hash from, Hash to, JSONValue o) {
+        var patches = new ArrayList<Patch>();
+
+        for (var file : o.asArray()) {
+            var sourcePath = Path.of(file.get("old_path").asString());
+            var sourceFileType = FileType.fromOctal(file.get("a_mode").asString());
+
+            var targetPath = Path.of(file.get("new_path").asString());
+            var targetFileType = FileType.fromOctal(file.get("b_mode").asString());
+
+            var status = Status.from('M');
+            if (file.get("new_file").asBoolean()) {
+                status = Status.from('A');
+            } else if (file.get("renamed_file").asBoolean()) {
+                status = Status.from('R');
+            } else if (file.get("deleted_file").asBoolean()) {
+                status = Status.from('D');
+            }
+
+            var diff = file.get("diff").asString().split("\n");
+            var hunks = UnifiedDiffParser.parseSingleFileDiff(diff);
+
+            patches.add(new TextualPatch(sourcePath, sourceFileType, Hash.zero(),
+                                         targetPath, targetFileType, Hash.zero(),
+                                         status, hunks));
+        }
+
+        return new Diff(from, to, patches);
+    }
+
     @Override
-    public Optional<CommitMetadata> commitMetadata(Hash hash) {
+    public Optional<HostedCommit> commit(Hash hash) {
         var c = request.get("repository/commits/" + hash.hex())
                        .onError(r -> Optional.of(JSON.of()))
                        .execute();
-        return c.isNull()? Optional.empty() : Optional.of(gitLabHost.toCommitMetadata(c));
+        if (!c.isNull()) {
+            return Optional.empty();
+        }
+        var url = URI.create(c.get("web_url").asString());
+        var metadata = toCommitMetadata(c);
+        var diff = request.get("repository/commits/" + hash.hex() + "/diff")
+                          .onError(r -> Optional.of(JSON.of()))
+                          .execute();
+        var parentDiffs = new ArrayList<Diff>();
+        if (!diff.isNull()) {
+            parentDiffs.add(toDiff(metadata.parents().get(0), hash, diff));
+        }
+        return Optional.of(new HostedCommit(metadata, parentDiffs, url));
     }
 
     @Override

--- a/test/src/main/java/org/openjdk/skara/test/TestHost.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHost.java
@@ -157,15 +157,10 @@ public class TestHost implements Forge, IssueTracker {
     @Override
     public Optional<HostedCommit> search(Hash hash) {
         for (var key : data.repositories.keySet()) {
-            var repo = data.repositories.get(key);
-            try {
-                var commit = repo.lookup(hash);
-                if (commit.isPresent()) {
-                    var url = URI.create("file://" + repo.root() + "/commits/" + hash.hex());
-                    return Optional.of(new HostedCommit(commit.get().metadata(), commit.get().parentDiffs(), url));
-                }
-            } catch (IOException e) {
-                return Optional.empty();
+            var repo = repository(key).orElseThrow();
+            var commit = repo.commit(hash);
+            if (commit.isPresent()) {
+                return commit;
             }
         }
         return Optional.empty();

--- a/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
@@ -233,9 +233,14 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
     }
 
     @Override
-    public Optional<CommitMetadata> commitMetadata(Hash hash) {
+    public Optional<HostedCommit> commit(Hash hash) {
         try {
-            return localRepository.commitMetadata(hash);
+            var commit = localRepository.lookup(hash);
+            if (!commit.isPresent()) {
+                return Optional.empty();
+            }
+            var url = URI.create("file://" + localRepository.root() + "/commits/" + hash.hex());
+            return Optional.of(new HostedCommit(commit.get().metadata(), commit.get().parentDiffs(), url));
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }


### PR DESCRIPTION
Hi all,

please review this patch that refactors `HostedRepository.commitMetadata` to `HostedRepository.commit`. This also allows `Forge.search` to be simplified for both `GitLabHost` and `GitHubHost`.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ⏳ (1/1 running) | ⏳ (1/1 running) | ⏳ (1/1 running) |

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/901/head:pull/901`
`$ git checkout pull/901`
