### PR TITLE
build: update to Gradle 6.8.3

### DIFF
--- a/deps.env
+++ b/deps.env
@@ -7,5 +7,5 @@ JDK_MACOS_X64_SHA256="578b17748f5a7d111474bc4c9b5a8a06b4a4aa1ba4a4bc3fef014e079e
 JDK_WINDOWS_X64_URL="https://download.java.net/java/GA/jdk15.0.2/0d1cfde4252546c6931946de8db48ee2/7/GPL/openjdk-15.0.2_windows-x64_bin.zip"
 JDK_WINDOWS_X64_SHA256="ecbe7f32bc6bff2b6c8e9b68f19cbf4ddf54a492c918ba471f32d645cf1c5cf4"
 
-GRADLE_URL="https://services.gradle.org/distributions/gradle-6.8.2-bin.zip"
-GRADLE_SHA256="8de6efc274ab52332a9c820366dd5cf5fc9d35ec7078fd70c8ec6913431ee610"
+GRADLE_URL="https://services.gradle.org/distributions/gradle-6.8.3-bin.zip"
+GRADLE_SHA256="7faa7198769f872826c8ef4f1450f839ec27f0b4d5d1e51bade63667cbccd205"


### PR DESCRIPTION
Hi all,

please review this small patch that updates Gradle to version `6.8.3`.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/skara pull/1086/head:pull/1086`
`$ git checkout pull/1086`

To update a local copy of the PR:
`$ git checkout pull/1086`
`$ git pull https://git.openjdk.java.net/skara pull/1086/head`
