### PR TITLE
forge: more precise status for GitHub diff

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -383,11 +383,28 @@ public class GitHubRepository implements HostedRepository {
         return new CommitMetadata(hash, parents, author, authored, committer, committed, message);
     }
 
+    private Status toStatus(String status) {
+        switch (status) {
+            case "modified":
+                return Status.from('M');
+            case "removed":
+                return Status.from('D');
+            case "added":
+                return Status.from('A');
+            case "renamed":
+                return Status.from('R');
+            case "copied":
+                return Status.from('C');
+            default:
+                throw new IllegalArgumentException("Unexpected status: " + status);
+        }
+    }
+
     Diff toDiff(Hash from, Hash to, JSONValue files) {
         var patches = new ArrayList<Patch>();
 
         for (var file : files.asArray()) {
-            var status = Status.from(file.get("status").asString().toUpperCase().charAt(0));
+            var status = toStatus(file.get("status").asString());
             var targetPath = Path.of(file.get("filename").asString());
             var sourcePath = status.isRenamed() || status.isCopied() ?
                 Path.of(file.get("previous_filename").asString()) :


### PR DESCRIPTION
Hi all,

please review this patch that makes the parsing of the `"status"` field from GitHub for diffs more precise.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ⏳ (1/1 running) | ⏳ (1/1 running) | ⏳ (1/1 running) |

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/917/head:pull/917`
`$ git checkout pull/917`
