### PR TITLE
627: Review comments are in different order in different e-mails

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
@@ -354,7 +354,10 @@ class ArchiveWorkItem implements WorkItem {
             }
 
             // File specific comments
-            var reviewComments = pr.reviewComments();
+            var reviewComments = pr.reviewComments().stream()
+                                   .sorted(Comparator.comparing(ReviewComment::line))
+                                   .sorted(Comparator.comparing(ReviewComment::path))
+                                   .collect(Collectors.toList());
             for (var reviewComment : reviewComments) {
                 if (ignoreComment(reviewComment.author(), reviewComment.body())) {
                     continue;


### PR DESCRIPTION
Sort review comments by filename and line to make the resulting emails more consistent.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-627](https://bugs.openjdk.java.net/browse/SKARA-627): Review comments are in different order in different e-mails


### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/skara pull/1067/head:pull/1067`
`$ git checkout pull/1067`
