### PR TITLE
git-pr-create: allow --cc for all jdk[0-9]* repos

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrCreate.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrCreate.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.nio.file.*;
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.regex.Pattern;
 
 import static org.openjdk.skara.cli.pr.Utils.*;
 
@@ -305,7 +306,7 @@ public class GitPrCreate {
 
         var mailingLists = new ArrayList<String>();
         var parentProject = projectName(parentRepo.url());
-        var isTargetingJDKRepo = parentProject.endsWith("jdk");
+        var isTargetingJDKRepo = parentProject.matches(".*\\/jdk[0-9]*");
         var cc = getOption("cc", "create", arguments);
         var isCCManual = cc != null && !cc.equals("auto");
         if (!isTargetingJDKRepo && isCCManual) {


### PR DESCRIPTION
Hi all,

please review this small patch that makes the `--cc` flag for `git pr create` work for jdk release repositories like [jdk16](https://github.com/openjdk/jdk16).

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/975/head:pull/975`
`$ git checkout pull/975`
