### PR TITLE
Make the auto labeller less aggressive

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandWorkItem.java
@@ -207,6 +207,8 @@ public class CommandWorkItem extends PullRequestWorkItem {
                 // Must re-fetch PR after running the command, the command might have updated the PR
                 var updatedPR = pr.repository().pullRequest(pr.id());
                 return List.of(new LabelerWorkItem(bot, updatedPR, errorHandler));
+            } else {
+                return List.of();
             }
         }
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandWorkItem.java
@@ -201,15 +201,12 @@ public class CommandWorkItem extends PullRequestWorkItem {
 
         if (nextCommand.isEmpty()) {
             log.info("No new non-external PR commands found, stopping further processing");
-            // When all commands are processed, it's time to check labels
-            // Must re-fetch PR after running the command, the command might have updated the PR
-            var updatedPR = pr.repository().pullRequest(pr.id());
 
-            if (!pr.labels().contains("integrated")) {
+            if (!bot.isAutoLabelled(pr)) {
+                // When all commands are processed, it's time to check labels
+                // Must re-fetch PR after running the command, the command might have updated the PR
+                var updatedPR = pr.repository().pullRequest(pr.id());
                 return List.of(new LabelerWorkItem(bot, updatedPR, errorHandler));
-            } else {
-                log.info("Skip updating labels in integrated PR");
-                return List.of();
             }
         }
 


### PR DESCRIPTION
Only run automatic labeling of PRs once, to avoid interfering with manual decisions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/992/head:pull/992`
`$ git checkout pull/992`
