### PR TITLE
Fix skara update on Windows when CWD is not skara repository dir

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitSkara.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitSkara.java
@@ -165,7 +165,7 @@ public class GitSkara {
             System.out.println("Rebuilding ...");
             var cmd = new ArrayList<String>();
             if (System.getProperty("os.name").toLowerCase().startsWith("win")) {
-                cmd.add("gradlew.bat");
+                cmd.add(parent.resolve("gradlew.bat").toString());
             } else {
                 cmd.addAll(List.of("sh", "gradlew"));
             }


### PR DESCRIPTION
On my windows client, I'm running in an issue when updating the skara tools. I see the following output/exception:

Checking for updates ...
Found the following updates:
- forge: patch for commit can be null
Rebuilding ...
Exception in thread "main" java.io.IOException: Cannot run program "gradlew.bat" (in directory "C:\git\OpenJDK\skara"): CreateProcess error=2, The system cannot find the file specified
        at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1128)
        at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1071)
        at org.openjdk.skara.cli/org.openjdk.skara.cli.GitSkara.update(GitSkara.java:176)
        at org.openjdk.skara.cli/org.openjdk.skara.cli.GitSkara.main(GitSkara.java:230)
Caused by: java.io.IOException: CreateProcess error=2, The system cannot find the file specified
        at java.base/java.lang.ProcessImpl.create(Native Method)
        at java.base/java.lang.ProcessImpl.<init>(ProcessImpl.java:483)
        at java.base/java.lang.ProcessImpl.start(ProcessImpl.java:158)
        at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1107)
        ... 3 more

The issue seems to be that only "gradlew.bat" is added as command to the gradle call (https://github.com/openjdk/skara/blob/master/cli/src/main/java/org/openjdk/skara/cli/GitSkara.java#L168). The process directory is set to the skara repository directory. However, "gradlew.bat" isn't resolved against the working directory by Processbuilder, but probably only against the current %PATH%.

Currently, when running "git skara update" out of the skara repository path, it'll work.

With the proposed tiny fix to resolve gradlew.bat before starting the Processbuilder it can be run from any working directory.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/916/head:pull/916`
`$ git checkout pull/916`
