### PR TITLE
pr: add /tag commit command

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommandWorkItem.java
@@ -46,7 +46,8 @@ public class CommitCommandWorkItem implements WorkItem {
 
     private static final Map<String, CommandHandler> commandHandlers = Map.ofEntries(
             Map.entry("help", new HelpCommand()),
-            Map.entry("backport", new BackportCommand())
+            Map.entry("backport", new BackportCommand()),
+            Map.entry("tag", new TagCommand())
     );
 
     static class HelpCommand implements CommandHandler {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/TagCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/TagCommand.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.pr;
+
+import org.openjdk.skara.forge.HostedCommit;
+import org.openjdk.skara.forge.PullRequest;
+import org.openjdk.skara.issuetracker.Comment;
+import org.openjdk.skara.vcs.*;
+import org.openjdk.skara.vcs.openjdk.CommitMessageParsers;
+import org.openjdk.skara.jcheck.JCheckConfiguration;
+
+import java.io.PrintWriter;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.time.format.DateTimeFormatter;
+
+public class TagCommand implements CommandHandler {
+    private void showHelp(PrintWriter reply) {
+        reply.println("Usage: `/tag <name>`");
+    }
+
+    @Override
+    public String description() {
+        return "Create a tag for the given commit";
+    }
+
+    @Override
+    public boolean allowedInCommit() {
+        return true;
+    }
+
+    @Override
+    public boolean allowedInPullRequest() {
+        return false;
+    }
+
+    @Override
+    public void handle(PullRequestBot bot, HostedCommit commit, CensusInstance censusInstance, Path scratchPath, CommandInvocation command, List<Comment> allComments, PrintWriter reply) {
+        try {
+            var username = command.user().username();
+            if (censusInstance.contributor(command.user()).isEmpty()) {
+                reply.println("@" + username + " only OpenJDK [contributors](https://openjdk.java.net/bylaws#contributor) can use the `/tag` command.");
+                return;
+            }
+            if (!bot.integrators().contains(username)) {
+                reply.println("@" + username + " only integrators for this repository are allowed to use the `/tag` command.");
+                return;
+            }
+
+            var args = command.args();
+            if (args.isBlank()) {
+                showHelp(reply);
+                return;
+            }
+
+            var parts = args.split(" ");
+            if (parts.length > 1) {
+                showHelp(reply);
+                return;
+            }
+            var tagName = parts[0];
+
+            var localRepoDir = scratchPath.resolve("tag-command")
+                                          .resolve(bot.repo().name());
+            var localRepo = bot.hostedRepositoryPool()
+                               .orElseThrow(() -> new IllegalStateException("Missing repository pool for PR bot"))
+                               .materialize(bot.repo(), localRepoDir);
+
+            var existingTagNames = localRepo.tags().stream().map(Tag::name).collect(Collectors.toSet());
+            if (existingTagNames.contains(tagName)) {
+                var hash = localRepo.resolve(tagName).orElseThrow(() ->
+                        new IllegalStateException("Cannot resolve tag with name " + tagName + " in repo " + bot.repo().name()));
+                var hashUrl = bot.repo().webUrl(hash);
+                reply.println("@" + username + " a tag with name `" + tagName + "` already exists that refers to commit [" + hash.abbreviate() + "](" + hashUrl + "].");
+                return;
+            }
+
+            var jcheckConf = JCheckConfiguration.from(localRepo, commit.hash());
+            var tagPattern = jcheckConf.isPresent() ? jcheckConf.get().repository().tags() : null;
+            if (tagPattern != null && !tagName.matches(tagPattern)) {
+                reply.println("@" + username + " the given tag name `" + tagName + "` is not of the form `" + tagPattern + "`.");
+                return;
+            }
+
+            var domain = censusInstance.configuration().census().domain();
+            var contributor = censusInstance.contributor(command.user()).orElseThrow();
+            var email = contributor.username() + "@" + domain;
+            var message = "Added tag " + tagName + " for changeset " + commit.hash().abbreviate();
+            var tag = localRepo.tag(commit.hash(), tagName, message, contributor.username(), email);
+            localRepo.push(tag, bot.repo().url(), false);
+            reply.println("@" + username + " the tag [" + tag.name() + "](" + bot.repo().webUrl(tag) + ") was successfully created.");
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/TagCommitCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/TagCommitCommandTests.java
@@ -1,0 +1,304 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.pr;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.openjdk.skara.issuetracker.Issue;
+import org.openjdk.skara.test.*;
+import org.openjdk.skara.vcs.Tag;
+import org.openjdk.skara.vcs.Repository;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.util.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TagCommitCommandTests {
+    @Test
+    void simple(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var reviewer = credentials.getHostedRepository();
+
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addAuthor(author.forge().currentUser().id())
+                                           .addReviewer(reviewer.forge().currentUser().id());
+            var seedFolder = tempFolder.path().resolve("seed");
+            var bot = PullRequestBot.newBuilder()
+                                    .repo(author)
+                                    .integrators(Set.of(author.forge().currentUser().username()))
+                                    .censusRepo(censusBuilder.build())
+                                    .censusLink("https://census.com/{{contributor}}-profile")
+                                    .seedStorage(seedFolder)
+                                    .forks(Map.of(author.name(), author))
+                                    .build();
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
+            var masterHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Add a tag command
+            author.addCommitComment(masterHash, "/tag v1.0");
+            TestBotRunner.runPeriodicItems(bot);
+
+            var recentCommitComments = author.recentCommitComments();
+            assertEquals(2, recentCommitComments.size());
+            var botReply = recentCommitComments.get(0);
+            assertTrue(botReply.body().contains("tag"));
+            assertTrue(botReply.body().contains("was successfully created"));
+
+            var localAuthorRepoDir = tempFolder.path().resolve("author");
+            var localAuthorRepo = Repository.clone(author.url(), localAuthorRepoDir);
+            var tags = localAuthorRepo.tags();
+            assertEquals(List.of(new Tag("v1.0")), tags);
+        }
+    }
+
+    @Test
+    void missingTagName(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var reviewer = credentials.getHostedRepository();
+
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addAuthor(author.forge().currentUser().id())
+                                           .addReviewer(reviewer.forge().currentUser().id());
+            var seedFolder = tempFolder.path().resolve("seed");
+            var bot = PullRequestBot.newBuilder()
+                                    .repo(author)
+                                    .integrators(Set.of(author.forge().currentUser().username()))
+                                    .censusRepo(censusBuilder.build())
+                                    .censusLink("https://census.com/{{contributor}}-profile")
+                                    .seedStorage(seedFolder)
+                                    .forks(Map.of(author.name(), author))
+                                    .build();
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
+            var masterHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Add a tag command
+            author.addCommitComment(masterHash, "/tag");
+            TestBotRunner.runPeriodicItems(bot);
+
+            var recentCommitComments = author.recentCommitComments();
+            assertEquals(2, recentCommitComments.size());
+            var botReply = recentCommitComments.get(0);
+            assertTrue(botReply.body().contains("Usage: `/tag <name>`"));
+
+            var localAuthorRepoDir = tempFolder.path().resolve("author");
+            var localAuthorRepo = Repository.clone(author.url(), localAuthorRepoDir);
+            var tags = localAuthorRepo.tags();
+            assertEquals(List.of(), tags);
+        }
+    }
+
+    @Test
+    void multipleTagNames(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var reviewer = credentials.getHostedRepository();
+
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addAuthor(author.forge().currentUser().id())
+                                           .addReviewer(reviewer.forge().currentUser().id());
+            var seedFolder = tempFolder.path().resolve("seed");
+            var bot = PullRequestBot.newBuilder()
+                                    .repo(author)
+                                    .integrators(Set.of(author.forge().currentUser().username()))
+                                    .censusRepo(censusBuilder.build())
+                                    .censusLink("https://census.com/{{contributor}}-profile")
+                                    .seedStorage(seedFolder)
+                                    .forks(Map.of(author.name(), author))
+                                    .build();
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
+            var masterHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Add a tag command
+            author.addCommitComment(masterHash, "/tag a b c");
+            TestBotRunner.runPeriodicItems(bot);
+
+            var recentCommitComments = author.recentCommitComments();
+            assertEquals(2, recentCommitComments.size());
+            var botReply = recentCommitComments.get(0);
+            assertTrue(botReply.body().contains("Usage: `/tag <name>`"));
+
+            var localAuthorRepoDir = tempFolder.path().resolve("author");
+            var localAuthorRepo = Repository.clone(author.url(), localAuthorRepoDir);
+            var tags = localAuthorRepo.tags();
+            assertEquals(List.of(), tags);
+        }
+    }
+
+    @Test
+    void existingTag(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var reviewer = credentials.getHostedRepository();
+
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addAuthor(author.forge().currentUser().id())
+                                           .addReviewer(reviewer.forge().currentUser().id());
+            var seedFolder = tempFolder.path().resolve("seed");
+            var bot = PullRequestBot.newBuilder()
+                                    .repo(author)
+                                    .integrators(Set.of(author.forge().currentUser().username()))
+                                    .censusRepo(censusBuilder.build())
+                                    .censusLink("https://census.com/{{contributor}}-profile")
+                                    .seedStorage(seedFolder)
+                                    .forks(Map.of(author.name(), author))
+                                    .build();
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
+            var masterHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Add a tag command
+            author.addCommitComment(masterHash, "/tag v1.0");
+            TestBotRunner.runPeriodicItems(bot);
+
+            var recentCommitComments = author.recentCommitComments();
+            assertEquals(2, recentCommitComments.size());
+            var botReply = recentCommitComments.get(0);
+            assertTrue(botReply.body().contains("tag"));
+            assertTrue(botReply.body().contains("was successfully created"));
+
+            var localAuthorRepoDir = tempFolder.path().resolve("author");
+            var localAuthorRepo = Repository.clone(author.url(), localAuthorRepoDir);
+            var tags = localAuthorRepo.tags();
+            assertEquals(List.of(new Tag("v1.0")), tags);
+
+            // Make another commit
+            var anotherHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(anotherHash, author.url(), "master", true);
+
+            // Try to re-create an existing tag
+            author.addCommitComment(anotherHash, "/tag v1.0");
+            TestBotRunner.runPeriodicItems(bot);
+
+            recentCommitComments = author.recentCommitComments();
+            assertEquals(4, recentCommitComments.size());
+            botReply = recentCommitComments.get(0);
+            assertTrue(botReply.body().contains("a tag with name `v1.0` already exists"));
+        }
+    }
+
+    @Test
+    void nonIntegrator(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var reviewer = credentials.getHostedRepository();
+
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addAuthor(author.forge().currentUser().id())
+                                           .addReviewer(reviewer.forge().currentUser().id());
+            var seedFolder = tempFolder.path().resolve("seed");
+            var bot = PullRequestBot.newBuilder()
+                                    .repo(author)
+                                    .censusRepo(censusBuilder.build())
+                                    .censusLink("https://census.com/{{contributor}}-profile")
+                                    .seedStorage(seedFolder)
+                                    .forks(Map.of(author.name(), author))
+                                    .build();
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
+            var masterHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Add a tag command
+            author.addCommitComment(masterHash, "/tag v1.0");
+            TestBotRunner.runPeriodicItems(bot);
+
+            var recentCommitComments = author.recentCommitComments();
+            assertEquals(2, recentCommitComments.size());
+            var botReply = recentCommitComments.get(0);
+            assertTrue(botReply.body().contains("only integrators for this repository are allowed to use the `/tag` command"));
+
+            var localAuthorRepoDir = tempFolder.path().resolve("author");
+            var localAuthorRepo = Repository.clone(author.url(), localAuthorRepoDir);
+            var tags = localAuthorRepo.tags();
+            assertEquals(List.of(), tags);
+        }
+    }
+
+    @Test
+    void nonConformingTag(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var reviewer = credentials.getHostedRepository();
+
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addAuthor(author.forge().currentUser().id())
+                                           .addReviewer(reviewer.forge().currentUser().id());
+            var seedFolder = tempFolder.path().resolve("seed");
+            var bot = PullRequestBot.newBuilder()
+                                    .repo(author)
+                                    .integrators(Set.of(author.forge().currentUser().username()))
+                                    .censusRepo(censusBuilder.build())
+                                    .censusLink("https://census.com/{{contributor}}-profile")
+                                    .seedStorage(seedFolder)
+                                    .forks(Map.of(author.name(), author))
+                                    .build();
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
+            var jcheckConf = localRepo.root().resolve(".jcheck").resolve("conf");
+            Files.write(jcheckConf, List.of("[repository]", "tags=foo"), StandardOpenOption.APPEND);
+            localRepo.add(List.of(Path.of(".jcheck", "conf")));
+            localRepo.commit("Added tags spec", "testauthor", "ta@none.none");
+            var masterHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Add a tag command
+            author.addCommitComment(masterHash, "/tag bar");
+            TestBotRunner.runPeriodicItems(bot);
+
+            var recentCommitComments = author.recentCommitComments();
+            assertEquals(2, recentCommitComments.size());
+            var botReply = recentCommitComments.get(0);
+            System.out.println(botReply);
+            assertTrue(botReply.body().contains("the given tag name `bar` is not of the form `foo`"));
+
+            var localAuthorRepoDir = tempFolder.path().resolve("author");
+            var localAuthorRepo = Repository.clone(author.url(), localAuthorRepoDir);
+            var tags = localAuthorRepo.tags();
+            assertEquals(List.of(), tags);
+        }
+    }
+}


### PR DESCRIPTION
Hi all,

please review this patch that adds the `/tag` commit command. As the name implies, the command is used to create a tag with the given name referring to the commit the command is applied to. The command will check that the tag isn't already used and that it conforms to an eventual `.jcheck/conf` configuration.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/1056/head:pull/1056`
`$ git checkout pull/1056`
