### PR TITLE
cli: use label description for e-mail in git-pr-create

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrCreate.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrCreate.java
@@ -344,19 +344,23 @@ public class GitPrCreate {
             } else {
                 var suggested = suggestedLabels(repo, host, parentProject, targetBranch, headRef);
                 var labelNameToLabel = parentRepo.labels().stream().collect(Collectors.toMap(l -> l.name(), l -> l));
-                System.out.println("The following mailing lists will be CC:d for the \"RFR\" e-mail:");
                 for (var label : suggested) {
                     if (label.endsWith("-dev")) {
                         label = label.substring(0, label.length() - "-dev".length());
                     }
-                    var list = labelNameToLabel.getOrDefault(label, new Label(label)).description().orElse(label + "-dev@openjdk.java.net");
-                    if (cc == null) {
+                    var desc = labelNameToLabel.getOrDefault(label, new Label(label)).description();
+                    if (desc.isPresent()) {
+                        mailingLists.add(desc.get());
+                    }
+                }
+                if (!mailingLists.isEmpty()) {
+                    System.out.println("The following mailing lists will be CC:d for the \"RFR\" e-mail:");
+                    for (var list : mailingLists) {
                         System.out.println("- " + list);
                     }
-                    mailingLists.add(list);
                 }
             }
-            if (cc == null || !cc.equals("auto")) {
+            if (!mailingLists.isEmpty()) {
                 System.out.println("");
                 System.out.print("Do you want to proceed with this mailing list selection? [Y/n]: ");
                 var scanner = new Scanner(System.in);

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrCreate.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrCreate.java
@@ -25,6 +25,7 @@ package org.openjdk.skara.cli.pr;
 import org.openjdk.skara.args.*;
 import org.openjdk.skara.cli.*;
 import org.openjdk.skara.forge.*;
+import org.openjdk.skara.issuetracker.Label;
 import org.openjdk.skara.json.JSON;
 import org.openjdk.skara.vcs.*;
 import org.openjdk.skara.vcs.openjdk.CommitMessageParsers;
@@ -342,14 +343,13 @@ public class GitPrCreate {
                 }
             } else {
                 var suggested = suggestedLabels(repo, host, parentProject, targetBranch, headRef);
+                var labelNameToLabel = parentRepo.labels().stream().collect(Collectors.toMap(l -> l.name(), l -> l));
                 System.out.println("The following mailing lists will be CC:d for the \"RFR\" e-mail:");
                 for (var label : suggested) {
-                    String list = null;
                     if (label.endsWith("-dev")) {
-                        list = label + "@openjdk.java.net";
-                    } else {
-                        list = label + "-dev@openjdk.java.net";
+                        label = label.substring(0, label.length() - "-dev".length());
                     }
+                    var list = labelNameToLabel.getOrDefault(label, new Label(label)).description().orElse(label + "-dev@openjdk.java.net");
                     if (cc == null) {
                         System.out.println("- " + list);
                     }


### PR DESCRIPTION
Hi all,

please review this small patch that uses the label description in `git pr create` to map the label to a mailing list.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**) ⚠️ Review applies to 1dcd1344bf12132148f0d9245da9d54218cf3012


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/skara pull/1091/head:pull/1091`
`$ git checkout pull/1091`

To update a local copy of the PR:
`$ git checkout pull/1091`
`$ git pull https://git.openjdk.java.net/skara pull/1091/head`
