### PR TITLE
584: additional check for "git sync"

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitSync.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitSync.java
@@ -195,6 +195,13 @@ public class GitSync {
         var toPushPath = remotes.contains(to) ?
             Remote.toURI(repo.pullPath(to)) : Remote.toURI(to);
 
+        var canonicalPushPath = Remote.toWebURI(Remote.canonicalize(toPushPath).toString());
+        var canonicalPullPath = Remote.toWebURI(Remote.canonicalize(fromPullPath).toString());
+        if (canonicalPushPath.equals(canonicalPullPath)) {
+            System.err.println("error: --from and --to refer to the same repository: " + canonicalPushPath.toString());
+            System.exit(1);
+        }
+
         var toScheme = toPushPath.getScheme();
         if (toScheme.equals("https") || toScheme.equals("http")) {
             var token = System.getenv("GIT_TOKEN");

--- a/cli/src/main/java/org/openjdk/skara/cli/Remote.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/Remote.java
@@ -111,4 +111,11 @@ public class Remote {
 
         throw new IOException("Cannot construct URI for " + remotePath);
     }
+
+    public static URI canonicalize(URI uri) throws IOException {
+        if (uri.getScheme().equals("ssh")) {
+            return sshCanonicalize(uri);
+        }
+        return uri;
+    }
 }


### PR DESCRIPTION
Hi all,

please review this patch that makes `git-sync` check if the `--from` and `--to` arguments refer to the same repository. If they do, then `git-sync` exits with an error.

Testing:
- [x] Manual testing on Linux x64

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) |

### Issue
 * [SKARA-584](https://bugs.openjdk.java.net/browse/SKARA-584): additional check for "git sync"


### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/906/head:pull/906`
`$ git checkout pull/906`
