### PR TITLE
"java.se" matches "java.security.jgss" as well

### DIFF
--- a/config/mailinglist/rules/jdk.json
+++ b/config/mailinglist/rules/jdk.json
@@ -215,7 +215,7 @@
             "src/java.naming/",
             "src/java.prefs/",
             "src/java.rmi/",
-            "src/java.se",
+            "src/java.se/",
             "src/java.smartcardio/",
             "src/java.sql",
             "src/java.transaction.xa",

--- a/config/mailinglist/rules/jdk.json
+++ b/config/mailinglist/rules/jdk.json
@@ -218,7 +218,7 @@
             "src/java.se/",
             "src/java.smartcardio/",
             "src/java.sql",
-            "src/java.transaction.xa",
+            "src/java.transaction.xa/",
             "src/java.xml/",
             "src/jdk.accessibility/",
             "src/jdk.incubator.foreign/",
@@ -233,7 +233,7 @@
             "src/jdk.jstatd/",
             "src/jdk.naming.dns/",
             "src/jdk.naming.rmi/",
-            "src/jdk.nio.mapmode",
+            "src/jdk.nio.mapmode/",
             "src/jdk.unsupported/",
             "src/jdk.xml.dom/",
             "src/jdk.zipfs/",
@@ -562,8 +562,8 @@
         ],
         "kulla": [
             "make/modules/jdk.jshell",
-            "src/jdk.editpad",
-            "src/jdk.internal.ed",
+            "src/jdk.editpad/",
+            "src/jdk.internal.ed/",
             "src/jdk.internal.le/",
             "src/jdk.jshell/",
             "test/langtools/jdk/jshell/"
@@ -602,7 +602,7 @@
         "nio": [
             "src/java.base/\\w+/classes/sun/nio/",
             "src/java.base/\\w+/native/libnio/",
-            "src/jdk.nio.mapmode",
+            "src/jdk.nio.mapmode/",
             "src/jdk.zipfs/share/classes/jdk/nio/",
             "test/jdk/com/sun/nio/",
             "test/jdk/java/nio/",


### PR DESCRIPTION
core-libs does not need to care about these security-related modules.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - no project role) ⚠️ Review applies to 441ef9639d72658e41632d89704ef8be34c72f6b
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**) ⚠️ Review applies to 441ef9639d72658e41632d89704ef8be34c72f6b
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - no project role)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/980/head:pull/980`
`$ git checkout pull/980`
