### PR TITLE
jira: skip security check for labels

### DIFF
--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraIssue.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraIssue.java
@@ -234,10 +234,6 @@ public class JiraIssue implements Issue {
 
     @Override
     public void addLabel(String label) {
-        if (needSecurity) {
-            log.warning("Issue label does not support setting a security level - ignoring");
-            return;
-        }
         var query = JSON.object()
                         .put("update", JSON.object()
                                            .put("labels", JSON.array().add(JSON.object()


### PR DESCRIPTION
Labels themselves do not have a security level, so don't have to check that when setting them.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ⏳ (1/1 running) | ⏳ (1/1 running) | ⏳ (1/1 running) |

### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/928/head:pull/928`
`$ git checkout pull/928`
