### PR TITLE
769: Replies to e-mail comments on GitHub are threaded incorrectly

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveItem.java
@@ -296,7 +296,7 @@ class ArchiveItem {
         return Optional.empty();
     }
 
-    static ArchiveItem findParent(List<ArchiveItem> generated, Comment comment) {
+    static ArchiveItem findParent(List<ArchiveItem> generated, List<BridgedComment> bridgedComments, Comment comment) {
         var eligible = new ArrayList<ArchiveItem>();
         for (var item : generated) {
             if (item.id().startsWith("pc") || item.id().startsWith("rv")) {
@@ -310,6 +310,14 @@ class ArchiveItem {
         if (lastMention.isPresent()) {
             return lastMention.get();
         }
+
+        // It is possible to quote a bridged comment when replying - make these eligible as well
+        for (var bridged : bridgedComments) {
+            var item = new ArchiveItem(generated.get(0), "br" + bridged.messageId().address(), bridged.created(), bridged.created(),
+                                       bridged.author(), null, generated.get(0).subject, null, bridged::body, null);
+            eligible.add(item);
+        }
+
         var lastQuoted = findLastQuoted(comment.body(), eligible);
         if (lastQuoted.isPresent()) {
             return lastQuoted.get();

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
@@ -188,6 +188,9 @@ class ArchiveWorkItem implements WorkItem {
         if (bot.ignoredUsers().contains(originalAuthor.username())) {
             return bot.emailAddress();
         }
+        if (BridgedComment.isBridgedUser(originalAuthor)) {
+            return EmailAddress.from(originalAuthor.fullName(), originalAuthor.email().orElseThrow());
+        }
 
         var contributor = censusInstance.namespace().get(originalAuthor.id());
         if (contributor == null) {

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/BridgedComment.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/BridgedComment.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.mlbridge;
+
+import org.openjdk.skara.email.*;
+import org.openjdk.skara.forge.PullRequest;
+import org.openjdk.skara.host.HostUser;
+import org.openjdk.skara.issuetracker.Comment;
+
+import java.nio.charset.StandardCharsets;
+import java.time.ZonedDateTime;
+import java.util.*;
+import java.util.regex.Pattern;
+
+public class BridgedComment {
+    private final EmailAddress messageId;
+    private final String body;
+    private final HostUser author;
+    private final ZonedDateTime created;
+
+    private final static String bridgedMailMarker = "<!-- Bridged id (%s) -->";
+    private final static Pattern bridgedMailId = Pattern.compile("^<!-- Bridged id \\(([=\\w]+)\\) -->");
+    private final static Pattern bridgedSender = Pattern.compile("Mailing list message from \\[(.*?)]\\(mailto:(\\S+)\\)");
+
+    private BridgedComment(String body, EmailAddress messageId, HostUser author, ZonedDateTime created) {
+        this.messageId = messageId;
+        this.body = body;
+        this.author = author;
+        this.created = created;
+    }
+
+    static Optional<BridgedComment> from(Comment comment, HostUser botUser) {
+        if (!comment.author().equals(botUser)) {
+            return Optional.empty();
+        }
+        var matcher = bridgedMailId.matcher(comment.body());
+        if (!matcher.find()) {
+            return Optional.empty();
+        }
+        var id = new String(Base64.getDecoder().decode(matcher.group(1)), StandardCharsets.UTF_8);
+        var senderMatcher = bridgedSender.matcher(comment.body());
+        if (!senderMatcher.find()) {
+            return Optional.empty();
+        }
+        var author = HostUser.builder()
+                             .id("bridged")
+                             .username("bridged")
+                             .fullName(senderMatcher.group(1))
+                             .email(senderMatcher.group(2))
+                             .build();
+        var headerEnd = comment.body().indexOf("\n\n", senderMatcher.end());
+        var bridgedBody = comment.body().substring(headerEnd).strip();
+        return Optional.of(new BridgedComment(bridgedBody, EmailAddress.from(id), author, comment.createdAt()));
+    }
+
+    static BridgedComment post(PullRequest pr, Email email) {
+        var marker = String.format(bridgedMailMarker,
+                                   Base64.getEncoder().encodeToString(email.id().address().getBytes(StandardCharsets.UTF_8)));
+
+        var filteredEmail = QuoteFilter.stripLinkBlock(email.body(), pr.webUrl());
+        var body = marker + "\n" +
+                "*Mailing list message from [" + email.author().fullName().orElse(email.author().localPart()) +
+                "](mailto:" + email.author().address() + ") on [" + email.sender().localPart() +
+                "](mailto:" + email.sender().address() + "):*\n\n" +
+                TextToMarkdown.escapeFormatting(filteredEmail);
+        if (body.length() > 64000) {
+            body = body.substring(0, 64000) + "...\n\n" + "" +
+                    "This message was too large to bridge in full, and has been truncated. " +
+                    "Please check the mailing list archive to see the full text.";
+        }
+        var comment = pr.addComment(body);
+        return BridgedComment.from(comment, pr.repository().forge().currentUser()).orElseThrow();
+    }
+
+    public EmailAddress messageId() {
+        return messageId;
+    }
+
+    public String body() {
+        return body;
+    }
+
+    public HostUser author() {
+        return author;
+    }
+
+    public ZonedDateTime created() {
+        return created;
+    }
+
+    public static boolean isBridgedUser(HostUser user) {
+        // All supported platforms use numerical IDs, so this special one can not cause conflicts
+        return user.id().equals("bridged");
+    }
+}

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/ArchiveItemTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/ArchiveItemTests.java
@@ -71,14 +71,14 @@ public class ArchiveItemTests {
             var a1 = fromComment(pr, c1);
             var a2 = fromComment(pr, c2);
 
-            assertEquals(a0, ArchiveItem.findParent(List.of(a0, a1, a2), createComment(user3, "Plain unrelated reply")));
+            assertEquals(a0, ArchiveItem.findParent(List.of(a0, a1, a2), List.of(), createComment(user3, "Plain unrelated reply")));
 
-            assertEquals(a1, ArchiveItem.findParent(List.of(a0, a1, a2), createComment(user3, "> First comment\n\nI agree")));
-            assertEquals(a1, ArchiveItem.findParent(List.of(a0, a1, a2), createComment(user3, "> First comment\n>with two lines\n\nI agree")));
-            assertEquals(a1, ArchiveItem.findParent(List.of(a0, a1, a2), createComment(user3, "\n> First comment\n\nI agree")));
+            assertEquals(a1, ArchiveItem.findParent(List.of(a0, a1, a2), List.of(), createComment(user3, "> First comment\n\nI agree")));
+            assertEquals(a1, ArchiveItem.findParent(List.of(a0, a1, a2), List.of(), createComment(user3, "> First comment\n>with two lines\n\nI agree")));
+            assertEquals(a1, ArchiveItem.findParent(List.of(a0, a1, a2), List.of(), createComment(user3, "\n> First comment\n\nI agree")));
 
-            assertEquals(a1, ArchiveItem.findParent(List.of(a0, a1, a2), createComment(user3, "@user1 I agree")));
-            assertEquals(a1, ArchiveItem.findParent(List.of(a0, a1, a2), createComment(user3, "@user1\nI agree")));
+            assertEquals(a1, ArchiveItem.findParent(List.of(a0, a1, a2), List.of(), createComment(user3, "@user1 I agree")));
+            assertEquals(a1, ArchiveItem.findParent(List.of(a0, a1, a2), List.of(), createComment(user3, "@user1\nI agree")));
         }
     }
 }


### PR DESCRIPTION
If a comment is done in reply to a bridged email, setup reply-to headers correctly pointing to the source of the bridged comment.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-769](https://bugs.openjdk.java.net/browse/SKARA-769): Replies to e-mail comments on GitHub are threaded incorrectly


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1111/head:pull/1111` \
`$ git checkout pull/1111`

Update a local copy of the PR: \
`$ git checkout pull/1111` \
`$ git pull https://git.openjdk.java.net/skara pull/1111/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1111`

View PR using the GUI difftool: \
`$ git pr show -t 1111`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1111.diff">https://git.openjdk.java.net/skara/pull/1111.diff</a>

</details>
