### PR TITLE
mlbridge: use nicer link for webrev commits

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
@@ -155,7 +155,7 @@ class ArchiveWorkItem implements WorkItem {
         comment += "### Webrevs" + "\n";
         comment += webrevListMarker + "\n";
         comment += " * " + String.format("%02d", index) + ": " + webrevDescriptions;
-        comment += " (" + pr.filesUrl(pr.headHash()) + ")\n";
+        comment += " ([" + pr.headHash().abbreviate() + "](" + pr.filesUrl(pr.headHash()) + "))\n";
 
         if (existing.isPresent()) {
             if (existing.get().body().contains(webrevDescriptions)) {


### PR DESCRIPTION
Hi all,

please review this patch that formats the link to the commit after a webrev version a bit nicer. After my change in f16663b766fa02ced204bb1ca8d334a4ca776092 we are showing the full link, which is a bit verbose. This patch restores the old behavior where we just show an abbreviated hash.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1098/head:pull/1098` \
`$ git checkout pull/1098`

Update a local copy of the PR: \
`$ git checkout pull/1098` \
`$ git pull https://git.openjdk.java.net/skara pull/1098/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1098`

View PR using the GUI difftool: \
`$ git pr show -t 1098`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1098.diff">https://git.openjdk.java.net/skara/pull/1098.diff</a>

</details>
