### PR TITLE
checkout: use to repo name as path to marks

### DIFF
--- a/bots/checkout/src/main/java/org/openjdk/skara/bots/checkout/CheckoutBot.java
+++ b/bots/checkout/src/main/java/org/openjdk/skara/bots/checkout/CheckoutBot.java
@@ -118,8 +118,8 @@ public class CheckoutBot implements Bot, WorkItem {
             fromRepo.checkout(branch);
             fromRepo.pull("origin", branch.name(), true);
 
-            var repoName = Path.of(webURI().getPath()).getFileName().toString();
-            var marksDir = scratch.resolve("checkout").resolve("marks").resolve(repoName);
+            var toRepoName = to.getFileName().toString();
+            var marksDir = scratch.resolve("checkout").resolve("marks").resolve(toRepoName);
             Files.createDirectories(marksDir);
             var marks = marksStorage.materialize(marksDir);
             var converter = new GitToHgConverter(branch);

--- a/bots/checkout/src/main/java/org/openjdk/skara/bots/checkout/CheckoutBotFactory.java
+++ b/bots/checkout/src/main/java/org/openjdk/skara/bots/checkout/CheckoutBotFactory.java
@@ -53,8 +53,8 @@ public class CheckoutBotFactory implements BotFactory {
             var fromBranch = new Branch(repo.get("from").get("branch").asString());
             var to = Path.of(repo.get("to").asString());
 
-            var repoName = from.webUrl().getPath().substring(1) + ".git"; // Remove leading '/'
-            var markStorage = MarkStorage.create(marksRepo, marksUser, repoName);
+            var toRepoName = to.getFileName().toString();
+            var markStorage = MarkStorage.create(marksRepo, marksUser, toRepoName);
 
             bots.add(new CheckoutBot(from, fromBranch, to, storage, markStorage));
         }


### PR DESCRIPTION
Hi all,

please review this small patch that makes the `checkout` bot use the filename of the to path as the path for storing marks (compared to using the name of the from repo).

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/1001/head:pull/1001`
`$ git checkout pull/1001`
