### PR TITLE
pr: update error message for backports

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
@@ -119,8 +119,8 @@ public class BackportCommand implements CommandHandler {
             var didApply = localRepo.cherryPick(fetchHead);
             if (!didApply) {
                 var lines = new ArrayList<String>();
-                lines.add("@" + username + " :warning: could not backport `" + hash.abbreviate() + "` to " +
-                          "[" + repoName + "](" + targetRepo.webUrl() + "] due to conflicts in the following files:");
+                lines.add("@" + username + " could **not** automatically backport `" + hash.abbreviate() + "` to " +
+                          "[" + repoName + "](" + targetRepo.webUrl() + ") due to conflicts in the following files:");
                 lines.add("");
                 var unmerged = localRepo.status()
                                         .stream()
@@ -142,7 +142,7 @@ public class BackportCommand implements CommandHandler {
                 lines.add("$ git commit -m 'Backport " + hash.hex() + "'");
                 lines.add("```");
                 lines.add("");
-                lines.add("Once you have resolved the conflicts as explained above continue with creating a pull request towards the [" + repoName + "](" + targetRepo.webUrl() + ") with the title \"Backport " + hash.hex() + "\".");
+                lines.add("Once you have resolved the conflicts as explained above continue with creating a pull request towards the [" + repoName + "](" + targetRepo.webUrl() + ") with the title `Backport " + hash.hex() + "`.");
 
                 reply.println(String.join("\n", lines));
                 localRepo.reset(head, true);

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportCommitCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportCommitCommandTests.java
@@ -193,7 +193,7 @@ public class BackportCommitCommandTests {
             var recentCommitComments = author.recentCommitComments();
             assertEquals(2, recentCommitComments.size());
             var botReply = recentCommitComments.get(0);
-            assertTrue(botReply.body().contains(":warning: could not backport"));
+            assertTrue(botReply.body().contains("could **not** automatically backport"));
             assertEquals(List.of(), author.pullRequests());
         }
     }


### PR DESCRIPTION
Hi all,

please review this patch that fixes the Markdown for the error message when a commit cannot be automatically backported.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1101/head:pull/1101` \
`$ git checkout pull/1101`

Update a local copy of the PR: \
`$ git checkout pull/1101` \
`$ git pull https://git.openjdk.java.net/skara pull/1101/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1101`

View PR using the GUI difftool: \
`$ git pr show -t 1101`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1101.diff">https://git.openjdk.java.net/skara/pull/1101.diff</a>

</details>
