### PR TITLE
pr: fetch commit comments in work item

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommentsWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommentsWorkItem.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.pr;
+
+import org.openjdk.skara.bot.WorkItem;
+import org.openjdk.skara.forge.HostedRepository;
+
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+class CommitCommentsWorkItem implements WorkItem {
+    private final PullRequestBot bot;
+    private final HostedRepository repo;
+
+    private static final ConcurrentHashMap<String, Boolean> processed = new ConcurrentHashMap<>();
+    private static final Logger log = Logger.getLogger("org.openjdk.skara.bots.pr");
+
+    CommitCommentsWorkItem(PullRequestBot bot, HostedRepository repo) {
+        this.bot = bot;
+        this.repo = repo;
+    }
+
+    @Override
+    public boolean concurrentWith(WorkItem other) {
+        return true;
+    }
+
+    @Override
+    public Collection<WorkItem> run(Path scratchPath) {
+        log.info("Looking for recent commit comments for repository " + repo.name());
+
+        return repo.recentCommitComments()
+                   .stream()
+                   .filter(cc -> !processed.containsKey(cc.id()))
+                   .map(cc -> {
+                       processed.put(cc.id(), true);
+                       return new CommitCommandWorkItem(bot, cc, e -> processed.remove(cc.id()));
+                   })
+                   .collect(Collectors.toList());
+
+    }
+}

--- a/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
@@ -41,7 +41,6 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
     private final Repository localRepository;
     private final Pattern pullRequestPattern;
     private final Map<Hash, List<CommitComment>> commitComments;
-    private int nextCommitCommentId;
 
     public TestHostedRepository(TestHost host, String projectName, Repository localRepository) {
         super(host, projectName);
@@ -50,7 +49,6 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
         this.localRepository = localRepository;
         pullRequestPattern = Pattern.compile(url().toString() + "/pr/" + "(\\d+)");
         commitComments = new HashMap<>();
-        nextCommitCommentId = 0;
     }
 
     @Override
@@ -222,15 +220,14 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
 
     @Override
     public CommitComment addCommitComment(Hash hash, String body) {
-        var id = nextCommitCommentId;
-        nextCommitCommentId += 1;
         var createdAt = ZonedDateTime.now();
+        var id = createdAt.toInstant().toString();
 
         if (!commitComments.containsKey(hash)) {
             commitComments.put(hash, new ArrayList<>());
         }
         var comments = commitComments.get(hash);
-        var comment = new CommitComment(hash, null, -1, Integer.toString(id), body, host.currentUser(), createdAt, createdAt);
+        var comment = new CommitComment(hash, null, -1, id, body, host.currentUser(), createdAt, createdAt);
         comments.add(comment);
         return comment;
     }


### PR DESCRIPTION
Hi all,

please review this patch that fetches recent commit comments in a separate `WorkItem` for the `PullRequestBot`. This is to ensure that:

- possible exceptions thrown when fetching recent commit comments do not impact other `WorkItem`s generated by `PullRequestBot.getPeriodicItems`
- other `WorkItem`s can continue to make progress if the call to `recentCommitComments` takes a long time

Testing:
- [x] `make test` passes on Linux x64

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/1031/head:pull/1031`
`$ git checkout pull/1031`
