### PR TITLE
Backport security level should be inherited from main issue

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierBuilder.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierBuilder.java
@@ -36,7 +36,6 @@ class IssueNotifierBuilder {
     private boolean setFixVersion = false;
     private Map<String, String> fixVersions = null;
     private JbsVault vault = null;
-    private String securityLevel = null;
     private boolean prOnly = true;
     private String buildName = null;
 
@@ -81,11 +80,6 @@ class IssueNotifierBuilder {
         return this;
     }
 
-    public IssueNotifierBuilder securityLevel(String securityLevel) {
-        this.securityLevel = securityLevel;
-        return this;
-    }
-
     public IssueNotifierBuilder prOnly(boolean prOnly) {
         this.prOnly = prOnly;
         return this;
@@ -97,7 +91,7 @@ class IssueNotifierBuilder {
     }
 
     IssueNotifier build() {
-        var jbsBackport = new JbsBackport(issueProject.webUrl(), vault, securityLevel);
+        var jbsBackport = new JbsBackport(issueProject.webUrl(), vault);
         return new IssueNotifier(issueProject, reviewLink, reviewIcon, commitLink, commitIcon,
                                  setFixVersion, fixVersions, jbsBackport, prOnly, buildName);
     }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierFactory.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierFactory.java
@@ -84,10 +84,6 @@ public class IssueNotifierFactory implements NotifierFactory {
             }
         }
 
-        if (notifierConfiguration.contains("security")) {
-            builder.securityLevel(notifierConfiguration.get("security").asString());
-        }
-
         if (notifierConfiguration.contains("pronly")) {
             builder.prOnly(notifierConfiguration.get("pronly").asBoolean());
         }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/JbsBackport.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/JbsBackport.java
@@ -31,7 +31,6 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 public class JbsBackport {
-    private final String securityLevel;
     private final RestRequest backportRequest;
 
     private static URI backportRequest(URI uri) {
@@ -40,8 +39,7 @@ public class JbsBackport {
                          .build();
     }
 
-    JbsBackport(URI uri, JbsVault vault, String securityLevel) {
-        this.securityLevel = securityLevel;
+    JbsBackport(URI uri, JbsVault vault) {
         if (vault != null) {
             backportRequest = new RestRequest(backportRequest(uri), vault.authId(), () -> Arrays.asList("Cookie", vault.getCookie()));
         } else {
@@ -75,8 +73,8 @@ public class JbsBackport {
         if (assignee != null) {
             request.body("assignee", assignee);
         }
-        if (securityLevel != null) {
-            request.body("level", securityLevel);
+        if (primary.properties().containsKey("security")) {
+            request.body("level", primary.properties().get("security").asString());
         }
         var response = request.execute();
         var issue = primary.project().issue(response.get("key").asString()).orElseThrow();

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
@@ -1028,6 +1028,7 @@ public class IssueNotifierTests {
                                                  Map.of("issuetype", JSON.of("Enhancement"),
                                                         "customfield_10008", JSON.of("java.io")
                                                  ));
+            var level = issue.properties().get("security");
             issue.setProperty("fixVersions", JSON.array().add("13.0.1"));
             issue.setProperty("priority", JSON.of("1"));
             issue.addLabel("test");
@@ -1061,6 +1062,11 @@ public class IssueNotifierTests {
 
             // Labels should not
             assertEquals(0, backport.labelNames().size());
+
+            // If the parent issue has a security level (can be configured when running a test manually) it should be propagated
+            if (level != null) {
+                assertEquals(level.asString(), backport.properties().get("security").asString());
+            }
         }
     }
 }

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraProject.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraProject.java
@@ -212,7 +212,7 @@ public class JiraProject implements IssueProject {
     }
 
     private static final Set<String> knownProperties = Set.of("issuetype", "fixVersions", "versions", "priority", "components");
-    private static final Set<String> readOnlyProperties = Set.of("resolution");
+    private static final Set<String> readOnlyProperties = Set.of("resolution", "security");
 
     boolean isAllowedProperty(String name, boolean forWrite) {
         if (knownProperties.contains(name)) {
@@ -248,7 +248,8 @@ public class JiraProject implements IssueProject {
                 } // fall-through
             case "issuetype":
                 return Optional.of(JSON.of(value.get("name").asString()));
-            case "priority":
+            case "priority": // fall-through
+            case "security":
                 return Optional.of(JSON.of(value.get("id").asString()));
             default:
                 return Optional.of(value);


### PR DESCRIPTION
This is a change Robin prepared, but we need to deploy it ASAP to match the new behavior in the backport plugin after the Jira upgrade. The security level of a backport should simply be based on the security level of the primary bug.