### PR TITLE
Allow '+' to be in branch names in merge PR titles

### DIFF
--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
@@ -39,6 +39,7 @@ import java.util.stream.Collectors;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.openjdk.skara.bots.pr.PullRequestAsserts.assertLastCommentContains;
+import static org.openjdk.skara.forge.CheckStatus.SUCCESS;
 
 class MergeTests {
     @Test
@@ -1082,7 +1083,54 @@ class MergeTests {
             assertEquals(1, error, () -> pr.comments().stream().map(Comment::body).collect(Collectors.joining("\n\n")));
 
             var check = pr.checks(mergeHash).get("jcheck");
-            assertEquals("- Could not determine the source for this merge. A Merge PR title must be specified on the format: Merge `project`:`branch` to allow verification of the merge contents.", check.summary().orElseThrow());
+            assertEquals("- Could not determine the source for this merge. A Merge PR title must be specified on the format: `^Merge ([-/\\w:+]+)$` to allow verification of the merge contents.", check.summary().orElseThrow());
+        }
+    }
+
+    @Test
+    void branchWithPlus(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+
+            var author = credentials.getHostedRepository();
+            var integrator = credentials.getHostedRepository();
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addCommitter(author.forge().currentUser().id())
+                                           .addReviewer(integrator.forge().currentUser().id());
+            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
+
+            // Populate the projects repository
+            var localRepoFolder = tempFolder.path().resolve("localrepo");
+            var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType(), Path.of("appendable.txt"), Set.of("merge"), "1.0");
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Make a change in another branch
+            var otherHash = CheckableRepository.appendAndCommit(localRepo, "Change in other",
+                                                                "Other\n\nReviewed-by: integrationreviewer2");
+            localRepo.push(otherHash, author.url(), "other", true);
+
+            // Go back to the original master
+            localRepo.checkout(masterHash, true);
+
+            // Make a change with a corresponding PR
+            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated", StandardCharsets.UTF_8);
+            localRepo.add(unrelated);
+            var updatedMaster = localRepo.commit("Unrelated", "some", "some@one");
+            localRepo.push(updatedMaster, author.url(), "master");
+
+            localRepo.merge(otherHash);
+            var mergeHash = localRepo.commit("Merge commit", "some", "some@one");
+            localRepo.push(mergeHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "Merge branch-a+b");
+
+            // Let the bot check the status
+            TestBotRunner.runPeriodicItems(mergeBot);
+
+            // should be successful
+            var check = pr.checks(mergeHash).get("jcheck");
+            assertSame(SUCCESS, check.status());
         }
     }
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
@@ -1083,7 +1083,7 @@ class MergeTests {
             assertEquals(1, error, () -> pr.comments().stream().map(Comment::body).collect(Collectors.joining("\n\n")));
 
             var check = pr.checks(mergeHash).get("jcheck");
-            assertEquals("- Could not determine the source for this merge. A Merge PR title must be specified of the format: `^Merge ([-/\\w:+]+)$` to allow verification of the merge contents.", check.summary().orElseThrow());
+            assertEquals("- Could not determine the source for this merge. A Merge PR title must be specified in the format: `^Merge ([-/\\w:+]+)$` to allow verification of the merge contents.", check.summary().orElseThrow());
         }
     }
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
@@ -1109,7 +1109,7 @@ class MergeTests {
             // Make a change in another branch
             var otherHash = CheckableRepository.appendAndCommit(localRepo, "Change in other",
                                                                 "Other\n\nReviewed-by: integrationreviewer2");
-            localRepo.push(otherHash, author.url(), "other", true);
+            localRepo.push(otherHash, author.url(), "branch-a+b", true);
 
             // Go back to the original master
             localRepo.checkout(masterHash, true);

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
@@ -1083,7 +1083,7 @@ class MergeTests {
             assertEquals(1, error, () -> pr.comments().stream().map(Comment::body).collect(Collectors.joining("\n\n")));
 
             var check = pr.checks(mergeHash).get("jcheck");
-            assertEquals("- Could not determine the source for this merge. A Merge PR title must be specified on the format: `^Merge ([-/\\w:+]+)$` to allow verification of the merge contents.", check.summary().orElseThrow());
+            assertEquals("- Could not determine the source for this merge. A Merge PR title must be specified of the format: `^Merge ([-/\\w:+]+)$` to allow verification of the merge contents.", check.summary().orElseThrow());
         }
     }
 

--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequestUtils.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequestUtils.java
@@ -62,7 +62,7 @@ public class PullRequestUtils {
     private static Hash fetchMergeSource(PullRequest pr, Repository localRepo) throws IOException, CommitFailure {
         var sourceMatcher = mergeSourcePattern.matcher(pr.title());
         if (!sourceMatcher.matches()) {
-            throw new CommitFailure("Could not determine the source for this merge. A Merge PR title must be specified of the format: `" +
+            throw new CommitFailure("Could not determine the source for this merge. A Merge PR title must be specified in the format: `" +
                                             mergeSourcePattern.toString() + "` to allow verification of the merge contents.");
         }
 

--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequestUtils.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequestUtils.java
@@ -62,8 +62,8 @@ public class PullRequestUtils {
     private static Hash fetchMergeSource(PullRequest pr, Repository localRepo) throws IOException, CommitFailure {
         var sourceMatcher = mergeSourcePattern.matcher(pr.title());
         if (!sourceMatcher.matches()) {
-            throw new CommitFailure("Could not determine the source for this merge. A Merge PR title must be specified on the format: " +
-                                            "Merge `project`:`branch` to allow verification of the merge contents.");
+            throw new CommitFailure("Could not determine the source for this merge. A Merge PR title must be specified on the format: `" +
+                                            mergeSourcePattern.toString() + "` to allow verification of the merge contents.");
         }
 
         var source = sourceMatcher.group(1);

--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequestUtils.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequestUtils.java
@@ -39,7 +39,7 @@ public class PullRequestUtils {
                                 committer.name(), committer.email(), ZonedDateTime.now(), List.of(targetHash(pr, localRepo)), localRepo.tree(finalHead));
     }
 
-    private final static Pattern mergeSourcePattern = Pattern.compile("^Merge ([-/\\w:]+)$");
+    private final static Pattern mergeSourcePattern = Pattern.compile("^Merge ([-/\\w:+]+)$");
 
     private static Optional<Hash> fetchRef(Repository localRepo, URI uri, String ref) throws IOException {
         // Just a plain name - is this a branch?

--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequestUtils.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequestUtils.java
@@ -62,7 +62,7 @@ public class PullRequestUtils {
     private static Hash fetchMergeSource(PullRequest pr, Repository localRepo) throws IOException, CommitFailure {
         var sourceMatcher = mergeSourcePattern.matcher(pr.title());
         if (!sourceMatcher.matches()) {
-            throw new CommitFailure("Could not determine the source for this merge. A Merge PR title must be specified on the format: `" +
+            throw new CommitFailure("Could not determine the source for this merge. A Merge PR title must be specified of the format: `" +
                                             mergeSourcePattern.toString() + "` to allow verification of the merge contents.");
         }
 


### PR DESCRIPTION
Allow '+' to be in branch names in merge PR titles. I've also sharpened the error message to include the exact pattern the bot checks for.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**) ⚠️ Review applies to 5ea7abcf51c4662a75f88b34ad261ea78c7c1f0f


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/970/head:pull/970`
`$ git checkout pull/970`
