### PR TITLE
vcs: add ReadOnlyRepository.contains for Hash

### DIFF
--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/TestRepository.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/TestRepository.java
@@ -329,4 +329,8 @@ class TestRepository implements ReadOnlyRepository {
     public List<CommitMetadata> follow(Path path, Hash from, Hash to) {
         return List.of();
     }
+
+    public boolean contains(Hash h) {
+        return false;
+    }
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
@@ -88,6 +88,7 @@ public interface ReadOnlyRepository {
         return resolve(b.name());
     }
     boolean contains(Branch b, Hash h) throws IOException;
+    boolean contains(Hash h) throws IOException;
     Optional<String> username() throws IOException;
     Optional<byte[]> show(Path p, Hash h) throws IOException;
     default Optional<List<String>> lines(Path p, Hash h) throws IOException {

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -179,7 +179,8 @@ public class GitRepository implements Repository {
         return new GitCommits(dir, range, reverse, n);
     }
 
-    private boolean exists(Hash h) throws IOException {
+    @Override
+    public boolean contains(Hash h) throws IOException {
         try (var p = capture("git", "cat-file", "-e", h.hex())) {
             var res = p.await();
             return res.status() == 0;
@@ -188,7 +189,7 @@ public class GitRepository implements Repository {
 
     @Override
     public Optional<Commit> lookup(Hash h) throws IOException {
-        if (!exists(h)) {
+        if (!contains(h)) {
             return Optional.empty();
         }
 

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -235,7 +235,8 @@ public class HgRepository implements Repository {
         return new HgCommits(dir, range, ext, reverse, n);
     }
 
-    private boolean exists(Hash h) throws IOException {
+    @Override
+    public boolean contains(Hash h) throws IOException {
         try (var p = capture("hg", "log", "--rev=" + h.hex(), "--template={node}\n")) {
             var res = p.await();
             return res.status() == 0;
@@ -244,7 +245,7 @@ public class HgRepository implements Repository {
 
     @Override
     public Optional<Commit> lookup(Hash h) throws IOException {
-        if (!exists(h)) {
+        if (!contains(h)) {
             return Optional.empty();
         }
         var commits = commits(h.hex()).asList();

--- a/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
@@ -2824,4 +2824,21 @@ public class RepositoryTests {
             assertEquals(List.of(), r.diff(second).patches());
         }
     }
+
+    @ParameterizedTest
+    @EnumSource(VCS.class)
+    void testRepositoryContains(VCS vcs) throws IOException {
+        try (var dir = new TemporaryDirectory()) {
+            var r = Repository.init(dir.path(), vcs);
+            assertTrue(r.isClean());
+
+            var readme = dir.path().resolve("README.md");
+            Files.writeString(readme, "Hello world\n");
+            r.add(readme);
+            var hash = r.commit("Added readme", "duke", "duke@openjdk.java.net");
+
+            assertTrue(r.contains(hash));
+            assertFalse(r.contains(new Hash("0123456789012345678901234567890123456789")));
+        }
+    }
 }


### PR DESCRIPTION
Hi all,

please review this small patch that adds an overload `ReadOnlyRepository.contains` for just a `Hash` that checks if the repository does contain the given hash.

Testing:
- [x] Added a new unit test

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ⏳ (1/1 running) | ⏳ (1/1 running) | ⏳ (1/1 running) |

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/925/head:pull/925`
`$ git checkout pull/925`
