### PR TITLE
pr: show diff of diffs for backports

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
@@ -91,25 +91,56 @@ public interface Repository extends ReadOnlyRepository {
     default void config(String section, String key, String value) throws IOException {
         config(section, key, value, false);
     }
-    Hash commit(String message,
+    default Hash commit(String message,
                 String authorName,
-                String authorEmail) throws IOException;
+                String authorEmail) throws IOException {
+        return commit(message, authorName, authorEmail, false);
+    }
     Hash commit(String message,
                 String authorName,
                 String authorEmail,
-                ZonedDateTime date) throws IOException;
+                boolean allowEmpty) throws IOException;
+    default Hash commit(String message,
+                String authorName,
+                String authorEmail,
+                ZonedDateTime date) throws IOException {
+        return commit(message, authorName, authorEmail, date, false);
+    }
+    Hash commit(String message,
+                String authorName,
+                String authorEmail,
+                ZonedDateTime date,
+                boolean allowEmpty) throws IOException;
+    default Hash commit(String message,
+                String authorName,
+                String authorEmail,
+                String committerName,
+                String committerEmail) throws IOException {
+        return commit(message, authorName, authorEmail, committerName, committerEmail, false);
+    }
     Hash commit(String message,
                 String authorName,
                 String authorEmail,
                 String committerName,
-                String committerEmail) throws IOException;
+                String committerEmail,
+                boolean allowEmpty) throws IOException;
+    default Hash commit(String message,
+                String authorName,
+                String authorEmail,
+                ZonedDateTime authorDate,
+                String committerName,
+                String committerEmail,
+                ZonedDateTime committerDate) throws IOException {
+        return commit(message, authorName, authorEmail, authorDate, committerName, committerEmail, committerDate, false);
+    }
     Hash commit(String message,
                 String authorName,
                 String authorEmail,
                 ZonedDateTime authorDate,
                 String committerName,
                 String committerEmail,
-                ZonedDateTime committerDate) throws IOException;
+                ZonedDateTime committerDate,
+                boolean allowEmpty) throws IOException;
     Hash commit(String message,
                 String authorName,
                 String authorEmail,

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -690,13 +690,13 @@ public class GitRepository implements Repository {
     }
 
     @Override
-    public Hash commit(String message, String authorName, String authorEmail)  throws IOException {
-        return commit(message, authorName, authorEmail, null);
+    public Hash commit(String message, String authorName, String authorEmail, boolean allowEmpty)  throws IOException {
+        return commit(message, authorName, authorEmail, null, allowEmpty);
     }
 
     @Override
-    public Hash commit(String message, String authorName, String authorEmail, ZonedDateTime authorDate)  throws IOException {
-        return commit(message, authorName, authorEmail, authorDate, authorName, authorEmail, authorDate);
+    public Hash commit(String message, String authorName, String authorEmail, ZonedDateTime authorDate, boolean allowEmpty)  throws IOException {
+        return commit(message, authorName, authorEmail, authorDate, authorName, authorEmail, authorDate, allowEmpty);
     }
 
     @Override
@@ -704,8 +704,9 @@ public class GitRepository implements Repository {
                        String authorName,
                        String authorEmail,
                        String committerName,
-                       String committerEmail) throws IOException {
-        return commit(message, authorName, authorEmail, null, committerName, committerEmail, null);
+                       String committerEmail,
+                       boolean allowEmpty) throws IOException {
+        return commit(message, authorName, authorEmail, null, committerName, committerEmail, null, allowEmpty);
     }
 
     @Override
@@ -715,8 +716,14 @@ public class GitRepository implements Repository {
                        ZonedDateTime authorDate,
                        String committerName,
                        String committerEmail,
-                       ZonedDateTime committerDate) throws IOException {
-        var cmd = Process.capture("git", "commit", "--message=" + message)
+                       ZonedDateTime committerDate,
+                       boolean allowEmpty) throws IOException {
+        var args = new ArrayList<String>();
+        args.addAll(List.of("git", "commit", "--message=" + message));
+        if (allowEmpty) {
+            args.add("--allow-empty");
+        }
+        var cmd = Process.capture(args.toArray(new String[0]))
                          .workdir(dir)
                          .environ("GIT_AUTHOR_NAME", authorName)
                          .environ("GIT_AUTHOR_EMAIL", authorEmail)

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -624,12 +624,12 @@ public class HgRepository implements Repository {
 
 
     @Override
-    public Hash commit(String message, String authorName, String authorEmail)  throws IOException {
+    public Hash commit(String message, String authorName, String authorEmail, boolean allowEmpty)  throws IOException {
         return commit(message, authorName, authorEmail, null);
     }
 
     @Override
-    public Hash commit(String message, String authorName, String authorEmail, ZonedDateTime authorDate)  throws IOException {
+    public Hash commit(String message, String authorName, String authorEmail, ZonedDateTime authorDate, boolean allowEmpty)  throws IOException {
         var user = authorEmail == null ? authorName : authorName + " <" + authorEmail + ">";
         var cmd = new ArrayList<String>();
         cmd.addAll(List.of("hg", "commit", "--message=" + message, "--user=" + user));
@@ -648,7 +648,8 @@ public class HgRepository implements Repository {
                        String authorName,
                        String authorEmail,
                        String committerName,
-                       String committerEmail) throws IOException {
+                       String committerEmail,
+                       boolean allowEmpty) throws IOException {
         return commit(message, authorName, authorEmail, null, committerName, committerEmail, null);
     }
 
@@ -659,7 +660,8 @@ public class HgRepository implements Repository {
                        ZonedDateTime authorDate,
                        String committerName,
                        String committerEmail,
-                       ZonedDateTime committerDate) throws IOException {
+                       ZonedDateTime committerDate,
+                       boolean allowEmpty) throws IOException {
         if (!Objects.equals(authorName, committerName) ||
             !Objects.equals(authorEmail, committerEmail) ||
             !Objects.equals(authorDate, committerDate)) {

--- a/vcs/src/test/java/org/openjdk/skara/vcs/DiffComparatorTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/DiffComparatorTests.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.vcs;
+
+import org.openjdk.skara.test.TemporaryDirectory;
+
+import java.io.*;
+import java.nio.file.*;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class DiffComparatorTests {
+    @Test
+    void simpleAdd() throws IOException {
+        var ft = FileType.fromOctal("100644");
+        var path = Path.of("README");
+        var hash = Hash.zero();
+        var status = Status.from('A');
+
+        var aHunks = new ArrayList<Hunk>();
+        aHunks.add(new Hunk(new Range(0, 0), List.of(),
+                            new Range(0, 1), List.of("Hello, world")));
+        var aPatches = new ArrayList<Patch>();
+        aPatches.add(new TextualPatch(path, ft, hash,
+                                      path, ft, hash,
+                                      status, aHunks));
+        var aDiff = new Diff(hash, hash, aPatches);
+
+        var bHunks = new ArrayList<Hunk>();
+        bHunks.add(new Hunk(new Range(0, 0), List.of(),
+                            new Range(0, 2), List.of("Hello, world", "Hello again!")));
+        var bPatches = new ArrayList<Patch>();
+        bPatches.add(new TextualPatch(path, ft, hash,
+                                      path, ft, hash,
+                                      status, bHunks));
+        var bDiff = new Diff(hash, hash, bPatches);
+
+        var diffDiff = DiffComparator.diff(aDiff, bDiff);
+        var diffDiffPatches = diffDiff.patches();
+        assertEquals(1, diffDiffPatches.size());
+        assertTrue(diffDiffPatches.get(0).isTextual());
+
+        var diffDiffPatch = diffDiffPatches.get(0).asTextualPatch();
+        assertTrue(diffDiffPatch.status().isModified());
+        assertEquals(Optional.of(path), diffDiffPatch.source().path());
+        assertEquals(Optional.of(path), diffDiffPatch.target().path());
+
+        var diffDiffHunks = diffDiffPatch.hunks();
+        assertEquals(1, diffDiffHunks.size());
+        var diffDiffHunk = diffDiffHunks.get(0);
+        assertEquals(List.of(), diffDiffHunk.source().lines());
+        assertEquals(List.of("Hello again!"), diffDiffHunk.target().lines());
+        assertEquals(new Range(2, 0), diffDiffHunk.source().range());
+        assertEquals(new Range(2, 1), diffDiffHunk.target().range());
+    }
+
+    @Test
+    void simpleRemoval() throws IOException {
+        var ft = FileType.fromOctal("100644");
+        var path = Path.of("README");
+        var hash = Hash.zero();
+        var status = Status.from('A');
+
+        var aHunks = new ArrayList<Hunk>();
+        aHunks.add(new Hunk(new Range(0, 0), List.of(),
+                            new Range(0, 1), List.of("Hello, world", "Hello again!")));
+        var aPatches = new ArrayList<Patch>();
+        aPatches.add(new TextualPatch(path, ft, hash,
+                                      path, ft, hash,
+                                      status, aHunks));
+        var aDiff = new Diff(hash, hash, aPatches);
+
+        var bHunks = new ArrayList<Hunk>();
+        bHunks.add(new Hunk(new Range(0, 0), List.of(),
+                            new Range(0, 2), List.of("Hello, world")));
+        var bPatches = new ArrayList<Patch>();
+        bPatches.add(new TextualPatch(path, ft, hash,
+                                      path, ft, hash,
+                                      status, bHunks));
+        var bDiff = new Diff(hash, hash, bPatches);
+
+        var diffDiff = DiffComparator.diff(aDiff, bDiff);
+        var diffDiffPatches = diffDiff.patches();
+        assertEquals(1, diffDiffPatches.size());
+        assertTrue(diffDiffPatches.get(0).isTextual());
+
+        var diffDiffPatch = diffDiffPatches.get(0).asTextualPatch();
+        assertTrue(diffDiffPatch.status().isModified());
+        assertEquals(Optional.of(path), diffDiffPatch.source().path());
+        assertEquals(Optional.of(path), diffDiffPatch.target().path());
+
+        var diffDiffHunks = diffDiffPatch.hunks();
+        assertEquals(1, diffDiffHunks.size());
+        var diffDiffHunk = diffDiffHunks.get(0);
+        assertEquals(List.of("Hello again!"), diffDiffHunk.source().lines());
+        assertEquals(List.of(), diffDiffHunk.target().lines());
+        assertEquals(new Range(2, 1), diffDiffHunk.source().range());
+        assertEquals(new Range(2, 0), diffDiffHunk.target().range());
+    }
+
+    @Test
+    void removalOfSameFile() throws IOException {
+        var ft = FileType.fromOctal("100644");
+        var path1 = Path.of("README1");
+        var path2 = Path.of("README1");
+        var hash = Hash.zero();
+        var status = Status.from('D');
+
+        var aHunks = new ArrayList<Hunk>();
+        aHunks.add(new Hunk(new Range(1, 1), List.of("Hello world"),
+                            new Range(1, 0), List.of()));
+        var aPatches = new ArrayList<Patch>();
+        aPatches.add(new TextualPatch(path1, ft, hash,
+                                      path1, ft, hash,
+                                      status, aHunks));
+        var aDiff = new Diff(hash, hash, aPatches);
+
+        var bHunks = new ArrayList<Hunk>();
+        bHunks.add(new Hunk(new Range(1, 1), List.of("Hello world"),
+                            new Range(1, 0), List.of()));
+        var bPatches = new ArrayList<Patch>();
+        bPatches.add(new TextualPatch(path2, ft, hash,
+                                      path2, ft, hash,
+                                      status, bHunks));
+        var bDiff = new Diff(hash, hash, bPatches);
+
+        var diffDiff = DiffComparator.diff(aDiff, bDiff);
+        var diffDiffPatches = diffDiff.patches();
+        assertEquals(List.of(), diffDiffPatches);
+    }
+
+    @Test
+    void removalOfDifferentFile() throws IOException {
+        var ft = FileType.fromOctal("100644");
+        var path1 = Path.of("README1");
+        var path2 = Path.of("README2");
+        var hash = Hash.zero();
+        var status = Status.from('D');
+
+        var aHunks = new ArrayList<Hunk>();
+        aHunks.add(new Hunk(new Range(1, 1), List.of("Hello world"),
+                            new Range(1, 0), List.of()));
+        var aPatches = new ArrayList<Patch>();
+        aPatches.add(new TextualPatch(path1, ft, hash,
+                                      path1, ft, hash,
+                                      status, aHunks));
+        var aDiff = new Diff(hash, hash, aPatches);
+
+        var bHunks = new ArrayList<Hunk>();
+        bHunks.add(new Hunk(new Range(1, 1), List.of("Hello world"),
+                            new Range(1, 0), List.of()));
+        var bPatches = new ArrayList<Patch>();
+        bPatches.add(new TextualPatch(path2, ft, hash,
+                                      path2, ft, hash,
+                                      status, bHunks));
+        var bDiff = new Diff(hash, hash, bPatches);
+
+        var diffDiff = DiffComparator.diff(aDiff, bDiff);
+        var diffDiffPatches = diffDiff.patches();
+        assertEquals(2, diffDiffPatches.size());
+
+        var added = diffDiffPatches.get(0);
+        assertTrue(added.status().isAdded());
+        assertEquals(Optional.of(path1), added.target().path());
+
+        var deleted = diffDiffPatches.get(1);
+        assertTrue(deleted.status().isDeleted());
+        assertEquals(Optional.of(path2), deleted.source().path());
+    }
+}


### PR DESCRIPTION
Hi all,

please review this patch that shows a "diff of diffs" for backports - i.e. the backport commit will be compared to the original commit and the differences will be shown (for non-clean backports). I also added some unit tests for the new `DiffComparator` utility.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/973/head:pull/973`
`$ git checkout pull/973`
