### PR TITLE
pr: separate commit and pr commands

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -312,6 +312,6 @@ class CheckWorkItem extends PullRequestWorkItem {
 
         // Must re-fetch PR after executing CheckRun
         var updatedPR = pr.repository().pullRequest(pr.id());
-        return List.of(new CommandWorkItem(bot, updatedPR, errorHandler));
+        return List.of(new PullRequestCommandWorkItem(bot, updatedPR, errorHandler));
     }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommandWorkItem.java
@@ -56,7 +56,7 @@ public class CommitCommandWorkItem implements WorkItem {
             Stream.concat(
                     commandHandlers.entrySet().stream()
                                    .map(entry -> entry.getKey() + " - " + entry.getValue().description()),
-                    bot.externalCommands().entrySet().stream()
+                    bot.externalCommitCommands().entrySet().stream()
                        .map(entry -> entry.getKey() + " - " + entry.getValue())
             ).sorted().forEachOrdered(c -> reply.println(" * " + c));
         }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -42,7 +42,8 @@ class PullRequestBot implements Bot {
     private final HostedRepository censusRepo;
     private final String censusRef;
     private final LabelConfiguration labelConfiguration;
-    private final Map<String, String> externalCommands;
+    private final Map<String, String> externalPullRequestCommands;
+    private final Map<String, String> externalCommitCommands;
     private final Map<String, String> blockingCheckLabels;
     private final Set<String> readyLabels;
     private final Set<String> twoReviewersLabels;
@@ -64,8 +65,8 @@ class PullRequestBot implements Bot {
 
     private Instant lastFullUpdate;
 
-    PullRequestBot(HostedRepository repo, HostedRepository censusRepo, String censusRef,
-                   LabelConfiguration labelConfiguration, Map<String, String> externalCommands,
+    PullRequestBot(HostedRepository repo, HostedRepository censusRepo, String censusRef, LabelConfiguration labelConfiguration,
+                   Map<String, String> externalPullRequestCommands, Map<String, String> externalCommitCommands,
                    Map<String, String> blockingCheckLabels, Set<String> readyLabels,
                    Set<String> twoReviewersLabels, Set<String> twentyFourHoursLabels,
                    Map<String, Pattern> readyComments, IssueProject issueProject,
@@ -76,7 +77,8 @@ class PullRequestBot implements Bot {
         this.censusRepo = censusRepo;
         this.censusRef = censusRef;
         this.labelConfiguration = labelConfiguration;
-        this.externalCommands = externalCommands;
+        this.externalPullRequestCommands = externalPullRequestCommands;
+        this.externalCommitCommands = externalCommitCommands;
         this.blockingCheckLabels = blockingCheckLabels;
         this.readyLabels = readyLabels;
         this.twoReviewersLabels = twoReviewersLabels;
@@ -163,7 +165,7 @@ class PullRequestBot implements Bot {
                     ret.add(new CheckWorkItem(this, pr, e -> updateCache.invalidate(pr)));
                 } else {
                     // Closed PR's do not need to be checked
-                    ret.add(new CommandWorkItem(this, pr, e -> updateCache.invalidate(pr)));
+                    ret.add(new PullRequestCommandWorkItem(this, pr, e -> updateCache.invalidate(pr)));
                 }
             }
         }
@@ -212,8 +214,12 @@ class PullRequestBot implements Bot {
         return labelConfiguration;
     }
 
-    Map<String, String> externalCommands() {
-        return externalCommands;
+    Map<String, String> externalPullRequestCommands() {
+        return externalPullRequestCommands;
+    }
+
+    Map<String, String> externalCommitCommands() {
+        return externalCommitCommands;
     }
 
     Map<String, String> blockingCheckLabels() {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
@@ -37,7 +37,8 @@ public class PullRequestBotBuilder {
     private HostedRepository censusRepo;
     private String censusRef = Branch.defaultFor(VCS.GIT).name();
     private LabelConfiguration labelConfiguration = LabelConfigurationJson.builder().build();
-    private Map<String, String> externalCommands = Map.of();
+    private Map<String, String> externalPullRequestCommands = Map.of();
+    private Map<String, String> externalCommitCommands = Map.of();
     private Map<String, String> blockingCheckLabels = Map.of();
     private Set<String> readyLabels = Set.of();
     private Set<String> twoReviewersLabels = Set.of();
@@ -76,8 +77,13 @@ public class PullRequestBotBuilder {
         return this;
     }
 
-    public PullRequestBotBuilder externalCommands(Map<String, String> externalCommands) {
-        this.externalCommands = externalCommands;
+    public PullRequestBotBuilder externalPullRequestCommands(Map<String, String> externalPullRequestCommands) {
+        this.externalPullRequestCommands = externalPullRequestCommands;
+        return this;
+    }
+
+    public PullRequestBotBuilder externalCommitCommands(Map<String, String> externalCommitCommands) {
+        this.externalCommitCommands = externalCommitCommands;
         return this;
     }
 
@@ -152,7 +158,8 @@ public class PullRequestBotBuilder {
     }
 
     public PullRequestBot build() {
-        return new PullRequestBot(repo, censusRepo, censusRef, labelConfiguration, externalCommands,
+        return new PullRequestBot(repo, censusRepo, censusRef, labelConfiguration,
+                                  externalPullRequestCommands, externalCommitCommands,
                                   blockingCheckLabels, readyLabels, twoReviewersLabels, twentyFourHoursLabels,
                                   readyComments, issueProject, ignoreStaleReviews,
                                   allowedTargetBranches, seedStorage, confOverrideRepo, confOverrideName,

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
@@ -42,10 +42,17 @@ public class PullRequestBotFactory implements BotFactory {
         var ret = new ArrayList<Bot>();
         var specific = configuration.specific();
 
-        var external = new HashMap<String, String>();
-        if (specific.contains("external")) {
-            for (var command : specific.get("external").fields()) {
-                external.put(command.name(), command.value().asString());
+        var externalPullRequestCommands = new HashMap<String, String>();
+        if (specific.contains("external") && specific.get("external").contains("pr")) {
+            for (var command : specific.get("external").get("pr").fields()) {
+                externalPullRequestCommands.put(command.name(), command.value().asString());
+            }
+        }
+
+        var externalCommitCommands = new HashMap<String, String>();
+        if (specific.contains("external") && specific.get("external").contains("commit")) {
+            for (var command : specific.get("external").get("commit").fields()) {
+                externalCommitCommands.put(command.name(), command.value().asString());
             }
         }
 
@@ -96,7 +103,8 @@ public class PullRequestBotFactory implements BotFactory {
                                            .blockingCheckLabels(blockers)
                                            .readyLabels(readyLabels)
                                            .readyComments(readyComments)
-                                           .externalCommands(external)
+                                           .externalPullRequestCommands(externalPullRequestCommands)
+                                           .externalCommitCommands(externalCommitCommands)
                                            .seedStorage(configuration.storageFolder().resolve("seeds"))
                                            .forks(forks);
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
@@ -35,7 +35,7 @@ import java.util.logging.Logger;
 import java.util.regex.*;
 import java.util.stream.*;
 
-public class CommandWorkItem extends PullRequestWorkItem {
+public class PullRequestCommandWorkItem extends PullRequestWorkItem {
     private static final Logger log = Logger.getLogger("org.openjdk.skara.bots.pr");
 
     private static final String commandReplyMarker = "<!-- Jmerge command reply message (%s) -->";
@@ -67,7 +67,7 @@ public class CommandWorkItem extends PullRequestWorkItem {
                     commandHandlers.entrySet().stream()
                                    .filter(entry -> entry.getValue().allowedInPullRequest())
                                    .map(entry -> entry.getKey() + " - " + entry.getValue().description()),
-                    bot.externalCommands().entrySet().stream()
+                    bot.externalPullRequestCommands().entrySet().stream()
                                           .map(entry -> entry.getKey() + " - " + entry.getValue())
             ).sorted().forEachOrdered(c -> reply.println(" * " + c));
         }
@@ -79,7 +79,7 @@ public class CommandWorkItem extends PullRequestWorkItem {
                     commandHandlers.entrySet().stream()
                                    .filter(entry -> entry.getValue().allowedInCommit())
                                    .map(entry -> entry.getKey() + " - " + entry.getValue().description()),
-                    bot.externalCommands().entrySet().stream()
+                    bot.externalPullRequestCommands().entrySet().stream()
                        .map(entry -> entry.getKey() + " - " + entry.getValue())
             ).sorted().forEachOrdered(c -> reply.println(" * " + c));
         }
@@ -95,7 +95,7 @@ public class CommandWorkItem extends PullRequestWorkItem {
         }
     }
 
-    CommandWorkItem(PullRequestBot bot, PullRequest pr, Consumer<RuntimeException> errorHandler) {
+    PullRequestCommandWorkItem(PullRequestBot bot, PullRequest pr, Consumer<RuntimeException> errorHandler) {
         super(bot, pr, errorHandler);
     }
 
@@ -129,7 +129,7 @@ public class CommandWorkItem extends PullRequestWorkItem {
 
         return allCommands.stream()
                           .filter(ci -> !handled.contains(ci.id()))
-                          .filter(ci -> !bot.externalCommands().containsKey(ci.name()))
+                          .filter(ci -> !bot.externalPullRequestCommands().containsKey(ci.name()))
                           .findFirst();
     }
 
@@ -175,7 +175,7 @@ public class CommandWorkItem extends PullRequestWorkItem {
             } else {
                 if (handler.get().allowedInPullRequest()) {
                     if (command.id().startsWith("body") && !handler.get().allowedInBody()) {
-                        handler = Optional.of(new CommandWorkItem.InvalidBodyCommandHandler());
+                        handler = Optional.of(new PullRequestCommandWorkItem.InvalidBodyCommandHandler());
                     }
                     handler.get().handle(bot, pr, censusInstance, scratchPath, command, allComments, printer);
                 } else {
@@ -236,6 +236,6 @@ public class CommandWorkItem extends PullRequestWorkItem {
 
     @Override
     public String toString() {
-        return "CommandWorkItem@" + pr.repository().name() + "#" + pr.id();
+        return "PullRequestCommandWorkItem@" + pr.repository().name() + "#" + pr.id();
     }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestCommandTests.java
@@ -32,7 +32,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.openjdk.skara.bots.pr.PullRequestAsserts.assertLastCommentContains;
 
-class CommandTests {
+class PullRequestCommandTests {
     @Test
     void invalidCommand(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
@@ -276,7 +276,7 @@ class CommandTests {
             var mergeBot = PullRequestBot.newBuilder()
                                          .repo(integrator)
                                          .censusRepo(censusBuilder.build())
-                                         .externalCommands(Map.of("external", "Help for external command"))
+                                         .externalPullRequestCommands(Map.of("external", "Help for external command"))
                                          .build();
 
             // Populate the projects repository


### PR DESCRIPTION
Hi all,

please review this pull request that properly separates pull request and commit commands at the source code level. The class `CommandWorkItem` is renamed to `PullRequestCommandWorkItem` and then I did a number of smaller follow-out refactorings from this renaming.

Testing:
- [x] `make test` passes on Linux x64

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/1038/head:pull/1038`
`$ git checkout pull/1038`
