### PR TITLE
Add support for using ssh cloning with GitLab

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabForgeFactory.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabForgeFactory.java
@@ -57,10 +57,10 @@ public class GitLabForgeFactory implements ForgeFactory {
         }
 
         var userHost = userName + "." + hostName;
-        var existingBlock = Pattern.compile("^Match host=" + Pattern.quote(userHost) + "(?:\\R[ \\t]+.*)+", Pattern.MULTILINE);
+        var existingBlock = Pattern.compile("^Match host " + Pattern.quote(userHost) + "(?:\\R[ \\t]+.*)+", Pattern.MULTILINE);
         var existingMatcher = existingBlock.matcher(existing);
         var filtered = existingMatcher.replaceAll("");
-        var result = "Match host=" + userHost + "\n" +
+        var result = "Match host " + userHost + "\n" +
                 "  Hostname " + hostName + "\n" +
                 "  PreferredAuthentications publickey\n" +
                 "  StrictHostKeyChecking no\n" +

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabHost.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabHost.java
@@ -26,20 +26,19 @@ import org.openjdk.skara.forge.*;
 import org.openjdk.skara.host.*;
 import org.openjdk.skara.json.*;
 import org.openjdk.skara.network.*;
-import org.openjdk.skara.vcs.*;
+import org.openjdk.skara.vcs.Hash;
 
 import java.io.IOException;
 import java.net.*;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
 import java.util.*;
-import java.util.stream.Collectors;
 import java.util.logging.Logger;
-import java.time.ZonedDateTime;
+import java.util.stream.Collectors;
 
 public class GitLabHost implements Forge {
     private final String name;
     private final URI uri;
+    private final boolean useSsh;
     private final Credential pat;
     private final RestRequest request;
     private final Logger log = Logger.getLogger("org.openjdk.skara.forge.gitlab");
@@ -47,9 +46,10 @@ public class GitLabHost implements Forge {
 
     private HostUser cachedCurrentUser = null;
 
-    GitLabHost(String name, URI uri, Credential pat, Set<String> groups) {
+    GitLabHost(String name, URI uri, boolean useSsh, Credential pat, Set<String> groups) {
         this.name = name;
         this.uri = uri;
+        this.useSsh = useSsh;
         this.pat = pat;
         this.groups = groups;
 
@@ -59,9 +59,10 @@ public class GitLabHost implements Forge {
         request = new RestRequest(baseApi, pat.username(), () -> Arrays.asList("Private-Token", pat.password()));
     }
 
-    GitLabHost(String name, URI uri, Set<String> groups) {
+    GitLabHost(String name, URI uri, boolean useSsh, Set<String> groups) {
         this.name = name;
         this.uri = uri;
+        this.useSsh = useSsh;
         this.pat = null;
         this.groups = groups;
 
@@ -73,6 +74,10 @@ public class GitLabHost implements Forge {
 
     public URI getUri() {
         return uri;
+    }
+
+    boolean useSsh() {
+        return useSsh;
     }
 
     Optional<Credential> getPat() {

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -482,7 +482,7 @@ public class GitRepository implements Repository {
         } else {
             cmd.add("--no-tags");
         }
-        cmd.add(uri.toString());
+        cmd.add(decodeUri(uri));
         cmd.add(refspec);
         try (var p = capture(cmd)) {
             await(p);
@@ -492,7 +492,7 @@ public class GitRepository implements Repository {
 
     @Override
     public void fetchAll(URI uri, boolean includeTags) throws IOException {
-        var cmd = new ArrayList<>(List.of("git", "fetch", "--recurse-submodules=on-demand", "--prune", uri.toString()));
+        var cmd = new ArrayList<>(List.of("git", "fetch", "--recurse-submodules=on-demand", "--prune", decodeUri(uri)));
         cmd.add("+refs/heads/*:refs/heads/*");
         if (includeTags) {
             cmd.add("+refs/tags/*:refs/tags/*");
@@ -566,7 +566,7 @@ public class GitRepository implements Repository {
 
     @Override
     public void pushAll(URI uri) throws IOException {
-        try (var p = capture("git", "push", "--mirror", uri.toString())) {
+        try (var p = capture("git", "push", "--mirror", decodeUri(uri))) {
             await(p);
         }
     }
@@ -579,7 +579,7 @@ public class GitRepository implements Repository {
         }
         refspec += hash.hex() + ":" + ref;
 
-        try (var p = capture("git", "push", uri.toString(), refspec)) {
+        try (var p = capture("git", "push", decodeUri(uri), refspec)) {
             await(p);
         }
     }
@@ -1344,6 +1344,14 @@ public class GitRepository implements Repository {
         }
     }
 
+    private static String decodeUri(URI from) {
+        if (from.getScheme().equals("ssh")) {
+            return from.toString().substring(6);
+        } else {
+            return from.toString();
+        }
+    }
+
     public static Repository clone(URI from, Path to, boolean isBare, Path seed) throws IOException {
         var cmd = new ArrayList<String>();
         cmd.addAll(List.of("git", "clone"));
@@ -1356,7 +1364,7 @@ public class GitRepository implements Repository {
             cmd.add("--reference-if-able");
             cmd.add(seed.toString());
         }
-        cmd.addAll(List.of(from.toString(), to.toString()));
+        cmd.addAll(List.of(decodeUri(from), to.toString()));
         try (var p = capture(Path.of("").toAbsolutePath(), cmd)) {
             await(p);
         }
@@ -1365,7 +1373,7 @@ public class GitRepository implements Repository {
 
     public static Repository mirror(URI from, Path to) throws IOException {
         var cwd = Path.of("").toAbsolutePath();
-        try (var p = capture(cwd, "git", "clone", "--mirror", from.toString(), to.toString())) {
+        try (var p = capture(cwd, "git", "clone", "--mirror", decodeUri(from), to.toString())) {
             await(p);
         }
         return new GitRepository(to);


### PR DESCRIPTION
Add support for configuring a GitLab forge to use ssh for cloning repositories using a private ssh key.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - Committer)
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/1057/head:pull/1057`
`$ git checkout pull/1057`
