### PR TITLE
build: update to Gradle 6.7.1

### DIFF
--- a/deps.env
+++ b/deps.env
@@ -7,5 +7,5 @@ JDK_MACOS_X64_SHA256="386a96eeef63bf94b450809d69ceaa1c9e32a97230e0a120c1b41786b7
 JDK_WINDOWS_X64_URL="https://download.java.net/java/GA/jdk14.0.2/205943a0976c4ed48cb16f1043c5c647/12/GPL/openjdk-14.0.2_windows-x64_bin.zip"
 JDK_WINDOWS_X64_SHA256="20600c0bda9d1db9d20dbe1ab656a5f9175ffb990ef3df6af5d994673e4d8ff9"
 
-GRADLE_URL="https://services.gradle.org/distributions/gradle-6.6-bin.zip"
-GRADLE_SHA256="e6f83508f0970452f56197f610d13c5f593baaf43c0e3c6a571e5967be754025"
+GRADLE_URL="https://services.gradle.org/distributions/gradle-6.7.1-bin.zip"
+GRADLE_SHA256="3239b5ed86c3838a37d983ac100573f64c1f3fd8e1eb6c89fa5f9529b5ec091d"


### PR DESCRIPTION
Hi all,

please review this patch that updates the Gradle version used to build Skara to 6.7.1.

Testing:
- [x] `make`
- [x] `make images`
- [x] `make test`

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/968/head:pull/968`
`$ git checkout pull/968`
