### PR TITLE
cli: use credentials for --from in git-sync

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitSync.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitSync.java
@@ -177,6 +177,19 @@ public class GitSync {
 
         var fromPullPath = remotes.contains(from) ?
             Remote.toURI(repo.pullPath(from)) : Remote.toURI(from);
+        var fromScheme = fromPullPath.getScheme();
+        if (fromScheme.equals("https") || fromScheme.equals("http")) {
+            var token = System.getenv("GIT_TOKEN");
+            var username = getOption("username", arguments, repo);
+            var credentials = GitCredentials.fill(fromPullPath.getHost(),
+                                                  fromPullPath.getPath(),
+                                                  username,
+                                                  token,
+                                                  fromScheme);
+            if (credentials.password() != null && credentials.username() != null && token != null) {
+                fromPullPath = URI.create(fromScheme + "://" + credentials.username() + ":" + credentials.password() + "@" + fromPullPath.getHost() + fromPullPath.getPath());
+            }
+        }
 
         String to = null;
         if (arguments.contains("to")) {


### PR DESCRIPTION
Hi all,

please review this patch that makes sure that `git-sync` uses a username and password when fetching from the "from" repository in for case when `GIT_TOKEN` is set in the environment.

Testing:
- [x] Manual testing on Linux x64

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/skara pull/1079/head:pull/1079`
`$ git checkout pull/1079`

To update a local copy of the PR:
`$ git checkout pull/1079`
`$ git pull https://git.openjdk.java.net/skara pull/1079/head`
