### PR TITLE
vcs: use correct loop variable

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/DiffComparator.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/DiffComparator.java
@@ -76,8 +76,8 @@ public class DiffComparator {
                 return false;
             }
             for (var j = 0; j < aHunk.source().lines().size(); j++) {
-                var aLine = aHunk.source().lines().get(i);
-                var bLine = bHunk.source().lines().get(i);
+                var aLine = aHunk.source().lines().get(j);
+                var bLine = bHunk.source().lines().get(j);
                 if (!aLine.equals(bLine)) {
                     return false;
                 }
@@ -87,8 +87,8 @@ public class DiffComparator {
                 return false;
             }
             for (var j = 0; j < aHunk.target().lines().size(); j++) {
-                var aLine = aHunk.target().lines().get(i);
-                var bLine = bHunk.target().lines().get(i);
+                var aLine = aHunk.target().lines().get(j);
+                var bLine = bHunk.target().lines().get(j);
                 if (!aLine.equals(bLine)) {
                     return false;
                 }


### PR DESCRIPTION
Hi all,

please review this small patch that updates `DiffComparator.java` to use the correct loop variable (sigh).

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ⏳ (1/1 running) | ⏳ (1/1 running) | ⏳ (1/1 running) |

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/958/head:pull/958`
`$ git checkout pull/958`
