### PR TITLE
No point in cleaning a bare materialization

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepositoryPool.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepositoryPool.java
@@ -156,7 +156,9 @@ public class HostedRepositoryPool {
                     return cloneSeeded(path, allowStale, bare);
                 } else {
                     try {
-                        localRepoInstance.clean();
+                        if (!bare) {
+                            localRepoInstance.clean();
+                        }
                         return localRepoInstance;
                     } catch (IOException e) {
                         removeOldClone(path, "uncleanable");


### PR DESCRIPTION
We can skip the cleaning step when reusing a bare materialization.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) |

### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/909/head:pull/909`
`$ git checkout pull/909`
