### PR TITLE
Add newline after closed issue warning

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -482,9 +482,8 @@ class CheckRun {
                             }
                             if (iss.get().state() != org.openjdk.skara.issuetracker.Issue.State.OPEN) {
                                 if (!pr.labels().contains("backport")) {
-                                    progressBody.append(" ⚠️ Issue is not open.\n");
+                                    progressBody.append(" ⚠️ Issue is not open.");
                                 }
-                                continue;
                             }
                             if (properties.containsKey("issuetype") && !primaryTypes.contains(properties.get("issuetype").asString())) {
                                 progressBody.append(" ⚠️ Unexpected issue type `").append(properties.get("issuetype").asString()).append("`.");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -482,7 +482,7 @@ class CheckRun {
                             }
                             if (iss.get().state() != org.openjdk.skara.issuetracker.Issue.State.OPEN) {
                                 if (!pr.labels().contains("backport")) {
-                                    progressBody.append(" ⚠️ Issue is not open.");
+                                    progressBody.append(" ⚠️ Issue is not open.\n");
                                 }
                                 continue;
                             }


### PR DESCRIPTION
Adds a missing newline after the 'issue is not open' warning, which is currently missing, and leads to the list not being formatted correctly. See e.g. https://github.com/openjdk/jdk/pull/1444

![image](https://user-images.githubusercontent.com/5962029/100388139-12f8ff80-302a-11eb-876a-25943c7d75d8.png)

Any testing needed for this?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**) ⚠️ Review applies to 00e70cda7833f59d8c237a42fb1185e040a973fc


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/963/head:pull/963`
`$ git checkout pull/963`
