### PR TITLE
forge: add HostedRepository.createPullRequestUrl

### DIFF
--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
@@ -186,6 +186,11 @@ class InMemoryHostedRepository implements HostedRepository {
     }
 
     @Override
+    public URI createPullRequestUrl(HostedRepository target, String sourceRef, String targetRef) {
+        return null;
+    }
+
+    @Override
     public URI webUrl(Branch branch) {
         return null;
     }

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
@@ -184,4 +184,9 @@ class InMemoryHostedRepository implements HostedRepository {
     public List<CommitComment> recentCommitComments() {
         return List.of();
     }
+
+    @Override
+    public URI webUrl(Branch branch) {
+        return null;
+    }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
@@ -76,6 +76,9 @@ public interface HostedRepository {
     Optional<HostedCommit> commit(Hash hash);
     List<Check> allChecks(Hash hash);
     WorkflowStatus workflowStatus();
+    URI createPullRequestUrl(HostedRepository target,
+                             String targetRef,
+                             String sourceRef);
 
     default PullRequest createPullRequest(HostedRepository target,
                                           String targetRef,

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
@@ -59,6 +59,7 @@ public interface HostedRepository {
     URI webUrl();
     URI nonTransformedWebUrl();
     URI webUrl(Hash hash);
+    URI webUrl(Branch branch);
     URI webUrl(String baseRef, String headRef);
     VCS repositoryType();
     String fileContents(String filename, String ref);

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -506,4 +506,11 @@ public class GitHubRepository implements HostedRepository {
         var endpoint = "/" + repository + "/tree/" + branch.name();
         return gitHubHost.getWebURI(endpoint);
     }
+
+    @Override
+    public URI createPullRequestUrl(HostedRepository target, String targetRef, String sourceRef) {
+        var sourceGroup = repository.split("/")[0];
+        var endpoint = "/" + target.name() + "/" + targetRef + "..." + sourceGroup + ":" + sourceRef;
+        return gitHubHost.getWebURI(endpoint);
+    }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -500,4 +500,10 @@ public class GitHubRepository implements HostedRepository {
             return WorkflowStatus.ENABLED;
         }
     }
+
+    @Override
+    public URI webUrl(Branch branch) {
+        var endpoint = "/" + repository + "/tree/" + branch.name();
+        return gitHubHost.getWebURI(endpoint);
+    }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabHost.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabHost.java
@@ -247,4 +247,8 @@ public class GitLabHost implements Forge {
     public String hostname() {
         return uri.getHost();
     }
+
+    URI getWebUri(String endpoint) {
+        return URI.create(uri.toString() + endpoint);
+    }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -525,4 +525,16 @@ public class GitLabRepository implements HostedRepository {
         var endpoint = "/" + projectName + "/-/tree/" + branch.name();
         return gitLabHost.getWebUri(endpoint);
     }
+
+    @Override
+    public URI createPullRequestUrl(HostedRepository target, String targetRef, String sourceRef) {
+        var id = json.get("id").asInt();
+        var targetId = ((GitLabRepository) target).json.get("id").asInt();
+        var endpoint = "/" + projectName + "/-/merge_requests/new?" +
+                       "merge_request[source_project_id]=" + id +
+                       "&merge_request[source_branch]=" + sourceRef +
+                       "&merge_request[target_project]=" + targetId +
+                       "&merge_request[target_branch]=" + targetRef;
+        return gitLabHost.getWebUri(endpoint);
+    }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -519,4 +519,10 @@ public class GitLabRepository implements HostedRepository {
             return WorkflowStatus.DISABLED;
         }
     }
+
+    @Override
+    public URI webUrl(Branch branch) {
+        var endpoint = "/" + projectName + "/-/tree/" + branch.name();
+        return gitLabHost.getWebUri(endpoint);
+    }
 }

--- a/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
@@ -268,6 +268,11 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
         return WorkflowStatus.ENABLED;
     }
 
+    @Override
+    public URI webUrl(Branch branch) {
+        return URI.create(webUrl() + "/branch/" + branch.name());
+    }
+
     Repository localRepository() {
         return localRepository;
     }

--- a/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
@@ -269,6 +269,11 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
     }
 
     @Override
+    public URI createPullRequestUrl(HostedRepository target, String sourceRef, String targetRef) {
+        return URI.create(target.webUrl().toString() + "/pull/new/" + targetRef + "..." + projectName + ":" + sourceRef);
+    }
+
+    @Override
     public URI webUrl(Branch branch) {
         return URI.create(webUrl() + "/branch/" + branch.name());
     }


### PR DESCRIPTION
Hi all,

please review this small patch that adds the `HostedRepository.createPullRequestUrl` for getting the URL that a user can click to create a pull request between two `HostedRepository` instances.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/1028/head:pull/1028`
`$ git checkout pull/1028`
