### PR TITLE
868: Skara should ignore .gitconfig and /etc/gitconfig

### DIFF
--- a/process/src/main/java/org/openjdk/skara/process/Process.java
+++ b/process/src/main/java/org/openjdk/skara/process/Process.java
@@ -67,7 +67,7 @@ public class Process {
             return this;
         }
 
-        public Description environMap(Map<String, String> keyValueMap) {
+        public Description environ(Map<String, String> keyValueMap) {
             if (keyValueMap != null) {
                 getCurrentProcessBuilderSetup().environment.putAll(keyValueMap);
             }

--- a/process/src/main/java/org/openjdk/skara/process/Process.java
+++ b/process/src/main/java/org/openjdk/skara/process/Process.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,6 +64,13 @@ public class Process {
 
         public Description environ(String key, String value) {
             getCurrentProcessBuilderSetup().environment.put(key, value);
+            return this;
+        }
+
+        public Description environMap(Map<String, String> keyValueMap) {
+            if (keyValueMap != null) {
+                getCurrentProcessBuilderSetup().environment.putAll(keyValueMap);
+            }
             return this;
         }
 

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitCommits.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitCommits.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -81,6 +81,7 @@ class GitCommits implements Commits, AutoCloseable {
         cmd.add(range);
         var pb = new ProcessBuilder(cmd);
         pb.directory(dir.toFile());
+        pb.environment().putAll(GitRepository.NO_CONFIG_ENV);
         var command = pb.command();
         try {
             var p = pb.start();

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -97,7 +97,7 @@ public class GitRepository implements Repository {
     private static Execution capture(Path cwd, Map<String, String> env, String... cmd) {
         return Process.capture(cmd)
                       .workdir(cwd)
-                      .environMap(env)
+                      .environ(env)
                       .execute();
     }
 
@@ -734,7 +734,7 @@ public class GitRepository implements Repository {
                        ZonedDateTime committerDate) throws IOException {
         var cmd = Process.capture("git", "commit", "--message=" + message)
                          .workdir(dir)
-                         .environMap(NO_CONFIG_ENV)
+                         .environ(NO_CONFIG_ENV)
                          .environ("GIT_AUTHOR_NAME", authorName)
                          .environ("GIT_AUTHOR_EMAIL", authorEmail)
                          .environ("GIT_COMMITTER_NAME", committerName)
@@ -770,7 +770,7 @@ public class GitRepository implements Repository {
         }
         var cmd = Process.capture(cmdLine.toArray(new String[0]))
                 .workdir(dir)
-                .environMap(NO_CONFIG_ENV)
+                .environ(NO_CONFIG_ENV)
                 .environ("GIT_AUTHOR_NAME", authorName)
                 .environ("GIT_AUTHOR_EMAIL", authorEmail)
                 .environ("GIT_COMMITTER_NAME", committerName)
@@ -823,7 +823,7 @@ public class GitRepository implements Repository {
         }
         var cmd = Process.capture("git", "commit", "--amend", "--reset-author", "--message=" + message)
                          .workdir(dir)
-                         .environMap(NO_CONFIG_ENV)
+                         .environ(NO_CONFIG_ENV)
                          .environ("GIT_AUTHOR_NAME", authorName)
                          .environ("GIT_AUTHOR_EMAIL", authorEmail)
                          .environ("GIT_COMMITTER_NAME", committerName)
@@ -838,7 +838,7 @@ public class GitRepository implements Repository {
     public Tag tag(Hash hash, String name, String message, String authorName, String authorEmail, ZonedDateTime date) throws IOException {
         var cmd = Process.capture("git", "tag", "--annotate", "--message=" + message, name, hash.hex())
                          .workdir(dir)
-                         .environMap(NO_CONFIG_ENV)
+                         .environ(NO_CONFIG_ENV)
                          .environ("GIT_AUTHOR_NAME", authorName)
                          .environ("GIT_AUTHOR_EMAIL", authorEmail)
                          .environ("GIT_COMMITTER_NAME", authorName)
@@ -898,7 +898,7 @@ public class GitRepository implements Repository {
                             .environ("GIT_COMMITTER_NAME", committerName)
                             .environ("GIT_COMMITTER_EMAIL", committerEmail)
                             .workdir(dir)
-                            .environMap(NO_CONFIG_ENV)
+                            .environ(NO_CONFIG_ENV)
                             .execute()) {
             await(p);
         }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -82,7 +82,7 @@ public class GitRepository implements Repository {
         return capture(cmd.toArray(new String[0]));
     }
 
-    private Execution capture(Path cwd, Map<String, String> env, List<String> cmd) {
+    private static Execution capture(Path cwd, Map<String, String> env, List<String> cmd) {
         return capture(cwd, env, cmd.toArray(new String[0]));
     }
 
@@ -90,7 +90,7 @@ public class GitRepository implements Repository {
         return capture(dir, cmd);
     }
 
-    private static Execution capture(Path cwd, String... cmd) {
+    public static Execution capture(Path cwd, String... cmd) {
         return capture(cwd, NO_CONFIG_ENV, cmd);
     }
 

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,12 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 public class GitRepository implements Repository {
+    public final static Map<String, String> NO_CONFIG_ENV = Map.of(
+            "HOME", "/this-does-not-exist-and-if-you-create-it-you-are-in-trouble",
+            "XDG_CONFIG_HOME", "/this-does-not-exist-and-if-you-create-it-you-are-in-trouble",
+            "GIT_CONFIG_NOSYSTEM", "true"
+    );
+
     private final Path dir;
     private final Logger log = Logger.getLogger("org.openjdk.skara.vcs.git");
     private Path cachedRoot = null;
@@ -51,6 +57,7 @@ public class GitRepository implements Repository {
         log.fine("Executing " + String.join(" ", cmd));
         var pb = new ProcessBuilder(cmd);
         pb.directory(dir.toFile());
+        pb.environment().putAll(NO_CONFIG_ENV);
         pb.redirectError(ProcessBuilder.Redirect.DISCARD);
         return pb.start();
     }
@@ -75,13 +82,22 @@ public class GitRepository implements Repository {
         return capture(cmd.toArray(new String[0]));
     }
 
+    private Execution capture(Path cwd, Map<String, String> env, List<String> cmd) {
+        return capture(cwd, env, cmd.toArray(new String[0]));
+    }
+
     private Execution capture(String... cmd) {
         return capture(dir, cmd);
     }
 
     private static Execution capture(Path cwd, String... cmd) {
+        return capture(cwd, NO_CONFIG_ENV, cmd);
+    }
+
+    private static Execution capture(Path cwd, Map<String, String> env, String... cmd) {
         return Process.capture(cmd)
                       .workdir(cwd)
+                      .environMap(env)
                       .execute();
     }
 
@@ -718,6 +734,7 @@ public class GitRepository implements Repository {
                        ZonedDateTime committerDate) throws IOException {
         var cmd = Process.capture("git", "commit", "--message=" + message)
                          .workdir(dir)
+                         .environMap(NO_CONFIG_ENV)
                          .environ("GIT_AUTHOR_NAME", authorName)
                          .environ("GIT_AUTHOR_EMAIL", authorEmail)
                          .environ("GIT_COMMITTER_NAME", committerName)
@@ -753,6 +770,7 @@ public class GitRepository implements Repository {
         }
         var cmd = Process.capture(cmdLine.toArray(new String[0]))
                 .workdir(dir)
+                .environMap(NO_CONFIG_ENV)
                 .environ("GIT_AUTHOR_NAME", authorName)
                 .environ("GIT_AUTHOR_EMAIL", authorEmail)
                 .environ("GIT_COMMITTER_NAME", committerName)
@@ -805,6 +823,7 @@ public class GitRepository implements Repository {
         }
         var cmd = Process.capture("git", "commit", "--amend", "--reset-author", "--message=" + message)
                          .workdir(dir)
+                         .environMap(NO_CONFIG_ENV)
                          .environ("GIT_AUTHOR_NAME", authorName)
                          .environ("GIT_AUTHOR_EMAIL", authorEmail)
                          .environ("GIT_COMMITTER_NAME", committerName)
@@ -819,6 +838,7 @@ public class GitRepository implements Repository {
     public Tag tag(Hash hash, String name, String message, String authorName, String authorEmail, ZonedDateTime date) throws IOException {
         var cmd = Process.capture("git", "tag", "--annotate", "--message=" + message, name, hash.hex())
                          .workdir(dir)
+                         .environMap(NO_CONFIG_ENV)
                          .environ("GIT_AUTHOR_NAME", authorName)
                          .environ("GIT_AUTHOR_EMAIL", authorEmail)
                          .environ("GIT_COMMITTER_NAME", authorName)
@@ -878,6 +898,7 @@ public class GitRepository implements Repository {
                             .environ("GIT_COMMITTER_NAME", committerName)
                             .environ("GIT_COMMITTER_EMAIL", committerEmail)
                             .workdir(dir)
+                            .environMap(NO_CONFIG_ENV)
                             .execute()) {
             await(p);
         }
@@ -1133,7 +1154,8 @@ public class GitRepository implements Repository {
 
     @Override
     public List<String> config(String key) throws IOException {
-        try (var p = capture("git", "config", key)) {
+        // We must explicitly do this *with* the user's .gitconfig, so override NO_CONFIG_ENV
+        try (var p = capture(dir, Collections.emptyMap(), "git", "config", key)) {
             var res = p.await();
             return res.status() == 0 ? res.stdout() : List.of();
         }
@@ -1531,7 +1553,8 @@ public class GitRepository implements Repository {
         }
         cmd.add(section + "." + key);
         cmd.add(value);
-        try (var p = capture(cmd)) {
+        // We must explicitly do this *with* the user's .gitconfig, so override NO_CONFIG_ENV
+        try (var p = capture(dir, Collections.emptyMap(), cmd)) {
             await(p);
         }
     }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -95,7 +95,7 @@ public class HgRepository implements Repository {
     }
     public static Execution capture(Path cwd, String... cmd) {
         return Process.capture(cmd)
-                      .environMap(NO_CONFIG_ENV)
+                      .environ(NO_CONFIG_ENV)
                       .workdir(cwd)
                       .execute();
     }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,14 @@ import java.util.stream.*;
 import java.net.URI;
 
 public class HgRepository implements Repository {
+    public final static Map<String, String> NO_CONFIG_ENV = Map.of(
+            "HGRCPATH", "",
+            "HGPLAIN", "",
+            "HGEDITOR", "",
+            "EDITOR", "",
+            "VISUAL", ""
+    );
+
     private static final String EXT_PY = "ext.py";
     private final Path dir;
     private final Logger log = Logger.getLogger("org.openjdk.skara.vcs.hg");
@@ -54,8 +62,7 @@ public class HgRepository implements Repository {
         var pb = new ProcessBuilder(cmd);
         pb.directory(dir.toFile());
         pb.redirectError(ProcessBuilder.Redirect.DISCARD);
-        pb.environment().put("HGRCPATH", "");
-        pb.environment().put("HGPLAIN", "");
+        pb.environment().putAll(NO_CONFIG_ENV);
         return pb.start();
     }
 
@@ -86,10 +93,9 @@ public class HgRepository implements Repository {
     private static Execution capture(Path cwd, List<String> cmd) {
         return capture(cwd, cmd.toArray(new String[0]));
     }
-    private static Execution capture(Path cwd, String... cmd) {
+    public static Execution capture(Path cwd, String... cmd) {
         return Process.capture(cmd)
-                      .environ("HGRCPATH", "")
-                      .environ("HGPLAIN", "")
+                      .environMap(NO_CONFIG_ENV)
                       .workdir(cwd)
                       .execute();
     }
@@ -589,8 +595,7 @@ public class HgRepository implements Repository {
         pb.directory(dir.toFile());
         pb.redirectError(ProcessBuilder.Redirect.DISCARD);
         pb.redirectOutput(to.toFile());
-        pb.environment().put("HGRCPATH", "");
-        pb.environment().put("HGPLAIN", "");
+        pb.environment().putAll(NO_CONFIG_ENV);
         var p = pb.start();
         try {
             await(p);

--- a/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ import org.openjdk.skara.test.TemporaryDirectory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.openjdk.skara.vcs.git.GitRepository;
 
 import java.io.IOException;
 import java.net.URI;
@@ -1653,6 +1654,7 @@ public class RepositoryTests {
             pb.environment().put("GIT_COMMITTER_NAME", "duke");
             pb.environment().put("GIT_COMMITTER_EMAIL", "duke@openjdk.org");
             pb.directory(dir.path().toFile());
+            pb.environment().putAll(GitRepository.NO_CONFIG_ENV);
 
             var res = pb.start().waitFor();
             assertEquals(0, res);
@@ -1686,6 +1688,7 @@ public class RepositoryTests {
             pb.environment().put("GIT_COMMITTER_NAME", "duke");
             pb.environment().put("GIT_COMMITTER_EMAIL", "duke@openjdk.org");
             pb.directory(dir.path().toFile());
+            pb.environment().putAll(GitRepository.NO_CONFIG_ENV);
 
             var res = pb.start().waitFor();
             assertEquals(0, res);
@@ -2448,6 +2451,7 @@ public class RepositoryTests {
             // so use a ProcessBuilder and invoke git directly here
             var pb = new ProcessBuilder("git", "tag", "test-tag", head.hex());
             pb.directory(repo.root().toFile());
+            pb.environment().putAll(GitRepository.NO_CONFIG_ENV);
             assertEquals(0, pb.start().waitFor());
 
             var tags = repo.tags();


### PR DESCRIPTION
Skara is already ignoring .hgrc for mercurial, but the corresponding solution for git was never put in place.

I also fixed a problem where an error condition would cause an infinite loop, which I ran into during testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-868](https://bugs.openjdk.java.net/browse/SKARA-868): Skara should ignore .gitconfig and /etc/gitconfig


### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**) ⚠️ Review applies to 96e826123adb9dcadd11ca971dc238815e6485db


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/997/head:pull/997`
`$ git checkout pull/997`
