### PR TITLE
659: Multi-line commands aren't filtered properly

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
@@ -40,7 +40,7 @@ import java.util.stream.Collectors;
 class ArchiveMessages {
     private static final Pattern commentPattern = Pattern.compile("<!--.*?-->",
                                                                   Pattern.DOTALL | Pattern.MULTILINE);
-    private static final Pattern commandPattern = Pattern.compile("^\\s*/([A-Za-z]+).*$", Pattern.MULTILINE);
+    private static final Pattern commandPattern = Pattern.compile("^\\s*/([A-Za-z]+).*$", Pattern.MULTILINE | Pattern.DOTALL);
 
     private static String filterCommentsAndCommands(String body) {
         var parsedBody = PullRequestBody.parse(body);

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -1494,6 +1494,7 @@ class MailingListBridgeBotTests {
             pr.addComment("/integrate stuff");
             pr.addComment("the command is /hello there");
             pr.addComment("but this will be parsed\n/newline command");
+            pr.addComment("/multiline\nwill be dropped");
             TestBotRunner.runPeriodicItems(mlBot);
 
             // Run an archive pass
@@ -1514,6 +1515,8 @@ class MailingListBridgeBotTests {
             assertTrue(archiveContains(archiveFolder.path(), "/hello there"));
             assertTrue(archiveContains(archiveFolder.path(), "but this will be parsed"));
             assertFalse(archiveContains(archiveFolder.path(), "/newline"));
+            assertFalse(archiveContains(archiveFolder.path(), "/multiline"));
+            assertFalse(archiveContains(archiveFolder.path(), "will be dropped"));
         }
     }
 


### PR DESCRIPTION
After a command has been found, filter out the rest of the body.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-659](https://bugs.openjdk.java.net/browse/SKARA-659): Multi-line commands aren't filtered properly


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/skara pull/1092/head:pull/1092`
`$ git checkout pull/1092`

To update a local copy of the PR:
`$ git checkout pull/1092`
`$ git pull https://git.openjdk.java.net/skara pull/1092/head`
