### PR TITLE
Ensure that the pr head is present locally when pushing a dependency branch

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifier.java
@@ -48,6 +48,7 @@ public class PullRequestBranchNotifier implements Notifier, PullRequestListener 
         var hostedRepositoryPool = new HostedRepositoryPool(seedFolder);
         try {
             var seedRepo = hostedRepositoryPool.seedRepository(pr.repository(), false);
+            seedRepo.fetch(pr.repository().url(), pr.headHash().hex());
             seedRepo.push(pr.headHash(), pr.repository().url(), PreIntegrations.preIntegrateBranch(pr), true);
         } catch (IOException e) {
             throw new UncheckedIOException(e);


### PR DESCRIPTION
When the pull request branch notifier creates a dependency target branch, we need to ensure that the head commit is actually present locally.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) |

### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/918/head:pull/918`
`$ git checkout pull/918`
