### PR TITLE
forge: diff for GitLab commits can be empty

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -436,8 +436,10 @@ public class GitLabRepository implements HostedRepository {
                 targetFileType = FileType.fromOctal(file.get("b_mode").asString());
             }
 
-            var diff = file.get("diff").asString().split("\n");
-            var hunks = UnifiedDiffParser.parseSingleFileDiff(diff);
+            var diff = file.get("diff").asString();
+            var hunks = diff.isEmpty() ?
+                new ArrayList<Hunk>() :
+                UnifiedDiffParser.parseSingleFileDiff(diff.split("\n"));
 
             patches.add(new TextualPatch(sourcePath, sourceFileType, Hash.zero(),
                                          targetPath, targetFileType, Hash.zero(),


### PR DESCRIPTION
Hi all,

please review this patch that handles an edge case when the `"diff"` for a commit from GitLab can be empty (the case for a renamed file for example).

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) |

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/932/head:pull/932`
`$ git checkout pull/932`
