### PR TITLE
pr: add /integrate auto

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -310,6 +310,10 @@ class CheckWorkItem extends PullRequestWorkItem {
             }
         }
 
+        if (pr.labels().contains("auto") && pr.labels().contains("ready") && !pr.labels().contains("sponsor")) {
+            pr.addComment("/integrate\n" + PullRequestCommandWorkItem.VALID_BOT_COMMAND_MARKER);
+        }
+
         // Must re-fetch PR after executing CheckRun
         var updatedPR = pr.repository().pullRequest(pr.id());
         return List.of(new PullRequestCommandWorkItem(bot, updatedPR, errorHandler));

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
@@ -40,7 +40,6 @@ public class PullRequestCommandWorkItem extends PullRequestWorkItem {
 
     private static final String commandReplyMarker = "<!-- Jmerge command reply message (%s) -->";
     private static final Pattern commandReplyPattern = Pattern.compile("<!-- Jmerge command reply message \\((\\S+)\\) -->");
-    private static final String selfCommandMarker = "<!-- Valid self-command -->";
     private final static Pattern pushedPattern = Pattern.compile("Pushed as commit ([a-f0-9]{40})\\.");
 
     private static final Map<String, CommandHandler> commandHandlers = Map.ofEntries(
@@ -58,6 +57,8 @@ public class PullRequestCommandWorkItem extends PullRequestWorkItem {
             Map.entry("cc", new LabelCommand("cc")),
             Map.entry("clean", new CleanCommand())
     );
+
+    public static final String VALID_BOT_COMMAND_MARKER = "<!-- Valid self-command -->";
 
     static class HelpCommand implements CommandHandler {
         @Override
@@ -116,7 +117,7 @@ public class PullRequestCommandWorkItem extends PullRequestWorkItem {
         var body = PullRequestBody.parse(pr).bodyText();
         var allCommands = Stream.concat(CommandExtractor.extractCommands(commandHandlers, body, "body", pr.author()).stream(),
                                         comments.stream()
-                                                .filter(comment -> !comment.author().equals(self) || comment.body().endsWith(selfCommandMarker))
+                                                .filter(comment -> !comment.author().equals(self) || comment.body().endsWith(VALID_BOT_COMMAND_MARKER))
                                                 .flatMap(c -> CommandExtractor.extractCommands(commandHandlers, c.body(), c.id(), c.author()).stream()))
                                 .collect(Collectors.toList());
 

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Hash.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Hash.java
@@ -64,4 +64,8 @@ public class Hash {
     public String abbreviate() {
         return hex().substring(0, 8);
     }
+
+    public boolean isValid() {
+        return hex.toLowerCase().matches("[a-f0-9]{40}");
+    }
 }


### PR DESCRIPTION
Hi all,

please review this patch that adds the `auto` and `manual` arguments to the `/integrate` pull request command. If a contributor issues `/integrate auto` then the pull request will be automatically integrated when the pull request is ready (i.e. when jcheck passes). To aid reviewers that this is the case the label "auto" will be added to such pull requests. A contributor can always go back to "manual" mode by issuing the `/integrate auto`.

This functionality is useful for smaller patches where you are certain that they are correct, for example fixing a typo in a comment. It it also useful for clean backports since most projects consider clean backports ready to be integrated without a review. This allows a backporter to add `/integrate auto` to the bottom of the PR body for a clean backport and then it will automatically be integrated if it is considered clean.

I also added a bunch of unit tests.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/skara pull/1071/head:pull/1071`
`$ git checkout pull/1071`

To update a local copy of the PR:
`$ git checkout pull/1071`
`$ git pull https://git.openjdk.java.net/skara pull/1071/head`
