### PR TITLE
forge: GitLab members endpoint return 404 for non-members

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -573,6 +573,9 @@ public class GitLabRepository implements HostedRepository {
     @Override
     public boolean canPush(HostUser user) {
         var accessLevel = request.get("members/" + user.id())
+                                 .onError(r -> r.statusCode() == 404 ?
+                                                   Optional.of(JSON.object().put("access_level", 0)) :
+                                                   Optional.empty())
                                  .execute()
                                  .get("access_level")
                                  .asInt();


### PR DESCRIPTION
Hi all,

please review this patch that fixes how `GitLabRepository.canPush` uses the `members` REST endpoint. Turns out that the `members` endpoint returns a `404` if the user is _not_ a member of the project (not documented of course :smile: ).

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1106/head:pull/1106` \
`$ git checkout pull/1106`

Update a local copy of the PR: \
`$ git checkout pull/1106` \
`$ git pull https://git.openjdk.java.net/skara pull/1106/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1106`

View PR using the GUI difftool: \
`$ git pr show -t 1106`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1106.diff">https://git.openjdk.java.net/skara/pull/1106.diff</a>

</details>
