### PR TITLE
vcs: handle "No newline at end of file" in UnifiedDiffParser

### DIFF
--- a/vcs/src/test/java/org/openjdk/skara/vcs/UnifiedDiffParserTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/UnifiedDiffParserTests.java
@@ -398,4 +398,27 @@ public class UnifiedDiffParserTests {
             assertFalse(hunks.isEmpty());
         }
     }
+
+    @Test
+    public void noNewline() {
+        var diff =
+            "diff --git a/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java b/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java\n" +
+            "index 489f49ef..e777f0f8 100644\n" +
+            "--- a/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java\n" +
+            "+++ b/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java\n" +
+            "@@ -211,6 +211,14 @@ public Hash branchHash(String ref) {\n" +
+            "+    static class CustomSelectorProviderImpl extends SelectorProvider {\n" +
+            "+        @Override public DatagramChannel openDatagramChannel() { return null; }\n" +
+            "+        @Override public DatagramChannel openDatagramChannel(ProtocolFamily family) { return null; }\n" +
+            "+        @Override public Pipe openPipe() { return null; }\n" +
+            "+        @Override public AbstractSelector openSelector() { return null; }\n" +
+            "+        @Override public ServerSocketChannel openServerSocketChannel() { return null; }\n" +
+            "+        @Override public SocketChannel openSocketChannel() { return null; }\n" +
+            "+    }\n" +
+            "+}\n" +
+            "\\ No newline at end of file\n";
+        var hunks = UnifiedDiffParser.parseSingleFileDiff(diff.split("\n"));
+        assertEquals(1, hunks.size());
+        assertFalse(hunks.get(0).target().hasNewlineAtEndOfFile());
+    }
 }


### PR DESCRIPTION
Hi all,

please review this patch that handles a `\ No newline at end of file` line in a unified diff.

Testing:
- [x] Added a new unit test

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ⏳ (1/1 running) | ⏳ (1/1 running) | ⏳ (1/1 running) |

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/915/head:pull/915`
`$ git checkout pull/915`
