### PR TITLE
715: Generated email wrongly includes previous unrelated comments

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveItem.java
@@ -297,14 +297,11 @@ class ArchiveItem {
     }
 
     static ArchiveItem findParent(List<ArchiveItem> generated, Comment comment) {
-        ArchiveItem lastCommentOrReview = generated.get(0);
         var eligible = new ArrayList<ArchiveItem>();
-        eligible.add(lastCommentOrReview);
         for (var item : generated) {
             if (item.id().startsWith("pc") || item.id().startsWith("rv")) {
-                if (item.createdAt().isBefore(comment.createdAt()) && item.createdAt().isAfter(lastCommentOrReview.createdAt())) {
-                    lastCommentOrReview = item;
-                    eligible.add(lastCommentOrReview);
+                if (item.createdAt().isBefore(comment.createdAt())) {
+                    eligible.add(item);
                 }
             }
         }
@@ -318,7 +315,15 @@ class ArchiveItem {
             return lastQuoted.get();
         }
 
-        return lastCommentOrReview;
+        ArchiveItem lastRevisionItem = generated.get(0);
+        for (var item : generated) {
+            if (item.id().startsWith("ha")) {
+                if (item.createdAt().isBefore(comment.createdAt())) {
+                    lastRevisionItem = item;
+                }
+            }
+        }
+        return lastRevisionItem;
     }
 
     static ArchiveItem findRevisionItem(List<ArchiveItem> generated, Hash hash) {

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/ArchiveItemTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/ArchiveItemTests.java
@@ -23,12 +23,14 @@
 package org.openjdk.skara.bots.mlbridge;
 
 import org.junit.jupiter.api.*;
-import org.openjdk.skara.forge.PullRequest;
+import org.openjdk.skara.forge.*;
 import org.openjdk.skara.host.HostUser;
 import org.openjdk.skara.issuetracker.Comment;
-import org.openjdk.skara.test.HostCredentials;
+import org.openjdk.skara.test.*;
+import org.openjdk.skara.vcs.Repository;
 
 import java.io.IOException;
+import java.net.URI;
 import java.time.ZonedDateTime;
 import java.util.List;
 
@@ -41,14 +43,21 @@ public class ArchiveItemTests {
         return new Comment(Integer.toString(curId++), body, user, ZonedDateTime.now(), ZonedDateTime.now());
     }
 
+    private ArchiveItem fromPullRequest(PullRequest pr, Repository repo) throws IOException {
+        var base = repo.resolve("master").orElseThrow();
+        return ArchiveItem.from(pr, repo, null, URI.create("http://www.example.com"), "", null, null, ZonedDateTime.now(), ZonedDateTime.now(), base, base, "", "");
+    }
+
     private ArchiveItem fromComment(PullRequest pr, Comment comment) {
         return ArchiveItem.from(pr, comment, null, null);
     }
 
     @Test
     void simple(TestInfo testInfo) throws IOException {
-        try (var credentials = new HostCredentials(testInfo)) {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
             var repo = credentials.getHostedRepository();
+            var localRepo = CheckableRepository.init(tempFolder.path(), repo.repositoryType());
             var pr = credentials.createPullRequest(repo, "master", "master", "Test");
 
             var user1 = HostUser.create("1", "user1", "User Uno");
@@ -58,17 +67,18 @@ public class ArchiveItemTests {
             var c1 = createComment(user1, "First comment\nwith two lines");
             var c2 = createComment(user2, "Second comment");
 
+            var a0 = fromPullRequest(pr, localRepo);
             var a1 = fromComment(pr, c1);
             var a2 = fromComment(pr, c2);
 
-            assertEquals(a2, ArchiveItem.findParent(List.of(a1, a2), createComment(user3, "Plain reply")));
+            assertEquals(a0, ArchiveItem.findParent(List.of(a0, a1, a2), createComment(user3, "Plain unrelated reply")));
 
-            assertEquals(a1, ArchiveItem.findParent(List.of(a1, a2), createComment(user3, "> First comment\n\nI agree")));
-            assertEquals(a1, ArchiveItem.findParent(List.of(a1, a2), createComment(user3, "> First comment\n>with two lines\n\nI agree")));
-            assertEquals(a1, ArchiveItem.findParent(List.of(a1, a2), createComment(user3, "\n> First comment\n\nI agree")));
+            assertEquals(a1, ArchiveItem.findParent(List.of(a0, a1, a2), createComment(user3, "> First comment\n\nI agree")));
+            assertEquals(a1, ArchiveItem.findParent(List.of(a0, a1, a2), createComment(user3, "> First comment\n>with two lines\n\nI agree")));
+            assertEquals(a1, ArchiveItem.findParent(List.of(a0, a1, a2), createComment(user3, "\n> First comment\n\nI agree")));
 
-            assertEquals(a1, ArchiveItem.findParent(List.of(a1, a2), createComment(user3, "@user1 I agree")));
-            assertEquals(a1, ArchiveItem.findParent(List.of(a1, a2), createComment(user3, "@user1\nI agree")));
+            assertEquals(a1, ArchiveItem.findParent(List.of(a0, a1, a2), createComment(user3, "@user1 I agree")));
+            assertEquals(a1, ArchiveItem.findParent(List.of(a0, a1, a2), createComment(user3, "@user1\nI agree")));
         }
     }
 }


### PR DESCRIPTION
When selecting a parent for a new comment, use the last revision email as parent if no quote / mention is found, as just using the latest one can be confusing if that's not really the intended context.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-715](https://bugs.openjdk.java.net/browse/SKARA-715): Generated email wrongly includes previous unrelated comments


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1108/head:pull/1108` \
`$ git checkout pull/1108`

Update a local copy of the PR: \
`$ git checkout pull/1108` \
`$ git pull https://git.openjdk.java.net/skara pull/1108/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1108`

View PR using the GUI difftool: \
`$ git pr show -t 1108`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1108.diff">https://git.openjdk.java.net/skara/pull/1108.diff</a>

</details>
