### PR TITLE
Avoid resetting an existing storage file

### DIFF
--- a/storage/src/main/java/module-info.java
+++ b/storage/src/main/java/module-info.java
@@ -25,6 +25,7 @@ module org.openjdk.skara.storage {
     requires org.openjdk.skara.host;
     requires org.openjdk.skara.forge;
     requires org.openjdk.skara.vcs;
+    requires java.logging;
 
     exports org.openjdk.skara.storage;
 }


### PR DESCRIPTION
If a materialization of a HostedRepositoryStorage fails due to an intermittent problem, we must ensure that we do not incorrectly try to create the ref as if it did not yet exist.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ⏳ (1/1 running) |

### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/933/head:pull/933`
`$ git checkout pull/933`
