### PR TITLE
880: Map jdk.jpackage to core-libs-dev

### DIFF
--- a/config/mailinglist/rules/jdk.json
+++ b/config/mailinglist/rules/jdk.json
@@ -222,7 +222,7 @@
             "src/java.xml/",
             "src/jdk.accessibility/",
             "src/jdk.incubator.foreign/",
-            "src/jdk.incubator.jpackage/",
+            "src/jdk.jpackage/",
             "src/jdk.internal.jvmstat/",
             "src/jdk.internal.opt/",
             "src/jdk.jartool/",


### PR DESCRIPTION
The `jpackage` tool moved from the `jdk.incubator.jpackage` module to `jdk.jpackage` in JDK 16. The `jdk.json` config file needs to be updated accordingly so that `jpackage` reviews are sent to `core-libs-dev`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-880](https://bugs.openjdk.java.net/browse/SKARA-880): Map jdk.jpackage to core-libs-dev


### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/996/head:pull/996`
`$ git checkout pull/996`
