### PR TITLE
cli: make it possible to configure forge name

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/ForgeUtils.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/ForgeUtils.java
@@ -41,6 +41,19 @@ public class ForgeUtils {
         System.exit(1);
     }
 
+    private static void gitConfig(String key, String value) {
+        try {
+            var pb = new ProcessBuilder("git", "config", key, value);
+            pb.redirectOutput(ProcessBuilder.Redirect.DISCARD);
+            pb.redirectError(ProcessBuilder.Redirect.DISCARD);
+            pb.start().waitFor();
+        } catch (InterruptedException e) {
+            // do nothing
+        } catch (IOException e) {
+            // do nothing
+        }
+    }
+
     private static String gitConfig(String key) {
         try {
             var pb = new ProcessBuilder("git", "config", key);
@@ -118,7 +131,11 @@ public class ForgeUtils {
             var forge = credentials == null ? Forge.from(name, uri) : Forge.from(name, uri, credentials);
             return Optional.of(forge);
         }
-        return credentials == null ? Forge.from(uri) : Forge.from(uri, credentials);
+        var forge = credentials == null ? Forge.from(uri) : Forge.from(uri, credentials);
+        if (forge.isPresent()) {
+            gitConfig("forge.name", forge.get().name().toLowerCase());
+        }
+        return forge;
     }
 
     public static Forge getForge(URI uri, ReadOnlyRepository repo, String command, Arguments arguments) throws IOException {

--- a/cli/src/main/java/org/openjdk/skara/cli/GitBackport.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitBackport.java
@@ -151,7 +151,7 @@ public class GitBackport {
                 var token = System.getenv("GIT_TOKEN");
                 var credentials = GitCredentials.fill(canonical.getHost(), canonical.getPath(), username, token, canonical.getScheme());
                 var forgeURI = URI.create(canonical.getScheme() + "://" + canonical.getHost());
-                var forge = Forge.from(forgeURI, new Credential(credentials.username(), credentials.password()));
+                var forge = ForgeUtils.from(forgeURI, new Credential(credentials.username(), credentials.password()));
                 if (forge.isEmpty()) {
                     System.err.println("error: could not find forge at " + forgeURI.getHost());
                     System.exit(1);

--- a/cli/src/main/java/org/openjdk/skara/cli/GitCommitComments.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitCommitComments.java
@@ -174,7 +174,7 @@ public class GitCommitComments {
             exit("error: no username for " + webURI.getHost() + " found, use git-credentials or the flag --username");
         }
 
-        var host = Forge.from(webURI, new Credential(credentials.username(), credentials.password()));
+        var host = ForgeUtils.from(webURI, new Credential(credentials.username(), credentials.password()));
         if (host.isEmpty()) {
             exit("error: could not connect to host " + webURI.getHost());
         }

--- a/cli/src/main/java/org/openjdk/skara/cli/GitDefpath.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitDefpath.java
@@ -289,11 +289,11 @@ public class GitDefpath {
                 var originPullPath = repo.pullPath("origin");
                 var uri = Remote.toWebURI(originPullPath);
                 try {
-                    upstreamURI = Forge.from(uri)
-                                       .flatMap(f -> f.repository(uri.getPath().substring(1)))
-                                       .flatMap(r -> r.parent())
-                                       .map(p -> p.webUrl())
-                                       .orElse(null);
+                    upstreamURI = ForgeUtils.from(uri)
+                                            .flatMap(f -> f.repository(uri.getPath().substring(1)))
+                                            .flatMap(r -> r.parent())
+                                            .map(p -> p.webUrl())
+                                            .orElse(null);
                 } catch (Throwable t) {
                     System.err.println("error: could not find upstream repository");
                     System.exit(1);
@@ -324,11 +324,11 @@ public class GitDefpath {
                     System.exit(1);
                 }
                 try {
-                    forkURI = Forge.from(uri, new Credential(credentials.username(), credentials.password()))
-                                   .flatMap(f -> f.repository(uri.getPath().substring(1)))
-                                   .map(r -> r.fork())
-                                   .map(fork -> fork.webUrl())
-                                   .orElse(null);
+                    forkURI = ForgeUtils.from(uri, new Credential(credentials.username(), credentials.password()))
+                                        .flatMap(f -> f.repository(uri.getPath().substring(1)))
+                                        .map(r -> r.fork())
+                                        .map(fork -> fork.webUrl())
+                                        .orElse(null);
                 } catch (Throwable t) {
                     System.err.println("error: could not find fork for upstream repository");
                     System.exit(1);

--- a/cli/src/main/java/org/openjdk/skara/cli/GitFork.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitFork.java
@@ -265,7 +265,7 @@ public class GitFork {
             exit("error: no username for " + webURI.getHost() + " found, use git-credentials or the flag --username");
         }
 
-        var host = Forge.from(webURI, new Credential(credentials.username(), credentials.password()));
+        var host = ForgeUtils.from(webURI, new Credential(credentials.username(), credentials.password()));
         if (host.isEmpty()) {
             exit("error: could not connect to host " + webURI.getHost());
         }

--- a/cli/src/main/java/org/openjdk/skara/cli/GitSync.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitSync.java
@@ -156,11 +156,11 @@ public class GitSync {
                         var originPullPath = repo.pullPath("origin");
                         try {
                             var uri = Remote.toWebURI(originPullPath);
-                            from = Forge.from(uri)
-                                        .flatMap(f -> f.repository(uri.getPath().substring(1)))
-                                        .flatMap(r -> r.parent())
-                                        .map(p -> p.webUrl().toString())
-                                        .orElse(null);
+                            from = ForgeUtils.from(uri)
+                                             .flatMap(f -> f.repository(uri.getPath().substring(1)))
+                                             .flatMap(r -> r.parent())
+                                             .map(p -> p.webUrl().toString())
+                                             .orElse(null);
                         } catch (Throwable e) {
                             from = null;
                         }

--- a/forge/src/main/java/org/openjdk/skara/forge/Forge.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/Forge.java
@@ -46,6 +46,14 @@ public interface Forge extends Host {
         return factory.get().create(uri, credential, configuration);
     }
 
+    static Forge from(String name, URI uri, Credential credential) {
+        return from(name, uri, credential, null);
+    }
+
+    static Forge from(String name, URI uri) {
+        return from(name, uri, null);
+    }
+
     static Optional<Forge> from(URI uri, Credential credential, JSONObject configuration) {
         var factories = ForgeFactory.getForgeFactories();
 


### PR DESCRIPTION
Hi all,

please review this patch that makes it possible to configure the forge name for a repository using `git config forge.name`, for example `git config forge.name github`. This can be useful for speeding up the forge selection logic in `Forge.from` so that the code doesn't have to query multiple candidate forges.

Testing:
- [x] Manual testing on Linux x64

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/skara pull/1076/head:pull/1076`
`$ git checkout pull/1076`

To update a local copy of the PR:
`$ git checkout pull/1076`
`$ git pull https://git.openjdk.java.net/skara pull/1076/head`
