### PR TITLE
pr: add "backport" label for backports

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -195,7 +195,6 @@ class CheckWorkItem extends PullRequestWorkItem {
 
             var m = BACKPORT_TITLE_PATTERN.matcher(pr.title());
             if (m.matches()) {
-                pr.addLabel("backport");
                 var hash = new Hash(m.group(1));
                 var metadata = pr.repository().forge().search(hash);
                 if (metadata.isPresent()) {
@@ -225,6 +224,7 @@ class CheckWorkItem extends PullRequestWorkItem {
                     text += " from the original [commit](" + metadata.get().url() + ").";
                     comment.add(text);
                     pr.addComment(String.join("\n", comment));
+                    pr.addLabel("backport");
                     return List.of(new CheckWorkItem(bot, pr.repository().pullRequest(pr.id()), errorHandler));
                 } else {
                     var botUser = pr.repository().forge().currentUser();

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -195,6 +195,7 @@ class CheckWorkItem extends PullRequestWorkItem {
 
             var m = BACKPORT_TITLE_PATTERN.matcher(pr.title());
             if (m.matches()) {
+                pr.addLabel("backport");
                 var hash = new Hash(m.group(1));
                 var metadata = pr.repository().forge().search(hash);
                 if (metadata.isPresent()) {

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportTests.java
@@ -379,7 +379,7 @@ class BackportTests {
             assertLastCommentContains(pr, "<!-- backport error -->");
             assertLastCommentContains(pr, ":warning:");
             assertLastCommentContains(pr, "could not find any commit with hash `0123456789012345678901234567890123456789`");
-            assertTrue(pr.labels().contains("backport"));
+            assertFalse(pr.labels().contains("backport"));
 
             // Re-running the bot should not cause any more error comments
             TestBotRunner.runPeriodicItems(bot);

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportTests.java
@@ -93,6 +93,7 @@ class BackportTests {
             assertTrue(backportComment.contains("This backport pull request has now been updated with issue"));
             assertTrue(backportComment.contains("<!-- backport " + releaseHash.hex() + " -->"));
             assertEquals(issue1Number + ": An issue", pr.title());
+            assertTrue(pr.labels().contains("backport"));
 
             // Approve PR and re-run bot
             var prAsReviewer = reviewer.pullRequest(pr.id());
@@ -194,6 +195,7 @@ class BackportTests {
             assertTrue(backportComment.contains("This backport pull request has now been updated with issue"));
             assertTrue(backportComment.contains("<!-- backport " + releaseHash.hex() + " -->"));
             assertEquals(issue1Number + ": An issue", pr.title());
+            assertTrue(pr.labels().contains("backport"));
 
             // Approve PR and re-run bot
             var prAsReviewer = reviewer.pullRequest(pr.id());
@@ -297,6 +299,7 @@ class BackportTests {
             assertTrue(backportComment.contains("This backport pull request has now been updated with issue"));
             assertTrue(backportComment.contains("<!-- backport " + releaseHash.hex() + " -->"));
             assertEquals(issue1Number + ": An issue", pr.title());
+            assertTrue(pr.labels().contains("backport"));
 
             // Approve PR and re-run bot
             var prAsReviewer = reviewer.pullRequest(pr.id());
@@ -376,6 +379,7 @@ class BackportTests {
             assertLastCommentContains(pr, "<!-- backport error -->");
             assertLastCommentContains(pr, ":warning:");
             assertLastCommentContains(pr, "could not find any commit with hash `0123456789012345678901234567890123456789`");
+            assertTrue(pr.labels().contains("backport"));
 
             // Re-running the bot should not cause any more error comments
             TestBotRunner.runPeriodicItems(bot);
@@ -439,6 +443,7 @@ class BackportTests {
             assertTrue(backportComment.contains("This backport pull request has now been updated with issue"));
             assertTrue(backportComment.contains("<!-- backport " + releaseHash.hex() + " -->"));
             assertEquals(issue1Number + ": An issue", pr.title());
+            assertTrue(pr.labels().contains("backport"));
 
             // The bot should have added the "clean" label
             assertTrue(pr.labels().contains("clean"));
@@ -509,6 +514,7 @@ class BackportTests {
             assertTrue(backportComment.contains("This backport pull request has now been updated with issue"));
             assertTrue(backportComment.contains("<!-- backport " + upstreamHash.hex() + " -->"));
             assertEquals(issue2Number + ": Another issue", pr.title());
+            assertTrue(pr.labels().contains("backport"));
 
             // The bot should have added the "clean" label
             assertTrue(pr.labels().contains("clean"));
@@ -579,6 +585,7 @@ class BackportTests {
             assertTrue(backportComment.contains("This backport pull request has now been updated with issue"));
             assertTrue(backportComment.contains("<!-- backport " + upstreamHash.hex() + " -->"));
             assertEquals(issue2Number + ": Another issue", pr.title());
+            assertTrue(pr.labels().contains("backport"));
 
             // The bot should not have added the "clean" label
             assertFalse(pr.labels().contains("clean"));
@@ -652,6 +659,7 @@ class BackportTests {
             assertTrue(backportComment.contains("This backport pull request has now been updated with issue"));
             assertTrue(backportComment.contains("<!-- backport " + upstreamHash.hex() + " -->"));
             assertEquals(issue2Number + ": Another issue", pr.title());
+            assertTrue(pr.labels().contains("backport"));
 
             // The bot should not have added the "clean" label
             assertFalse(pr.labels().contains("clean"));
@@ -717,6 +725,7 @@ class BackportTests {
             assertTrue(pr.labels().contains("ready"));
             assertTrue(pr.labels().contains("rfr"));
             assertTrue(pr.labels().contains("clean"));
+            assertTrue(pr.labels().contains("backport"));
 
             // Integrate
             var prAsCommitter = author.pullRequest(pr.id());
@@ -814,6 +823,7 @@ class BackportTests {
             assertTrue(pr.labels().contains("rfr"));
             assertTrue(pr.labels().contains("clean"));
             assertFalse(pr.labels().contains("sponsor"));
+            assertTrue(pr.labels().contains("backport"));
 
             // Integrate
             var prAsAuthor = author.pullRequest(pr.id());


### PR DESCRIPTION
Hi all,

please review this patch that adds the label "backport" for backport-style pull requests.

Testing:
- [x] Updated a number of unit tests

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) |

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/923/head:pull/923`
`$ git checkout pull/923`
