### PR TITLE
forge: fix GitLabRepository.recentCommitComments

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -358,7 +358,7 @@ public class GitLabRepository implements HostedRepository {
     @Override
     public List<CommitComment> recentCommitComments() {
         var twoDaysAgo = ZonedDateTime.now().minusDays(2);
-        var formatter = DateTimeFormatter.ofPattern("yyyy-MM-DD");
+        var formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
         return request.get("events")
                       .param("after", twoDaysAgo.format(formatter))
                       .execute()
@@ -370,12 +370,12 @@ public class GitLabRepository implements HostedRepository {
                           var createdAt = ZonedDateTime.parse(o.get("note").get("created_at").asString());
                           var body = o.get("note").get("body").asString();
                           var user = gitLabHost.parseAuthorField(o);
-                          var id = o.get("note").get("id").asString();
+                          var id = o.get("note").get("id").asInt();
                           Supplier<Hash> hash = () -> commitWithComment(o.get("target_title").asString(),
                                                                         body,
                                                                         createdAt,
                                                                         user);
-                          return new CommitComment(hash, null, -1, id, body, user, createdAt, createdAt);
+                          return new CommitComment(hash, null, -1, String.valueOf(id), body, user, createdAt, createdAt);
                       })
                       .collect(Collectors.toList());
     }


### PR DESCRIPTION
Hi all,

please review this patch that fixes `recentCommitsComments` for `GitLabRepository`. The formatting of the `after` parameter was wrong (used day of year instead of day of month) and the `id` was using `String` instead of `int` as type.

Thanks,
Erik

/summary
- Fix formatting of "after"
- Fix type of "id"

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) |

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/912/head:pull/912`
`$ git checkout pull/912`
