### PR TITLE
Allow targeting non-open issues with the label command

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -587,6 +587,12 @@ class CheckRun {
                                 progressBody.append(" ⚠️ Title mismatch between PR and JBS.");
                                 setExpiration(Duration.ofMinutes(10));
                             }
+                            if (iss.get().state() != org.openjdk.skara.issuetracker.Issue.State.OPEN) {
+                                if (!pr.labels().contains("backport")) {
+                                    progressBody.append(" ⚠️ Issue is not open.");
+                                }
+                                continue;
+                            }
                             progressBody.append("\n");
                         } else {
                             progressBody.append("⚠️ Failed to retrieve information on issue `");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IssueCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IssueCommand.java
@@ -139,10 +139,6 @@ public class IssueCommand implements CommandHandler {
                     reply.println("The issue `" + issue.shortId() + "` was not found in the `" + bot.issueProject().name() + "` project - make sure you have entered it correctly.");
                     continue;
                 }
-                if (validatedIssue.get().state() != org.openjdk.skara.issuetracker.Issue.State.OPEN) {
-                    reply.println("The issue [" + validatedIssue.get().id() + "](" + validatedIssue.get().webUrl() + ") isn't open - make sure you have selected the correct issue.");
-                    continue;
-                }
                 if (issue.description() == null) {
                     validatedIssues.add(new Issue(validatedIssue.get().id(), validatedIssue.get().title()));
                 } else {


### PR DESCRIPTION
Add a warning to the PR body instead if a non-open issues is targeted (unless the PR is marked as a backport).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ⏳ (1/1 running) |

### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/943/head:pull/943`
`$ git checkout pull/943`
