### PR TITLE
git-pr: update git-pr -h

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrHelp.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrHelp.java
@@ -71,6 +71,12 @@ public class GitPrHelp {
         commands.put("sponsor", Pair.of(GitPrSponsor.inputs, GitPrSponsor.flags));
         commands.put("test", Pair.of(GitPrTest.inputs, GitPrTest.flags));
         commands.put("info", Pair.of(GitPrInfo.inputs, GitPrInfo.flags));
+        commands.put("issue", Pair.of(GitPrIssue.inputs, GitPrIssue.flags));
+        commands.put("reviewer", Pair.of(GitPrReviewer.inputs, GitPrReviewer.flags));
+        commands.put("summary", Pair.of(GitPrSummary.inputs, GitPrSummary.flags));
+        commands.put("cc", Pair.of(GitPrCC.inputs, GitPrCC.flags));
+        commands.put("csr", Pair.of(GitPrCSR.inputs, GitPrCSR.flags));
+        commands.put("contributor", Pair.of(GitPrContributor.inputs, GitPrContributor.flags));
     }
 
     private static String describe(List<Input> inputs) {


### PR DESCRIPTION
Hi all,

please review this small update to `git pr -h` that adds some missing sub-commands to the help output.

Testing:
- [x] Manual testing on Linux x64

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) |

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/953/head:pull/953`
`$ git checkout pull/953`
