### PR TITLE
Really fix so tests ignore .gitconfig

### DIFF
--- a/bots/checkout/src/test/java/org/openjdk/skara/bots/checkout/CheckoutBotTests.java
+++ b/bots/checkout/src/test/java/org/openjdk/skara/bots/checkout/CheckoutBotTests.java
@@ -22,11 +22,8 @@
  */
 package org.openjdk.skara.bots.checkout;
 
-import org.openjdk.skara.forge.HostedRepository;
-import org.openjdk.skara.storage.StorageBuilder;
 import org.openjdk.skara.test.*;
 import org.openjdk.skara.host.HostUser;
-import org.openjdk.skara.vcs.Tag;
 import org.openjdk.skara.vcs.*;
 
 import org.junit.jupiter.api.*;
@@ -61,7 +58,7 @@ class CheckoutBotTests {
             var host = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));
             var marksLocalDir = tmp.path().resolve("marks.git");
             Files.createDirectories(marksLocalDir);
-            var marksLocalRepo = Repository.init(marksLocalDir, VCS.GIT);
+            var marksLocalRepo = TestableRepository.init(marksLocalDir, VCS.GIT);
             marksLocalRepo.config("receive", "denyCurrentBranch", "ignore");
             var marksHostedRepo = new TestHostedRepository(host, "marks", marksLocalRepo);
 
@@ -74,7 +71,7 @@ class CheckoutBotTests {
 
             var gitLocalDir = tmp.path().resolve("from.git");
             Files.createDirectories(gitLocalDir);
-            var gitLocalRepo = Repository.init(gitLocalDir, VCS.GIT);
+            var gitLocalRepo = TestableRepository.init(gitLocalDir, VCS.GIT);
             populate(gitLocalRepo);
             var gitHostedRepo = new TestHostedRepository(host, "from", gitLocalRepo);
 
@@ -93,7 +90,7 @@ class CheckoutBotTests {
             var host = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));
             var marksLocalDir = tmp.path().resolve("marks.git");
             Files.createDirectories(marksLocalDir);
-            var marksLocalRepo = Repository.init(marksLocalDir, VCS.GIT);
+            var marksLocalRepo = TestableRepository.init(marksLocalDir, VCS.GIT);
             marksLocalRepo.config("receive", "denyCurrentBranch", "ignore");
             var marksHostedRepo = new TestHostedRepository(host, "marks", marksLocalRepo);
 
@@ -107,7 +104,7 @@ class CheckoutBotTests {
 
             var gitLocalDir = tmp.path().resolve("from.git");
             Files.createDirectories(gitLocalDir);
-            var gitLocalRepo = Repository.init(gitLocalDir, VCS.GIT);
+            var gitLocalRepo = TestableRepository.init(gitLocalDir, VCS.GIT);
             populate(gitLocalRepo);
             var gitHostedRepo = new TestHostedRepository(host, "from", gitLocalRepo);
 

--- a/bots/forward/src/test/java/org/openjdk/skara/bots/forward/ForwardBotTests.java
+++ b/bots/forward/src/test/java/org/openjdk/skara/bots/forward/ForwardBotTests.java
@@ -44,11 +44,11 @@ class ForwardBotTests {
             var host = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));
 
             var fromDir = temp.path().resolve("from.git");
-            var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
+            var fromLocalRepo = TestableRepository.init(fromDir, VCS.GIT);
             var fromHostedRepo = new TestHostedRepository(host, "test", fromLocalRepo);
 
             var toDir = temp.path().resolve("to.git");
-            var toLocalRepo = Repository.init(toDir, VCS.GIT);
+            var toLocalRepo = TestableRepository.init(toDir, VCS.GIT);
             var gitConfig = toDir.resolve(".git").resolve("config");
             Files.write(gitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
                         StandardOpenOption.APPEND);
@@ -81,11 +81,11 @@ class ForwardBotTests {
             var host = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));
 
             var fromDir = temp.path().resolve("from.git");
-            var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
+            var fromLocalRepo = TestableRepository.init(fromDir, VCS.GIT);
             var fromHostedRepo = new TestHostedRepository(host, "test", fromLocalRepo);
 
             var toDir = temp.path().resolve("to.git");
-            var toLocalRepo = Repository.init(toDir, VCS.GIT);
+            var toLocalRepo = TestableRepository.init(toDir, VCS.GIT);
             var gitConfig = toDir.resolve(".git").resolve("config");
             Files.write(gitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
                         StandardOpenOption.APPEND);

--- a/bots/hgbridge/src/test/java/org/openjdk/skara/bots/hgbridge/BridgeBotTests.java
+++ b/bots/hgbridge/src/test/java/org/openjdk/skara/bots/hgbridge/BridgeBotTests.java
@@ -69,7 +69,7 @@ class BridgeBotTests {
             this.destinations(List.of(destination));
 
             var host = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));
-            var marksLocalRepo = Repository.init(marksRepoPath.resolve("marks.git"), VCS.GIT);
+            var marksLocalRepo = TestableRepository.init(marksRepoPath.resolve("marks.git"), VCS.GIT);
 
             var initialFile = marksLocalRepo.root().resolve("init.txt");
             if (!Files.exists(initialFile)) {

--- a/bots/merge/src/test/java/org/openjdk/skara/bots/merge/MergeBotTests.java
+++ b/bots/merge/src/test/java/org/openjdk/skara/bots/merge/MergeBotTests.java
@@ -45,18 +45,18 @@ class MergeBotTests {
             var host = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));
 
             var fromDir = temp.path().resolve("from.git");
-            var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
+            var fromLocalRepo = TestableRepository.init(fromDir, VCS.GIT);
             var fromHostedRepo = new TestHostedRepository(host, "test", fromLocalRepo);
 
             var toDir = temp.path().resolve("to.git");
-            var toLocalRepo = Repository.init(toDir, VCS.GIT);
+            var toLocalRepo = TestableRepository.init(toDir, VCS.GIT);
             var toGitConfig = toDir.resolve(".git").resolve("config");
             Files.write(toGitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
                         StandardOpenOption.APPEND);
             var toHostedRepo = new TestHostedRepository(host, "test-mirror", toLocalRepo);
 
             var forkDir = temp.path().resolve("fork.git");
-            var forkLocalRepo = Repository.init(forkDir, VCS.GIT);
+            var forkLocalRepo = TestableRepository.init(forkDir, VCS.GIT);
             var forkGitConfig = forkDir.resolve(".git").resolve("config");
             Files.write(forkGitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
                         StandardOpenOption.APPEND);
@@ -120,18 +120,18 @@ class MergeBotTests {
             var host = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));
 
             var fromDir = temp.path().resolve("from.git");
-            var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
+            var fromLocalRepo = TestableRepository.init(fromDir, VCS.GIT);
             var fromHostedRepo = new TestHostedRepository(host, "test", fromLocalRepo);
 
             var toDir = temp.path().resolve("to.git");
-            var toLocalRepo = Repository.init(toDir, VCS.GIT);
+            var toLocalRepo = TestableRepository.init(toDir, VCS.GIT);
             var toGitConfig = toDir.resolve(".git").resolve("config");
             Files.write(toGitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
                         StandardOpenOption.APPEND);
             var toHostedRepo = new TestHostedRepository(host, "test-mirror", toLocalRepo);
 
             var forkDir = temp.path().resolve("fork.git");
-            var forkLocalRepo = Repository.init(forkDir, VCS.GIT);
+            var forkLocalRepo = TestableRepository.init(forkDir, VCS.GIT);
             var forkGitConfig = forkDir.resolve(".git").resolve("config");
             Files.write(forkGitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
                         StandardOpenOption.APPEND);
@@ -209,18 +209,18 @@ class MergeBotTests {
             var host = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));
 
             var fromDir = temp.path().resolve("from.git");
-            var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
+            var fromLocalRepo = TestableRepository.init(fromDir, VCS.GIT);
             var fromHostedRepo = new TestHostedRepository(host, "test", fromLocalRepo);
 
             var toDir = temp.path().resolve("to.git");
-            var toLocalRepo = Repository.init(toDir, VCS.GIT);
+            var toLocalRepo = TestableRepository.init(toDir, VCS.GIT);
             var toGitConfig = toDir.resolve(".git").resolve("config");
             Files.write(toGitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
                         StandardOpenOption.APPEND);
             var toHostedRepo = new TestHostedRepository(host, "test-mirror", toLocalRepo);
 
             var forkDir = temp.path().resolve("fork.git");
-            var forkLocalRepo = Repository.init(forkDir, VCS.GIT);
+            var forkLocalRepo = TestableRepository.init(forkDir, VCS.GIT);
             var forkGitConfig = forkDir.resolve(".git").resolve("config");
             Files.write(forkGitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
                         StandardOpenOption.APPEND);
@@ -301,18 +301,18 @@ class MergeBotTests {
             var host = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));
 
             var fromDir = temp.path().resolve("from.git");
-            var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
+            var fromLocalRepo = TestableRepository.init(fromDir, VCS.GIT);
             var fromHostedRepo = new TestHostedRepository(host, "test", fromLocalRepo);
 
             var toDir = temp.path().resolve("to.git");
-            var toLocalRepo = Repository.init(toDir, VCS.GIT);
+            var toLocalRepo = TestableRepository.init(toDir, VCS.GIT);
             var toGitConfig = toDir.resolve(".git").resolve("config");
             Files.write(toGitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
                         StandardOpenOption.APPEND);
             var toHostedRepo = new TestHostedRepository(host, "test-mirror", toLocalRepo);
 
             var forkDir = temp.path().resolve("fork.git");
-            var forkLocalRepo = Repository.init(forkDir, VCS.GIT);
+            var forkLocalRepo = TestableRepository.init(forkDir, VCS.GIT);
             var forkGitConfig = forkDir.resolve(".git").resolve("config");
             Files.write(forkGitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
                         StandardOpenOption.APPEND);
@@ -372,18 +372,18 @@ class MergeBotTests {
             var host = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));
 
             var fromDir = temp.path().resolve("from.git");
-            var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
+            var fromLocalRepo = TestableRepository.init(fromDir, VCS.GIT);
             var fromHostedRepo = new TestHostedRepository(host, "test", fromLocalRepo);
 
             var toDir = temp.path().resolve("to.git");
-            var toLocalRepo = Repository.init(toDir, VCS.GIT);
+            var toLocalRepo = TestableRepository.init(toDir, VCS.GIT);
             var toGitConfig = toDir.resolve(".git").resolve("config");
             Files.write(toGitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
                         StandardOpenOption.APPEND);
             var toHostedRepo = new TestHostedRepository(host, "test-mirror", toLocalRepo);
 
             var forkDir = temp.path().resolve("fork.git");
-            var forkLocalRepo = Repository.init(forkDir, VCS.GIT);
+            var forkLocalRepo = TestableRepository.init(forkDir, VCS.GIT);
             var forkGitConfig = forkDir.resolve(".git").resolve("config");
             Files.write(forkGitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
                         StandardOpenOption.APPEND);
@@ -435,19 +435,19 @@ class MergeBotTests {
             assertEquals("Merge test:master", pr.title());
 
             var fromDir2 = temp.path().resolve("from2.git");
-            var fromLocalRepo2 = Repository.init(fromDir2, VCS.GIT);
+            var fromLocalRepo2 = TestableRepository.init(fromDir2, VCS.GIT);
             var fromHostedRepo2 = new TestHostedRepository(host, "test-2", fromLocalRepo2);
 
             var host2 = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));
             var toDir2 = temp.path().resolve("to2.git");
-            var toLocalRepo2 = Repository.init(toDir2, VCS.GIT);
+            var toLocalRepo2 = TestableRepository.init(toDir2, VCS.GIT);
             var toGitConfig2 = toDir2.resolve(".git").resolve("config");
             Files.write(toGitConfig2, List.of("[receive]", "denyCurrentBranch = ignore"),
                         StandardOpenOption.APPEND);
             var toHostedRepo2 = new TestHostedRepository(host2, "test-mirror-2", toLocalRepo2);
 
             var forkDir2 = temp.path().resolve("fork2.git");
-            var forkLocalRepo2 = Repository.init(forkDir2, VCS.GIT);
+            var forkLocalRepo2 = TestableRepository.init(forkDir2, VCS.GIT);
             var forkGitConfig2 = forkDir2.resolve(".git").resolve("config");
             Files.write(forkGitConfig2, List.of("[receive]", "denyCurrentBranch = ignore"),
                         StandardOpenOption.APPEND);
@@ -504,18 +504,18 @@ class MergeBotTests {
             var host = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));
 
             var fromDir = temp.path().resolve("from.git");
-            var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
+            var fromLocalRepo = TestableRepository.init(fromDir, VCS.GIT);
             var fromHostedRepo = new TestHostedRepository(host, "test", fromLocalRepo);
 
             var toDir = temp.path().resolve("to.git");
-            var toLocalRepo = Repository.init(toDir, VCS.GIT);
+            var toLocalRepo = TestableRepository.init(toDir, VCS.GIT);
             var toGitConfig = toDir.resolve(".git").resolve("config");
             Files.write(toGitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
                         StandardOpenOption.APPEND);
             var toHostedRepo = new TestHostedRepository(host, "test-mirror", toLocalRepo);
 
             var forkDir = temp.path().resolve("fork.git");
-            var forkLocalRepo = Repository.init(forkDir, VCS.GIT);
+            var forkLocalRepo = TestableRepository.init(forkDir, VCS.GIT);
             var forkGitConfig = forkDir.resolve(".git").resolve("config");
             Files.write(forkGitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
                         StandardOpenOption.APPEND);
@@ -575,18 +575,18 @@ class MergeBotTests {
             var host = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));
 
             var fromDir = temp.path().resolve("from.git");
-            var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
+            var fromLocalRepo = TestableRepository.init(fromDir, VCS.GIT);
             var fromHostedRepo = new TestHostedRepository(host, "test", fromLocalRepo);
 
             var toDir = temp.path().resolve("to.git");
-            var toLocalRepo = Repository.init(toDir, VCS.GIT);
+            var toLocalRepo = TestableRepository.init(toDir, VCS.GIT);
             var toGitConfig = toDir.resolve(".git").resolve("config");
             Files.write(toGitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
                         StandardOpenOption.APPEND);
             var toHostedRepo = new TestHostedRepository(host, "test-mirror", toLocalRepo);
 
             var forkDir = temp.path().resolve("fork.git");
-            var forkLocalRepo = Repository.init(forkDir, VCS.GIT);
+            var forkLocalRepo = TestableRepository.init(forkDir, VCS.GIT);
             var forkGitConfig = forkDir.resolve(".git").resolve("config");
             Files.write(forkGitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
                         StandardOpenOption.APPEND);
@@ -687,18 +687,18 @@ class MergeBotTests {
             var host = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));
 
             var fromDir = temp.path().resolve("from.git");
-            var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
+            var fromLocalRepo = TestableRepository.init(fromDir, VCS.GIT);
             var fromHostedRepo = new TestHostedRepository(host, "test", fromLocalRepo);
 
             var toDir = temp.path().resolve("to.git");
-            var toLocalRepo = Repository.init(toDir, VCS.GIT);
+            var toLocalRepo = TestableRepository.init(toDir, VCS.GIT);
             var toGitConfig = toDir.resolve(".git").resolve("config");
             Files.write(toGitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
                         StandardOpenOption.APPEND);
             var toHostedRepo = new TestHostedRepository(host, "test-mirror", toLocalRepo);
 
             var forkDir = temp.path().resolve("fork.git");
-            var forkLocalRepo = Repository.init(forkDir, VCS.GIT);
+            var forkLocalRepo = TestableRepository.init(forkDir, VCS.GIT);
             var forkGitConfig = forkDir.resolve(".git").resolve("config");
             Files.write(forkGitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
                         StandardOpenOption.APPEND);
@@ -802,18 +802,18 @@ class MergeBotTests {
             var host = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));
 
             var fromDir = temp.path().resolve("from.git");
-            var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
+            var fromLocalRepo = TestableRepository.init(fromDir, VCS.GIT);
             var fromHostedRepo = new TestHostedRepository(host, "test", fromLocalRepo);
 
             var toDir = temp.path().resolve("to.git");
-            var toLocalRepo = Repository.init(toDir, VCS.GIT);
+            var toLocalRepo = TestableRepository.init(toDir, VCS.GIT);
             var toGitConfig = toDir.resolve(".git").resolve("config");
             Files.write(toGitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
                         StandardOpenOption.APPEND);
             var toHostedRepo = new TestHostedRepository(host, "test", toLocalRepo);
 
             var forkDir = temp.path().resolve("fork.git");
-            var forkLocalRepo = Repository.init(forkDir, VCS.GIT);
+            var forkLocalRepo = TestableRepository.init(forkDir, VCS.GIT);
             var forkGitConfig = forkDir.resolve(".git").resolve("config");
             Files.write(forkGitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
                         StandardOpenOption.APPEND);
@@ -923,18 +923,18 @@ class MergeBotTests {
             var host = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));
 
             var fromDir = temp.path().resolve("from.git");
-            var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
+            var fromLocalRepo = TestableRepository.init(fromDir, VCS.GIT);
             var fromHostedRepo = new TestHostedRepository(host, "test", fromLocalRepo);
 
             var toDir = temp.path().resolve("to.git");
-            var toLocalRepo = Repository.init(toDir, VCS.GIT);
+            var toLocalRepo = TestableRepository.init(toDir, VCS.GIT);
             var toGitConfig = toDir.resolve(".git").resolve("config");
             Files.write(toGitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
                         StandardOpenOption.APPEND);
             var toHostedRepo = new TestHostedRepository(host, "test-mirror", toLocalRepo);
 
             var forkDir = temp.path().resolve("fork.git");
-            var forkLocalRepo = Repository.init(forkDir, VCS.GIT);
+            var forkLocalRepo = TestableRepository.init(forkDir, VCS.GIT);
             var forkGitConfig = forkDir.resolve(".git").resolve("config");
             Files.write(forkGitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
                         StandardOpenOption.APPEND);
@@ -1044,18 +1044,18 @@ class MergeBotTests {
             var host = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));
 
             var fromDir = temp.path().resolve("from.git");
-            var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
+            var fromLocalRepo = TestableRepository.init(fromDir, VCS.GIT);
             var fromHostedRepo = new TestHostedRepository(host, "test", fromLocalRepo);
 
             var toDir = temp.path().resolve("to.git");
-            var toLocalRepo = Repository.init(toDir, VCS.GIT);
+            var toLocalRepo = TestableRepository.init(toDir, VCS.GIT);
             var toGitConfig = toDir.resolve(".git").resolve("config");
             Files.write(toGitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
                         StandardOpenOption.APPEND);
             var toHostedRepo = new TestHostedRepository(host, "test", toLocalRepo);
 
             var forkDir = temp.path().resolve("fork.git");
-            var forkLocalRepo = Repository.init(forkDir, VCS.GIT);
+            var forkLocalRepo = TestableRepository.init(forkDir, VCS.GIT);
             var forkGitConfig = forkDir.resolve(".git").resolve("config");
             Files.write(forkGitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
                         StandardOpenOption.APPEND);
@@ -1165,18 +1165,18 @@ class MergeBotTests {
             var host = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));
 
             var fromDir = temp.path().resolve("from.git");
-            var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
+            var fromLocalRepo = TestableRepository.init(fromDir, VCS.GIT);
             var fromHostedRepo = new TestHostedRepository(host, "test", fromLocalRepo);
 
             var toDir = temp.path().resolve("to.git");
-            var toLocalRepo = Repository.init(toDir, VCS.GIT);
+            var toLocalRepo = TestableRepository.init(toDir, VCS.GIT);
             var toGitConfig = toDir.resolve(".git").resolve("config");
             Files.write(toGitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
                         StandardOpenOption.APPEND);
             var toHostedRepo = new TestHostedRepository(host, "test", toLocalRepo);
 
             var forkDir = temp.path().resolve("fork.git");
-            var forkLocalRepo = Repository.init(forkDir, VCS.GIT);
+            var forkLocalRepo = TestableRepository.init(forkDir, VCS.GIT);
             var forkGitConfig = forkDir.resolve(".git").resolve("config");
             Files.write(forkGitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
                         StandardOpenOption.APPEND);
@@ -1292,18 +1292,18 @@ class MergeBotTests {
             var host = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));
 
             var fromDir = temp.path().resolve("from.git");
-            var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
+            var fromLocalRepo = TestableRepository.init(fromDir, VCS.GIT);
             var fromHostedRepo = new TestHostedRepository(host, "test", fromLocalRepo);
 
             var toDir = temp.path().resolve("to.git");
-            var toLocalRepo = Repository.init(toDir, VCS.GIT);
+            var toLocalRepo = TestableRepository.init(toDir, VCS.GIT);
             var toGitConfig = toDir.resolve(".git").resolve("config");
             Files.write(toGitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
                     StandardOpenOption.APPEND);
             var toHostedRepo = new TestHostedRepository(host, "test-mirror", toLocalRepo);
 
             var forkDir = temp.path().resolve("fork.git");
-            var forkLocalRepo = Repository.init(forkDir, VCS.GIT);
+            var forkLocalRepo = TestableRepository.init(forkDir, VCS.GIT);
             var forkGitConfig = forkDir.resolve(".git").resolve("config");
             Files.write(forkGitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
                     StandardOpenOption.APPEND);
@@ -1349,7 +1349,7 @@ class MergeBotTests {
 
             // But push something out of place to the local storage as well
             var sanitizedForkUrl = URLEncoder.encode(toFork.webUrl().toString(), StandardCharsets.UTF_8);
-            var storageRepo = Repository.init(storage.resolve(sanitizedForkUrl), VCS.GIT);
+            var storageRepo = TestableRepository.init(storage.resolve(sanitizedForkUrl), VCS.GIT);
             var divergedForkFile = storageRepo.root().resolve("d.txt");
             Files.writeString(divergedForkFile, "Hello D\n");
             storageRepo.add(divergedForkFile);

--- a/bots/mirror/src/test/java/org/openjdk/skara/bots/mirror/MirrorBotTests.java
+++ b/bots/mirror/src/test/java/org/openjdk/skara/bots/mirror/MirrorBotTests.java
@@ -43,11 +43,11 @@ class MirrorBotTests {
             var host = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));
 
             var fromDir = temp.path().resolve("from.git");
-            var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
+            var fromLocalRepo = TestableRepository.init(fromDir, VCS.GIT);
             var fromHostedRepo = new TestHostedRepository(host, "test", fromLocalRepo);
 
             var toDir = temp.path().resolve("to.git");
-            var toLocalRepo = Repository.init(toDir, VCS.GIT);
+            var toLocalRepo = TestableRepository.init(toDir, VCS.GIT);
             var gitConfig = toDir.resolve(".git").resolve("config");
             Files.write(gitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
                         StandardOpenOption.APPEND);
@@ -80,11 +80,11 @@ class MirrorBotTests {
             var host = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));
 
             var fromDir = temp.path().resolve("from.git");
-            var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
+            var fromLocalRepo = TestableRepository.init(fromDir, VCS.GIT);
             var fromHostedRepo = new TestHostedRepository(host, "test", fromLocalRepo);
 
             var toDir = temp.path().resolve("to.git");
-            var toLocalRepo = Repository.init(toDir, VCS.GIT);
+            var toLocalRepo = TestableRepository.init(toDir, VCS.GIT);
             var gitConfig = toDir.resolve(".git").resolve("config");
             Files.write(gitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
                         StandardOpenOption.APPEND);
@@ -126,11 +126,11 @@ class MirrorBotTests {
             var host = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));
 
             var fromDir = temp.path().resolve("from.git");
-            var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
+            var fromLocalRepo = TestableRepository.init(fromDir, VCS.GIT);
             var fromHostedRepo = new TestHostedRepository(host, "test", fromLocalRepo);
 
             var toDir = temp.path().resolve("to.git");
-            var toLocalRepo = Repository.init(toDir, VCS.GIT);
+            var toLocalRepo = TestableRepository.init(toDir, VCS.GIT);
             var gitConfig = toDir.resolve(".git").resolve("config");
             Files.write(gitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
                         StandardOpenOption.APPEND);
@@ -171,11 +171,11 @@ class MirrorBotTests {
             var host = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));
 
             var fromDir = temp.path().resolve("from.git");
-            var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
+            var fromLocalRepo = TestableRepository.init(fromDir, VCS.GIT);
             var fromHostedRepo = new TestHostedRepository(host, "test", fromLocalRepo);
 
             var toDir = temp.path().resolve("to.git");
-            var toLocalRepo = Repository.init(toDir, VCS.GIT);
+            var toLocalRepo = TestableRepository.init(toDir, VCS.GIT);
             var gitConfig = toDir.resolve(".git").resolve("config");
             Files.write(gitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
                         StandardOpenOption.APPEND);
@@ -226,11 +226,11 @@ class MirrorBotTests {
             var host = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));
 
             var fromDir = temp.path().resolve("from.git");
-            var fromLocalRepo = Repository.init(fromDir, VCS.GIT);
+            var fromLocalRepo = TestableRepository.init(fromDir, VCS.GIT);
             var fromHostedRepo = new TestHostedRepository(host, "test", fromLocalRepo);
 
             var toDir = temp.path().resolve("to.git");
-            var toLocalRepo = Repository.init(toDir, VCS.GIT);
+            var toLocalRepo = TestableRepository.init(toDir, VCS.GIT);
             var gitConfig = toDir.resolve(".git").resolve("config");
             Files.write(gitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
                         StandardOpenOption.APPEND);

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdateHistoryTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdateHistoryTests.java
@@ -25,6 +25,7 @@ package org.openjdk.skara.bots.notify;
 import org.openjdk.skara.forge.HostedRepository;
 import org.openjdk.skara.storage.StorageBuilder;
 import org.openjdk.skara.test.HostCredentials;
+import org.openjdk.skara.test.TestableRepository;
 import org.openjdk.skara.vcs.Tag;
 import org.openjdk.skara.vcs.*;
 
@@ -39,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class UpdateHistoryTests {
     private String resetHostedRepository(HostedRepository repository) throws IOException {
         var folder = Files.createTempDirectory("updatehistory");
-        var localRepository = Repository.init(folder, repository.repositoryType());
+        var localRepository = TestableRepository.init(folder, repository.repositoryType());
         var firstFile = folder.resolve("first.txt");
         Files.writeString(firstFile, "First file to commit");
         localRepository.add(firstFile);

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/TestWorkItemTests.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/TestWorkItemTests.java
@@ -484,7 +484,7 @@ class TestWorkItemTests {
     void approvedPendingRequestShouldBeStarted() throws IOException {
         try (var tmp = new TemporaryDirectory()) {
             var localRepoDir = tmp.path().resolve("repository.git");
-            var localRepo = Repository.init(localRepoDir, VCS.GIT);
+            var localRepo = TestableRepository.init(localRepoDir, VCS.GIT);
             var readme = localRepoDir.resolve("README");
             Files.writeString(readme, "Hello\n");
             localRepo.add(readme);
@@ -593,7 +593,7 @@ class TestWorkItemTests {
     void cancellingApprovedPendingRequestShouldBeCancel() throws IOException {
         try (var tmp = new TemporaryDirectory()) {
             var localRepoDir = tmp.path().resolve("repository.git");
-            var localRepo = Repository.init(localRepoDir, VCS.GIT);
+            var localRepo = TestableRepository.init(localRepoDir, VCS.GIT);
             var readme = localRepoDir.resolve("README");
             Files.writeString(readme, "Hello\n");
             localRepo.add(readme);
@@ -719,7 +719,7 @@ class TestWorkItemTests {
     void errorWhenCreatingTestJobShouldResultInError() throws IOException {
         try (var tmp = new TemporaryDirectory()) {
             var localRepoDir = tmp.path().resolve("repository.git");
-            var localRepo = Repository.init(localRepoDir, VCS.GIT);
+            var localRepo = TestableRepository.init(localRepoDir, VCS.GIT);
             var readme = localRepoDir.resolve("README");
             Files.writeString(readme, "Hello\n");
             localRepo.add(readme);
@@ -808,7 +808,7 @@ class TestWorkItemTests {
     void finishedJobShouldResultInFinishedComment() throws IOException {
         try (var tmp = new TemporaryDirectory()) {
             var localRepoDir = tmp.path().resolve("repository.git");
-            var localRepo = Repository.init(localRepoDir, VCS.GIT);
+            var localRepo = TestableRepository.init(localRepoDir, VCS.GIT);
             var readme = localRepoDir.resolve("README");
             Files.writeString(readme, "Hello\n");
             localRepo.add(readme);
@@ -962,7 +962,7 @@ class TestWorkItemTests {
     void userOnApprovelistDoesNotNeedApproval() throws IOException {
         try (var tmp = new TemporaryDirectory()) {
             var localRepoDir = tmp.path().resolve("repository.git");
-            var localRepo = Repository.init(localRepoDir, VCS.GIT);
+            var localRepo = TestableRepository.init(localRepoDir, VCS.GIT);
             var readme = localRepoDir.resolve("README");
             Files.writeString(readme, "Hello\n");
             localRepo.add(readme);

--- a/bots/topological/src/test/java/org/openjdk/skara/bots/topological/TopologicalBotTests.java
+++ b/bots/topological/src/test/java/org/openjdk/skara/bots/topological/TopologicalBotTests.java
@@ -46,7 +46,7 @@ class TopologicalBotTests {
             var host = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));
 
             var fromDir = temp.path().resolve("from.git");
-            var repo = Repository.init(fromDir, VCS.GIT);
+            var repo = TestableRepository.init(fromDir, VCS.GIT);
             var gitConfig = repo.root().resolve(".git").resolve("config");
             Files.write(gitConfig, List.of("[receive]", "denyCurrentBranch = ignore"),
                         StandardOpenOption.APPEND);
@@ -116,7 +116,7 @@ class TopologicalBotTests {
             var host = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));
 
             var fromDir = temp.path().resolve("from.git");
-            var repo = Repository.init(fromDir, VCS.GIT);
+            var repo = TestableRepository.init(fromDir, VCS.GIT);
             var gitConfig = repo.root().resolve(".git").resolve("config");
             Files.write(gitConfig, List.of("[receive]", "denyCurrentBranch = ignore"), APPEND);
             var hostedRepo = new TestHostedRepository(host, "test", repo);

--- a/forge/src/test/java/org/openjdk/skara/forge/ForgeTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/ForgeTests.java
@@ -29,6 +29,7 @@ import org.openjdk.skara.json.JSONObject;
 import org.openjdk.skara.test.TemporaryDirectory;
 import org.openjdk.skara.test.TestHost;
 import org.openjdk.skara.test.TestHostedRepository;
+import org.openjdk.skara.test.TestableRepository;
 import org.openjdk.skara.vcs.Hash;
 import org.openjdk.skara.vcs.Repository;
 import org.openjdk.skara.vcs.VCS;
@@ -99,7 +100,7 @@ class ForgeTests {
         try (var tmp = new TemporaryDirectory()) {
             var gitLocalDir = tmp.path().resolve("review.git");
             Files.createDirectories(gitLocalDir);
-            var gitLocalRepo = Repository.init(gitLocalDir, VCS.GIT);
+            var gitLocalRepo = TestableRepository.init(gitLocalDir, VCS.GIT);
             var hash = createCommit(gitLocalRepo);
 
             var host = TestHost.createNew(List.of(HostUser.create(0, "duke", "J. Duke")));

--- a/forge/src/test/java/org/openjdk/skara/forge/HostedRepositoryPoolTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/HostedRepositoryPoolTests.java
@@ -101,7 +101,7 @@ public class HostedRepositoryPoolTests {
             localRepo.push(masterHash, source.url(), "master", true);
 
             var pool = new HostedRepositoryPool(seedFolder.path());
-            var empty = Repository.init(cloneFolder.path(), VCS.GIT);
+            var empty = TestableRepository.init(cloneFolder.path(), VCS.GIT);
             assertThrows(IOException.class, () -> empty.checkout(new Branch("master"), true));
             var clone = pool.checkout(source, "master", cloneFolder.path());
             assertFalse(CheckableRepository.hasBeenEdited(clone));

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/DuplicateIssuesCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/DuplicateIssuesCheckTests.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.skara.jcheck;
 
+import org.openjdk.skara.test.TestableRepository;
 import org.openjdk.skara.vcs.*;
 import org.openjdk.skara.vcs.openjdk.*;
 import org.openjdk.skara.test.TemporaryDirectory;
@@ -60,7 +61,7 @@ class DuplicateIssuesCheckTests {
     @Test
     void noDuplicatedIssuesShouldPass() throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), VCS.GIT);
+            var r = TestableRepository.init(dir.path(), VCS.GIT);
 
             var readme = dir.path().resolve("README");
             Files.write(readme, List.of("Hello, world!"));
@@ -85,7 +86,7 @@ class DuplicateIssuesCheckTests {
     @Test
     void duplicateIssuesInMessageShouldFail() throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), VCS.GIT);
+            var r = TestableRepository.init(dir.path(), VCS.GIT);
 
             var readme = dir.path().resolve("README");
             Files.write(readme, List.of("Hello, world!"));
@@ -115,7 +116,7 @@ class DuplicateIssuesCheckTests {
     @Test
     void duplicateIssuesInPreviousCommitsShouldFail() throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), VCS.GIT);
+            var r = TestableRepository.init(dir.path(), VCS.GIT);
 
             var readme = dir.path().resolve("README");
             Files.write(readme, List.of("Hello, world!"));

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/JCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/JCheckTests.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.openjdk.skara.census.Census;
 import org.openjdk.skara.test.TemporaryDirectory;
+import org.openjdk.skara.test.TestableRepository;
 import org.openjdk.skara.vcs.*;
 import org.openjdk.skara.vcs.openjdk.CommitMessageParsers;
 
@@ -40,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class JCheckTests {
     static class CheckableRepository {
         public static Repository create(Path path, VCS vcs) throws IOException {
-            var repo = Repository.init(path, vcs);
+            var repo = TestableRepository.init(path, vcs);
 
             Files.createDirectories(path.resolve(".jcheck"));
             var checkConf = path.resolve(".jcheck/conf");

--- a/storage/src/test/java/org/openjdk/skara/storage/HostedRepositoryStorageTests.java
+++ b/storage/src/test/java/org/openjdk/skara/storage/HostedRepositoryStorageTests.java
@@ -55,7 +55,7 @@ public class HostedRepositoryStorageTests {
             storage.put(List.of("a", "b"));
 
             // Corrupt the destination path and materialize again
-            var localRepo = Repository.init(tempFolder.path(), VCS.GIT);
+            var localRepo = TestableRepository.init(tempFolder.path(), VCS.GIT);
             localRepo.checkout(new Branch("storage"));
             assertThrows(RuntimeException.class, () -> new HostedRepositoryStorage<>(repo, tempFolder.path(), "master", "test.txt",
                                                                                      "duke", "duke@openjdk.java.org",

--- a/storage/src/test/java/org/openjdk/skara/storage/RepositoryStorageTests.java
+++ b/storage/src/test/java/org/openjdk/skara/storage/RepositoryStorageTests.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.skara.storage;
 
+import org.openjdk.skara.test.TestableRepository;
 import org.openjdk.skara.vcs.*;
 
 import org.junit.jupiter.params.ParameterizedTest;
@@ -49,7 +50,7 @@ class RepositoryStorageTests {
     @EnumSource(VCS.class)
     void simple(VCS vcs) throws IOException {
         var tmpDir = Files.createTempDirectory("repositorystorage");
-        var repository = Repository.init(tmpDir, vcs);
+        var repository = TestableRepository.init(tmpDir, vcs);
         var storage = stringStorage(repository);
 
         assertEquals(Set.of(), storage.current());
@@ -61,7 +62,7 @@ class RepositoryStorageTests {
     @EnumSource(VCS.class)
     void multiple(VCS vcs) throws IOException {
         var tmpDir = Files.createTempDirectory("repositorystorage");
-        var repository = Repository.init(tmpDir, vcs);
+        var repository = TestableRepository.init(tmpDir, vcs);
         var storage = stringStorage(repository);
 
         assertEquals(Set.of(), storage.current());
@@ -73,7 +74,7 @@ class RepositoryStorageTests {
     @EnumSource(VCS.class)
     void retained(VCS vcs) throws IOException {
         var tmpDir = Files.createTempDirectory("repositorystorage");
-        var repository = Repository.init(tmpDir, vcs);
+        var repository = TestableRepository.init(tmpDir, vcs);
         var storage = stringStorage(repository);
 
         assertEquals(Set.of(), storage.current());
@@ -89,7 +90,7 @@ class RepositoryStorageTests {
     @EnumSource(VCS.class)
     void duplicates(VCS vcs) throws IOException {
         var tmpDir = Files.createTempDirectory("repositorystorage");
-        var repository = Repository.init(tmpDir, vcs);
+        var repository = TestableRepository.init(tmpDir, vcs);
         var storage = stringStorage(repository);
 
         assertEquals(Set.of(), storage.current());

--- a/test/src/main/java/org/openjdk/skara/test/HostCredentials.java
+++ b/test/src/main/java/org/openjdk/skara/test/HostCredentials.java
@@ -285,7 +285,7 @@ public class HostCredentials implements AutoCloseable {
                 localRepo = Repository.materialize(repoFolder, repo.url(), "testlock");
             } catch (IOException e) {
                 // If the branch does not exist, we'll try to create it
-                localRepo = Repository.init(repoFolder, VCS.GIT);
+                localRepo = TestableRepository.init(repoFolder, VCS.GIT);
             }
 
             if (Files.exists(lockFile)) {

--- a/test/src/main/java/org/openjdk/skara/test/TestHost.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHost.java
@@ -55,7 +55,7 @@ public class TestHost implements Forge, IssueTracker {
         var folder = new TemporaryDirectory();
         data.folders.add(folder);
         try {
-            var repo = Repository.init(folder.path().resolve("hosted.git"), VCS.GIT);
+            var repo = TestableRepository.init(folder.path().resolve("hosted.git"), VCS.GIT);
             Files.writeString(repo.root().resolve("content.txt"), "Initial content", StandardCharsets.UTF_8);
             repo.add(repo.root().resolve("content.txt"));
             var hash = repo.commit("Initial content", "author", "author@none");

--- a/test/src/main/java/org/openjdk/skara/test/TestableRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestableRepository.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.test;
+
+import org.openjdk.skara.vcs.Repository;
+import org.openjdk.skara.vcs.VCS;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+public class TestableRepository {
+    public static Repository init(Path p, VCS vcs) throws IOException {
+        Repository.ignoreConfiguration();
+        return Repository.init(p, vcs);
+    }
+}

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -191,6 +191,14 @@ public interface Repository extends ReadOnlyRepository {
             default:
                 throw new IllegalArgumentException("Invalid enum value: " + vcs);
         }
+    }
+
+    /**
+     * Turn on a static flag of all repository providers to ignore local configuration.
+     */
+    static void ignoreConfiguration() {
+        GitRepository.ignoreConfiguration();
+        HgRepository.ignoreConfiguration();
     }
 
     static Optional<Repository> get(Path p) throws IOException {

--- a/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
@@ -28,6 +28,7 @@ import org.openjdk.skara.test.TemporaryDirectory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.openjdk.skara.test.TestableRepository;
 import org.openjdk.skara.vcs.git.GitRepository;
 import org.openjdk.skara.vcs.hg.HgRepository;
 
@@ -72,7 +73,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testExistsOnInitializedRepository(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
             assertTrue(r.exists());
         }
     }
@@ -81,7 +82,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testExistsOnSubdir() throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), VCS.GIT);
+            var r = TestableRepository.init(dir.path(), VCS.GIT);
             assertTrue(r.exists());
 
             var subdir = Paths.get(dir.toString(), "test");
@@ -95,7 +96,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testRootOnTopLevel() throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), VCS.GIT);
+            var r = TestableRepository.init(dir.path(), VCS.GIT);
             assertEquals(dir.toString(), r.root().toString());
         }
     }
@@ -104,7 +105,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testRootOnSubdirectory(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
             assertEquals(dir.toString(), r.root().toString());
 
             var subdir = Paths.get(dir.toString(), "sub");
@@ -119,7 +120,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testResolveOnEmptyRepository(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
             assertTrue(r.resolve("HEAD").isEmpty());
         }
     }
@@ -128,7 +129,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testResolveWithHEAD(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
 
             var readme = dir.path().resolve("README");
             Files.write(readme, List.of("Hello, readme!"));
@@ -143,7 +144,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testConfig(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
 
             if (vcs == VCS.GIT) {
                 var config = dir.path().resolve(".git").resolve("config");
@@ -163,7 +164,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testCurrentBranchOnEmptyRepository(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
             assertEquals(r.defaultBranch(), r.currentBranch().get());
         }
     }
@@ -172,7 +173,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testCheckout(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
 
             var readme = dir.path().resolve("README");
             Files.write(readme, List.of("Hello, readme!"));
@@ -199,7 +200,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testLines(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
 
             var readme = dir.path().resolve("README");
             Files.write(readme, List.of("Hello, readme!"));
@@ -222,7 +223,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testLinesInSubdir(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            Repository.init(dir.path(), vcs);
+            TestableRepository.init(dir.path(), vcs);
 
             var subdir = dir.path().resolve("sub");
             Files.createDirectories(subdir);
@@ -250,7 +251,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testCommitListingOnEmptyRepo(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
             assertTrue(r.commits().asList().isEmpty());
         }
     }
@@ -259,7 +260,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testCommitListingWithSingleCommit(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
 
             var readme = dir.path().resolve("README");
             Files.write(readme, List.of("Hello, readme!"));
@@ -339,7 +340,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testCommitListingWithMultipleCommits(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
 
             var readme = dir.path().resolve("README");
             Files.write(readme, List.of("Hello, readme!"));
@@ -408,7 +409,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testSquashDeletes(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
 
             var file1 = dir.path().resolve("file1.txt");
             Files.write(file1, List.of("Hello, file 1!"));
@@ -467,7 +468,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testSquash(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
 
             var readme = dir.path().resolve("README");
             Files.write(readme, List.of("Hello, readme!"));
@@ -542,7 +543,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testMergeBase(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
 
             var readme = dir.path().resolve("README");
             Files.write(readme, List.of("Hello, readme!"));
@@ -567,7 +568,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testIsAncestor(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
 
             var readme = dir.path().resolve("README");
             Files.write(readme, List.of("Hello, readme!"));
@@ -595,7 +596,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testRebase(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
 
             var readme = dir.path().resolve("README");
             Files.write(readme, List.of("Hello, readme!"));
@@ -668,7 +669,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testInitializedRepositoryIsEmpty(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
             assertTrue(r.isEmpty());
         }
     }
@@ -677,7 +678,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testRepositoryWithCommitIsNonEmpty(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
 
             var readme = dir.path().resolve("README");
             Files.write(readme, List.of("Hello, readme!"));
@@ -693,7 +694,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testEmptyRepositoryIsHealthy(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
             assertTrue(r.isHealthy());
         }
     }
@@ -702,7 +703,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testNonEmptyRepositoryIsHealthy(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
 
             var readme = dir.path().resolve("README");
             Files.write(readme, List.of("Hello, readme!"));
@@ -719,7 +720,7 @@ public class RepositoryTests {
     void testNonCheckedOutRepositoryIsHealthy(VCS vcs) throws IOException {
         try (var dir1 = new TemporaryDirectory();
              var dir2 = new TemporaryDirectory()) {
-            var r1 = Repository.init(dir1.path(), vcs);
+            var r1 = TestableRepository.init(dir1.path(), vcs);
 
             var readme = dir1.path().resolve("README");
             Files.write(readme, List.of("Hello, readme!"));
@@ -728,7 +729,7 @@ public class RepositoryTests {
             var hash = r1.commit("Add README", "duke", "duke@openjdk.java.net");
             r1.tag(hash, "tag", "tagging", "duke", "duke@openjdk.java.net");
 
-            var r2 = Repository.init(dir2.path(), vcs);
+            var r2 = TestableRepository.init(dir2.path(), vcs);
             r2.fetch(r1.root().toUri(), r1.defaultBranch().name());
 
             assertTrue(r2.isHealthy());
@@ -739,7 +740,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testBranchesOnEmptyRepository(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
             var expected = vcs == VCS.GIT ? List.of() : List.of(new Branch("default"));
             assertEquals(List.of(), r.branches());
         }
@@ -749,7 +750,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testBranchesOnNonEmptyRepository(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
 
             var readme = dir.path().resolve("README");
             Files.write(readme, List.of("Hello, readme!"));
@@ -765,7 +766,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testTagsOnEmptyRepository(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
             var expected = vcs == VCS.GIT ? List.of() : List.of(new Tag("tip"));
             assertEquals(expected, r.tags());
         }
@@ -775,7 +776,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testTagsOnNonEmptyRepository(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
 
             var readme = dir.path().resolve("README");
             Files.write(readme, List.of("Hello, readme!"));
@@ -792,7 +793,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testFetchAndPush(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var upstream = Repository.init(dir.path(), vcs);
+            var upstream = TestableRepository.init(dir.path(), vcs);
 
             if (vcs == VCS.GIT) {
                 Files.write(upstream.root().resolve(".git").resolve("config"),
@@ -807,7 +808,7 @@ public class RepositoryTests {
             upstream.commit("Add README", "duke", "duke@openjdk.java.net");
 
             try (var dir2 = new TemporaryDirectory()) {
-                var downstream = Repository.init(dir2.path(), vcs);
+                var downstream = TestableRepository.init(dir2.path(), vcs);
 
                  // note: forcing unix path separators for URI
                 var upstreamURI = URI.create("file:///" + dir.toString().replace('\\', '/'));
@@ -835,7 +836,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testClean(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
             r.clean();
 
             var readme = dir.path().resolve("README");
@@ -863,7 +864,7 @@ public class RepositoryTests {
 
             // Mercurial cannot currently deal with this situation
             if (vcs != VCS.HG) {
-                var subRepo = Repository.init(dir.path().resolve("submodule"), vcs);
+                var subRepo = TestableRepository.init(dir.path().resolve("submodule"), vcs);
                 var subRepoFile = subRepo.root().resolve("file.txt");
                 Files.write(subRepoFile, List.of("Looks like a file in a submodule"));
 
@@ -878,7 +879,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testCleanIgnored(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
             r.clean();
 
             var readme = dir.path().resolve("README");
@@ -902,7 +903,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testDiffBetweenCommits(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
 
             var readme = dir.path().resolve("README");
             Files.write(readme, List.of("Hello, readme!"));
@@ -951,7 +952,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testDiffBetweenCommitsWithMultiplePatches(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
 
             var readme = dir.path().resolve("README");
             Files.write(readme, List.of("Hello, readme!"));
@@ -1020,7 +1021,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testDiffBetweenCommitsWithMultipleHunks(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
 
             var abc = dir.path().resolve("abc.txt");
             Files.write(abc, List.of("A", "B", "C"));
@@ -1083,7 +1084,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testDiffWithRemoval(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
 
             var readme = dir.path().resolve("README");
             Files.write(readme, List.of("Hello, world!"));
@@ -1132,7 +1133,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testDiffWithAddition(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
 
             var readme = dir.path().resolve("README");
             Files.write(readme, List.of("Hello, world!"));
@@ -1182,7 +1183,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testDiffWithWorkingDir(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
 
             var readme = dir.path().resolve("README");
             Files.write(readme, List.of("Hello, world!"));
@@ -1229,7 +1230,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testCommitMetadata(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
 
             var readme = dir.path().resolve("README");
             Files.write(readme, List.of("Hello, world!"));
@@ -1255,7 +1256,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testCommitMetadataWithFiles(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
 
             var readme1 = dir.path().resolve("README_1");
             Files.write(readme1, List.of("1"));
@@ -1292,7 +1293,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testCommitMetadataWithReverse(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
 
             var readme = dir.path().resolve("README");
             Files.write(readme, List.of("Hello, world!"));
@@ -1319,7 +1320,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testTrivialMerge(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
 
             var readme = dir.path().resolve("README");
             Files.write(readme, List.of("Hello, world!"));
@@ -1372,7 +1373,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testMergeWithEdit(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
 
             var readme = dir.path().resolve("README");
             Files.write(readme, List.of("Hello, world!"));
@@ -1456,7 +1457,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testDefaultBranch(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
             var expected = vcs == VCS.GIT ? "master" : "default";
             assertEquals(expected, r.defaultBranch().name());
         }
@@ -1466,7 +1467,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testPaths(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
             var remote = vcs == VCS.GIT ? "origin" : "default";
             r.setPaths(remote, "http://pull", "http://push");
             assertEquals("http://pull", r.pullPath(remote));
@@ -1478,7 +1479,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testIsValidRevisionRange(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
             assertFalse(r.isValidRevisionRange("foo"));
 
             var readme = dir.path().resolve("README");
@@ -1494,7 +1495,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testDefaultTag(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
             var expected = vcs == VCS.GIT ? Optional.empty() : Optional.of(new Tag("tip"));
             assertEquals(expected, r.defaultTag());
         }
@@ -1504,7 +1505,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testTag(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
 
             var readme = dir.path().resolve("README");
             Files.write(readme, List.of("Hello, world!"));
@@ -1525,7 +1526,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testIsClean(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
             assertTrue(r.isClean());
 
             var readme = dir.path().resolve("README");
@@ -1550,7 +1551,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testShowOnExecutableFiles(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
             assertTrue(r.isClean());
 
             var readOnlyExecutableFile = dir.path().resolve("hello.sh");
@@ -1586,7 +1587,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testDiffOnFilenamesWithSpace(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
             assertTrue(r.isClean());
 
             var fileWithSpaceInName = dir.path().resolve("hello world.txt");
@@ -1610,7 +1611,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testDiffAgainstInitialRevision(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
             assertTrue(r.isClean());
 
             var readme = dir.path().resolve("README.md");
@@ -1630,7 +1631,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testStatusAgainstInitialRevision(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
             assertTrue(r.isClean());
 
             var readme = dir.path().resolve("README.md");
@@ -1651,7 +1652,7 @@ public class RepositoryTests {
     @Test
     void testSingleEmptyCommit() throws IOException, InterruptedException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), VCS.GIT);
+            var r = TestableRepository.init(dir.path(), VCS.GIT);
             assertTrue(r.isClean());
 
             // must ust git directly to be able to pass --allow-empty
@@ -1680,7 +1681,7 @@ public class RepositoryTests {
     @Test
     void testEmptyCommitWithParent() throws IOException, InterruptedException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), VCS.GIT);
+            var r = TestableRepository.init(dir.path(), VCS.GIT);
             assertTrue(r.isClean());
 
             var f = Files.createFile(dir.path().resolve("hello.txt"));
@@ -1715,7 +1716,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testAmend(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
             assertTrue(r.isClean());
 
             var f = dir.path().resolve("README");
@@ -1737,7 +1738,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testRevert(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
             assertTrue(r.isClean());
 
             var f = dir.path().resolve("README");
@@ -1764,7 +1765,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testFiles(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
             assertTrue(r.isClean());
 
             var f = dir.path().resolve("README");
@@ -1805,7 +1806,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testDump(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
             assertTrue(r.isClean());
 
             var f = dir.path().resolve("README");
@@ -1826,7 +1827,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testStatus(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
             assertTrue(r.isClean());
 
             var f = dir.path().resolve("README");
@@ -1856,7 +1857,7 @@ public class RepositoryTests {
     @Test
     void testStatusWithUnicodeFiles() throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), VCS.GIT);
+            var r = TestableRepository.init(dir.path(), VCS.GIT);
             assertTrue(r.isClean());
 
             var f = dir.path().resolve("REÁDME.md");
@@ -1880,7 +1881,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testTrackLineEndings(VCS vcs) throws IOException, InterruptedException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
             if (vcs == VCS.GIT) { // turn of git's meddling
                 int exitCode = new ProcessBuilder()
                         .command("git", "config", "--local", "core.autocrlf", "false")
@@ -1926,7 +1927,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testContains(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
             assertTrue(r.isClean());
 
             var f = dir.path().resolve("README");
@@ -1948,7 +1949,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testAbortMerge(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
             assertTrue(r.isClean());
 
             var f = dir.path().resolve("README");
@@ -1978,7 +1979,7 @@ public class RepositoryTests {
         assumeTrue(vcs == VCS.GIT); // FIXME reset is not yet implemented for HG
 
         try (var dir = new TemporaryDirectory()) {
-            var repo = Repository.init(dir.path(), vcs);
+            var repo = TestableRepository.init(dir.path(), vcs);
             assertTrue(repo.isClean());
 
             var f = dir.path().resolve("README");
@@ -2004,7 +2005,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testRemotes(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var repo = Repository.init(dir.path(), vcs);
+            var repo = TestableRepository.init(dir.path(), vcs);
             assertEquals(List.of(), repo.remotes());
             repo.addRemote("foobar", "https://foo/bar");
             assertEquals(List.of("foobar"), repo.remotes());
@@ -2015,13 +2016,13 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testRemoteBranches(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var upstream = Repository.init(dir.path().resolve("upstream"), vcs);
+            var upstream = TestableRepository.init(dir.path().resolve("upstream"), vcs);
             var readme = upstream.root().resolve("README");
             Files.writeString(readme, "Hello\n");
             upstream.add(readme);
             var head = upstream.commit("Added README", "duke", "duke@openjdk.org");
 
-            var fork = Repository.init(dir.path().resolve("fork"), vcs);
+            var fork = TestableRepository.init(dir.path().resolve("fork"), vcs);
             fork.addRemote("upstream", upstream.root().toUri().toString());
             var refs = fork.remoteBranches("upstream");
             assertEquals(1, refs.size());
@@ -2035,7 +2036,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testSubmodulesOnEmptyRepo(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var repo = Repository.init(dir.path(), vcs);
+            var repo = TestableRepository.init(dir.path(), vcs);
             assertEquals(List.of(), repo.submodules());
         }
     }
@@ -2044,7 +2045,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testSubmodulesOnRepoWithNoSubmodules(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var repo = Repository.init(dir.path().resolve("repo"), vcs);
+            var repo = TestableRepository.init(dir.path().resolve("repo"), vcs);
             var readme = repo.root().resolve("README");
             Files.writeString(readme, "Hello\n");
             repo.add(readme);
@@ -2057,13 +2058,13 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testSubmodulesOnRepoWithSubmodule(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var submodule = Repository.init(dir.path().resolve("submodule"), vcs);
+            var submodule = TestableRepository.init(dir.path().resolve("submodule"), vcs);
             var readme = submodule.root().resolve("README");
             Files.writeString(readme, "Hello\n");
             submodule.add(readme);
             var head = submodule.commit("Added README", "duke", "duke@openjdk.org");
 
-            var repo = Repository.init(dir.path().resolve("repo"), vcs);
+            var repo = TestableRepository.init(dir.path().resolve("repo"), vcs);
             var pullPath = submodule.root().toAbsolutePath().toString();
             repo.addSubmodule(pullPath, Path.of("sub"));
             repo.commit("Added submodule", "duke", "duke@openjdk.org");
@@ -2081,7 +2082,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testAnnotateTag(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory(false)) {
-            var repo = Repository.init(dir.path(), vcs);
+            var repo = TestableRepository.init(dir.path(), vcs);
             var readme = repo.root().resolve("README");
             var now = ZonedDateTime.now();
             Files.writeString(readme, "Hello\n");
@@ -2106,7 +2107,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testAnnotateTagOnMissingTag(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var repo = Repository.init(dir.path(), vcs);
+            var repo = TestableRepository.init(dir.path(), vcs);
             var readme = repo.root().resolve("README");
             var now = ZonedDateTime.now();
             Files.writeString(readme, "Hello\n");
@@ -2121,7 +2122,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testAnnotateTagOnEmptyRepo(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var repo = Repository.init(dir.path(), vcs);
+            var repo = TestableRepository.init(dir.path(), vcs);
             assertEquals(Optional.empty(), repo.annotate(new Tag("unknown")));
         }
     }
@@ -2130,7 +2131,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testDiffWithFileList(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var repo = Repository.init(dir.path(), vcs);
+            var repo = TestableRepository.init(dir.path(), vcs);
             var readme = repo.root().resolve("README");
             Files.writeString(readme, "Hello\n");
             repo.add(readme);
@@ -2182,7 +2183,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testWritingConfigValue(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var repo = Repository.init(dir.path(), vcs);
+            var repo = TestableRepository.init(dir.path(), vcs);
             assertEquals(List.of(), repo.config("test.key"));
             repo.config("test", "key", "value");
             assertEquals(List.of("value"), repo.config("test.key"));
@@ -2229,7 +2230,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testFetchRemote(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var upstream = Repository.init(dir.path(), vcs);
+            var upstream = TestableRepository.init(dir.path(), vcs);
             var readme = dir.path().resolve("README");
             Files.write(readme, List.of("Hello, readme!"));
 
@@ -2237,7 +2238,7 @@ public class RepositoryTests {
             upstream.commit("Add README", "duke", "duke@openjdk.java.net");
 
             try (var dir2 = new TemporaryDirectory()) {
-                var downstream = Repository.init(dir2.path(), vcs);
+                var downstream = TestableRepository.init(dir2.path(), vcs);
 
                  // note: forcing unix path separators for URI
                 var upstreamURI = URI.create("file:///" + dir.toString().replace('\\', '/'));
@@ -2254,7 +2255,7 @@ public class RepositoryTests {
         assumeTrue(vcs == VCS.GIT); // FIXME hard to test with hg due to bookmarks and branches
         try (var dir = new TemporaryDirectory(false)) {
             var upstreamDir = dir.path().resolve("upstream" + (vcs == VCS.GIT ? ".git" : ".hg"));
-            var upstream = Repository.init(upstreamDir, vcs);
+            var upstream = TestableRepository.init(upstreamDir, vcs);
 
             Files.write(upstream.root().resolve(".git").resolve("config"),
                         List.of("[receive]", "denyCurrentBranch=ignore"),
@@ -2301,7 +2302,7 @@ public class RepositoryTests {
     void testUnmergedStatus(VCS vcs) throws IOException {
         assumeTrue(vcs == VCS.GIT);
         try (var dir = new TemporaryDirectory(false)) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
 
             var readme = dir.path().resolve("README");
             Files.write(readme, List.of("Hello, world!"));
@@ -2337,7 +2338,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testRangeSingle(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var repo = Repository.init(dir.path(), vcs);
+            var repo = TestableRepository.init(dir.path(), vcs);
             var range = repo.range(new Hash("0123456789"));
             if (vcs == VCS.GIT) {
                 assertEquals("0123456789^!", range);
@@ -2353,7 +2354,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testRangeInclusive(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var repo = Repository.init(dir.path(), vcs);
+            var repo = TestableRepository.init(dir.path(), vcs);
             var range = repo.rangeInclusive(new Hash("01234"), new Hash("56789"));
             if (vcs == VCS.GIT) {
                 assertEquals("01234^..56789", range);
@@ -2369,7 +2370,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testRangeExclusive(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var repo = Repository.init(dir.path(), vcs);
+            var repo = TestableRepository.init(dir.path(), vcs);
             var range = repo.rangeExclusive(new Hash("01234"), new Hash("56789"));
             if (vcs == VCS.GIT) {
                 assertEquals("01234..56789", range);
@@ -2384,14 +2385,14 @@ public class RepositoryTests {
     @Test
     void testHgRepoNestedInGitRepo() throws IOException {
         try (var gitDir = new TemporaryDirectory()) {
-            var gitRepo = Repository.init(gitDir.path(), VCS.GIT);
+            var gitRepo = TestableRepository.init(gitDir.path(), VCS.GIT);
             var gitFile = gitRepo.root().resolve("git-file.txt");
             Files.write(gitFile, List.of("Hello, Git!"));
             gitRepo.add(gitFile);
             var gitHash = gitRepo.commit("Added git-file.txt", "duke", "duke@openjdk.java.net");
 
             var hgDir = gitRepo.root().resolve("hg");
-            var hgRepo = Repository.init(hgDir, VCS.HG);
+            var hgRepo = TestableRepository.init(hgDir, VCS.HG);
             var hgFile = hgRepo.root().resolve("hg-file.txt");
             Files.write(hgFile, List.of("Hello, Mercurial!"));
             hgRepo.add(hgFile);
@@ -2412,14 +2413,14 @@ public class RepositoryTests {
     @Test
     void testGitRepoNestedInHgRepo() throws IOException {
         try (var hgDir = new TemporaryDirectory()) {
-            var hgRepo = Repository.init(hgDir.path(), VCS.HG);
+            var hgRepo = TestableRepository.init(hgDir.path(), VCS.HG);
             var hgFile = hgRepo.root().resolve("hg-file.txt");
             Files.write(hgFile, List.of("Hello, Mercurial!"));
             hgRepo.add(hgFile);
             var hgHash = hgRepo.commit("Added hg-file.txt", "duke", "duke@openjdk.java.net");
 
             var gitDir = hgRepo.root().resolve("git");
-            var gitRepo = Repository.init(gitDir, VCS.GIT);
+            var gitRepo = TestableRepository.init(gitDir, VCS.GIT);
             var gitFile = gitRepo.root().resolve("git-file.txt");
             Files.write(gitFile, List.of("Hello, Git!"));
             gitRepo.add(gitFile);
@@ -2440,13 +2441,13 @@ public class RepositoryTests {
     @Test
     void testGitAndHgRepoInSameDirectory() throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var hgRepo = Repository.init(dir.path(), VCS.HG);
+            var hgRepo = TestableRepository.init(dir.path(), VCS.HG);
             var hgFile = hgRepo.root().resolve("hg-file.txt");
             Files.write(hgFile, List.of("Hello, Mercurial!"));
             hgRepo.add(hgFile);
             var hgHash = hgRepo.commit("Added hg-file.txt", "duke", "duke@openjdk.java.net");
 
-            var gitRepo = Repository.init(dir.path(), VCS.GIT);
+            var gitRepo = TestableRepository.init(dir.path(), VCS.GIT);
             var gitFile = gitRepo.root().resolve("git-file.txt");
             Files.write(gitFile, List.of("Hello, Git!"));
             gitRepo.add(gitFile);
@@ -2459,7 +2460,7 @@ public class RepositoryTests {
     @Test
     void testCommitterDate() throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var repo = Repository.init(dir.path(), VCS.GIT);
+            var repo = TestableRepository.init(dir.path(), VCS.GIT);
             var readme = dir.path().resolve("README");
             Files.write(readme, List.of("Hello, readme!"));
 
@@ -2483,7 +2484,7 @@ public class RepositoryTests {
     @Test
     void testLightweightTags() throws IOException, InterruptedException {
         try (var dir = new TemporaryDirectory()) {
-            var repo = Repository.init(dir.path(), VCS.GIT);
+            var repo = TestableRepository.init(dir.path(), VCS.GIT);
             var readme = dir.path().resolve("README");
             Files.write(readme, List.of("Hello, readme!"));
 
@@ -2512,7 +2513,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testMergeCommitWithRenamedP0AndModifiedP1(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory(false)) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
 
             var readme = dir.path().resolve("README.old");
             Files.write(readme, List.of("Hello, world!"));
@@ -2557,7 +2558,7 @@ public class RepositoryTests {
     @Test
     void testMercurialTagWithoutEmail() throws IOException, InterruptedException {
         try (var dir = new TemporaryDirectory()) {
-            var repo = Repository.init(dir.path(), VCS.HG);
+            var repo = TestableRepository.init(dir.path(), VCS.HG);
             var readme = dir.path().resolve("README");
             Files.write(readme, List.of("Hello, readme!"));
             repo.add(readme);
@@ -2573,7 +2574,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testNonFastForwardMerge(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
 
             var readme = dir.path().resolve("README");
             Files.write(readme, List.of("Hello, readme!"));
@@ -2597,7 +2598,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testFastForwardMerge(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
 
             var readme = dir.path().resolve("README");
             Files.write(readme, List.of("Hello, readme!"));
@@ -2623,7 +2624,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testDeleteUntrackedFiles(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
 
             var readme = dir.path().resolve("README");
             Files.write(readme, List.of("Hello, readme!"));
@@ -2648,7 +2649,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testTimestampOnTags(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
 
             var readme = dir.path().resolve("README");
             Files.write(readme, List.of("Hello, readme!"));
@@ -2667,7 +2668,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testFollow(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
 
             var readme = dir.path().resolve("README");
             Files.write(readme, List.of("Hello, readme!"));
@@ -2693,7 +2694,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testFollowMergeCommit(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory(false)) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
 
             var readme = dir.path().resolve("README");
             Files.write(readme, List.of("Hello, readme!"));
@@ -2742,7 +2743,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testPull(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var upstream = Repository.init(dir.path(), vcs);
+            var upstream = TestableRepository.init(dir.path(), vcs);
             var readme = dir.path().resolve("README");
             Files.write(readme, List.of("Hello, readme!"));
 
@@ -2751,7 +2752,7 @@ public class RepositoryTests {
             upstream.tag(head, "1.0", "Added tag 1.0", "duke", "duke@openjdk.java.net");
 
             try (var dir2 = new TemporaryDirectory()) {
-                var downstream = Repository.init(dir2.path(), vcs);
+                var downstream = TestableRepository.init(dir2.path(), vcs);
 
                  // note: forcing unix path separators for URI
                 var upstreamURI = URI.create("file:///" + dir.toString().replace('\\', '/'));
@@ -2778,7 +2779,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testNonExistingLookup(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
             assertTrue(r.isClean());
 
             var readme = dir.path().resolve("README.md");
@@ -2795,7 +2796,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testSuccessfulCherryPicking(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
             assertTrue(r.isClean());
 
             var readme = dir.path().resolve("README.md");
@@ -2834,7 +2835,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testFailingCherryPicking(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory(false)) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
             assertTrue(r.isClean());
 
             var readme = dir.path().resolve("README.md");
@@ -2876,7 +2877,7 @@ public class RepositoryTests {
     @EnumSource(VCS.class)
     void testRepositoryContains(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
-            var r = Repository.init(dir.path(), vcs);
+            var r = TestableRepository.init(dir.path(), vcs);
             assertTrue(r.isClean());
 
             var readme = dir.path().resolve("README.md");

--- a/vcs/src/test/java/org/openjdk/skara/vcs/openjdk/converter/GitToHgConverterTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/openjdk/converter/GitToHgConverterTests.java
@@ -23,6 +23,7 @@
 package org.openjdk.skara.vcs.openjdk.converter;
 
 import org.openjdk.skara.test.TemporaryDirectory;
+import org.openjdk.skara.test.TestableRepository;
 import org.openjdk.skara.vcs.*;
 import org.openjdk.skara.vcs.openjdk.convert.GitToHgConverter;
 import org.openjdk.skara.vcs.openjdk.convert.Mark;
@@ -111,14 +112,14 @@ class GitToHgConverterTests {
     void convertOneCommit() throws IOException {
         try (var hgRoot = new TemporaryDirectory();
              var gitRoot = new TemporaryDirectory()) {
-            var gitRepo = Repository.init(gitRoot.path(), VCS.GIT);
+            var gitRepo = TestableRepository.init(gitRoot.path(), VCS.GIT);
             var readme = gitRoot.path().resolve("README.md");
 
             Files.writeString(readme, "Hello, world");
             gitRepo.add(readme);
             gitRepo.commit("1234567: Added README", "Foo Bar", "foo@openjdk.java.net");
 
-            var hgRepo = Repository.init(hgRoot.path(), VCS.HG);
+            var hgRepo = TestableRepository.init(hgRoot.path(), VCS.HG);
             var converter = new GitToHgConverter();
             var marks = converter.convert(gitRepo, hgRepo);
 
@@ -142,7 +143,7 @@ class GitToHgConverterTests {
     void convertOneSponsoredCommit() throws IOException {
         try (var hgRoot = new TemporaryDirectory();
              var gitRoot = new TemporaryDirectory()) {
-            var gitRepo = Repository.init(gitRoot.path(), VCS.GIT);
+            var gitRepo = TestableRepository.init(gitRoot.path(), VCS.GIT);
             var readme = gitRoot.path().resolve("README.md");
 
             Files.writeString(readme, "Hello, world");
@@ -150,7 +151,7 @@ class GitToHgConverterTests {
             gitRepo.commit("1234567: Added README", "Foo Bar", "foo@host.com",
                                                     "Baz Bar", "baz@openjdk.java.net");
 
-            var hgRepo = Repository.init(hgRoot.path(), VCS.HG);
+            var hgRepo = TestableRepository.init(hgRoot.path(), VCS.HG);
             var converter = new GitToHgConverter();
             var marks = converter.convert(gitRepo, hgRepo);
 
@@ -169,7 +170,7 @@ class GitToHgConverterTests {
     void convertRepoWithCopy() throws IOException {
         try (var hgRoot = new TemporaryDirectory();
              var gitRoot = new TemporaryDirectory()) {
-            var gitRepo = Repository.init(gitRoot.path(), VCS.GIT);
+            var gitRepo = TestableRepository.init(gitRoot.path(), VCS.GIT);
             var readme = gitRoot.path().resolve("README.md");
 
             Files.writeString(readme, "Hello, world");
@@ -180,7 +181,7 @@ class GitToHgConverterTests {
             gitRepo.copy(readme, readme2);
             gitRepo.commit("Copied README", "Foo Bar", "foo@openjdk.java.net");
 
-            var hgRepo = Repository.init(hgRoot.path(), VCS.HG);
+            var hgRepo = TestableRepository.init(hgRoot.path(), VCS.HG);
             var converter = new GitToHgConverter();
             var marks = converter.convert(gitRepo, hgRepo);
 
@@ -204,7 +205,7 @@ class GitToHgConverterTests {
     void convertRepoWithMove() throws IOException {
         try (var hgRoot = new TemporaryDirectory();
              var gitRoot = new TemporaryDirectory()) {
-            var gitRepo = Repository.init(gitRoot.path(), VCS.GIT);
+            var gitRepo = TestableRepository.init(gitRoot.path(), VCS.GIT);
             var readme = gitRoot.path().resolve("README.md");
 
             Files.writeString(readme, "Hello, world");
@@ -215,7 +216,7 @@ class GitToHgConverterTests {
             gitRepo.move(readme, readme2);
             gitRepo.commit("Moved README", "Foo Bar", "foo@openjdk.java.net");
 
-            var hgRepo = Repository.init(hgRoot.path(), VCS.HG);
+            var hgRepo = TestableRepository.init(hgRoot.path(), VCS.HG);
             var converter = new GitToHgConverter();
             var marks = converter.convert(gitRepo, hgRepo);
 
@@ -239,7 +240,7 @@ class GitToHgConverterTests {
     void convertOneCoAuthoredCommit() throws IOException {
         try (var hgRoot = new TemporaryDirectory();
              var gitRoot = new TemporaryDirectory()) {
-            var gitRepo = Repository.init(gitRoot.path(), VCS.GIT);
+            var gitRepo = TestableRepository.init(gitRoot.path(), VCS.GIT);
             var readme = gitRoot.path().resolve("README.md");
 
             Files.writeString(readme, "Hello, world");
@@ -248,7 +249,7 @@ class GitToHgConverterTests {
             gitRepo.commit(String.join("\n", message), "Foo Bar", "foo@host.com",
                                                        "Baz Bar", "baz@openjdk.java.net");
 
-            var hgRepo = Repository.init(hgRoot.path(), VCS.HG);
+            var hgRepo = TestableRepository.init(hgRoot.path(), VCS.HG);
             var converter = new GitToHgConverter();
             var marks = converter.convert(gitRepo, hgRepo);
 
@@ -267,7 +268,7 @@ class GitToHgConverterTests {
     void convertCommitWithSummary() throws IOException {
         try (var hgRoot = new TemporaryDirectory();
              var gitRoot = new TemporaryDirectory()) {
-            var gitRepo = Repository.init(gitRoot.path(), VCS.GIT);
+            var gitRepo = TestableRepository.init(gitRoot.path(), VCS.GIT);
             var readme = gitRoot.path().resolve("README.md");
 
             Files.writeString(readme, "Hello, world");
@@ -280,7 +281,7 @@ class GitToHgConverterTests {
             gitRepo.commit(String.join("\n", message), "Foo Bar", "foo@host.com",
                                                        "Baz Bar", "baz@openjdk.java.net");
 
-            var hgRepo = Repository.init(hgRoot.path(), VCS.HG);
+            var hgRepo = TestableRepository.init(hgRoot.path(), VCS.HG);
             var converter = new GitToHgConverter();
             var marks = converter.convert(gitRepo, hgRepo);
 
@@ -301,7 +302,7 @@ class GitToHgConverterTests {
     void convertMergeCommit() throws IOException {
         try (var hgRoot = new TemporaryDirectory();
              var gitRoot = new TemporaryDirectory()) {
-            var gitRepo = Repository.init(gitRoot.path(), VCS.GIT);
+            var gitRepo = TestableRepository.init(gitRoot.path(), VCS.GIT);
             var readme = gitRoot.path().resolve("README.md");
 
             Files.writeString(readme, "First line");
@@ -327,7 +328,7 @@ class GitToHgConverterTests {
             gitRepo.merge(toMerge);
             gitRepo.commit("Merge", "Foo Bar", "foo@openjdk.java.net");
 
-            var hgRepo = Repository.init(hgRoot.path(), VCS.HG);
+            var hgRepo = TestableRepository.init(hgRoot.path(), VCS.HG);
             var converter = new GitToHgConverter();
             var marks = converter.convert(gitRepo, hgRepo);
             assertReposEquals(marks, gitRepo, hgRepo);
@@ -338,7 +339,7 @@ class GitToHgConverterTests {
     void convertMergeCommitWithP0Diff() throws IOException {
         try (var hgRoot = new TemporaryDirectory();
              var gitRoot = new TemporaryDirectory()) {
-            var gitRepo = Repository.init(gitRoot.path(), VCS.GIT);
+            var gitRepo = TestableRepository.init(gitRoot.path(), VCS.GIT);
             var readme = gitRoot.path().resolve("README.md");
 
             Files.writeString(readme, "First line\n");
@@ -366,7 +367,7 @@ class GitToHgConverterTests {
             gitRepo.add(readme);
             gitRepo.commit("Merge", "Foo Bar", "foo@openjdk.java.net");
 
-            var hgRepo = Repository.init(hgRoot.path(), VCS.HG);
+            var hgRepo = TestableRepository.init(hgRoot.path(), VCS.HG);
             var converter = new GitToHgConverter();
             var marks = converter.convert(gitRepo, hgRepo);
             assertReposEquals(marks, gitRepo, hgRepo);
@@ -377,7 +378,7 @@ class GitToHgConverterTests {
     void convertMergeCommitWithP1Diff() throws IOException {
         try (var hgRoot = new TemporaryDirectory();
              var gitRoot = new TemporaryDirectory()) {
-            var gitRepo = Repository.init(gitRoot.path(), VCS.GIT);
+            var gitRepo = TestableRepository.init(gitRoot.path(), VCS.GIT);
             var readme = gitRoot.path().resolve("README.md");
 
             Files.writeString(readme, "First line\n");
@@ -405,7 +406,7 @@ class GitToHgConverterTests {
             gitRepo.add(contributing);
             gitRepo.commit("Merge", "Foo Bar", "foo@openjdk.java.net");
 
-            var hgRepo = Repository.init(hgRoot.path(), VCS.HG);
+            var hgRepo = TestableRepository.init(hgRoot.path(), VCS.HG);
             var converter = new GitToHgConverter();
             var marks = converter.convert(gitRepo, hgRepo);
             assertReposEquals(marks, gitRepo, hgRepo);
@@ -416,7 +417,7 @@ class GitToHgConverterTests {
         try (var hgRoot = new TemporaryDirectory(false);
              var gitRoot = new TemporaryDirectory(false)) {
             var gitRepo = Repository.clone(URI.create("https://git.openjdk.java.net/" + repo + ".git"), gitRoot.path());
-            var hgRepo = Repository.init(hgRoot.path(), VCS.HG);
+            var hgRepo = TestableRepository.init(hgRoot.path(), VCS.HG);
             var converter = new GitToHgConverter(new Branch("master"));
             var marks = converter.convert(gitRepo, hgRepo);
             assertReposEquals(marks, gitRepo, hgRepo);
@@ -427,7 +428,7 @@ class GitToHgConverterTests {
     void convertGitTag() throws IOException {
         try (var hgRoot = new TemporaryDirectory(false);
              var gitRoot = new TemporaryDirectory(false)) {
-            var gitRepo = Repository.init(gitRoot.path(), VCS.GIT);
+            var gitRepo = TestableRepository.init(gitRoot.path(), VCS.GIT);
             var readme = gitRoot.path().resolve("README.md");
 
             Files.writeString(readme, "First line\n");
@@ -440,7 +441,7 @@ class GitToHgConverterTests {
             var tagDate = ZonedDateTime.parse("2020-08-24T11:30:32+02:00");
             var tag = gitRepo.tag(second, "1.0", "Added tag 1.0", "Foo Bar", "foo@openjdk.java.net", tagDate);
 
-            var hgRepo = Repository.init(hgRoot.path(), VCS.HG);
+            var hgRepo = TestableRepository.init(hgRoot.path(), VCS.HG);
             var converter = new GitToHgConverter();
             var marks = converter.convert(gitRepo, hgRepo);
             var lastMark = marks.get(marks.size() - 1);

--- a/vcs/src/test/java/org/openjdk/skara/vcs/openjdk/converter/HgToGitConverterTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/openjdk/converter/HgToGitConverterTests.java
@@ -23,6 +23,7 @@
 package org.openjdk.skara.vcs.openjdk.converter;
 
 import org.openjdk.skara.test.TemporaryDirectory;
+import org.openjdk.skara.test.TestableRepository;
 import org.openjdk.skara.vcs.*;
 import org.openjdk.skara.vcs.openjdk.convert.HgToGitConverter;
 
@@ -39,14 +40,14 @@ class HgToGitConverterTests {
     void convertOneCommit() throws IOException {
         try (var hgRoot = new TemporaryDirectory();
              var gitRoot = new TemporaryDirectory()) {
-            var hgRepo = Repository.init(hgRoot.path(), VCS.HG);
+            var hgRepo = TestableRepository.init(hgRoot.path(), VCS.HG);
             var readme = hgRoot.path().resolve("README.md");
 
             Files.writeString(readme, "Hello, world");
             hgRepo.add(readme);
             hgRepo.commit("1234567: Added README", "foo", "foo@localhost");
 
-            var gitRepo = Repository.init(gitRoot.path(), VCS.GIT);
+            var gitRepo = TestableRepository.init(gitRoot.path(), VCS.GIT);
 
             var converter = new HgToGitConverter(Map.of(), Map.of(), Set.of(), Set.of(),
                                                  Map.of("foo", "Foo Bar <foo@openjdk.java.net>"), Map.of(), Map.of());
@@ -120,7 +121,7 @@ class HgToGitConverterTests {
     void convertOneSponsoredCommit() throws IOException {
         try (var hgRoot = new TemporaryDirectory();
              var gitRoot = new TemporaryDirectory()) {
-            var hgRepo = Repository.init(hgRoot.path(), VCS.HG);
+            var hgRepo = TestableRepository.init(hgRoot.path(), VCS.HG);
             var readme = hgRoot.path().resolve("README.md");
 
             Files.writeString(readme, "Hello, world");
@@ -128,7 +129,7 @@ class HgToGitConverterTests {
             var message = List.of("1234567: Added README", "Contributed-by: baz@domain.org");
             hgRepo.commit(String.join("\n", message), "foo", "foo@host.com");
 
-            var gitRepo = Repository.init(gitRoot.path(), VCS.GIT);
+            var gitRepo = TestableRepository.init(gitRoot.path(), VCS.GIT);
 
             var converter = new HgToGitConverter(Map.of(), Map.of(), Set.of(), Set.of(),
                                                  Map.of("foo", "Foo Bar <foo@openjdk.java.net>"),
@@ -155,7 +156,7 @@ class HgToGitConverterTests {
     void convertOneCoAuthoredCommit() throws IOException {
         try (var hgRoot = new TemporaryDirectory();
              var gitRoot = new TemporaryDirectory()) {
-            var hgRepo = Repository.init(hgRoot.path(), VCS.HG);
+            var hgRepo = TestableRepository.init(hgRoot.path(), VCS.HG);
             var readme = hgRoot.path().resolve("README.md");
 
             Files.writeString(readme, "Hello, world");
@@ -163,7 +164,7 @@ class HgToGitConverterTests {
             var message = List.of("1234567: Added README", "Contributed-by: baz@domain.org, foo@host.com");
             hgRepo.commit(String.join("\n", message), "foo", "foo@host.com");
 
-            var gitRepo = Repository.init(gitRoot.path(), VCS.GIT);
+            var gitRepo = TestableRepository.init(gitRoot.path(), VCS.GIT);
 
             var converter = new HgToGitConverter(Map.of(), Map.of(), Set.of(), Set.of(),
                                                  Map.of("foo", "Foo Bar <foo@openjdk.java.net>"),
@@ -192,7 +193,7 @@ class HgToGitConverterTests {
     void convertCommitWithSummary() throws IOException {
         try (var hgRoot = new TemporaryDirectory();
              var gitRoot = new TemporaryDirectory()) {
-            var hgRepo = Repository.init(hgRoot.path(), VCS.HG);
+            var hgRepo = TestableRepository.init(hgRoot.path(), VCS.HG);
             var readme = hgRoot.path().resolve("README.md");
 
             Files.writeString(readme, "Hello, world");
@@ -200,7 +201,7 @@ class HgToGitConverterTests {
             var message = List.of("1234567: Added README", "Summary: additional text", "Contributed-by: baz@domain.org, foo@host.com");
             hgRepo.commit(String.join("\n", message), "foo", "foo@host.com");
 
-            var gitRepo = Repository.init(gitRoot.path(), VCS.GIT);
+            var gitRepo = TestableRepository.init(gitRoot.path(), VCS.GIT);
 
             var converter = new HgToGitConverter(Map.of(), Map.of(), Set.of(), Set.of(),
                                                  Map.of("foo", "Foo Bar <foo@openjdk.java.net>"),

--- a/webrev/src/test/java/org/openjdk/skara/webrev/WebrevTests.java
+++ b/webrev/src/test/java/org/openjdk/skara/webrev/WebrevTests.java
@@ -23,6 +23,7 @@
 package org.openjdk.skara.webrev;
 
 import org.openjdk.skara.test.TemporaryDirectory;
+import org.openjdk.skara.test.TestableRepository;
 import org.openjdk.skara.vcs.*;
 
 import org.junit.jupiter.params.ParameterizedTest;
@@ -45,7 +46,7 @@ class WebrevTests {
     void simple(VCS vcs) throws IOException {
         try (var repoFolder = new TemporaryDirectory();
              var webrevFolder = new TemporaryDirectory()) {
-            var repo = Repository.init(repoFolder.path(), vcs);
+            var repo = TestableRepository.init(repoFolder.path(), vcs);
             var file = repoFolder.path().resolve("x.txt");
             Files.writeString(file, "1\n2\n3\n", StandardCharsets.UTF_8);
             repo.add(file);
@@ -65,7 +66,7 @@ class WebrevTests {
     void middle(VCS vcs) throws IOException {
         try (var repoFolder = new TemporaryDirectory();
              var webrevFolder = new TemporaryDirectory()) {
-            var repo = Repository.init(repoFolder.path(), vcs);
+            var repo = TestableRepository.init(repoFolder.path(), vcs);
             var file = repoFolder.path().resolve("x.txt");
             Files.writeString(file, "1\n2\n3\n4\n5\n6\n7\n8\n9\n", StandardCharsets.UTF_8);
             repo.add(file);
@@ -84,7 +85,7 @@ class WebrevTests {
     void emptySourceHunk(VCS vcs) throws IOException {
         try (var repoFolder = new TemporaryDirectory();
         var webrevFolder = new TemporaryDirectory()) {
-            var repo = Repository.init(repoFolder.path(), vcs);
+            var repo = TestableRepository.init(repoFolder.path(), vcs);
             var file = repoFolder.path().resolve("x.txt");
             Files.writeString(file, "1\n2\n3\n", StandardCharsets.UTF_8);
             repo.add(file);
@@ -103,7 +104,7 @@ class WebrevTests {
     void removedHeader(VCS vcs) throws IOException {
         try (var repoFolder = new TemporaryDirectory();
              var webrevFolder = new TemporaryDirectory()) {
-            var repo = Repository.init(repoFolder.path(), vcs);
+            var repo = TestableRepository.init(repoFolder.path(), vcs);
             var file = repoFolder.path().resolve("x.txt");
             Files.writeString(file, "1\n2\n3\n4\n5\n6\n7\n8\n9\n", StandardCharsets.UTF_8);
             repo.add(file);
@@ -121,7 +122,7 @@ class WebrevTests {
     @EnumSource(VCS.class)
     void removeBinaryFile(VCS vcs) throws IOException {
         try (var tmp = new TemporaryDirectory()) {
-            var repo = Repository.init(tmp.path().resolve("repo"), vcs);
+            var repo = TestableRepository.init(tmp.path().resolve("repo"), vcs);
             var binaryFile = repo.root().resolve("x.jpg");
             byte[] contents = {0x1, 0x2, 0x3, 0x4, 0x5, 0x0, 0x2, 0x3, 0x4, 0x5};
             Files.write(binaryFile, contents);
@@ -138,7 +139,7 @@ class WebrevTests {
     @EnumSource(VCS.class)
     void addBinaryFile(VCS vcs) throws IOException {
         try (var tmp = new TemporaryDirectory()) {
-            var repo = Repository.init(tmp.path().resolve("repo"), vcs);
+            var repo = TestableRepository.init(tmp.path().resolve("repo"), vcs);
             var readme = repo.root().resolve("README");
             Files.writeString(readme, "Hello\n");
             repo.add(readme);
@@ -158,7 +159,7 @@ class WebrevTests {
     @EnumSource(VCS.class)
     void modifyBinaryFile(VCS vcs) throws IOException {
         try (var tmp = new TemporaryDirectory()) {
-            var repo = Repository.init(tmp.path().resolve("repo"), vcs);
+            var repo = TestableRepository.init(tmp.path().resolve("repo"), vcs);
             var readme = repo.root().resolve("README");
             var binaryFile = repo.root().resolve("x.jpg");
             byte[] contents = {0x1, 0x2, 0x3, 0x4, 0x5, 0x0, 0x2, 0x3, 0x4, 0x5};
@@ -180,7 +181,7 @@ class WebrevTests {
     void reservedName(VCS vcs) throws IOException {
         try (var repoFolder = new TemporaryDirectory();
              var webrevFolder = new TemporaryDirectory()) {
-            var repo = Repository.init(repoFolder.path(), vcs);
+            var repo = TestableRepository.init(repoFolder.path(), vcs);
             var file = repoFolder.path().resolve("index.html");
             Files.writeString(file, "1\n2\n3\n", StandardCharsets.UTF_8);
             repo.add(file);


### PR DESCRIPTION
It turned out that [SKARA-913](https://bugs.openjdk.java.net/browse/SKARA-913) which fixed unwanted side effects of [SKARA-868](https://bugs.openjdk.java.net/browse/SKARA-868), in fact broke Skara testing completely the way SKARA-868 was supposed to fix. In SKARA-913 only a few of the Skara tests were properly configured to really ignore the local configuration; something I discovered lately when running all tests on a machine with a .gitconfig that foils several git tests from running.

Since there is no really single point of entry to say to the Repository logic "I am now running a test", I have created a wrapper TestableRepository.init(), which calls Repository.init() and makes sure ignoreConfiguration is on.

At least this solves the problem for me. There might be other tests hiding where other strange configurations provoke a failure; I know of no systematic way to find all these, so I'll guess we have to fix that when it is discovered.