### PR TITLE
Only consider backports with a proper link relationship

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/Backports.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/Backports.java
@@ -195,6 +195,8 @@ public class Backports {
         var links = primary.links();
         return links.stream()
                     .filter(l -> l.issue().isPresent())
+                    .filter(l -> l.relationship().isPresent())
+                    .filter(l -> l.relationship().get().equals("backported by") || l.relationship().get().equals("backport of"))
                     .map(l -> l.issue().get())
                     .filter(i -> i.state() != Issue.State.OPEN)
                     .filter(i -> i.properties().containsKey("issuetype"))

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/BackportsTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/BackportsTests.java
@@ -86,15 +86,25 @@ public class BackportsTests {
 
             var issue2 = credentials.createIssue(issueProject, "Issue 2");
             issue2.setProperty("issuetype", JSON.of("Bug"));
+            issue2.setState(Issue.State.RESOLVED);
             issue1.addLink(Link.create(issue2, "duplicated by").build());
 
             var issue3 = credentials.createIssue(issueProject, "Issue 3");
             issue3.setProperty("issuetype", JSON.of("CSR"));
+            issue3.setState(Issue.State.RESOLVED);
             issue1.addLink(Link.create(issue3, "CSRed by").build());
+
+            var issue4 = credentials.createIssue(issueProject, "Issue 4");
+            issue4.setProperty("issuetype", JSON.of("Backport"));
+            issue4.setState(Issue.State.RESOLVED);
+            issue1.addLink(Link.create(issue4, "related to").build());
 
             assertEquals(issue1, Backports.findMainIssue(issue1).orElseThrow());
             assertEquals(issue2, Backports.findMainIssue(issue2).orElseThrow());
             assertEquals(Optional.empty(), Backports.findMainIssue(issue3));
+            assertEquals(Optional.empty(), Backports.findMainIssue(issue4));
+
+            assertEquals(List.of(), Backports.findBackports(issue1));
         }
     }
 


### PR DESCRIPTION
If an issue links to a backport, it should only be consider an actual backport if the link type is correct (to avoid looking at backport issues linked as "related to" for example).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/960/head:pull/960`
`$ git checkout pull/960`
