### PR TITLE
749: If an integration fails at a late stage, it will both say that it succeeded and failed

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
@@ -165,6 +165,9 @@ public class IntegrateCommand implements CommandHandler {
             // Rebase and push it!
             if (!localHash.equals(PullRequestUtils.targetHash(pr, localRepo))) {
                 var amendedHash = checkablePr.amendManualReviewers(localHash, censusInstance.namespace(), original);
+                localRepo.push(amendedHash, pr.repository().url(), pr.targetRef());
+                success = true;
+
                 var finalRebaseMessage = rebaseMessage.toString();
                 if (!finalRebaseMessage.isBlank()) {
                     reply.println(rebaseMessage.toString());
@@ -172,8 +175,6 @@ public class IntegrateCommand implements CommandHandler {
                 reply.println("Pushed as commit " + amendedHash.hex() + ".");
                 reply.println();
                 reply.println(":bulb: You may see a message that your pull request was closed with unmerged commits. This can be safely ignored.");
-                localRepo.push(amendedHash, pr.repository().url(), pr.targetRef());
-                success = true;
                 pr.setState(PullRequest.State.CLOSED);
                 pr.addLabel("integrated");
                 pr.removeLabel("ready");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
@@ -138,6 +138,7 @@ public class SponsorCommand implements CommandHandler {
 
             if (!localHash.equals(PullRequestUtils.targetHash(pr, localRepo))) {
                 var amendedHash = checkablePr.amendManualReviewers(localHash, censusInstance.namespace(), original);
+                localRepo.push(amendedHash, pr.repository().url(), pr.targetRef());
                 var finalRebaseMessage = rebaseMessage.toString();
                 if (!finalRebaseMessage.isBlank()) {
                     reply.println(rebaseMessage.toString());
@@ -145,7 +146,6 @@ public class SponsorCommand implements CommandHandler {
                 reply.println("Pushed as commit " + amendedHash.hex() + ".");
                 reply.println();
                 reply.println(":bulb: You may see a message that your pull request was closed with unmerged commits. This can be safely ignored.");
-                localRepo.push(amendedHash, pr.repository().url(), pr.targetRef());
                 pr.setState(PullRequest.State.CLOSED);
                 pr.addLabel("integrated");
                 pr.removeLabel("sponsor");


### PR DESCRIPTION
Wait with outputting the success message until after the final push command during `/integrate` or `/sponsor` has actually completed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-749](https://bugs.openjdk.java.net/browse/SKARA-749): If an integration fails at a late stage, it will both say that it succeeded and failed


### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/985/head:pull/985`
`$ git checkout pull/985`
