### PR TITLE
The latest request may not contain the full set of headers

### DIFF
--- a/network/src/main/java/org/openjdk/skara/network/RestRequestCache.java
+++ b/network/src/main/java/org/openjdk/skara/network/RestRequestCache.java
@@ -125,7 +125,14 @@ enum RestRequestCache {
 
         @Override
         public HttpHeaders headers() {
-            return fromRequest.headers();
+            var combined = new HashMap<String, List<String>>();
+            for (var header : original.headers().map().entrySet()) {
+                combined.put(header.getKey(), header.getValue());
+            }
+            for (var header : fromRequest.headers().map().entrySet()) {
+                combined.put(header.getKey(), header.getValue());
+            }
+            return HttpHeaders.of(combined, (a, b) -> true);
         }
 
         @Override


### PR DESCRIPTION
When returning a cached result as a response to a 304, use the combined set of headers.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/972/head:pull/972`
`$ git checkout pull/972`
