### PR TITLE
issuetracker: add Label class

### DIFF
--- a/bots/csr/src/main/java/org/openjdk/skara/bots/csr/CSRBot.java
+++ b/bots/csr/src/main/java/org/openjdk/skara/bots/csr/CSRBot.java
@@ -69,7 +69,7 @@ class CSRBot implements Bot, WorkItem {
             }
 
             log.info("Checking CSR label for " + describe(pr) + "...");
-            if (pr.labels().contains(CSR_LABEL)) {
+            if (pr.labelNames().contains(CSR_LABEL)) {
                 hasCSRLabel.add(pr.id());
             } else {
                 hasCSRLabel.remove(pr.id());

--- a/bots/csr/src/test/java/org/openjdk/skara/bots/csr/CSRBotTests.java
+++ b/bots/csr/src/test/java/org/openjdk/skara/bots/csr/CSRBotTests.java
@@ -69,7 +69,7 @@ class CSRBotTests {
             TestBotRunner.runPeriodicItems(bot);
 
             // The bot should have removed the CSR label
-            assertFalse(pr.labels().contains("csr"));
+            assertFalse(pr.labelNames().contains("csr"));
         }
     }
 
@@ -100,7 +100,7 @@ class CSRBotTests {
             TestBotRunner.runPeriodicItems(bot);
 
             // The bot should have kept the CSR label
-            assertTrue(pr.labels().contains("csr"));
+            assertTrue(pr.labelNames().contains("csr"));
         }
     }
 
@@ -131,7 +131,7 @@ class CSRBotTests {
             TestBotRunner.runPeriodicItems(bot);
 
             // The bot should have kept the CSR label
-            assertTrue(pr.labels().contains("csr"));
+            assertTrue(pr.labelNames().contains("csr"));
         }
     }
 
@@ -169,7 +169,7 @@ class CSRBotTests {
             TestBotRunner.runPeriodicItems(bot);
 
             // The bot should have removed the CSR label
-            assertTrue(pr.labels().contains("csr"));
+            assertTrue(pr.labelNames().contains("csr"));
         }
     }
 

--- a/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
+++ b/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
@@ -322,7 +322,7 @@ class MergeBot implements Bot, WorkItem {
                         // to just wait until the next time the bot runs
                         shouldMerge = false;
 
-                        if (pr.labels().contains("ready") && !pr.labels().contains("sponsor")) {
+                        if (pr.labelNames().contains("ready") && !pr.labelNames().contains("sponsor")) {
                             var comments = pr.comments();
                             var integrateComments =
                                 comments.stream()

--- a/bots/merge/src/test/java/org/openjdk/skara/bots/merge/MergeBotTests.java
+++ b/bots/merge/src/test/java/org/openjdk/skara/bots/merge/MergeBotTests.java
@@ -362,7 +362,7 @@ class MergeBotTests {
             assertEquals(1, pullRequests.size());
             var pr = pullRequests.get(0);
             assertEquals("Merge test:master", pr.title());
-            assertTrue(pr.labels().contains("failed-auto-merge"));
+            assertTrue(pr.labelNames().contains("failed-auto-merge"));
         }
     }
 
@@ -637,7 +637,7 @@ class MergeBotTests {
             assertEquals(1, pullRequests.size());
             var pr = pullRequests.get(0);
             assertEquals("Merge test:master", pr.title());
-            assertTrue(pr.labels().contains("failed-auto-merge"));
+            assertTrue(pr.labelNames().contains("failed-auto-merge"));
             assertTrue(forkLocalRepo.branches().contains(new Branch("master")));
             assertTrue(forkLocalRepo.branches().contains(new Branch("2")));
 

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
@@ -255,7 +255,7 @@ class ArchiveWorkItem implements WorkItem {
         var mbox = MailingListServerFactory.createMboxFileServer(mboxBasePath);
         var reviewArchiveList = mbox.getList(pr.id());
         var sentMails = parseArchive(reviewArchiveList);
-        var labels = new HashSet<>(pr.labels());
+        var labels = new HashSet<>(pr.labelNames());
 
         // First determine if this PR should be inspected further or not
         if (sentMails.isEmpty()) {

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
@@ -169,7 +169,7 @@ class ReviewArchive {
         // Post a closed notice for regular RFR threads that weren't integrated
         if (pr.state() != Issue.State.OPEN) {
             var parent = generated.get(0);
-            if (pr.labels().contains("integrated")) {
+            if (pr.labelNames().contains("integrated")) {
                 var hash = findIntegratedHash();
                 if (hash.isPresent()) {
                     var commit = localRepo.lookup(hash.get());

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/NotifyBot.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/NotifyBot.java
@@ -67,7 +67,7 @@ public class NotifyBot implements Bot, Emitter {
     }
 
     private boolean isOfInterest(PullRequest pr) {
-        var labels = new HashSet<>(pr.labels());
+        var labels = new HashSet<>(pr.labelNames());
         if (!(labels.contains("rfr") || labels.contains("integrated"))) {
             log.fine("PR is not yet ready - needs either 'rfr' or 'integrated' label");
             return false;

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/PullRequestWorkItem.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/PullRequestWorkItem.java
@@ -54,7 +54,7 @@ public class PullRequestWorkItem implements WorkItem {
     private final static Pattern pushedPattern = Pattern.compile("Pushed as commit ([a-f0-9]{40})\\.");
 
     private Hash resultingCommitHash() {
-        if (pr.labels().contains("integrated")) {
+        if (pr.labelNames().contains("integrated")) {
             return pr.comments().stream()
                      .filter(comment -> comment.author().id().equals(integratorId))
                      .map(Comment::body)

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/JbsBackport.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/JbsBackport.java
@@ -82,7 +82,7 @@ public class JbsBackport {
         var issue = primary.project().issue(response.get("key").asString()).orElseThrow();
 
         // The backport should not have any labels set - if it does, clear them
-        var labels = issue.labels();
+        var labels = issue.labelNames();
         if (!labels.isEmpty()) {
             issue.setLabels(List.of());
         }

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
@@ -965,7 +965,7 @@ public class IssueNotifierTests {
             assertEquals("java.io", backport.properties().get("customfield_10008").asString());
 
             // Labels should not
-            assertEquals(0, backport.labels().size());
+            assertEquals(0, backport.labelNames().size());
         }
     }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CSRCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CSRCommand.java
@@ -62,7 +62,7 @@ public class CSRCommand implements CommandHandler {
             return;
         }
 
-        var labels = pr.labels();
+        var labels = pr.labelNames();
 
         var cmd = command.args().trim().toLowerCase();
         if (!cmd.isEmpty() && !(cmd.equals("needed") || cmd.equals("unneeded") || cmd.equals("uneeded"))) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -474,7 +474,7 @@ class CheckRun {
                                 setExpiration(Duration.ofMinutes(10));
                             }
                             if (iss.get().state() != org.openjdk.skara.issuetracker.Issue.State.OPEN) {
-                                if (!pr.labels().contains("backport")) {
+                                if (!pr.labelNames().contains("backport")) {
                                     progressBody.append(" ⚠️ Issue is not open.");
                                 }
                             }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -216,7 +216,7 @@ class CheckWorkItem extends PullRequestWorkItem {
                                            bot.confOverrideRepository().orElse(null), bot.confOverrideName(), bot.confOverrideRef()).orElseThrow();
         var comments = pr.comments();
         var allReviews = pr.reviews();
-        var labels = new HashSet<>(pr.labels());
+        var labels = new HashSet<>(pr.labelNames());
 
         // Filter out the active reviews
         var activeReviews = CheckablePullRequest.filterActiveReviews(allReviews);
@@ -310,7 +310,7 @@ class CheckWorkItem extends PullRequestWorkItem {
             }
         }
 
-        if (pr.labels().contains("auto") && pr.labels().contains("ready") && !pr.labels().contains("sponsor")) {
+        if (pr.labelNames().contains("auto") && pr.labelNames().contains("ready") && !pr.labelNames().contains("sponsor")) {
             pr.addComment("/integrate\n" + PullRequestCommandWorkItem.VALID_BOT_COMMAND_MARKER);
         }
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CleanCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CleanCommand.java
@@ -61,12 +61,12 @@ public class CleanCommand implements CommandHandler {
             return;
         }
 
-        if (!pr.labels().contains("backport")) {
+        if (!pr.labelNames().contains("backport")) {
             reply.println("@" + username + " can only mark [backport pull requests](https://wiki.openjdk.java.net/display/SKARA/Backports#Backports-BackportPullRequests) as clean");
             return;
         }
 
-        if (pr.labels().contains("clean")) {
+        if (pr.labelNames().contains("clean")) {
             reply.println("@" + username + " this backport pull request is already marked as clean");
             return;
         }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
@@ -93,7 +93,7 @@ public class IntegrateCommand implements CommandHandler {
                 reply.println("This pull request will be automatically integrated when it is ready");
                 return;
             } else if (arg.equals("manual")) {
-                if (pr.labels().contains("auto")) {
+                if (pr.labelNames().contains("auto")) {
                     pr.removeLabel("auto");
                 }
                 reply.println("This pull request will have to be integrated manually using the "+
@@ -116,7 +116,7 @@ public class IntegrateCommand implements CommandHandler {
             return;
         }
 
-        var labels = new HashSet<>(pr.labels());
+        var labels = new HashSet<>(pr.labelNames());
         if (!labels.contains("ready")) {
             reply.println("This PR has not yet been marked as ready for integration.");
             return;

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelCommand.java
@@ -81,7 +81,7 @@ public class LabelCommand implements CommandHandler {
             showHelp(bot.labelConfiguration(), reply);
             return;
         }
-        var currentLabels = new HashSet<>(pr.labels());
+        var currentLabels = new HashSet<>(pr.labelNames());
         if (argumentMatcher.group(1) == null || argumentMatcher.group(1).equals("add")) {
             for (var label : labels) {
                 if (!currentLabels.contains(label)) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
@@ -136,7 +136,7 @@ public class LabelerWorkItem extends PullRequestWorkItem {
         }
 
         // If the PR already has one of the allowed labels, that is also considered to override automatic labelling
-        var existingAllowed = new HashSet<>(pr.labels());
+        var existingAllowed = new HashSet<>(pr.labelNames());
         existingAllowed.retainAll(bot.labelConfiguration().allowed());
         if (!existingAllowed.isEmpty()) {
             bot.setAutoLabelled(pr);
@@ -149,7 +149,7 @@ public class LabelerWorkItem extends PullRequestWorkItem {
             var hostedRepositoryPool = new HostedRepositoryPool(seedPath);
             var localRepo = PullRequestUtils.materialize(hostedRepositoryPool, pr, path);
             var newLabels = getLabels(localRepo);
-            var currentLabels = pr.labels().stream()
+            var currentLabels = pr.labelNames().stream()
                                   .filter(key -> bot.labelConfiguration().allowed().contains(key))
                                   .collect(Collectors.toSet());
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -110,7 +110,7 @@ class PullRequestBot implements Bot {
     }
 
     private boolean isReady(PullRequest pr) {
-        var labels = new HashSet<>(pr.labels());
+        var labels = new HashSet<>(pr.labelNames());
         for (var readyLabel : readyLabels) {
             if (!labels.contains(readyLabel)) {
                 log.fine("PR is not yet ready - missing label '" + readyLabel + "'");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
@@ -222,7 +222,7 @@ public class PullRequestCommandWorkItem extends PullRequestWorkItem {
         var command = nextCommand.get();
         log.info("Processing command: " + command.id() + " - " + command.name());
 
-        if (!pr.labels().contains("integrated")) {
+        if (!pr.labelNames().contains("integrated")) {
             processCommand(pr, census, scratchPath.resolve("pr").resolve("command"), command, comments, false);
             // Must re-fetch PR after running the command, the command might have updated the PR
             var updatedPR = pr.repository().pullRequest(pr.id());

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
@@ -64,7 +64,7 @@ public class SponsorCommand implements CommandHandler {
             return;
         }
 
-        var labels = new HashSet<>(pr.labels());
+        var labels = new HashSet<>(pr.labelNames());
         if (!labels.contains("ready")) {
             reply.println("This PR has not yet been marked as ready for integration.");
             return;

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportTests.java
@@ -93,7 +93,7 @@ class BackportTests {
             assertTrue(backportComment.contains("This backport pull request has now been updated with issue"));
             assertTrue(backportComment.contains("<!-- backport " + releaseHash.hex() + " -->"));
             assertEquals(issue1Number + ": An issue", pr.title());
-            assertTrue(pr.labels().contains("backport"));
+            assertTrue(pr.labelNames().contains("backport"));
 
             // Approve PR and re-run bot
             var prAsReviewer = reviewer.pullRequest(pr.id());
@@ -195,7 +195,7 @@ class BackportTests {
             assertTrue(backportComment.contains("This backport pull request has now been updated with issue"));
             assertTrue(backportComment.contains("<!-- backport " + releaseHash.hex() + " -->"));
             assertEquals(issue1Number + ": An issue", pr.title());
-            assertTrue(pr.labels().contains("backport"));
+            assertTrue(pr.labelNames().contains("backport"));
 
             // Approve PR and re-run bot
             var prAsReviewer = reviewer.pullRequest(pr.id());
@@ -299,7 +299,7 @@ class BackportTests {
             assertTrue(backportComment.contains("This backport pull request has now been updated with issue"));
             assertTrue(backportComment.contains("<!-- backport " + releaseHash.hex() + " -->"));
             assertEquals(issue1Number + ": An issue", pr.title());
-            assertTrue(pr.labels().contains("backport"));
+            assertTrue(pr.labelNames().contains("backport"));
 
             // Approve PR and re-run bot
             var prAsReviewer = reviewer.pullRequest(pr.id());
@@ -379,7 +379,7 @@ class BackportTests {
             assertLastCommentContains(pr, "<!-- backport error -->");
             assertLastCommentContains(pr, ":warning:");
             assertLastCommentContains(pr, "could not find any commit with hash `0123456789012345678901234567890123456789`");
-            assertFalse(pr.labels().contains("backport"));
+            assertFalse(pr.labelNames().contains("backport"));
 
             // Re-running the bot should not cause any more error comments
             TestBotRunner.runPeriodicItems(bot);
@@ -443,10 +443,10 @@ class BackportTests {
             assertTrue(backportComment.contains("This backport pull request has now been updated with issue"));
             assertTrue(backportComment.contains("<!-- backport " + releaseHash.hex() + " -->"));
             assertEquals(issue1Number + ": An issue", pr.title());
-            assertTrue(pr.labels().contains("backport"));
+            assertTrue(pr.labelNames().contains("backport"));
 
             // The bot should have added the "clean" label
-            assertTrue(pr.labels().contains("clean"));
+            assertTrue(pr.labelNames().contains("clean"));
         }
     }
 
@@ -514,10 +514,10 @@ class BackportTests {
             assertTrue(backportComment.contains("This backport pull request has now been updated with issue"));
             assertTrue(backportComment.contains("<!-- backport " + upstreamHash.hex() + " -->"));
             assertEquals(issue2Number + ": Another issue", pr.title());
-            assertTrue(pr.labels().contains("backport"));
+            assertTrue(pr.labelNames().contains("backport"));
 
             // The bot should have added the "clean" label
-            assertTrue(pr.labels().contains("clean"));
+            assertTrue(pr.labelNames().contains("clean"));
         }
     }
 
@@ -585,10 +585,10 @@ class BackportTests {
             assertTrue(backportComment.contains("This backport pull request has now been updated with issue"));
             assertTrue(backportComment.contains("<!-- backport " + upstreamHash.hex() + " -->"));
             assertEquals(issue2Number + ": Another issue", pr.title());
-            assertTrue(pr.labels().contains("backport"));
+            assertTrue(pr.labelNames().contains("backport"));
 
             // The bot should not have added the "clean" label
-            assertFalse(pr.labels().contains("clean"));
+            assertFalse(pr.labelNames().contains("clean"));
         }
     }
 
@@ -659,10 +659,10 @@ class BackportTests {
             assertTrue(backportComment.contains("This backport pull request has now been updated with issue"));
             assertTrue(backportComment.contains("<!-- backport " + upstreamHash.hex() + " -->"));
             assertEquals(issue2Number + ": Another issue", pr.title());
-            assertTrue(pr.labels().contains("backport"));
+            assertTrue(pr.labelNames().contains("backport"));
 
             // The bot should not have added the "clean" label
-            assertFalse(pr.labels().contains("clean"));
+            assertFalse(pr.labelNames().contains("clean"));
         }
     }
 
@@ -722,10 +722,10 @@ class BackportTests {
             assertTrue(backportComment.contains("<!-- backport " + releaseHash.hex() + " -->"));
             assertEquals(issue1Number + ": An issue", pr.title());
             assertLastCommentContains(pr, "This change now passes all *automated* pre-integration checks");
-            assertTrue(pr.labels().contains("ready"));
-            assertTrue(pr.labels().contains("rfr"));
-            assertTrue(pr.labels().contains("clean"));
-            assertTrue(pr.labels().contains("backport"));
+            assertTrue(pr.labelNames().contains("ready"));
+            assertTrue(pr.labelNames().contains("rfr"));
+            assertTrue(pr.labelNames().contains("clean"));
+            assertTrue(pr.labelNames().contains("backport"));
 
             // Integrate
             var prAsCommitter = author.pullRequest(pr.id());
@@ -819,11 +819,11 @@ class BackportTests {
             assertTrue(backportComment.contains("<!-- backport " + releaseHash.hex() + " -->"));
             assertEquals(issue1Number + ": An issue", pr.title());
             assertLastCommentContains(pr, "This change now passes all *automated* pre-integration checks");
-            assertTrue(pr.labels().contains("ready"));
-            assertTrue(pr.labels().contains("rfr"));
-            assertTrue(pr.labels().contains("clean"));
-            assertFalse(pr.labels().contains("sponsor"));
-            assertTrue(pr.labels().contains("backport"));
+            assertTrue(pr.labelNames().contains("ready"));
+            assertTrue(pr.labelNames().contains("rfr"));
+            assertTrue(pr.labelNames().contains("clean"));
+            assertFalse(pr.labelNames().contains("sponsor"));
+            assertTrue(pr.labelNames().contains("backport"));
 
             // Integrate
             var prAsAuthor = author.pullRequest(pr.id());
@@ -831,7 +831,7 @@ class BackportTests {
             TestBotRunner.runPeriodicItems(bot);
 
             // The bot should reply with a sponsor message
-            assertTrue(pr.labels().contains("sponsor"));
+            assertTrue(pr.labelNames().contains("sponsor"));
 
             // Sponsor the commit
             var prAsReviewer = reviewer.pullRequest(pr.id());
@@ -928,7 +928,7 @@ class BackportTests {
             assertTrue(backportComment.contains("This backport pull request has now been updated with issue"));
             assertTrue(backportComment.contains("<!-- backport " + releaseHash.hex() + " -->"));
             assertEquals(issue1Number + ": An issue", pr.title());
-            assertTrue(pr.labels().contains("backport"));
+            assertTrue(pr.labelNames().contains("backport"));
         }
     }
 
@@ -987,7 +987,7 @@ class BackportTests {
             assertTrue(backportComment.contains("This backport pull request has now been updated with issue"));
             assertTrue(backportComment.contains("<!-- backport " + releaseHash.hex() + " -->"));
             assertEquals(issue1Number + ": An issue", pr.title());
-            assertTrue(pr.labels().contains("backport"));
+            assertTrue(pr.labelNames().contains("backport"));
         }
     }
 
@@ -1046,7 +1046,7 @@ class BackportTests {
             assertTrue(backportComment.contains("This backport pull request has now been updated with issue"));
             assertTrue(backportComment.contains("<!-- backport " + releaseHash.hex() + " -->"));
             assertEquals(issue1Number + ": An issue", pr.title());
-            assertTrue(pr.labels().contains("backport"));
+            assertTrue(pr.labelNames().contains("backport"));
         }
     }
 
@@ -1105,7 +1105,7 @@ class BackportTests {
             assertTrue(backportComment.contains("This backport pull request has now been updated with issue"));
             assertTrue(backportComment.contains("<!-- backport " + releaseHash.hex() + " -->"));
             assertEquals(issue1Number + ": An issue", pr.title());
-            assertTrue(pr.labels().contains("backport"));
+            assertTrue(pr.labelNames().contains("backport"));
 
             // Approve PR and re-run bot
             var prAsReviewer = reviewer.pullRequest(pr.id());
@@ -1203,7 +1203,7 @@ class BackportTests {
             var backportComment = pr.comments().get(0).body();
             assertTrue(backportComment.contains("<!-- backport error -->"));
             assertTrue(backportComment.contains("the commit `" + releaseHash.hex() + "` does not refer to an issue"));
-            assertFalse(pr.labels().contains("backport"));
+            assertFalse(pr.labelNames().contains("backport"));
         }
     }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CSRTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CSRTests.java
@@ -71,7 +71,7 @@ class CSRTests {
             assertLastCommentContains(pr, "has indicated that a " +
                                           "[compatibility and specification](https://wiki.openjdk.java.net/display/csr/Main) (CSR) request " +
                                           "is needed for this pull request.");
-            assertTrue(pr.labels().contains("csr"));
+            assertTrue(pr.labelNames().contains("csr"));
 
 
             // No longer require CSR
@@ -81,7 +81,7 @@ class CSRTests {
             // The bot should reply with a message that a CSR is no longer needed
             assertLastCommentContains(pr, "determined that a [CSR](https://wiki.openjdk.java.net/display/csr/Main) request " +
                                           "is not needed for this pull request.");
-            assertFalse(pr.labels().contains("csr"));
+            assertFalse(pr.labelNames().contains("csr"));
 
             // Require CSR again with long form
             prAsReviewer.addComment("/csr needed");
@@ -91,7 +91,7 @@ class CSRTests {
             assertLastCommentContains(pr, "has indicated that a " +
                                           "[compatibility and specification](https://wiki.openjdk.java.net/display/csr/Main) (CSR) request " +
                                           "is needed for this pull request.");
-            assertTrue(pr.labels().contains("csr"));
+            assertTrue(pr.labelNames().contains("csr"));
         }
     }
 
@@ -135,7 +135,7 @@ class CSRTests {
             // The bot should reply with a message that the CSR is already aproved
             assertLastCommentContains(pr, "the issue for this pull request");
             assertLastCommentContains(pr, "already has an approved CSR request");
-            assertFalse(pr.labels().contains("csr"));
+            assertFalse(pr.labelNames().contains("csr"));
         }
     }
 
@@ -175,7 +175,7 @@ class CSRTests {
                                           "(CSR) request is needed for this pull request.");
             assertLastCommentContains(pr, "this pull request must refer to an issue in [JBS]");
             assertLastCommentContains(pr, "to be able to link it to a CSR request. To refer this pull request to an issue in JBS");
-            assertTrue(pr.labels().contains("csr"));
+            assertTrue(pr.labelNames().contains("csr"));
         }
     }
 
@@ -212,14 +212,14 @@ class CSRTests {
             assertLastCommentContains(pr, "has indicated that a " +
                                           "[compatibility and specification](https://wiki.openjdk.java.net/display/csr/Main) (CSR) request " +
                                           "is needed for this pull request.");
-            assertTrue(pr.labels().contains("csr"));
+            assertTrue(pr.labelNames().contains("csr"));
 
             // Stating that a CSR is not needed should not work
             pr.addComment("/csr unneeded");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(pr, "only [Reviewers]");
             assertLastCommentContains(pr, "can determine that a CSR is not needed.");
-            assertTrue(pr.labels().contains("csr"));
+            assertTrue(pr.labelNames().contains("csr"));
         }
     }
 
@@ -256,7 +256,7 @@ class CSRTests {
             // Show help
             assertLastCommentContains(pr, "usage: `/csr [needed|unneeded]`, requires that the issue the pull request refers to links " +
                                           "to an approved [CSR](https://wiki.openjdk.java.net/display/csr/Main) request.");
-            assertFalse(pr.labels().contains("csr"));
+            assertFalse(pr.labelNames().contains("csr"));
         }
     }
 
@@ -297,7 +297,7 @@ class CSRTests {
                                           "(CSR) request is needed for this pull request.");
             assertLastCommentContains(pr, "this pull request must refer to an issue in [JBS]");
             assertLastCommentContains(pr, "to be able to link it to a CSR request. To refer this pull request to an issue in JBS");
-            assertTrue(pr.labels().contains("csr"));
+            assertTrue(pr.labelNames().contains("csr"));
         }
     }
 
@@ -337,7 +337,7 @@ class CSRTests {
             assertLastCommentContains(pr, "has indicated that a " +
                                           "[compatibility and specification](https://wiki.openjdk.java.net/display/csr/Main) (CSR) request " +
                                           "is needed for this pull request.");
-            assertTrue(pr.labels().contains("csr"));
+            assertTrue(pr.labelNames().contains("csr"));
 
             // Require a CSR again
             prAsReviewer.addComment("/csr");
@@ -346,7 +346,7 @@ class CSRTests {
             // The bot should reply with a message that a CSR is already required
             assertLastCommentContains(pr, "an approved [CSR]");
             assertLastCommentContains(pr, "request is already required for this pull request.");
-            assertTrue(pr.labels().contains("csr"));
+            assertTrue(pr.labelNames().contains("csr"));
         }
     }
 
@@ -467,7 +467,7 @@ class CSRTests {
             assertLastCommentContains(pr, "has indicated that a " +
                                           "[compatibility and specification](https://wiki.openjdk.java.net/display/csr/Main) (CSR) request " +
                                           "is needed for this pull request.");
-            assertTrue(pr.labels().contains("csr"));
+            assertTrue(pr.labelNames().contains("csr"));
         }
     }
 
@@ -505,7 +505,7 @@ class CSRTests {
 
             // PR should be ready
             var prAsAuthor = author.pullRequest(pr.id());
-            assertTrue(prAsAuthor.labels().contains("ready"));
+            assertTrue(prAsAuthor.labelNames().contains("ready"));
 
             // Require CSR
             prAsReviewer = reviewer.pullRequest(pr.id());
@@ -518,11 +518,11 @@ class CSRTests {
             assertLastCommentContains(pr, "has indicated that a " +
                                           "[compatibility and specification](https://wiki.openjdk.java.net/display/csr/Main) (CSR) request " +
                                           "is needed for this pull request.");
-            assertTrue(pr.labels().contains("csr"));
+            assertTrue(pr.labelNames().contains("csr"));
 
             // PR should not be ready
             prAsAuthor = author.pullRequest(pr.id());
-            assertFalse(prAsAuthor.labels().contains("ready"));
+            assertFalse(prAsAuthor.labelNames().contains("ready"));
 
             // The body should contain a note about why
             assertTrue(pr.body().contains("change requires a CSR request to be approved"));

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -77,8 +77,8 @@ class CheckTests {
             assertEquals(CheckStatus.SUCCESS, check.status());
 
             // The PR should now be ready for review
-            assertTrue(pr.labels().contains("rfr"));
-            assertFalse(pr.labels().contains("ready"));
+            assertTrue(pr.labelNames().contains("rfr"));
+            assertFalse(pr.labelNames().contains("ready"));
 
             // Approve it as another user
             var approvalPr = reviewer.pullRequest(pr.id());
@@ -94,7 +94,7 @@ class CheckTests {
             assertEquals(CheckStatus.SUCCESS, check.status());
 
             // The PR should now be ready
-            assertTrue(pr.labels().contains("ready"));
+            assertTrue(pr.labelNames().contains("ready"));
             assertTrue(pr.body().contains("https://census.com/integrationreviewer2-profile"));
         }
     }
@@ -126,7 +126,7 @@ class CheckTests {
             TestBotRunner.runPeriodicItems(checkBot);
 
             // The PR should not be flagged as ready for review
-            assertFalse(pr.labels().contains("rfr"));
+            assertFalse(pr.labelNames().contains("rfr"));
 
             // Approve it as another user
             var approvalPr = reviewer.pullRequest(pr.id());
@@ -142,7 +142,7 @@ class CheckTests {
             assertEquals(CheckStatus.FAILURE, check.status());
 
             // The PR should not still not be flagged as ready for review
-            assertFalse(pr.labels().contains("rfr"));
+            assertFalse(pr.labelNames().contains("rfr"));
 
             // Remove the trailing whitespace in a new commit
             editHash = CheckableRepository.replaceAndCommit(localRepo, "A line without a trailing whitespace");
@@ -162,7 +162,7 @@ class CheckTests {
             TestBotRunner.runPeriodicItems(checkBot);
 
             // The PR should now be ready
-            assertTrue(pr.labels().contains("ready"));
+            assertTrue(pr.labelNames().contains("ready"));
 
             // The check should now be successful
             checks = pr.checks(editHash);
@@ -333,8 +333,8 @@ class CheckTests {
             assertEquals(CheckStatus.SUCCESS, check.status());
 
             // The PR should now be ready for review
-            assertTrue(pr.labels().contains("rfr"));
-            assertFalse(pr.labels().contains("ready"));
+            assertTrue(pr.labelNames().contains("rfr"));
+            assertFalse(pr.labelNames().contains("ready"));
 
             // Approve it as another user
             var approvalPr = reviewer.pullRequest(pr.id());
@@ -350,8 +350,8 @@ class CheckTests {
             assertEquals(CheckStatus.SUCCESS, check.status());
 
             // The PR should now be ready
-            assertTrue(pr.labels().contains("rfr"));
-            assertTrue(pr.labels().contains("ready"));
+            assertTrue(pr.labelNames().contains("rfr"));
+            assertTrue(pr.labelNames().contains("ready"));
 
             var addedHash = CheckableRepository.appendAndCommit(localRepo, "trailing whitespace   ");
             localRepo.push(addedHash, author.url(), "edit");
@@ -370,8 +370,8 @@ class CheckTests {
             TestBotRunner.runPeriodicItems(checkBot);
 
             // The PR is now neither ready for review nor integration
-            assertFalse(pr.labels().contains("rfr"));
-            assertFalse(pr.labels().contains("ready"));
+            assertFalse(pr.labelNames().contains("rfr"));
+            assertFalse(pr.labelNames().contains("ready"));
 
             // The check should now be failing
             checks = pr.checks(addedHash);
@@ -528,7 +528,7 @@ class CheckTests {
 
             // Get all messages up to date
             TestBotRunner.runPeriodicItems(mergeBot);
-            assertTrue(pr.labels().contains("ready"));
+            assertTrue(pr.labelNames().contains("ready"));
 
             // Push something conflicting to master
             localRepo.checkout(masterHash, true);
@@ -546,8 +546,8 @@ class CheckTests {
             assertEquals(0, updated);
 
             // The PR should be flagged as outdated
-            assertTrue(pr.labels().contains("merge-conflict"));
-            assertFalse(pr.labels().contains("ready"));
+            assertTrue(pr.labelNames().contains("merge-conflict"));
+            assertFalse(pr.labelNames().contains("ready"));
 
             // An instructional message should have been bosted
             var help = pr.comments().stream()
@@ -575,8 +575,8 @@ class CheckTests {
             assertEquals(1, updated);
 
             // The PR should not be flagged as outdated
-            assertFalse(pr.labels().contains("merge-conflict"));
-            assertTrue(pr.labels().contains("ready"));
+            assertFalse(pr.labelNames().contains("merge-conflict"));
+            assertTrue(pr.labelNames().contains("ready"));
         }
     }
 
@@ -614,17 +614,17 @@ class CheckTests {
             assertTrue(check.summary().orElseThrow().contains("Test Blocker"));
 
             // The PR should not yet be ready for review
-            assertTrue(pr.labels().contains("block"));
-            assertFalse(pr.labels().contains("rfr"));
-            assertFalse(pr.labels().contains("ready"));
+            assertTrue(pr.labelNames().contains("block"));
+            assertFalse(pr.labelNames().contains("rfr"));
+            assertFalse(pr.labelNames().contains("ready"));
 
             // Check the status again
             pr.removeLabel("block");
             TestBotRunner.runPeriodicItems(checkBot);
 
             // The PR should now be ready for review
-            assertTrue(pr.labels().contains("rfr"));
-            assertFalse(pr.labels().contains("ready"));
+            assertTrue(pr.labelNames().contains("rfr"));
+            assertFalse(pr.labelNames().contains("ready"));
         }
     }
 
@@ -673,16 +673,16 @@ class CheckTests {
             assertTrue(updatedPr.body().contains("Replace this text with a description of your pull request"));
 
             // The PR should not yet be ready for review
-            assertFalse(pr.labels().contains("rfr"));
-            assertFalse(pr.labels().contains("ready"));
+            assertFalse(pr.labelNames().contains("rfr"));
+            assertFalse(pr.labelNames().contains("ready"));
 
             // Check the status again
             pr.setBody("Here's that body");
             TestBotRunner.runPeriodicItems(checkBot);
 
             // The PR should now be ready for review
-            assertTrue(pr.labels().contains("rfr"));
-            assertFalse(pr.labels().contains("ready"));
+            assertTrue(pr.labelNames().contains("rfr"));
+            assertFalse(pr.labelNames().contains("ready"));
 
             // The additional errors should be gone
             updatedPr = author.pullRequest(pr.id());
@@ -740,8 +740,8 @@ class CheckTests {
             assertTrue(updatedPr.body().contains("Executable files are not allowed (file: executable.exe)"));
 
             // The PR should not yet be ready for review
-            assertFalse(pr.labels().contains("rfr"));
-            assertFalse(pr.labels().contains("ready"));
+            assertFalse(pr.labelNames().contains("rfr"));
+            assertFalse(pr.labelNames().contains("ready"));
 
             // Drop that error
             Files.setPosixFilePermissions(tempFolder.path().resolve("executable.exe"), Set.of(PosixFilePermission.OWNER_READ));
@@ -751,8 +751,8 @@ class CheckTests {
             TestBotRunner.runPeriodicItems(checkBot);
 
             // The PR should now be ready for review
-            assertTrue(pr.labels().contains("rfr"));
-            assertFalse(pr.labels().contains("ready"));
+            assertTrue(pr.labelNames().contains("rfr"));
+            assertFalse(pr.labelNames().contains("ready"));
 
             // The additional errors should be gone
             updatedPr = author.pullRequest(pr.id());
@@ -791,14 +791,14 @@ class CheckTests {
             assertEquals(0, checks.size());
 
             // The PR should not yet be ready for review
-            assertFalse(pr.labels().contains("rfr"));
+            assertFalse(pr.labelNames().contains("rfr"));
 
             // Check the status again
             pr.addLabel("good-to-go");
             TestBotRunner.runPeriodicItems(checkBot);
 
             // The PR should now be ready for review
-            assertTrue(pr.labels().contains("rfr"));
+            assertTrue(pr.labelNames().contains("rfr"));
         }
     }
 
@@ -832,7 +832,7 @@ class CheckTests {
             assertEquals(0, checks.size());
 
             // The PR should not yet be ready for review
-            assertFalse(pr.labels().contains("rfr"));
+            assertFalse(pr.labelNames().contains("rfr"));
 
             // Check the status again
             var reviewerPr = reviewer.pullRequest(pr.id());
@@ -840,7 +840,7 @@ class CheckTests {
             TestBotRunner.runPeriodicItems(checkBot);
 
             // The PR should now be ready for review
-            assertTrue(pr.labels().contains("rfr"));
+            assertTrue(pr.labelNames().contains("rfr"));
         }
     }
 
@@ -1257,8 +1257,8 @@ class CheckTests {
             assertEquals(CheckStatus.SUCCESS, check.status());
 
             // The PR should still not be ready for review as it is a draft
-            assertFalse(pr.labels().contains("rfr"));
-            assertFalse(pr.labels().contains("ready"));
+            assertFalse(pr.labelNames().contains("rfr"));
+            assertFalse(pr.labelNames().contains("ready"));
         }
     }
 
@@ -1407,7 +1407,7 @@ class CheckTests {
             TestBotRunner.runPeriodicItems(checkBot);
 
             // The PR should be flagged as ready
-            assertTrue(pr.labels().contains("ready"));
+            assertTrue(pr.labelNames().contains("ready"));
             assertFalse(pr.body().contains("Re-review required"));
 
             // Add another commit
@@ -1428,8 +1428,8 @@ class CheckTests {
             TestBotRunner.runPeriodicItems(checkBot);
 
             // The PR should no longer be ready, as the review is stale
-            assertFalse(pr.labels().contains("ready"));
-            assertTrue(pr.labels().contains("rfr"));
+            assertFalse(pr.labelNames().contains("ready"));
+            assertTrue(pr.labelNames().contains("rfr"));
             assertTrue(pr.body().contains("Re-review required"));
         }
     }
@@ -1717,7 +1717,7 @@ class CheckTests {
 
             // Check the status (should become ready immediately as reviewercount is overridden to 0)
             TestBotRunner.runPeriodicItems(checkBot);
-            assertEquals(Set.of("rfr", "ready"), new HashSet<>(pr.labels()));
+            assertEquals(Set.of("rfr", "ready"), new HashSet<>(pr.labelNames()));
         }
     }
 
@@ -1765,7 +1765,7 @@ class CheckTests {
 
             // Check the status (should become ready immediately as reviewercount is overridden to 0)
             TestBotRunner.runPeriodicItems(checkBot);
-            assertEquals(Set.of("rfr", "ready"), new HashSet<>(pr.labels()));
+            assertEquals(Set.of("rfr", "ready"), new HashSet<>(pr.labelNames()));
         }
     }
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CleanCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CleanCommandTests.java
@@ -64,14 +64,14 @@ public class CleanCommandTests {
             var pr = credentials.createPullRequest(author, "master", "edit", "123: This is a pull request");
             TestBotRunner.runPeriodicItems(prBot);
 
-            assertFalse(pr.labels().contains("backport"));
-            assertFalse(pr.labels().contains("clean"));
+            assertFalse(pr.labelNames().contains("backport"));
+            assertFalse(pr.labelNames().contains("clean"));
 
             // Try to issue the "/clean" PR command, should not work
             pr.addComment("/clean");
             TestBotRunner.runPeriodicItems(prBot);
-            assertFalse(pr.labels().contains("backport"));
-            assertFalse(pr.labels().contains("clean"));
+            assertFalse(pr.labelNames().contains("backport"));
+            assertFalse(pr.labelNames().contains("clean"));
             assertLastCommentContains(pr, "can only mark [backport pull requests]");
             assertLastCommentContains(pr, "as clean");
         }
@@ -131,15 +131,15 @@ public class CleanCommandTests {
             assertTrue(backportComment.contains("This backport pull request has now been updated with issue"));
             assertTrue(backportComment.contains("<!-- backport " + releaseHash.hex() + " -->"));
             assertEquals(issue1Number + ": An issue", pr.title());
-            assertTrue(pr.labels().contains("backport"));
+            assertTrue(pr.labelNames().contains("backport"));
 
             // The bot should have added the "clean" label
-            assertTrue(pr.labels().contains("clean"));
+            assertTrue(pr.labelNames().contains("clean"));
 
             // Issue the "/clean" PR command, should do nothing
             pr.addComment("/clean");
             TestBotRunner.runPeriodicItems(bot);
-            assertTrue(pr.labels().contains("clean"));
+            assertTrue(pr.labelNames().contains("clean"));
             assertLastCommentContains(pr, "this backport pull request is already marked as clean");
         }
     }
@@ -206,15 +206,15 @@ public class CleanCommandTests {
             assertTrue(backportComment.contains("This backport pull request has now been updated with issue"));
             assertTrue(backportComment.contains("<!-- backport " + upstreamHash.hex() + " -->"));
             assertEquals(issue2Number + ": Another issue", pr.title());
-            assertTrue(pr.labels().contains("backport"));
+            assertTrue(pr.labelNames().contains("backport"));
 
             // The bot should not have added the "clean" label
-            assertFalse(pr.labels().contains("clean"));
+            assertFalse(pr.labelNames().contains("clean"));
 
             // Use the "/clean" pull request command to mark the backport PR as clean
             pr.addComment("/clean");
             TestBotRunner.runPeriodicItems(bot);
-            assertTrue(pr.labels().contains("clean"));
+            assertTrue(pr.labelNames().contains("clean"));
             assertLastCommentContains(pr, "this backport pull request is now marked as clean");
         }
     }
@@ -283,16 +283,16 @@ public class CleanCommandTests {
             assertTrue(backportComment.contains("This backport pull request has now been updated with issue"));
             assertTrue(backportComment.contains("<!-- backport " + upstreamHash.hex() + " -->"));
             assertEquals(issue2Number + ": Another issue", pr.title());
-            assertTrue(pr.labels().contains("backport"));
+            assertTrue(pr.labelNames().contains("backport"));
 
             // The bot should not have added the "clean" label
-            assertFalse(pr.labels().contains("clean"));
+            assertFalse(pr.labelNames().contains("clean"));
 
             // Use the "/clean" pull request command as author, should not work
             var prAsAuthor = contributor.pullRequest(pr.id());
             prAsAuthor.addComment("/clean");
             TestBotRunner.runPeriodicItems(bot);
-            assertFalse(pr.labels().contains("clean"));
+            assertFalse(pr.labelNames().contains("clean"));
             assertLastCommentContains(pr, "only OpenJDK [Committers]");
             assertLastCommentContains(pr, "can use the `/clean` command");
         }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrateTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrateTests.java
@@ -99,10 +99,10 @@ class IntegrateTests {
             assertEquals("integrationcommitter1@openjdk.java.net", headCommit.author().email());
             assertEquals("Generated Committer 1", headCommit.committer().name());
             assertEquals("integrationcommitter1@openjdk.java.net", headCommit.committer().email());
-            assertTrue(pr.labels().contains("integrated"));
+            assertTrue(pr.labelNames().contains("integrated"));
 
             // Ready label should have been removed
-            assertFalse(pr.labels().contains("ready"));
+            assertFalse(pr.labelNames().contains("ready"));
         }
     }
 
@@ -812,7 +812,7 @@ class IntegrateTests {
 
             // The bot should respond with a failure about missing e-mail
             pr = author.pullRequest(pr.id());
-            assertFalse(pr.labels().contains("ready"));
+            assertFalse(pr.labelNames().contains("ready"));
             var checks = pr.checks(pr.headHash());
             assertTrue(checks.containsKey("jcheck"));
             var jcheck = checks.get("jcheck");
@@ -873,7 +873,7 @@ class IntegrateTests {
             assertEquals(1, pushed);
 
             // Ready label should remain
-            assertTrue(pr.labels().contains("ready"));
+            assertTrue(pr.labelNames().contains("ready"));
         }
     }
 
@@ -910,7 +910,7 @@ class IntegrateTests {
                                       .filter(c -> c.body().contains("This pull request will be automatically integrated"))
                                       .count();
             assertEquals(1, integrateComments);
-            assertTrue(pr.labels().contains("auto"));
+            assertTrue(pr.labelNames().contains("auto"));
 
             // Approve it as another user
             var approvalPr = integrator.pullRequest(pr.id());
@@ -935,10 +935,10 @@ class IntegrateTests {
             assertEquals("integrationcommitter1@openjdk.java.net", headCommit.author().email());
             assertEquals("Generated Committer 1", headCommit.committer().name());
             assertEquals("integrationcommitter1@openjdk.java.net", headCommit.committer().email());
-            assertTrue(pr.labels().contains("integrated"));
+            assertTrue(pr.labelNames().contains("integrated"));
 
             // Ready label should have been removed
-            assertFalse(pr.labels().contains("ready"));
+            assertFalse(pr.labelNames().contains("ready"));
         }
     }
 
@@ -976,7 +976,7 @@ class IntegrateTests {
                                       .filter(c -> c.body().contains("This pull request will be automatically integrated"))
                                       .count();
             assertEquals(1, integrateComments);
-            assertTrue(pr.labels().contains("auto"));
+            assertTrue(pr.labelNames().contains("auto"));
 
             // Approve it as another user
             var approvalPr = integrator.pullRequest(pr.id());
@@ -1001,10 +1001,10 @@ class IntegrateTests {
             assertEquals("integrationcommitter1@openjdk.java.net", headCommit.author().email());
             assertEquals("Generated Committer 1", headCommit.committer().name());
             assertEquals("integrationcommitter1@openjdk.java.net", headCommit.committer().email());
-            assertTrue(pr.labels().contains("integrated"));
+            assertTrue(pr.labelNames().contains("integrated"));
 
             // Ready label should have been removed
-            assertFalse(pr.labels().contains("ready"));
+            assertFalse(pr.labelNames().contains("ready"));
         }
     }
 
@@ -1041,7 +1041,7 @@ class IntegrateTests {
                                       .filter(c -> c.body().contains("This pull request will be automatically integrated"))
                                       .count();
             assertEquals(1, integrateComments);
-            assertTrue(pr.labels().contains("auto"));
+            assertTrue(pr.labelNames().contains("auto"));
 
             // Make a comment to integrate manually
             pr.addComment("/integrate manual");
@@ -1055,7 +1055,7 @@ class IntegrateTests {
             assertEquals(1, replies);
 
             // The "auto" label should have been removed
-            assertFalse(pr.labels().contains("auto"));
+            assertFalse(pr.labelNames().contains("auto"));
 
             // Approve it as another user
             var approvalPr = integrator.pullRequest(pr.id());
@@ -1092,10 +1092,10 @@ class IntegrateTests {
             assertEquals("integrationcommitter1@openjdk.java.net", headCommit.author().email());
             assertEquals("Generated Committer 1", headCommit.committer().name());
             assertEquals("integrationcommitter1@openjdk.java.net", headCommit.committer().email());
-            assertTrue(pr.labels().contains("integrated"));
+            assertTrue(pr.labelNames().contains("integrated"));
 
             // Ready label should have been removed
-            assertFalse(pr.labels().contains("ready"));
+            assertFalse(pr.labelNames().contains("ready"));
         }
     }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelTests.java
@@ -162,7 +162,7 @@ public class LabelTests {
 
             // The bot should have applied one label automatically
             TestBotRunner.runPeriodicItems(prBot);
-            assertEquals(Set.of("2", "rfr"), new HashSet<>(pr.labels()));
+            assertEquals(Set.of("2", "rfr"), new HashSet<>(pr.labelNames()));
             assertLastCommentContains(pr, "The following label will be automatically applied");
             assertLastCommentContains(pr, "`2`");
 
@@ -179,13 +179,13 @@ public class LabelTests {
 
             // The bot should not apply labels since the user has manually removed labels
             TestBotRunner.runPeriodicItems(prBot);
-            assertEquals(Set.of("rfr"), new HashSet<>(pr.labels()));
+            assertEquals(Set.of("rfr"), new HashSet<>(pr.labelNames()));
 
             // Adding the label manually is fine
             pr.addComment("/label add group");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(pr, "The `group` label was successfully added.");
-            assertEquals(Set.of("group", "rfr"), new HashSet<>(pr.labels()));
+            assertEquals(Set.of("group", "rfr"), new HashSet<>(pr.labelNames()));
         }
     }
 
@@ -226,7 +226,7 @@ public class LabelTests {
 
             // The bot will not add any label automatically
             TestBotRunner.runPeriodicItems(prBot);
-            assertEquals(Set.of("1", "rfr"), new HashSet<>(pr.labels()));
+            assertEquals(Set.of("1", "rfr"), new HashSet<>(pr.labelNames()));
             assertEquals(1, pr.comments().size());
             assertLastCommentContains(pr, "The `1` label was successfully added.");
 
@@ -238,14 +238,14 @@ public class LabelTests {
 
             // The bot will still not do any automatic labelling
             TestBotRunner.runPeriodicItems(prBot);
-            assertEquals(Set.of("1", "rfr"), new HashSet<>(pr.labels()));
+            assertEquals(Set.of("1", "rfr"), new HashSet<>(pr.labelNames()));
 
             // Adding manually is still fine
             pr.addComment("/label add group 2");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(pr, "The `group` label was successfully added.");
             assertLastCommentContains(pr, "The `2` label was successfully added.");
-            assertEquals(Set.of("1", "2", "group", "rfr"), new HashSet<>(pr.labels()));
+            assertEquals(Set.of("1", "2", "group", "rfr"), new HashSet<>(pr.labelNames()));
         }
     }
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelerTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelerTests.java
@@ -69,7 +69,7 @@ class LabelerTests {
 
             // Check the status - only the rfr label should be set
             TestBotRunner.runPeriodicItems(labelBot);
-            assertEquals(Set.of("rfr"), new HashSet<>(pr.labels()));
+            assertEquals(Set.of("rfr"), new HashSet<>(pr.labelNames()));
             assertLastCommentContains(pr, "However, no automatic labelling rule matches the changes in this pull request.");
             assertLastCommentContains(pr, "<details>");
             assertLastCommentContains(pr, "<summary>Applicable Labels</summary>");
@@ -119,7 +119,7 @@ class LabelerTests {
 
             // Check the status - there should now be a test1 label
             TestBotRunner.runPeriodicItems(labelBot);
-            assertEquals(Set.of("rfr", "test1"), new HashSet<>(pr.labels()));
+            assertEquals(Set.of("rfr", "test1"), new HashSet<>(pr.labelNames()));
         }
     }
 
@@ -167,7 +167,7 @@ class LabelerTests {
 
             // Check the status - there should still only be a test2 label
             TestBotRunner.runPeriodicItems(labelBot);
-            assertEquals(Set.of("rfr", "test2"), new HashSet<>(pr.labels()));
+            assertEquals(Set.of("rfr", "test2"), new HashSet<>(pr.labelNames()));
         }
     }
 
@@ -214,7 +214,7 @@ class LabelerTests {
 
             // Check the status - there should still only be a test2 label
             TestBotRunner.runPeriodicItems(labelBot);
-            assertEquals(Set.of("rfr", "test2"), new HashSet<>(pr.labels()));
+            assertEquals(Set.of("rfr", "test2"), new HashSet<>(pr.labelNames()));
         }
     }
 
@@ -261,7 +261,7 @@ class LabelerTests {
 
             // Check the status - the test1 label should have been added
             TestBotRunner.runPeriodicItems(labelBot);
-            assertEquals(Set.of("rfr", "test1", "test42"), new HashSet<>(pr.labels()));
+            assertEquals(Set.of("rfr", "test1", "test42"), new HashSet<>(pr.labelNames()));
         }
     }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PreIntegrateTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PreIntegrateTests.java
@@ -113,7 +113,7 @@ public class PreIntegrateTests {
             TestBotRunner.runPeriodicItems(mergeBot);
             followUpPr = author.pullRequest(followUpPr.id());
             assertFalse(followUpPr.body().contains("Integration blocker"));
-            assertTrue(followUpPr.labels().contains("ready"));
+            assertTrue(followUpPr.labelNames().contains("ready"));
 
             // Push something else unrelated to the target
             var currentMaster = localRepo.fetch(author.url(), "master");

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ReviewerTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ReviewerTests.java
@@ -72,7 +72,7 @@ class ReviewerTests {
             TestBotRunner.runPeriodicItems(prBot);
 
             // The bot should not yet consider the PR ready
-            assertFalse(pr.labels().contains("ready"));
+            assertFalse(pr.labelNames().contains("ready"));
 
             // Remove it again
             pr.addComment("/reviewer remove @" + integrator.forge().currentUser().username());

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ReviewersTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ReviewersTests.java
@@ -104,7 +104,7 @@ public class ReviewersTests {
 
             // The PR should not yet be considered as ready for review
             var updatedPr = author.pullRequest(pr.id());
-            assertFalse(updatedPr.labels().contains("ready"));
+            assertFalse(updatedPr.labelNames().contains("ready"));
 
             // Now reduce the number of required reviewers
             reviewerPr.addComment("/reviewers 1");
@@ -113,7 +113,7 @@ public class ReviewersTests {
 
             // The PR should now be considered as ready for review
             updatedPr = author.pullRequest(pr.id());
-            assertTrue(updatedPr.labels().contains("ready"));
+            assertTrue(updatedPr.labelNames().contains("ready"));
 
             // Now request that the lead reviews
             reviewerPr.addComment("/reviewers 1 lead");
@@ -123,7 +123,7 @@ public class ReviewersTests {
 
             // The PR should no longer be considered as ready for review
             updatedPr = author.pullRequest(pr.id());
-            assertFalse(updatedPr.labels().contains("ready"));
+            assertFalse(updatedPr.labelNames().contains("ready"));
 
             // Drop the extra requirement that it should be the lead
             reviewerPr.addComment("/reviewers 1");
@@ -133,7 +133,7 @@ public class ReviewersTests {
 
             // The PR should now be considered as ready for review yet again
             updatedPr = author.pullRequest(pr.id());
-            assertTrue(updatedPr.labels().contains("ready"));
+            assertTrue(updatedPr.labelNames().contains("ready"));
         }
     }
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/SponsorTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/SponsorTests.java
@@ -114,9 +114,9 @@ class SponsorTests {
 
             assertEquals("Generated Reviewer 1", headCommit.committer().name());
             assertEquals("integrationreviewer1@openjdk.java.net", headCommit.committer().email());
-            assertTrue(pr.labels().contains("integrated"));
-            assertFalse(pr.labels().contains("ready"));
-            assertFalse(pr.labels().contains("sponsor"));
+            assertTrue(pr.labelNames().contains("integrated"));
+            assertFalse(pr.labelNames().contains("ready"));
+            assertFalse(pr.labelNames().contains("sponsor"));
         }
     }
 
@@ -276,7 +276,7 @@ class SponsorTests {
                           .filter(comment -> comment.body().contains("at version " + editHash.hex()))
                           .count();
             assertEquals(1, ready);
-            assertTrue(pr.labels().contains("sponsor"));
+            assertTrue(pr.labelNames().contains("sponsor"));
 
             // Push another change
             var updateHash = CheckableRepository.appendAndCommit(localRepo, "Yet more stuff", "Append commit", authorFullName, "ta@none.none");
@@ -294,7 +294,7 @@ class SponsorTests {
 
             // The label should have been dropped
             TestBotRunner.runPeriodicItems(mergeBot);
-            assertFalse(pr.labels().contains("sponsor"));
+            assertFalse(pr.labelNames().contains("sponsor"));
 
             // Reviewer now tries to sponsor
             var reviewerPr = reviewer.pullRequest(pr.id());
@@ -310,12 +310,12 @@ class SponsorTests {
             // Flag it as ready for integration again
             pr.addComment("/integrate");
             TestBotRunner.runPeriodicItems(mergeBot);
-            assertTrue(pr.labels().contains("sponsor"));
+            assertTrue(pr.labelNames().contains("sponsor"));
 
             // It should now be possible to sponsor
             reviewerPr.addComment("/sponsor");
             TestBotRunner.runPeriodicItems(mergeBot);
-            assertFalse(pr.labels().contains("sponsor"));
+            assertFalse(pr.labelNames().contains("sponsor"));
 
             // The bot should have pushed the commit
             var pushed = pr.comments().stream()
@@ -512,14 +512,14 @@ class SponsorTests {
                           .filter(comment -> comment.body().contains("at version " + editHash.hex()))
                           .count();
             assertEquals(1, ready);
-            assertTrue(pr.labels().contains("sponsor"));
+            assertTrue(pr.labelNames().contains("sponsor"));
 
             // The reviewer now changes their mind
             approvalPr.addReview(Review.Verdict.DISAPPROVED, "No wait, disapproved");
 
             // The label should have been dropped
             TestBotRunner.runPeriodicItems(mergeBot);
-            assertFalse(pr.labels().contains("sponsor"));
+            assertFalse(pr.labelNames().contains("sponsor"));
 
             // Reviewer now tries to sponsor
             var reviewerPr = reviewer.pullRequest(pr.id());
@@ -532,12 +532,12 @@ class SponsorTests {
             // Make it ready for integration again
             approvalPr.addReview(Review.Verdict.APPROVED, "Sorry, wrong button");
             TestBotRunner.runPeriodicItems(mergeBot);
-            assertTrue(pr.labels().contains("sponsor"));
+            assertTrue(pr.labelNames().contains("sponsor"));
 
             // It should now be possible to sponsor
             reviewerPr.addComment("/sponsor");
             TestBotRunner.runPeriodicItems(mergeBot);
-            assertFalse(pr.labels().contains("sponsor"));
+            assertFalse(pr.labelNames().contains("sponsor"));
 
             // The bot should have pushed the commit
             var pushed = pr.comments().stream()
@@ -751,7 +751,7 @@ class SponsorTests {
                           .filter(comment -> comment.body().contains("at version " + editHash.hex()))
                           .count();
             assertEquals(1, ready);
-            assertTrue(pr.labels().contains("sponsor"));
+            assertTrue(pr.labelNames().contains("sponsor"));
 
             // Reviewer now sponsor
             var reviewerPr = reviewer.pullRequest(pr.id());

--- a/bots/synclabel/src/main/java/org/openjdk/skara/bots/synclabel/SyncLabelBotUpdateLabelWorkItem.java
+++ b/bots/synclabel/src/main/java/org/openjdk/skara/bots/synclabel/SyncLabelBotUpdateLabelWorkItem.java
@@ -63,7 +63,7 @@ public class SyncLabelBotUpdateLabelWorkItem implements WorkItem {
         }
 
         var allIssues = Stream.concat(Stream.of(issue.get()), Backports.findBackports(issue.get(), true).stream())
-                              .filter(i -> !i.labels().contains("hgupdate-sync-ignore"))
+                              .filter(i -> !i.labelNames().contains("hgupdate-sync-ignore"))
                               .filter(i -> Backports.mainFixVersion(i).isPresent())
                               .filter(i -> bot.inspect().matcher(Backports.mainFixVersion(i).get().raw()).matches())
                               .filter(i -> !bot.ignore().matcher(Backports.mainFixVersion(i).get().raw()).matches())
@@ -74,14 +74,14 @@ public class SyncLabelBotUpdateLabelWorkItem implements WorkItem {
             var version = Backports.mainFixVersion(i);
             var versionString = version.map(JdkVersion::raw).orElse("no fix version");
             if (needsLabel.contains(i)) {
-                if (i.labels().contains("hgupdate-sync")) {
+                if (i.labelNames().contains("hgupdate-sync")) {
                     log.finer(i.id() + " (" + versionString + ") - already labeled");
                 } else {
                     log.info(i.id() + " (" + versionString + ") - needs to be labeled");
                     i.addLabel("hgupdate-sync");
                 }
             } else {
-                if (i.labels().contains("hgupdate-sync")) {
+                if (i.labelNames().contains("hgupdate-sync")) {
                     log.info(i.id() + " (" + versionString + ") - labeled incorrectly!");
                     i.removeLabel("hgupdate-sync");
                 } else {

--- a/bots/synclabel/src/test/java/org/openjdk/skara/bots/synclabel/SyncLabelBotTests.java
+++ b/bots/synclabel/src/test/java/org/openjdk/skara/bots/synclabel/SyncLabelBotTests.java
@@ -68,7 +68,7 @@ public class SyncLabelBotTests {
             issue1.setProperty("issuetype", JSON.of("Bug"));
             issue1.setState(RESOLVED);
             TestBotRunner.runPeriodicItems(syncLabelBot);
-            assertEquals(List.of(), issue1.labels());
+            assertEquals(List.of(), issue1.labelNames());
 
             var issue2 = credentials.createIssue(issueProject, "Issue 2");
             issue2.setProperty("fixVersions", JSON.array().add(JSON.of("8u162")));
@@ -76,7 +76,7 @@ public class SyncLabelBotTests {
             issue2.setState(RESOLVED);
             issue1.addLink(Link.create(issue2, "backported by").build());
             TestBotRunner.runPeriodicItems(syncLabelBot);
-            assertEquals(List.of("hgupdate-sync"), issue1.labels());
+            assertEquals(List.of("hgupdate-sync"), issue1.labelNames());
 
             var issue3 = credentials.createIssue(issueProject, "Issue 3");
             issue3.setProperty("fixVersions", JSON.array().add(JSON.of("10")));
@@ -84,7 +84,7 @@ public class SyncLabelBotTests {
             issue3.setState(RESOLVED);
             issue1.addLink(Link.create(issue3, "backported by").build());
             TestBotRunner.runPeriodicItems(syncLabelBot);
-            assertEquals(List.of(), issue3.labels());
+            assertEquals(List.of(), issue3.labelNames());
 
             var issue4 = credentials.createIssue(issueProject, "Issue 4");
             issue4.setProperty("fixVersions", JSON.array().add(JSON.of("11")));
@@ -92,17 +92,17 @@ public class SyncLabelBotTests {
             issue4.setState(RESOLVED);
             issue1.addLink(Link.create(issue4, "backported by").build());
             TestBotRunner.runPeriodicItems(syncLabelBot);
-            assertEquals(List.of("hgupdate-sync"), issue1.labels());
-            assertEquals(List.of(), issue2.labels());
-            assertEquals(List.of(), issue3.labels());
-            assertEquals(List.of("hgupdate-sync"), issue4.labels());
+            assertEquals(List.of("hgupdate-sync"), issue1.labelNames());
+            assertEquals(List.of(), issue2.labelNames());
+            assertEquals(List.of(), issue3.labelNames());
+            assertEquals(List.of("hgupdate-sync"), issue4.labelNames());
 
             // Ensure it is stable
             TestBotRunner.runPeriodicItems(syncLabelBot);
-            assertEquals(List.of("hgupdate-sync"), issue1.labels());
-            assertEquals(List.of(), issue2.labels());
-            assertEquals(List.of(), issue3.labels());
-            assertEquals(List.of("hgupdate-sync"), issue4.labels());
+            assertEquals(List.of("hgupdate-sync"), issue1.labelNames());
+            assertEquals(List.of(), issue2.labelNames());
+            assertEquals(List.of(), issue3.labelNames());
+            assertEquals(List.of("hgupdate-sync"), issue4.labelNames());
         }
     }
 
@@ -136,20 +136,20 @@ public class SyncLabelBotTests {
 
             // First correct them
             TestBotRunner.runPeriodicItems(syncLabelBot);
-            assertEquals(List.of("hgupdate-sync"), issue1.labels());
-            assertEquals(List.of(), issue2.labels());
-            assertEquals(List.of(), issue3.labels());
-            assertEquals(List.of("hgupdate-sync"), issue4.labels());
+            assertEquals(List.of("hgupdate-sync"), issue1.labelNames());
+            assertEquals(List.of(), issue2.labelNames());
+            assertEquals(List.of(), issue3.labelNames());
+            assertEquals(List.of("hgupdate-sync"), issue4.labelNames());
 
             // Intentionally mislabel
             issue2.addLabel("hgupdate-sync");
 
             // They should be restored
             TestBotRunner.runPeriodicItems(syncLabelBot);
-            assertEquals(List.of("hgupdate-sync"), issue1.labels());
-            assertEquals(List.of(), issue2.labels());
-            assertEquals(List.of(), issue3.labels());
-            assertEquals(List.of("hgupdate-sync"), issue4.labels());
+            assertEquals(List.of("hgupdate-sync"), issue1.labelNames());
+            assertEquals(List.of(), issue2.labelNames());
+            assertEquals(List.of(), issue3.labelNames());
+            assertEquals(List.of("hgupdate-sync"), issue4.labelNames());
         }
     }
 
@@ -166,7 +166,7 @@ public class SyncLabelBotTests {
             issue1.setProperty("issuetype", JSON.of("Bug"));
             issue1.setState(RESOLVED);
             TestBotRunner.runPeriodicItems(syncLabelBot);
-            assertEquals(List.of(), issue1.labels());
+            assertEquals(List.of(), issue1.labelNames());
 
             var issue2 = credentials.createIssue(issueProject, "Issue 2");
             issue2.setProperty("fixVersions", JSON.array().add(JSON.of("8u162")));
@@ -174,7 +174,7 @@ public class SyncLabelBotTests {
             issue2.setState(RESOLVED);
             issue1.addLink(Link.create(issue2, "backported by").build());
             TestBotRunner.runPeriodicItems(syncLabelBot);
-            assertEquals(List.of("hgupdate-sync"), issue1.labels());
+            assertEquals(List.of("hgupdate-sync"), issue1.labelNames());
 
             var issue3 = credentials.createIssue(issueProject, "Issue 3");
             issue3.setProperty("fixVersions", JSON.array().add(JSON.of("10")));
@@ -182,7 +182,7 @@ public class SyncLabelBotTests {
             issue3.setState(RESOLVED);
             issue1.addLink(Link.create(issue3, "backported by").build());
             TestBotRunner.runPeriodicItems(syncLabelBot);
-            assertEquals(List.of(), issue3.labels());
+            assertEquals(List.of(), issue3.labelNames());
 
             var issue4 = credentials.createIssue(issueProject, "Issue 4");
             issue4.setProperty("fixVersions", JSON.array().add(JSON.of("11")));
@@ -190,18 +190,18 @@ public class SyncLabelBotTests {
             issue4.setState(RESOLVED);
             issue1.addLink(Link.create(issue4, "backported by").build());
             TestBotRunner.runPeriodicItems(syncLabelBot);
-            assertEquals(List.of("hgupdate-sync"), issue1.labels());
-            assertEquals(List.of(), issue2.labels());
-            assertEquals(List.of(), issue3.labels());
-            assertEquals(List.of("hgupdate-sync"), issue4.labels());
+            assertEquals(List.of("hgupdate-sync"), issue1.labelNames());
+            assertEquals(List.of(), issue2.labelNames());
+            assertEquals(List.of(), issue3.labelNames());
+            assertEquals(List.of("hgupdate-sync"), issue4.labelNames());
 
             // Now ignore one of them - it should cause another to change
             issue3.addLabel("hgupdate-sync-ignore");
             TestBotRunner.runPeriodicItems(syncLabelBot);
-            assertEquals(List.of("hgupdate-sync"), issue1.labels());
-            assertEquals(List.of(), issue2.labels());
-            assertEquals(List.of("hgupdate-sync-ignore"), issue3.labels());
-            assertEquals(List.of(), issue4.labels());
+            assertEquals(List.of("hgupdate-sync"), issue1.labelNames());
+            assertEquals(List.of(), issue2.labelNames());
+            assertEquals(List.of("hgupdate-sync-ignore"), issue3.labelNames());
+            assertEquals(List.of(), issue4.labelNames());
 
             // Rearrange it a bit more
             var issue5 = credentials.createIssue(issueProject, "Issue 5");
@@ -210,27 +210,27 @@ public class SyncLabelBotTests {
             issue5.setState(RESOLVED);
             issue1.addLink(Link.create(issue5, "backported by").build());
             TestBotRunner.runPeriodicItems(syncLabelBot);
-            assertEquals(List.of("hgupdate-sync"), issue5.labels());
+            assertEquals(List.of("hgupdate-sync"), issue5.labelNames());
 
             // Now ignore another
             issue2.addLabel("hgupdate-sync-ignore");
             TestBotRunner.runPeriodicItems(syncLabelBot);
-            assertEquals(List.of(), issue1.labels());
-            assertEquals(List.of("hgupdate-sync-ignore"), issue2.labels());
-            assertEquals(List.of("hgupdate-sync-ignore"), issue3.labels());
-            assertEquals(List.of(), issue4.labels());
-            assertEquals(List.of("hgupdate-sync"), issue5.labels());
+            assertEquals(List.of(), issue1.labelNames());
+            assertEquals(List.of("hgupdate-sync-ignore"), issue2.labelNames());
+            assertEquals(List.of("hgupdate-sync-ignore"), issue3.labelNames());
+            assertEquals(List.of(), issue4.labelNames());
+            assertEquals(List.of("hgupdate-sync"), issue5.labelNames());
 
             // Now ignore the main issue as well
             issue1.addLabel("hgupdate-sync-ignore");
 
             // This should lead to issue 5 no longer being a sync issue
             TestBotRunner.runPeriodicItems(syncLabelBot);
-            assertEquals(List.of("hgupdate-sync-ignore"), issue1.labels());
-            assertEquals(List.of("hgupdate-sync-ignore"), issue2.labels());
-            assertEquals(List.of("hgupdate-sync-ignore"), issue3.labels());
-            assertEquals(List.of(), issue4.labels());
-            assertEquals(List.of(), issue5.labels());
+            assertEquals(List.of("hgupdate-sync-ignore"), issue1.labelNames());
+            assertEquals(List.of("hgupdate-sync-ignore"), issue2.labelNames());
+            assertEquals(List.of("hgupdate-sync-ignore"), issue3.labelNames());
+            assertEquals(List.of(), issue4.labelNames());
+            assertEquals(List.of(), issue5.labelNames());
         }
     }
 
@@ -247,7 +247,7 @@ public class SyncLabelBotTests {
             issue1.setProperty("issuetype", JSON.of("Bug"));
             issue1.setState(RESOLVED);
             TestBotRunner.runPeriodicItems(syncLabelBot);
-            assertEquals(List.of(), issue1.labels());
+            assertEquals(List.of(), issue1.labelNames());
 
             var issue2 = credentials.createIssue(issueProject, "Issue 2");
             issue2.setProperty("fixVersions", JSON.array().add(JSON.of("8u261")));
@@ -255,7 +255,7 @@ public class SyncLabelBotTests {
             issue2.setState(RESOLVED);
             issue1.addLink(Link.create(issue2, "backported by").build());
             TestBotRunner.runPeriodicItems(syncLabelBot);
-            assertEquals(List.of(), issue1.labels());
+            assertEquals(List.of(), issue1.labelNames());
 
             var issue3 = credentials.createIssue(issueProject, "Issue 3");
             issue3.setProperty("fixVersions", JSON.array().add(JSON.of("8u251")));
@@ -263,7 +263,7 @@ public class SyncLabelBotTests {
             issue3.setState(RESOLVED);
             issue1.addLink(Link.create(issue3, "backported by").build());
             TestBotRunner.runPeriodicItems(syncLabelBot);
-            assertEquals(List.of("hgupdate-sync"), issue3.labels());
+            assertEquals(List.of("hgupdate-sync"), issue3.labelNames());
 
             var issue4 = credentials.createIssue(issueProject, "Issue 4");
             issue4.setProperty("fixVersions", JSON.array().add(JSON.of("emb-8u251")));
@@ -272,18 +272,18 @@ public class SyncLabelBotTests {
             issue1.addLink(Link.create(issue4, "backported by").build());
 
             TestBotRunner.runPeriodicItems(syncLabelBot);
-            assertEquals(List.of(), issue1.labels());
-            assertEquals(List.of("hgupdate-sync"), issue2.labels());
-            assertEquals(List.of("hgupdate-sync"), issue3.labels());
-            assertEquals(List.of(), issue4.labels());
+            assertEquals(List.of(), issue1.labelNames());
+            assertEquals(List.of("hgupdate-sync"), issue2.labelNames());
+            assertEquals(List.of("hgupdate-sync"), issue3.labelNames());
+            assertEquals(List.of(), issue4.labelNames());
 
             // Now try it with a configured ignore - issue 3 should lose its label
             var syncLabelBotWithIgnore = testBotBuilder(issueProject, storageFolder, null, "8u4\\d").create("synclabel", JSON.object());
             TestBotRunner.runPeriodicItems(syncLabelBotWithIgnore);
-            assertEquals(List.of(), issue1.labels());
-            assertEquals(List.of("hgupdate-sync"), issue2.labels());
-            assertEquals(List.of(), issue3.labels());
-            assertEquals(List.of(), issue4.labels());
+            assertEquals(List.of(), issue1.labelNames());
+            assertEquals(List.of("hgupdate-sync"), issue2.labelNames());
+            assertEquals(List.of(), issue3.labelNames());
+            assertEquals(List.of(), issue4.labelNames());
         }
     }
 
@@ -300,7 +300,7 @@ public class SyncLabelBotTests {
             issue1.setProperty("issuetype", JSON.of("Bug"));
             issue1.setState(RESOLVED);
             TestBotRunner.runPeriodicItems(syncLabelBot);
-            assertEquals(List.of(), issue1.labels());
+            assertEquals(List.of(), issue1.labelNames());
 
             var issue2 = credentials.createIssue(issueProject, "Issue 2");
             issue2.setProperty("fixVersions", JSON.array().add(JSON.of("8u261")));
@@ -308,7 +308,7 @@ public class SyncLabelBotTests {
             issue2.setState(RESOLVED);
             issue1.addLink(Link.create(issue2, "backported by").build());
             TestBotRunner.runPeriodicItems(syncLabelBot);
-            assertEquals(List.of(), issue1.labels());
+            assertEquals(List.of(), issue1.labelNames());
 
             var issue3 = credentials.createIssue(issueProject, "Issue 3");
             issue3.setProperty("fixVersions", JSON.array().add(JSON.of("8u251")));
@@ -316,7 +316,7 @@ public class SyncLabelBotTests {
             issue3.setState(RESOLVED);
             issue1.addLink(Link.create(issue3, "backported by").build());
             TestBotRunner.runPeriodicItems(syncLabelBot);
-            assertEquals(List.of("hgupdate-sync"), issue3.labels());
+            assertEquals(List.of("hgupdate-sync"), issue3.labelNames());
 
             var issue4 = credentials.createIssue(issueProject, "Issue 4");
             issue4.setProperty("fixVersions", JSON.array().add(JSON.of("8u361")));
@@ -325,18 +325,18 @@ public class SyncLabelBotTests {
             issue1.addLink(Link.create(issue4, "backported by").build());
 
             TestBotRunner.runPeriodicItems(syncLabelBot);
-            assertEquals(List.of(), issue1.labels());
-            assertEquals(List.of("hgupdate-sync"), issue2.labels());
-            assertEquals(List.of("hgupdate-sync"), issue3.labels());
-            assertEquals(List.of("hgupdate-sync"), issue4.labels());
+            assertEquals(List.of(), issue1.labelNames());
+            assertEquals(List.of("hgupdate-sync"), issue2.labelNames());
+            assertEquals(List.of("hgupdate-sync"), issue3.labelNames());
+            assertEquals(List.of("hgupdate-sync"), issue4.labelNames());
 
             // Now try it with a configured include - issue 2 will now lose its label
             var syncLabelBotWithIgnore = testBotBuilder(issueProject, storageFolder, "8u\\d6\\d", null).create("synclabel", JSON.object());
             TestBotRunner.runPeriodicItems(syncLabelBotWithIgnore);
-            assertEquals(List.of(), issue1.labels());
-            assertEquals(List.of(), issue2.labels());
-            assertEquals(List.of("hgupdate-sync"), issue3.labels());
-            assertEquals(List.of("hgupdate-sync"), issue4.labels());
+            assertEquals(List.of(), issue1.labelNames());
+            assertEquals(List.of(), issue2.labelNames());
+            assertEquals(List.of("hgupdate-sync"), issue3.labelNames());
+            assertEquals(List.of("hgupdate-sync"), issue4.labelNames());
         }
     }
 
@@ -353,7 +353,7 @@ public class SyncLabelBotTests {
             issue1.setProperty("issuetype", JSON.of("Bug"));
             issue1.setState(RESOLVED);
             TestBotRunner.runPeriodicItems(syncLabelBot);
-            assertEquals(List.of(), issue1.labels());
+            assertEquals(List.of(), issue1.labelNames());
 
             var issue2 = credentials.createIssue(issueProject, "Issue 2");
             issue2.setProperty("fixVersions", JSON.array().add(JSON.of("8u271")));
@@ -362,7 +362,7 @@ public class SyncLabelBotTests {
             issue2.setState(RESOLVED);
             issue1.addLink(Link.create(issue2, "backported by").build());
             TestBotRunner.runPeriodicItems(syncLabelBot);
-            assertEquals(List.of(), issue1.labels());
+            assertEquals(List.of(), issue1.labelNames());
 
             var issue3 = credentials.createIssue(issueProject, "Issue 3");
             issue3.setProperty("fixVersions", JSON.array().add(JSON.of("8u291")));
@@ -370,7 +370,7 @@ public class SyncLabelBotTests {
             issue3.setState(RESOLVED);
             issue1.addLink(Link.create(issue3, "backported by").build());
             TestBotRunner.runPeriodicItems(syncLabelBot);
-            assertEquals(List.of(), issue3.labels());
+            assertEquals(List.of(), issue3.labelNames());
 
             var issue4 = credentials.createIssue(issueProject, "Issue 4");
             issue4.setProperty("fixVersions", JSON.array().add(JSON.of("8u301")));
@@ -378,10 +378,10 @@ public class SyncLabelBotTests {
             issue4.setState(RESOLVED);
             issue1.addLink(Link.create(issue4, "backported by").build());
             TestBotRunner.runPeriodicItems(syncLabelBot);
-            assertEquals(List.of(), issue1.labels());
-            assertEquals(List.of(), issue2.labels());
-            assertEquals(List.of(), issue3.labels());
-            assertEquals(List.of("hgupdate-sync"), issue4.labels());
+            assertEquals(List.of(), issue1.labelNames());
+            assertEquals(List.of(), issue2.labelNames());
+            assertEquals(List.of(), issue3.labelNames());
+            assertEquals(List.of("hgupdate-sync"), issue4.labelNames());
         }
     }
 }

--- a/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestWorkItem.java
+++ b/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestWorkItem.java
@@ -329,7 +329,7 @@ public class TestWorkItem implements WorkItem {
                     log.warning("Could not find check for job with " + jobId + " for hash " + hash + " for PR " + pr.webUrl());
                 }
             }
-            if (pr.labels().contains(TEST_REQUEST_LABEL)) {
+            if (pr.labelNames().contains(TEST_REQUEST_LABEL)) {
                 pr.removeLabel(TEST_REQUEST_LABEL);
             }
         } else if (stage == Stage.REQUESTED) {
@@ -363,7 +363,7 @@ public class TestWorkItem implements WorkItem {
             Hash head = null;
             List<String> jobs = null;
 
-            if (pr.labels().contains(TEST_REQUEST_LABEL)) {
+            if (pr.labelNames().contains(TEST_REQUEST_LABEL)) {
                 pr.removeLabel(TEST_REQUEST_LABEL);
             }
 

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
@@ -24,6 +24,7 @@ package org.openjdk.skara.bots.tester;
 
 import org.openjdk.skara.forge.*;
 import org.openjdk.skara.host.HostUser;
+import org.openjdk.skara.issuetracker.Label;
 import org.openjdk.skara.json.JSONValue;
 import org.openjdk.skara.vcs.*;
 
@@ -212,5 +213,10 @@ class InMemoryHostedRepository implements HostedRepository {
 
     @Override
     public void restrictPushAccess(Branch branch, List<HostUser> users) {
+    }
+
+    @Override
+    public List<Label> labels() {
+        return List.of();
     }
 }

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
@@ -29,6 +29,7 @@ import org.openjdk.skara.json.JSONValue;
 import org.openjdk.skara.vcs.*;
 
 import java.util.*;
+import java.util.stream.Collectors;
 import java.time.*;
 import java.net.*;
 
@@ -223,8 +224,8 @@ class InMemoryPullRequest implements PullRequest {
     }
 
     @Override
-    public List<String> labels() {
-        return new ArrayList<String>(labels);
+    public List<Label> labels() {
+        return labels.stream().map(s -> new Label(s)).collect(Collectors.toList());
     }
 
     @Override

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/TestWorkItemTests.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/TestWorkItemTests.java
@@ -1187,7 +1187,7 @@ class TestWorkItemTests {
             assertEquals("@duke you need to get approval to run the tests in tier1 for commits up until 01234567",
                          lines[3]);
 
-            assertEquals(List.of("test-request"), pr.labels());
+            assertEquals(List.of("test-request"), pr.labelNames());
 
             // Nothing should change if we run it yet again
             item.run(scratch);
@@ -1270,7 +1270,7 @@ class TestWorkItemTests {
             assertEquals("@duke you need to get approval to run the tests in tier1 for commits up until 01234567",
                          lines[3]);
 
-            assertEquals(List.of("test-request"), pr.labels());
+            assertEquals(List.of("test-request"), pr.labelNames());
 
             // Nothing should change if we run it yet again
             item.run(scratch);
@@ -1295,7 +1295,7 @@ class TestWorkItemTests {
             assertEquals(fourthComment, comments.get(3));
             assertEquals(fifthComment, comments.get(4));
 
-            assertEquals(List.of(), pr.labels());
+            assertEquals(List.of(), pr.labelNames());
         }
     }
 }

--- a/cli/src/main/java/org/openjdk/skara/cli/debug/IssueRedecorate.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/debug/IssueRedecorate.java
@@ -92,13 +92,13 @@ public class IssueRedecorate {
             var version = Backports.mainFixVersion(i);
             var versionString = version.map(JdkVersion::raw).orElse("no fix version");
             if (needsLabel.contains(i)) {
-                if (i.labels().contains("hgupdate-sync")) {
+                if (i.labelNames().contains("hgupdate-sync")) {
                     System.out.println("✔️ " + i.id() + " (" + versionString + ") - already labeled");
                 } else {
                     System.out.println("⏳ " + i.id() + " (" + versionString + ") - needs to be labeled");
                 }
             } else {
-                if (i.labels().contains("hgupdate-sync")) {
+                if (i.labelNames().contains("hgupdate-sync")) {
                     System.out.println("❌ " + i.id() + " (" + versionString + ") - labeled incorrectly");
                 } else {
                     System.out.println("✔️ " + i.id() + " (" + versionString + ") - not labeled");

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrInfo.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrInfo.java
@@ -225,7 +225,7 @@ public class GitPrInfo {
             if (showDecoration) {
                 System.out.format(fmt, "Labels:");
             }
-            System.out.println(String.join(", ", pr.labels()));
+            System.out.println(String.join(", ", pr.labelNames()));
         }
 
         if (showAll || showAssignees) {

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrList.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrList.java
@@ -190,7 +190,7 @@ public class GitPrList {
                 continue;
             }
 
-            var prLabels = new HashSet<>(pr.labels());
+            var prLabels = pr.labelNames();
             if (!filterLabels.isEmpty() && !filterLabels.stream().anyMatch(prLabels::contains)) {
                 continue;
             }

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/Utils.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/Utils.java
@@ -97,7 +97,7 @@ class Utils {
     }
 
     static String statusForPullRequest(PullRequest pr) {
-        var labels = pr.labels();
+        var labels = pr.labelNames();
         if (pr.isDraft()) {
             return "DRAFT";
         } else if (labels.contains("integrated")) {

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
@@ -24,6 +24,7 @@ package org.openjdk.skara.forge;
 
 import org.openjdk.skara.host.HostUser;
 import org.openjdk.skara.json.JSONValue;
+import org.openjdk.skara.issuetracker.Label;
 import org.openjdk.skara.vcs.*;
 
 import java.net.URI;
@@ -87,6 +88,7 @@ public interface HostedRepository {
     void addCollaborator(HostUser user, boolean canPush);
     boolean canPush(HostUser user);
     void restrictPushAccess(Branch branch, List<HostUser> users);
+    List<Label> labels();
 
     default PullRequest createPullRequest(HostedRepository target,
                                           String targetRef,

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -24,6 +24,7 @@ package org.openjdk.skara.forge.github;
 
 import org.openjdk.skara.forge.*;
 import org.openjdk.skara.host.HostUser;
+import org.openjdk.skara.issuetracker.Label;
 import org.openjdk.skara.json.*;
 import org.openjdk.skara.network.*;
 import org.openjdk.skara.vcs.*;
@@ -550,5 +551,14 @@ public class GitHubRepository implements HostedRepository {
         request.put("branches/" + branch.name() + "/protection")
                .body(query)
                .execute();
+    }
+
+    @Override
+    public List<Label> labels() {
+        return request.get("labels")
+                      .execute()
+                      .stream()
+                      .map(o -> new Label(o.get("name").asString(), o.get("description").asString()))
+                      .collect(Collectors.toList());
     }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -24,6 +24,7 @@ package org.openjdk.skara.forge.gitlab;
 
 import org.openjdk.skara.forge.*;
 import org.openjdk.skara.host.HostUser;
+import org.openjdk.skara.issuetracker.Label;
 import org.openjdk.skara.json.*;
 import org.openjdk.skara.network.*;
 import org.openjdk.skara.vcs.*;
@@ -579,5 +580,13 @@ public class GitLabRepository implements HostedRepository {
     public void restrictPushAccess(Branch branch, List<HostUser> users) {
         // Not possible to implement using GitLab Community Edition.
         // Must work around in admin web UI using groups.
+    }
+
+    List<Label> labels() {
+        return request.get("labels")
+                      .execute()
+                      .stream()
+                      .map(o -> new Label(o.get("name").asString(), o.get("description").asString()))
+                      .collect(Collectors.toList());
     }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -582,7 +582,8 @@ public class GitLabRepository implements HostedRepository {
         // Must work around in admin web UI using groups.
     }
 
-    List<Label> labels() {
+    @Override
+    public List<Label> labels() {
         return request.get("labels")
                       .execute()
                       .stream()

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/Issue.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/Issue.java
@@ -28,6 +28,7 @@ import org.openjdk.skara.json.JSONValue;
 import java.net.URI;
 import java.time.ZonedDateTime;
 import java.util.*;
+import java.util.stream.Collectors;
 
 public interface Issue {
     /**
@@ -144,6 +145,9 @@ public interface Issue {
      * @param label
      */
     void removeLabel(String label);
+    default void removeLabel(Label label) {
+        removeLabel(label.name());
+    }
 
     /**
      * Set the given labels and remove any others.
@@ -154,7 +158,10 @@ public interface Issue {
      * Retrieves all the currently set labels.
      * @return
      */
-    List<String> labels();
+    List<Label> labels();
+    default List<String> labelNames() {
+        return labels().stream().map(Label::name).collect(Collectors.toList());
+    }
 
     /**
      * Returns a link that will lead to the issue.

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/Label.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/Label.java
@@ -1,0 +1,13 @@
+public class Label {
+    public Label(String name, String description) {
+        this.name = name;
+        this.description
+    }
+    public String name() {
+        return name;
+    }
+
+    public String description() {
+        return description;
+    }
+}

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/Label.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/Label.java
@@ -1,13 +1,79 @@
-public class Label {
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.skara.issuetracker;
+
+import java.util.Objects;
+import java.util.Optional;
+
+public class Label implements Comparable<Label> {
+    private final String name;
+    private final String description;
+
+    public Label(String name) {
+        this(name, null);
+    }
+
     public Label(String name, String description) {
         this.name = name;
-        this.description
+        this.description = description;
     }
+
     public String name() {
         return name;
     }
 
-    public String description() {
-        return description;
+    public Optional<String> description() {
+        return Optional.ofNullable(description);
+    }
+
+    @Override
+    public int compareTo(Label l) {
+        return name.compareTo(l.name);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!(o instanceof Label)) {
+            return false;
+        }
+
+        var l = (Label) o;
+        return Objects.equals(name, l.name) &&
+               Objects.equals(description, l.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, description);
+    }
+
+    @Override
+    public String toString() {
+        return name;
     }
 }

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraIssue.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraIssue.java
@@ -264,9 +264,9 @@ public class JiraIssue implements Issue {
     }
 
     @Override
-    public List<String> labels() {
+    public List<Label> labels() {
         return json.get("fields").get("labels").stream()
-                   .map(JSONValue::asString)
+                   .map(s -> new Label(s.asString()))
                    .collect(Collectors.toList());
     }
 

--- a/issuetracker/src/test/java/org/openjdk/skara/issuetracker/IssueTrackerTests.java
+++ b/issuetracker/src/test/java/org/openjdk/skara/issuetracker/IssueTrackerTests.java
@@ -65,7 +65,7 @@ class IssueTrackerTests {
             issue.setProperty("fixVersions", JSON.array().add("1.0").add("2.0"));
             issue.setProperty("fixVersions", JSON.array().add("3.0"));
             var updated = project.issue(issue.id()).orElseThrow();
-            assertEquals(List.of("another"), updated.labels());
+            assertEquals(List.of("another"), updated.labelNames());
             assertEquals(1, updated.properties().get("fixVersions").asArray().size());
             assertEquals("3.0", updated.properties().get("fixVersions").get(0).asString());
             assertEquals(List.of(project.issueTracker().currentUser()), updated.assignees());

--- a/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
@@ -25,6 +25,7 @@ package org.openjdk.skara.test;
 import org.openjdk.skara.forge.*;
 import org.openjdk.skara.host.HostUser;
 import org.openjdk.skara.issuetracker.Issue;
+import org.openjdk.skara.issuetracker.Label;
 import org.openjdk.skara.json.JSONValue;
 import org.openjdk.skara.vcs.*;
 
@@ -299,5 +300,10 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
 
     Repository localRepository() {
         return localRepository;
+    }
+
+    @Override
+    public List<Label> labels() {
+        return List.of();
     }
 }

--- a/test/src/main/java/org/openjdk/skara/test/TestIssue.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestIssue.java
@@ -30,6 +30,7 @@ import org.openjdk.skara.network.URIBuilder;
 import java.net.URI;
 import java.time.ZonedDateTime;
 import java.util.*;
+import java.util.stream.Collectors;
 
 public class TestIssue implements Issue {
     protected final String id;
@@ -175,8 +176,8 @@ public class TestIssue implements Issue {
     }
 
     @Override
-    public List<String> labels() {
-        return new ArrayList<>(data.labels.keySet());
+    public List<Label> labels() {
+        return data.labels.keySet().stream().map(s -> new Label(s)).collect(Collectors.toList());
     }
 
     @Override


### PR DESCRIPTION
Hi all,

please review this patch that introduces the `Label` class in the `issuetracker` package. The `Label` class provides access to an eventual description of the label, previously we only returned the label names. The majority of the patch is a simple refactoring of changing existing calls to `Issue.labels` to `Issue.labelNames`.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**) ⚠️ Review applies to 0d2b4bbdc3d0f56018bb595e88e37d3c3549c956


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/skara pull/1089/head:pull/1089`
`$ git checkout pull/1089`

To update a local copy of the PR:
`$ git checkout pull/1089`
`$ git pull https://git.openjdk.java.net/skara pull/1089/head`
