### PR TITLE
Reviewing help markdown does not work on gitlab

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -530,30 +530,30 @@ class CheckRun {
     private String reviewUsingGitHelp() {
         var repoUrl = pr.repository().webUrl();
         var firstTime =
-           "`$ git fetch " + repoUrl + " " + pr.fetchRef() + ":pull/" + pr.id() + "`\n" +
+           "`$ git fetch " + repoUrl + " " + pr.fetchRef() + ":pull/" + pr.id() + "` \\\n" +
            "`$ git checkout pull/" + pr.id() + "`\n";
         var updating =
-           "`$ git checkout pull/" + pr.id() + "`\n" +
+           "`$ git checkout pull/" + pr.id() + "` \\\n" +
            "`$ git pull " + repoUrl + " " + pr.fetchRef() + "`\n";
 
-        return "Checkout this PR locally:\n" +
+        return "Checkout this PR locally: \\\n" +
                 firstTime +
                 "\n" +
-                "Update a local copy of the PR:\n" +
+                "Update a local copy of the PR: \\\n" +
                 updating;
     }
 
     private String reviewUsingSkaraHelp() {
-        return "Checkout this PR locally:\n" +
+        return "Checkout this PR locally: \\\n" +
                 ("`$ git pr checkout " + pr.id() + "`\n") +
                 "\n" +
-                "View PR using the GUI difftool:\n" +
+                "View PR using the GUI difftool: \\\n" +
                 ("`$ git pr show -t " + pr.id() + "`\n");
     }
 
     private String reviewUsingDiffsHelp() {
         var diffUrl = pr.repository().webUrl() + "/pull/" + pr.id() + ".diff";
-        return "Download this PR as a diff file:\n" +
+        return "Download this PR as a diff file: \\\n" +
                 "<a href=\"" + diffUrl + "\">" + diffUrl + "</a>\n";
     }
 


### PR DESCRIPTION
It turned out the markdown code for the review helper worked fine on github, but not on gitlab...

So much for markdown "standard" :-(

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/skara pull/1096/head:pull/1096`
`$ git checkout pull/1096`

To update a local copy of the PR:
`$ git checkout pull/1096`
`$ git pull https://git.openjdk.java.net/skara pull/1096/head`
