### PR TITLE
846: Document the need to enable Github Actions on personal forks that offer testing

### DIFF
--- a/bots/testinfo/src/main/java/org/openjdk/skara/bots/testinfo/TestInfoBot.java
+++ b/bots/testinfo/src/main/java/org/openjdk/skara/bots/testinfo/TestInfoBot.java
@@ -46,7 +46,7 @@ public class TestInfoBot implements Bot {
 
     private Check testingNotConfiguredNotice(PullRequest pr) {
         var sourceRepoUrl = pr.sourceRepository().orElseThrow().nonTransformedWebUrl().toString();
-        if (sourceRepoUrl.toLowerCase().contains("github.com")) {
+        if (pr.sourceRepository().orElseThrow().forge().name().equals("GitHub")) {
             sourceRepoUrl += "/actions";
         }
 

--- a/bots/testinfo/src/main/java/org/openjdk/skara/bots/testinfo/TestInfoBot.java
+++ b/bots/testinfo/src/main/java/org/openjdk/skara/bots/testinfo/TestInfoBot.java
@@ -44,6 +44,30 @@ public class TestInfoBot implements Bot {
         return pr.id() + "#" + pr.headHash().hex();
     }
 
+    private Check testingNotConfiguredNotice(PullRequest pr) {
+        var sourceRepoUrl = pr.sourceRepository().orElseThrow().nonTransformedWebUrl().toString();
+        if (sourceRepoUrl.toLowerCase().contains("github.com")) {
+            sourceRepoUrl += "/actions";
+        }
+
+        return CheckBuilder.create("Pre-submit test status", pr.headHash())
+                           .skipped()
+                           .title("Testing is not configured")
+                           .summary("In order to run pre-submit tests, the [source repository](" +
+                                            sourceRepoUrl + ")" +
+                                            " must be properly configured to allow test execution. " +
+                                            "See https://wiki.openjdk.java.net/display/SKARA/Testing for more information on how to configure this.")
+                           .build();
+    }
+
+    private Check testingEnabledNotice(PullRequest pr) {
+        return CheckBuilder.create("Pre-submit test status", pr.headHash())
+                           .complete(true)
+                           .title("Tests are now enabled")
+                           .summary("Pre-submit tests have been now been enabled for the source repository")
+                           .build();
+    }
+
     @Override
     public List<WorkItem> getPeriodicItems() {
         var prs = repo.pullRequests(ZonedDateTime.now().minus(Duration.ofDays(1)));
@@ -63,18 +87,35 @@ public class TestInfoBot implements Bot {
 
             var sourceRepo = pr.sourceRepository().get();
             var checks = sourceRepo.allChecks(pr.headHash());
-            var summarizedChecks = TestResults.summarize(checks);
+            var noticeCheck = checks.stream()
+                                    .filter(check -> check.name().equals("Pre-submit test status"))
+                                    .findAny();
 
-            if (summarizedChecks.isEmpty()) {
-                // No test related checks found, they may not have started yet, so we'll keep looking
-                expirations.put(expirationKey, Instant.now().plus(Duration.ofMinutes(2)));
-                continue;
+            if (sourceRepo.workflowStatus() == WorkflowStatus.NOT_CONFIGURED) {
+                if (noticeCheck.isEmpty()) {
+                    ret.add(new TestInfoBotWorkItem(pr, List.of(testingNotConfiguredNotice(pr))));
+                }
+            } else if (sourceRepo.workflowStatus() == WorkflowStatus.DISABLED) {
+                // Explicitly disabled - could possibly post a notice
             } else {
-                expirations.put(expirationKey, Instant.now().plus(TestResults.expiresIn(checks).orElse(Duration.ofMinutes(30))));
-            }
+                var summarizedChecks = TestResults.summarize(checks);
+                if (summarizedChecks.isEmpty()) {
+                    // No test related checks found, they may not have started yet, so we'll keep looking
+                    expirations.put(expirationKey, Instant.now().plus(Duration.ofMinutes(2)));
+                    continue;
+                } else {
+                    expirations.put(expirationKey, Instant.now().plus(TestResults.expiresIn(checks).orElse(Duration.ofMinutes(30))));
+                }
 
-            // Time to refresh test info
-            ret.add(new TestInfoBotWorkItem(pr, summarizedChecks));
+                if (noticeCheck.isPresent()) {
+                    // If a disabled notice has been posted earlier, we can't delete it - just mark it completed
+                    summarizedChecks = new ArrayList<>(summarizedChecks);
+                    summarizedChecks.add(testingEnabledNotice(pr));
+                }
+
+                // Time to refresh test info
+                ret.add(new TestInfoBotWorkItem(pr, summarizedChecks));
+            }
         }
         return ret;
     }

--- a/bots/testinfo/src/test/java/org/openjdk/skara/bots/testinfo/TestInfoTests.java
+++ b/bots/testinfo/src/test/java/org/openjdk/skara/bots/testinfo/TestInfoTests.java
@@ -17,12 +17,6 @@ public class TestInfoTests {
         try (var credentials = new HostCredentials(testInfo);
              var tempFolder = new TemporaryDirectory()) {
             var author = credentials.getHostedRepository();
-            var reviewer = credentials.getHostedRepository();
-            var issues = credentials.getIssueProject();
-
-            var censusBuilder = credentials.getCensusBuilder()
-                                           .addAuthor(author.forge().currentUser().id())
-                                           .addReviewer(reviewer.forge().currentUser().id());
             var checkBot = new TestInfoBot(author);
 
             // Populate the projects repository
@@ -77,12 +71,6 @@ public class TestInfoTests {
         try (var credentials = new HostCredentials(testInfo);
              var tempFolder = new TemporaryDirectory()) {
             var author = credentials.getHostedRepository();
-            var reviewer = credentials.getHostedRepository();
-            var issues = credentials.getIssueProject();
-
-            var censusBuilder = credentials.getCensusBuilder()
-                                           .addAuthor(author.forge().currentUser().id())
-                                           .addReviewer(reviewer.forge().currentUser().id());
             var checkBot = new TestInfoBot(author);
 
             // Populate the projects repository

--- a/forge/src/main/java/org/openjdk/skara/forge/CheckBuilder.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/CheckBuilder.java
@@ -130,6 +130,18 @@ public class CheckBuilder {
         return this;
     }
 
+    public CheckBuilder skipped() {
+        status = CheckStatus.SKIPPED;
+        completedAt = ZonedDateTime.now();
+        return this;
+    }
+
+    public CheckBuilder skipped(ZonedDateTime actionRequiredAt) {
+        status = CheckStatus.SKIPPED;
+        completedAt = ZonedDateTime.now();
+        return this;
+    }
+
     public Check build() {
         return new Check(name, hash, status, startedAt, completedAt, metadata, title, summary, annotations, details);
     }

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
@@ -73,6 +73,7 @@ public interface HostedRepository {
     void updateCommitComment(String id, String body);
     Optional<HostedCommit> commit(Hash hash);
     List<Check> allChecks(Hash hash);
+    WorkflowStatus workflowStatus();
 
     default PullRequest createPullRequest(HostedRepository target,
                                           String targetRef,

--- a/forge/src/main/java/org/openjdk/skara/forge/WorkflowStatus.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/WorkflowStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,10 +22,8 @@
  */
 package org.openjdk.skara.forge;
 
-public enum CheckStatus {
-    IN_PROGRESS,
-    SUCCESS,
-    FAILURE,
-    CANCELLED,
-    SKIPPED
+public enum WorkflowStatus {
+    NOT_CONFIGURED,
+    ENABLED,
+    DISABLED,
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -402,19 +402,11 @@ public class GitHubPullRequest implements PullRequest {
                                 var conclusion = c.get("conclusion").asString();
                                 var completedAt = ZonedDateTime.parse(c.get("completed_at").asString());
                                 switch (conclusion) {
-                                    case "cancelled":
-                                        checkBuilder.cancel(completedAt);
-                                        break;
-                                    case "success":
-                                        checkBuilder.complete(true, completedAt);
-                                        break;
-                                    case "failure":
-                                        // fallthrough
-                                    case "neutral":
-                                        checkBuilder.complete(false, completedAt);
-                                        break;
-                                    default:
-                                        throw new IllegalStateException("Unexpected conclusion: " + conclusion);
+                                    case "cancelled" -> checkBuilder.cancel(completedAt);
+                                    case "success" -> checkBuilder.complete(true, completedAt);
+                                    case "action_required", "failure", "neutral" -> checkBuilder.complete(false, completedAt);
+                                    case "skipped" -> checkBuilder.skipped(completedAt);
+                                    default -> throw new IllegalStateException("Unexpected conclusion: " + conclusion);
                                 }
                             }
                             if (c.contains("external_id")) {

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -488,4 +488,13 @@ public class GitLabRepository implements HostedRepository {
     public List<Check> allChecks(Hash hash) {
         return List.of();
     }
+
+    @Override
+    public WorkflowStatus workflowStatus() {
+        if (json.contains("jobs_enabled")) {
+            return json.get("jobs_enabled").asBoolean() ? WorkflowStatus.ENABLED : WorkflowStatus.DISABLED;
+        } else {
+            return WorkflowStatus.DISABLED;
+        }
+    }
 }

--- a/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
@@ -263,6 +263,11 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
                    .collect(Collectors.toList());
     }
 
+    @Override
+    public WorkflowStatus workflowStatus() {
+        return WorkflowStatus.ENABLED;
+    }
+
     Repository localRepository() {
         return localRepository;
     }


### PR DESCRIPTION
Forks created after pre-submit testing using GitHub actions was introduced need to explicitly allow GitHub actions. Post a notice as a separate check result if we detect this condition.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-846](https://bugs.openjdk.java.net/browse/SKARA-846): Document the need to enable Github Actions on personal forks that offer testing


### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**) ⚠️ Review applies to e9734bd25f714e521baa11632403eda96a2d82ee


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/974/head:pull/974`
`$ git checkout pull/974`
