### PR TITLE
Add support for setting all labels in a single request

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/JbsBackport.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/JbsBackport.java
@@ -83,8 +83,8 @@ public class JbsBackport {
 
         // The backport should not have any labels set - if it does, clear them
         var labels = issue.labels();
-        for (var label : labels) {
-            issue.removeLabel(label);
+        if (!labels.isEmpty()) {
+            issue.setLabels(List.of());
         }
         return issue;
     }

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
@@ -218,6 +218,11 @@ class InMemoryPullRequest implements PullRequest {
     }
 
     @Override
+    public void setLabels(List<String> labels) {
+        this.labels = new HashSet<>(labels);
+    }
+
+    @Override
     public List<String> labels() {
         return new ArrayList<String>(labels);
     }

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -539,6 +539,19 @@ public class GitHubPullRequest implements PullRequest {
     }
 
     @Override
+    public void setLabels(List<String> labels) {
+        var labelArray = JSON.array();
+        for (var label : labels) {
+            labelArray.add(label);
+        }
+        var query = JSON.object().put("labels", labelArray);
+        request.put("issues/" + json.get("number").toString() + "/labels")
+               .body(query)
+               .execute();
+        this.labels = labels;
+    }
+
+    @Override
     public List<String> labels() {
         if (labels == null) {
             labels = request.get("issues/" + json.get("number").toString() + "/labels").execute().stream()

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -647,6 +647,14 @@ public class GitLabMergeRequest implements PullRequest {
     }
 
     @Override
+    public void setLabels(List<String> labels) {
+        request.put("")
+               .body("labels", String.join(",", labels))
+               .execute();
+        this.labels = labels;
+    }
+
+    @Override
     public List<String> labels() {
         if (labels == null) {
             var currentJson = request.get("").execute().asObject();

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/Issue.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/Issue.java
@@ -146,6 +146,11 @@ public interface Issue {
     void removeLabel(String label);
 
     /**
+     * Set the given labels and remove any others.
+     */
+    void setLabels(List<String> labels);
+
+    /**
      * Retrieves all the currently set labels.
      * @return
      */

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraIssue.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraIssue.java
@@ -251,6 +251,19 @@ public class JiraIssue implements Issue {
     }
 
     @Override
+    public void setLabels(List<String> labels) {
+        var labelsArray = JSON.array();
+        for (var label : labels) {
+            labelsArray.add(label);
+        }
+        var query = JSON.object()
+                        .put("update", JSON.object()
+                                           .put("labels", JSON.array().add(JSON.object()
+                                                                               .put("set", labelsArray))));
+        request.put("").body(query).execute();
+    }
+
+    @Override
     public List<String> labels() {
         return json.get("fields").get("labels").stream()
                    .map(JSONValue::asString)

--- a/test/src/main/java/org/openjdk/skara/test/TestIssue.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestIssue.java
@@ -164,6 +164,16 @@ public class TestIssue implements Issue {
     }
 
     @Override
+    public void setLabels(List<String> labels) {
+        data.labels.clear();
+        var now = ZonedDateTime.now();
+        for (var label : labels) {
+            data.labels.put(label, now);
+        }
+        data.lastUpdate = now;
+    }
+
+    @Override
     public List<String> labels() {
         return new ArrayList<>(data.labels.keySet());
     }


### PR DESCRIPTION
Add support for setting all labels of an issue / PR with a single call, and use it for clearing labels on newly created backports.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/993/head:pull/993`
`$ git checkout pull/993`
