### PR TITLE
build: run build and tests in parallel

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,23 @@ configure(subprojects.findAll() { it.name != 'bots' }) {
         reports.html.enabled = false
     }
 
+    tasks.withType(Test).configureEach {
+        maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
+    }
+
+    tasks.withType(Test).configureEach {
+        forkEvery = 100
+    }
+
+    tasks.withType(Test).configureEach {
+        reports.html.enabled = false
+        reports.junitXml.enabled = false
+    }
+
+    tasks.withType(JavaCompile).configureEach {
+        options.fork = true
+    }
+
     publishing {
         repositories {
             maven {

--- a/deps.env
+++ b/deps.env
@@ -7,5 +7,5 @@ JDK_MACOS_X64_SHA256="578b17748f5a7d111474bc4c9b5a8a06b4a4aa1ba4a4bc3fef014e079e
 JDK_WINDOWS_X64_URL="https://download.java.net/java/GA/jdk15.0.2/0d1cfde4252546c6931946de8db48ee2/7/GPL/openjdk-15.0.2_windows-x64_bin.zip"
 JDK_WINDOWS_X64_SHA256="ecbe7f32bc6bff2b6c8e9b68f19cbf4ddf54a492c918ba471f32d645cf1c5cf4"
 
-GRADLE_URL="https://services.gradle.org/distributions/gradle-6.7.1-bin.zip"
-GRADLE_SHA256="3239b5ed86c3838a37d983ac100573f64c1f3fd8e1eb6c89fa5f9529b5ec091d"
+GRADLE_URL="https://services.gradle.org/distributions/gradle-6.8.2-bin.zip"
+GRADLE_SHA256="8de6efc274ab52332a9c820366dd5cf5fc9d35ec7078fd70c8ec6913431ee610"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.vfs.watch=true
+org.gradle.parallel=true
+org.gradle.jvmargs=-Xmx2048M


### PR DESCRIPTION
Hi all,

please review this patch that enables builds and tests to happen in parallel. I also tweaked the build a little:

- the Gradle daemon now gets an `Xmx` of `2048 Mb`
- Gradle will run up to 100 tests in the same JVM before forking a new one
- the JVM for compiling will be forked, reducing heap pressure on the Gradle daemon thread
- enabled the file system watching feature for faster rebuilds

The results on my AMD Ryzen 5 3600 is that `sh gradlew clean && sh gradlew --info test` went from ~10 minutes to ~2 minutes :partying_face: :rocket: 

Testing:
- [x] `make images` on Linux x64
- [x] `make test` on Linux x64

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/1009/head:pull/1009`
`$ git checkout pull/1009`
