### PR TITLE
forge: only update HostUser once

### DIFF
--- a/host/src/main/java/org/openjdk/skara/host/HostUser.java
+++ b/host/src/main/java/org/openjdk/skara/host/HostUser.java
@@ -31,6 +31,7 @@ public class HostUser {
     private String username;
     private String fullName;
     private String email;
+    private boolean hasUpdated;
     private final Supplier<HostUser> supplier;
 
     public static class Builder {
@@ -80,6 +81,7 @@ public class HostUser {
         this.username = username;
         this.fullName = fullName;
         this.email = email;
+        this.hasUpdated = false;
         this.supplier = supplier;
     }
 
@@ -114,11 +116,15 @@ public class HostUser {
     }
 
     private void update() {
+        if (hasUpdated) {
+            return;
+        }
         var result = supplier.get();
         id = result.id;
         username = result.username;
         fullName = result.fullName;
         email = result.email;
+        hasUpdated = true;
     }
 
     public String id() {


### PR DESCRIPTION
Hi all,

please review this patch that ensures that `HostUser` only lazily updates fields once.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) |

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/903/head:pull/903`
`$ git checkout pull/903`
