### PR TITLE
785: Failed tag updates are not automatically retried

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryWorkItem.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryWorkItem.java
@@ -155,7 +155,7 @@ public class RepositoryWorkItem implements WorkItem {
         var errors = new ArrayList<Throwable>();
         var tags = localRepo.tags();
         var newTags = tags.stream()
-                          .filter(tag -> !history.hasTag(tag, listener.name()))
+                          .filter(tag -> !history.hasTag(tag, listener.name()) || history.shouldRetryTagUpdate(tag, listener.name()))
                           .collect(Collectors.toList());
 
         if (tags.size() == newTags.size()) {


### PR DESCRIPTION
When the issue notifier encounters an error during tag processing, it flags the tag as in need of retry. However, the retry flag was not actually checked in subsequent runs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-785](https://bugs.openjdk.java.net/browse/SKARA-785): Failed tag updates are not automatically retried


### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/1060/head:pull/1060`
`$ git checkout pull/1060`
