### PR TITLE
vcs: make RepositoryTests deterministic

### DIFF
--- a/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
@@ -2963,19 +2963,19 @@ public class RepositoryTests {
 
             metadata = r.commitMetadataFor(List.of(r.defaultBranch(), b1));
             assertEquals(2, metadata.size());
-            assertEquals(second, metadata.get(0).hash());
-            assertEquals(first, metadata.get(1).hash());
+            assertTrue(metadata.stream().anyMatch(c -> c.hash().equals(first)));
+            assertTrue(metadata.stream().anyMatch(c -> c.hash().equals(second)));
 
             metadata = r.commitMetadataFor(List.of(r.defaultBranch(), b2));
             assertEquals(2, metadata.size());
-            assertEquals(third, metadata.get(0).hash());
-            assertEquals(first, metadata.get(1).hash());
+            assertTrue(metadata.stream().anyMatch(c -> c.hash().equals(first)));
+            assertTrue(metadata.stream().anyMatch(c -> c.hash().equals(third)));
 
             metadata = r.commitMetadataFor(List.of(r.defaultBranch(), b1, b2));
             assertEquals(3, metadata.size());
-            assertEquals(second, metadata.get(0).hash());
-            assertEquals(third, metadata.get(1).hash());
-            assertEquals(first, metadata.get(2).hash());
+            assertTrue(metadata.stream().anyMatch(c -> c.hash().equals(first)));
+            assertTrue(metadata.stream().anyMatch(c -> c.hash().equals(second)));
+            assertTrue(metadata.stream().anyMatch(c -> c.hash().equals(third)));
         }
     }
 }


### PR DESCRIPTION
Hi all,

please review this small patch to make the test `RepositoryTests.testCommitMetadataWithBranchesWithGit` deterministic. The problem is that different versions of `git` can traverse the commit graph differently and the resulting list from the call to `commitMetadataFor` might therefore contain commits in an unknown order. The test should therefore not assume that the commits are ordered in a particular way, but instead ensure that the list contains only the expected commits.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/1061/head:pull/1061`
`$ git checkout pull/1061`
