### PR TITLE
pr: handle exceptions when fetching commit comments

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -35,6 +35,7 @@ import java.time.*;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Logger;
+import java.util.logging.Level;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -191,10 +192,15 @@ class PullRequestBot implements Bot {
             prs = remoteRepo.pullRequests(ZonedDateTime.now().minus(Duration.ofDays(1)));
         }
 
-        var commitComments = remoteRepo.recentCommitComments()
+        List<CommitComment> commitComments = List.of();
+        try {
+            commitComments = remoteRepo.recentCommitComments()
                                        .stream()
                                        .filter(cc -> !processedCommitComments.contains(cc.id()))
                                        .collect(Collectors.toList());
+        } catch (Throwable e) {
+            log.log(Level.SEVERE, "Could not fetch commit comments for " + remoteRepo.name(), e);
+        }
 
         return getWorkItems(prs, commitComments);
     }


### PR DESCRIPTION
Hi all,

please review this patch that handles exceptions thrown fetching commit comments for a repository. Handling here means logging the exception and moving on, there isn't much more we can at this point in the code.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/1029/head:pull/1029`
`$ git checkout pull/1029`
