### PR TITLE
forge: add webUrl(Tag tag) method

### DIFF
--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
@@ -197,6 +197,11 @@ class InMemoryHostedRepository implements HostedRepository {
     }
 
     @Override
+    public URI webUrl(Tag tag) {
+        return null;
+    }
+
+    @Override
     public void addCollaborator(HostUser user, boolean canPush) {
     }
 

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
@@ -61,6 +61,7 @@ public interface HostedRepository {
     URI nonTransformedWebUrl();
     URI webUrl(Hash hash);
     URI webUrl(Branch branch);
+    URI webUrl(Tag tag);
     URI webUrl(String baseRef, String headRef);
     VCS repositoryType();
     String fileContents(String filename, String ref);

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -509,6 +509,12 @@ public class GitHubRepository implements HostedRepository {
     }
 
     @Override
+    public URI webUrl(Tag tag) {
+        var endpoint = "/" + repository + "/releases/tag/" + tag.name();
+        return gitHubHost.getWebURI(endpoint);
+    }
+
+    @Override
     public URI createPullRequestUrl(HostedRepository target, String targetRef, String sourceRef) {
         var sourceGroup = repository.split("/")[0];
         var endpoint = "/" + target.name() + "/" + targetRef + "..." + sourceGroup + ":" + sourceRef;

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -537,6 +537,12 @@ public class GitLabRepository implements HostedRepository {
     }
 
     @Override
+    public URI webUrl(Tag tag) {
+        var endpoint = "/" + projectName + "/-/tags/" + tag.name();
+        return gitLabHost.getWebUri(endpoint);
+    }
+
+    @Override
     public URI createPullRequestUrl(HostedRepository target, String targetRef, String sourceRef) {
         var id = json.get("id").asInt();
         var targetId = ((GitLabRepository) target).json.get("id").asInt();

--- a/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
@@ -278,6 +278,11 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
     }
 
     @Override
+    public URI webUrl(Tag tag) {
+        return URI.create(webUrl() + "/tag/" + tag.name());
+    }
+
+    @Override
     public void addCollaborator(HostUser user, boolean canPush) {
         collaborators.put(user.username(), canPush);
     }


### PR DESCRIPTION
Hi all,

please review this small patch that adds support to `HostedRepository` for getting the web URL for a given tag.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/1054/head:pull/1054`
`$ git checkout pull/1054`
