### PR TITLE
768: Skara bot should prevent attempt to use JBS backport issue ID in PR

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -52,7 +52,6 @@ class PullRequestBot implements Bot {
     private final Map<String, Pattern> readyComments;
     private final IssueProject issueProject;
     private final boolean ignoreStaleReviews;
-    private final Set<String> allowedIssueTypes;
     private final Pattern allowedTargetBranches;
     private final Path seedStorage;
     private final HostedRepository confOverrideRepo;
@@ -73,7 +72,7 @@ class PullRequestBot implements Bot {
                    Map<String, String> blockingCheckLabels, Set<String> readyLabels,
                    Set<String> twoReviewersLabels, Set<String> twentyFourHoursLabels,
                    Map<String, Pattern> readyComments, IssueProject issueProject,
-                   boolean ignoreStaleReviews, Set<String> allowedIssueTypes, Pattern allowedTargetBranches,
+                   boolean ignoreStaleReviews, Pattern allowedTargetBranches,
                    Path seedStorage, HostedRepository confOverrideRepo, String confOverrideName,
                    String confOverrideRef, String censusLink, List<HostUser> commitCommandUsers) {
         remoteRepo = repo;
@@ -88,7 +87,6 @@ class PullRequestBot implements Bot {
         this.issueProject = issueProject;
         this.readyComments = readyComments;
         this.ignoreStaleReviews = ignoreStaleReviews;
-        this.allowedIssueTypes = allowedIssueTypes;
         this.allowedTargetBranches = allowedTargetBranches;
         this.seedStorage = seedStorage;
         this.confOverrideRepo = confOverrideRepo;
@@ -263,10 +261,6 @@ class PullRequestBot implements Bot {
 
     boolean ignoreStaleReviews() {
         return ignoreStaleReviews;
-    }
-
-    Set<String> allowedIssueTypes() {
-        return allowedIssueTypes;
     }
 
     Pattern allowedTargetBranches() {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
@@ -45,7 +45,6 @@ public class PullRequestBotBuilder {
     private Map<String, Pattern> readyComments = Map.of();
     private IssueProject issueProject = null;
     private boolean ignoreStaleReviews = false;
-    private Set<String> allowedIssueTypes = null;
     private Pattern allowedTargetBranches = Pattern.compile(".*");
     private Path seedStorage = null;
     private HostedRepository confOverrideRepo = null;
@@ -117,11 +116,6 @@ public class PullRequestBotBuilder {
         return this;
     }
 
-    public PullRequestBotBuilder allowedIssueTypes(Set<String> allowedIssueTypes) {
-        this.allowedIssueTypes = allowedIssueTypes;
-        return this;
-    }
-
     public PullRequestBotBuilder allowedTargetBranches(String allowedTargetBranches) {
         this.allowedTargetBranches = Pattern.compile(allowedTargetBranches);
         return this;
@@ -160,7 +154,7 @@ public class PullRequestBotBuilder {
     public PullRequestBot build() {
         return new PullRequestBot(repo, censusRepo, censusRef, labelConfiguration, externalCommands,
                                   blockingCheckLabels, readyLabels, twoReviewersLabels, twentyFourHoursLabels,
-                                  readyComments, issueProject, ignoreStaleReviews, allowedIssueTypes,
+                                  readyComments, issueProject, ignoreStaleReviews,
                                   allowedTargetBranches, seedStorage, confOverrideRepo, confOverrideName,
                                   confOverrideRef, censusLink, commitCommandUsers);
     }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
@@ -118,12 +118,6 @@ public class PullRequestBotFactory implements BotFactory {
             if (repo.value().contains("ignorestale")) {
                 botBuilder.ignoreStaleReviews(repo.value().get("ignorestale").asBoolean());
             }
-            if (repo.value().contains("issuetypes")) {
-                var types = repo.value().get("issuetypes").stream()
-                                                          .map(JSONValue::asString)
-                                                          .collect(Collectors.toSet());
-                botBuilder.allowedIssueTypes(types);
-            }
             if (repo.value().contains("targetbranches")) {
                 botBuilder.allowedTargetBranches(repo.value().get("targetbranches").asString());
             }


### PR DESCRIPTION
Check that the issue type is of an allowed type.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ⏳ (1/1 running) |

### Issue
 * [SKARA-768](https://bugs.openjdk.java.net/browse/SKARA-768): Skara bot should prevent attempt to use JBS backport issue ID in PR


### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/944/head:pull/944`
`$ git checkout pull/944`
