### PR TITLE
forge: double time-span for recent commit comments for GitLab

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -366,10 +366,10 @@ public class GitLabRepository implements HostedRepository {
 
     @Override
     public List<CommitComment> recentCommitComments() {
-        var twoDaysAgo = ZonedDateTime.now().minusDays(2);
+        var fourDaysAgo = ZonedDateTime.now().minusDays(4);
         var formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
         return request.get("events")
-                      .param("after", twoDaysAgo.format(formatter))
+                      .param("after", fourDaysAgo.format(formatter))
                       .execute()
                       .stream()
                       .filter(o -> o.contains("note") &&


### PR DESCRIPTION
Hi all,

please review this patch that increases the time span for fetching recent commit comments for a GitLab repository from `2` to `4` days. This ensures that the bots have some margin to fetch commit comments made prior to a weekend (in the unlikely case that the bots would be down over the weekend).

Testing:
- [x] `make test` passes on Linux x64

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/1014/head:pull/1014`
`$ git checkout pull/1014`
