### PR TITLE
checkout: refine logging levels

### DIFF
--- a/bots/checkout/src/main/java/org/openjdk/skara/bots/checkout/CheckoutBot.java
+++ b/bots/checkout/src/main/java/org/openjdk/skara/bots/checkout/CheckoutBot.java
@@ -140,9 +140,12 @@ public class CheckoutBot implements Bot, WorkItem {
                     var convertedGitHashes = existing.stream().map(Mark::git).collect(Collectors.toSet());
                     var gitHead = fromRepo.head();
                     if (!convertedGitHashes.contains(gitHead)) {
+                        log.info("Found Git commits that needs to be converted. Git HEAD: " + gitHead.hex());
                         Collections.sort(existing);
                         converter.convert(fromRepo, toRepo, existing);
                         hasConverted = true;
+                    } else {
+                        log.info("No new Git commits to convert");
                     }
                 }
             } finally {

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitCommitMetadata.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitCommitMetadata.java
@@ -60,7 +60,7 @@ class GitCommitMetadata {
 
     public static CommitMetadata read(UnixStreamReader reader) throws IOException {
         var hash = new Hash(reader.readLine());
-        log.fine("Parsing: " + hash.hex());
+        log.finest("Parsing: " + hash.hex());
 
         var parentHashes = reader.readLine();
         if (parentHashes.equals("")) {
@@ -74,20 +74,20 @@ class GitCommitMetadata {
         var dateFormatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
 
         var authorName = reader.readLine();
-        log.finer("authorName: " + authorName);
+        log.finest("authorName: " + authorName);
         var authorEmail = reader.readLine();
-        log.finer("authorEmail: " + authorEmail);
+        log.finest("authorEmail: " + authorEmail);
         var author = new Author(authorName, authorEmail);
         var authored = ZonedDateTime.parse(reader.readLine(), dateFormatter);
-        log.finer("authorDate: " + authored);
+        log.finest("authorDate: " + authored);
 
         var committerName = reader.readLine();
-        log.finer("committerName: " + committerName);
+        log.finest("committerName: " + committerName);
         var committerEmail = reader.readLine();
-        log.finer("committerEmail " + committerName);
+        log.finest("committerEmail " + committerName);
         var committer = new Author(committerName, committerEmail);
         var committed = ZonedDateTime.parse(reader.readLine(), dateFormatter);
-        log.finer("committerDate: " + committed);
+        log.finest("committerDate: " + committed);
 
 
         var message = new ArrayList<String>();

--- a/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/convert/GitToHgConverter.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/convert/GitToHgConverter.java
@@ -187,6 +187,7 @@ public class GitToHgConverter implements Converter {
         var missing = new TreeSet<>(gitTags);
         missing.removeAll(hgTags);
         for (var name : missing) {
+            log.info("Converting tag " + name);
             var gitHash = gitRepo.resolve(name).orElseThrow(() ->
                     new IOException("Cannot resolve known tag " + name)
             );
@@ -201,6 +202,7 @@ public class GitToHgConverter implements Converter {
                 hgRepo.tag(hgHash, name, "Added tag " + name + " for " + hgHash.abbreviate(), "duke", null, null);
             }
             var hgTagCommitHash = hgRepo.head();
+            log.info("Converted tag " + name + " with resulting hash " + hgTagCommitHash.hex());
             var last = marks.get(marks.size() - 1);
             var newMark = new Mark(last.key(), last.hg(), last.git(), hgTagCommitHash);
             marks.set(marks.size() - 1, newMark);
@@ -215,7 +217,7 @@ public class GitToHgConverter implements Converter {
         var gitRoot = gitRepo.root();
 
         for (var commit : commits) {
-            log.fine("Converting Git hash: " + commit.hash().hex());
+            log.info("Converting Git hash: " + commit.hash().hex());
             var parents = commit.parents();
             var gitParent0 = parents.get(0);
             var status0 = gitRepo.status(gitParent0, commit.hash());
@@ -272,7 +274,7 @@ public class GitToHgConverter implements Converter {
             } else {
                 hgHash = hgRepo.commit(hgMessage, hgAuthor, null, date);
             }
-            log.fine("Converted hg hash: " + hgHash.hex());
+            log.info("Converted hg hash: " + hgHash.hex());
 
             marks.add(new Mark(marks.size() + 1, hgHash, commit.hash()));
             gitToHg.put(commit.hash(), hgHash);


### PR DESCRIPTION
Hi all,

please review this small patch that refines the logging levels for the `checkout` bot.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/987/head:pull/987`
`$ git checkout pull/987`
