### PR TITLE
pr: update all local branches for commit comments

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommentsWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommentsWorkItem.java
@@ -67,12 +67,14 @@ class CommitCommentsWorkItem implements WorkItem {
             var hostedRepositoryPool = new HostedRepositoryPool(seedPath);
             var localRepoPath = scratchPath.resolve("pr").resolve("commit-comments").resolve(bot.repo().name());
             var localRepo = hostedRepositoryPool.materialize(bot.repo(), localRepoPath);
+            localRepo.fetchAllRemotes(false);
             var remoteBranches = bot.repo().branches()
                                            .stream()
                                            .filter(b -> !b.name().startsWith("pr/"))
                                            .collect(Collectors.toList());
             for (var branch : remoteBranches) {
-                localRepo.fetch(bot.repo().url(), branch.name());
+                localRepo.checkout(new Branch(branch.name()));
+                localRepo.merge(new Branch("origin/" + branch.name()), Repository.FastForward.ONLY);
             }
 
             var commitTitleToCommits = new HashMap<String, Set<Hash>>();


### PR DESCRIPTION
Hi all,

please review this patch that makes `CommitCommentsWorkItem` properly update all local branches prior to calling `ReadOnlyRepository.commitMetdata`. `ReadOnlyRepository.commitMetadata` is essentially `rev-list —all` for Git and all local refs need to be updated for this to work. In order to make as few networks call as possible I manually merge each local branch with its remote counterpart (instead of doing `pull`).

Testing:
- [x] `make test` passes on Linux x64

Thanks,
Erik