### PR TITLE
744: The "Webrevs" link in the PR has confusing link to the changes for just one commit

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
@@ -155,7 +155,7 @@ class ArchiveWorkItem implements WorkItem {
         comment += "### Webrevs" + "\n";
         comment += webrevListMarker + "\n";
         comment += " * " + String.format("%02d", index) + ": " + webrevDescriptions;
-        comment += " (" + pr.headHash() + ")\n";
+        comment += " (" + pr.filesUrl(pr.headHash()) + ")\n";
 
         if (existing.isPresent()) {
             if (existing.get().body().contains(webrevDescriptions)) {

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
@@ -314,4 +314,9 @@ class InMemoryPullRequest implements PullRequest {
     public Optional<HostUser> closedBy() {
         return Optional.empty();
     }
+
+    @Override
+    public URI filesUrl(Hash hash) {
+        return null;
+    }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
@@ -161,4 +161,6 @@ public interface PullRequest extends Issue {
      * @return
      */
     void setTargetRef(String targetRef);
+
+    URI filesUrl(Hash hash);
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -738,4 +738,10 @@ public class GitHubPullRequest implements PullRequest {
                       .reduce((a, b) -> b)
                       .map(e -> host.parseUserObject(e.get("actor")));
     }
+
+    @Override
+    public URI filesUrl(Hash hash) {
+        var endpoint = "/" + repository.name() + "/pull/" + id() + "/files/" + hash.hex();
+        return host.getWebURI(endpoint);
+    }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -788,4 +788,10 @@ public class GitLabMergeRequest implements PullRequest {
 
         return Optional.of(host.parseAuthorObject(json.get("closed_by").asObject()));
     }
+
+    @Override
+    public URI filesUrl(Hash hash) {
+        var endpoint = "/" + repository.name() + "/-/merge_requests/" + id() + "/diffs?commit_id=" + hash.hex();
+        return host.getWebUri(endpoint);
+    }
 }

--- a/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
@@ -257,4 +257,9 @@ public class TestPullRequest extends TestIssue implements PullRequest {
             throw new UncheckedIOException(e);
         }
     }
+
+    @Override
+    public URI filesUrl(Hash hash) {
+        return URI.create(webUrl().toString() + "/files/" + hash.hex());
+    }
 }


### PR DESCRIPTION
Hi all,

please review this pull request that makes the link to the commit after the webrev be a bit more useful. Previously we relied on the forge to "do the right thing" we it noticed a full hash to a commit (link to the changes). This worked fine on GitLab but didn't work as well on GitHub. I have now introduced a proper abstraction and use that to provide the same link on GitLab but a better link on GitHub.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-744](https://bugs.openjdk.java.net/browse/SKARA-744): The "Webrevs" link in the PR has confusing link to the changes for just one commit


### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/skara pull/1077/head:pull/1077`
`$ git checkout pull/1077`

To update a local copy of the PR:
`$ git checkout pull/1077`
`$ git pull https://git.openjdk.java.net/skara pull/1077/head`
