### PR TITLE
pr: do not run commit commands when .jcheck/conf is missing

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -213,7 +213,7 @@ class CheckWorkItem extends PullRequestWorkItem {
         var hostedRepositoryPool = new HostedRepositoryPool(seedPath);
 
         var census = CensusInstance.create(hostedRepositoryPool, bot.censusRepo(), bot.censusRef(), scratchPath.resolve("census"), pr,
-                                           bot.confOverrideRepository().orElse(null), bot.confOverrideName(), bot.confOverrideRef());
+                                           bot.confOverrideRepository().orElse(null), bot.confOverrideName(), bot.confOverrideRef()).orElseThrow();
         var comments = pr.comments();
         var allReviews = pr.reviews();
         var labels = new HashSet<>(pr.labels());

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommandWorkItem.java
@@ -162,12 +162,11 @@ public class CommitCommandWorkItem implements WorkItem {
                                                bot.confOverrideRef());
             var command = nextCommand.get();
             if (census.isEmpty()) {
-                var writer = new StringWriter();
-                var printer = new PrintWriter(writer);
-                printer.println(String.format(commandReplyMarker, command.id()));
-                printer.println("@" + command.user().username() +
-                                " there is no `.jcheck/conf` present at revision " +
-                                commit.hash().abbreviate() + " - cannot process command.");
+                var comment = String.format(commandReplyMarker, command.id()) + "\n" +
+                              "@" + command.user().username() +
+                              " there is no `.jcheck/conf` present at revision " +
+                              commit.hash().abbreviate() + " - cannot process command.";
+                bot.repo().addCommitComment(commit.hash(), comment);
             } else {
                 processCommand(scratchPath, commit, census.get(), command, allComments);
             }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
@@ -217,7 +217,7 @@ public class PullRequestCommandWorkItem extends PullRequestWorkItem {
         var hostedRepositoryPool = new HostedRepositoryPool(seedPath);
 
         var census = CensusInstance.create(hostedRepositoryPool, bot.censusRepo(), bot.censusRef(), scratchPath.resolve("census"), pr,
-                                           bot.confOverrideRepository().orElse(null), bot.confOverrideName(), bot.confOverrideRef());
+                                           bot.confOverrideRepository().orElse(null), bot.confOverrideName(), bot.confOverrideRef()).orElseThrow();
         var command = nextCommand.get();
         log.info("Processing command: " + command.id() + " - " + command.name());
 


### PR DESCRIPTION
Hi all,

please review this patch that ensures that we do _not_ run commit commands if there is no `.jcheck/conf` present in the tree for the commit.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**) ⚠️ Review applies to 3b462e33a4fff83fab760682684eb5faba4b35c3


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/skara pull/1070/head:pull/1070`
`$ git checkout pull/1070`

To update a local copy of the PR:
`$ git checkout pull/1070`
`$ git pull https://git.openjdk.java.net/skara pull/1070/head`
