### PR TITLE
build: top-level gradle do not need images

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,6 @@ plugins {
     id 'proxy'
     id 'version'
     id 'reproduce'
-    id 'images'
 }
 
 configure(subprojects.findAll() { it.name != 'bots' }) {


### PR DESCRIPTION
Hi all,

please remove this little clean-up after de5c089d7b219b4efa0fa38f467e3db553d6c1b5. The top-level build does not need to use the `images` plugin, that line was only added for debugging purposes and should be removed.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/1005/head:pull/1005`
`$ git checkout pull/1005`
