### PR TITLE
Avoid considering fixVersions that are not valid releases when calculating the hgupdate-sync label

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
@@ -225,7 +225,7 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
                     }
 
                     if (requestedVersion != null) {
-                        var fixVersion = JdkVersion.parse(requestedVersion);
+                        var fixVersion = JdkVersion.parse(requestedVersion).orElseThrow();
                         var existing = Backports.findIssue(issue, fixVersion);
                         if (existing.isEmpty()) {
                             issue = jbsBackport.createBackport(issue, requestedVersion, username.orElse(null));
@@ -345,7 +345,7 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
                 if (requestedVersion == null) {
                     throw new RuntimeException("Failed to determine requested fixVersion for " + issue.id());
                 }
-                var fixVersion = JdkVersion.parse(requestedVersion);
+                var fixVersion = JdkVersion.parse(requestedVersion).orElseThrow();
                 var existing = Backports.findIssue(issue, fixVersion);
                 if (existing.isEmpty()) {
                     throw new RuntimeException("Cannot find a properly resolved issue for: " + issue.id());

--- a/jbs/src/main/java/org/openjdk/skara/jbs/Backports.java
+++ b/jbs/src/main/java/org/openjdk/skara/jbs/Backports.java
@@ -74,9 +74,9 @@ public class Backports {
             return Optional.empty();
         }
         if (issue.properties().containsKey("customfield_10006") && issue.properties().get("customfield_10006").isObject()) {
-            return Optional.of(JdkVersion.parse(versionString.get(0), issue.properties().get("customfield_10006").get("value").asString()));
+            return JdkVersion.parse(versionString.get(0), issue.properties().get("customfield_10006").get("value").asString());
         } else {
-            return Optional.of(JdkVersion.parse(versionString.get(0)));
+            return JdkVersion.parse(versionString.get(0));
         }
     }
 
@@ -133,7 +133,7 @@ public class Backports {
         if (mainVersion.isEmpty()) {
             return false;
         }
-        return mainVersion.get().equals(poolVersion) || mainVersion.get().equals(openVersion);
+        return mainVersion.get().equals(poolVersion.orElseThrow()) || mainVersion.get().equals(openVersion.orElseThrow());
     }
 
     /**

--- a/jbs/src/main/java/org/openjdk/skara/jbs/JdkVersion.java
+++ b/jbs/src/main/java/org/openjdk/skara/jbs/JdkVersion.java
@@ -33,7 +33,7 @@ public class JdkVersion implements Comparable<JdkVersion> {
     private final String build;
 
     private final static Pattern jdkVersionPattern = Pattern.compile("(5\\.0|[1-9][0-9]?)(u([0-9]{1,3}))?$");
-    private final static Pattern hsxVersionPattern = Pattern.compile("(hs[1-9][0-9]{1,2})(\\\\.([0-9]{1,3}))?$");
+    private final static Pattern hsxVersionPattern = Pattern.compile("(hs[1-9][0-9]{1,2})(\\.([0-9]{1,3}))?$");
     private final static Pattern embVersionPattern = Pattern.compile("(emb-[8-9])(u([0-9]{1,3}))?$");
     private final static Pattern ojVersionPattern = Pattern.compile("(openjdk[1-9][0-9]?)(u([0-9]{1,3}))?$");
 
@@ -64,15 +64,14 @@ public class JdkVersion implements Comparable<JdkVersion> {
             }
 
             finalComponents.addAll(Arrays.asList(raw.split("\\.")));
+
+            // All components except the optional one must be numeric
+            finalComponents.forEach(Integer::parseUnsignedInt);
+
             if (optional != null) {
                 finalComponents.add(null);
                 finalComponents.add(optional);
             }
-        }
-
-        // Never leave a trailing 'u' in the major version
-        if (finalComponents.get(0).endsWith("u")) {
-            finalComponents.set(0, finalComponents.get(0).substring(0, finalComponents.get(0).length() - 1));
         }
 
         return finalComponents;
@@ -92,12 +91,20 @@ public class JdkVersion implements Comparable<JdkVersion> {
                            .findAny().orElse(null);
     }
 
-    public static JdkVersion parse(String raw) {
-        return new JdkVersion(raw, null);
+    public static Optional<JdkVersion> parse(String raw) {
+        try {
+            return Optional.of(new JdkVersion(raw, null));
+        } catch (NumberFormatException e) {
+            return Optional.empty();
+        }
     }
 
-    public static JdkVersion parse(String raw, String build) {
-        return new JdkVersion(raw, build);
+    public static Optional<JdkVersion> parse(String raw, String build) {
+        try {
+            return Optional.of(new JdkVersion(raw, build));
+        } catch (NumberFormatException e) {
+            return Optional.empty();
+        }
     }
 
     public List<String> components() {

--- a/jbs/src/main/java/org/openjdk/skara/jbs/JdkVersion.java
+++ b/jbs/src/main/java/org/openjdk/skara/jbs/JdkVersion.java
@@ -36,6 +36,7 @@ public class JdkVersion implements Comparable<JdkVersion> {
     private final static Pattern hsxVersionPattern = Pattern.compile("(hs[1-9][0-9]{1,2})(\\.([0-9]{1,3}))?$");
     private final static Pattern embVersionPattern = Pattern.compile("(emb-[8-9])(u([0-9]{1,3}))?$");
     private final static Pattern ojVersionPattern = Pattern.compile("(openjdk[1-9][0-9]?)(u([0-9]{1,3}))?$");
+    private final static Pattern fxVersionPattern = Pattern.compile("(openjfx[1-9][0-9]?)(u([0-9]{1,3}))?$");
 
     private final static Pattern legacyPrefixPattern = Pattern.compile("^([^\\d]*)\\d+$");
 
@@ -43,7 +44,7 @@ public class JdkVersion implements Comparable<JdkVersion> {
         var finalComponents = new ArrayList<String>();
 
         // First check for the legacy patterns
-        for (var legacyPattern : List.of(jdkVersionPattern, hsxVersionPattern, embVersionPattern, ojVersionPattern)) {
+        for (var legacyPattern : List.of(jdkVersionPattern, hsxVersionPattern, embVersionPattern, ojVersionPattern, fxVersionPattern)) {
             var legacyMatcher = legacyPattern.matcher(raw);
             if (legacyMatcher.matches()) {
                 finalComponents.add(legacyMatcher.group(1));

--- a/jbs/src/test/java/org/openjdk/skara/jbs/BackportsTests.java
+++ b/jbs/src/test/java/org/openjdk/skara/jbs/BackportsTests.java
@@ -157,23 +157,23 @@ public class BackportsTests {
 
             issue.setProperty("fixVersions", JSON.array().add("11-pool"));
             backport.setProperty("fixVersions", JSON.array().add("12-pool"));
-            assertEquals(issue, Backports.findIssue(issue, JdkVersion.parse("11.1")).orElseThrow());
-            assertEquals(backport, Backports.findIssue(issue, JdkVersion.parse("12.2")).orElseThrow());
-            assertEquals(Optional.empty(), Backports.findIssue(issue, JdkVersion.parse("13.3")));
+            assertEquals(issue, Backports.findIssue(issue, JdkVersion.parse("11.1").orElseThrow()).orElseThrow());
+            assertEquals(backport, Backports.findIssue(issue, JdkVersion.parse("12.2").orElseThrow()).orElseThrow());
+            assertEquals(Optional.empty(), Backports.findIssue(issue, JdkVersion.parse("13.3").orElseThrow()));
 
             issue.setProperty("fixVersions", JSON.array().add("tbd"));
-            assertEquals(issue, Backports.findIssue(issue, JdkVersion.parse("11.1")).orElseThrow());
+            assertEquals(issue, Backports.findIssue(issue, JdkVersion.parse("11.1").orElseThrow()).orElseThrow());
 
             issue.setProperty("fixVersions", JSON.array().add("12.2"));
             backport.setProperty("fixVersions", JSON.array().add("tbd"));
-            assertEquals(issue, Backports.findIssue(issue, JdkVersion.parse("12.2")).orElseThrow());
-            assertEquals(backport, Backports.findIssue(issue, JdkVersion.parse("11.1")).orElseThrow());
+            assertEquals(issue, Backports.findIssue(issue, JdkVersion.parse("12.2").orElseThrow()).orElseThrow());
+            assertEquals(backport, Backports.findIssue(issue, JdkVersion.parse("11.1").orElseThrow()).orElseThrow());
 
             issue.setProperty("fixVersions", JSON.array().add("12.2"));
             backport.setProperty("fixVersions", JSON.array().add("11.1"));
-            assertEquals(issue, Backports.findIssue(issue, JdkVersion.parse("12.2")).orElseThrow());
-            assertEquals(backport, Backports.findIssue(issue, JdkVersion.parse("11.1")).orElseThrow());
-            assertEquals(Optional.empty(), Backports.findIssue(issue, JdkVersion.parse("13.3")));
+            assertEquals(issue, Backports.findIssue(issue, JdkVersion.parse("12.2").orElseThrow()).orElseThrow());
+            assertEquals(backport, Backports.findIssue(issue, JdkVersion.parse("11.1").orElseThrow()).orElseThrow());
+            assertEquals(Optional.empty(), Backports.findIssue(issue, JdkVersion.parse("13.3").orElseThrow()));
         }
     }
 
@@ -270,7 +270,7 @@ public class BackportsTests {
             backports.assertLabeled();
 
             backports.addBackports("openjfx14", "openjfx16");
-            backports.assertLabeled("openjfx15", "openjfx16");
+            backports.assertLabeled();
         }
     }
 
@@ -461,6 +461,17 @@ public class BackportsTests {
             backports.assertLabeled();
 
             backports.addBackports("15-pool#open", "11-pool#open", "8-pool#open", "7-pool#open");
+            backports.assertLabeled();
+        }
+    }
+
+    @Test
+    void labelTest8242283(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo)) {
+            var backports = new BackportManager(credentials, "15");
+            backports.assertLabeled();
+
+            backports.addBackports("14.0.2", "14u-cpu", "11.0.9-oracle", "11.0.9");
             backports.assertLabeled();
         }
     }

--- a/jbs/src/test/java/org/openjdk/skara/jbs/BackportsTests.java
+++ b/jbs/src/test/java/org/openjdk/skara/jbs/BackportsTests.java
@@ -270,7 +270,7 @@ public class BackportsTests {
             backports.assertLabeled();
 
             backports.addBackports("openjfx14", "openjfx16");
-            backports.assertLabeled();
+            backports.assertLabeled("openjfx15", "openjfx16");
         }
     }
 

--- a/jbs/src/test/java/org/openjdk/skara/jbs/JdkVersionTests.java
+++ b/jbs/src/test/java/org/openjdk/skara/jbs/JdkVersionTests.java
@@ -24,70 +24,74 @@ package org.openjdk.skara.jbs;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
+import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class JdkVersionTests {
+    private JdkVersion from(String raw) {
+        return JdkVersion.parse(raw).orElseThrow();
+    }
+
     @Test
     void jep223() {
-        assertEquals(List.of("8"), JdkVersion.parse("8").components());
-        assertEquals(List.of("9", "0", "4"), JdkVersion.parse("9.0.4").components());
-        assertEquals(List.of("10", "0", "2"), JdkVersion.parse("10.0.2").components());
-        assertEquals(List.of("11"), JdkVersion.parse("11").components());
-        assertEquals(List.of("11", "0", "3"), JdkVersion.parse("11.0.3").components());
-        assertEquals(List.of("12", "0", "2"), JdkVersion.parse("12.0.2").components());
+        assertEquals(List.of("8"), from("8").components());
+        assertEquals(List.of("9", "0", "4"), from("9.0.4").components());
+        assertEquals(List.of("10", "0", "2"), from("10.0.2").components());
+        assertEquals(List.of("11"), from("11").components());
+        assertEquals(List.of("11", "0", "3"), from("11.0.3").components());
+        assertEquals(List.of("12", "0", "2"), from("12.0.2").components());
     }
 
     @Test
     void jep322() {
-        assertEquals(List.of("11", "0", "2", "0", "1"), JdkVersion.parse("11.0.2.0.1-oracle").components());
-        assertEquals("oracle", JdkVersion.parse("11.0.2.0.1-oracle").opt().orElseThrow());
-        assertEquals(List.of("11", "0", "3"), JdkVersion.parse("11.0.3-oracle").components());
-        assertEquals("oracle", JdkVersion.parse("11.0.3-oracle").opt().orElseThrow());
-        assertEquals(List.of("12"), JdkVersion.parse("12u-cpu").components());
-        assertEquals("cpu", JdkVersion.parse("12u-cpu").opt().orElseThrow());
-        assertEquals(List.of("13"), JdkVersion.parse("13u-open").components());
-        assertEquals("open", JdkVersion.parse("13u-open").opt().orElseThrow());
+        assertEquals(List.of("11", "0", "2", "0", "1"), from("11.0.2.0.1-oracle").components());
+        assertEquals("oracle", from("11.0.2.0.1-oracle").opt().orElseThrow());
+        assertEquals(List.of("11", "0", "3"), from("11.0.3-oracle").components());
+        assertEquals("oracle", from("11.0.3-oracle").opt().orElseThrow());
     }
 
     @Test
     void legacy() {
-        assertEquals(List.of("5.0", "45"), JdkVersion.parse("5.0u45").components());
-        assertEquals(List.of("6", "201"), JdkVersion.parse("6u201").components());
-        assertEquals(List.of("7", "40"), JdkVersion.parse("7u40").components());
-        assertEquals(List.of("8", "211"), JdkVersion.parse("8u211").components());
-        assertEquals(List.of("emb-8", "171"), JdkVersion.parse("emb-8u171").components());
-        assertEquals(List.of("hs22", "4"), JdkVersion.parse("hs22.4").components());
-        assertEquals(List.of("hs23"), JdkVersion.parse("hs23").components());
-        assertEquals(List.of("openjdk7"), JdkVersion.parse("openjdk7u").components());
-        assertEquals(List.of("openjdk8"), JdkVersion.parse("openjdk8").components());
-        assertEquals(List.of("openjdk8", "211"), JdkVersion.parse("openjdk8u211").components());
+        assertEquals(List.of("5.0", "45"), from("5.0u45").components());
+        assertEquals(List.of("6", "201"), from("6u201").components());
+        assertEquals(List.of("7", "40"), from("7u40").components());
+        assertEquals(List.of("8", "211"), from("8u211").components());
+        assertEquals(List.of("emb-8", "171"), from("emb-8u171").components());
+        assertEquals(List.of("hs22", "4"), from("hs22.4").components());
+        assertEquals(List.of("hs23"), from("hs23").components());
+        assertEquals(List.of("openjdk7"), from("openjdk7").components());
+        assertEquals(List.of("openjdk8"), from("openjdk8").components());
+        assertEquals(List.of("openjdk8", "211"), from("openjdk8u211").components());
     }
 
     @Test
     void order() {
-        assertEquals(0, JdkVersion.parse("5.0u45").compareTo(JdkVersion.parse("5.0u45")));
-        assertEquals(0, JdkVersion.parse("11.0.3").compareTo(JdkVersion.parse("11.0.3")));
-        assertEquals(0, JdkVersion.parse("11.0.2.0.1-oracle").compareTo(JdkVersion.parse("11.0.2.0.1-oracle")));
+        assertEquals(0, from("5.0u45").compareTo(from("5.0u45")));
+        assertEquals(0, from("11.0.3").compareTo(from("11.0.3")));
+        assertEquals(0, from("11.0.2.0.1-oracle").compareTo(from("11.0.2.0.1-oracle")));
 
-        assertEquals(1, JdkVersion.parse("6u201").compareTo(JdkVersion.parse("5.0u45")));
-        assertEquals(-1, JdkVersion.parse("5.0u45").compareTo(JdkVersion.parse("6u201")));
+        assertEquals(1, from("6u201").compareTo(from("5.0u45")));
+        assertEquals(-1, from("5.0u45").compareTo(from("6u201")));
 
-        assertEquals(-1, JdkVersion.parse("11.0.2.0.1").compareTo(JdkVersion.parse("11.0.2.0.1-oracle")));
-        assertEquals(1, JdkVersion.parse("11.0.2.0.1-oracle").compareTo(JdkVersion.parse("11.0.2.0.1")));
+        assertEquals(-1, from("11.0.2.0.1").compareTo(from("11.0.2.0.1-oracle")));
+        assertEquals(1, from("11.0.2.0.1-oracle").compareTo(from("11.0.2.0.1")));
 
-        assertEquals(-1, JdkVersion.parse("9.0.4").compareTo(JdkVersion.parse("10.0.2")));
-        assertEquals(-1, JdkVersion.parse("11").compareTo(JdkVersion.parse("11.0.3")));
-        assertEquals(-1, JdkVersion.parse("emb-8u171").compareTo(JdkVersion.parse("emb-8u175")));
-        assertEquals(-1, JdkVersion.parse("emb-8u71").compareTo(JdkVersion.parse("emb-8u170")));
-        assertEquals(-1, JdkVersion.parse("openjdk7u").compareTo(JdkVersion.parse("openjdk7u42")));
-        assertEquals(-1, JdkVersion.parse("hs22.4").compareTo(JdkVersion.parse("hs23")));
+        assertEquals(-1, from("9.0.4").compareTo(from("10.0.2")));
+        assertEquals(-1, from("11").compareTo(from("11.0.3")));
+        assertEquals(-1, from("emb-8u171").compareTo(from("emb-8u175")));
+        assertEquals(-1, from("emb-8u71").compareTo(from("emb-8u170")));
+        assertEquals(-1, from("openjdk7").compareTo(from("openjdk7u42")));
+        assertEquals(-1, from("hs22.4").compareTo(from("hs23")));
     }
 
     @Test
     void nonConforming() {
-        assertEquals("bla", JdkVersion.parse("bla").feature());
-        assertEquals("", JdkVersion.parse("").feature());
+        assertEquals(Optional.empty(), JdkVersion.parse("bla"));
+        assertEquals(Optional.empty(), JdkVersion.parse(""));
+        assertEquals(Optional.empty(), JdkVersion.parse("12u-cpu"));
+        assertEquals(Optional.empty(), JdkVersion.parse("12u-cpu"));
+        assertEquals(Optional.empty(), JdkVersion.parse("13u-open"));
+        assertEquals(Optional.empty(), JdkVersion.parse("13u-open"));
     }
 }

--- a/jbs/src/test/java/org/openjdk/skara/jbs/JdkVersionTests.java
+++ b/jbs/src/test/java/org/openjdk/skara/jbs/JdkVersionTests.java
@@ -90,8 +90,6 @@ public class JdkVersionTests {
         assertEquals(Optional.empty(), JdkVersion.parse("bla"));
         assertEquals(Optional.empty(), JdkVersion.parse(""));
         assertEquals(Optional.empty(), JdkVersion.parse("12u-cpu"));
-        assertEquals(Optional.empty(), JdkVersion.parse("12u-cpu"));
-        assertEquals(Optional.empty(), JdkVersion.parse("13u-open"));
         assertEquals(Optional.empty(), JdkVersion.parse("13u-open"));
     }
 }


### PR DESCRIPTION
There may be backport records that have fixVersions that should be ignored when calculating which of them should receive the hgupdate-sync label.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**) ⚠️ Review applies to 3dc9a7e25f2f5b0e64beb5998db05255274aa2f8
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - no project role) ⚠️ Review applies to 3dc9a7e25f2f5b0e64beb5998db05255274aa2f8


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/1010/head:pull/1010`
`$ git checkout pull/1010`
