### PR TITLE
forge: fix GitLabRepository.recentCommitComments

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/CommitComment.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/CommitComment.java
@@ -29,11 +29,9 @@ import org.openjdk.skara.vcs.Hash;
 import java.nio.file.Path;
 import java.time.ZonedDateTime;
 import java.util.*;
-import java.util.function.Supplier;
 
 public class CommitComment extends Comment {
     private Hash commit;
-    private final Supplier<Hash> commitSupplier;
     private final Path path;
     private final int line;
 
@@ -41,16 +39,6 @@ public class CommitComment extends Comment {
         super(id, body, author, createdAt, updatedAt);
 
         this.commit = commit;
-        this.commitSupplier = null;
-        this.path = path;
-        this.line = line;
-    }
-
-    public CommitComment(Supplier<Hash> commitSupplier, Path path, int line, String id, String body, HostUser author, ZonedDateTime createdAt, ZonedDateTime updatedAt) {
-        super(id, body, author, createdAt, updatedAt);
-
-        this.commit = null;
-        this.commitSupplier = commitSupplier;
         this.path = path;
         this.line = line;
     }
@@ -59,9 +47,6 @@ public class CommitComment extends Comment {
      * Returns the hash of the commit.
      */
     public Hash commit() {
-        if (commit == null) {
-            commit = commitSupplier.get();
-        }
         return commit;
     }
 


### PR DESCRIPTION
Hi all,

please review this patch that re-works `GitLab.recentCommitComments` into its hopefully final shape. This patch fixes two problems:

- multiple commits can have the same commit message title (i.e. first line of commit message)
- GitLab sometimes returns a trimmed `target_title` for commit comment events

The first problem is fixed by always starting out with fetching the entire history (once) and then always return a set of candidate hashes for a given commit title. We can then fetch the commit comments for each of the candidate hashes to figure which hash the comment was made on. The solution to the second problem then piggy-backs on the first solution: if a hash with a given title isn't found, and the title ends with `...`, then go through all commit message titles and check if any of them has the given title as prefix.

The drawback is that it can take a couple of minutes to populate the initial commit message title to hash mapping, but since 874a89ceb0d5fd742db75b6f9744b56e200cfe32 this will run in a separate `WorkItem`, so the degraded performance won't affect other `WorkItem`s during startup. Once the map is populated there will only be one additional REST request for most calls to `recentCommitComments`.

Testing:
- [x] `make test` passes on Linux x64
- [x] Manual testing against GitLab on Linux x64 with `git skara debug commit-comments`

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/1032/head:pull/1032`
`$ git checkout pull/1032`
