### PR TITLE
572: Auto-correct PR title if it is a prefix of the JBS issue title

### DIFF
--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -921,15 +921,17 @@ class CheckTests {
 
             assertTrue(prBadTitle.body().contains("Title mismatch between PR and JBS for issue"));
 
-            var prCutOff =  credentials.createPullRequest(author, "master", "edit", issue1.id() + ": My first issue with a very long title that is going to be cut off by …", List.of("…the Git Forge provider"), false);
+            var prCutOff =  credentials.createPullRequest(author, "master", "edit", issue1.id() + ": My first issue with a very long title that is going to be cut off by …", List.of("…the Git Forge provider", "", "It also has a second line!"), false);
 
             // Check the status
             TestBotRunner.runPeriodicItems(checkBot);
 
             assertFalse(prCutOff.body().contains("Title mismatch between PR and JBS for issue"));
 
-            // And the body should contain the issue title
+            // The PR title should contain the full issue title
             assertEquals("1: My first issue with a very long title that is going to be cut off by the Git Forge provider", prCutOff.title());
+            // And the body should not contain the issue title
+            assertTrue(prCutOff.body().startsWith("It also has a second line!"));
         }
     }
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -914,7 +914,7 @@ class CheckTests {
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
             localRepo.push(editHash, author.url(), "edit", true);
-            var prBadTitle =  credentials.createPullRequest(author, "master", "edit", issue1.id() + ": My first issue with a very long title that is going to be cut off by …", List.of("…the Git Forge provider"), false);
+            var prBadTitle =  credentials.createPullRequest(author, "master", "edit", issue1.id() + ": My OTHER issue with a very long title that is going to be cut off by …", List.of("…the Git Forge provider"), false);
 
             // Check the status
             TestBotRunner.runPeriodicItems(checkBot);
@@ -929,7 +929,7 @@ class CheckTests {
             assertFalse(prCutOff.body().contains("Title mismatch between PR and JBS for issue"));
 
             // And the body should contain the issue title
-            assertEquals("TEST-1: My first issue with a very long title that is going to be cut off by the Git Forge provider", prCutOff.title());
+            assertEquals("1: My first issue with a very long title that is going to be cut off by the Git Forge provider", prCutOff.title());
         }
     }
 


### PR DESCRIPTION
The PR bot should auto-correct PR titles if they are a known prefix of a JBS issue title instead of showing a warning that there is a mismatch between PR and JBS title.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-572](https://bugs.openjdk.java.net/browse/SKARA-572): Auto-correct PR title if it is a prefix of the JBS issue title


### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/1023/head:pull/1023`
`$ git checkout pull/1023`
