### PR TITLE
757: git webrev with file list fails if any file has not changed

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitWebrev.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitWebrev.java
@@ -193,6 +193,8 @@ public class GitWebrev {
         if (arguments.contains("verbose") || arguments.contains("debug")) {
             var level = arguments.contains("debug") ? Level.FINER : Level.FINE;
             Logging.setup(level);
+        } else {
+            Logging.setup(Level.WARNING);
         }
 
         var cwd = Paths.get("").toAbsolutePath();

--- a/cli/src/main/java/org/openjdk/skara/cli/MinimalFormatter.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/MinimalFormatter.java
@@ -24,9 +24,19 @@ package org.openjdk.skara.cli;
 
 import java.util.logging.Formatter;
 import java.util.logging.LogRecord;
+import java.util.logging.Level;
 
 class MinimalFormatter extends Formatter {
     public String format(LogRecord record) {
-        return record.getMessage() + "\n";
+        var prefix = "";
+        var level = record.getLevel();
+        if (level.equals(Level.SEVERE)) {
+            prefix = "error: ";
+        } else if (level.equals(Level.WARNING)) {
+            prefix = "warning: ";
+        } else if (level.equals(Level.INFO)) {
+            prefix = "info: ";
+        }
+        return prefix + record.getMessage() + "\n";
     }
 }

--- a/webrev/src/main/java/org/openjdk/skara/webrev/Webrev.java
+++ b/webrev/src/main/java/org/openjdk/skara/webrev/Webrev.java
@@ -344,7 +344,7 @@ public class Webrev {
                     } else if (bySourcePath.containsKey(file)) {
                         sorted.add(bySourcePath.get(file));
                     } else {
-                        throw new IOException("Filename not present in diff: " + file);
+                        log.warning("ignoring file not present in diff: " + file);
                     }
                 }
                 patches = sorted;


### PR DESCRIPTION
Hi all,

please review this patch that makes `git-webrev` print a warning when it encounters a file not present in the diff (for example if the user supplied a file list as argument).

Testing:
- [x] Manual testing on Linux x64

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-757](https://bugs.openjdk.java.net/browse/SKARA-757): git webrev with file list fails if any file has not changed


### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/skara pull/1074/head:pull/1074`
`$ git checkout pull/1074`

To update a local copy of the PR:
`$ git checkout pull/1074`
`$ git pull https://git.openjdk.java.net/skara pull/1074/head`
