### PR TITLE
forge: fix recentCommitComments for GitHub

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubHost.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubHost.java
@@ -216,13 +216,6 @@ public class GitHubHost implements Forge {
                        .build();
     }
 
-    HostUser hostUser(String username) {
-        return HostUser.builder()
-                       .username(username)
-                       .supplier(() -> user(username).orElseThrow())
-                       .build();
-    }
-
     @Override
     public boolean isValid() {
         try {

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -298,19 +298,28 @@ public class GitHubRepository implements HostedRepository {
         var name = parts[1];
 
         var query = String.join("\n", List.of(
-            "query {",
-            "    repository(owner: \"" + owner + "\", name: \"" + name + "\") {",
-            "        commitComments(last: 200) {",
-            "            nodes {",
-            "                createdAt",
-            "                updatedAt",
-            "                author { login }",
-            "                databaseId",
-            "                commit { oid }",
-            "                body",
-            "            }",
-            "        }",
+            "{",
+            "  repository(owner: \"" + owner + "\", name: \"" + name + "\") {",
+            "    commitComments(last: 100) {",
+            "      nodes {",
+            "        createdAt,",
+            "        updatedAt,",
+            "        author {,",
+            "          login,",
+            "          __typename,",
+            "          ... on Bot {",
+            "            databaseId",
+            "          },",
+            "          ... on User {",
+            "            databaseId",
+            "          },",
+            "        },",
+            "        databaseId,",
+            "        commit { oid },",
+            "        body",
+            "      }",
             "    }",
+            "  }",
             "}"
         ));
 
@@ -319,27 +328,35 @@ public class GitHubRepository implements HostedRepository {
                              .body(JSON.object().put("query", query))
                              .execute()
                              .get("data");
-        return data.get("repository")
-                   .get("commitComments")
-                   .get("nodes")
-                   .stream()
-                   .map(o -> {
-                       var hash = new Hash(o.get("commit").get("oid").asString());
-                       var createdAt = ZonedDateTime.parse(o.get("createdAt").asString());
-                       var updatedAt = ZonedDateTime.parse(o.get("updatedAt").asString());
-                       var id = o.get("databaseId").asString();
-                       var body = o.get("body").asString();
-                       var user = gitHubHost.hostUser(o.get("login").asString());
-                       return new CommitComment(hash,
-                                                null,
-                                                -1,
-                                                id,
-                                                body,
-                                                user,
-                                                createdAt,
-                                                updatedAt);
-                   })
-                   .collect(Collectors.toList());
+        var comments = data.get("repository")
+                           .get("commitComments")
+                           .get("nodes")
+                           .stream()
+                           .map(o -> {
+                               var hash = new Hash(o.get("commit").get("oid").asString());
+                               var createdAt = ZonedDateTime.parse(o.get("createdAt").asString());
+                               var updatedAt = ZonedDateTime.parse(o.get("updatedAt").asString());
+                               var id = String.valueOf(o.get("databaseId").asInt());
+                               var body = o.get("body").asString();
+                               var username = o.get("author").get("login").asString();
+                               var typename = o.get("author").get("__typename").asString();
+                               if (typename.equals("Bot")) {
+                                   username += "[bot]";
+                               }
+                               var userid = o.get("author").get("databaseId").asInt();
+                               var user = gitHubHost.hostUser(userid, username);
+                               return new CommitComment(hash,
+                                                        null,
+                                                        -1,
+                                                        id,
+                                                        body,
+                                                        user,
+                                                        createdAt,
+                                                        updatedAt);
+                           })
+                           .collect(Collectors.toList());
+        Collections.reverse(comments);
+        return comments;
     }
 
     @Override


### PR DESCRIPTION
Hi all,

please review this patch that fixes `recentCommitComments` for `GitHubRepository` via tweaking the GraphQL query a bit.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) |

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/904/head:pull/904`
`$ git checkout pull/904`
