### PR TITLE
843: Mails are not forwarded to a closed PR any more

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveReaderWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveReaderWorkItem.java
@@ -23,7 +23,7 @@
 package org.openjdk.skara.bots.mlbridge;
 
 import org.openjdk.skara.bot.WorkItem;
-import org.openjdk.skara.mailinglist.MailingList;
+import org.openjdk.skara.mailinglist.MailingListReader;
 
 import java.nio.file.Path;
 import java.time.Duration;
@@ -31,9 +31,9 @@ import java.util.*;
 
 public class ArchiveReaderWorkItem implements WorkItem {
     private final MailingListArchiveReaderBot bot;
-    private final MailingList list;
+    private final MailingListReader list;
 
-    ArchiveReaderWorkItem(MailingListArchiveReaderBot bot, MailingList list) {
+    ArchiveReaderWorkItem(MailingListArchiveReaderBot bot, MailingListReader list) {
         this.bot = bot;
         this.list = list;
     }

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
@@ -171,7 +171,7 @@ class ArchiveWorkItem implements WorkItem {
         }
     }
 
-    private List<Email> parseArchive(MailingList archive) {
+    private List<Email> parseArchive(MailingListReader archive) {
         var conversations = archive.conversations(Duration.ofDays(365));
 
         if (conversations.size() == 0) {
@@ -253,7 +253,7 @@ class ArchiveWorkItem implements WorkItem {
         var archiveRepo = materializeArchive(path);
         var mboxBasePath = path.resolve(bot.codeRepo().name());
         var mbox = MailingListServerFactory.createMboxFileServer(mboxBasePath);
-        var reviewArchiveList = mbox.getList(pr.id());
+        var reviewArchiveList = mbox.getListReader(pr.id());
         var sentMails = parseArchive(reviewArchiveList);
         var labels = new HashSet<>(pr.labelNames());
 

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBot.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBot.java
@@ -36,7 +36,7 @@ import java.util.stream.Collectors;
 
 public class MailingListArchiveReaderBot implements Bot {
     private final EmailAddress archivePoster;
-    private final MailingList list;
+    private final MailingListReader list;
     private final Set<HostedRepository> repositories;
     private final Map<EmailAddress, String> parsedConversations = new HashMap<>();
     private final Map<EmailAddress, PullRequest> resolvedPullRequests = new HashMap<>();
@@ -45,7 +45,7 @@ public class MailingListArchiveReaderBot implements Bot {
     private final Pattern pullRequestLinkPattern = Pattern.compile("^(?:PR: |Pull request:\\R)(.*?)$", Pattern.MULTILINE);
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots.mlbridge");
 
-    MailingListArchiveReaderBot(EmailAddress archivePoster, MailingList list, Set<HostedRepository> repositories) {
+    MailingListArchiveReaderBot(EmailAddress archivePoster, MailingListReader list, Set<HostedRepository> repositories) {
         this.archivePoster = archivePoster;
         this.list = list;
         this.repositories = repositories;

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBot.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBot.java
@@ -36,7 +36,7 @@ import java.util.stream.Collectors;
 
 public class MailingListArchiveReaderBot implements Bot {
     private final EmailAddress archivePoster;
-    private final Set<MailingList> lists;
+    private final MailingList list;
     private final Set<HostedRepository> repositories;
     private final Map<EmailAddress, String> parsedConversations = new HashMap<>();
     private final Map<EmailAddress, PullRequest> resolvedPullRequests = new HashMap<>();
@@ -45,9 +45,9 @@ public class MailingListArchiveReaderBot implements Bot {
     private final Pattern pullRequestLinkPattern = Pattern.compile("^(?:PR: |Pull request:\\R)(.*?)$", Pattern.MULTILINE);
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots.mlbridge");
 
-    MailingListArchiveReaderBot(EmailAddress archivePoster, Set<MailingList> lists, Set<HostedRepository> repositories) {
+    MailingListArchiveReaderBot(EmailAddress archivePoster, MailingList list, Set<HostedRepository> repositories) {
         this.archivePoster = archivePoster;
-        this.lists = lists;
+        this.list = list;
         this.repositories = repositories;
     }
 
@@ -131,11 +131,9 @@ public class MailingListArchiveReaderBot implements Bot {
 
     @Override
     public List<WorkItem> getPeriodicItems() {
-        var readerItems = lists.stream()
-                               .map(list -> new ArchiveReaderWorkItem(this, list))
-                               .collect(Collectors.toList());
-
-        var ret = new ArrayList<WorkItem>(readerItems);
+        var readerItems = new ArchiveReaderWorkItem(this, list);
+        var ret = new ArrayList<WorkItem>();
+        ret.add(readerItems);
 
         // Check if there are any potential new comments to post
         var item = commentQueue.poll();

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotFactory.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotFactory.java
@@ -99,6 +99,7 @@ public class MailingListBridgeBotFactory implements BotFactory {
                 .collect(Collectors.toMap(obj -> obj.get("user").asString(),
                                           obj -> Pattern.compile(obj.get("pattern").asString())));
         var cooldown = specific.contains("cooldown") ? Duration.parse(specific.get("cooldown").asString()) : Duration.ofMinutes(1);
+        var mailmanServer = MailingListServerFactory.createMailmanServer(listArchive, listSmtp, Duration.ZERO);
 
         for (var repoConfig : specific.get("repositories").asArray()) {
             var repo = repoConfig.get("repository").asString();
@@ -109,7 +110,15 @@ public class MailingListBridgeBotFactory implements BotFactory {
                     repoConfig.get("headers").fields().stream()
                               .collect(Collectors.toMap(JSONObject.Field::name, field -> field.value().asString())) :
                     Map.of();
+
             var lists = parseLists(repoConfig.get("lists"));
+            var listsForReading = listNamesForReading.stream()
+                                                     .map(EmailAddress::localPart)
+                                                     .collect(Collectors.toList());
+            var bot = new MailingListArchiveReaderBot(from, mailmanServer.getList(listsForReading.toArray(new String[0])), allRepositories);
+            ret.add(bot);
+
+
             var folder = repoConfig.contains("folder") ? repoConfig.get("folder").asString() : configuration.repositoryName(repo);
 
             var webrevGenerateHTML = true;
@@ -163,14 +172,6 @@ public class MailingListBridgeBotFactory implements BotFactory {
             }
             allRepositories.add(configuration.repository(repo));
         }
-
-        var mailmanServer = MailingListServerFactory.createMailmanServer(listArchive, listSmtp, Duration.ZERO);
-        var listsForReading = listNamesForReading.stream()
-                                   .map(name -> mailmanServer.getList(name.toString()))
-                                   .collect(Collectors.toSet());
-
-        var bot = new MailingListArchiveReaderBot(from, listsForReading, allRepositories);
-        ret.add(bot);
 
         return ret;
     }

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBotTests.java
@@ -38,7 +38,7 @@ import java.util.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 class MailingListArchiveReaderBotTests {
-    private void addReply(Conversation conversation, EmailAddress recipient, MailingList mailingList, PullRequest pr, String reply) {
+    private void addReply(Conversation conversation, EmailAddress recipient, MailingListServer mailingListServer, PullRequest pr, String reply) {
         var first = conversation.first();
         var references = first.id().toString();
         var email = Email.create(EmailAddress.from("Commenter", "c@test.test"), "Re: RFR: " + pr.title(), reply)
@@ -47,11 +47,11 @@ class MailingListArchiveReaderBotTests {
                          .header("In-Reply-To", first.id().toString())
                          .header("References", references)
                          .build();
-        mailingList.post(email);
+        mailingListServer.post(email);
     }
 
-    private void addReply(Conversation conversation, EmailAddress recipient, MailingList mailingList, PullRequest pr) {
-        addReply(conversation, recipient, mailingList, pr, "Looks good");
+    private void addReply(Conversation conversation, EmailAddress recipient, MailingListServer mailingListServer, PullRequest pr) {
+        addReply(conversation, recipient, mailingListServer, pr, "Looks good");
     }
 
     @Test
@@ -87,7 +87,7 @@ class MailingListArchiveReaderBotTests {
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(),
                                                                              Duration.ZERO);
             var mailmanList = mailmanServer.getList(listAddress.address());
-            var readerBot = new MailingListArchiveReaderBot(from, Set.of(mailmanList), Set.of(archive));
+            var readerBot = new MailingListArchiveReaderBot(from, mailmanList, Set.of(archive));
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -113,7 +113,7 @@ class MailingListArchiveReaderBotTests {
             // Post a reply directly to the list
             var conversations = mailmanList.conversations(Duration.ofDays(1));
             assertEquals(1, conversations.size());
-            addReply(conversations.get(0), listAddress, mailmanList, pr);
+            addReply(conversations.get(0), listAddress, mailmanServer, pr);
             listServer.processIncoming();
 
             // Another archive reader pass - has to be done twice
@@ -163,7 +163,7 @@ class MailingListArchiveReaderBotTests {
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(),
                                                                              Duration.ZERO);
             var mailmanList = mailmanServer.getList(listAddress.address());
-            var readerBot = new MailingListArchiveReaderBot(from, Set.of(mailmanList), Set.of(archive));
+            var readerBot = new MailingListArchiveReaderBot(from, mailmanList, Set.of(archive));
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -185,7 +185,7 @@ class MailingListArchiveReaderBotTests {
             // Post a reply directly to the list
             var conversations = mailmanList.conversations(Duration.ofDays(1));
             assertEquals(1, conversations.size());
-            addReply(conversations.get(0), listAddress, mailmanList, pr);
+            addReply(conversations.get(0), listAddress, mailmanServer, pr);
             listServer.processIncoming();
 
             // Another archive reader pass - has to be done twice
@@ -196,7 +196,7 @@ class MailingListArchiveReaderBotTests {
             var updated = pr.comments();
             assertEquals(2, updated.size());
 
-            var newReaderBot = new MailingListArchiveReaderBot(from, Set.of(mailmanList), Set.of(archive));
+            var newReaderBot = new MailingListArchiveReaderBot(from, mailmanList, Set.of(archive));
             TestBotRunner.runPeriodicItems(newReaderBot);
             TestBotRunner.runPeriodicItems(newReaderBot);
 
@@ -239,7 +239,7 @@ class MailingListArchiveReaderBotTests {
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(),
                                                                              Duration.ZERO);
             var mailmanList = mailmanServer.getList(listAddress.address());
-            var readerBot = new MailingListArchiveReaderBot(from, Set.of(mailmanList), Set.of(archive));
+            var readerBot = new MailingListArchiveReaderBot(from, mailmanList, Set.of(archive));
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -267,7 +267,7 @@ class MailingListArchiveReaderBotTests {
             assertEquals(1, conversations.size());
 
             var replyBody = "This line is about 30 bytes long\n".repeat(1000 * 10);
-            addReply(conversations.get(0), listAddress, mailmanList, pr, replyBody);
+            addReply(conversations.get(0), listAddress, mailmanServer, pr, replyBody);
             listServer.processIncoming();
 
             // Another archive reader pass - has to be done twice

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBotTests.java
@@ -86,7 +86,7 @@ class MailingListArchiveReaderBotTests {
             // The mailing list as well
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(),
                                                                              Duration.ZERO);
-            var mailmanList = mailmanServer.getList(listAddress.address());
+            var mailmanList = mailmanServer.getListReader(listAddress.address());
             var readerBot = new MailingListArchiveReaderBot(from, mailmanList, Set.of(archive));
 
             // Populate the projects repository
@@ -162,7 +162,7 @@ class MailingListArchiveReaderBotTests {
             // The mailing list as well
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(),
                                                                              Duration.ZERO);
-            var mailmanList = mailmanServer.getList(listAddress.address());
+            var mailmanList = mailmanServer.getListReader(listAddress.address());
             var readerBot = new MailingListArchiveReaderBot(from, mailmanList, Set.of(archive));
 
             // Populate the projects repository
@@ -238,7 +238,7 @@ class MailingListArchiveReaderBotTests {
             // The mailing list as well
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(),
                                                                              Duration.ZERO);
-            var mailmanList = mailmanServer.getList(listAddress.address());
+            var mailmanList = mailmanServer.getListReader(listAddress.address());
             var readerBot = new MailingListArchiveReaderBot(from, mailmanList, Set.of(archive));
 
             // Populate the projects repository

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -215,7 +215,7 @@ class MailingListBridgeBotTests {
             // The mailing list as well
             listServer.processIncoming();
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
-            var mailmanList = mailmanServer.getList(listAddress.address());
+            var mailmanList = mailmanServer.getListReader(listAddress.address());
             var conversations = mailmanList.conversations(Duration.ofDays(1));
             assertEquals(1, conversations.size());
             var mail = conversations.get(0).first();
@@ -797,7 +797,7 @@ class MailingListBridgeBotTests {
 
             // The mailing list as well
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
-            var mailmanList = mailmanServer.getList(listAddress.address());
+            var mailmanList = mailmanServer.getListReader(listAddress.address());
             var conversations = mailmanList.conversations(Duration.ofDays(1));
             assertEquals(1, conversations.size());
             var mail = conversations.get(0).first();
@@ -885,7 +885,7 @@ class MailingListBridgeBotTests {
 
             // As well as the mailing list
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
-            var mailmanList = mailmanServer.getList(listAddress.address());
+            var mailmanList = mailmanServer.getListReader(listAddress.address());
             var conversations = mailmanList.conversations(Duration.ofDays(1));
             assertEquals(1, conversations.size());
             var mail = conversations.get(0).first();
@@ -1002,7 +1002,7 @@ class MailingListBridgeBotTests {
 
             // Check the mailing list
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
-            var mailmanList = mailmanServer.getList(listAddress.address());
+            var mailmanList = mailmanServer.getListReader(listAddress.address());
             var conversations = mailmanList.conversations(Duration.ofDays(1));
             assertEquals(1, conversations.size());
             var mail = conversations.get(0).first();
@@ -1605,7 +1605,7 @@ class MailingListBridgeBotTests {
 
             // Check that sender address is set properly
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
-            var mailmanList = mailmanServer.getList(listAddress.address());
+            var mailmanList = mailmanServer.getListReader(listAddress.address());
             var conversations = mailmanList.conversations(Duration.ofDays(1));
             assertEquals(1, conversations.size());
             for (var newMail : conversations.get(0).allMessages()) {
@@ -1732,7 +1732,7 @@ class MailingListBridgeBotTests {
 
             // Check that sender address is set properly
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
-            var mailmanList = mailmanServer.getList(listAddress.address());
+            var mailmanList = mailmanServer.getListReader(listAddress.address());
             var conversations = mailmanList.conversations(Duration.ofDays(1));
             assertEquals(1, conversations.size());
             for (var newMail : conversations.get(0).allMessages()) {
@@ -2897,7 +2897,7 @@ class MailingListBridgeBotTests {
 
             // The mail should have been sent to list1
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
-            var mailmanList = mailmanServer.getList(listAddress1.address());
+            var mailmanList = mailmanServer.getListReader(listAddress1.address());
             var conversations = mailmanList.conversations(Duration.ofDays(1));
             assertEquals(1, conversations.size());
             var mail = conversations.get(0).first();
@@ -3029,7 +3029,7 @@ class MailingListBridgeBotTests {
             // The mailing list as well
             listServer.processIncoming();
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
-            var mailmanList = mailmanServer.getList(listAddress.address());
+            var mailmanList = mailmanServer.getListReader(listAddress.address());
             var conversations = mailmanList.conversations(Duration.ofDays(1));
             assertEquals(1, conversations.size());
             var mail = conversations.get(0).first();

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/mailinglist/MailingListNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/mailinglist/MailingListNotifier.java
@@ -25,7 +25,7 @@ package org.openjdk.skara.bots.notify.mailinglist;
 import org.openjdk.skara.bots.notify.*;
 import org.openjdk.skara.email.*;
 import org.openjdk.skara.forge.*;
-import org.openjdk.skara.mailinglist.MailingList;
+import org.openjdk.skara.mailinglist.*;
 import org.openjdk.skara.vcs.*;
 import org.openjdk.skara.vcs.openjdk.OpenJDKTag;
 
@@ -37,7 +37,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 class MailingListNotifier implements Notifier, RepositoryListener {
-    private final MailingList list;
+    private final MailingListServer server;
     private final EmailAddress recipient;
     private final EmailAddress sender;
     private final EmailAddress author;
@@ -55,10 +55,10 @@ class MailingListNotifier implements Notifier, RepositoryListener {
         PR
     }
 
-    MailingListNotifier(MailingList list, EmailAddress recipient, EmailAddress sender, EmailAddress author,
-                       boolean includeBranch, boolean reportNewTags, boolean reportNewBranches, boolean reportNewBuilds,
-                       Mode mode, Map<String, String> headers, Pattern allowedAuthorDomains) {
-        this.list = list;
+    MailingListNotifier(MailingListServer server, EmailAddress recipient, EmailAddress sender, EmailAddress author,
+                        boolean includeBranch, boolean reportNewTags, boolean reportNewBranches, boolean reportNewBuilds,
+                        Mode mode, Map<String, String> headers, Pattern allowedAuthorDomains) {
+        this.server = server;
         this.recipient = recipient;
         this.sender = sender;
         this.author = author;
@@ -208,7 +208,7 @@ class MailingListNotifier implements Notifier, RepositoryListener {
                          .build();
 
         try {
-            list.post(email);
+            server.post(email);
         } catch (RuntimeException e) {
             throw new NonRetriableException(e);
         }
@@ -278,7 +278,7 @@ class MailingListNotifier implements Notifier, RepositoryListener {
         }
 
         try {
-            list.post(email.build());
+            server.post(email.build());
         } catch (RuntimeException e) {
             throw new NonRetriableException(e);
         }
@@ -311,7 +311,7 @@ class MailingListNotifier implements Notifier, RepositoryListener {
         }
 
         try {
-            list.post(email.build());
+            server.post(email.build());
         } catch (RuntimeException e) {
             throw new NonRetriableException(e);
         }
@@ -369,7 +369,7 @@ class MailingListNotifier implements Notifier, RepositoryListener {
                          .headers(commitHeaders(repository, commits))
                          .build();
         try {
-            list.post(email);
+            server.post(email);
         } catch (RuntimeException e) {
             throw new NonRetriableException(e);
         }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/mailinglist/MailingListNotifierBuilder.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/mailinglist/MailingListNotifierBuilder.java
@@ -23,13 +23,13 @@
 package org.openjdk.skara.bots.notify.mailinglist;
 
 import org.openjdk.skara.email.EmailAddress;
-import org.openjdk.skara.mailinglist.MailingList;
+import org.openjdk.skara.mailinglist.*;
 
 import java.util.Map;
 import java.util.regex.Pattern;
 
 class MailingListNotifierBuilder {
-    private MailingList list;
+    private MailingListServer server;
     private EmailAddress recipient;
     private EmailAddress sender;
     private EmailAddress author = null;
@@ -43,8 +43,8 @@ class MailingListNotifierBuilder {
     private boolean repoInSubject = false;
     private Pattern branchInSubject = Pattern.compile("a^"); // Does not match anything
 
-    public MailingListNotifierBuilder list(MailingList list) {
-        this.list = list;
+    public MailingListNotifierBuilder server(MailingListServer server) {
+        this.server = server;
         return this;
     }
 
@@ -99,7 +99,7 @@ class MailingListNotifierBuilder {
     }
 
     public MailingListNotifier build() {
-        return new MailingListNotifier(list, recipient, sender, author, includeBranch, reportNewTags, reportNewBranches,
-                                      reportNewBuilds, mode, headers, allowedAuthorDomains);
+        return new MailingListNotifier(server, recipient, sender, author, includeBranch, reportNewTags, reportNewBranches,
+                                       reportNewBuilds, mode, headers, allowedAuthorDomains);
     }
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/mailinglist/MailingListNotifierFactory.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/mailinglist/MailingListNotifierFactory.java
@@ -54,7 +54,7 @@ public class MailingListNotifierFactory implements NotifierFactory {
         var allowedDomains = author == null ? Pattern.compile(notifierConfiguration.get("domains").asString()) : null;
 
         var builder = MailingListNotifier.newBuilder()
-                                         .list(listServer.getList(recipient))
+                                         .server(listServer)
                                          .recipient(recipientAddress)
                                          .sender(sender)
                                          .author(author)

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/mailinglist/MailingListNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/mailinglist/MailingListNotifierTests.java
@@ -52,7 +52,7 @@ public class MailingListNotifierTests {
 
             var listAddress = EmailAddress.parse(listServer.createList("test"));
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
-            var mailmanList = mailmanServer.getList(listAddress.address());
+            var mailmanList = mailmanServer.getListReader(listAddress.address());
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
             var prStateStorage = createPullRequestStateStorage(repo);
@@ -124,7 +124,7 @@ public class MailingListNotifierTests {
 
             var listAddress = EmailAddress.parse(listServer.createList("test"));
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
-            var mailmanList = mailmanServer.getList(listAddress.address());
+            var mailmanList = mailmanServer.getListReader(listAddress.address());
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
             var prStateStorage = createPullRequestStateStorage(repo);
@@ -196,7 +196,7 @@ public class MailingListNotifierTests {
 
             var listAddress = EmailAddress.parse(listServer.createList("test"));
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
-            var mailmanList = mailmanServer.getList(listAddress.address());
+            var mailmanList = mailmanServer.getListReader(listAddress.address());
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
             var prStateStorage = createPullRequestStateStorage(repo);
@@ -274,7 +274,7 @@ public class MailingListNotifierTests {
 
             var listAddress = EmailAddress.parse(listServer.createList("test"));
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
-            var mailmanList = mailmanServer.getList(listAddress.address());
+            var mailmanList = mailmanServer.getListReader(listAddress.address());
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
             var prStateStorage = createPullRequestStateStorage(repo);
@@ -338,7 +338,7 @@ public class MailingListNotifierTests {
 
             var listAddress = EmailAddress.parse(listServer.createList("test"));
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
-            var mailmanList = mailmanServer.getList(listAddress.address());
+            var mailmanList = mailmanServer.getListReader(listAddress.address());
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
             var prStateStorage = createPullRequestStateStorage(repo);
@@ -436,7 +436,7 @@ public class MailingListNotifierTests {
 
             var listAddress = EmailAddress.parse(listServer.createList("test"));
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
-            var mailmanList = mailmanServer.getList(listAddress.address());
+            var mailmanList = mailmanServer.getListReader(listAddress.address());
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
             var prStateStorage = createPullRequestStateStorage(repo);
@@ -522,7 +522,7 @@ public class MailingListNotifierTests {
 
             var listAddress = EmailAddress.parse(listServer.createList("test"));
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
-            var mailmanList = mailmanServer.getList(listAddress.address());
+            var mailmanList = mailmanServer.getListReader(listAddress.address());
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
             var prStateStorage = createPullRequestStateStorage(repo);
@@ -613,7 +613,7 @@ public class MailingListNotifierTests {
 
             var listAddress = EmailAddress.parse(listServer.createList("test"));
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
-            var mailmanList = mailmanServer.getList(listAddress.address());
+            var mailmanList = mailmanServer.getListReader(listAddress.address());
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
             var prStateStorage = createPullRequestStateStorage(repo);
@@ -710,7 +710,7 @@ public class MailingListNotifierTests {
 
             var listAddress = EmailAddress.parse(listServer.createList("test"));
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
-            var mailmanList = mailmanServer.getList(listAddress.address());
+            var mailmanList = mailmanServer.getListReader(listAddress.address());
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
             var prStateStorage = createPullRequestStateStorage(repo);
@@ -806,7 +806,7 @@ public class MailingListNotifierTests {
 
             var listAddress = EmailAddress.parse(listServer.createList("test"));
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
-            var mailmanList = mailmanServer.getList(listAddress.address());
+            var mailmanList = mailmanServer.getListReader(listAddress.address());
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
             var prStateStorage = createPullRequestStateStorage(repo);
@@ -925,7 +925,7 @@ public class MailingListNotifierTests {
 
             var listAddress = EmailAddress.parse(listServer.createList("test"));
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
-            var mailmanList = mailmanServer.getList(listAddress.address());
+            var mailmanList = mailmanServer.getListReader(listAddress.address());
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
             var prStateStorage = createPullRequestStateStorage(repo);
@@ -1019,7 +1019,7 @@ public class MailingListNotifierTests {
 
             var listAddress = EmailAddress.parse(listServer.createList("test"));
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
-            var mailmanList = mailmanServer.getList(listAddress.address());
+            var mailmanList = mailmanServer.getListReader(listAddress.address());
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
             var prStateStorage = createPullRequestStateStorage(repo);
@@ -1099,7 +1099,7 @@ public class MailingListNotifierTests {
 
             var listAddress = EmailAddress.parse(listServer.createList("test"));
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
-            var mailmanList = mailmanServer.getList(listAddress.address());
+            var mailmanList = mailmanServer.getListReader(listAddress.address());
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
             var prStateStorage = createPullRequestStateStorage(repo);

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/mailinglist/MailingListNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/mailinglist/MailingListNotifierTests.java
@@ -68,7 +68,7 @@ public class MailingListNotifierTests {
                                      .prStateStorageBuilder(prStateStorage)
                                      .build();
             var updater = MailingListNotifier.newBuilder()
-                                             .list(mailmanList)
+                                             .server(mailmanServer)
                                              .recipient(listAddress)
                                              .sender(sender)
                                              .reportNewTags(false)
@@ -140,7 +140,7 @@ public class MailingListNotifierTests {
                                      .prStateStorageBuilder(prStateStorage)
                                      .build();
             var updater = MailingListNotifier.newBuilder()
-                                             .list(mailmanList)
+                                             .server(mailmanServer)
                                              .recipient(listAddress)
                                              .sender(sender)
                                              .reportNewTags(false)
@@ -212,7 +212,7 @@ public class MailingListNotifierTests {
                                      .prStateStorageBuilder(prStateStorage)
                                      .build();
             var updater = MailingListNotifier.newBuilder()
-                                             .list(mailmanList)
+                                             .server(mailmanServer)
                                              .recipient(listAddress)
                                              .sender(sender)
                                              .reportNewTags(false)
@@ -290,7 +290,7 @@ public class MailingListNotifierTests {
                                      .prStateStorageBuilder(prStateStorage)
                                      .build();
             var updater = MailingListNotifier.newBuilder()
-                                             .list(mailmanList)
+                                             .server(mailmanServer)
                                              .recipient(listAddress)
                                              .sender(sender)
                                              .reportNewTags(false)
@@ -355,7 +355,7 @@ public class MailingListNotifierTests {
                                      .prStateStorageBuilder(prStateStorage)
                                      .build();
             var updater = MailingListNotifier.newBuilder()
-                                             .list(mailmanList)
+                                             .server(mailmanServer)
                                              .recipient(listAddress)
                                              .sender(sender)
                                              .author(author)
@@ -453,7 +453,7 @@ public class MailingListNotifierTests {
                                      .prStateStorageBuilder(prStateStorage)
                                      .build();
             var updater = MailingListNotifier.newBuilder()
-                                             .list(mailmanList)
+                                             .server(mailmanServer)
                                              .recipient(listAddress)
                                              .sender(sender)
                                              .author(author)
@@ -486,7 +486,7 @@ public class MailingListNotifierTests {
             var rfr = Email.create(sender, "RFR: My PR", "PR: " + pr.webUrl().toString())
                            .recipient(listAddress)
                            .build();
-            mailmanList.post(rfr);
+            mailmanServer.post(rfr);
             listServer.processIncoming();
 
             // And an integration (but it hasn't reached master just yet)
@@ -538,7 +538,7 @@ public class MailingListNotifierTests {
                                      .prStateStorageBuilder(prStateStorage)
                                      .build();
             var updater = MailingListNotifier.newBuilder()
-                                             .list(mailmanList)
+                                             .server(mailmanServer)
                                              .recipient(listAddress)
                                              .sender(sender)
                                              .reportNewTags(false)
@@ -570,7 +570,7 @@ public class MailingListNotifierTests {
                            .author(EmailAddress.from("duke", "duke@duke.duke"))
                            .recipient(listAddress)
                            .build();
-            mailmanList.post(rfr);
+            mailmanServer.post(rfr);
             listServer.processIncoming();
 
             // And an integration
@@ -629,7 +629,7 @@ public class MailingListNotifierTests {
                                      .prStateStorageBuilder(prStateStorage)
                                      .build();
             var updater = MailingListNotifier.newBuilder()
-                                             .list(mailmanList)
+                                             .server(mailmanServer)
                                              .recipient(listAddress)
                                              .sender(sender)
                                              .reportNewTags(false)
@@ -669,7 +669,7 @@ public class MailingListNotifierTests {
                            .author(EmailAddress.from("duke", "duke@duke.duke"))
                            .recipient(listAddress)
                            .build();
-            mailmanList.post(rfr);
+            mailmanServer.post(rfr);
             listServer.processIncoming();
 
             // And an integration
@@ -726,7 +726,7 @@ public class MailingListNotifierTests {
                                      .prStateStorageBuilder(prStateStorage)
                                      .build();
             var updater = MailingListNotifier.newBuilder()
-                                             .list(mailmanList)
+                                             .server(mailmanServer)
                                              .recipient(listAddress)
                                              .sender(sender)
                                              .author(null)
@@ -755,7 +755,7 @@ public class MailingListNotifierTests {
                            .author(EmailAddress.from("duke", "duke@duke.duke"))
                            .recipient(listAddress)
                            .build();
-            mailmanList.post(rfr);
+            mailmanServer.post(rfr);
             listServer.processIncoming();
 
             // And an integration
@@ -822,7 +822,7 @@ public class MailingListNotifierTests {
                                      .prStateStorageBuilder(prStateStorage)
                                      .build();
             var updater = MailingListNotifier.newBuilder()
-                                             .list(mailmanList)
+                                             .server(mailmanServer)
                                              .recipient(listAddress)
                                              .sender(sender)
                                              .reportNewBranches(false)
@@ -831,7 +831,7 @@ public class MailingListNotifierTests {
             updater.attachTo(notifyBot);
 
             var noTagsUpdater = MailingListNotifier.newBuilder()
-                                                   .list(mailmanList)
+                                                   .server(mailmanServer)
                                                    .recipient(listAddress)
                                                    .sender(sender)
                                                    .reportNewTags(false)
@@ -941,7 +941,7 @@ public class MailingListNotifierTests {
                                      .prStateStorageBuilder(prStateStorage)
                                      .build();
             var updater = MailingListNotifier.newBuilder()
-                                             .list(mailmanList)
+                                             .server(mailmanServer)
                                              .recipient(listAddress)
                                              .sender(sender)
                                              .reportNewBranches(false)
@@ -950,7 +950,7 @@ public class MailingListNotifierTests {
                                              .build();
             updater.attachTo(notifyBot);
             var noTagsUpdater = MailingListNotifier.newBuilder()
-                                                   .list(mailmanList)
+                                                   .server(mailmanServer)
                                                    .recipient(listAddress)
                                                    .sender(sender)
                                                    .reportNewTags(false)
@@ -1035,7 +1035,7 @@ public class MailingListNotifierTests {
                                      .prStateStorageBuilder(prStateStorage)
                                      .build();
             var updater = MailingListNotifier.newBuilder()
-                                             .list(mailmanList)
+                                             .server(mailmanServer)
                                              .recipient(listAddress)
                                              .sender(sender)
                                              .reportNewTags(false)
@@ -1115,7 +1115,7 @@ public class MailingListNotifierTests {
                                      .prStateStorageBuilder(prStateStorage)
                                      .build();
             var updater = MailingListNotifier.newBuilder()
-                                             .list(mailmanList)
+                                             .server(mailmanServer)
                                              .recipient(listAddress)
                                              .sender(sender)
                                              .reportNewTags(false)

--- a/mailinglist/src/main/java/org/openjdk/skara/mailinglist/MailingList.java
+++ b/mailinglist/src/main/java/org/openjdk/skara/mailinglist/MailingList.java
@@ -22,12 +22,9 @@
  */
 package org.openjdk.skara.mailinglist;
 
-import org.openjdk.skara.email.*;
-
 import java.time.Duration;
-import java.util.*;
+import java.util.List;
 
 public interface MailingList {
-    void post(Email email);
     List<Conversation> conversations(Duration maxAge);
 }

--- a/mailinglist/src/main/java/org/openjdk/skara/mailinglist/MailingListReader.java
+++ b/mailinglist/src/main/java/org/openjdk/skara/mailinglist/MailingListReader.java
@@ -25,6 +25,6 @@ package org.openjdk.skara.mailinglist;
 import java.time.Duration;
 import java.util.List;
 
-public interface MailingList {
+public interface MailingListReader {
     List<Conversation> conversations(Duration maxAge);
 }

--- a/mailinglist/src/main/java/org/openjdk/skara/mailinglist/MailingListServer.java
+++ b/mailinglist/src/main/java/org/openjdk/skara/mailinglist/MailingListServer.java
@@ -25,6 +25,6 @@ package org.openjdk.skara.mailinglist;
 import org.openjdk.skara.email.Email;
 
 public interface MailingListServer {
-    MailingList getList(String... names);
+    MailingListReader getListReader(String... listNames);
     void post(Email email);
 }

--- a/mailinglist/src/main/java/org/openjdk/skara/mailinglist/MailingListServer.java
+++ b/mailinglist/src/main/java/org/openjdk/skara/mailinglist/MailingListServer.java
@@ -22,6 +22,9 @@
  */
 package org.openjdk.skara.mailinglist;
 
+import org.openjdk.skara.email.Email;
+
 public interface MailingListServer {
-    MailingList getList(String name);
+    MailingList getList(String... names);
+    void post(Email email);
 }

--- a/mailinglist/src/main/java/org/openjdk/skara/mailinglist/MailingListServerFactory.java
+++ b/mailinglist/src/main/java/org/openjdk/skara/mailinglist/MailingListServerFactory.java
@@ -30,7 +30,6 @@ import java.nio.file.Path;
 import java.time.Duration;
 
 public class MailingListServerFactory {
-
     public static MailingListServer createMailmanServer(URI archive, String smtp, Duration sendInterval) {
         return new MailmanServer(archive, smtp, sendInterval);
     }

--- a/mailinglist/src/main/java/org/openjdk/skara/mailinglist/Mbox.java
+++ b/mailinglist/src/main/java/org/openjdk/skara/mailinglist/Mbox.java
@@ -83,8 +83,7 @@ public class Mbox {
 
     private static final Pattern inReplyToPattern = Pattern.compile("<(.*@.*?)>");
 
-    public static List<Conversation> parseMbox(String mbox, EmailAddress sender) {
-        var emails = splitMbox(mbox, sender);
+    public static List<Conversation> parseMbox(List<Email> emails) {
         var idToMail = emails.stream().collect(Collectors.toMap(Email::id, Function.identity(), (a, b) -> a));
         var idToConversation = idToMail.values().stream()
                                        .filter(email -> !email.hasHeader("In-Reply-To"))

--- a/mailinglist/src/main/java/org/openjdk/skara/mailinglist/mailman/MailmanList.java
+++ b/mailinglist/src/main/java/org/openjdk/skara/mailinglist/mailman/MailmanList.java
@@ -36,7 +36,7 @@ import java.util.stream.Collectors;
 
 public class MailmanList implements MailingList {
     private final MailmanServer server;
-    private final EmailAddress listAddress;
+    private final List<String> names = new ArrayList<>();
     private final Logger log = Logger.getLogger("org.openjdk.skara.mailinglist");
     private final ConcurrentMap<URI, HttpResponse<String>> pageCache = new ConcurrentHashMap<>();
     private List<Conversation> cachedConversations = new ArrayList<>();
@@ -44,19 +44,20 @@ public class MailmanList implements MailingList {
                                                        .connectTimeout(Duration.ofSeconds(10))
                                                        .build();
 
-    MailmanList(MailmanServer server, EmailAddress name) {
+    MailmanList(MailmanServer server, Collection<String> names) {
         this.server = server;
-        this.listAddress = name;
+        for (var name : names) {
+            if (name.contains("@")) {
+                this.names.add(EmailAddress.parse(name).localPart());
+            } else {
+                this.names.add(name);
+            }
+        }
     }
 
     @Override
     public String toString() {
-        return "MailmanList:" + listAddress;
-    }
-
-    @Override
-    public void post(Email email) {
-        server.sendMessage(email);
+        return "MailmanList:" + String.join(", ", names);
     }
 
     private List<ZonedDateTime> getMonthRange(Duration maxAge) {
@@ -75,7 +76,7 @@ public class MailmanList implements MailingList {
         return ret;
     }
 
-    private Optional<HttpResponse<String>> getPage(HttpClient client, URI uri) {
+    private Optional<HttpResponse<String>> getPage(URI uri) {
         var requestBuilder = HttpRequest.newBuilder(uri)
                                         .timeout(Duration.ofSeconds(30))
                                         .GET();
@@ -114,39 +115,44 @@ public class MailmanList implements MailingList {
                                                   .sorted(Comparator.reverseOrder())
                                                   .collect(Collectors.toList());
 
-        var actualPages = new LinkedList<String>();
-        var useCached = false;
+        var useCached = new HashMap<String, Boolean>();
+        for (var name : names) {
+            useCached.put(name, false);
+        }
         var newContent = false;
+        var emails = new ArrayList<Email>();
         for (var month : potentialPages) {
-            URI mboxUri = server.getMbox(listAddress.localPart(), month);
+            for (var name : names) {
+                URI mboxUri = server.getMbox(name, month);
+                var sender = EmailAddress.from(name + "@" + mboxUri.getHost());
 
-            if (useCached) {
-                var cachedResponse = pageCache.get(mboxUri);
-                if (cachedResponse == null) {
-                    break;
+                if (useCached.get(name)) {
+                    var cachedResponse = pageCache.get(mboxUri);
+                    if (cachedResponse == null) {
+                        break;
+                    } else {
+                        emails.addAll(0, Mbox.splitMbox(cachedResponse.body(), sender));
+                    }
                 } else {
-                    actualPages.addFirst(cachedResponse.body());
-                }
-            } else {
-                var mboxResponse = getPage(client, mboxUri);
-                if (mboxResponse.isEmpty()) {
-                    break;
-                }
-                if (mboxResponse.get().statusCode() == 304) {
-                    actualPages.addFirst(pageCache.get(mboxUri).body());
-                    useCached = true;
-                } else {
-                    actualPages.addFirst(mboxResponse.get().body());
-                    newContent = true;
+                    var mboxResponse = getPage(mboxUri);
+                    if (mboxResponse.isEmpty()) {
+                        break;
+                    }
+                    if (mboxResponse.get().statusCode() == 304) {
+                        emails.addAll(0, Mbox.splitMbox(pageCache.get(mboxUri).body(), sender));
+                        useCached.put(name, true);
+                    } else {
+                        emails.addAll(0, Mbox.splitMbox(mboxResponse.get().body(), sender));
+                        newContent = true;
+                    }
                 }
             }
         }
 
         if (newContent) {
-            var concatenatedMbox = String.join("", actualPages);
-            var mails = Mbox.parseMbox(concatenatedMbox, listAddress);
+            var conversations = Mbox.parseConversations(emails);
             var threshold = ZonedDateTime.now().minus(maxAge);
-            cachedConversations = mails.stream()
+            cachedConversations = conversations.stream()
                                        .filter(mail -> mail.first().date().isAfter(threshold))
                                        .collect(Collectors.toList());
         }

--- a/mailinglist/src/main/java/org/openjdk/skara/mailinglist/mailman/MailmanListReader.java
+++ b/mailinglist/src/main/java/org/openjdk/skara/mailinglist/mailman/MailmanListReader.java
@@ -34,7 +34,7 @@ import java.util.concurrent.*;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
-public class MailmanList implements MailingList {
+public class MailmanListReader implements MailingListReader {
     private final MailmanServer server;
     private final List<String> names = new ArrayList<>();
     private final Logger log = Logger.getLogger("org.openjdk.skara.mailinglist");
@@ -44,7 +44,7 @@ public class MailmanList implements MailingList {
                                                        .connectTimeout(Duration.ofSeconds(10))
                                                        .build();
 
-    MailmanList(MailmanServer server, Collection<String> names) {
+    MailmanListReader(MailmanServer server, Collection<String> names) {
         this.server = server;
         for (var name : names) {
             if (name.contains("@")) {

--- a/mailinglist/src/main/java/org/openjdk/skara/mailinglist/mailman/MailmanListReader.java
+++ b/mailinglist/src/main/java/org/openjdk/skara/mailinglist/mailman/MailmanListReader.java
@@ -150,7 +150,7 @@ public class MailmanListReader implements MailingListReader {
         }
 
         if (newContent) {
-            var conversations = Mbox.parseConversations(emails);
+            var conversations = Mbox.parseMbox(emails);
             var threshold = ZonedDateTime.now().minus(maxAge);
             cachedConversations = conversations.stream()
                                        .filter(mail -> mail.first().date().isAfter(threshold))

--- a/mailinglist/src/main/java/org/openjdk/skara/mailinglist/mailman/MailmanServer.java
+++ b/mailinglist/src/main/java/org/openjdk/skara/mailinglist/mailman/MailmanServer.java
@@ -71,7 +71,7 @@ public class MailmanServer implements MailingListServer {
     }
 
     @Override
-    public MailingList getList(String... names) {
-        return new MailmanList(this, Arrays.asList(names));
+    public MailingListReader getListReader(String... listNames) {
+        return new MailmanListReader(this, Arrays.asList(listNames));
     }
 }

--- a/mailinglist/src/main/java/org/openjdk/skara/mailinglist/mailman/MailmanServer.java
+++ b/mailinglist/src/main/java/org/openjdk/skara/mailinglist/mailman/MailmanServer.java
@@ -23,20 +23,20 @@
 package org.openjdk.skara.mailinglist.mailman;
 
 import org.openjdk.skara.email.*;
-import org.openjdk.skara.network.URIBuilder;
 import org.openjdk.skara.mailinglist.*;
+import org.openjdk.skara.network.URIBuilder;
 
 import java.io.*;
 import java.net.URI;
 import java.time.*;
 import java.time.format.DateTimeFormatter;
-import java.util.Locale;
+import java.util.*;
 
 public class MailmanServer implements MailingListServer {
     private final URI archive;
     private final String smtpServer;
+    private final Duration sendInterval;
     private volatile Instant lastSend;
-    private Duration sendInterval;
 
     public MailmanServer(URI archive, String smtpServer, Duration sendInterval) {
         this.archive = archive;
@@ -46,7 +46,7 @@ public class MailmanServer implements MailingListServer {
     }
 
     URI getMbox(String listName, ZonedDateTime month) {
-        var dateStr = DateTimeFormatter.ofPattern("YYYY-MMMM", Locale.US).format(month);
+        var dateStr = DateTimeFormatter.ofPattern("yyyy-MMMM", Locale.US).format(month);
         return URIBuilder.base(archive).appendPath(listName + "/" + dateStr + ".txt").build();
     }
 
@@ -66,7 +66,12 @@ public class MailmanServer implements MailingListServer {
     }
 
     @Override
-    public MailingList getList(String name) {
-        return new MailmanList(this, EmailAddress.parse(name));
+    public void post(Email email) {
+        sendMessage(email);
+    }
+
+    @Override
+    public MailingList getList(String... names) {
+        return new MailmanList(this, Arrays.asList(names));
     }
 }

--- a/mailinglist/src/main/java/org/openjdk/skara/mailinglist/mboxfile/MboxFileListReader.java
+++ b/mailinglist/src/main/java/org/openjdk/skara/mailinglist/mboxfile/MboxFileListReader.java
@@ -33,12 +33,12 @@ import java.util.*;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
-public class MboxFileList implements MailingList {
+public class MboxFileListReader implements MailingListReader {
     private final Path base;
     private final Collection<String> names;
     private final Logger log = Logger.getLogger("org.openjdk.skara.mailinglist");
 
-    MboxFileList(Path base, Collection<String> names) {
+    MboxFileListReader(Path base, Collection<String> names) {
         this.base = base;
         this.names = names;
     }

--- a/mailinglist/src/main/java/org/openjdk/skara/mailinglist/mboxfile/MboxFileListReader.java
+++ b/mailinglist/src/main/java/org/openjdk/skara/mailinglist/mboxfile/MboxFileListReader.java
@@ -59,7 +59,7 @@ public class MboxFileListReader implements MailingListReader {
             return new LinkedList<>();
         }
         var cutoff = Instant.now().minus(maxAge);
-        return Mbox.parseConversations(emails).stream()
+        return Mbox.parseMbox(emails).stream()
                    .filter(email -> email.first().date().toInstant().isAfter(cutoff))
                    .collect(Collectors.toList());
     }

--- a/mailinglist/src/main/java/org/openjdk/skara/mailinglist/mboxfile/MboxFileListServer.java
+++ b/mailinglist/src/main/java/org/openjdk/skara/mailinglist/mboxfile/MboxFileListServer.java
@@ -83,7 +83,7 @@ public class MboxFileListServer implements MailingListServer {
     }
 
     @Override
-    public MailingList getList(String... names) {
-        return new MboxFileList(base, Arrays.asList(names));
+    public MailingListReader getListReader(String... listNames) {
+        return new MboxFileListReader(base, Arrays.asList(listNames));
     }
 }

--- a/mailinglist/src/test/java/org/openjdk/skara/mailinglist/MailmanTests.java
+++ b/mailinglist/src/test/java/org/openjdk/skara/mailinglist/MailmanTests.java
@@ -38,7 +38,7 @@ class MailmanTests {
             var listAddress = testServer.createList("test");
             var mailmanServer = MailingListServerFactory.createMailmanServer(testServer.getArchive(), testServer.getSMTP(),
                                                                              Duration.ZERO);
-            var mailmanList = mailmanServer.getList(listAddress);
+            var mailmanList = mailmanServer.getListReader(listAddress);
             var sender = EmailAddress.from("Test", "test@test.email");
             var mail = Email.create(sender, "Subject", "Body")
                             .recipient(EmailAddress.parse(listAddress))
@@ -63,7 +63,7 @@ class MailmanTests {
             var listAddress = testServer.createList("test");
             var mailmanServer = MailingListServerFactory.createMailmanServer(testServer.getArchive(), testServer.getSMTP(),
                                                                              Duration.ZERO);
-            var mailmanList = mailmanServer.getList(listAddress);
+            var mailmanList = mailmanServer.getListReader(listAddress);
             var sender = EmailAddress.from("Test", "test@test.email");
             var sentParent = Email.create(sender, "Subject", "Body")
                                   .recipient(EmailAddress.parse(listAddress))
@@ -109,7 +109,7 @@ class MailmanTests {
             var listAddress = testServer.createList("test");
             var mailmanServer = MailingListServerFactory.createMailmanServer(testServer.getArchive(), testServer.getSMTP(),
                                                                              Duration.ZERO);
-            var mailmanList = mailmanServer.getList(listAddress);
+            var mailmanList = mailmanServer.getListReader(listAddress);
             var sender = EmailAddress.from("Test", "test@test.email");
             var mail = Email.create(sender, "Subject", "Body")
                             .recipient(EmailAddress.parse(listAddress))
@@ -143,7 +143,7 @@ class MailmanTests {
             var listAddress = testServer.createList("test");
             var mailmanServer = MailingListServerFactory.createMailmanServer(testServer.getArchive(), testServer.getSMTP(),
                                                                              Duration.ofDays(1));
-            var mailmanList = mailmanServer.getList(listAddress);
+            var mailmanList = mailmanServer.getListReader(listAddress);
             var sender = EmailAddress.from("Test", "test@test.email");
             var mail1 = Email.create(sender, "Subject 1", "Body 1")
                              .recipient(EmailAddress.parse(listAddress))

--- a/mailinglist/src/test/java/org/openjdk/skara/mailinglist/MailmanTests.java
+++ b/mailinglist/src/test/java/org/openjdk/skara/mailinglist/MailmanTests.java
@@ -22,10 +22,9 @@
  */
 package org.openjdk.skara.mailinglist;
 
+import org.junit.jupiter.api.Test;
 import org.openjdk.skara.email.*;
 import org.openjdk.skara.test.TestMailmanServer;
-
-import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -44,7 +43,7 @@ class MailmanTests {
             var mail = Email.create(sender, "Subject", "Body")
                             .recipient(EmailAddress.parse(listAddress))
                             .build();
-            mailmanList.post(mail);
+            mailmanServer.post(mail);
             var expectedMail = Email.from(mail)
                                     .sender(EmailAddress.parse(listAddress))
                                     .build();
@@ -69,7 +68,7 @@ class MailmanTests {
             var sentParent = Email.create(sender, "Subject", "Body")
                                   .recipient(EmailAddress.parse(listAddress))
                                   .build();
-            mailmanList.post(sentParent);
+            mailmanServer.post(sentParent);
             testServer.processIncoming();
             var expectedParent = Email.from(sentParent)
                                       .sender(EmailAddress.parse(listAddress))
@@ -85,7 +84,7 @@ class MailmanTests {
                                  .recipient(EmailAddress.parse(listAddress))
                                  .header("In-Reply-To", sentParent.id().toString())
                                  .build();
-            mailmanList.post(sentReply);
+            mailmanServer.post(sentReply);
             var expectedReply = Email.from(sentReply)
                                      .sender(EmailAddress.parse(listAddress))
                                      .build();
@@ -115,7 +114,7 @@ class MailmanTests {
             var mail = Email.create(sender, "Subject", "Body")
                             .recipient(EmailAddress.parse(listAddress))
                             .build();
-            mailmanList.post(mail);
+            mailmanServer.post(mail);
             testServer.processIncoming();
 
             var expectedMail = Email.from(mail)
@@ -153,8 +152,8 @@ class MailmanTests {
                              .recipient(EmailAddress.parse(listAddress))
                              .build();
             new Thread(() -> {
-                mailmanList.post(mail1);
-                mailmanList.post(mail2);
+                mailmanServer.post(mail1);
+                mailmanServer.post(mail2);
             }).start();
             var expectedMail = Email.from(mail1)
                                     .sender(EmailAddress.parse(listAddress))

--- a/mailinglist/src/test/java/org/openjdk/skara/mailinglist/MboxTests.java
+++ b/mailinglist/src/test/java/org/openjdk/skara/mailinglist/MboxTests.java
@@ -39,7 +39,7 @@ class MboxTests {
     void simple() {
         try (var folder = new TemporaryDirectory()) {
             var mbox = MailingListServerFactory.createMboxFileServer(folder.path());
-            var list = mbox.getList("test");
+            var list = mbox.getListReader("test");
 
             var sender = EmailAddress.from("test", "test@test.mail");
             var sentMail = Email.create(sender, "Subject", "Message")
@@ -60,7 +60,7 @@ class MboxTests {
     void multiple() {
         try (var folder = new TemporaryDirectory()) {
             var mbox = MailingListServerFactory.createMboxFileServer(folder.path());
-            var list = mbox.getList("test");
+            var list = mbox.getListReader("test");
 
             var sender1 = EmailAddress.from("test1", "test1@test.mail");
             var sender2 = EmailAddress.from("test2", "test2@test.mail");
@@ -99,7 +99,7 @@ class MboxTests {
     void uninitialized() {
         try (var folder = new TemporaryDirectory()) {
             var mbox = MailingListServerFactory.createMboxFileServer(folder.path());
-            var list = mbox.getList("test");
+            var list = mbox.getListReader("test");
             var conversations = list.conversations(Duration.ofDays(1));
             assertEquals(0, conversations.size());
         }
@@ -109,7 +109,7 @@ class MboxTests {
     void differentAuthor() {
         try (var folder = new TemporaryDirectory()) {
             var mbox = MailingListServerFactory.createMboxFileServer(folder.path());
-            var list = mbox.getList("test");
+            var list = mbox.getListReader("test");
 
             var sender = EmailAddress.from("test1", "test1@test.mail");
             var author = EmailAddress.from("test2", "test2@test.mail");
@@ -132,7 +132,7 @@ class MboxTests {
     void encodedFrom() {
         try (var folder = new TemporaryDirectory()) {
             var mbox = MailingListServerFactory.createMboxFileServer(folder.path());
-            var list = mbox.getList("test");
+            var list = mbox.getListReader("test");
 
             var sender = EmailAddress.from("test", "test@test.mail");
             var sentMail = Email.create(sender, "Subject", """
@@ -157,7 +157,7 @@ class MboxTests {
     void utf8Encode() {
         try (var folder = new TemporaryDirectory()) {
             var mbox = MailingListServerFactory.createMboxFileServer(folder.path());
-            var list = mbox.getList("test");
+            var list = mbox.getListReader("test");
 
             var sender = EmailAddress.from("têßt", "test@test.mail");
             var sentMail = Email.create(sender, "Sübjeçt", "(╯°□°)╯︵ ┻━┻")
@@ -190,7 +190,7 @@ class MboxTests {
                                       From this point onwards, it may be hard to parse this
                                       """, StandardCharsets.UTF_8);
             var mbox = MailingListServerFactory.createMboxFileServer(folder.path());
-            var list = mbox.getList("test");
+            var list = mbox.getListReader("test");
             var conversations = list.conversations(Duration.ofDays(365 * 100));
             assertEquals(1, conversations.size());
             var conversation = conversations.get(0);
@@ -224,7 +224,7 @@ class MboxTests {
                                       """,
                               StandardCharsets.UTF_8);
             var mbox = MailingListServerFactory.createMboxFileServer(folder.path());
-            var list = mbox.getList("test");
+            var list = mbox.getListReader("test");
             var conversations = list.conversations(Duration.ofDays(365 * 100));
             assertEquals(1, conversations.size());
             var conversation = conversations.get(0);
@@ -265,7 +265,7 @@ class MboxTests {
                                       """,
                               StandardCharsets.UTF_8);
             var mbox = MailingListServerFactory.createMboxFileServer(folder.path());
-            var list = mbox.getList("test");
+            var list = mbox.getListReader("test");
             var conversations = list.conversations(Duration.ofDays(365 * 100));
             assertEquals(1, conversations.size());
             var conversation = conversations.get(0);
@@ -327,7 +327,7 @@ class MboxTests {
                                       """,
                               StandardCharsets.UTF_8);
             var mbox = MailingListServerFactory.createMboxFileServer(folder.path());
-            var list = mbox.getList("test1", "test2");
+            var list = mbox.getListReader("test1", "test2");
             var conversations = list.conversations(Duration.ofDays(365 * 100));
             assertEquals(1, conversations.size());
             var conversation = conversations.get(0);
@@ -371,7 +371,7 @@ class MboxTests {
                                       """,
                               StandardCharsets.UTF_8);
             var mbox = MailingListServerFactory.createMboxFileServer(folder.path());
-            var list = mbox.getList("test1", "test2");
+            var list = mbox.getListReader("test1", "test2");
             var conversations = list.conversations(Duration.ofDays(365 * 100));
             assertEquals(1, conversations.size());
             var conversation = conversations.get(0);

--- a/test/src/main/java/org/openjdk/skara/test/TestMailmanServer.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestMailmanServer.java
@@ -101,7 +101,7 @@ public class TestMailmanServer implements AutoCloseable {
     }
 
     public String createList(String name) throws IOException {
-        var listName = EmailAddress.parse(name + "@testserver.test").toString();
+        var listName = EmailAddress.parse(name + "@" + httpServer.getAddress().getHostString()).toString();
         var listPath = Files.createTempFile("list-" + name, ".txt");
         lists.put(name, listPath);
         return listName;


### PR DESCRIPTION
When bridging emails from mailing lists to pull requests, it is necessary to look at lists that can contain cross-posts as a single source. Otherwise, parts of a thread may be missed as it is only found on a certain list, while other parts are on another list. This is commonly the case for the jdk repositories which has its reviews split over many lists.

To facilitate this, a MailingList can now be sourced from multiple actual lists, and is setup in that way when bridging repositories that are configured to use multiple lists for reviews. Sending mails are now done through the MailingListServer instead, as the actual target of a mail has always been decided by the email headers, and not the list send() was invoked on.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-843](https://bugs.openjdk.java.net/browse/SKARA-843): Mails are not forwarded to a closed PR any more


### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1103/head:pull/1103` \
`$ git checkout pull/1103`

Update a local copy of the PR: \
`$ git checkout pull/1103` \
`$ git pull https://git.openjdk.java.net/skara pull/1103/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1103`

View PR using the GUI difftool: \
`$ git pr show -t 1103`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1103.diff">https://git.openjdk.java.net/skara/pull/1103.diff</a>

</details>
