### PR TITLE
Allow configuration of version patterns to either include or ignore

### DIFF
--- a/bots/synclabel/src/main/java/org/openjdk/skara/bots/synclabel/SyncLabelBot.java
+++ b/bots/synclabel/src/main/java/org/openjdk/skara/bots/synclabel/SyncLabelBot.java
@@ -28,17 +28,34 @@ import org.openjdk.skara.issuetracker.IssueProject;
 import java.time.*;
 import java.util.*;
 import java.util.logging.Logger;
+import java.util.regex.Pattern;
 
 public class SyncLabelBot implements Bot {
     private final IssueProject issueProject;
+    private final Pattern inspect;
+    private final Pattern ignore;
     private final Map<String, ZonedDateTime> issueUpdatedAt = new HashMap<>();
 
     private ZonedDateTime lastUpdate;
 
     private static final Logger log = Logger.getLogger("org.openjdk.skara.bots");
 
-    SyncLabelBot(IssueProject issueProject) {
+    SyncLabelBot(IssueProject issueProject, Pattern inspect, Pattern ignore) {
         this.issueProject = issueProject;
+        this.inspect = inspect;
+        this.ignore = ignore;
+    }
+
+    IssueProject issueProject() {
+        return issueProject;
+    }
+
+    Pattern inspect() {
+        return inspect;
+    }
+
+    Pattern ignore() {
+        return ignore;
     }
 
     @Override
@@ -61,7 +78,7 @@ public class SyncLabelBot implements Bot {
                 }
             }
             issueUpdatedAt.put(issue.id(), issue.updatedAt());
-            ret.add(new SyncLabelBotFindMainIssueWorkItem(issueProject, issue.id()));
+            ret.add(new SyncLabelBotFindMainIssueWorkItem(this, issue.id()));
         }
         return ret;
     }

--- a/bots/synclabel/src/main/java/org/openjdk/skara/bots/synclabel/SyncLabelBotFactory.java
+++ b/bots/synclabel/src/main/java/org/openjdk/skara/bots/synclabel/SyncLabelBotFactory.java
@@ -26,6 +26,7 @@ import org.openjdk.skara.bot.*;
 
 import java.util.*;
 import java.util.logging.Logger;
+import java.util.regex.Pattern;
 
 public class SyncLabelBotFactory implements BotFactory {
     private static final Logger log = Logger.getLogger("org.openjdk.skara.bots");
@@ -40,7 +41,10 @@ public class SyncLabelBotFactory implements BotFactory {
         var bots = new ArrayList<Bot>();
         var specific = configuration.specific();
         for (var issueproject : specific.get("issueprojects").asArray()) {
-            bots.add(new SyncLabelBot(configuration.issueProject(issueproject.asString())));
+            var project = configuration.issueProject(issueproject.get("project").asString());
+            var inspect = issueproject.contains("inspect") ? Pattern.compile(issueproject.get("inspect").asString()) : Pattern.compile(".*");
+            var ignore = issueproject.contains("ignore") ? Pattern.compile(issueproject.get("ignore").asString()) : Pattern.compile("\\b\\B");
+            bots.add(new SyncLabelBot(project, inspect, ignore));
         }
         return bots;
     }

--- a/bots/synclabel/src/main/java/org/openjdk/skara/bots/synclabel/SyncLabelBotFindMainIssueWorkItem.java
+++ b/bots/synclabel/src/main/java/org/openjdk/skara/bots/synclabel/SyncLabelBotFindMainIssueWorkItem.java
@@ -23,7 +23,6 @@
 package org.openjdk.skara.bots.synclabel;
 
 import org.openjdk.skara.bot.WorkItem;
-import org.openjdk.skara.issuetracker.IssueProject;
 import org.openjdk.skara.jbs.Backports;
 
 import java.nio.file.Path;
@@ -31,12 +30,12 @@ import java.util.*;
 import java.util.logging.Logger;
 
 public class SyncLabelBotFindMainIssueWorkItem implements WorkItem {
-    private final IssueProject issueProject;
     private final String issueId;
     private static final Logger log = Logger.getLogger("org.openjdk.skara.bots");
+    private final SyncLabelBot bot;
 
-    SyncLabelBotFindMainIssueWorkItem(IssueProject issueProject, String issueId) {
-        this.issueProject = issueProject;
+    SyncLabelBotFindMainIssueWorkItem(SyncLabelBot bot, String issueId) {
+        this.bot = bot;
         this.issueId = issueId;
     }
 
@@ -51,7 +50,7 @@ public class SyncLabelBotFindMainIssueWorkItem implements WorkItem {
 
     @Override
     public Collection<WorkItem> run(Path scratchPath) {
-        var issue = issueProject.issue(issueId);
+        var issue = bot.issueProject().issue(issueId);
         if (issue.isEmpty()) {
             log.severe("Issue " + issueId + " is no longer present!");
             return List.of();
@@ -63,7 +62,7 @@ public class SyncLabelBotFindMainIssueWorkItem implements WorkItem {
             return List.of();
         }
 
-        return List.of(new SyncLabelBotUpdateLabelWorkItem(issueProject, primary.get().id()));
+        return List.of(new SyncLabelBotUpdateLabelWorkItem(bot, primary.get().id()));
     }
 
     @Override


### PR DESCRIPTION
Allow configuring of version patterns that should either be included or ignored when determining which issues are considered when applying the hgupdate-sync label.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/1040/head:pull/1040`
`$ git checkout pull/1040`
