### PR TITLE
forge: fix type of id in GitLabHost.search

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabHost.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabHost.java
@@ -230,11 +230,11 @@ public class GitLabHost implements Forge {
             var ids = request.get("groups/" + group + "/projects")
                                   .execute()
                                   .stream()
-                                  .map(o -> o.get("id").asString())
+                                  .map(o -> o.get("id").asInt())
                                   .collect(Collectors.toList());
             for (var id : ids) {
-                var project = repository(id);
-                var commit = project.get().commit(hash);
+                var project = new GitLabRepository(this, id);
+                var commit = project.commit(hash);
                 if (commit.isPresent()) {
                     return commit;
                 }


### PR DESCRIPTION
Hi all,

please review this small patch that fixes `id` to be of correct type `int` in `GitLabHost.search`.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) |

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/911/head:pull/911`
`$ git checkout pull/911`
