### PR TITLE
Ensure that labels do not propagate to backports

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierBuilder.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierBuilder.java
@@ -35,6 +35,8 @@ class IssueNotifierBuilder {
     private URI commitIcon = null;
     private boolean setFixVersion = false;
     private Map<String, String> fixVersions = null;
+    private JbsVault vault = null;
+    private String securityLevel = null;
     private boolean prOnly = true;
     private String buildName = null;
 
@@ -74,6 +76,16 @@ class IssueNotifierBuilder {
         return this;
     }
 
+    public IssueNotifierBuilder vault(JbsVault vault) {
+        this.vault = vault;
+        return this;
+    }
+
+    public IssueNotifierBuilder securityLevel(String securityLevel) {
+        this.securityLevel = securityLevel;
+        return this;
+    }
+
     public IssueNotifierBuilder prOnly(boolean prOnly) {
         this.prOnly = prOnly;
         return this;
@@ -85,7 +97,8 @@ class IssueNotifierBuilder {
     }
 
     IssueNotifier build() {
+        var jbsBackport = new JbsBackport(issueProject.webUrl(), vault, securityLevel);
         return new IssueNotifier(issueProject, reviewLink, reviewIcon, commitLink, commitIcon,
-                                 setFixVersion, fixVersions, prOnly, buildName);
+                                 setFixVersion, fixVersions, jbsBackport, prOnly, buildName);
     }
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierFactory.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierFactory.java
@@ -2,7 +2,9 @@ package org.openjdk.skara.bots.notify.issue;
 
 import org.openjdk.skara.bot.BotConfiguration;
 import org.openjdk.skara.bots.notify.*;
+import org.openjdk.skara.host.Credential;
 import org.openjdk.skara.json.JSONObject;
+import org.openjdk.skara.network.URIBuilder;
 
 import java.net.URI;
 import java.util.stream.Collectors;
@@ -45,6 +47,23 @@ public class IssueNotifierFactory implements NotifierFactory {
         }
         if (notifierConfiguration.contains("buildname")) {
             builder.buildName(notifierConfiguration.get("buildname").asString());
+        }
+
+        if (notifierConfiguration.contains("vault")) {
+            var vaultConfiguration = notifierConfiguration.get("vault").asObject();
+            var credential = new Credential(vaultConfiguration.get("username").asString(), vaultConfiguration.get("password").asString());
+
+            if (credential.username().startsWith("https://")) {
+                var vaultUrl = URIBuilder.base(credential.username()).build();
+                var jbsVault = new JbsVault(vaultUrl, credential.password(), issueProject.webUrl());
+                builder.vault(jbsVault);
+            } else {
+                throw new RuntimeException("basic authentication not implemented yet");
+            }
+        }
+
+        if (notifierConfiguration.contains("security")) {
+            builder.securityLevel(notifierConfiguration.get("security").asString());
         }
 
         if (notifierConfiguration.contains("pronly")) {

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/JbsBackport.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/JbsBackport.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.notify.issue;
+
+import org.openjdk.skara.issuetracker.*;
+import org.openjdk.skara.json.JSON;
+import org.openjdk.skara.network.*;
+
+import java.net.URI;
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class JbsBackport {
+    private final String securityLevel;
+    private final RestRequest backportRequest;
+
+    private static URI backportRequest(URI uri) {
+        return URIBuilder.base(uri)
+                         .setPath("/rest/jbs/1.0/backport/")
+                         .build();
+    }
+
+    JbsBackport(URI uri, JbsVault vault, String securityLevel) {
+        this.securityLevel = securityLevel;
+        if (vault != null) {
+            backportRequest = new RestRequest(backportRequest(uri), vault.authId(), () -> Arrays.asList("Cookie", vault.getCookie()));
+        } else {
+            backportRequest = null;
+        }
+    }
+
+    private Issue createBackportIssue(Issue primary) {
+        var finalProperties = new HashMap<>(primary.properties());
+        finalProperties.put("issuetype", JSON.of("Backport"));
+
+        var backport = primary.project().createIssue(primary.title(), primary.body().lines().collect(Collectors.toList()), finalProperties);
+
+        var backportLink = Link.create(backport, "backported by").build();
+        primary.addLink(backportLink);
+        return backport;
+    }
+
+    public Issue createBackport(Issue primary, String fixVersion, String assignee) {
+        if (backportRequest == null) {
+            if (primary.project().webUrl().toString().contains("openjdk.java.net")) {
+                throw new RuntimeException("Backports on JBS require vault authentication");
+            } else {
+                return createBackportIssue(primary);
+            }
+        }
+
+        var request = backportRequest.post()
+                                     .body("parentIssueKey", primary.id())
+                                     .body("fixVersion", fixVersion);
+        if (assignee != null) {
+            request.body("assignee", assignee);
+        }
+        if (securityLevel != null) {
+            request.body("level", securityLevel);
+        }
+        var response = request.execute();
+        return primary.project().issue(response.get("key").asString()).orElseThrow();
+    }
+}

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/JbsBackport.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/JbsBackport.java
@@ -79,6 +79,13 @@ public class JbsBackport {
             request.body("level", securityLevel);
         }
         var response = request.execute();
-        return primary.project().issue(response.get("key").asString()).orElseThrow();
+        var issue = primary.project().issue(response.get("key").asString()).orElseThrow();
+
+        // The backport should not have any labels set - if it does, clear them
+        var labels = issue.labels();
+        for (var label : labels) {
+            issue.removeLabel(label);
+        }
+        return issue;
     }
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/JbsVault.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/JbsVault.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.notify.issue;
+
+import org.openjdk.skara.json.JSON;
+import org.openjdk.skara.network.*;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.security.*;
+import java.util.*;
+import java.util.logging.Logger;
+
+public class JbsVault {
+    private final RestRequest request;
+    private final String authId;
+    private final URI authProbe;
+    private static final Logger log = Logger.getLogger("org.openjdk.skara.bots.notify");
+
+    private String cookie;
+
+    private String checksum(String body) {
+        try {
+            var digest = MessageDigest.getInstance("SHA-256");
+            digest.update(body.getBytes(StandardCharsets.UTF_8));
+            return Base64.getUrlEncoder().encodeToString(digest.digest());
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("Cannot find SHA-256");
+        }
+    }
+
+    JbsVault(URI vaultUri, String vaultToken, URI jiraUri) {
+        authId = checksum(vaultToken);
+        request = new RestRequest(vaultUri, authId, () -> Arrays.asList(
+                "X-Vault-Token", vaultToken
+        ));
+        this.authProbe = URIBuilder.base(jiraUri).setPath("/rest/api/2/myself").build();
+    }
+
+    String getCookie() {
+        if (cookie != null) {
+            var authProbeRequest = new RestRequest(authProbe, authId, () -> Arrays.asList("Cookie", cookie));
+            var res = authProbeRequest.get()
+                                      .onError(error -> error.statusCode() >= 400 ? Optional.of(JSON.of("AUTH_ERROR")) : Optional.empty())
+                                      .execute();
+            if (res.isObject() && !res.contains("AUTH_ERROR")) {
+                return cookie;
+            }
+        }
+
+        // Renewal time
+        var result = request.get("").execute();
+        cookie = result.get("data").get("cookie.name").asString() + "=" + result.get("data").get("cookie.value").asString();
+        log.info("Renewed Jira token (" + cookie + ")");
+        return cookie;
+    }
+
+    String authId() {
+        return authId;
+    }
+}

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
@@ -834,7 +834,9 @@ public class IssueNotifierTests {
             // Create an issue and commit a fix
             var issue = issueProject.createIssue("This is an issue", List.of("Indeed"),
                                                  Map.of("issuetype", JSON.of("Enhancement"),
-                                                        "customfield_10008", JSON.of("java.io"),
+                                                        "customfield_10008", JSON.object()
+                                                                                 .put("id", 244)
+                                                                                 .put("name", "java.io"),
                                                         "customfield_10005", JSON.array()
                                                                                  .add(JSON.object()
                                                                                           .put("id", "17010")
@@ -870,7 +872,8 @@ public class IssueNotifierTests {
 
             // Custom properties should also propagate
             assertEquals("1", backport.properties().get("priority").asString());
-            assertEquals("java.io", backport.properties().get("customfield_10008").asString());
+            assertEquals(244, backport.properties().get("customfield_10008").get("id").asInt());
+            assertEquals("java.io", backport.properties().get("customfield_10008").get("name").asString());
             assertEquals(2, backport.properties().get("customfield_10005").asArray().size());
         }
     }

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
@@ -834,19 +834,12 @@ public class IssueNotifierTests {
             // Create an issue and commit a fix
             var issue = issueProject.createIssue("This is an issue", List.of("Indeed"),
                                                  Map.of("issuetype", JSON.of("Enhancement"),
-                                                        "customfield_10008", JSON.object()
-                                                                                 .put("id", 244)
-                                                                                 .put("name", "java.io"),
-                                                        "customfield_10005", JSON.array()
-                                                                                 .add(JSON.object()
-                                                                                          .put("id", "17010")
-                                                                                          .put("value", "generic"))
-                                                                                 .add(JSON.object()
-                                                                                          .put("id", "17019")
-                                                                                          .put("value", "other"))
+                                                        "customfield_10008", JSON.of("java.io")
                                                  ));
             issue.setProperty("fixVersions", JSON.array().add("13.0.1"));
             issue.setProperty("priority", JSON.of("1"));
+            issue.addLabel("test");
+            issue.addLabel("temporary");
 
             var authorEmailAddress = issueProject.issueTracker().currentUser().username() + "@openjdk.org";
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", issue.id() + ": Fix that issue", "Duke", authorEmailAddress);
@@ -872,9 +865,10 @@ public class IssueNotifierTests {
 
             // Custom properties should also propagate
             assertEquals("1", backport.properties().get("priority").asString());
-            assertEquals(244, backport.properties().get("customfield_10008").get("id").asInt());
-            assertEquals("java.io", backport.properties().get("customfield_10008").get("name").asString());
-            assertEquals(2, backport.properties().get("customfield_10005").asArray().size());
+            assertEquals("java.io", backport.properties().get("customfield_10008").asString());
+
+            // Labels should not
+            assertEquals(0, backport.labels().size());
         }
     }
 

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraProject.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraProject.java
@@ -353,14 +353,8 @@ public class JiraProject implements IssueProject {
                                                                                        finalProperties,
                                                                                        null)));
         query.put("fields", fields);
-        if (properties.containsKey("security")) {
-            if (!properties.get("security").isNull()) {
-                fields.put("security", properties.get("security"));
-            }
-        } else {
-            jiraHost.securityLevel().ifPresent(securityLevel -> fields.put("security", JSON.object()
-                                                                                           .put("id", securityLevel)));
-        }
+        jiraHost.securityLevel().ifPresent(securityLevel -> fields.put("security", JSON.object()
+                                                                                       .put("id", securityLevel)));
         var data = request.post("issue")
                           .body(query)
                           .execute();


### PR DESCRIPTION
If the backport creation endpoint does not clear the labels, we can do it manually.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/965/head:pull/965`
`$ git checkout pull/965`
