### PR TITLE
forge: add HostedRepository.webUrl for Branch

### DIFF
--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
@@ -184,4 +184,9 @@ class InMemoryHostedRepository implements HostedRepository {
     public List<CommitComment> recentCommitComments() {
         return List.of();
     }
+
+    @Override
+    public URI webUrl(Branch branch) {
+        return null;
+    }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
@@ -59,6 +59,7 @@ public interface HostedRepository {
     URI webUrl();
     URI nonTransformedWebUrl();
     URI webUrl(Hash hash);
+    URI webUrl(Branch branch);
     URI webUrl(String baseRef, String headRef);
     VCS repositoryType();
     String fileContents(String filename, String ref);

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -500,4 +500,10 @@ public class GitHubRepository implements HostedRepository {
             return WorkflowStatus.ENABLED;
         }
     }
+
+    @Override
+    public URI webUrl(Branch branch) {
+        var endpoint = "/" + repository + "/tree/" + branch.name();
+        return gitHubHost.getWebURI(endpoint);
+    }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabHost.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabHost.java
@@ -247,4 +247,8 @@ public class GitLabHost implements Forge {
     public String hostname() {
         return uri.getHost();
     }
+
+    URI getWebUri(String endpoint) {
+        return URI.create(uri.toString() + endpoint);
+    }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -519,4 +519,10 @@ public class GitLabRepository implements HostedRepository {
             return WorkflowStatus.DISABLED;
         }
     }
+
+    @Override
+    public URI webUrl(Branch branch) {
+        var endpoint = "/" + projectName + "/-/tree/" + branch.name();
+        return gitLabHost.getWebUri(endpoint);
+    }
 }

--- a/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
@@ -268,6 +268,11 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
         return WorkflowStatus.ENABLED;
     }
 
+    @Override
+    public URI webUrl(Branch branch) {
+        return URI.create(webUrl() + "/branch/" + branch.name());
+    }
+
     Repository localRepository() {
         return localRepository;
     }


### PR DESCRIPTION
Hi all,

please review this small patch that adds an overload for `webUrl` for a `Branch` on `HostedRepository`.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/1027/head:pull/1027`
`$ git checkout pull/1027`
