### PR TITLE
pr: only act on commit comments on known branches

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommandWorkItem.java
@@ -27,7 +27,7 @@ import org.openjdk.skara.forge.*;
 import org.openjdk.skara.issuetracker.Comment;
 
 import java.io.*;
-import java.nio.file.Path;
+import java.nio.file.*;
 import java.util.*;
 import java.util.logging.Logger;
 import java.util.regex.*;

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CommitCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CommitCommandTests.java
@@ -25,9 +25,12 @@ package org.openjdk.skara.bots.pr;
 import org.junit.jupiter.api.*;
 import org.openjdk.skara.issuetracker.Issue;
 import org.openjdk.skara.test.*;
+import org.openjdk.skara.vcs.Hash;
 
 import java.io.IOException;
 import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CommitCommandTests {
     @Test
@@ -119,6 +122,46 @@ public class CommitCommandTests {
             pr.addComment("/integrate");
             TestBotRunner.runPeriodicItems(bot);
             PullRequestAsserts.assertLastCommentContains(pr, "can only be used in open pull requests");
+        }
+    }
+
+    @Test
+    void commitNotItRepository(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var reviewer = credentials.getHostedRepository();
+
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addAuthor(author.forge().currentUser().id())
+                                           .addReviewer(reviewer.forge().currentUser().id());
+            var seedFolder = tempFolder.path().resolve("seed");
+            var bot = PullRequestBot.newBuilder()
+                                    .repo(author)
+                                    .censusRepo(censusBuilder.build())
+                                    .censusLink("https://census.com/{{contributor}}-profile")
+                                    .seedStorage(seedFolder)
+                                    .build();
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Make a change directly on master
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.url(), "master");
+
+            // Make a commit only present in pr branch
+            var prHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(prHash, author.url(), "pr/1", true);
+
+            // Add a help command to commit in pr branch
+            var comment = author.addCommitComment(prHash, "/help");
+            TestBotRunner.runPeriodicItems(bot);
+
+            // Verify that the bot did *not* reply
+            assertEquals(List.of(comment), author.commitComments(prHash));
         }
     }
 }


### PR DESCRIPTION
Hi all,

please review this patch that makes the `CommitCommentsWorkItem` filter out commit comments that aren't made on commits on a known branch in the remote repository. Some forges can return comments on commits in pull requests, which aren't comments we want to act upon (commit commands are only for integrated commits on a known branch).

Testing:
- [x] Added a unit test
- [x] `make test` passes on Linux x64

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/1034/head:pull/1034`
`$ git checkout pull/1034`
