### PR TITLE
905: Github UI code markdown can fail to get copied correctly into email

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MarkdownToText.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MarkdownToText.java
@@ -27,7 +27,7 @@ import java.util.regex.*;
 public class MarkdownToText {
     private static final Pattern emojiPattern = Pattern.compile("(:([0-9a-z_+-]+):)");
     private static final Pattern suggestionPattern = Pattern.compile("^```suggestion$", Pattern.MULTILINE);
-    private static final Pattern codePattern = Pattern.compile("^```(?:\\w+)?\\R?", Pattern.MULTILINE);
+    private static final Pattern codePattern = Pattern.compile("^```+(?:\\w+)?$", Pattern.MULTILINE);
     private static final Pattern escapesPattern = Pattern.compile("\\\\([!\"#$%&'()*+,\\-./:;<=?@\\[\\]^_`{|}~])", Pattern.MULTILINE);
     private static final Pattern entitiesPattern = Pattern.compile("&#32;", Pattern.MULTILINE);
 

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MarkdownToTextTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MarkdownToTextTests.java
@@ -24,7 +24,8 @@ package org.openjdk.skara.bots.mlbridge;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 class MarkdownToTextTests {
     @Test
@@ -49,6 +50,8 @@ class MarkdownToTextTests {
         assertEquals("Just some text", MarkdownToText.removeFormatting("```\nJust some text\n```"));
         assertEquals("Multi\nline", MarkdownToText.removeFormatting("```\nMulti\nline\n```"));
         assertEquals("Script", MarkdownToText.removeFormatting("```bash\nScript\n```"));
+        assertEquals("Longer", MarkdownToText.removeFormatting("`````bash\nLonger\n`````"));
+        assertEquals("``bash\nShorter\n``", MarkdownToText.removeFormatting("``bash\nShorter\n``"));
     }
 
     @Test
@@ -64,5 +67,10 @@ class MarkdownToTextTests {
     @Test
     void entities() {
         assertEquals("space is here", MarkdownToText.removeFormatting("space&#32;is here"));
+    }
+
+    @Test
+    void singleLineCode() {
+        assertEquals("```assert_locked_or_safepoint(Threads_lock);```", MarkdownToText.removeFormatting("```assert_locked_or_safepoint(Threads_lock);```"));
     }
 }


### PR DESCRIPTION
When filtering out certain markdown for sending plain-text emails, only remove multiline code formatting block markers and retain inline ones.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-905](https://bugs.openjdk.java.net/browse/SKARA-905): Github UI code markdown can fail to get copied correctly into email


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1112/head:pull/1112` \
`$ git checkout pull/1112`

Update a local copy of the PR: \
`$ git checkout pull/1112` \
`$ git pull https://git.openjdk.java.net/skara pull/1112/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1112`

View PR using the GUI difftool: \
`$ git pr show -t 1112`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1112.diff">https://git.openjdk.java.net/skara/pull/1112.diff</a>

</details>
