### PR TITLE
pr: use separate scratch for commit-comments work item

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommentsWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommentsWorkItem.java
@@ -65,9 +65,8 @@ class CommitCommentsWorkItem implements WorkItem {
         try {
             var seedPath = bot.seedStorage().orElse(scratchPath.resolve("seeds"));
             var hostedRepositoryPool = new HostedRepositoryPool(seedPath);
-            var localRepoDir = scratchPath.resolve(bot.repo().name());
-            Files.createDirectories(localRepoDir);
-            var localRepo = hostedRepositoryPool.materialize(bot.repo(), localRepoDir);
+            var localRepoPath = scratchPath.resolve("pr").resolve("commit-comments").resolve(bot.repo().name());
+            var localRepo = hostedRepositoryPool.materialize(bot.repo(), localRepoPath);
             var remoteBranches = bot.repo().branches()
                                            .stream()
                                            .filter(b -> !b.name().startsWith("pr/"))


### PR DESCRIPTION
Hi all,

please review this patch puts the materialized repositories for the `CommitCommensWorkItem` into a separate directory.

Testing:
- [x] `make test` passes on Linux x64

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/1036/head:pull/1036`
`$ git checkout pull/1036`
