### PR TITLE
pr: align handleCommit and handle

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandHandler.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandHandler.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.skara.bots.pr;
 
+import org.openjdk.skara.forge.HostedCommit;
 import org.openjdk.skara.forge.PullRequest;
 import org.openjdk.skara.issuetracker.Comment;
 import org.openjdk.skara.vcs.*;
@@ -36,7 +37,7 @@ interface CommandHandler {
     default void handle(PullRequestBot bot, PullRequest pr, CensusInstance censusInstance, Path scratchPath, CommandInvocation command, List<Comment> allComments, PrintWriter reply)
     {
     }
-    default void handleCommit(PullRequestBot bot, Hash hash, Path scratchPath, CommandInvocation command, List<Comment> allComments, PrintWriter reply) {
+    default void handle(PullRequestBot bot, HostedCommit commit, CensusInstance censusInstance, Path scratchPath, CommandInvocation command, List<Comment> allComments, PrintWriter reply) {
     }
 
     default boolean multiLine() {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandWorkItem.java
@@ -72,7 +72,7 @@ public class CommandWorkItem extends PullRequestWorkItem {
         }
 
         @Override
-        public void handleCommit(PullRequestBot bot, Hash hash, Path scratchPath, CommandInvocation command, List<Comment> allComments, PrintWriter reply) {
+        public void handle(PullRequestBot bot, HostedCommit hash, CensusInstance censusInstance, Path scratchPath, CommandInvocation command, List<Comment> allComments, PrintWriter reply) {
             reply.println("Available commands:");
             Stream.concat(
                     commandHandlers.entrySet().stream()
@@ -159,7 +159,8 @@ public class CommandWorkItem extends PullRequestWorkItem {
                 if (handler.get().allowedInCommit()) {
                     var hash = resultingCommitHash(allComments);
                     if (hash.isPresent()) {
-                        handler.get().handleCommit(bot, hash.get(), scratchPath, command, allComments, printer);
+                        var commit = pr.repository().commit(hash.get()).orElseThrow();
+                        handler.get().handle(bot, commit, censusInstance, scratchPath, command, allComments, printer);
                     } else {
                         printer.print("The command `");
                         printer.print(command.name());

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepositoryPool.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepositoryPool.java
@@ -193,17 +193,13 @@ public class HostedRepositoryPool {
         return checkout(hostedRepository, ref, path, true);
     }
 
-    public Optional<List<String>> lines(HostedRepository hostedRepository, Path p, String ref) throws IOException {
+    public Optional<List<String>> lines(HostedRepository hostedRepository, Path p, Hash hash) throws IOException {
         var hostedRepositoryInstance = new HostedRepositoryInstance(hostedRepository);
         var seedRepo = hostedRepositoryInstance.seedRepository(true);
-        var refHash = seedRepo.resolve(ref);
-        if (refHash.isEmpty()) {
+        if (!seedRepo.contains(hash)) {
             // It may fail because the seed is stale - need to refresh it now
             seedRepo.fetchAll(hostedRepository.url(), true);
-            refHash = seedRepo.resolve(ref);
         }
-
-        var hash = refHash.orElseThrow(() -> new IOException("Ref not found: " + ref));
         return seedRepo.lines(p, hash);
     }
 


### PR DESCRIPTION
Hi all,

please review this patch that aligns `handleCommit` and `handle` in  `CommandHandler`. This gives handlers for commit commands access to the commit, a census instance, etc.

Testing:
- [x] `make test` passes on Linux x64

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ⏳ (1/1 running) | ⏳ (1/1 running) | ⏳ (1/1 running) |

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/926/head:pull/926`
`$ git checkout pull/926`
