### PR TITLE
mlbridge: use bot email address when auto-closing PRs

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveItem.java
@@ -215,7 +215,8 @@ class ArchiveItem {
     }
 
     static ArchiveItem closedNotice(PullRequest pr, HostUserToEmailAuthor hostUserToEmailAuthor, ArchiveItem parent, String subjectPrefix) {
-        return new ArchiveItem(parent, "cn", pr.updatedAt(), pr.updatedAt(), pr.author(), Map.of("PR-Closed-Notice", "0"),
+        var closedBy = pr.closedBy().orElseThrow(() -> new RuntimeException("PR is not closed by anyone: " + pr.id()));
+        return new ArchiveItem(parent, "cn", pr.updatedAt(), pr.updatedAt(), closedBy, Map.of("PR-Closed-Notice", "0"),
                                () -> String.format("%sWithdrawn: %s", subjectPrefix, pr.title()),
                                () -> ArchiveMessages.composeReplyHeader(parent.createdAt(), hostUserToEmailAuthor.author(parent.author())),
                                () -> ArchiveMessages.composeClosedNotice(pr),

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
@@ -185,7 +185,7 @@ class ArchiveWorkItem implements WorkItem {
     }
 
     private EmailAddress getAuthorAddress(CensusInstance censusInstance, HostUser originalAuthor) {
-        if (originalAuthor.username().endsWith("[bot]")) {
+        if (bot.ignoredUsers().contains(originalAuthor.username())) {
             return bot.emailAddress();
         }
 

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
@@ -185,6 +185,10 @@ class ArchiveWorkItem implements WorkItem {
     }
 
     private EmailAddress getAuthorAddress(CensusInstance censusInstance, HostUser originalAuthor) {
+        if (originalAuthor.username().endsWith("[bot]")) {
+            return bot.emailAddress();
+        }
+
         var contributor = censusInstance.namespace().get(originalAuthor.id());
         if (contributor == null) {
             return EmailAddress.from(originalAuthor.fullName(),

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -638,8 +638,9 @@ class MailingListBridgeBotTests {
             Repository.materialize(archiveFolder.path(), archive.url(), "master");
             assertTrue(archiveContains(archiveFolder.path(), "Subject: RFR: 1234: This is a pull request"));
 
-            // Close it
-            pr.setState(Issue.State.CLOSED);
+            // Close it (as a separate user)
+            var closerPr = ignored.pullRequest(pr.id());
+            closerPr.setState(Issue.State.CLOSED);
 
             // Run another archive pass
             TestBotRunner.runPeriodicItems(mlBot);
@@ -655,6 +656,11 @@ class MailingListBridgeBotTests {
             Repository.materialize(archiveFolder.path(), archive.url(), "master");
             assertEquals(1, archiveContainsCount(archiveFolder.path(), "Subject: Withdrawn: 1234: This is a pull request"));
             assertEquals(1, archiveContainsCount(archiveFolder.path(), "Subject: Re: RFR: 1234: This is a pull request"));
+
+            // The closer should be the bot account - not the PR creator nor the closer
+            assertEquals(2, archiveContainsCount(archiveFolder.path(), Pattern.quote("From: test+2+user2 at openjdk.java.net (User Number 2)")));
+            assertEquals(1, archiveContainsCount(archiveFolder.path(), Pattern.quote("From: test at test.mail (test)")));
+            assertEquals(0, archiveContainsCount(archiveFolder.path(), Pattern.quote("From: test+3+user3 at openjdk.java.net (User Number 3)")));
         }
     }
 

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
@@ -304,4 +304,9 @@ class InMemoryPullRequest implements PullRequest {
     public Diff diff() {
         return null;
     }
+
+    @Override
+    public Optional<HostUser> closedBy() {
+        return Optional.empty();
+    }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -702,4 +702,20 @@ public class GitHubPullRequest implements PullRequest {
         var targetHash = repository.branchHash(targetRef());
         return repository.toDiff(targetHash, headHash(), files);
     }
+
+    @Override
+    public Optional<HostUser> closedBy() {
+        if (!isClosed()) {
+            return Optional.empty();
+        }
+
+        return request.get("issues/" + json.get("number").toString() + "/timeline")
+                      .execute()
+                      .stream()
+                      .map(JSONValue::asObject)
+                      .filter(obj -> obj.contains("event"))
+                      .filter(obj -> obj.get("event").asString().equals("closed"))
+                      .reduce((a, b) -> b)
+                      .map(e -> host.parseUserObject(e.get("actor")));
+    }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -771,4 +771,13 @@ public class GitLabMergeRequest implements PullRequest {
         var targetHash = repository.branchHash(targetRef());
         return repository.toDiff(targetHash, headHash(), changes.get("changes"));
     }
+
+    @Override
+    public Optional<HostUser> closedBy() {
+        if (!isClosed()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(host.parseAuthorObject(json.get("closed_by").asObject()));
+    }
 }

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/Issue.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/Issue.java
@@ -115,6 +115,18 @@ public interface Issue {
      */
     State state();
 
+    default boolean isOpen() {
+        return state() == State.OPEN;
+    }
+
+    default boolean isClosed() {
+        return state() == State.CLOSED;
+    }
+
+    default boolean isResolved() {
+        return state() == State.RESOLVED;
+    }
+
     /**
      * Set the state.
      * @param state Desired state
@@ -173,4 +185,6 @@ public interface Issue {
     void setProperty(String name, JSONValue value);
 
     void removeProperty(String name);
+
+    Optional<HostUser> closedBy();
 }

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraIssue.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraIssue.java
@@ -539,4 +539,9 @@ public class JiraIssue implements Issue {
     public void removeProperty(String name) {
 
     }
+
+    @Override
+    public Optional<HostUser> closedBy() {
+        throw new RuntimeException("Not implemented yet");
+    }
 }

--- a/test/src/main/java/org/openjdk/skara/test/IssueData.java
+++ b/test/src/main/java/org/openjdk/skara/test/IssueData.java
@@ -40,4 +40,5 @@ class IssueData {
     final Map<String, JSONValue> properties = new HashMap<>();
     ZonedDateTime created = ZonedDateTime.now();
     ZonedDateTime lastUpdate = created;
+    HostUser closedBy = null;
 }

--- a/test/src/main/java/org/openjdk/skara/test/TestIssue.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestIssue.java
@@ -147,6 +147,7 @@ public class TestIssue implements Issue {
     public void setState(State state) {
         data.state = state;
         data.lastUpdate = ZonedDateTime.now();
+        data.closedBy = user;
     }
 
     @Override
@@ -248,6 +249,6 @@ public class TestIssue implements Issue {
 
     @Override
     public Optional<HostUser> closedBy() {
-        return isClosed() ? Optional.of(author) : Optional.empty();
+        return isClosed() ? Optional.of(data.closedBy) : Optional.empty();
     }
 }

--- a/test/src/main/java/org/openjdk/skara/test/TestIssue.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestIssue.java
@@ -245,4 +245,9 @@ public class TestIssue implements Issue {
         data.properties.remove(name);
         data.lastUpdate = ZonedDateTime.now();
     }
+
+    @Override
+    public Optional<HostUser> closedBy() {
+        return isClosed() ? Optional.of(author) : Optional.empty();
+    }
 }


### PR DESCRIPTION
Hi all,

please review this patch that ensures that the bot's email address is used when auto-closing pull requests (not the creator of the pull requests' email).

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/983/head:pull/983`
`$ git checkout pull/983`
