### PR TITLE
Avoid trying to update build number for tags that don't have one

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryWorkItem.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryWorkItem.java
@@ -182,7 +182,7 @@ public class RepositoryWorkItem implements WorkItem {
                                 .map(OpenJDKTag::create)
                                 .filter(Optional::isPresent)
                                 .map(Optional::get)
-                                .sorted(Comparator.comparingInt(OpenJDKTag::buildNum))
+                                .sorted(Comparator.comparingInt(tag -> tag.buildNum().orElse(-1)))
                                 .collect(Collectors.toList());
         for (var tag : newJdkTags) {
             var commits = new ArrayList<Commit>();

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
@@ -281,6 +281,9 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
         if (buildName == null) {
             return;
         }
+        if (tag.buildNum().isEmpty()) {
+            return;
+        }
 
         for (var commit : commits) {
             var commitMessage = CommitMessageParsers.v1.parse(commit);
@@ -343,7 +346,7 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
 
                 // Check if the build name should be updated
                 var oldBuild = issue.properties().getOrDefault("customfield_10006", JSON.of());
-                var newBuild = "b" + String.format("%02d", tag.buildNum());
+                var newBuild = "b" + String.format("%02d", tag.buildNum().get());
                 if (BuildCompare.shouldReplace(newBuild, oldBuild.asString())) {
                     issue.setProperty("customfield_10006", JSON.of(newBuild));
                 } else {

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/json/JsonNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/json/JsonNotifier.java
@@ -95,7 +95,10 @@ class JsonNotifier implements Notifier, RepositoryListener {
 
     @Override
     public void onNewOpenJDKTagCommits(HostedRepository repository, Repository localRepository, List<Commit> commits, OpenJDKTag tag, Tag.Annotated annotation) throws NonRetriableException {
-        var build = String.format("b%02d", tag.buildNum());
+        if (tag.buildNum().isEmpty()) {
+            return;
+        }
+        var build = String.format("b%02d", tag.buildNum().get());
         try (var writer = new JsonWriter(path, repository.name())) {
             var issues = new ArrayList<Issue>();
             for (var commit : commits) {

--- a/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/OpenJDKTag.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/OpenJDKTag.java
@@ -108,25 +108,25 @@ public class OpenJDKTag {
      *
      * @return
      */
-    public int buildNum() {
+    public Optional<Integer> buildNum() {
         if (buildNum == null) {
-            return 0;
+            return Optional.empty();
         }
-        return Integer.parseInt(buildNum);
+        return Optional.of(Integer.parseInt(buildNum));
     }
 
     /**
-     * Tag of the previous build (if any).
+     * Tag of the previous build (if any). Build 0 (and no build number at all) have no previous build.
      *
      * @return
      */
     public Optional<OpenJDKTag> previous() {
-        if (buildNum() == 0) {
+        if (buildNum().orElse(0) == 0) {
             return Optional.empty();
         }
 
         // Make sure build numbers < 10 for JDK 9 tags are not prefixed with '0'
-        var previousBuildNum = buildNum() - 1;
+        var previousBuildNum = buildNum().get() - 1;
         var formattedBuildNum = String.format(buildPrefix.equals("+") ? "%d" : "%02d", previousBuildNum);
         var tagName = prefix + buildPrefix + formattedBuildNum;
         var tag = new Tag(tagName);

--- a/vcs/src/test/java/org/openjdk/skara/vcs/openjdk/OpenJDKTagTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/openjdk/OpenJDKTagTests.java
@@ -33,64 +33,64 @@ class OpenJDKTagTests {
     void parseTags() {
         var tag = new Tag("jdk-10+20");
         var jdkTag = OpenJDKTag.create(tag).orElseThrow();
-        assertEquals(20, jdkTag.buildNum());
+        assertEquals(20, jdkTag.buildNum().orElseThrow());
         var previousTag = jdkTag.previous().orElseThrow();
-        assertEquals(19, previousTag.buildNum());
+        assertEquals(19, previousTag.buildNum().orElseThrow());
     }
 
     @Test
     void parseSingleDigitTags() {
         var tag = new Tag("jdk-10+10");
         var jdkTag = OpenJDKTag.create(tag).orElseThrow();
-        assertEquals(10, jdkTag.buildNum());
+        assertEquals(10, jdkTag.buildNum().orElseThrow());
         var previousTag = jdkTag.previous().orElseThrow();
         assertEquals("jdk-10+9", previousTag.tag().name());
-        assertEquals(9, previousTag.buildNum());
+        assertEquals(9, previousTag.buildNum().orElseThrow());
     }
 
     @Test
     void parseLegacyTags() {
         var tag = new Tag("jdk7-b147");
         var jdkTag = OpenJDKTag.create(tag).orElseThrow();
-        assertEquals(147, jdkTag.buildNum());
+        assertEquals(147, jdkTag.buildNum().orElseThrow());
         var previousTag = jdkTag.previous().orElseThrow();
-        assertEquals(146, previousTag.buildNum());
+        assertEquals(146, previousTag.buildNum().orElseThrow());
     }
 
     @Test
     void parseSingleDigitLegacyTags() {
         var tag = new Tag("jdk7-b10");
         var jdkTag = OpenJDKTag.create(tag).orElseThrow();
-        assertEquals(10, jdkTag.buildNum());
+        assertEquals(10, jdkTag.buildNum().orElseThrow());
         var previousTag = jdkTag.previous().orElseThrow();
         assertEquals("jdk7-b09", previousTag.tag().name());
-        assertEquals(9, previousTag.buildNum());
+        assertEquals(9, previousTag.buildNum().orElseThrow());
     }
 
     @Test
     void parseHotspotTags() {
         var tag = new Tag("hs23.6-b19");
         var jdkTag = OpenJDKTag.create(tag).orElseThrow();
-        assertEquals(19, jdkTag.buildNum());
+        assertEquals(19, jdkTag.buildNum().orElseThrow());
         var previousTag = jdkTag.previous().orElseThrow();
-        assertEquals(18, previousTag.buildNum());
+        assertEquals(18, previousTag.buildNum().orElseThrow());
     }
 
     @Test
     void parseSingleDigitHotspotTags() {
         var tag = new Tag("hs23.6-b10");
         var jdkTag = OpenJDKTag.create(tag).orElseThrow();
-        assertEquals(10, jdkTag.buildNum());
+        assertEquals(10, jdkTag.buildNum().orElseThrow());
         var previousTag = jdkTag.previous().orElseThrow();
         assertEquals("hs23.6-b09", previousTag.tag().name());
-        assertEquals(9, previousTag.buildNum());
+        assertEquals(9, previousTag.buildNum().orElseThrow());
     }
 
     @Test
     void noPrevious() {
         var tag = new Tag("jdk-10+0");
         var jdkTag = OpenJDKTag.create(tag).orElseThrow();
-        assertEquals(0, jdkTag.buildNum());
+        assertEquals(0, jdkTag.buildNum().orElseThrow());
         assertFalse(jdkTag.previous().isPresent());
     }
 
@@ -99,9 +99,9 @@ class OpenJDKTagTests {
         var tag = new Tag("12.1.3+14");
         var jdkTag = OpenJDKTag.create(tag).orElseThrow();
         assertEquals("12.1.3", jdkTag.version());
-        assertEquals(14, jdkTag.buildNum());
+        assertEquals(14, jdkTag.buildNum().orElseThrow());
         var previousTag = jdkTag.previous().orElseThrow();
-        assertEquals(13, previousTag.buildNum());
+        assertEquals(13, previousTag.buildNum().orElseThrow());
     }
 
     @Test
@@ -109,6 +109,6 @@ class OpenJDKTagTests {
         var tag = new Tag("12.1-ga");
         var jdkTag = OpenJDKTag.create(tag).orElseThrow();
         assertEquals("12.1", jdkTag.version());
-        assertEquals(0, jdkTag.buildNum());
+        assertTrue(jdkTag.buildNum().isEmpty());
     }
 }


### PR DESCRIPTION
The issue notifier can be configured to update the build number of issues when a corresponding tag is created. However, certain tags don't contain build number information, so don't attempt this for those.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/skara pull/1082/head:pull/1082`
`$ git checkout pull/1082`

To update a local copy of the PR:
`$ git checkout pull/1082`
`$ git pull https://git.openjdk.java.net/skara pull/1082/head`
