### PR TITLE
vcs: only convert tags that are part of branch

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/convert/GitToHgConverter.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/convert/GitToHgConverter.java
@@ -186,10 +186,17 @@ public class GitToHgConverter implements Converter {
         }
         var missing = new TreeSet<>(gitTags);
         missing.removeAll(hgTags);
+        var gitBranchHead = gitRepo.resolve(branch).orElseThrow(() ->
+            new IOException("Cannot resolve Git branch " + branch)
+        );
         for (var name : missing) {
             var gitHash = gitRepo.resolve(name).orElseThrow(() ->
                     new IOException("Cannot resolve known tag " + name)
             );
+            if (!gitRepo.isAncestor(gitBranchHead, gitHash)) {
+                // The tag is referring to a commit on another branch
+                continue;
+            }
             var hgHash = gitToHg.get(gitHash);
             var annotated = gitRepo.annotate(new Tag(name));
             if (annotated.isPresent()) {


### PR DESCRIPTION
Hi all,

please review this patch that ensures that the `GitToHgConverter` only converts tags that are pointing to commits on the branch the converter is converting.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/988/head:pull/988`
`$ git checkout pull/988`
