### PR TITLE
cli: rework git-backport

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ and [Git](https://git-scm.com/) hashes
 - git-skara - learn about and update the Skara CLI tools
 - git-trees - run a git command in a tree of repositories
 - git-publish - publishes a local branch to a remote repository
+- git-backport - backports a commit from another repository onto the current branch
 
 There are also CLI tools available for importing OpenJDK
 [Mercurial](https://mercurial-scm.org/) repositories into

--- a/cli/src/main/java/org/openjdk/skara/cli/GitSkara.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitSkara.java
@@ -212,6 +212,7 @@ public class GitSkara {
         commands.put("proxy", GitProxy::main);
         commands.put("trees", GitTrees::main);
         commands.put("hg-export", GitHgExport::main);
+        commands.put("backport", GitBackport::main);
 
         commands.put("update", GitSkara::update);
         commands.put("-h", GitSkara::help);

--- a/skara.gitconfig
+++ b/skara.gitconfig
@@ -36,6 +36,7 @@
         proxy = ! git skara proxy
         trees = ! git skara trees
         hg-export = ! git skara hg-export
+        backport = ! git skara backport
 
         tcommit = trees commit
         tconfig = trees config


### PR DESCRIPTION
Hi all,

please review this patch that reworks how `git-backport` functions. `git-backport` is now much smaller (and more focused) than it used to be and now composes much better with other Skara CLI tools like `git-pr-create`. `git-backport` now simply fetches a commit from a remote repository and cherry-picks the fetched commit on top of the current branch (without committing). `git-backport` then finally makes a commit with the proper backport commit message (a commit message of the form `Backport <HASH>`).

The tool `git-backport` is now meant to be used in combination with `git-pr-create`, `git-pr-set` and `git-pr-integrate`. The following example shows how a commit can be backported, a pull request created, marking the pull request as clean and then finally integrating the pull request:

```
$ git checkout -b backport-5a01c3d68ac2
$ git backport --from=openjdk/jdk 5a01c3d68ac22b7ee6f0746405a9bdef43281cb7
$ git pr create
$ sleep 15 # give the bots some time to work
$ git pr set --clean
$ sleep 15 # allow the bots to do some more work
$ git pr integrate
$ git checkout -
```

All (or parts) of the above can of course be wrapped into a [git alias](https://git-scm.com/book/en/v2/Git-Basics-Git-Aliases) for those that don't like to type. The following show an example alias defined in `~/.gitconfig`:

```
[alias]
bp = "!f() { \
        git checkout -b backport-$1 && \
        git backport --from=openjdk/jdk $1 && \
        git pr create; \
      }; f"
```

A user can then simply run `git bp 5a01c3d68ac22b7ee6f0746405a9bdef43281cb7`.

The `--from` parameter to `git-backport` is configurable, so a user who most likely often backports from [openjdk/jdk](https://github.com/openjdk/jdk) can run the following to never have to set `--from` on the command-line:

```
$ git config --global backport.from https://github.com/openjdk/jdk
```

Note that `git-backport` only requires a personal access token (PAT) in the case when the `--from` option contains a simple repository name, for example `jdk`. In all other cases there is no need for a PAT, making the command accessible for those who are not using PATs. 

Testing:
- [x] Manual testing on Linux x64

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/1025/head:pull/1025`
`$ git checkout pull/1025`
