### PR TITLE
732: Large changes cause empty webrevs

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
@@ -174,8 +174,14 @@ class WebrevStorage {
     }
 
     private boolean shouldBeReplaced(Path file) {
+        var neverReplace = Set.of(
+            "index.html",
+            "comparison.json",
+            "commits.json",
+            "metadata.json"
+        );
         try {
-            if (file.getFileName().toString().equals("index.html")) {
+            if (neverReplace.contains(file.getFileName().toString())) {
                 return false;
             } else {
                 return Files.size(file) >= 1000 * 1000;


### PR DESCRIPTION
Hi all,

please review this patch that makes sure that we don't replace `commits.json`, `comparison.json` nor `metadata.json` with placeholders for webrevs.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-732](https://bugs.openjdk.java.net/browse/SKARA-732): Large changes cause empty webrevs


### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/977/head:pull/977`
`$ git checkout pull/977`
