### PR TITLE
Move PR target ref resolution to the utilities class

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveItem.java
@@ -56,7 +56,7 @@ class ArchiveItem {
         }
 
         try {
-            localRepo.merge(pr.targetHash());
+            localRepo.merge(PullRequestUtils.targetHash(pr, localRepo));
             // No problem means no conflict
             return Optional.empty();
         } catch (IOException e) {

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
@@ -158,7 +158,7 @@ class ReviewArchive {
                 } else {
                     throw new RuntimeException("PR " + pr.webUrl() + " has integrated label but no integration comment");
                 }
-            } else if (localRepo.isAncestor(pr.headHash(), pr.targetHash())) {
+            } else if (localRepo.isAncestor(pr.headHash(), PullRequestUtils.targetHash(pr, localRepo))) {
                 var commit = localRepo.lookup(pr.headHash());
                 var reply = ArchiveItem.integratedNotice(pr, localRepo, commit.orElseThrow(), hostUserToEmailAuthor, parent, subjectPrefix);
                 generated.add(reply);

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -697,7 +697,7 @@ class CheckRun {
 
         try {
             var hasContributingFile =
-                !localRepo.files(pr.targetHash(), Path.of("CONTRIBUTING.md")).isEmpty();
+                !localRepo.files(PullRequestUtils.targetHash(pr, localRepo), Path.of("CONTRIBUTING.md")).isEmpty();
             if (hasContributingFile) {
                 message.append("\n\nℹ️ This project also has non-automated pre-integration requirements. Please see the file ");
                 message.append("[CONTRIBUTING.md](https://github.com/");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommandWorkItem.java
@@ -25,7 +25,6 @@ package org.openjdk.skara.bots.pr;
 import org.openjdk.skara.bot.WorkItem;
 import org.openjdk.skara.forge.*;
 import org.openjdk.skara.issuetracker.Comment;
-import org.openjdk.skara.vcs.Hash;
 
 import java.io.*;
 import java.nio.file.Path;
@@ -147,7 +146,7 @@ public class CommitCommandWorkItem implements WorkItem {
         var seedPath = bot.seedStorage().orElse(scratchPath.resolve("seeds"));
         var hostedRepositoryPool = new HostedRepositoryPool(seedPath);
         var census = CensusInstance.create(hostedRepositoryPool, bot.censusRepo(), bot.censusRef(),
-                                           scratchPath.resolve("census"), bot.repo(), commit.hash(),
+                                           scratchPath.resolve("census"), bot.repo(), commit.hash().hex(),
                                            bot.confOverrideRepository().orElse(null),
                                            bot.confOverrideName(),
                                            bot.confOverrideRef());

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
@@ -113,9 +113,9 @@ public class IntegrateCommand implements CommandHandler {
             var rebaseMessage = new StringWriter();
             if (!command.args().isBlank()) {
                 var wantedHash = new Hash(command.args());
-                if (!pr.targetHash().equals(wantedHash)) {
+                if (!PullRequestUtils.targetHash(pr, localRepo).equals(wantedHash)) {
                     reply.print("The head of the target branch is no longer at the requested hash " + wantedHash);
-                    reply.println(" - it has moved to " + pr.targetHash() + ". Aborting integration.");
+                    reply.println(" - it has moved to " + PullRequestUtils.targetHash(pr, localRepo) + ". Aborting integration.");
                     return;
                 }
             };
@@ -163,7 +163,7 @@ public class IntegrateCommand implements CommandHandler {
             }
 
             // Rebase and push it!
-            if (!localHash.equals(pr.targetHash())) {
+            if (!localHash.equals(PullRequestUtils.targetHash(pr, localRepo))) {
                 var amendedHash = checkablePr.amendManualReviewers(localHash, censusInstance.namespace(), original);
                 var finalRebaseMessage = rebaseMessage.toString();
                 if (!finalRebaseMessage.isBlank()) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
@@ -97,9 +97,9 @@ public class SponsorCommand implements CommandHandler {
             var rebaseMessage = new StringWriter();
             if (!command.args().isBlank()) {
                 var wantedHash = new Hash(command.args());
-                if (!pr.targetHash().equals(wantedHash)) {
+                if (!PullRequestUtils.targetHash(pr, localRepo).equals(wantedHash)) {
                     reply.print("The head of the target branch is no longer at the requested hash " + wantedHash);
-                    reply.println(" - it has moved to " + pr.targetHash() + ". Aborting integration.");
+                    reply.println(" - it has moved to " + PullRequestUtils.targetHash(pr, localRepo) + ". Aborting integration.");
                     return;
                 }
             }
@@ -136,7 +136,7 @@ public class SponsorCommand implements CommandHandler {
                 return;
             }
 
-            if (!localHash.equals(pr.targetHash())) {
+            if (!localHash.equals(PullRequestUtils.targetHash(pr, localRepo))) {
                 var amendedHash = checkablePr.amendManualReviewers(localHash, censusInstance.namespace(), original);
                 var finalRebaseMessage = rebaseMessage.toString();
                 if (!finalRebaseMessage.isBlank()) {

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
@@ -111,11 +111,6 @@ class InMemoryPullRequest implements PullRequest {
     }
 
     @Override
-    public Hash targetHash() {
-        return null;
-    }
-
-    @Override
     public String title() {
         return null;
     }

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepositoryPool.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepositoryPool.java
@@ -207,13 +207,10 @@ public class HostedRepositoryPool {
         throw lastException;
     }
 
-    public Optional<List<String>> lines(HostedRepository hostedRepository, Path p, Hash hash) throws IOException {
+    public Optional<List<String>> lines(HostedRepository hostedRepository, Path p, String ref) throws IOException {
         var hostedRepositoryInstance = new HostedRepositoryInstance(hostedRepository);
         var seedRepo = hostedRepositoryInstance.seedRepository(true);
-        if (!seedRepo.contains(hash)) {
-            // It may fail because the seed is stale - need to refresh it now
-            fetchWithRetry(seedRepo, hostedRepository.url());
-        }
+        var hash = seedRepo.resolve(ref).orElseThrow(() -> new IllegalArgumentException("Unknown ref: " + ref));
         return seedRepo.lines(p, hash);
     }
 

--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
@@ -110,12 +110,6 @@ public interface PullRequest extends Issue {
     String targetRef();
 
     /**
-     * Returns the current head of the ref the request is intended to be merged into.
-     * @return
-     */
-    Hash targetHash();
-
-    /**
      * List of completed checks on the given hash.
      * @return
      */

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -46,7 +46,6 @@ public class GitHubPullRequest implements PullRequest {
     private final Logger log = Logger.getLogger("org.openjdk.skara.host");
 
     private List<String> labels = null;
-    private Hash targetHash = null;
 
     GitHubPullRequest(GitHubRepository repository, JSONValue jsonValue, RestRequest request) {
         this.host = (GitHubHost)repository.forge();
@@ -295,19 +294,7 @@ public class GitHubPullRequest implements PullRequest {
 
     @Override
     public String targetRef() {
-        var targetRef = json.get("base").get("ref").asString();
-        if (targetHash == null) {
-            // Read this value before returning, to ensure that future fetches of this ref contains the hash
-            targetHash = repository.branchHash(targetRef);
-        }
-        return targetRef;
-    }
-
-    @Override
-    public Hash targetHash() {
-        // Ensure that the field is populated
-        targetRef();
-        return targetHash;
+        return json.get("base").get("ref").asString();
     }
 
     @Override
@@ -720,6 +707,7 @@ public class GitHubPullRequest implements PullRequest {
     @Override
     public Diff diff() {
         var files = request.get("pulls/" + json.get("number").toString() + "/files").execute();
-        return repository.toDiff(targetHash(), headHash(), files);
+        var targetHash = repository.branchHash(targetRef());
+        return repository.toDiff(targetHash, headHash(), files);
     }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -45,7 +45,6 @@ public class GitLabMergeRequest implements PullRequest {
     private final GitLabRepository repository;
     private final GitLabHost host;
 
-    private Hash targetHash = null;
     private List<String> labels;
 
     GitLabMergeRequest(GitLabRepository repository, GitLabHost host, JSONValue jsonValue, RestRequest request) {
@@ -300,18 +299,7 @@ public class GitLabMergeRequest implements PullRequest {
     @Override
     public String targetRef() {
         var targetRef = json.get("target_branch").asString();
-        if (targetHash == null) {
-            // Read this value before returning, to ensure that future fetches of this ref contains the hash
-            targetHash = repository.branchHash(targetRef);
-        }
         return targetRef;
-    }
-
-    @Override
-    public Hash targetHash() {
-        // Ensure that the field is populated
-        targetRef();
-        return targetHash;
     }
 
     @Override
@@ -755,6 +743,7 @@ public class GitLabMergeRequest implements PullRequest {
     @Override
     public Diff diff() {
         var changes = request.get("changes").execute();
-        return repository.toDiff(targetHash(), headHash(), changes.get("changes"));
+        var targetHash = repository.branchHash(targetRef());
+        return repository.toDiff(targetHash, headHash(), changes.get("changes"));
     }
 }

--- a/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
@@ -161,11 +161,6 @@ public class TestPullRequest extends TestIssue implements PullRequest {
     }
 
     @Override
-    public Hash targetHash() {
-        return targetRepository.branchHash(data.targetRef);
-    }
-
-    @Override
     public Map<String, Check> checks(Hash hash) {
         return data.checks.stream()
                 .filter(check -> check.hash().equals(hash))
@@ -247,15 +242,16 @@ public class TestPullRequest extends TestIssue implements PullRequest {
     @Override
     public Diff diff() {
         try {
+            var targetHash = targetRepository.branchHash(targetRef());
             var targetLocalRepository = targetRepository.localRepository();
             var sourceLocalRepository = sourceRepository.localRepository();
             if (targetLocalRepository.root().equals(sourceLocalRepository.root())) {
                 // same target and source repo, must contain both commits
-                return targetLocalRepository.diff(targetHash(), headHash());
+                return targetLocalRepository.diff(targetHash, headHash());
             } else {
                 var uri = URI.create("file://" + sourceLocalRepository.root().toString());
                 var fetchHead = targetLocalRepository.fetch(uri, sourceRef);
-                return targetLocalRepository.diff(targetHash(), fetchHead);
+                return targetLocalRepository.diff(targetHash, fetchHead);
             }
         } catch (IOException e) {
             throw new UncheckedIOException(e);


### PR DESCRIPTION
The target ref resolution is better done locally to avoid races and also unnecessary API calls when only the ref name is used.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) |

### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/940/head:pull/940`
`$ git checkout pull/940`
