### PR TITLE
pr: add /clean command

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -255,9 +255,18 @@ class CheckRun {
         if (isClean && !hasCleanLabel) {
             pr.addLabel("clean");
         }
-        if (!isClean && hasCleanLabel) {
+
+        var botUser = pr.repository().forge().currentUser();
+        var isCleanLabelManuallyAdded =
+            pr.comments()
+              .stream()
+              .filter(c -> c.author().equals(botUser))
+              .anyMatch(c -> c.body().contains("this backport pull request is now marked as clean"));
+
+        if (!isCleanLabelManuallyAdded && !isClean && hasCleanLabel) {
             pr.removeLabel("clean");
         }
+
         return isClean;
     }
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CleanCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CleanCommand.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.pr;
+
+import org.openjdk.skara.forge.HostedCommit;
+import org.openjdk.skara.forge.PullRequest;
+import org.openjdk.skara.issuetracker.Comment;
+import org.openjdk.skara.vcs.*;
+import org.openjdk.skara.vcs.openjdk.CommitMessageParsers;
+
+import java.io.PrintWriter;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.time.format.DateTimeFormatter;
+
+public class CleanCommand implements CommandHandler {
+    private void showHelp(PrintWriter reply) {
+        reply.println("Usage: `/clean`");
+    }
+
+    @Override
+    public String description() {
+        return "Mark the backport pull request as a clean backport";
+    }
+
+    @Override
+    public boolean allowedInBody() {
+        return true;
+    }
+
+    @Override
+    public void handle(PullRequestBot bot, PullRequest pr, CensusInstance censusInstance, Path scratchPath, CommandInvocation command, List<Comment> allComments, PrintWriter reply)
+    {
+        var username = command.user().username();
+        if (!censusInstance.isCommitter(command.user())) {
+            reply.println("@" + username + " only OpenJDK [Committers](https://openjdk.java.net/bylaws#committer) can use the `/clean` command");
+            return;
+        }
+
+        if (!pr.labels().contains("backport")) {
+            reply.println("@" + username + " can only mark [backport pull requests](https://wiki.openjdk.java.net/display/SKARA/Backports#Backports-BackportPullRequests) as clean");
+            return;
+        }
+
+        if (pr.labels().contains("clean")) {
+            reply.println("@" + username + " this backport pull request is already marked as clean");
+            return;
+        }
+
+        pr.addLabel("clean");
+        reply.println("@" + username + " this backport pull request is now marked as clean");
+    }
+}

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandWorkItem.java
@@ -55,7 +55,8 @@ public class CommandWorkItem extends PullRequestWorkItem {
             Map.entry("csr", new CSRCommand()),
             Map.entry("reviewer", new ReviewerCommand()),
             Map.entry("label", new LabelCommand()),
-            Map.entry("cc", new LabelCommand("cc"))
+            Map.entry("cc", new LabelCommand("cc")),
+            Map.entry("clean", new CleanCommand())
     );
 
     static class HelpCommand implements CommandHandler {

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CleanCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CleanCommandTests.java
@@ -1,0 +1,300 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.pr;
+
+import org.openjdk.skara.forge.*;
+import org.junit.jupiter.api.*;
+import org.openjdk.skara.test.*;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.util.*;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.openjdk.skara.bots.pr.PullRequestAsserts.assertLastCommentContains;
+
+public class CleanCommandTests {
+    @Test
+    void cleanCommandOnRegularPullRequestShouldNotWork(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var integrator = credentials.getHostedRepository();
+
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addCommitter(author.forge().currentUser().id())
+                                           .addReviewer(integrator.forge().currentUser().id());
+
+            var prBot = PullRequestBot.newBuilder()
+                                      .repo(integrator)
+                                      .censusRepo(censusBuilder.build())
+                                      .build();
+
+            // Populate the projects repository
+            var localRepoFolder = tempFolder.path().resolve("localrepo");
+            var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "123: This is a pull request");
+            TestBotRunner.runPeriodicItems(prBot);
+
+            assertFalse(pr.labels().contains("backport"));
+            assertFalse(pr.labels().contains("clean"));
+
+            // Try to issue the "/clean" PR command, should not work
+            pr.addComment("/clean");
+            TestBotRunner.runPeriodicItems(prBot);
+            assertFalse(pr.labels().contains("backport"));
+            assertFalse(pr.labels().contains("clean"));
+            assertLastCommentContains(pr, "can only mark [backport pull requests]");
+            assertLastCommentContains(pr, "as clean");
+        }
+    }
+
+    @Test
+    void alreadyCleanPullRequest(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory(false);
+             var pushedFolder = new TemporaryDirectory(false)) {
+
+            var author = credentials.getHostedRepository();
+            var integrator = credentials.getHostedRepository();
+            var issues = credentials.getIssueProject();
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addCommitter(author.forge().currentUser().id())
+                                           .addReviewer(integrator.forge().currentUser().id());
+            var bot = PullRequestBot.newBuilder()
+                                    .repo(integrator)
+                                    .censusRepo(censusBuilder.build())
+                                    .issueProject(issues)
+                                    .build();
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            var releaseBranch = localRepo.branch(masterHash, "release");
+            localRepo.checkout(releaseBranch);
+            var newFile = localRepo.root().resolve("a_new_file.txt");
+            Files.writeString(newFile, "hello");
+            localRepo.add(newFile);
+            var issue1 = credentials.createIssue(issues, "An issue");
+            var issue1Number = issue1.id().split("-")[1];
+            var originalMessage = issue1Number + ": An issue\n" +
+                                  "\n" +
+                                  "Reviewed-by: integrationreviewer2";
+            var releaseHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.java.net");
+            localRepo.push(releaseHash, author.url(), "refs/heads/release", true);
+
+            // "backport" the new file to the master branch
+            localRepo.checkout(localRepo.defaultBranch());
+            var editBranch = localRepo.branch(masterHash, "edit");
+            localRepo.checkout(editBranch);
+            var newFile2 = localRepo.root().resolve("a_new_file.txt");
+            Files.writeString(newFile2, "hello");
+            localRepo.add(newFile2);
+            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.java.net");
+            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "Backport " + releaseHash.hex());
+
+            // The bot should reply with a backport message
+            TestBotRunner.runPeriodicItems(bot);
+            var comments = pr.comments();
+            var backportComment = comments.get(0).body();
+            assertTrue(backportComment.contains("This backport pull request has now been updated with issue"));
+            assertTrue(backportComment.contains("<!-- backport " + releaseHash.hex() + " -->"));
+            assertEquals(issue1Number + ": An issue", pr.title());
+            assertTrue(pr.labels().contains("backport"));
+
+            // The bot should have added the "clean" label
+            assertTrue(pr.labels().contains("clean"));
+
+            // Issue the "/clean" PR command, should do nothing
+            pr.addComment("/clean");
+            TestBotRunner.runPeriodicItems(bot);
+            assertTrue(pr.labels().contains("clean"));
+            assertLastCommentContains(pr, "this backport pull request is already marked as clean");
+        }
+    }
+
+    @Test
+    void makeNonCleanBackportClean(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory(false);
+             var pushedFolder = new TemporaryDirectory(false)) {
+
+            var author = credentials.getHostedRepository();
+            var integrator = credentials.getHostedRepository();
+            var issues = credentials.getIssueProject();
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addCommitter(author.forge().currentUser().id())
+                                           .addReviewer(integrator.forge().currentUser().id());
+            var bot = PullRequestBot.newBuilder()
+                                    .repo(integrator)
+                                    .censusRepo(censusBuilder.build())
+                                    .issueProject(issues)
+                                    .build();
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
+
+            var newFile = localRepo.root().resolve("a_new_file.txt");
+            Files.writeString(newFile, "a\nb\nc\nd");
+            localRepo.add(newFile);
+            var issue1 = credentials.createIssue(issues, "An issue");
+            var issue1Number = issue1.id().split("-")[1];
+            var originalMessage = issue1Number + ": An issue\n" +
+                                  "\n" +
+                                  "Reviewed-by: integrationreviewer2";
+            var masterHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.java.net");
+
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            var releaseBranch = localRepo.branch(masterHash, "release");
+            localRepo.checkout(releaseBranch);
+            Files.writeString(newFile, "a\nb\nc\nd\ne");
+            localRepo.add(newFile);
+            var issue2 = credentials.createIssue(issues, "Another issue");
+            var issue2Number = issue2.id().split("-")[1];
+            var upstreamMessage = issue2Number + ": Another issue\n" +
+                                  "\n" +
+                                  "Reviewed-by: integrationreviewer2";
+            var upstreamHash = localRepo.commit(upstreamMessage, "integrationcommitter1", "integrationcommitter1@openjdk.java.net");
+            localRepo.push(upstreamHash, author.url(), "refs/heads/release", true);
+
+            // "backport" the new file to the master branch
+            localRepo.checkout(localRepo.defaultBranch());
+            var editBranch = localRepo.branch(masterHash, "edit");
+            localRepo.checkout(editBranch);
+            Files.writeString(newFile, "a\nb\nc\nd\nd");
+            localRepo.add(newFile);
+            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.java.net");
+            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "Backport " + upstreamHash.hex());
+
+            // The bot should reply with a backport message
+            TestBotRunner.runPeriodicItems(bot);
+            var comments = pr.comments();
+            var backportComment = comments.get(0).body();
+            assertTrue(backportComment.contains("This backport pull request has now been updated with issue"));
+            assertTrue(backportComment.contains("<!-- backport " + upstreamHash.hex() + " -->"));
+            assertEquals(issue2Number + ": Another issue", pr.title());
+            assertTrue(pr.labels().contains("backport"));
+
+            // The bot should not have added the "clean" label
+            assertFalse(pr.labels().contains("clean"));
+
+            // Use the "/clean" pull request command to mark the backport PR as clean
+            pr.addComment("/clean");
+            TestBotRunner.runPeriodicItems(bot);
+            assertTrue(pr.labels().contains("clean"));
+            assertLastCommentContains(pr, "this backport pull request is now marked as clean");
+        }
+    }
+
+    @Test
+    void authorShouldNotBeAllowed(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory(false);
+             var pushedFolder = new TemporaryDirectory(false)) {
+
+            var author = credentials.getHostedRepository();
+            var contributor = credentials.getHostedRepository();
+            var integrator = credentials.getHostedRepository();
+            var issues = credentials.getIssueProject();
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addAuthor(contributor.forge().currentUser().id())
+                                           .addCommitter(author.forge().currentUser().id())
+                                           .addReviewer(integrator.forge().currentUser().id());
+            var bot = PullRequestBot.newBuilder()
+                                    .repo(integrator)
+                                    .censusRepo(censusBuilder.build())
+                                    .issueProject(issues)
+                                    .build();
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
+
+            var newFile = localRepo.root().resolve("a_new_file.txt");
+            Files.writeString(newFile, "a\nb\nc\nd");
+            localRepo.add(newFile);
+            var issue1 = credentials.createIssue(issues, "An issue");
+            var issue1Number = issue1.id().split("-")[1];
+            var originalMessage = issue1Number + ": An issue\n" +
+                                  "\n" +
+                                  "Reviewed-by: integrationreviewer2";
+            var masterHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.java.net");
+
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            var releaseBranch = localRepo.branch(masterHash, "release");
+            localRepo.checkout(releaseBranch);
+            Files.writeString(newFile, "a\nb\nc\nd\ne");
+            localRepo.add(newFile);
+            var issue2 = credentials.createIssue(issues, "Another issue");
+            var issue2Number = issue2.id().split("-")[1];
+            var upstreamMessage = issue2Number + ": Another issue\n" +
+                                  "\n" +
+                                  "Reviewed-by: integrationreviewer2";
+            var upstreamHash = localRepo.commit(upstreamMessage, "integrationcommitter1", "integrationcommitter1@openjdk.java.net");
+            localRepo.push(upstreamHash, author.url(), "refs/heads/release", true);
+
+            // "backport" the new file to the master branch
+            localRepo.checkout(localRepo.defaultBranch());
+            var editBranch = localRepo.branch(masterHash, "edit");
+            localRepo.checkout(editBranch);
+            Files.writeString(newFile, "a\nb\nc\nd\nd");
+            localRepo.add(newFile);
+            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.java.net");
+            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "Backport " + upstreamHash.hex());
+
+            // The bot should reply with a backport message
+            TestBotRunner.runPeriodicItems(bot);
+            var comments = pr.comments();
+            var backportComment = comments.get(0).body();
+            assertTrue(backportComment.contains("This backport pull request has now been updated with issue"));
+            assertTrue(backportComment.contains("<!-- backport " + upstreamHash.hex() + " -->"));
+            assertEquals(issue2Number + ": Another issue", pr.title());
+            assertTrue(pr.labels().contains("backport"));
+
+            // The bot should not have added the "clean" label
+            assertFalse(pr.labels().contains("clean"));
+
+            // Use the "/clean" pull request command as author, should not work
+            var prAsAuthor = contributor.pullRequest(pr.id());
+            prAsAuthor.addComment("/clean");
+            TestBotRunner.runPeriodicItems(bot);
+            assertFalse(pr.labels().contains("clean"));
+            assertLastCommentContains(pr, "only OpenJDK [Committers]");
+            assertLastCommentContains(pr, "can use the `/clean` command");
+        }
+    }
+}

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrSet.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrSet.java
@@ -85,6 +85,10 @@ public class GitPrSet {
               .helptext("Mark the pull request as not draft")
               .optional(),
         Switch.shortcut("")
+              .fullname("clean")
+              .helptext("Set a backport pull request as clean")
+              .optional(),
+        Switch.shortcut("")
               .fullname("verbose")
               .helptext("Turn on verbose output")
               .optional(),
@@ -140,6 +144,13 @@ public class GitPrSet {
         var setClosed = getSwitch("closed", "set", arguments);
         if (setClosed) {
             pr.setState(PullRequest.State.CLOSED);
+        }
+
+        var setClean = getSwitch("clean", "set", arguments);
+        if (setClean) {
+            var command = pr.addComment("/clean");
+            var reply = awaitReplyTo(pr, command);
+            showReply(reply);
         }
 
         var setBody = getSwitch("body", "set", arguments);


### PR DESCRIPTION
Hi all,

please review this patch that adds the `/clean` pull request command for marking a backport pull request as clean. The command can be used by project Committers who determine that a backport is clean (even though the bot doesn't think so). This can for example be for simple things like the backport changing the copyright year, which the bot will not consider clean, but a human might.

I have also added the `--clean` flag to `git pr set` for those that prefer working from the command-line.

Testing:
- [x] Added a number of unit tests
- [x] `make test` passes on Linux x64

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/1024/head:pull/1024`
`$ git checkout pull/1024`
