### PR TITLE
checkout: use HostedRepository instead of URI

### DIFF
--- a/bots/checkout/src/main/java/org/openjdk/skara/bots/checkout/CheckoutBotFactory.java
+++ b/bots/checkout/src/main/java/org/openjdk/skara/bots/checkout/CheckoutBotFactory.java
@@ -49,16 +49,14 @@ public class CheckoutBotFactory implements BotFactory {
 
         var bots = new ArrayList<Bot>();
         for (var repo : specific.get("repositories").asArray()) {
-            var from = repo.get("from").asString();
-            var lastColon = from.lastIndexOf(":");
-            var fromURI = URI.create(from.substring(0, lastColon));
-            var fromBranch = new Branch(from.substring(lastColon + 1));
+            var from = configuration.repository(repo.get("from").get("repo").asString());
+            var fromBranch = new Branch(repo.get("from").get("branch").asString());
             var to = Path.of(repo.get("to").asString());
 
-            var repoName = fromURI.getPath().substring(1); // Remove leading '/'
+            var repoName = from.webUrl().getPath().substring(1) + ".git"; // Remove leading '/'
             var markStorage = MarkStorage.create(marksRepo, marksUser, repoName);
 
-            bots.add(new CheckoutBot(fromURI, fromBranch, to, storage, markStorage));
+            bots.add(new CheckoutBot(from, fromBranch, to, storage, markStorage));
         }
 
         return bots;

--- a/bots/checkout/src/test/java/org/openjdk/skara/bots/checkout/CheckoutBotTests.java
+++ b/bots/checkout/src/test/java/org/openjdk/skara/bots/checkout/CheckoutBotTests.java
@@ -78,7 +78,7 @@ class CheckoutBotTests {
             populate(gitLocalRepo);
             var gitHostedRepo = new TestHostedRepository(host, "from", gitLocalRepo);
 
-            var bot = new CheckoutBot(gitHostedRepo.url(), gitLocalRepo.defaultBranch(), hgDir, storage, marksStorage);
+            var bot = new CheckoutBot(gitHostedRepo, gitLocalRepo.defaultBranch(), hgDir, storage, marksStorage);
             var runner = new TestBotRunner();
             runner.runPeriodicItems(bot);
 
@@ -111,7 +111,7 @@ class CheckoutBotTests {
             populate(gitLocalRepo);
             var gitHostedRepo = new TestHostedRepository(host, "from", gitLocalRepo);
 
-            var bot = new CheckoutBot(gitHostedRepo.url(), gitLocalRepo.defaultBranch(), hgDir, storage, marksStorage);
+            var bot = new CheckoutBot(gitHostedRepo, gitLocalRepo.defaultBranch(), hgDir, storage, marksStorage);
             runner.runPeriodicItems(bot);
 
             var hgRepo = Repository.get(hgDir).orElseThrow();


### PR DESCRIPTION
Hi all,

please review this patch that makes the `checkout` bot use `HostedRepository` instead of `URI` for the `from` repository.

Testing:
- [x] Updated unit tests

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) |

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/931/head:pull/931`
`$ git checkout pull/931`
