### PR TITLE
734: ML->PR: full names containing non-ascii chars are displayed incorrectly.

### DIFF
--- a/email/src/main/java/org/openjdk/skara/email/MimeText.java
+++ b/email/src/main/java/org/openjdk/skara/email/MimeText.java
@@ -73,15 +73,16 @@ public class MimeText {
             } else {
                 var quotedDecodedSpaces = quotedMatcher.group(3).replace("_", " ");
                 var quotedPrintableMatcher = decodeQuotedPrintablePattern.matcher(quotedDecodedSpaces);
-                decoded.append(quotedPrintableMatcher.replaceAll(qmo -> {
+                var decodedAscii = quotedPrintableMatcher.replaceAll(qmo -> {
                     var byteValue = new byte[1];
                     byteValue[0] = (byte)Integer.parseInt(qmo.group(1), 16);
-                    try {
-                        return new String(byteValue, quotedMatcher.group(1));
-                    } catch (UnsupportedEncodingException e) {
-                        throw new RuntimeException(e);
-                    }
-                }));
+                    return new String(byteValue, StandardCharsets.ISO_8859_1);
+                });
+                try {
+                    decoded.append(new String(decodedAscii.getBytes(StandardCharsets.ISO_8859_1), quotedMatcher.group(1)));
+                } catch (UnsupportedEncodingException e) {
+                    throw new RuntimeException(e);
+                }
             }
             lastMatchEnd = quotedMatcher.end();
         }

--- a/email/src/test/java/org/openjdk/skara/email/MimeTextTests.java
+++ b/email/src/test/java/org/openjdk/skara/email/MimeTextTests.java
@@ -83,4 +83,9 @@ class MimeTextTests {
     void decodeIsoQSpaces() {
         assertEquals("Bä Bä Bä", MimeText.decode("=?iso-8859-1?Q?B=E4_B=E4=20B=E4?="));
     }
+
+    @Test
+    void multibyte() {
+        assertEquals("first.last at example.com (First Lüst)", MimeText.decode("first.last at example.com (=?UTF-8?Q?First_L=C3=BCst?=)"));
+    }
 }


### PR DESCRIPTION
Ensure that the MIME 'Q' text decoder properly handles multibyte values.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-734](https://bugs.openjdk.java.net/browse/SKARA-734): ML->PR: full names containing non-ascii chars are displayed incorrectly.


### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/skara pull/1090/head:pull/1090`
`$ git checkout pull/1090`

To update a local copy of the PR:
`$ git checkout pull/1090`
`$ git pull https://git.openjdk.java.net/skara pull/1090/head`
