### PR TITLE
SKARA-725: Rename git-pr-reviewer --add to git-pr-reviewer --credit

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrReviewer.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrReviewer.java
@@ -23,8 +23,6 @@
 package org.openjdk.skara.cli.pr;
 
 import org.openjdk.skara.args.*;
-import org.openjdk.skara.issuetracker.Comment;
-import org.openjdk.skara.forge.PullRequest;
 
 import static org.openjdk.skara.cli.pr.Utils.*;
 
@@ -34,7 +32,7 @@ import java.util.*;
 public class GitPrReviewer {
     static final List<Flag> flags = List.of(
         Option.shortcut("")
-              .fullname("add")
+              .fullname("credit")
               .describe("USERNAME")
               .helptext("Consider pull request reviewed by this user")
               .optional(),
@@ -73,16 +71,16 @@ public class GitPrReviewer {
         var id = pullRequestIdArgument(repo, arguments);
         var pr = getPullRequest(uri, repo, host, id);
 
-        if (arguments.contains("add")) {
-            var username = arguments.get("add").asString();
-            var comment = pr.addComment("/reviewer add" + " " + username);
+        if (arguments.contains("credit")) {
+            var username = arguments.get("credit").asString();
+            var comment = pr.addComment("/reviewer credit" + " " + username);
             showReply(awaitReplyTo(pr, comment));
         } else if (arguments.contains("remove")) {
             var username = arguments.get("remove").asString();
             var comment = pr.addComment("/reviewer remove" + " " + username);
             showReply(awaitReplyTo(pr, comment));
         } else {
-            System.err.println("error: must use either --add or --remove");
+            System.err.println("error: must use either --credit or --remove");
             System.exit(1);
         }
     }

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrReviewer.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrReviewer.java
@@ -34,7 +34,7 @@ public class GitPrReviewer {
         Option.shortcut("")
               .fullname("credit")
               .describe("USERNAME")
-              .helptext("Consider pull request reviewed by this user")
+              .helptext("Credit a person as a reviewer of this pull request")
               .optional(),
         Option.shortcut("")
               .fullname("remove")


### PR DESCRIPTION
Hi!
The patch renames the add option to the credit in accordance with the change in the `/reviewer` command on OpenJDK Github bot.

I was unable to find any related documentation that should reflect  this change. If something needs to be updated, kindly point me to it and I'll do the needful changes.

Thanks.
Regards,
Kartik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-725](https://bugs.openjdk.java.net/browse/SKARA-725): Rename git-pr-reviewer --add to git-pr-reviewer --credit


### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**) ⚠️ Review applies to e6dfcc8c347fdd12ff52b6c83d903c85dad4e5ef


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/938/head:pull/938`
`$ git checkout pull/938`
