### PR TITLE
vcs: add ReadOnlyRepository.commitMetadataFor

### DIFF
--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/TestRepository.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/TestRepository.java
@@ -185,6 +185,10 @@ class TestRepository implements ReadOnlyRepository {
         return List.of();
     }
 
+    public List<CommitMetadata> commitMetadataFor(List<Branch> branches) throws IOException {
+        return List.of();
+    }
+
     public Path root() throws IOException {
         return null;
     }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
@@ -70,6 +70,10 @@ public interface ReadOnlyRepository {
     List<CommitMetadata> commitMetadata(Hash from, Hash to, List<Path> paths) throws IOException;
     List<CommitMetadata> commitMetadata(String range, List<Path> paths, boolean reverse) throws IOException;
     List<CommitMetadata> commitMetadata(Hash from, Hash to, List<Path> paths, boolean reverse) throws IOException;
+
+    // Can't overload on both List<Path> and List<Branch>
+    List<CommitMetadata> commitMetadataFor(List<Branch> branches) throws IOException;
+
     String range(Hash h);
     String rangeInclusive(Hash from, Hash to);
     String rangeExclusive(Hash from, Hash to);

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -255,6 +255,19 @@ public class GitRepository implements Repository {
     }
 
     @Override
+    public List<CommitMetadata> commitMetadataFor(List<Branch> branches) throws IOException {
+        var args = new ArrayList<String>();
+        args.addAll(List.of("git", "rev-list",
+                                   "--format=" + GitCommitMetadata.FORMAT,
+                                   "--topo-order",
+                                   "--no-abbrev",
+                                   "--no-color"));
+        args.addAll(branches.stream().map(Branch::name).collect(Collectors.toList()));
+        args.add("--");
+        return readMetadata(args, "commit ");
+    }
+
+    @Override
     public List<CommitMetadata> commitMetadata(Hash from, Hash to, List<Path> paths, boolean reverse) throws IOException {
         return commitMetadata(from.hex() + ".." + to.hex(), paths, reverse);
     }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -308,6 +308,11 @@ public class HgRepository implements Repository {
     }
 
     @Override
+    public List<CommitMetadata> commitMetadataFor(List<Branch> branches) throws IOException {
+        throw new RuntimeException("Not implemented yet");
+    }
+
+    @Override
     public List<CommitMetadata> commitMetadata(String range) throws IOException {
         return commitMetadata(range, List.of(), false);
     }


### PR DESCRIPTION
Hi all,

please review this patch that adds the method `ReadOnlyRepository.commitMetadataFor`. I opted to *not* implement the Mercurial version due to the way `HgRepository` tries to mimic Git branches using bookmarks. The Skara code that uses `HgRepository` has never needed to use branches, so the the current bookmark implementation is more of a proof-of-concept. The implementation of the `ReadOnlyRepository.commitMetadataFor` for `HgRepository` would look something like the following:

```java
@Override
public List<CommitMetadata> commitMetadataFor(List<Branch> branches) throws IOException {
    var cmd = new ArrayList<String>();
    cmd.addAll(List.of("hg", "log", "--template", HgCommitMetadata.TEMPLATE));
    for (var branch : branches) {
        cmd.add("--rev");
        cmd.add("0:" + branch.name());
    }
    return readMetadata(cmd);
}
```

The above will get messy however if `branches` contains a proper branch (e.g. `default`) and not just a bookmark. This can be solved, but I don't think it is worth it right now. If we ever need to write a tool interacting with Mercurial repositories that needs `commitMetadataFor` then we can implement the method then.

Please also note that I had to name the method `commitMetadataFor` instead of just overloading `commitMetadata` since we already have `commitMetadata(List<Path>)`.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/1058/head:pull/1058`
`$ git checkout pull/1058`
