### PR TITLE
build: update to JDK 15.0.1

### DIFF
--- a/bots/cli/build.gradle
+++ b/bots/cli/build.gradle
@@ -93,8 +93,8 @@ images {
         options = ["--module-path", "plugins"]
         bundles = ['zip', 'tar.gz']
         jdk {
-            url = 'https://download.java.net/java/GA/jdk14.0.1/664493ef4a6946b186ff29eb326336a2/7/GPL/openjdk-14.0.1_linux-x64_bin.tar.gz'
-            sha256 = '22ce248e0bd69f23028625bede9d1b3080935b68d011eaaf9e241f84d6b9c4cc'
+            url = 'https://download.java.net/java/GA/jdk15.0.1/51f4f36ad4ef43e39d0dfdbaf6549e32/9/GPL/openjdk-15.0.1_linux-x64_bin.tar.gz'
+            sha256 = '83ec3a7b1649a6b31e021cde1e58ab447b07fb8173489f27f427e731c89ed84a'
         }
     }
 }

--- a/buildSrc/images/src/main/java/org/openjdk/skara/gradle/images/DownloadJDKTask.java
+++ b/buildSrc/images/src/main/java/org/openjdk/skara/gradle/images/DownloadJDKTask.java
@@ -79,7 +79,7 @@ public class DownloadJDKTask extends DefaultTask {
                     digest.update(bytes, 0, read);
                 }
             }
-            return new BigInteger(1, digest.digest()).toString(16);
+            return String.format("%064x", new BigInteger(1, digest.digest()));
         } catch (NoSuchAlgorithmException e) {
             throw new GradleException("this JRE does not support SHA-256");
         }

--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -79,8 +79,8 @@ images {
         launchers = ext.launchers
         bundles = ['zip', 'tar.gz']
         jdk {
-            url = 'https://download.java.net/java/GA/jdk14.0.1/664493ef4a6946b186ff29eb326336a2/7/GPL/openjdk-14.0.1_windows-x64_bin.zip'
-            sha256 = '26255f3f2fe7168ec0dce9d9f3825649c18540ba86279a7506c7f17dd3e537f9'
+            url = 'https://download.java.net/java/GA/jdk15.0.1/51f4f36ad4ef43e39d0dfdbaf6549e32/9/GPL/openjdk-15.0.1_windows-x64_bin.zip'
+            sha256 = '0a27c733fc7ceaaae3856a9c03f5e2304af30a32de6b454b8762ec02447c5464'
         }
     }
 
@@ -90,8 +90,8 @@ images {
         man = 'cli/resources/man'
         bundles = ['zip', 'tar.gz']
         jdk {
-            url = 'https://download.java.net/java/GA/jdk14.0.1/664493ef4a6946b186ff29eb326336a2/7/GPL/openjdk-14.0.1_linux-x64_bin.tar.gz'
-            sha256 = '22ce248e0bd69f23028625bede9d1b3080935b68d011eaaf9e241f84d6b9c4cc'
+            url = 'https://download.java.net/java/GA/jdk15.0.1/51f4f36ad4ef43e39d0dfdbaf6549e32/9/GPL/openjdk-15.0.1_linux-x64_bin.tar.gz'
+            sha256 = '83ec3a7b1649a6b31e021cde1e58ab447b07fb8173489f27f427e731c89ed84a'
         }
     }
 
@@ -101,8 +101,8 @@ images {
         man = 'cli/resources/man'
         bundles = ['zip', 'tar.gz']
         jdk {
-            url = 'https://download.java.net/java/GA/jdk14.0.1/664493ef4a6946b186ff29eb326336a2/7/GPL/openjdk-14.0.1_osx-x64_bin.tar.gz'
-            sha256 = 'd8aa6806e6cc99724395563bf02fc6907a7c801f4caef85b96ad44927193da07'
+            url = 'https://download.java.net/java/GA/jdk15.0.1/51f4f36ad4ef43e39d0dfdbaf6549e32/9/GPL/openjdk-15.0.1_osx-x64_bin.tar.gz'
+            sha256 = 'e1d4868fb082d9202261c5a05251eded56fb805da2d641a65f604988b00b1979'
         }
     }
 

--- a/deps.env
+++ b/deps.env
@@ -1,11 +1,11 @@
-JDK_LINUX_X64_URL="https://download.java.net/java/GA/jdk14.0.2/205943a0976c4ed48cb16f1043c5c647/12/GPL/openjdk-14.0.2_linux-x64_bin.tar.gz"
-JDK_LINUX_X64_SHA256="91310200f072045dc6cef2c8c23e7e6387b37c46e9de49623ce0fa461a24623d"
+JDK_LINUX_X64_URL="https://download.java.net/java/GA/jdk15.0.1/51f4f36ad4ef43e39d0dfdbaf6549e32/9/GPL/openjdk-15.0.1_linux-x64_bin.tar.gz"
+JDK_LINUX_X64_SHA256="83ec3a7b1649a6b31e021cde1e58ab447b07fb8173489f27f427e731c89ed84a"
 
-JDK_MACOS_X64_URL="https://download.java.net/java/GA/jdk14.0.2/205943a0976c4ed48cb16f1043c5c647/12/GPL/openjdk-14.0.2_osx-x64_bin.tar.gz"
-JDK_MACOS_X64_SHA256="386a96eeef63bf94b450809d69ceaa1c9e32a97230e0a120c1b41786b743ae84"
+JDK_MACOS_X64_URL="https://download.java.net/java/GA/jdk15.0.1/51f4f36ad4ef43e39d0dfdbaf6549e32/9/GPL/openjdk-15.0.1_osx-x64_bin.tar.gz"
+JDK_MACOS_X64_SHA256="e1d4868fb082d9202261c5a05251eded56fb805da2d641a65f604988b00b1979"
 
-JDK_WINDOWS_X64_URL="https://download.java.net/java/GA/jdk14.0.2/205943a0976c4ed48cb16f1043c5c647/12/GPL/openjdk-14.0.2_windows-x64_bin.zip"
-JDK_WINDOWS_X64_SHA256="20600c0bda9d1db9d20dbe1ab656a5f9175ffb990ef3df6af5d994673e4d8ff9"
+JDK_WINDOWS_X64_URL="https://download.java.net/java/GA/jdk15.0.1/51f4f36ad4ef43e39d0dfdbaf6549e32/9/GPL/openjdk-15.0.1_windows-x64_bin.zip"
+JDK_WINDOWS_X64_SHA256="0a27c733fc7ceaaae3856a9c03f5e2304af30a32de6b454b8762ec02447c5464"
 
 GRADLE_URL="https://services.gradle.org/distributions/gradle-6.7.1-bin.zip"
 GRADLE_SHA256="3239b5ed86c3838a37d983ac100573f64c1f3fd8e1eb6c89fa5f9529b5ec091d"

--- a/email/src/main/java/org/openjdk/skara/email/Email.java
+++ b/email/src/main/java/org/openjdk/skara/email/Email.java
@@ -40,7 +40,7 @@ public class Email {
     private final Map<String, String> headers;
 
     private final static Pattern mboxMessageHeaderBodyPattern = Pattern.compile(
-            "\\R{2}", Pattern.MULTILINE);
+            "(\\r\\n){2}|(\\n){2}", Pattern.MULTILINE);
     private final static Pattern mboxMessageHeaderPattern = Pattern.compile(
             "^([-\\w]+): ((?:.(?!\\R\\w))*.)", Pattern.MULTILINE | Pattern.DOTALL);
 


### PR DESCRIPTION
Hi all,

please review this patch that updates the JDK used for building Skara to 15.0.1.

Testing:
- [x] `make images`
- [x] `make test`

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/969/head:pull/969`
`$ git checkout pull/969`
