### PR TITLE
Ensure the ssh configuration folder exists

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabForgeFactory.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabForgeFactory.java
@@ -49,6 +49,13 @@ public class GitLabForgeFactory implements ForgeFactory {
 
     private void configureSshKey(String userName, String hostName, String sshKey) {
         var cfgPath = Path.of(System.getProperty("user.home"), ".ssh");
+        if (!Files.isDirectory(cfgPath)) {
+            try {
+                Files.createDirectories(cfgPath);
+            } catch (IOException ignored) {
+            }
+        }
+
         var cfgFile = cfgPath.resolve("config");
         var existing = "";
         try {


### PR DESCRIPTION
The ssh configuration folder needs to exist before a new configuration file can be created there.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/1065/head:pull/1065`
`$ git checkout pull/1065`
