### PR TITLE
GitLab approval support missing asString

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -108,13 +108,13 @@ public class GitLabMergeRequest implements PullRequest {
         var approvals = request.get("notes").execute().stream()
                       .map(JSONValue::asObject)
                       .filter(obj -> obj.get("system").asBoolean())
-                      .filter(obj -> obj.get("body").contains("approved this merge request"))
+                      .filter(obj -> obj.get("body").asString().contains("approved this merge request"))
                       .map(obj -> {
                           var reviewerObj = obj.get("author").asObject();
                           var reviewer = HostUser.create(reviewerObj.get("id").asInt(),
                                                          reviewerObj.get("username").asString(),
                                                          reviewerObj.get("name").asString());
-                          var verdict = obj.get("body").contains("unapproved") ? Review.Verdict.NONE : Review.Verdict.APPROVED;
+                          var verdict = obj.get("body").asString().contains("unapproved") ? Review.Verdict.NONE : Review.Verdict.APPROVED;
                           var createdAt = ZonedDateTime.parse(obj.get("created_at").asString());
 
                           // Find the latest commit that isn't created after our review


### PR DESCRIPTION
This minor fix makes the approval button support for GitLab work properly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) |

### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/941/head:pull/941`
`$ git checkout pull/941`
