### PR TITLE
Filter out invalid GitLab merge requests

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -117,7 +117,7 @@ public class GitLabRepository implements HostedRepository {
 
     // Sometimes GitLab returns merge requests that cannot be acted upon
     private boolean hasHeadHash(JSONValue json) {
-        return json.contains("sha") && !json.get("sha").isNull());
+        return json.contains("sha") && !json.get("sha").isNull();
     }
 
     @Override

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -116,13 +116,8 @@ public class GitLabRepository implements HostedRepository {
     }
 
     // Sometimes GitLab returns merge requests that cannot be acted upon
-    private boolean mergeRequestValid(JSONValue mrJson) {
-        var obj = mrJson.asObject();
-        if (!obj.contains("sha") || obj.get("sha").isNull()) {
-            return false;
-        }
-
-        return true;
+    private boolean hasHeadHash(JSONValue json) {
+        return json.contains("sha") && !json.get("sha").isNull());
     }
 
     @Override
@@ -130,7 +125,7 @@ public class GitLabRepository implements HostedRepository {
         return request.get("merge_requests")
                       .param("state", "opened")
                       .execute().stream()
-                      .filter(this::mergeRequestValid)
+                      .filter(this::hasHeadHash)
                       .map(value -> new GitLabMergeRequest(this, gitLabHost, value, request))
                       .collect(Collectors.toList());
     }
@@ -141,7 +136,7 @@ public class GitLabRepository implements HostedRepository {
                       .param("order_by", "updated_at")
                       .param("updated_after", updatedAfter.format(DateTimeFormatter.ISO_DATE_TIME))
                       .execute().stream()
-                      .filter(this::mergeRequestValid)
+                      .filter(this::hasHeadHash)
                       .map(value -> new GitLabMergeRequest(this, gitLabHost, value, request))
                       .collect(Collectors.toList());
     }


### PR DESCRIPTION
Sometimes GitLab returns merge request data that doesn't contain a head hash. Since we can't really do anything with these, just ignore them.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ⏳ (1/1 running) |

### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**) ⚠️ Review applies to abdedc96ab458fdc3a671ef664d98dfc4660df50


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/956/head:pull/956`
`$ git checkout pull/956`
