### PR TITLE
Add tabfiles to jcheck configuration

### DIFF
--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/WhitespaceCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/WhitespaceCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,11 +26,8 @@ import org.openjdk.skara.census.Census;
 import org.openjdk.skara.vcs.Commit;
 import org.openjdk.skara.vcs.openjdk.CommitMessage;
 
-import java.io.IOException;
-import java.nio.file.Path;
 import java.util.*;
 import java.util.regex.Pattern;
-import java.util.stream.Stream;
 import java.util.logging.Logger;
 
 public class WhitespaceCheck extends CommitCheck {
@@ -41,6 +38,7 @@ public class WhitespaceCheck extends CommitCheck {
         var metadata = CommitIssue.metadata(commit, message, conf, this);
         var issues = new ArrayList<Issue>();
         var pattern = Pattern.compile(conf.checks().whitespace().files());
+        var tabPattern = Pattern.compile(conf.checks().whitespace().tabfiles());
 
         for (var diff : commit.parentDiffs()) {
             for (var patch : diff.patches()) {
@@ -56,7 +54,8 @@ public class WhitespaceCheck extends CommitCheck {
                             var row = hunk.target().range().start() + i;
                             var tabIndex = line.indexOf('\t');
                             var crIndex = line.indexOf('\r');
-                            if (tabIndex >= 0 || crIndex >= 0 || line.endsWith(" ")) {
+                            var ignoreTab = tabPattern.matcher(path.toString()).matches();
+                            if ((tabIndex >= 0 && !ignoreTab) || crIndex >= 0 || line.endsWith(" ")) {
                                 var errors = new ArrayList<WhitespaceIssue.Error>();
                                 var trailing = true;
                                 for (var index = line.length() - 1; index >= 0; index--) {

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/WhitespaceCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/WhitespaceCheck.java
@@ -38,7 +38,7 @@ public class WhitespaceCheck extends CommitCheck {
         var metadata = CommitIssue.metadata(commit, message, conf, this);
         var issues = new ArrayList<Issue>();
         var pattern = Pattern.compile(conf.checks().whitespace().files());
-        var tabPattern = Pattern.compile(conf.checks().whitespace().tabfiles());
+        var tabPattern = Pattern.compile(conf.checks().whitespace().ignoreTabs());
 
         for (var diff : commit.parentDiffs()) {
             for (var patch : diff.patches()) {

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/WhitespaceCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/WhitespaceCheck.java
@@ -55,13 +55,14 @@ public class WhitespaceCheck extends CommitCheck {
                             var tabIndex = line.indexOf('\t');
                             var crIndex = line.indexOf('\r');
                             var ignoreTab = tabPattern.matcher(path.toString()).matches();
-                            if ((tabIndex >= 0 && !ignoreTab) || crIndex >= 0 || line.endsWith(" ")) {
+                            if ((tabIndex >= 0 && !ignoreTab) || crIndex >= 0
+                                    || line.endsWith(" ") || line.endsWith("\t")) {
                                 var errors = new ArrayList<WhitespaceIssue.Error>();
                                 var trailing = true;
                                 for (var index = line.length() - 1; index >= 0; index--) {
-                                    if (line.charAt(index) == ' ' && trailing) {
+                                    if ((line.charAt(index) == ' ' || line.charAt(index) == '\t') && trailing) {
                                         errors.add(WhitespaceIssue.trailing(index));
-                                    } else if (line.charAt(index) == '\t') {
+                                    } else if (line.charAt(index) == '\t'  && !ignoreTab) {
                                         errors.add(WhitespaceIssue.tab(index));
                                     } else if (line.charAt(index) == '\r') {
                                         errors.add(WhitespaceIssue.cr(index));

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/WhitespaceConfiguration.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/WhitespaceConfiguration.java
@@ -29,19 +29,19 @@ public class WhitespaceConfiguration {
         new WhitespaceConfiguration(".*\\.cpp|.*\\.hpp|.*\\.c|.*\\.h|.*\\.java", "");
 
     private final String files;
-    private final String tabfiles;
+    private final String ignoreTabs;
 
-    WhitespaceConfiguration(String files, String tabfiles) {
+    WhitespaceConfiguration(String files, String ignoreTabs) {
         this.files = files;
-        this.tabfiles = tabfiles;
+        this.ignoreTabs = ignoreTabs;
     }
 
     public String files() {
         return files;
     }
 
-    public String tabfiles() {
-        return tabfiles;
+    public String ignoreTabs() {
+        return ignoreTabs;
     }
 
     static String name() {
@@ -54,7 +54,7 @@ public class WhitespaceConfiguration {
         }
 
         var files = s.get("files", DEFAULT.files());
-        var tabfiles = s.get("tabfiles", DEFAULT.tabfiles());
-        return new WhitespaceConfiguration(files, tabfiles);
+        var ignoreTabs = s.get("ignore-tabs", DEFAULT.ignoreTabs());
+        return new WhitespaceConfiguration(files, ignoreTabs);
     }
 }

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/WhitespaceConfiguration.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/WhitespaceConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,22 +24,24 @@ package org.openjdk.skara.jcheck;
 
 import org.openjdk.skara.ini.Section;
 
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 public class WhitespaceConfiguration {
     static final WhitespaceConfiguration DEFAULT =
-        new WhitespaceConfiguration(".*\\.cpp|.*\\.hpp|.*\\.c|.*\\.h|.*\\.java");
+        new WhitespaceConfiguration(".*\\.cpp|.*\\.hpp|.*\\.c|.*\\.h|.*\\.java", "");
 
     private final String files;
+    private final String tabfiles;
 
-    WhitespaceConfiguration(String files) {
+    WhitespaceConfiguration(String files, String tabfiles) {
         this.files = files;
+        this.tabfiles = tabfiles;
     }
 
     public String files() {
         return files;
+    }
+
+    public String tabfiles() {
+        return tabfiles;
     }
 
     static String name() {
@@ -52,6 +54,7 @@ public class WhitespaceConfiguration {
         }
 
         var files = s.get("files", DEFAULT.files());
-        return new WhitespaceConfiguration(files);
+        var tabfiles = s.get("tabfiles", DEFAULT.tabfiles());
+        return new WhitespaceConfiguration(files, tabfiles);
     }
 }


### PR DESCRIPTION
The tabfiles setting is just like the files setting, but it lists files in which tabs are allowed.

(This is to support makefiles)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to 4aaa659f33923f13afe96ab50a75a67d27eafd70
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/929/head:pull/929`
`$ git checkout pull/929`
