### PR TITLE
forge: pass commit-title-to-commits map to GitLab

### DIFF
--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
@@ -181,7 +181,7 @@ class InMemoryHostedRepository implements HostedRepository {
     }
 
     @Override
-    public List<CommitComment> recentCommitComments() {
+    public List<CommitComment> recentCommitComments(Map<String, Set<Hash>> commitTitleToCommits) {
         return List.of();
     }
 

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
@@ -70,7 +70,10 @@ public interface HostedRepository {
     Hash branchHash(String ref);
     List<HostedBranch> branches();
     List<CommitComment> commitComments(Hash hash);
-    List<CommitComment> recentCommitComments();
+    default List<CommitComment> recentCommitComments() {
+        return recentCommitComments(Map.of());
+    }
+    List<CommitComment> recentCommitComments(Map<String, Set<Hash>> commitTitleToCommits);
     CommitComment addCommitComment(Hash hash, String body);
     void updateCommitComment(String id, String body);
     Optional<HostedCommit> commit(Hash hash);

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -292,7 +292,7 @@ public class GitHubRepository implements HostedRepository {
     }
 
     @Override
-    public List<CommitComment> recentCommitComments() {
+    public List<CommitComment> recentCommitComments(Map<String, Set<Hash>> commitTitleToCommits) {
         var parts = name().split("/");
         var owner = parts[0];
         var name = parts[1];

--- a/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
@@ -210,7 +210,7 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
     }
 
     @Override
-    public List<CommitComment> recentCommitComments() {
+    public List<CommitComment> recentCommitComments(Map<String, Set<Hash>> commitTitleToCommits) {
         return commitComments.values()
                              .stream()
                              .flatMap(e -> e.stream())


### PR DESCRIPTION
Hi all,

please review this patch that greatly simplifies `GitLabRepository.recentCommitComments`. Now that `CommitCommentsWorkItem` has a `Repository` instance anyhow for filtering out applicable commits, we can use that to create a "commit titles to commits" map and pass that to `GitLabRepository.recentCommitComments`. This greatly speeds up the function call (avoid a bunch of expensive REST requests). Other forges can just ignore the argument.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/1035/head:pull/1035`
`$ git checkout pull/1035`
