### PR TITLE
Run skara pre-submit tests against the latest commit on the target branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 #
 # The pre-submit tests will only runs for forks of the TARGET_PROJECT defined below. This is set to "skara" by default,
-# and can be changed by downstream projects if they also want to run pre-submit tests. 
+# and can be changed by downstream projects if they also want to run pre-submit tests.
 #
 # The tests will attempt to merge the latest commits from TARGET_BRANCH before executing, to ensure that what is tested
 # is as close as possible to what the final integration result will be. This is set to "master" by default, and can
@@ -55,9 +55,9 @@ jobs:
       - name: Determine merge strategy
         id: try_merge_target
         run: >
-          (git -c user.name="presubmit" -c user.email="presubmit@github.actions" merge --no-edit ${{ steps.merge_target.outputs.hash }} && 
+          (git -c user.name="presubmit" -c user.email="presubmit@github.actions" merge --no-edit ${{ steps.merge_target.outputs.hash }} &&
             echo "::set-output name=command::git -c user.name="presubmit" -c user.email="presubmit@github.actions" merge --no-edit ${{ steps.merge_target.outputs.hash }}") ||
-          (git merge --abort && git -c user.name="presubmit" -c user.email="presubmit@github.actions" rebase ${{ steps.merge_target.outputs.hash }} && 
+          (git merge --abort && git -c user.name="presubmit" -c user.email="presubmit@github.actions" rebase ${{ steps.merge_target.outputs.hash }} &&
             echo "::set-output name=command::git -c user.name="presubmit" -c user.email="presubmit@github.actions" rebase ${{ steps.merge_target.outputs.hash }}") ||
           echo "::set-output name=command::echo There are merge conflicts with the target that will have to be resolved before integration"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,31 +1,124 @@
-name: Build and test
+#
+# The pre-submit tests will only runs for forks of the TARGET_PROJECT defined below. This is set to "skara" by default,
+# and can be changed by downstream projects if they also want to run pre-submit tests. 
+#
+# The tests will attempt to merge the latest commits from TARGET_BRANCH before executing, to ensure that what is tested
+# is as close as possible to what the final integration result will be. This is set to "master" by default, and can
+# be changed by downstream projects that utilize multiple branches in order to select the correct one.
+#
+name: Pre-submit tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+      - master
+      - pr/*
 
 jobs:
+  prerequisites:
+    name: Prerequisites
+    runs-on: "ubuntu-latest"
+    env:
+      TARGET_PROJECT: skara
+      TARGET_BRANCH: master
+    outputs:
+      should_run: ${{ steps.check_submit.outputs.should_run }}
+      fetch_target_command: ${{ steps.merge_target.outputs.command }}
+      merge_target_command: ${{ steps.try_merge_target.outputs.command }}
+
+    steps:
+      - name: Determine target project name (fork source)
+        id: upstream_repo
+        uses: actions/github-script@v3
+        with:
+          result-encoding: string
+          script: "return (await github.repos.get( {owner: context.repo.owner, repo: context.repo.repo })).data.source.name"
+
+      - name: Check if submit tests should actually run
+        id: check_submit
+        run: echo "::set-output name=should_run::${{ env.TARGET_PROJECT == steps.upstream_repo.outputs.result }}"
+
+      - name: Checkout the source
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1000
+        if: steps.check_submit.outputs.should_run != 'false'
+
+      - name: Determine merge target hash
+        id: merge_target
+        run: |
+          git fetch https://github.com/openjdk/${{ steps.upstream_repo.outputs.result }} ${TARGET_BRANCH}
+          echo "::set-output name=hash::`git rev-parse FETCH_HEAD`"
+          echo "::set-output name=command::git fetch https://github.com/openjdk/${{ steps.upstream_repo.outputs.result }} ${TARGET_BRANCH}"
+        if: steps.check_submit.outputs.should_run != 'false'
+
+      - name: Determine merge strategy
+        id: try_merge_target
+        run: >
+          (git -c user.name="presubmit" -c user.email="presubmit@github.actions" merge --no-edit ${{ steps.merge_target.outputs.hash }} && 
+            echo "::set-output name=command::git -c user.name="presubmit" -c user.email="presubmit@github.actions" merge --no-edit ${{ steps.merge_target.outputs.hash }}") ||
+          (git merge --abort && git -c user.name="presubmit" -c user.email="presubmit@github.actions" rebase ${{ steps.merge_target.outputs.hash }} && 
+            echo "::set-output name=command::git -c user.name="presubmit" -c user.email="presubmit@github.actions" rebase ${{ steps.merge_target.outputs.hash }}") ||
+          echo "::set-output name=command::echo There are merge conflicts with the target that will have to be resolved before integration"
+
   linux:
     name: Linux x64
-    runs-on: 'ubuntu-20.04'
+    runs-on: "ubuntu-20.04"
+    needs: prerequisites
+    if: needs.prerequisites.outputs.should_run
+
     steps:
-    - uses: actions/checkout@v1
-    - name: Build and test
-      run: sh gradlew test --info --stacktrace
+      - name: Checkout the source
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1000
+
+      - name: Merge latest changes from target branch
+        run: |
+          ${{ needs.prerequisites.outputs.fetch_target_command }}
+          ${{ needs.prerequisites.outputs.merge_target_command }}
+
+      - name: Build and test
+        run: sh gradlew test --info --stacktrace
 
   mac:
     name: macOS x64
-    runs-on: 'macos-10.15'
+    runs-on: "macos-10.15"
+    needs: prerequisites
+
     steps:
-    - uses: actions/checkout@v1
-    - name: Install Mercurial
-      run: brew install mercurial
-    - name: Build and test
-      run: sh gradlew test --info --stacktrace
+      - name: Checkout the source
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1000
+
+      - name: Merge latest changes from target branch
+        run: |
+          ${{ needs.prerequisites.outputs.fetch_target_command }}
+          ${{ needs.prerequisites.outputs.merge_target_command }}
+
+      - name: Install Mercurial
+        run: brew install mercurial
+
+      - name: Build and test
+        run: sh gradlew test --info --stacktrace
 
   win:
     name: Windows x64
-    runs-on: 'windows-2019'
+    runs-on: "windows-2019"
+    needs: prerequisites
+
     steps:
-    - uses: actions/checkout@v1
-    - name: Build and test
-      run: gradlew.bat test --info --stacktrace
-      shell: cmd
+      - name: Checkout the source
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1000
+
+      - name: Merge latest changes from target branch
+        run: |
+          ${{ needs.prerequisites.outputs.fetch_target_command }}
+          ${{ needs.prerequisites.outputs.merge_target_command }}
+
+      - name: Build and test
+        run: gradlew.bat test --info --stacktrace
+        shell: cmd


### PR DESCRIPTION
If possible, the pre-submit tests should merge the latest content from the target branch to increase the odds of detecting problems that would otherwise remain undetected until actual integration. This is similar to how actions normally run within the context of a PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ⏳ (1/1 running) | ✔️ (1/1 passed) | ⏳ (1/1 running) |

### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/946/head:pull/946`
`$ git checkout pull/946`
