### PR TITLE
pr: add CommitCommandWorkItem.toString

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommandWorkItem.java
@@ -171,4 +171,9 @@ public class CommitCommandWorkItem implements WorkItem {
     public void handleRuntimeException(RuntimeException e) {
         onError.accept(e);
     }
+
+    @Override
+    public String toString() {
+        return "CommitCommandWorkItem@" + bot.repo().name() + ":" + commitComment.commit().abbreviate();
+    }
 }


### PR DESCRIPTION
Hi all,

please review this small patch that overrides `toString` for `CommitCommandWorkItem`.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/skara pull/1069/head:pull/1069`
`$ git checkout pull/1069`

To update a local copy of the PR:
`$ git checkout pull/1069`
`$ git pull https://git.openjdk.java.net/skara pull/1069/head`
