### PR TITLE
forge: return commit comment from addCommitComment

### DIFF
--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
@@ -157,7 +157,8 @@ class InMemoryHostedRepository implements HostedRepository {
     }
 
     @Override
-    public void addCommitComment(Hash commit, String body) {
+    public CommitComment addCommitComment(Hash commit, String body) {
+        return null;
     }
 
     @Override

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
@@ -69,7 +69,7 @@ public interface HostedRepository {
     List<HostedBranch> branches();
     List<CommitComment> commitComments(Hash hash);
     List<CommitComment> recentCommitComments();
-    void addCommitComment(Hash hash, String body);
+    CommitComment addCommitComment(Hash hash, String body);
     void updateCommitComment(String id, String body);
     Optional<HostedCommit> commit(Hash hash);
     List<Check> allChecks(Hash hash);

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -360,11 +360,12 @@ public class GitHubRepository implements HostedRepository {
     }
 
     @Override
-    public void addCommitComment(Hash hash, String body) {
+    public CommitComment addCommitComment(Hash hash, String body) {
         var query = JSON.object().put("body", body);
-        request.post("commits/" + hash.hex() + "/comments")
-               .body(query)
-               .execute();
+        var result = request.post("commits/" + hash.hex() + "/comments")
+                            .body(query)
+                            .execute();
+        return toCommitComment(result);
     }
 
     @Override

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -300,7 +300,7 @@ public class GitLabRepository implements HostedRepository {
        // GitLab does not offer an id for commit comments
        var body = o.get("note").asString();
        var user = gitLabHost.parseAuthorField(o);
-       var id = Integer.toString(Objects.hash(createdAt.toString(), body, user.id()));
+       var id = Integer.toString((hash.hex() + createdAt.toString() + user.id()).hashCode());
        return new CommitComment(hash,
                                 path,
                                 line,

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -298,12 +298,14 @@ public class GitLabRepository implements HostedRepository {
        // GitLab does not offer updated_at for commit comments
        var createdAt = ZonedDateTime.parse(o.get("created_at").asString());
        // GitLab does not offer an id for commit comments
-       var id = "";
+       var body = o.get("note").asString();
+       var user = gitLabHost.parseAuthorField(o);
+       var id = Integer.toString(Objects.hash(createdAt.toString(), body, user.id()));
        return new CommitComment(hash,
                                 path,
                                 line,
                                 id,
-                                o.get("note").asString(),
+                                body,
                                 gitLabHost.parseAuthorField(o),
                                 createdAt,
                                 createdAt);
@@ -381,11 +383,12 @@ public class GitLabRepository implements HostedRepository {
     }
 
     @Override
-    public void addCommitComment(Hash hash, String body) {
+    public CommitComment addCommitComment(Hash hash, String body) {
         var query = JSON.object().put("note", body);
-        request.post("repository/commits/" + hash.hex() + "/comments")
-               .body(query)
-               .execute();
+        var result = request.post("repository/commits/" + hash.hex() + "/comments")
+                            .body(query)
+                            .execute();
+        return toCommitComment(hash, result);
     }
 
     @Override

--- a/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
@@ -221,7 +221,7 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
     }
 
     @Override
-    public void addCommitComment(Hash hash, String body) {
+    public CommitComment addCommitComment(Hash hash, String body) {
         var id = nextCommitCommentId;
         nextCommitCommentId += 1;
         var createdAt = ZonedDateTime.now();
@@ -230,7 +230,9 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
             commitComments.put(hash, new ArrayList<>());
         }
         var comments = commitComments.get(hash);
-        comments.add(new CommitComment(hash, null, -1, Integer.toString(id), body, host.currentUser(), createdAt, createdAt));
+        var comment = new CommitComment(hash, null, -1, Integer.toString(id), body, host.currentUser(), createdAt, createdAt);
+        comments.add(comment);
+        return comment;
     }
 
     @Override


### PR DESCRIPTION
Hi all,

please review this patch that makes `HostedRepository.addCommitComment` return the newly created commit comment. I had to make a workaround for GitLab's REST API since it doesn't return an id for commit comment. Instead we calculate an id based on the hash, the user's id an the time the comment was created.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ⏳ (1/1 running) | ⏳ (1/1 running) | ⏳ (1/1 running) |

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/947/head:pull/947`
`$ git checkout pull/947`
