### PR TITLE
pr: enable exclusion of commit comments authors

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommentsWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommentsWorkItem.java
@@ -36,13 +36,15 @@ import java.util.stream.Collectors;
 class CommitCommentsWorkItem implements WorkItem {
     private final PullRequestBot bot;
     private final HostedRepository repo;
+    private final Set<Integer> excludeCommitCommentsFrom;
 
     private static final ConcurrentHashMap<String, Boolean> processed = new ConcurrentHashMap<>();
     private static final Logger log = Logger.getLogger("org.openjdk.skara.bots.pr");
 
-    CommitCommentsWorkItem(PullRequestBot bot, HostedRepository repo) {
+    CommitCommentsWorkItem(PullRequestBot bot, HostedRepository repo, Set<Integer> excludeCommitCommentsFrom) {
         this.bot = bot;
         this.repo = repo;
+        this.excludeCommitCommentsFrom = excludeCommitCommentsFrom;
     }
 
     @Override
@@ -84,7 +86,7 @@ class CommitCommentsWorkItem implements WorkItem {
                     commitTitleToCommits.put(title, set);
                 }
             }
-            var commitComments = repo.recentCommitComments(commitTitleToCommits);
+            var commitComments = repo.recentCommitComments(commitTitleToCommits, excludeCommitCommentsFrom);
             return commitComments.stream()
                                  .filter(cc -> !processed.containsKey(cc.id()))
                                  .filter(cc -> remoteBranches.stream()

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -62,6 +62,7 @@ class PullRequestBot implements Bot {
     private final PullRequestUpdateCache updateCache;
     private final Map<String, HostedRepository> forks;
     private final Set<String> integrators;
+    private final Set<Integer> excludeCommitCommentsFrom;
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots.pr");
 
     private Instant lastFullUpdate;
@@ -74,7 +75,7 @@ class PullRequestBot implements Bot {
                    boolean ignoreStaleReviews, Pattern allowedTargetBranches,
                    Path seedStorage, HostedRepository confOverrideRepo, String confOverrideName,
                    String confOverrideRef, String censusLink, Map<String, HostedRepository> forks,
-                   Set<String> integrators) {
+                   Set<String> integrators, Set<Integer> excludeCommitCommentsFrom) {
         remoteRepo = repo;
         this.censusRepo = censusRepo;
         this.censusRef = censusRef;
@@ -96,6 +97,7 @@ class PullRequestBot implements Bot {
         this.censusLink = censusLink;
         this.forks = forks;
         this.integrators = integrators;
+        this.excludeCommitCommentsFrom = excludeCommitCommentsFrom;
 
         autoLabelled = new HashSet<>();
         scheduledRechecks = new ConcurrentHashMap<>();
@@ -156,7 +158,7 @@ class PullRequestBot implements Bot {
 
     private List<WorkItem> getWorkItems(List<PullRequest> pullRequests) {
         var ret = new LinkedList<WorkItem>();
-        ret.add(new CommitCommentsWorkItem(this, remoteRepo));
+        ret.add(new CommitCommentsWorkItem(this, remoteRepo, excludeCommitCommentsFrom));
 
         for (var pr : pullRequests) {
             if (updateCache.needsUpdate(pr) || checkHasExpired(pr)) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
@@ -52,6 +52,7 @@ public class PullRequestBotBuilder {
     private String censusLink = null;
     private Map<String, HostedRepository> forks = Map.of();
     private Set<String> integrators = Set.of();
+    private Set<Integer> excludeCommitCommentsFrom = Set.of();
 
     PullRequestBotBuilder() {
     }
@@ -161,12 +162,17 @@ public class PullRequestBotBuilder {
         return this;
     }
 
+    public PullRequestBotBuilder excludeCommitCommentsFrom(Set<Integer> excludeCommitCommentsFrom) {
+        this.excludeCommitCommentsFrom = excludeCommitCommentsFrom;
+        return this;
+    }
+
     public PullRequestBot build() {
         return new PullRequestBot(repo, censusRepo, censusRef, labelConfiguration,
                                   externalPullRequestCommands, externalCommitCommands,
                                   blockingCheckLabels, readyLabels, twoReviewersLabels, twentyFourHoursLabels,
                                   readyComments, issueProject, ignoreStaleReviews,
                                   allowedTargetBranches, seedStorage, confOverrideRepo, confOverrideName,
-                                  confOverrideRef, censusLink, forks, integrators);
+                                  confOverrideRef, censusLink, forks, integrators, excludeCommitCommentsFrom);
     }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
@@ -71,6 +71,14 @@ public class PullRequestBotFactory implements BotFactory {
             }
         }
 
+        var excludeCommitCommentsFrom = new HashSet<Integer>();
+        if (specific.contains("exclude-commit-comments-from")) {
+            specific.get("exclude-commit-comments-from")
+                    .stream()
+                    .map(o -> o.asInt())
+                    .forEach(id -> excludeCommitCommentsFrom.add(id));
+        }
+
         var readyLabels = specific.get("ready").get("labels").stream()
                                   .map(JSONValue::asString)
                                   .collect(Collectors.toSet());

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
@@ -182,7 +182,7 @@ class InMemoryHostedRepository implements HostedRepository {
     }
 
     @Override
-    public List<CommitComment> recentCommitComments(Map<String, Set<Hash>> commitTitleToCommits) {
+    public List<CommitComment> recentCommitComments(Map<String, Set<Hash>> commitTitleToCommits, Set<Integer> excludeAuthors) {
         return List.of();
     }
 

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
@@ -73,9 +73,9 @@ public interface HostedRepository {
     List<HostedBranch> branches();
     List<CommitComment> commitComments(Hash hash);
     default List<CommitComment> recentCommitComments() {
-        return recentCommitComments(Map.of());
+        return recentCommitComments(Map.of(), Set.of());
     }
-    List<CommitComment> recentCommitComments(Map<String, Set<Hash>> commitTitleToCommits);
+    List<CommitComment> recentCommitComments(Map<String, Set<Hash>> commitTitleToCommits, Set<Integer> excludeAuthors);
     CommitComment addCommitComment(Hash hash, String body);
     void updateCommitComment(String id, String body);
     Optional<HostedCommit> commit(Hash hash);

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -293,7 +293,7 @@ public class GitHubRepository implements HostedRepository {
     }
 
     @Override
-    public List<CommitComment> recentCommitComments(Map<String, Set<Hash>> commitTitleToCommits) {
+    public List<CommitComment> recentCommitComments(Map<String, Set<Hash>> commitTitleToCommits, Set<Integer> excludeAuthors) {
         var parts = name().split("/");
         var owner = parts[0];
         var name = parts[1];
@@ -333,6 +333,7 @@ public class GitHubRepository implements HostedRepository {
                            .get("commitComments")
                            .get("nodes")
                            .stream()
+                           .filter(o -> !excludeAuthors.contains(o.get("author").get("databaseId").asInt()))
                            .map(o -> {
                                var hash = new Hash(o.get("commit").get("oid").asString());
                                var createdAt = ZonedDateTime.parse(o.get("createdAt").asString());

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -382,7 +382,7 @@ public class GitLabRepository implements HostedRepository {
     }
 
     @Override
-    public List<CommitComment> recentCommitComments(Map<String, Set<Hash>> commitTitleToCommits) {
+    public List<CommitComment> recentCommitComments(Map<String, Set<Hash>> commitTitleToCommits, Set<Integer> excludeAuthors) {
         var fourDaysAgo = ZonedDateTime.now().minusDays(4);
         var formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
         var notes = request.get("events")
@@ -392,6 +392,9 @@ public class GitLabRepository implements HostedRepository {
                       .filter(o -> o.contains("note") &&
                                    o.get("note").contains("noteable_type") &&
                                    o.get("note").get("noteable_type").asString().equals("Commit"))
+                      .filter(o -> o.contains("author") &&
+                                   o.get("author").contains("id") &&
+                                   !excludeAuthors.contains(o.get("author").get("id").asInt()))
                       .collect(Collectors.toList());
 
         // Fetch eventual new commits

--- a/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
@@ -212,11 +212,12 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
     }
 
     @Override
-    public List<CommitComment> recentCommitComments(Map<String, Set<Hash>> commitTitleToCommits) {
+    public List<CommitComment> recentCommitComments(Map<String, Set<Hash>> commitTitleToCommits, Set<Integer> excludeAuthors) {
         return commitComments.values()
                              .stream()
                              .flatMap(e -> e.stream())
                              .sorted((c1, c2) -> c2.updatedAt().compareTo(c1.updatedAt()))
+                             .filter(c -> !excludeAuthors.contains(Integer.valueOf(c.author().id())))
                              .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
Hi all,

please review this patch that makes it possible to configure whose commits comments should be ignored. This mechanism will be used to exclude commit comments from the bots (who make the vast majority of commit comments). This will speed up `GitLabRepository.recentCommitComments` quite a bit.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/skara pull/1084/head:pull/1084`
`$ git checkout pull/1084`

To update a local copy of the PR:
`$ git checkout pull/1084`
`$ git pull https://git.openjdk.java.net/skara pull/1084/head`
