### PR TITLE
912: PR title correction logic can get stuck

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
@@ -172,7 +172,7 @@ class ArchiveMessages {
     static String composeConversation(PullRequest pr) {
         var filteredBody = filterCommentsAndCommands(pr.body());
         if (filteredBody.isEmpty()) {
-            filteredBody = pr.title().strip();
+            filteredBody = pr.title();
         }
 
         return filteredBody;

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -170,11 +170,11 @@ class CheckWorkItem extends PullRequestWorkItem {
 
             var issue = project.issue(id);
             if (issue.isPresent()) {
-                var issueTitle = issue.get().title();
+                var issueTitle = issue.get().title().strip();
                 if (title.isEmpty()) {
                     // If the title is in the form of "[project-]<bugid>" only
                     // we add the title from JBS
-                    var newPrTitle = id + ": " + issue.get().title();
+                    var newPrTitle = id + ": " + issueTitle;
                     pr.setTitle(newPrTitle);
                     return true;
                 } else {
@@ -184,9 +184,9 @@ class CheckWorkItem extends PullRequestWorkItem {
                         title = title.substring(0, title.length() - 1);
                     }
                     if (issueTitle.startsWith(title) && issueTitle.length() > title.length()) {
-                        var newPrTitle = id + ": " + issue.get().title();
+                        var newPrTitle = id + ": " + issueTitle;
                         pr.setTitle(newPrTitle);
-                        var remainingTitle = issue.get().title().substring(title.length());
+                        var remainingTitle = issueTitle.substring(title.length());
                         if (pr.body().startsWith(ELLIPSIS + remainingTitle + "\n\n")) {
                             // Remove remaning title, plus decorations
                             var newPrBody = pr.body().substring(remainingTitle.length() + 3);

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -170,7 +170,7 @@ class CheckWorkItem extends PullRequestWorkItem {
 
             var issue = project.issue(id);
             if (issue.isPresent()) {
-                var issueTitle = issue.get().title().strip();
+                var issueTitle = issue.get().title();
                 if (title.isEmpty()) {
                     // If the title is in the form of "[project-]<bugid>" only
                     // we add the title from JBS

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -947,7 +947,7 @@ class CheckTests {
             TestBotRunner.runPeriodicItems(checkBot);
 
             // The PR title should contain the issue title without trailing space
-            assertEquals("TEST-1: My second issue ending in space", prCutOff2.title());
+            assertEquals("TEST-2: My second issue ending in space", prCutOff2.title());
         }
     }
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -909,6 +909,7 @@ class CheckTests {
             var masterHash = localRepo.resolve("master").orElseThrow();
             localRepo.push(masterHash, author.url(), "master", true);
 
+            // Verify that a cut-off title is corrected
             var issue1 = issues.createIssue("My first issue with a very long title that is going to be cut off by the Git Forge provider", List.of("Hello"), Map.of());
 
             // Make a change with a corresponding PR
@@ -932,6 +933,21 @@ class CheckTests {
             assertEquals("1: My first issue with a very long title that is going to be cut off by the Git Forge provider", prCutOff.title());
             // And the body should not contain the issue title
             assertTrue(prCutOff.body().startsWith("It also has a second line!"));
+
+            // Verify that trailing space in issue is ignored
+            var issue2 = issues.createIssue("My second issue ending in space   ", List.of("Hello"), Map.of());
+
+            // Make a change with a corresponding PR
+            var editHash2 = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash2, author.url(), "edit", true);
+
+            var prCutOff2 =  credentials.createPullRequest(author, "master", "edit", issue2.id() + ": My second issue ending in space", List.of(), false);
+
+            // Check the status
+            TestBotRunner.runPeriodicItems(checkBot);
+
+            // The PR title should contain the issue title without trailing space
+            assertEquals("TEST-1: My second issue ending in space", prCutOff2.title());
         }
     }
 

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -306,7 +306,7 @@ public class GitHubPullRequest implements PullRequest {
 
     @Override
     public String title() {
-        return json.get("title").asString();
+        return json.get("title").asString().strip();
     }
 
     @Override

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -329,7 +329,7 @@ public class GitLabMergeRequest implements PullRequest {
 
     @Override
     public String title() {
-        return json.get("title").asString();
+        return json.get("title").asString().strip();
     }
 
     @Override

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/Issue.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/Issue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,7 +49,7 @@ public interface Issue {
     HostUser author();
 
     /**
-     * Title of the request.
+     * Title of the request. The implementation should make sure it is stripped.
      * @return
      */
     String title();

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraIssue.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraIssue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,7 +72,7 @@ public class JiraIssue implements Issue {
 
     @Override
     public String title() {
-        return json.get("fields").get("summary").asString();
+        return json.get("fields").get("summary").asString().strip();
     }
 
     @Override

--- a/test/src/main/java/org/openjdk/skara/test/TestIssue.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestIssue.java
@@ -82,7 +82,8 @@ public class TestIssue implements Issue {
 
     @Override
     public void setTitle(String title) {
-        data.title = title;
+        // the strip simulates gitlab behavior
+        data.title = title.strip();
         data.lastUpdate = ZonedDateTime.now();
     }
 

--- a/test/src/main/java/org/openjdk/skara/test/TestIssue.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestIssue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -77,7 +77,7 @@ public class TestIssue implements Issue {
 
     @Override
     public String title() {
-        return data.title;
+        return data.title.strip();
     }
 
     @Override


### PR DESCRIPTION
The PR title correct logic introduced with SKARA-572 can end up trying to correct the title forever. An observed case is where the JBS title ends with a trailing space. When trying to update the PR title to include this trailing space, it will be stripped by GitLab and no update will actually be done. This will then get retried again and again. 

The fix is to strip the JBS title before doing any comparisons.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-912](https://bugs.openjdk.java.net/browse/SKARA-912): PR title correction logic can get stuck


### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/1050/head:pull/1050`
`$ git checkout pull/1050`
