### PR TITLE
checkout: fetch origin before checking out branch

### DIFF
--- a/bots/checkout/src/main/java/org/openjdk/skara/bots/checkout/CheckoutBot.java
+++ b/bots/checkout/src/main/java/org/openjdk/skara/bots/checkout/CheckoutBot.java
@@ -114,6 +114,7 @@ public class CheckoutBot implements Bot, WorkItem {
                 fromRepo = Repository.get(fromDir).orElseThrow(() ->
                     new IllegalStateException("Git repository vanished from " + fromDir));
             }
+            fromRepo.fetchRemote("origin");
             fromRepo.checkout(branch);
             fromRepo.pull("origin", branch.name(), true);
 


### PR DESCRIPTION
Hi all,

please review this small patch that ensures that we fetches the remote `origin` before checking the source branch in the `checkout` bot. This is to ensure that the we have a local ref to the source branch in case we are are operating on a local Git repository that hasn't been updated in a while.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/999/head:pull/999`
`$ git checkout pull/999`
