### PR TITLE
forge: add HostedRepository.restrictPushAccess

### DIFF
--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
@@ -204,4 +204,8 @@ class InMemoryHostedRepository implements HostedRepository {
     public boolean canPush(HostUser user) {
         return false;
     }
+
+    @Override
+    public void restrictPushAccess(Branch branch, List<HostUser> users) {
+    }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
@@ -85,6 +85,7 @@ public interface HostedRepository {
                              String sourceRef);
     void addCollaborator(HostUser user, boolean canPush);
     boolean canPush(HostUser user);
+    void restrictPushAccess(Branch branch, List<HostUser> users);
 
     default PullRequest createPullRequest(HostedRepository target,
                                           String targetRef,

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -532,4 +532,17 @@ public class GitHubRepository implements HostedRepository {
                                 .asString();
         return permission.equals("admin") || permission.equals("write");
     }
+
+    @Override
+    public void restrictPushAccess(Branch branch, List<HostUser> users) {
+        var usernames = JSON.array();
+        for (var user : users) {
+            usernames.add(user.username());
+        }
+        var query = JSON.object()
+                        .put("restrictions", JSON.object().put("users", usernames));
+        request.put("branches/" + branch.name() + "/protection")
+               .body(query)
+               .execute();
+    }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -565,4 +565,10 @@ public class GitLabRepository implements HostedRepository {
                                  .asInt();
         return accessLevel >= 30;
     }
+
+    @Override
+    public void restrictPushAccess(Branch branch, List<HostUser> users) {
+        // Not possible to implement using GitLab Community Edition.
+        // Must work around in admin web UI using groups.
+    }
 }

--- a/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
@@ -287,6 +287,11 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
         return collaborators.getOrDefault(user.username(), false);
     }
 
+    @Override
+    public void restrictPushAccess(Branch branch, List<HostUser> users) {
+        // Not possible to simulate
+    }
+
     Repository localRepository() {
         return localRepository;
     }


### PR DESCRIPTION
Hi all,

please review this small patch that adds the method `HostedRepository.restrictPushAccess`. As the name implies the method can be used to restrict the user on a forge that can push to a specific branch in a hosted repository. Unfortunately this is hard to implement in `TestHostedRepository` (even if we would use hooks), so I opted to just do nothing in `TestHostedRepository`.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/1048/head:pull/1048`
`$ git checkout pull/1048`
