### PR TITLE
Allow issues to be excluded from the hgupdate-sync logic

### DIFF
--- a/bots/synclabel/src/main/java/org/openjdk/skara/bots/synclabel/SyncLabelBotUpdateLabelWorkItem.java
+++ b/bots/synclabel/src/main/java/org/openjdk/skara/bots/synclabel/SyncLabelBotUpdateLabelWorkItem.java
@@ -29,6 +29,7 @@ import org.openjdk.skara.jbs.*;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.logging.Logger;
+import java.util.stream.*;
 
 public class SyncLabelBotUpdateLabelWorkItem implements WorkItem {
     private final IssueProject issueProject;
@@ -62,10 +63,9 @@ public class SyncLabelBotUpdateLabelWorkItem implements WorkItem {
             return List.of();
         }
 
-        var related = Backports.findBackports(issue.get(), true);
-        var allIssues = new ArrayList<Issue>();
-        allIssues.add(issue.get());
-        allIssues.addAll(related);
+        var allIssues = Stream.concat(Stream.of(issue.get()), Backports.findBackports(issue.get(), true).stream())
+                              .filter(i -> !i.labels().contains("hgupdate-sync-ignore"))
+                              .collect(Collectors.toList());
 
         var needsLabel = Backports.releaseStreamDuplicates(allIssues);
         for (var i : allIssues) {

--- a/bots/synclabel/src/test/java/org/openjdk/skara/bots/synclabel/SyncLabelBotTests.java
+++ b/bots/synclabel/src/test/java/org/openjdk/skara/bots/synclabel/SyncLabelBotTests.java
@@ -141,4 +141,85 @@ public class SyncLabelBotTests {
             assertEquals(List.of("hgupdate-sync"), issue4.labels());
         }
     }
+
+    @Test
+    void testIgnored(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var storageFolder = tempFolder.path().resolve("storage");
+            var issueProject = credentials.getIssueProject();
+            var syncLabelBot = testBotBuilder(issueProject, storageFolder).create("synclabel", JSON.object());
+
+            var issue1 = credentials.createIssue(issueProject, "Issue 1");
+            issue1.setProperty("fixVersions", JSON.array().add(JSON.of("8u182")));
+            issue1.setProperty("issuetype", JSON.of("Bug"));
+            issue1.setState(RESOLVED);
+            TestBotRunner.runPeriodicItems(syncLabelBot);
+            assertEquals(List.of(), issue1.labels());
+
+            var issue2 = credentials.createIssue(issueProject, "Issue 2");
+            issue2.setProperty("fixVersions", JSON.array().add(JSON.of("8u162")));
+            issue2.setProperty("issuetype", JSON.of("Backport"));
+            issue2.setState(RESOLVED);
+            issue1.addLink(Link.create(issue2, "backported by").build());
+            TestBotRunner.runPeriodicItems(syncLabelBot);
+            assertEquals(List.of("hgupdate-sync"), issue1.labels());
+
+            var issue3 = credentials.createIssue(issueProject, "Issue 3");
+            issue3.setProperty("fixVersions", JSON.array().add(JSON.of("10")));
+            issue3.setProperty("issuetype", JSON.of("Backport"));
+            issue3.setState(RESOLVED);
+            issue1.addLink(Link.create(issue3, "backported by").build());
+            TestBotRunner.runPeriodicItems(syncLabelBot);
+            assertEquals(List.of(), issue3.labels());
+
+            var issue4 = credentials.createIssue(issueProject, "Issue 4");
+            issue4.setProperty("fixVersions", JSON.array().add(JSON.of("11")));
+            issue4.setProperty("issuetype", JSON.of("Backport"));
+            issue4.setState(RESOLVED);
+            issue1.addLink(Link.create(issue4, "backported by").build());
+            TestBotRunner.runPeriodicItems(syncLabelBot);
+            assertEquals(List.of("hgupdate-sync"), issue1.labels());
+            assertEquals(List.of(), issue2.labels());
+            assertEquals(List.of(), issue3.labels());
+            assertEquals(List.of("hgupdate-sync"), issue4.labels());
+
+            // Now ignore one of them - it should cause another to change
+            issue3.addLabel("hgupdate-sync-ignore");
+            TestBotRunner.runPeriodicItems(syncLabelBot);
+            assertEquals(List.of("hgupdate-sync"), issue1.labels());
+            assertEquals(List.of(), issue2.labels());
+            assertEquals(List.of("hgupdate-sync-ignore"), issue3.labels());
+            assertEquals(List.of(), issue4.labels());
+
+            // Rearrange it a bit more
+            var issue5 = credentials.createIssue(issueProject, "Issue 5");
+            issue5.setProperty("fixVersions", JSON.array().add(JSON.of("8u192")));
+            issue5.setProperty("issuetype", JSON.of("Backport"));
+            issue5.setState(RESOLVED);
+            issue1.addLink(Link.create(issue5, "backported by").build());
+            TestBotRunner.runPeriodicItems(syncLabelBot);
+            assertEquals(List.of("hgupdate-sync"), issue5.labels());
+
+            // Now ignore another
+            issue2.addLabel("hgupdate-sync-ignore");
+            TestBotRunner.runPeriodicItems(syncLabelBot);
+            assertEquals(List.of(), issue1.labels());
+            assertEquals(List.of("hgupdate-sync-ignore"), issue2.labels());
+            assertEquals(List.of("hgupdate-sync-ignore"), issue3.labels());
+            assertEquals(List.of(), issue4.labels());
+            assertEquals(List.of("hgupdate-sync"), issue5.labels());
+
+            // Now ignore the main issue as well
+            issue1.addLabel("hgupdate-sync-ignore");
+
+            // This should lead to issue 5 no longer being a sync issue
+            TestBotRunner.runPeriodicItems(syncLabelBot);
+            assertEquals(List.of("hgupdate-sync-ignore"), issue1.labels());
+            assertEquals(List.of("hgupdate-sync-ignore"), issue2.labels());
+            assertEquals(List.of("hgupdate-sync-ignore"), issue3.labels());
+            assertEquals(List.of(), issue4.labels());
+            assertEquals(List.of(), issue5.labels());
+        }
+    }
 }


### PR DESCRIPTION
Allow manual exclusion of certain issues when evaluating which ones should be marked with the hgupdate-sync label.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/1037/head:pull/1037`
`$ git checkout pull/1037`
