### PR TITLE
940: Exception during item execution: has integrated label but no integration comment

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifier.java
@@ -83,6 +83,7 @@ public class PullRequestBranchNotifier implements Notifier, PullRequestListener 
     @Override
     public void onStateChange(PullRequest pr, Issue.State oldState) {
         if (pr.state() == Issue.State.CLOSED) {
+            PreIntegrations.retargetDependencies(pr);
             deleteBranch(pr);
         } else {
             pushBranch(pr);

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
@@ -220,11 +220,6 @@ public class IntegrateCommand implements CommandHandler {
                                   "The error has been logged and will be investigated. It is possible that this error " +
                                   "is caused by a transient issue; feel free to retry the operation.");
         }
-
-        // Additional cleanup outside of the integration lock
-        if (success) {
-            PreIntegrations.retargetDependencies(pr);
-        }
     }
 
     @Override

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PreIntegrateTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PreIntegrateTests.java
@@ -109,6 +109,9 @@ public class PreIntegrateTests {
             // The bot should reply with an ok message
             assertLastCommentContains(pr, "Pushed as commit");
 
+            // The notifier will now retarget the follow up PR, simulate this
+            followUpPr.setTargetRef("master");
+
             // The second should now become ready
             TestBotRunner.runPeriodicItems(mergeBot);
             followUpPr = author.pullRequest(followUpPr.id());


### PR DESCRIPTION
Retarget any dependent pull requests before closing the target branch in the notifier, to avoid potential races.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-940](https://bugs.openjdk.java.net/browse/SKARA-940): Exception during item execution: has integrated label but no integration comment


### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1100/head:pull/1100` \
`$ git checkout pull/1100`

Update a local copy of the PR: \
`$ git checkout pull/1100` \
`$ git pull https://git.openjdk.java.net/skara pull/1100/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1100`

View PR using the GUI difftool: \
`$ git pr show -t 1100`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1100.diff">https://git.openjdk.java.net/skara/pull/1100.diff</a>

</details>
