### PR TITLE
SKARA-758: Add /check pull request command

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckCommand.java
@@ -1,0 +1,22 @@
+package org.openjdk.skara.bots.pr;
+
+import org.openjdk.skara.forge.PullRequest;
+import org.openjdk.skara.issuetracker.Comment;
+
+import java.io.PrintWriter;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+
+public class CheckCommand implements CommandHandler {
+    @Override
+    public String description() {
+        return "run Jcheck again";
+    }
+
+    @Override
+    public void handle(PullRequestBot bot, PullRequest pr, CensusInstance censusInstance, Path scratchPath, CommandInvocation command, List<Comment> allComments, PrintWriter reply) {
+        bot.scheduleRecheckAt(pr, Instant.now());
+    }
+
+}

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckCommand.java
@@ -1,11 +1,15 @@
 package org.openjdk.skara.bots.pr;
 
+import org.openjdk.skara.forge.HostedRepositoryPool;
 import org.openjdk.skara.forge.PullRequest;
+import org.openjdk.skara.forge.PullRequestUtils;
 import org.openjdk.skara.issuetracker.Comment;
 
+import java.io.IOException;
 import java.io.PrintWriter;
+import java.io.UncheckedIOException;
 import java.nio.file.Path;
-import java.time.Instant;
+import java.util.HashSet;
 import java.util.List;
 
 public class CheckCommand implements CommandHandler {
@@ -16,7 +20,22 @@ public class CheckCommand implements CommandHandler {
 
     @Override
     public void handle(PullRequestBot bot, PullRequest pr, CensusInstance censusInstance, Path scratchPath, CommandInvocation command, List<Comment> allComments, PrintWriter reply) {
-        bot.scheduleRecheckAt(pr, Instant.now());
+        try {
+            var workItem = new CheckWorkItem(bot, pr, e -> {});
+
+            var path = scratchPath.resolve("check").resolve(pr.repository().name());
+            var seedPath = bot.seedStorage().orElse(scratchPath.resolve("seeds"));
+            var hostedRepositoryPool = new HostedRepositoryPool(seedPath);
+            var localRepo = PullRequestUtils.materialize(hostedRepositoryPool, pr, path);
+
+            var allReviews = pr.reviews();
+            var activeReviews = CheckablePullRequest.filterActiveReviews(allReviews);
+            var activeLabels = new HashSet<>(pr.labels());
+
+            CheckRun.execute(workItem, pr, localRepo, allComments, allReviews, activeReviews, activeLabels, censusInstance, bot.ignoreStaleReviews());
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandWorkItem.java
@@ -55,7 +55,8 @@ public class CommandWorkItem extends PullRequestWorkItem {
             Map.entry("csr", new CSRCommand()),
             Map.entry("reviewer", new ReviewerCommand()),
             Map.entry("label", new LabelCommand()),
-            Map.entry("cc", new LabelCommand("cc"))
+            Map.entry("cc", new LabelCommand("cc")),
+            Map.entry("check", new CheckCommand())
     );
 
     static class HelpCommand implements CommandHandler {

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckCommandTests.java
@@ -1,0 +1,47 @@
+package org.openjdk.skara.bots.pr;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.openjdk.skara.test.CheckableRepository;
+import org.openjdk.skara.test.HostCredentials;
+import org.openjdk.skara.test.TemporaryDirectory;
+import org.openjdk.skara.test.TestBotRunner;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CheckCommandTests {
+    @Test
+    public void testCheckRun(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var integrator = credentials.getHostedRepository();
+
+            var censusBuilder = credentials.getCensusBuilder()
+                    .addReviewer(integrator.forge().currentUser().id())
+                    .addCommitter(author.forge().currentUser().id());
+            var prBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
+
+            // Populate the projects repository
+            var localRepoFolder = tempFolder.path().resolve("localrepo");
+            var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
+            pr.addComment("/check");
+
+            assertFalse(pr.checks(editHash).containsKey("jcheck"));
+            TestBotRunner.runPeriodicItems(prBot);
+            assertTrue(pr.checks(editHash).containsKey("jcheck"));
+        }
+    }
+
+}


### PR DESCRIPTION
Hi!
Kindly review the patch to allow manual execution of jcheck. I think it might be worthwhile to restrict this command to some specific people but I am not sure who that should be (maybe restricting to the author is enough but a reviewer might want to execute it as well in case its urgent). 

I wanted to test this locally by setting up the skara bots on my own repository but was unable to figure out how to do so due to lack of documentation.
Thanks.
Regards,
Kartik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 |
| --- | ----- | ----- |
| Build / test | ✔️ (1/1 passed) | ✔️ (1/1 passed) |

### Issue
 * [SKARA-758](https://bugs.openjdk.java.net/browse/SKARA-758): Add /check pull request command


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/954/head:pull/954`
`$ git checkout pull/954`
