### PR TITLE
823: git fork --setup-pre-push-hook  => FAIL

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitFork.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitFork.java
@@ -383,7 +383,7 @@ public class GitFork {
 
                 var setupPrePushHooksOption = getOption("setup-pre-push-hook", subsection, arguments);
                 if (setupPrePushHooksOption != null) {
-                    var res = GitJCheck.run(repo, new String[]{"--setup-pre-push-hook", setupPrePushHooksOption });
+                    var res = GitJCheck.run(repo, new String[]{"--setup-pre-push-hook"});
                     if (res != 0) {
                         System.exit(res);
                     }


### PR DESCRIPTION
Hi all,

please review this small patch that makes `git fork --setup-pre-push-hook` correctly pass `--setup-pre-push-hook` as  a switch to `git-jcheck`.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-823](https://bugs.openjdk.java.net/browse/SKARA-823): git fork --setup-pre-push-hook  => FAIL


### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/skara pull/1073/head:pull/1073`
`$ git checkout pull/1073`

To update a local copy of the PR:
`$ git checkout pull/1073`
`$ git pull https://git.openjdk.java.net/skara pull/1073/head`
