### PR TITLE
Initial version of CLI tool for hgupdate-sync label

### DIFF
--- a/bots/notify/build.gradle
+++ b/bots/notify/build.gradle
@@ -49,6 +49,7 @@ dependencies {
     implementation project(':email')
     implementation project(':storage')
     implementation project(':mailinglist')
+    implementation project(':jbs')
 
     testImplementation project(':test')
 }

--- a/bots/notify/src/main/java/module-info.java
+++ b/bots/notify/src/main/java/module-info.java
@@ -28,6 +28,7 @@ module org.openjdk.skara.bots.notify {
     requires org.openjdk.skara.storage;
     requires org.openjdk.skara.mailinglist;
     requires org.openjdk.skara.network;
+    requires org.openjdk.skara.jbs;
     requires java.logging;
     requires java.net.http;
 

--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -49,6 +49,7 @@ dependencies {
     implementation project(':proxy')
     implementation project(':version')
     implementation project(':process')
+    implementation project(':jbs')
 
     testImplementation project(':test')
 }

--- a/cli/src/main/java/org/openjdk/skara/cli/SkaraDebug.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/SkaraDebug.java
@@ -45,7 +45,10 @@ public class SkaraDebug {
                        .main(GitVerifyImport::main),
                 Command.name("mlrules")
                        .helptext("create and verify jdk mailing list filter rules")
-                       .main(GitMlRules::main)
+                       .main(GitMlRules::main),
+                Command.name("issue-redecorate")
+                       .helptext("reapplies the hgupdate-sync label to the given ussue")
+                       .main(IssueRedecorate::main)
         );
 
         HttpProxy.setup();

--- a/cli/src/main/java/org/openjdk/skara/cli/debug/IssueRedecorate.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/debug/IssueRedecorate.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.cli.debug;
+
+import org.openjdk.skara.args.*;
+import org.openjdk.skara.issuetracker.*;
+import org.openjdk.skara.jbs.*;
+import org.openjdk.skara.version.Version;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.*;
+
+public class IssueRedecorate {
+    static final List<Flag> flags = List.of(
+            Switch.shortcut("u")
+                  .fullname("url")
+                  .helptext("Alternative JBS URL (defaults to https://bugs.openjdk.java.net)")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("version")
+                  .helptext("Print the version of this tool")
+                  .optional());
+
+    static final List<Input> inputs = List.of(
+            Input.position(0)
+                 .describe("issue ID")
+                 .singular()
+                 .required()
+            );
+
+    public static void main(String[] args) throws IOException {
+        var parser = new ArgumentParser("git issue-redecorate", flags, inputs);
+        var arguments = parser.parse(args);
+
+        if (arguments.contains("version")) {
+            System.out.println("git-issue-redecorate version: " + Version.fromManifest().orElse("unknown"));
+            System.exit(0);
+        }
+
+        IssueTracker issueTracker = null;
+        var issueTrackerURI = URI.create(arguments.get("url").orString("https://bugs.openjdk.java.net"));
+        var issueTrackerFactories = IssueTrackerFactory.getIssueTrackerFactories();
+        for (var issueTrackerFactory : issueTrackerFactories) {
+            var tracker = issueTrackerFactory.create(issueTrackerURI, null, null);
+            if (tracker.isValid()) {
+                issueTracker = tracker;
+            }
+        }
+        if (issueTracker == null) {
+            System.out.println("Failed to create an issue tracker instance for " + issueTrackerURI);
+            System.exit(1);
+        }
+
+        var issueProject = issueTracker.project("JDK");
+        org.openjdk.skara.issuetracker.Issue issue = issueProject.issue(arguments.at(0).asString()).orElseThrow();
+
+        var mainIssue = Backports.findMainIssue(issue);
+        if (mainIssue.isEmpty()) {
+            System.out.println("No corresponding main issue found");
+            System.exit(0);
+        }
+        System.out.println("Looking at " + arguments.at(0).asString() + " - main issue is " + mainIssue.get().id());
+
+        var related = Backports.findBackports(mainIssue.get(), true);
+        var allIssues = new ArrayList<Issue>();
+        allIssues.add(mainIssue.get());
+        allIssues.addAll(related);
+
+        var needsLabel = new HashSet<>(Backports.releaseStreamDuplicates(allIssues));
+        for (var i : allIssues) {
+            var version = Backports.mainFixVersion(i);
+            var versionString = version.map(JdkVersion::raw).orElse("no fix version");
+            if (needsLabel.contains(i)) {
+                if (i.labels().contains("hgupdate-sync")) {
+                    System.out.println("✔️ " + i.id() + " (" + versionString + ") - already labeled");
+                } else {
+                    System.out.println("⏳ " + i.id() + " (" + versionString + ") - needs to be labeled");
+                }
+            } else {
+                if (i.labels().contains("hgupdate-sync")) {
+                    System.out.println("❌ " + i.id() + " (" + versionString + ") - labeled incorrectly");
+                } else {
+                    System.out.println("✔️ " + i.id() + " (" + versionString + ") - not labeled");
+                }
+            }
+        }
+    }
+}

--- a/jbs/build.gradle
+++ b/jbs/build.gradle
@@ -24,6 +24,7 @@
 module {
     name = 'org.openjdk.skara.jbs'
     test {
+        requires 'org.openjdk.skara.test'
         requires 'org.junit.jupiter.api'
         opens 'org.openjdk.skara.jbs' to 'org.junit.platform.commons'
     }

--- a/jbs/build.gradle
+++ b/jbs/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,22 +20,27 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-module org.openjdk.skara.cli {
-    requires org.openjdk.skara.vcs;
-    requires org.openjdk.skara.jcheck;
-    requires org.openjdk.skara.census;
-    requires org.openjdk.skara.webrev;
-    requires org.openjdk.skara.args;
-    requires org.openjdk.skara.json;
-    requires org.openjdk.skara.host;
-    requires org.openjdk.skara.forge;
-    requires org.openjdk.skara.proxy;
-    requires org.openjdk.skara.version;
-    requires org.openjdk.skara.process;
-    requires org.openjdk.skara.jbs;
 
-    requires java.net.http;
-    requires java.logging;
+module {
+    name = 'org.openjdk.skara.jbs'
+    test {
+        requires 'org.junit.jupiter.api'
+        opens 'org.openjdk.skara.jbs' to 'org.junit.platform.commons'
+    }
+}
 
-    exports org.openjdk.skara.cli;
+dependencies {
+    implementation project(':host')
+    implementation project(':issuetracker')
+    implementation project(':json')
+
+    testImplementation project(':test')
+}
+
+publishing {
+    publications {
+        args(MavenPublication) {
+            from components.java
+        }
+    }
 }

--- a/jbs/src/main/java/module-info.java
+++ b/jbs/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,22 +20,12 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-module org.openjdk.skara.cli {
-    requires org.openjdk.skara.vcs;
-    requires org.openjdk.skara.jcheck;
-    requires org.openjdk.skara.census;
-    requires org.openjdk.skara.webrev;
-    requires org.openjdk.skara.args;
-    requires org.openjdk.skara.json;
-    requires org.openjdk.skara.host;
-    requires org.openjdk.skara.forge;
-    requires org.openjdk.skara.proxy;
-    requires org.openjdk.skara.version;
-    requires org.openjdk.skara.process;
-    requires org.openjdk.skara.jbs;
-
+module org.openjdk.skara.jbs {
     requires java.net.http;
     requires java.logging;
 
-    exports org.openjdk.skara.cli;
+    requires org.openjdk.skara.issuetracker;
+    requires org.openjdk.skara.json;
+
+    exports org.openjdk.skara.jbs;
 }

--- a/jbs/src/main/java/org/openjdk/skara/jbs/BuildCompare.java
+++ b/jbs/src/main/java/org/openjdk/skara/jbs/BuildCompare.java
@@ -20,7 +20,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package org.openjdk.skara.bots.notify.issue;
+package org.openjdk.skara.jbs;
 
 import java.util.regex.Pattern;
 

--- a/jbs/src/main/java/org/openjdk/skara/jbs/JdkVersion.java
+++ b/jbs/src/main/java/org/openjdk/skara/jbs/JdkVersion.java
@@ -20,7 +20,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package org.openjdk.skara.bots.notify.issue;
+package org.openjdk.skara.jbs;
 
 import java.util.*;
 import java.util.regex.Pattern;
@@ -139,6 +139,10 @@ public class JdkVersion implements Comparable<JdkVersion> {
 
     public Optional<String> resolvedInBuild() {
         return Optional.ofNullable(build);
+    }
+
+    public String raw() {
+        return raw;
     }
 
     // Return the number from a numbered build (e.g., 'b12' -> 12), or -1 if not a numbered build.

--- a/jbs/src/test/java/org/openjdk/skara/jbs/BuildCompareTests.java
+++ b/jbs/src/test/java/org/openjdk/skara/jbs/BuildCompareTests.java
@@ -20,11 +20,12 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package org.openjdk.skara.bots.notify.issue;
+package org.openjdk.skara.jbs;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BuildCompareTests {
     @Test

--- a/jbs/src/test/java/org/openjdk/skara/jbs/JdkVersionTests.java
+++ b/jbs/src/test/java/org/openjdk/skara/jbs/JdkVersionTests.java
@@ -20,7 +20,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package org.openjdk.skara.bots.notify.issue;
+package org.openjdk.skara.jbs;
 
 import org.junit.jupiter.api.Test;
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -45,6 +45,7 @@ include 'network'
 include 'forge'
 include 'issuetracker'
 include 'version'
+include 'jbs'
 
 include 'bots:bridgekeeper'
 include 'bots:censussync'


### PR DESCRIPTION
An initial version of a hgupdate-sync-label CLI tool with associated refactorings, in preparation for further enhancements.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - no project role)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/1002/head:pull/1002`
`$ git checkout pull/1002`
