### PR TITLE
Remove java.lang.invoke from hotspot-compiler

### DIFF
--- a/config/mailinglist/rules/jdk.json
+++ b/config/mailinglist/rules/jdk.json
@@ -309,7 +309,6 @@
             "src/hotspot/share/libadt/",
             "src/hotspot/share/opto/",
             "src/hotspot/share/runtime/(deoptimization|frame|icache|registermap|sharedruntime|stub|sweeper|vframe)",
-            "src/java.base/share/classes/java/lang/invoke/",
             "src/jdk.aot/",
             "src/jdk.internal.vm.ci/",
             "src/jdk.internal.vm.compiler.management/",


### PR DESCRIPTION
As per request from Claes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/skara pull/1085/head:pull/1085`
`$ git checkout pull/1085`

To update a local copy of the PR:
`$ git checkout pull/1085`
`$ git pull https://git.openjdk.java.net/skara pull/1085/head`
