### PR TITLE
pr: use LinkedHashSet for CommitCommentsWorkItem

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommentsWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommentsWorkItem.java
@@ -79,7 +79,7 @@ class CommitCommentsWorkItem implements WorkItem {
                 if (commitTitleToCommits.containsKey(title)) {
                     commitTitleToCommits.get(title).add(commit.hash());
                 } else {
-                    var set = new HashSet<Hash>();
+                    var set = new LinkedHashSet<Hash>();
                     set.add(commit.hash());
                     commitTitleToCommits.put(title, set);
                 }


### PR DESCRIPTION
Hi all,

please review this patch that uses a `LinkedHashSet` instead of a regular `HashSet` for storing the hashes associated with a certain commit message title for the `CommitCommandsWorkItem`. This will increase the likelihood for `GitLabRepository.commitWithComment` finding the commit quicker, since `GitRepository.commitMetadataFor` will return metadata with the most recent commit first and the `LinkedHashSet` will return elements in insertion order when iterating over it. The effect is that `GitLabRepository.commitWithComment` will consider the candidates in chronological order with the most recent candidate first. This maps well to how contributors are likely to use commit commands - it will most likely be rare that someone makes a commit command on a very old commit.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/skara pull/1081/head:pull/1081`
`$ git checkout pull/1081`

To update a local copy of the PR:
`$ git checkout pull/1081`
`$ git pull https://git.openjdk.java.net/skara pull/1081/head`
