### PR TITLE
913: Skara should honor .gitconfig and /etc/gitconfig

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitCommits.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitCommits.java
@@ -81,7 +81,7 @@ class GitCommits implements Commits, AutoCloseable {
         cmd.add(range);
         var pb = new ProcessBuilder(cmd);
         pb.directory(dir.toFile());
-        pb.environment().putAll(GitRepository.NO_CONFIG_ENV);
+        pb.environment().putAll(GitRepository.currentEnv);
         var command = pb.command();
         try {
             var p = pb.start();

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -50,8 +50,8 @@ public class GitRepository implements Repository {
     private Path cachedRoot = null;
     private static final Hash EMPTY_TREE = new Hash("4b825dc642cb6eb9a060e54bf8d69288fbee4904");
 
-    public static void ignoreUserConfiguration(boolean ignore) {
-        currentEnv = ignore ? NO_CONFIG_ENV : Collections.emptyMap();
+    public static void ignoreConfiguration() {
+        currentEnv = NO_CONFIG_ENV;
     }
 
     private java.lang.Process start(String... cmd) throws IOException {

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -50,8 +50,8 @@ public class HgRepository implements Repository {
     private final Path dir;
     private final Logger log = Logger.getLogger("org.openjdk.skara.vcs.hg");
 
-    public static void ignoreUserConfiguration(boolean ignore) {
-        currentEnv = ignore ? NO_CONFIG_ENV : Collections.emptyMap();
+    public static void ignoreConfiguration() {
+        currentEnv = NO_CONFIG_ENV;
     }
 
     private void copyResource(String name, Path p) throws IOException {

--- a/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
@@ -23,6 +23,7 @@
 package org.openjdk.skara.vcs;
 
 import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
 import org.openjdk.skara.test.TemporaryDirectory;
 
 import org.junit.jupiter.api.Test;
@@ -44,6 +45,12 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class RepositoryTests {
+
+    @BeforeAll
+    static void setup() {
+        GitRepository.ignoreUserConfiguration(true);
+        HgRepository.ignoreUserConfiguration(true);
+    }
 
     @ParameterizedTest
     @EnumSource(VCS.class)
@@ -1655,7 +1662,7 @@ public class RepositoryTests {
             pb.environment().put("GIT_COMMITTER_NAME", "duke");
             pb.environment().put("GIT_COMMITTER_EMAIL", "duke@openjdk.org");
             pb.directory(dir.path().toFile());
-            pb.environment().putAll(GitRepository.NO_CONFIG_ENV);
+            pb.environment().putAll(GitRepository.currentEnv);
 
             var res = pb.start().waitFor();
             assertEquals(0, res);
@@ -1689,7 +1696,7 @@ public class RepositoryTests {
             pb.environment().put("GIT_COMMITTER_NAME", "duke");
             pb.environment().put("GIT_COMMITTER_EMAIL", "duke@openjdk.org");
             pb.directory(dir.path().toFile());
-            pb.environment().putAll(GitRepository.NO_CONFIG_ENV);
+            pb.environment().putAll(GitRepository.currentEnv);
 
             var res = pb.start().waitFor();
             assertEquals(0, res);
@@ -2488,7 +2495,7 @@ public class RepositoryTests {
             // so use a ProcessBuilder and invoke git directly here
             var pb = new ProcessBuilder("git", "tag", "test-tag", head.hex());
             pb.directory(repo.root().toFile());
-            pb.environment().putAll(GitRepository.NO_CONFIG_ENV);
+            pb.environment().putAll(GitRepository.currentEnv);
             assertEquals(0, pb.start().waitFor());
 
             var tags = repo.tags();

--- a/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
@@ -22,7 +22,6 @@
  */
 package org.openjdk.skara.vcs;
 
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.openjdk.skara.test.TemporaryDirectory;
 
@@ -48,8 +47,8 @@ public class RepositoryTests {
 
     @BeforeAll
     static void setup() {
-        GitRepository.ignoreUserConfiguration(true);
-        HgRepository.ignoreUserConfiguration(true);
+        GitRepository.ignoreConfiguration();
+        HgRepository.ignoreConfiguration();
     }
 
     @ParameterizedTest


### PR DESCRIPTION
In SKARA-868, the fix to ignore .gitconfig and /etc/gitconfig was applied universally, which is causing trouble for users. The intention from the filer was to just disable this when running the Skara tests. I still think we should have a way to ignore gitconfig when running tests, but we need to keep honoring the git configuration at runtime.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-913](https://bugs.openjdk.java.net/browse/SKARA-913): Skara should honor .gitconfig and /etc/gitconfig


### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/1049/head:pull/1049`
`$ git checkout pull/1049`
