### PR TITLE
vcs: add support for pushing single tag

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
@@ -57,6 +57,7 @@ public interface Repository extends ReadOnlyRepository {
     void pushAll(URI uri) throws IOException;
     void push(Hash hash, URI uri, String ref, boolean force) throws IOException;
     void push(Branch branch, String remote, boolean setUpstream) throws IOException;
+    void push(Tag tag, URI uri, boolean force) throws IOException;
     void clean() throws IOException;
     void reset(Hash target, boolean hard) throws IOException;
     void revert(Hash parent) throws IOException;

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -585,6 +585,16 @@ public class GitRepository implements Repository {
     }
 
     @Override
+    public void push(Tag tag, URI uri, boolean force) throws IOException {
+        var refspec = force ? "+" : "";
+        refspec += "refs/tags/" + tag.name() + ":refs/tags/" + tag.name();
+
+        try (var p = capture("git", "push", uri.toString(), refspec)) {
+            await(p);
+        }
+    }
+
+    @Override
     public void push(Branch branch, String remote, boolean setUpstream) throws IOException {
         var cmd = new ArrayList<String>();
         cmd.addAll(List.of("git", "push", remote, branch.name()));

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -572,6 +572,19 @@ public class HgRepository implements Repository {
     }
 
     @Override
+    public void push(Tag tag, URI uri, boolean force) throws IOException {
+        var cmd = new ArrayList<>(List.of("hg", "push"));
+        if (force) {
+            cmd.add("--force");
+        }
+        cmd.add(tag.name());
+        cmd.add(uri.toString());
+        try (var p = capture(cmd)) {
+            await(p);
+        }
+    }
+
+    @Override
     public boolean isClean() throws IOException {
         try (var p = capture("hg", "status")) {
             var output = await(p);


### PR DESCRIPTION
Hi all,

please review this patch that adds support to `Repository` for pushing a single tag. This is a bit hard to test with `HgRepository` given that tags in Mercurial are just commits, so I only added a test case for `GitRepository`.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/1052/head:pull/1052`
`$ git checkout pull/1052`
