### PR TITLE
forge: initial support for updating review comments

### DIFF
--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
@@ -161,6 +161,10 @@ class InMemoryHostedRepository implements HostedRepository {
     }
 
     @Override
+    public void updateCommitComment(String id, String body) {
+    }
+
+    @Override
     public Optional<HostedCommit> commit(Hash commit) {
         return Optional.empty();
     }

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
@@ -67,6 +67,10 @@ class InMemoryPullRequest implements PullRequest {
     }
 
     @Override
+    public void updateReview(int id, String body) {
+    }
+
+    @Override
     public ReviewComment addReviewComment(Hash base, Hash hash, String path, int line, String body) {
         return null;
     }

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
@@ -70,6 +70,7 @@ public interface HostedRepository {
     List<CommitComment> commitComments(Hash hash);
     List<CommitComment> recentCommitComments();
     void addCommitComment(Hash hash, String body);
+    void updateCommitComment(String id, String body);
     Optional<HostedCommit> commit(Hash hash);
     List<Check> allChecks(Hash hash);
 

--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
@@ -45,6 +45,11 @@ public interface PullRequest extends Issue {
     void addReview(Review.Verdict verdict, String body);
 
     /**
+     * Updates the comment body of a review.
+     */
+    void updateReview(int id, String body);
+
+    /**
      * Add a file specific comment.
      * @param hash
      * @param path

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -179,6 +179,13 @@ public class GitHubPullRequest implements PullRequest {
                .execute();
     }
 
+    @Override
+    public void updateReview(int id, String body) {
+        request.put("pulls/" + json.get("number").toString() + "/reviews/" + id)
+               .body("body", body)
+               .execute();
+    }
+
     private ReviewComment parseReviewComment(ReviewComment parent, JSONObject json) {
         var author = host.parseUserField(json);
         var threadId = parent == null ? json.get("id").toString() : parent.threadId();

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -367,6 +367,14 @@ public class GitHubRepository implements HostedRepository {
                .execute();
     }
 
+    @Override
+    public void updateCommitComment(String id, String body) {
+        var query = JSON.object().put("body", body);
+        request.patch("comments/" + id)
+               .body(query)
+               .execute();
+    }
+
     private CommitMetadata toCommitMetadata(JSONValue o) {
         var hash = new Hash(o.get("sha").asString());
         var parents = o.get("parents").stream()

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -171,6 +171,11 @@ public class GitLabMergeRequest implements PullRequest {
                .execute();
     }
 
+    @Override
+    public void updateReview(int id, String body) {
+        throw new RuntimeException("not implemented yet");
+    }
+
     private ReviewComment parseReviewComment(String discussionId, ReviewComment parent, JSONObject note) {
         int line;
         String path;

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -388,6 +388,11 @@ public class GitLabRepository implements HostedRepository {
                .execute();
     }
 
+    @Override
+    public void updateCommitComment(String id, String body) {
+        throw new RuntimeException("not implemented yet");
+    }
+
     private CommitMetadata toCommitMetadata(JSONValue o) {
         var hash = new Hash(o.get("id").asString());
         var parents = o.get("parent_ids").stream()

--- a/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
@@ -233,6 +233,11 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
     }
 
     @Override
+    public void updateCommitComment(String id, String body) {
+        throw new RuntimeException("not implemented yet");
+    }
+
+    @Override
     public Optional<HostedCommit> commit(Hash hash) {
         try {
             var commit = localRepository.lookup(hash);

--- a/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
@@ -107,6 +107,11 @@ public class TestPullRequest extends TestIssue implements PullRequest {
     }
 
     @Override
+    public void updateReview(int id, String body) {
+        throw new RuntimeException("not implemented yet");
+    }
+
+    @Override
     public ReviewComment addReviewComment(Hash base, Hash hash, String path, int line, String body) {
         var comment = new ReviewComment(null, String.valueOf(data.reviewComments.size()), hash, path, line, String.valueOf(data.reviewComments.size()), body, user, ZonedDateTime.now(), ZonedDateTime.now());
         data.reviewComments.add(comment);


### PR DESCRIPTION
Initial implementation of review comment updates for GitHub.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ⏳ (1/1 running) |

### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/927/head:pull/927`
`$ git checkout pull/927`
