### PR TITLE
Only consider resolved backports when applying sync label

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/Backports.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/Backports.java
@@ -196,6 +196,7 @@ public class Backports {
         return links.stream()
                     .filter(l -> l.issue().isPresent())
                     .map(l -> l.issue().get())
+                    .filter(i -> i.state() != Issue.State.OPEN)
                     .filter(i -> i.properties().containsKey("issuetype"))
                     .filter(i -> i.properties().get("issuetype").asString().equals("Backport"))
                     .collect(Collectors.toList());

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
@@ -898,20 +898,24 @@ public class IssueNotifierTests {
 
             var issue1 = credentials.createIssue(issueProject, "Issue 1");
             issue1.setProperty("issuetype", JSON.of("Bug"));
+            issue1.setState(RESOLVED);
 
             var issue2 = credentials.createIssue(issueProject, "Issue 2");
             issue2.setProperty("fixVersions", JSON.array().add(JSON.of("8u162")));
             issue2.setProperty("issuetype", JSON.of("Backport"));
+            issue2.setState(RESOLVED);
             issue1.addLink(Link.create(issue2, "backported by").build());
 
             var issue3 = credentials.createIssue(issueProject, "Issue 3");
             issue3.setProperty("fixVersions", JSON.array().add(JSON.of("10")));
             issue3.setProperty("issuetype", JSON.of("Backport"));
+            issue3.setState(RESOLVED);
             issue1.addLink(Link.create(issue3, "backported by").build());
 
             var issue4 = credentials.createIssue(issueProject, "Issue 4");
             issue4.setProperty("fixVersions", JSON.array().add(JSON.of("11")));
             issue4.setProperty("issuetype", JSON.of("Backport"));
+            issue4.setState(RESOLVED);
             issue1.addLink(Link.create(issue4, "backported by").build());
 
             // Mention one of the issues


### PR DESCRIPTION
Issues that are still open should not be considered when calculating which issues should have the sync label applied.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) |

### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**) ⚠️ Review applies to 4229cfb8608e86e32495e27259947edf9b2e866f


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/952/head:pull/952`
`$ git checkout pull/952`
