### PR TITLE
Make fetchAll the opposite of pushAll

### DIFF
--- a/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
+++ b/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
@@ -269,7 +269,7 @@ class MergeBot implements Bot, WorkItem {
         }
 
         // Must fetch once to update refs/heads
-        repo.fetchAll(false);
+        repo.fetchAllRemotes(false);
 
         return repo;
     }

--- a/bots/mirror/src/main/java/org/openjdk/skara/bots/mirror/MirrorBot.java
+++ b/bots/mirror/src/main/java/org/openjdk/skara/bots/mirror/MirrorBot.java
@@ -89,7 +89,7 @@ class MirrorBot implements Bot, WorkItem {
 
             if (shouldMirrorEverything) {
                 log.info("Pulling " + from.name());
-                repo.fetchAll(false);
+                repo.fetchAll(from.url(), false);
                 log.info("Pushing to " + to.name());
                 repo.pushAll(to.url());
             } else {

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryWorkItem.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryWorkItem.java
@@ -265,7 +265,7 @@ public class RepositoryWorkItem implements WorkItem {
                                      .stream()
                                      .filter(ref -> branches.matcher(ref.name()).matches())
                                      .collect(Collectors.toList());
-            localRepo.fetchAll(true);
+            localRepo.fetchAll(repository.url(), true);
 
             var history = UpdateHistory.create(tagStorageBuilder, historyPath.resolve("tags"), branchStorageBuilder, historyPath.resolve("branches"));
             var errors = new ArrayList<Throwable>();

--- a/bots/topological/src/main/java/org/openjdk/skara/bots/topological/TopologicalBot.java
+++ b/bots/topological/src/main/java/org/openjdk/skara/bots/topological/TopologicalBot.java
@@ -80,7 +80,7 @@ class TopologicalBot implements Bot, WorkItem {
                         .orElseThrow(() -> new RuntimeException("Repository in " + dir + " has vanished"));
             }
 
-            repo.fetchAll(false);
+            repo.fetchAll(hostedRepo.url(), false);
             var depsFile = repo.root().resolve(depsFileName);
 
             var orderedBranches = orderedBranches(repo, depsFile);

--- a/bots/topological/src/main/java/org/openjdk/skara/bots/topological/TopologicalBot.java
+++ b/bots/topological/src/main/java/org/openjdk/skara/bots/topological/TopologicalBot.java
@@ -80,7 +80,7 @@ class TopologicalBot implements Bot, WorkItem {
                         .orElseThrow(() -> new RuntimeException("Repository in " + dir + " has vanished"));
             }
 
-            repo.fetchAll(hostedRepo.url(), false);
+            repo.fetchAllRemotes(false);
             var depsFile = repo.root().resolve(depsFileName);
 
             var orderedBranches = orderedBranches(repo, depsFile);

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepositoryPool.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepositoryPool.java
@@ -95,7 +95,7 @@ public class HostedRepositoryPool {
             IOException lastException = null;
             for (int counter = 0; counter < 5; counter++) {
                 try {
-                    seedRepo.fetch(hostedRepository.url(), "+*:*", true);
+                    seedRepo.fetchAll(hostedRepository.url(), true);
                 } catch (IOException e) {
                     if (!allowStale) {
                         lastException = e;

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
@@ -45,10 +45,14 @@ public interface Repository extends ReadOnlyRepository {
         return fetch(uri, refspec, true);
     }
     Hash fetch(URI uri, String refspec, boolean includeTags) throws IOException;
-    default void fetchAll() throws IOException {
-        fetchAll(false);
+    default void fetchAll(URI uri) throws IOException {
+        fetchAll(uri, true);
     }
-    void fetchAll(boolean includeTags) throws IOException;
+    void fetchAll(URI uri, boolean includeTags) throws IOException;
+    default void fetchAllRemotes() throws IOException {
+        fetchAllRemotes(false);
+    }
+    void fetchAllRemotes(boolean includeTags) throws IOException;
     void fetchRemote(String remote) throws IOException;
     void pushAll(URI uri) throws IOException;
     void push(Hash hash, URI uri, String ref, boolean force) throws IOException;

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -469,7 +469,19 @@ public class GitRepository implements Repository {
     }
 
     @Override
-    public void fetchAll(boolean includeTags) throws IOException {
+    public void fetchAll(URI uri, boolean includeTags) throws IOException {
+        var cmd = new ArrayList<>(List.of("git", "fetch", "--recurse-submodules=on-demand", "--prune", uri.toString()));
+        cmd.add("+refs/heads/*:refs/heads/*");
+        if (includeTags) {
+            cmd.add("+refs/tags/*:refs/tags/*");
+        }
+        try (var p = capture(cmd)) {
+            await(p);
+        }
+    }
+
+    @Override
+    public void fetchAllRemotes(boolean includeTags) throws IOException {
         var cmd = new ArrayList<String>();
         cmd.addAll(List.of("git", "fetch", "--recurse-submodules=on-demand"));
         cmd.add("--prune");

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -448,6 +448,18 @@ public class HgRepository implements Repository {
         return fetch(uri != null ? uri.toString() : null, refspec);
     }
 
+    @Override
+    public void fetchAll(URI uri, boolean includeTags) throws IOException {
+        // Ignore includeTags, Mercurial always fetches tags
+        var cmd = new ArrayList<String>();
+        cmd.add("hg");
+        cmd.add("pull");
+        cmd.add(uri.toString());
+        try (var p = capture(cmd)) {
+            await(p);
+        }
+    }
+
     private Hash fetch(String from, String refspec) throws IOException {
         var oldHeads = new HashSet<Hash>(heads());
 
@@ -478,7 +490,7 @@ public class HgRepository implements Repository {
     }
 
     @Override
-    public void fetchAll(boolean includeTags) throws IOException {
+    public void fetchAllRemotes(boolean includeTags) throws IOException {
         // Ignore includeTags, Mercurial always fetches tags
         var pullPaths = new ArrayList<URI>();
         try (var p = capture("hg", "paths")) {


### PR DESCRIPTION
Since pushAll pushes all refs, rename fetchAll to fetchAllRemotes and create fetchAll that fetches all refs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) |

### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**) ⚠️ Review applies to d52d95dc668520f4292de462f920e0ba5b1e581e


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/905/head:pull/905`
`$ git checkout pull/905`
