### PR TITLE
574: git-info should use info from commit notifications

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/ForgeUtils.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/ForgeUtils.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.cli;
+
+import org.openjdk.skara.args.Arguments;
+import org.openjdk.skara.forge.Forge;
+import org.openjdk.skara.forge.HostedRepository;
+import org.openjdk.skara.host.Credential;
+import org.openjdk.skara.vcs.ReadOnlyRepository;
+import org.openjdk.skara.vcs.Repository;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+
+public class ForgeUtils {
+    private static void exit(String fmt, Object... args) {
+        System.err.println(String.format(fmt, args));
+        System.exit(1);
+    }
+
+    private static String gitConfig(String key) {
+        try {
+            var pb = new ProcessBuilder("git", "config", key);
+            pb.redirectOutput(ProcessBuilder.Redirect.PIPE);
+            pb.redirectError(ProcessBuilder.Redirect.DISCARD);
+            var p = pb.start();
+
+            var output = new String(p.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+            var res = p.waitFor();
+            if (res != 0) {
+                return null;
+            }
+
+            return output == null ? null : output.replace("\n", "");
+        } catch (InterruptedException e) {
+            return null;
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    public static String getOption(String name, String command, String subsection, Arguments arguments) {
+        if (arguments.contains(name)) {
+            return arguments.get(name).asString();
+        }
+
+        if (subsection != null && !subsection.isEmpty()) {
+            var subsectionSpecific = gitConfig(command + "." + subsection + "." + name);
+            if (subsectionSpecific != null) {
+                return subsectionSpecific;
+            }
+        }
+
+        return gitConfig(command + "." + name);
+    }
+
+    public static boolean getSwitch(String name, String command, String subsection, Arguments arguments) {
+        if (arguments.contains(name)) {
+            return true;
+        }
+
+        if (subsection != null && !subsection.isEmpty()) {
+            var subsectionSpecific = gitConfig(command + "." + subsection + "." + name);
+            if (subsectionSpecific != null) {
+                return subsectionSpecific.toLowerCase().equals("true");
+            }
+        }
+
+        var sectionSpecific = gitConfig(command + "." + name);
+        return sectionSpecific != null && sectionSpecific.toLowerCase().equals("true");
+    }
+
+    static Repository getRepo() throws IOException {
+        var cwd = Path.of("").toAbsolutePath();
+        return Repository.get(cwd).orElseThrow(() -> new IOException("no git repository found at " + cwd.toString()));
+    }
+
+    public static String getRemote(ReadOnlyRepository repo, String command, Arguments arguments) throws IOException {
+        var remote = getOption("remote", command, null, arguments);
+        return remote == null ? "origin" : remote;
+    }
+
+    public static URI getURI(ReadOnlyRepository repo, String command, Arguments arguments) throws IOException {
+        var remotePullPath = repo.pullPath(getRemote(repo, command, arguments));
+        return Remote.toWebURI(remotePullPath);
+    }
+
+    public static Forge getForge(URI uri, ReadOnlyRepository repo, String command, Arguments arguments) throws IOException {
+        var username = getOption("username", null, null, arguments);
+        var token = System.getenv("GIT_TOKEN");
+        var shouldUseToken = !getSwitch("no-token", command, null, arguments);
+        var credentials = !shouldUseToken ?
+                null :
+                GitCredentials.fill(uri.getHost(), uri.getPath(), username, token, uri.getScheme());
+        var forgeURI = URI.create(uri.getScheme() + "://" + uri.getHost());
+        var forge = credentials == null ?
+                Forge.from(forgeURI) :
+                Forge.from(forgeURI, new Credential(credentials.username(), credentials.password()));
+        if (forge.isEmpty()) {
+            if (!shouldUseToken) {
+                if (arguments.contains("verbose")) {
+                    System.err.println("");
+                }
+                System.err.println("warning: using this command with --no-token may result in rate limiting from " + forgeURI);
+                if (!arguments.contains("verbose")) {
+                    System.err.println("         Re-run with --verbose to see if you are being rate limited");
+                    System.err.println("");
+                }
+            }
+            exit("error: failed to connect to host: " + forgeURI);
+        }
+        if (credentials != null) {
+            GitCredentials.approve(credentials);
+        }
+        return forge.get();
+    }
+
+    public static String projectName(URI uri) {
+        var name = uri.getPath().toString().substring(1);
+        if (name.endsWith(".git")) {
+            name = name.substring(0, name.length() - ".git".length());
+        }
+        return name;
+    }
+
+    public static HostedRepository getHostedRepositoryFor(URI uri, ReadOnlyRepository repo, Forge host) throws IOException {
+        HostedRepository targetRepo = null;
+
+        try {
+            var upstream = Remote.toWebURI(repo.pullPath("upstream"));
+            targetRepo = host.repository(projectName(upstream)).orElse(null);
+        } catch (IOException e) {
+            // do nothing
+        }
+
+        if (targetRepo == null) {
+            var remoteRepo = host.repository(projectName(uri)).orElseThrow(() ->
+                    new IOException("Could not find repository at: " + uri.toString())
+            );
+            var parentRepo = remoteRepo.parent();
+            targetRepo = parentRepo.isPresent() ? parentRepo.get() : remoteRepo;
+        }
+
+        return targetRepo;
+    }
+}

--- a/cli/src/main/java/org/openjdk/skara/cli/GitInfo.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitInfo.java
@@ -78,28 +78,7 @@ public class GitInfo {
         var forge = ForgeUtils.getForge(repoUrl, repo, "info", arguments);
         var remoteRepo = ForgeUtils.getHostedRepositoryFor(repoUrl, repo, forge);
 
-        var comments = remoteRepo.commitComments(hash);
-        var reviewComment = comments.stream().filter(
-                c -> c.body().startsWith("<!-- COMMIT COMMENT NOTIFICATION -->")).findFirst();
-
-        if (reviewComment.isEmpty()) {
-            return null;
-        }
-
-        /** The review comment looks like this:
-         * <!-- COMMIT COMMENT NOTIFICATION -->
-         * ### Review
-         *
-         * - [openjdk/skara/123](https://git.openjdk.java.net/skara/pull/123)
-         */
-
-        var pattern = Pattern.compile("### Review[^]]*]\\((.*)\\)");
-        var matcher = pattern.matcher(reviewComment.get().body());
-        if (matcher.find()) {
-            return URI.create(matcher.group(1));
-        }
-
-        return null;
+        return remoteRepo.reviewUrl(hash);
     }
 
     public static void main(String[] args) throws IOException {

--- a/cli/src/main/java/org/openjdk/skara/cli/GitInfo.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,6 +65,25 @@ public class GitInfo {
     private static String jbsProject(ReadOnlyRepository repo, Hash hash) throws IOException {
         var conf = JCheckConfiguration.from(repo, hash).orElseThrow();
         return conf.general().jbs().toUpperCase();
+    }
+
+    private static URI getReviewUrl(ReadOnlyRepository repo, Hash hash, CommitMessage message) throws IOException {
+        var project = jbsProject(repo, hash);
+        if (message.issues().size() == 1) {
+            var issueId = message.issues().get(0).shortId();
+            var issueTracker = IssueTracker.from("jira", JBS);
+            var issue = issueTracker.project(project).issue(issueId);
+            if (issue.isPresent()) {
+                for (var link : issue.get().links()) {
+                    if (link.title().isPresent() && link.uri().isPresent()) {
+                        if (link.title().get().equals("Review")) {
+                            return link.uri().get();
+                        }
+                    }
+                }
+            }
+        }
+        return null;
     }
 
     public static void main(String[] args) throws IOException {
@@ -239,20 +258,9 @@ public class GitInfo {
 
         if (showReview) {
             var decoration = useDecoration? "Review: " : "";
-            var project = jbsProject(repo, hash);
-            if (message.issues().size() == 1) {
-                var issueId = message.issues().get(0).shortId();
-                var issueTracker = IssueTracker.from("jira", JBS);
-                var issue = issueTracker.project(project).issue(issueId);
-                if (issue.isPresent()) {
-                    for (var link : issue.get().links()) {
-                        if (link.title().isPresent() && link.uri().isPresent()) {
-                            if (link.title().get().equals("Review")) {
-                                System.out.println(decoration + link.uri().get());
-                            }
-                        }
-                    }
-                }
+            var reviewUrl = getReviewUrl(repo, hash, message);
+            if (reviewUrl != null) {
+                System.out.println(decoration + reviewUrl);
             }
         }
         if (showIssues) {

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrCreate.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrCreate.java
@@ -33,7 +33,6 @@ import java.io.IOException;
 import java.nio.file.*;
 import java.util.*;
 import java.util.stream.Collectors;
-import java.util.regex.Pattern;
 
 import static org.openjdk.skara.cli.pr.Utils.*;
 
@@ -145,7 +144,7 @@ public class GitPrCreate {
                 return null;
         });
 
-        var remoteRepo = host.repository(projectName(uri)).orElseThrow(() ->
+        var remoteRepo = host.repository(ForgeUtils.projectName(uri)).orElseThrow(() ->
                 new IOException("Could not find repository at " + uri.toString())
         );
         var parentRepo = remoteRepo.parent().orElseThrow(() ->
@@ -305,7 +304,7 @@ public class GitPrCreate {
         }
 
         var mailingLists = new ArrayList<String>();
-        var parentProject = projectName(parentRepo.url());
+        var parentProject = ForgeUtils.projectName(parentRepo.url());
         var isTargetingJDKRepo = parentProject.matches(".*\\/jdk[0-9]*");
         var cc = getOption("cc", "create", arguments);
         var isCCManual = cc != null && !cc.equals("auto");

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrList.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrList.java
@@ -23,6 +23,7 @@
 package org.openjdk.skara.cli.pr;
 
 import org.openjdk.skara.args.*;
+import org.openjdk.skara.cli.ForgeUtils;
 import org.openjdk.skara.host.HostUser;
 
 import static org.openjdk.skara.cli.pr.Utils.*;
@@ -115,7 +116,7 @@ public class GitPrList {
         var repo = getRepo();
         var uri = getURI(repo, arguments);
         var host = getForge(uri, repo, arguments);
-        var remoteRepo = getHostedRepositoryFor(uri, repo, host);
+        var remoteRepo = ForgeUtils.getHostedRepositoryFor(uri, repo, host);
 
         var prs = remoteRepo.pullRequests();
         var ids = new ArrayList<String>();

--- a/forge/src/test/java/org/openjdk/skara/forge/ForgeTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/ForgeTests.java
@@ -111,7 +111,7 @@ class ForgeTests {
             gitHostedRepo.addCommitComment(hash, """
                     <!-- COMMIT COMMENT NOTIFICATION -->
                     ### Review
-                    
+
                      - [openjdk/skara/123](https://git.openjdk.java.net/skara/pull/123)
                     """);
 

--- a/forge/src/test/java/org/openjdk/skara/forge/ForgeTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/ForgeTests.java
@@ -24,13 +24,23 @@ package org.openjdk.skara.forge;
 
 import org.junit.jupiter.api.Test;
 import org.openjdk.skara.host.Credential;
+import org.openjdk.skara.host.HostUser;
 import org.openjdk.skara.json.JSONObject;
+import org.openjdk.skara.test.TemporaryDirectory;
+import org.openjdk.skara.test.TestHost;
+import org.openjdk.skara.test.TestHostedRepository;
+import org.openjdk.skara.vcs.Hash;
+import org.openjdk.skara.vcs.Repository;
+import org.openjdk.skara.vcs.VCS;
 
+import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Files;
 import java.util.*;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class ForgeTests {
     @Test
@@ -74,5 +84,39 @@ class ForgeTests {
 
         assertEquals("something", allFactories.get(0).name());
         assertEquals("other", sorted.get(0).name());
+    }
+
+    private static Hash createCommit(Repository r) throws IOException {
+        var readme = r.root().resolve("README");
+        Files.write(readme, List.of("Hello, readme!"));
+
+        r.add(readme);
+        return r.commit("Add README", "duke", "duke@openjdk.java.net");
+    }
+
+    @Test
+    void reviewUrlTest() throws IOException {
+        try (var tmp = new TemporaryDirectory()) {
+            var gitLocalDir = tmp.path().resolve("review.git");
+            Files.createDirectories(gitLocalDir);
+            var gitLocalRepo = Repository.init(gitLocalDir, VCS.GIT);
+            var hash = createCommit(gitLocalRepo);
+
+            var host = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));
+            var gitHostedRepo = new TestHostedRepository(host, "review", gitLocalRepo);
+
+            var missingReviewUrl = gitHostedRepo.reviewUrl(hash);
+            assertNull(missingReviewUrl);
+
+            gitHostedRepo.addCommitComment(hash, """
+                    <!-- COMMIT COMMENT NOTIFICATION -->
+                    ### Review
+                    
+                     - [openjdk/skara/123](https://git.openjdk.java.net/skara/pull/123)
+                    """);
+
+            var reviewUrl = gitHostedRepo.reviewUrl(hash);
+            assertEquals(URI.create("https://git.openjdk.java.net/skara/pull/123"), reviewUrl);
+        }
     }
 }


### PR DESCRIPTION
git-info should use info from commit notifications to get the link to the review, not JBS (since not all PR have issues)

This required refactoring to move the hosted repo logic from cli/pr/Utils.java to where it can be accessed by all CLI tools. After some deliberating, I left a bunch of trivial wrappers in cli/pr/Utils.java -- otherwise this change would have touched *all* the files in cli/pr.

Testing: ad hoc testing of "git info" on some arbitrary Skara commits.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-574](https://bugs.openjdk.java.net/browse/SKARA-574): git-info should use info from commit notifications


### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**) ⚠️ Review applies to 50d827563e47142b011e9cee801e598112f5c2c3


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/1011/head:pull/1011`
`$ git checkout pull/1011`
