### PR TITLE
839: GitHub actions test results not always added to a PR

### DIFF
--- a/bots/testinfo/src/test/java/org/openjdk/skara/bots/testinfo/TestInfoTests.java
+++ b/bots/testinfo/src/test/java/org/openjdk/skara/bots/testinfo/TestInfoTests.java
@@ -71,4 +71,63 @@ public class TestInfoTests {
             assertEquals(CheckStatus.IN_PROGRESS, pr.checks(editHash).get("Pre-submit tests - ps4 - Build / test").status());
         }
     }
+
+    @Test
+    void update(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var reviewer = credentials.getHostedRepository();
+            var issues = credentials.getIssueProject();
+
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addAuthor(author.forge().currentUser().id())
+                                           .addReviewer(reviewer.forge().currentUser().id());
+            var checkBot = new TestInfoBot(author);
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(), Path.of("appendable.txt"),
+                                                     Set.of("issues"), null);
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Make a draft PR where we can add some checks
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.url(), "preedit", true);
+            var draftPr1 = credentials.createPullRequest(author, "master", "preedit", "This is a pull request", true);
+            var check1 = CheckBuilder.create("ps1", editHash).title("PS1");
+            draftPr1.createCheck(check1.build());
+            draftPr1.updateCheck(check1.complete(true).build());
+
+            // Now make an actual PR
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
+
+            // Check the status
+            TestBotRunner.runPeriodicItems(checkBot);
+
+            // Verify summarized checks
+            assertEquals(1, pr.checks(pr.headHash()).size());
+            assertEquals("1/1 passed", pr.checks(pr.headHash()).get("Pre-submit tests - ps1 - Build / test").title().orElseThrow());
+
+            // And a second one
+            var editHash2 = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash2, author.url(), "preedit");
+            var draftPr2 = credentials.createPullRequest(author, "master", "preedit", "This is a pull request", true);
+            var check2 = CheckBuilder.create("ps2", editHash2).title("PS2");
+            draftPr2.createCheck(check2.build());
+            draftPr2.updateCheck(check2.complete(false).build());
+
+            // Push an update to the PR
+            localRepo.push(editHash2, author.url(), "edit", true);
+
+            // Check the status
+            TestBotRunner.runPeriodicItems(checkBot);
+
+            // Verify summarized checks again
+            var updatedPr = pr.repository().pullRequest(pr.id());
+            assertEquals(1, updatedPr.checks(updatedPr.headHash()).size());
+            assertEquals("1/1 failed", updatedPr.checks(updatedPr.headHash()).get("Pre-submit tests - ps2 - Build / test").title().orElseThrow());
+        }
+    }
 }


### PR DESCRIPTION
The test info propagator did not take changes to a PR's head hash into account.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-839](https://bugs.openjdk.java.net/browse/SKARA-839): GitHub actions test results not always added to a PR


### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/967/head:pull/967`
`$ git checkout pull/967`
