### PR TITLE
323: ArgumentParser should support --version

### DIFF
--- a/args/src/main/java/org/openjdk/skara/args/ArgumentParser.java
+++ b/args/src/main/java/org/openjdk/skara/args/ArgumentParser.java
@@ -247,7 +247,9 @@ public class ArgumentParser {
             }
         }
 
-        if (!errors.isEmpty()) {
+        // If --version is specified then don't care about required flags or inputs
+        var showVersion = arguments.contains("version");
+        if (!errors.isEmpty() && !showVersion) {
             for (var error : errors) {
                 System.err.println(error);
             }


### PR DESCRIPTION
Hi all,

please review this patch that makes the CLI tools **not** show an error when required flags and inputs are missing _and_ the flag `--version` is specified. If a user runs `git <tool> --version` then they shouldn't have to add required flags or input, they just want to see the version.

Testing:
- [x] Manual testing on Linux x64

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-323](https://bugs.openjdk.java.net/browse/SKARA-323): ArgumentParser should support --version


### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/skara pull/1078/head:pull/1078`
`$ git checkout pull/1078`

To update a local copy of the PR:
`$ git checkout pull/1078`
`$ git pull https://git.openjdk.java.net/skara pull/1078/head`
