### PR TITLE
build: add convenience target for bots

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ images:
 	@sh gradlew images
 
 bots:
-	@sh gradlew :bots:cli:images
+	@sh gradlew bots
 
 offline:
 	@sh gradlew :offline

--- a/build.gradle
+++ b/build.gradle
@@ -174,6 +174,23 @@ task local(type: Copy) {
     into project.buildDir
 }
 
+task bots(type: Copy) {
+    doFirst {
+        delete project.rootDir.toString() + '/bots/bin'
+    }
+
+    dependsOn ':bots:cli:images'
+
+    def os = getOS()
+    def cpu = getCPU()
+
+    from zipTree(file(project.rootDir.toString() +
+                      '/bots/cli/build/distributions/cli' +
+                      '-' + project.version + '-' +
+                      os + '-' + cpu + '.zip'))
+    into project.rootDir.toString() + '/bots/bin'
+}
+
 task offline(type: Copy) {
     doFirst {
         delete project.buildDir


### PR DESCRIPTION
Hi all,

please review this patch that adds a convenience target for building and extracting a image for the bots. A developer can now just run `sh gradlew bots` (or `make bots`) and find an extracted image under `bots/bin`.

Testing:
- [x] Tested locally on Linux x64

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/1000/head:pull/1000`
`$ git checkout pull/1000`
