### PR TITLE
bot: don't run watchdogTrigger test on Windows

### DIFF
--- a/bot/src/test/java/org/openjdk/skara/bot/BotRunnerTests.java
+++ b/bot/src/test/java/org/openjdk/skara/bot/BotRunnerTests.java
@@ -23,6 +23,9 @@
 package org.openjdk.skara.bot;
 
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import static org.junit.jupiter.api.condition.OS.LINUX;
+import static org.junit.jupiter.api.condition.OS.MAC;
 import org.openjdk.skara.json.JSON;
 
 import java.nio.file.Path;
@@ -290,6 +293,7 @@ class BotRunnerTests {
     }
 
     @Test
+    @EnabledOnOs({LINUX, MAC})
     void watchdogTrigger() throws TimeoutException {
         var countdownLatch = new CountDownLatch(1);
         var item = new TestBlockedWorkItem(countdownLatch);


### PR DESCRIPTION
Hi all,

please review this small patch that disables the `BotRunnerTests.watchdogTrigger` on Windows. The bots aren't fully supported on Windows and this test has a tendency to fail intermittently in our GitHub Actions on Windows. So, lets disable the test on Windows for now until the bots one day might get proper Windows support.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/1059/head:pull/1059`
`$ git checkout pull/1059`
