### PR TITLE
pr: fix Markdown for /backport

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
@@ -170,7 +170,7 @@ public class BackportCommand implements CommandHandler {
                                            var link = "[" + c.username() + "](https://openjdk.java.net/census#" +
                                                       c.username() + ")";
                                            return c.fullName().isPresent() ?
-                                                    c.fullName() + " (" + link + ")" :
+                                                    c.fullName().get() + " (" + link + ")" :
                                                     link;
                                        })
                                        .collect(Collectors.toList());


### PR DESCRIPTION
Hi all,

please review this small patch that fixes the Markdown in the pull request created by the `/backport` commit command. I had simply forgotten to call `.get()` on an `Optinal<String>` :blush: 

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - no project role)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/1018/head:pull/1018`
`$ git checkout pull/1018`
