### PR TITLE
Avoid updating unchanged checks

### DIFF
--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
@@ -176,6 +176,11 @@ class InMemoryHostedRepository implements HostedRepository {
     }
 
     @Override
+    public WorkflowStatus workflowStatus() {
+        return WorkflowStatus.DISABLED;
+    }
+
+    @Override
     public List<CommitComment> recentCommitComments() {
         return List.of();
     }

--- a/bots/testinfo/src/main/java/org/openjdk/skara/bots/testinfo/TestInfoBot.java
+++ b/bots/testinfo/src/main/java/org/openjdk/skara/bots/testinfo/TestInfoBot.java
@@ -28,11 +28,12 @@ import org.openjdk.skara.forge.*;
 
 import java.time.*;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Logger;
 
 public class TestInfoBot implements Bot {
     private final HostedRepository repo;
-    private final Map<String, Instant> expirations = new HashMap<>();
+    private final Map<String, Instant> expirations = new ConcurrentHashMap<>();
 
     private static final Logger log = Logger.getLogger("org.openjdk.skara.bots");
 
@@ -44,30 +45,6 @@ public class TestInfoBot implements Bot {
         return pr.id() + "#" + pr.headHash().hex();
     }
 
-    private Check testingNotConfiguredNotice(PullRequest pr) {
-        var sourceRepoUrl = pr.sourceRepository().orElseThrow().nonTransformedWebUrl().toString();
-        if (pr.sourceRepository().orElseThrow().forge().name().equals("GitHub")) {
-            sourceRepoUrl += "/actions";
-        }
-
-        return CheckBuilder.create("Pre-submit test status", pr.headHash())
-                           .skipped()
-                           .title("Testing is not configured")
-                           .summary("In order to run pre-submit tests, the [source repository](" +
-                                            sourceRepoUrl + ")" +
-                                            " must be properly configured to allow test execution. " +
-                                            "See https://wiki.openjdk.java.net/display/SKARA/Testing for more information on how to configure this.")
-                           .build();
-    }
-
-    private Check testingEnabledNotice(PullRequest pr) {
-        return CheckBuilder.create("Pre-submit test status", pr.headHash())
-                           .complete(true)
-                           .title("Tests are now enabled")
-                           .summary("Pre-submit tests have been now been enabled for the source repository")
-                           .build();
-    }
-
     @Override
     public List<WorkItem> getPeriodicItems() {
         var prs = repo.pullRequests(ZonedDateTime.now().minus(Duration.ofDays(1)));
@@ -76,8 +53,8 @@ public class TestInfoBot implements Bot {
             if (pr.sourceRepository().isEmpty()) {
                 continue;
             }
-            var expirationKey = pullRequestToKey(pr);
 
+            var expirationKey = pullRequestToKey(pr);
             if (expirations.containsKey(expirationKey)) {
                 var expiresAt = expirations.get(expirationKey);
                 if (expiresAt.isAfter(Instant.now())) {
@@ -85,37 +62,7 @@ public class TestInfoBot implements Bot {
                 }
             }
 
-            var sourceRepo = pr.sourceRepository().get();
-            var checks = sourceRepo.allChecks(pr.headHash());
-            var noticeCheck = checks.stream()
-                                    .filter(check -> check.name().equals("Pre-submit test status"))
-                                    .findAny();
-
-            if (sourceRepo.workflowStatus() == WorkflowStatus.NOT_CONFIGURED) {
-                if (noticeCheck.isEmpty()) {
-                    ret.add(new TestInfoBotWorkItem(pr, List.of(testingNotConfiguredNotice(pr))));
-                }
-            } else if (sourceRepo.workflowStatus() == WorkflowStatus.DISABLED) {
-                // Explicitly disabled - could possibly post a notice
-            } else {
-                var summarizedChecks = TestResults.summarize(checks);
-                if (summarizedChecks.isEmpty()) {
-                    // No test related checks found, they may not have started yet, so we'll keep looking
-                    expirations.put(expirationKey, Instant.now().plus(Duration.ofMinutes(2)));
-                    continue;
-                } else {
-                    expirations.put(expirationKey, Instant.now().plus(TestResults.expiresIn(checks).orElse(Duration.ofMinutes(30))));
-                }
-
-                if (noticeCheck.isPresent()) {
-                    // If a disabled notice has been posted earlier, we can't delete it - just mark it completed
-                    summarizedChecks = new ArrayList<>(summarizedChecks);
-                    summarizedChecks.add(testingEnabledNotice(pr));
-                }
-
-                // Time to refresh test info
-                ret.add(new TestInfoBotWorkItem(pr, summarizedChecks));
-            }
+            ret.add(new TestInfoBotWorkItem(pr, expiresIn -> expirations.put(expirationKey, Instant.now().plus(expiresIn))));
         }
         return ret;
     }


### PR DESCRIPTION
When the test info bot summarizes checks, there's no need to update summarized items that haven't changed. Also update the not-configured notice properly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**) ⚠️ Review applies to b9d617553fe12345956ee95831801571f8f0633e


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/976/head:pull/976`
`$ git checkout pull/976`
