### PR TITLE
Update BotSlackHandlerTest timeout

### DIFF
--- a/bots/cli/src/test/java/org/openjdk/skara/bots/cli/BotSlackHandlerTests.java
+++ b/bots/cli/src/test/java/org/openjdk/skara/bots/cli/BotSlackHandlerTests.java
@@ -59,7 +59,7 @@ class BotSlackHandlerTests {
     @Test
     void throttled() throws IOException, InterruptedException {
         try (var receiver = new RestReceiver()) {
-            final var maxDuration = Duration.ofMillis(100);
+            final var maxDuration = Duration.ofMillis(1500);
             var handler = new BotSlackHandler(receiver.getEndpoint(), "test", maxDuration, new HashMap<>());
 
             // Post until we hit throttling


### PR DESCRIPTION
The timeout in combination with the default throttling can cause the test the fail.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - no project role)
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/1007/head:pull/1007`
`$ git checkout pull/1007`
