### PR TITLE
vcs: add support for cherry picking

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
@@ -160,6 +160,7 @@ public interface Repository extends ReadOnlyRepository {
     void setPaths(String remote, String pullPath, String pushPath) throws IOException;
     void apply(Diff diff, boolean force) throws IOException;
     void apply(Path patchFile, boolean force)  throws IOException;
+    boolean cherryPick(Hash hash) throws IOException;
     void copy(Path from, Path to) throws IOException;
     void move(Path from, Path to) throws IOException;
     default void setPaths(String remote, String pullPath) throws IOException {

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -1549,4 +1549,15 @@ public class GitRepository implements Repository {
     public String rangeExclusive(Hash from, Hash to) {
         return from.hex() + ".." + to.hex();
     }
+
+    @Override
+    public boolean cherryPick(Hash hash) throws IOException {
+        try (var p = capture("git", "cherry-pick", "--no-commit",
+                                                   "--keep-redundant-commits",
+                                                   "--strategy=recursive",
+                                                   "--strategy-option=patience",
+                                                   hash.hex())) {
+            return p.await().status() == 0;
+        }
+    }
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -1454,4 +1454,11 @@ public class HgRepository implements Repository {
     public String rangeExclusive(Hash from, Hash to) {
         return from.hex() + ":" + to.hex() + "-" + from.hex();
     }
+
+    @Override
+    public boolean cherryPick(Hash hash) throws IOException {
+        try (var p = capture("hg", "graft", "--no-commit", "--force", hash.hex())) {
+            return p.await().status() == 0;
+        }
+    }
 }


### PR DESCRIPTION
Hi all,

please review this patch that adds support for "cherry picking" commits to `Repository`.

Testing:
- [x] Added two new unit tests

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) |

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/921/head:pull/921`
`$ git checkout pull/921`
