### PR TITLE
Deprecate GitLab award emojis for flagging a PR as reviewed

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -674,6 +674,8 @@ class CheckRun {
 
         for (var added : reviewTracker.newReviews().entrySet()) {
             var body = added.getValue() + "\n" +
+                    " ⚠️ Marking a PR as reviewed using the emoji buttons is deprecated and will not be supported in the near future. " +
+                    "Please use the `Approve` button instead!\n\n" +
                     "This PR has been reviewed by " +
                     formatReviewer(added.getKey().reviewer()) + " - " +
                     verdictToString(added.getKey().verdict()) + ".";

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewTracker.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewTracker.java
@@ -48,8 +48,12 @@ class ReviewTracker {
             }
         }
 
-        // Find all reviews without a comment
+        // Find all reviews without a body and a comment
         for (var review : reviews) {
+            if (review.body().isPresent()) {
+                // Ignore these
+                continue;
+            }
             // Not notified yet
             if (!notified.contains(review.id())) {
                 newComments.put(review, String.format(reviewMarker, review.id()));


### PR DESCRIPTION
Before disabling support for GitLab award emojis as review markers, we can start with posting a notification about the preferred way.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) |

### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/939/head:pull/939`
`$ git checkout pull/939`
