### PR TITLE
Use proper build number formatting

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
@@ -343,7 +343,7 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
 
                 // Check if the build name should be updated
                 var oldBuild = issue.properties().getOrDefault("customfield_10006", JSON.of());
-                var newBuild = "b" + tag.buildNum();
+                var newBuild = "b" + String.format("%02d", tag.buildNum());
                 if (BuildCompare.shouldReplace(newBuild, oldBuild.asString())) {
                     issue.setProperty("customfield_10006", JSON.of(newBuild));
                 } else {

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
@@ -556,13 +556,32 @@ public class IssueNotifierTests {
             assertEquals(List.of(issueProject.issueTracker().currentUser()), updatedIssue.assignees());
 
             // Tag it
-            localRepo.tag(editHash, "jdk-16+10", "Second tag", "duke", "duke@openjdk.org");
+            localRepo.tag(editHash, "jdk-16+110", "Second tag", "duke", "duke@openjdk.org");
+            localRepo.push(new Branch(repo.url().toString()), "--tags", false);
+            TestBotRunner.runPeriodicItems(notifyBot);
+
+            // The build should now be updated
+            updatedIssue = issueProject.issue(issue.id()).orElseThrow();
+            assertEquals("b110", updatedIssue.properties().get("customfield_10006").asString());
+
+            // Tag it again
+            localRepo.tag(editHash, "jdk-16+10", "Third tag", "duke", "duke@openjdk.org");
             localRepo.push(new Branch(repo.url().toString()), "--tags", false);
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The build should now be updated
             updatedIssue = issueProject.issue(issue.id()).orElseThrow();
             assertEquals("b10", updatedIssue.properties().get("customfield_10006").asString());
+
+            // Tag it once again
+            localRepo.tag(editHash, "jdk-16+8", "Fourth tag", "duke", "duke@openjdk.org");
+            localRepo.push(new Branch(repo.url().toString()), "--tags", false);
+            TestBotRunner.runPeriodicItems(notifyBot);
+
+            // The build should now be updated
+            updatedIssue = issueProject.issue(issue.id()).orElseThrow();
+            assertEquals("b08", updatedIssue.properties().get("customfield_10006").asString());
+
         }
     }
 


### PR DESCRIPTION
Low build numbers should use a leading 0 for the custom field.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ⏳ (1/1 running) | ⏳ (1/1 running) | ⏳ (1/1 running) |

### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/934/head:pull/934`
`$ git checkout pull/934`
