### PR TITLE
681: No (obvious) way to remove "test-request" label

### DIFF
--- a/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestWorkItem.java
+++ b/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestWorkItem.java
@@ -329,6 +329,9 @@ public class TestWorkItem implements WorkItem {
                     log.warning("Could not find check for job with " + jobId + " for hash " + hash + " for PR " + pr.webUrl());
                 }
             }
+            if (pr.labels().contains(TEST_REQUEST_LABEL)) {
+                pr.removeLabel(TEST_REQUEST_LABEL);
+            }
         } else if (stage == Stage.REQUESTED) {
             var requestedJobs = state.requested().body().substring("/test".length());
             if (requestedJobs.trim().isEmpty()) {

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrTest.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrTest.java
@@ -51,6 +51,10 @@ public class GitPrTest {
               .helptext("Approve a test request")
               .optional(),
         Switch.shortcut("")
+              .fullname("cancel")
+              .helptext("Cancel a test request")
+              .optional(),
+        Switch.shortcut("")
               .fullname("verbose")
               .helptext("Turn on verbose output")
               .optional(),
@@ -84,6 +88,8 @@ public class GitPrTest {
         var command = "/test";
         if (arguments.contains("approve")) {
             command += " approve";
+        } else if (arguments.contains("cancel")) {
+            command += " cancel";
         } else if (arguments.contains("job")) {
             command += arguments.get("job").asString();
         }


### PR DESCRIPTION
Hi all,

please review this patch that removes the `test-request` label from a PR when the a test request is cancelled.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-681](https://bugs.openjdk.java.net/browse/SKARA-681): No (obvious) way to remove "test-request" label


### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/982/head:pull/982`
`$ git checkout pull/982`
