### PR TITLE
Ensure that a check that no longer requires a refresh is removed from the list

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -146,13 +146,15 @@ class PullRequestBot implements Bot {
     private boolean checkHasExpired(PullRequest pr) {
         var expiresAt = scheduledRechecks.get(pr.webUrl().toString());
         if (expiresAt != null && Instant.now().isAfter(expiresAt)) {
-            log.info("Check metadata has expired (expired at: " + expiresAt + ")");
+            log.info("Check metadata has expired (expired at: " + expiresAt + ") for PR #" + pr.id());
+            scheduledRechecks.remove(pr.webUrl().toString());
             return true;
         }
         return false;
     }
 
     void scheduleRecheckAt(PullRequest pr, Instant expiresAt) {
+        log.info("Setting check metadata expiration to: " + expiresAt + " for PR #" + pr.id());
         scheduledRechecks.put(pr.webUrl().toString(), expiresAt);
     }
 


### PR DESCRIPTION
When a check transitions from needing a periodic refresh to stable, it should be removed from the list of PRs that needs a refresh.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) |

### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/942/head:pull/942`
`$ git checkout pull/942`
