### PR TITLE
checkout: simplify conversion logic

### DIFF
--- a/bots/checkout/src/main/java/org/openjdk/skara/bots/checkout/CheckoutBot.java
+++ b/bots/checkout/src/main/java/org/openjdk/skara/bots/checkout/CheckoutBot.java
@@ -136,22 +136,15 @@ public class CheckoutBot implements Bot, WorkItem {
                         new IllegalStateException("Repository vanished from " + to));
                     var existing = new ArrayList<>(marks.current());
                     log.info("Found " + existing.size() + " existing marks");
-
-                    var convertedGitHashes = existing.stream().map(Mark::git).collect(Collectors.toSet());
-                    var gitHead = fromRepo.head();
-                    if (!convertedGitHashes.contains(gitHead)) {
-                        log.info("Found Git commits that needs to be converted. Git HEAD: " + gitHead.hex());
-                        Collections.sort(existing);
-                        converter.convert(fromRepo, toRepo, existing);
-                        hasConverted = true;
-                    } else {
-                        log.info("No new Git commits to convert");
-                    }
+                    converter.convert(fromRepo, toRepo, existing);
+                    hasConverted = true;
                 }
             } finally {
                 if (hasConverted) {
                     log.info("Storing " + converter.marks().size() + " marks");
                     marks.put(converter.marks());
+                } else {
+                    log.info("No conversion has taken place, not updating marks");
                 }
             }
         } catch (IOException e) {

--- a/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/convert/GitToHgConverter.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/convert/GitToHgConverter.java
@@ -194,8 +194,8 @@ public class GitToHgConverter implements Converter {
             var gitHash = gitRepo.resolve(name).orElseThrow(() ->
                     new IOException("Cannot resolve known tag " + name)
             );
-            if (!gitRepo.isAncestor(gitBranchHead, gitHash)) {
-                // The tag is referring to a commit on another branch
+            if (!gitRepo.isAncestor(gitHash, gitBranchHead)) {
+                log.info("Tag " + name + " refers to a commit not present on branch " + branch.name());
                 continue;
             }
             var hgHash = gitToHg.get(gitHash);


### PR DESCRIPTION
Hi all,

please review this small patch to simplify the logic for when to update the hosted storage used by the `checkout` bot.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/990/head:pull/990`
`$ git checkout pull/990`
