### PR TITLE
pr: update /backport command

### DIFF
--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportCommitCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportCommitCommandTests.java
@@ -67,34 +67,9 @@ public class BackportCommitCommandTests {
             assertEquals(2, recentCommitComments.size());
             var botReply = recentCommitComments.get(0);
             assertTrue(botReply.body().contains("backport"));
-            assertTrue(botReply.body().contains("created successfully."));
-
-            var pulls = author.pullRequests();
-            assertEquals(1, pulls.size());
-            var pr = pulls.get(0);
-            assertEquals("Backport " + editHash.hex(), pr.title());
-            assertEquals("master", pr.targetRef());
-
-            var prDiff = pr.diff();
-            var commitDiff = localRepo.diff(masterHash, editHash);
-            assertEquals(1, commitDiff.patches().size());
-            assertEquals(1, prDiff.patches().size());
-
-            var commitPatch = commitDiff.patches().get(0);
-            var prPatch = commitDiff.patches().get(0);
-            assertEquals(commitPatch.status(), prPatch.status());
-            assertEquals(commitPatch.target().path(), prPatch.target().path());
-            assertEquals(commitPatch.source().path(), prPatch.source().path());
-
-            var commitHunks = commitPatch.asTextualPatch().hunks();
-            var prHunks = prPatch.asTextualPatch().hunks();
-            assertEquals(commitHunks.size(), prHunks.size());
-            for (var i = 0; i < commitHunks.size(); i++) {
-                var commitHunk = commitHunks.get(i);
-                var prHunk = prHunks.get(i);
-                assertEquals(commitHunk.target().lines(), prHunk.target().lines());
-                assertEquals(commitHunk.source().lines(), prHunk.source().lines());
-            }
+            assertTrue(botReply.body().contains("was successfully created"));
+            assertTrue(botReply.body().contains("To create a pull request"));
+            assertTrue(botReply.body().contains("with this backport"));
         }
     }
 


### PR DESCRIPTION
Hi all,

please review this patch that updates the `/backport` commit command. This new version will _not_ create the pull request, instead it provides a link that the user can click to create the pull request. That is, the bot will still cherry-pick the original commit into its own repo, but the the user will create the pull request with a branch in the bot's repository as the source branch. This has the large benefit that the PR author is the person doing the backport (in the old model the bot was the PR author, that came with a number of issues).

The bot will grant the backporter exclusive access to the branch with the backport in its repository in case the person doing the backport need to make additional changes.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/1051/head:pull/1051`
`$ git checkout pull/1051`
