### PR TITLE
pr: remove commitCommandUsers

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
@@ -51,7 +51,6 @@ public class PullRequestBotBuilder {
     private String confOverrideName = ".conf/jcheck";
     private String confOverrideRef = Branch.defaultFor(VCS.GIT).name();
     private String censusLink = null;
-    private List<HostUser> commitCommandUsers = List.of();
     private Map<String, HostedRepository> forks = Map.of();
 
     PullRequestBotBuilder() {
@@ -147,11 +146,6 @@ public class PullRequestBotBuilder {
         return this;
     }
 
-    public PullRequestBotBuilder commitCommandUsers(List<HostUser> commitCommandUsers) {
-        this.commitCommandUsers = commitCommandUsers;
-        return this;
-    }
-
     public PullRequestBotBuilder forks(Map<String, HostedRepository> forks) {
         this.forks = forks;
         return this;
@@ -162,6 +156,6 @@ public class PullRequestBotBuilder {
                                   blockingCheckLabels, readyLabels, twoReviewersLabels, twentyFourHoursLabels,
                                   readyComments, issueProject, ignoreStaleReviews,
                                   allowedTargetBranches, seedStorage, confOverrideRepo, confOverrideName,
-                                  confOverrideRef, censusLink, commitCommandUsers, forks);
+                                  confOverrideRef, censusLink, forks);
     }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
@@ -141,14 +141,6 @@ public class PullRequestBotFactory implements BotFactory {
                 botBuilder.censusLink(repo.value().get("censuslink").asString());
             }
 
-            if (repo.value().contains("commitcommanders")) {
-                var allowed = repo.value().get("commitcommanders").stream()
-                                  .map(JSONValue::asString)
-                                  .map(s -> HostUser.builder().id(s).build())
-                                  .collect(Collectors.toList());
-                botBuilder.commitCommandUsers(allowed);
-            }
-
             ret.add(botBuilder.build());
         }
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportCommitCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportCommitCommandTests.java
@@ -47,7 +47,6 @@ public class BackportCommitCommandTests {
                                     .censusRepo(censusBuilder.build())
                                     .censusLink("https://census.com/{{contributor}}-profile")
                                     .seedStorage(seedFolder)
-                                    .commitCommandUsers(List.of(author.forge().currentUser()))
                                     .forks(Map.of(author.name(), author))
                                     .build();
 
@@ -115,7 +114,6 @@ public class BackportCommitCommandTests {
                                     .censusRepo(censusBuilder.build())
                                     .censusLink("https://census.com/{{contributor}}-profile")
                                     .seedStorage(seedFolder)
-                                    .commitCommandUsers(List.of(author.forge().currentUser()))
                                     .forks(Map.of(author.name(), author))
                                     .build();
 
@@ -157,7 +155,6 @@ public class BackportCommitCommandTests {
                                     .censusRepo(censusBuilder.build())
                                     .censusLink("https://census.com/{{contributor}}-profile")
                                     .seedStorage(seedFolder)
-                                    .commitCommandUsers(List.of(author.forge().currentUser()))
                                     .forks(Map.of(author.name(), author))
                                     .build();
 
@@ -199,7 +196,6 @@ public class BackportCommitCommandTests {
                                     .censusRepo(censusBuilder.build())
                                     .censusLink("https://census.com/{{contributor}}-profile")
                                     .seedStorage(seedFolder)
-                                    .commitCommandUsers(List.of(author.forge().currentUser()))
                                     .forks(Map.of(author.name(), author))
                                     .build();
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CommitCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CommitCommandTests.java
@@ -46,7 +46,6 @@ public class CommitCommandTests {
                                     .censusRepo(censusBuilder.build())
                                     .censusLink("https://census.com/{{contributor}}-profile")
                                     .seedStorage(seedFolder)
-                                    .commitCommandUsers(List.of(author.forge().currentUser()))
                                     .build();
 
             // Populate the projects repository
@@ -92,7 +91,6 @@ public class CommitCommandTests {
                                     .censusRepo(censusBuilder.build())
                                     .censusLink("https://census.com/{{contributor}}-profile")
                                     .seedStorage(seedFolder)
-                                    .commitCommandUsers(List.of(author.forge().currentUser()))
                                     .build();
 
             // Populate the projects repository


### PR DESCRIPTION
Hi all,

please review this patch that removes the `commitCommandUsers` functionality from the PR bot. There is no need to describe the users who should be allowed to issue commit commands, all users should be able to do so. Individual commit commands might choose to limit users (e.g. based on census), but that should be up to individual commit commands.

Testing:
- [x] `make test` passes on Linux x64

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - no project role)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/1016/head:pull/1016`
`$ git checkout pull/1016`
