### PR TITLE
943: remote: GitLab: You can only delete protected branches using the web interface

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifier.java
@@ -63,14 +63,7 @@ public class PullRequestBranchNotifier implements Notifier, PullRequestListener 
             log.info("Pull request pre-integration branch " + PreIntegrations.preIntegrateBranch(pr) + " doesn't exist on remote - ignoring");
             return;
         }
-
-        var hostedRepositoryPool = new HostedRepositoryPool(seedFolder);
-        try {
-            var seedRepo = hostedRepositoryPool.seedRepository(pr.repository(), false);
-            seedRepo.prune(new Branch(PreIntegrations.preIntegrateBranch(pr)), pr.repository().url().toString());
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+        pr.repository().deleteBranch(PreIntegrations.preIntegrateBranch(pr));
     }
 
     @Override

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifierTests.java
@@ -131,6 +131,17 @@ public class PullRequestBranchNotifierTests {
             // Push another change
             var updatedHash = CheckableRepository.appendAndCommit(localRepo, "Yet another line");
             localRepo.push(updatedHash, repo.url(), "source");
+
+            // Make sure that the push registered
+            var lastHeadHash = pr.headHash();
+            var refreshCount = 0;
+            do {
+                pr = repo.pullRequest(pr.id());
+                if (refreshCount++ > 100) {
+                    fail("The PR did not update after the new push");
+                }
+            } while (pr.headHash().equals(lastHeadHash));
+
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The branch should have been updated

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
@@ -154,6 +154,10 @@ class InMemoryHostedRepository implements HostedRepository {
     }
 
     @Override
+    public void deleteBranch(String ref) {
+    }
+
+    @Override
     public List<CommitComment> commitComments(Hash commit) {
         return List.of();
     }

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
@@ -72,6 +72,7 @@ public interface HostedRepository {
     long id();
     Hash branchHash(String ref);
     List<HostedBranch> branches();
+    void deleteBranch(String ref);
     List<CommitComment> commitComments(Hash hash);
     default List<CommitComment> recentCommitComments() {
         return recentCommitComments(Map.of(), Set.of());

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -270,6 +270,12 @@ public class GitHubRepository implements HostedRepository {
                        .collect(Collectors.toList());
     }
 
+    @Override
+    public void deleteBranch(String ref) {
+        request.delete("git/refs/heads/" + ref)
+               .execute();
+    }
+
     private CommitComment toCommitComment(JSONValue o) {
         var hash = new Hash(o.get("commit_id").asString());
         var line = o.get("line").isNull()? -1 : o.get("line").asInt();

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -313,6 +313,12 @@ public class GitLabRepository implements HostedRepository {
                        .collect(Collectors.toList());
     }
 
+    @Override
+    public void deleteBranch(String ref) {
+        request.delete("repository/branches/" + URLEncoder.encode(ref, StandardCharsets.US_ASCII))
+               .execute();
+    }
+
     private CommitComment toCommitComment(Hash hash, JSONValue o) {
        var line = o.get("line").isNull()? -1 : o.get("line").asInt();
        var path = o.get("path").isNull()? null : Path.of(o.get("path").asString());

--- a/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
@@ -205,6 +205,15 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
     }
 
     @Override
+    public void deleteBranch(String ref) {
+        try {
+            localRepository.delete(new Branch(ref));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
     public List<CommitComment> commitComments(Hash hash) {
         if (!commitComments.containsKey(hash)) {
             return List.of();


### PR DESCRIPTION
Use a rest api to delete branches, to allow dependent pr branches to be configured as protected.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-943](https://bugs.openjdk.java.net/browse/SKARA-943): remote: GitLab: You can only delete protected branches using the web interface


### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1105/head:pull/1105` \
`$ git checkout pull/1105`

Update a local copy of the PR: \
`$ git checkout pull/1105` \
`$ git pull https://git.openjdk.java.net/skara pull/1105/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1105`

View PR using the GUI difftool: \
`$ git pr show -t 1105`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1105.diff">https://git.openjdk.java.net/skara/pull/1105.diff</a>

</details>
