### PR TITLE
forge: add methods addCollaborator and canPush

### DIFF
--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
@@ -23,6 +23,7 @@
 package org.openjdk.skara.bots.tester;
 
 import org.openjdk.skara.forge.*;
+import org.openjdk.skara.host.HostUser;
 import org.openjdk.skara.json.JSONValue;
 import org.openjdk.skara.vcs.*;
 
@@ -193,5 +194,14 @@ class InMemoryHostedRepository implements HostedRepository {
     @Override
     public URI webUrl(Branch branch) {
         return null;
+    }
+
+    @Override
+    public void addCollaborator(HostUser user, boolean canPush) {
+    }
+
+    @Override
+    public boolean canPush(HostUser user) {
+        return false;
     }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.skara.forge;
 
+import org.openjdk.skara.host.HostUser;
 import org.openjdk.skara.json.JSONValue;
 import org.openjdk.skara.vcs.*;
 
@@ -82,6 +83,8 @@ public interface HostedRepository {
     URI createPullRequestUrl(HostedRepository target,
                              String targetRef,
                              String sourceRef);
+    void addCollaborator(HostUser user, boolean canPush);
+    boolean canPush(HostUser user);
 
     default PullRequest createPullRequest(HostedRepository target,
                                           String targetRef,

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -23,6 +23,7 @@
 package org.openjdk.skara.forge.github;
 
 import org.openjdk.skara.forge.*;
+import org.openjdk.skara.host.HostUser;
 import org.openjdk.skara.json.*;
 import org.openjdk.skara.network.*;
 import org.openjdk.skara.vcs.*;
@@ -512,5 +513,23 @@ public class GitHubRepository implements HostedRepository {
         var sourceGroup = repository.split("/")[0];
         var endpoint = "/" + target.name() + "/" + targetRef + "..." + sourceGroup + ":" + sourceRef;
         return gitHubHost.getWebURI(endpoint);
+    }
+
+    @Override
+    public void addCollaborator(HostUser user, boolean canPush) {
+        var query = JSON.object().put("permission", canPush ? "push" : "pull");
+        request.put("collaborators/" + user.username())
+               .body(query)
+               .execute();
+
+    }
+
+    @Override
+    public boolean canPush(HostUser user) {
+        var permission = request.get("collaborators/" + user.username())
+                                .execute()
+                                .get("permission")
+                                .asString();
+        return permission.equals("admin") || permission.equals("write");
     }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -547,4 +547,22 @@ public class GitLabRepository implements HostedRepository {
                        "&merge_request[target_branch]=" + targetRef;
         return gitLabHost.getWebUri(endpoint);
     }
+
+    @Override
+    public void addCollaborator(HostUser user, boolean canPush) {
+        var accessLevel = canPush ? "30" : "20";
+        var data = "user_id=" + user.id() + "&access_level=" + accessLevel;
+        request.post("members")
+               .body(data)
+               .execute();
+    }
+
+    @Override
+    public boolean canPush(HostUser user) {
+        var accessLevel = request.get("members/" + user.id())
+                                 .execute()
+                                 .get("access_level")
+                                 .asInt();
+        return accessLevel >= 30;
+    }
 }

--- a/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
@@ -23,6 +23,7 @@
 package org.openjdk.skara.test;
 
 import org.openjdk.skara.forge.*;
+import org.openjdk.skara.host.HostUser;
 import org.openjdk.skara.issuetracker.Issue;
 import org.openjdk.skara.json.JSONValue;
 import org.openjdk.skara.vcs.*;
@@ -41,6 +42,7 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
     private final Repository localRepository;
     private final Pattern pullRequestPattern;
     private final Map<Hash, List<CommitComment>> commitComments;
+    private Map<String, Boolean> collaborators = new HashMap<>();
 
     public TestHostedRepository(TestHost host, String projectName, Repository localRepository) {
         super(host, projectName);
@@ -273,6 +275,16 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
     @Override
     public URI webUrl(Branch branch) {
         return URI.create(webUrl() + "/branch/" + branch.name());
+    }
+
+    @Override
+    public void addCollaborator(HostUser user, boolean canPush) {
+        collaborators.put(user.username(), canPush);
+    }
+
+    @Override
+    public boolean canPush(HostUser user) {
+        return collaborators.getOrDefault(user.username(), false);
     }
 
     Repository localRepository() {


### PR DESCRIPTION
Hi all,

please review this patch that adds two methods to `HostedRepository`:

- `addCollabarator`
- `canPush`

These methods can be used to check and grant access for a user to a particular hosted repository.

Thanks,
Erik