### PR TITLE
forge: patch for commit can be null

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -394,8 +394,11 @@ public class GitHubRepository implements HostedRepository {
                 targetPath;
             var filetype = FileType.fromOctal("100644");
 
-            var diff = file.get("patch").asString().split("\n");
-            var hunks = UnifiedDiffParser.parseSingleFileDiff(diff);
+            var hunks = List.<Hunk>of();
+            if (file.contains("patch")) {
+                var diff = file.get("patch").asString().split("\n");
+                hunks = UnifiedDiffParser.parseSingleFileDiff(diff);
+            }
 
             patches.add(new TextualPatch(sourcePath, filetype, Hash.zero(),
                                          targetPath, filetype, Hash.zero(),


### PR DESCRIPTION
Hi all,

please review this patch that handles cases where the GitHub REST API returns `null` for the `"patch"` field for a `commit` object. This seems to primarily happen for very large merges that changes 200+ files.

Testing:
- [x] Manual testing on Linux x64

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ⏳ (1/1 running) |

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/914/head:pull/914`
`$ git checkout pull/914`
