### PR TITLE
vcs: handle binary files in UnifiedDiffParser

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/UnifiedDiffParser.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/UnifiedDiffParser.java
@@ -70,6 +70,10 @@ public class UnifiedDiffParser {
 
         var hunks = new ArrayList<Hunk>();
         while (i < lines.size()) {
+            if (lines.get(i).startsWith("Binary files ") && lines.get(i).endsWith(" differ")) {
+                i++;
+                continue;
+            }
             var words = lines.get(i).split("\\s");
             if (!words[0].startsWith("@@")) {
                 throw new IllegalStateException("Unexpected diff line at index " + i + ": " + lines.get(i));
@@ -151,6 +155,8 @@ public class UnifiedDiffParser {
                 } else if (previousLineType.equals("-")) {
                     sourceHasNewlineAtEndOfFile = false;
                 }
+                i++;
+            } else if (line.startsWith("Binary files") && line.endsWith("differ")) {
                 i++;
             } else {
                 throw new IllegalStateException("Unexpected diff line: " + line);

--- a/vcs/src/test/java/org/openjdk/skara/vcs/UnifiedDiffParserTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/UnifiedDiffParserTests.java
@@ -421,4 +421,15 @@ public class UnifiedDiffParserTests {
         assertEquals(1, hunks.size());
         assertFalse(hunks.get(0).target().hasNewlineAtEndOfFile());
     }
+
+    @Test
+    public void binaryFile() {
+        var diff =
+            "diff --git a/file.bin b/file.bin\n" +
+            "new file mode 100644\n" +
+            "index 0000000000000000000000000000000000000000..2020dd2b626d1bcf60351a2be801548eb65c53cd\n" +
+            "Binary files /dev/null and b/file.bin differ";
+        var hunks = UnifiedDiffParser.parseSingleFileDiff(diff.split("\n"));
+        assertEquals(List.of(), hunks);
+    }
 }


### PR DESCRIPTION
Hi all,

please review this patch that handles binary files in the `UnifiedDiffParser`.

Testing:
- [x] Added a unit test
- [x] `make test` passes on Linux x64

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) |

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/930/head:pull/930`
`$ git checkout pull/930`
