### PR TITLE
Avoid expensive operations when comparing commit command work items

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommandWorkItem.java
@@ -87,7 +87,7 @@ public class CommitCommandWorkItem implements WorkItem {
         if (!bot.repo().webUrl().equals(otherItem.bot.repo().webUrl())) {
             return true;
         }
-        if (!commitComment.commit().equals(otherItem.commitComment.commit())) {
+        if (!commitComment.id().equals(otherItem.commitComment.id())) {
             return true;
         }
         return false;

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -25,7 +25,6 @@ package org.openjdk.skara.bots.pr;
 import org.openjdk.skara.bot.*;
 import org.openjdk.skara.census.Contributor;
 import org.openjdk.skara.forge.*;
-import org.openjdk.skara.host.HostUser;
 import org.openjdk.skara.issuetracker.*;
 import org.openjdk.skara.json.JSONValue;
 
@@ -34,8 +33,7 @@ import java.nio.file.Path;
 import java.time.*;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.logging.Logger;
-import java.util.logging.Level;
+import java.util.logging.*;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -192,15 +190,10 @@ class PullRequestBot implements Bot {
             prs = remoteRepo.pullRequests(ZonedDateTime.now().minus(Duration.ofDays(1)));
         }
 
-        List<CommitComment> commitComments = List.of();
-        try {
-            commitComments = remoteRepo.recentCommitComments()
+        var commitComments = remoteRepo.recentCommitComments()
                                        .stream()
-                                       .filter(cc -> !processedCommitComments.contains(cc.id()))
+                                       .filter(cc -> !processedCommitComments.containsKey(cc.id()))
                                        .collect(Collectors.toList());
-        } catch (Throwable e) {
-            log.log(Level.SEVERE, "Could not fetch commit comments for " + remoteRepo.name(), e);
-        }
 
         return getWorkItems(prs, commitComments);
     }


### PR DESCRIPTION
Ensure that the concurrentWith operation does not perform any operations that may require API call.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/1030/head:pull/1030`
`$ git checkout pull/1030`
