### PR TITLE
939: Improve robustness and error reporting on invalid fixVersion

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryWorkItem.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryWorkItem.java
@@ -31,7 +31,7 @@ import org.openjdk.skara.vcs.openjdk.OpenJDKTag;
 import java.io.*;
 import java.nio.file.*;
 import java.util.*;
-import java.util.logging.Logger;
+import java.util.logging.*;
 import java.util.regex.Pattern;
 import java.util.stream.*;
 
@@ -126,9 +126,11 @@ public class RepositoryWorkItem implements WorkItem {
                 try {
                     handleUpdatedRef(localRepo, ref, commits, listener);
                 } catch (NonRetriableException e) {
+                    log.log(Level.INFO, "Non retriable exception occurred", e);
                     errors.add(e.cause());
                 } catch (RuntimeException e) {
                     // Attempt to roll back
+                    log.log(Level.INFO, "Retriable exception occurred", e);
                     history.setBranchHash(branch, listener.name(), lastHash.get());
                     errors.add(e);
                 }

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraProject.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraProject.java
@@ -157,6 +157,19 @@ public class JiraProject implements IssueProject {
         return ret;
     }
 
+    private String versionId(String name) {
+        var ret = versions().get(name);
+        if (ret == null) {
+            // Ensure this is not due to a stale cache
+            projectMetadataCache = null;
+            ret = versions().get(name);
+            if (ret == null) {
+                throw new RuntimeException("Unknown version `" + name + "`");
+            }
+        }
+        return ret;
+    }
+
     private void populateLinkTypesIfNeeded() {
         if (linkTypes != null) {
             return;
@@ -252,7 +265,7 @@ public class JiraProject implements IssueProject {
             case "versions":
                 return Optional.of(new JSONArray(value.stream()
                                                       .map(JSONValue::asString)
-                                                      .map(s -> JSON.object().put("id", versions().get(s)))
+                                                      .map(s -> JSON.object().put("id", versionId(s)))
                                                       .collect(Collectors.toList())));
             case "components":
                 return Optional.of(new JSONArray(value.stream()


### PR DESCRIPTION
If a fixVersion isn't found, ensure that we refresh the cache and log a proper error message if it still isn't found.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-939](https://bugs.openjdk.java.net/browse/SKARA-939): Improve robustness and error reporting on invalid fixVersion


### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1099/head:pull/1099` \
`$ git checkout pull/1099`

Update a local copy of the PR: \
`$ git checkout pull/1099` \
`$ git pull https://git.openjdk.java.net/skara pull/1099/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1099`

View PR using the GUI difftool: \
`$ git pr show -t 1099`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1099.diff">https://git.openjdk.java.net/skara/pull/1099.diff</a>

</details>
