### PR TITLE
Update to JDK 16

### DIFF
--- a/bot/src/main/java/org/openjdk/skara/bot/BotTaskAggregationHandler.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotTaskAggregationHandler.java
@@ -44,7 +44,7 @@ public abstract class BotTaskAggregationHandler extends StreamHandler {
         }
     }
 
-    private final Map<Integer, ThreadLogs> threadLogs;
+    private final Map<Long, ThreadLogs> threadLogs;
     private final Logger log;
 
     public BotTaskAggregationHandler() {
@@ -65,7 +65,7 @@ public abstract class BotTaskAggregationHandler extends StreamHandler {
     @Override
     public final void publish(LogRecord record) {
         var newEntry = new ThreadLogs();
-        var threadEntry = threadLogs.putIfAbsent(record.getThreadID(), newEntry);
+        var threadEntry = threadLogs.putIfAbsent(record.getLongThreadID(), newEntry);
         if (threadEntry == null) {
             threadEntry = newEntry;
         }

--- a/bot/src/test/java/org/openjdk/skara/bot/BotTaskAggregationHandlerTests.java
+++ b/bot/src/test/java/org/openjdk/skara/bot/BotTaskAggregationHandlerTests.java
@@ -155,9 +155,9 @@ class BotTaskAggregationHandlerTests {
 
         handler.taskRecords().stream()
                .flatMap(Collection::stream)
-               .forEach(record -> assertEquals(Integer.toString(record.getThreadID()), record.getMessage()));
+               .forEach(record -> assertEquals(Long.toString(record.getLongThreadID()), record.getMessage()));
         handler.nonTaskRecords()
-               .forEach(record -> assertEquals(Integer.toString(record.getThreadID()), record.getMessage()));
+               .forEach(record -> assertEquals(Long.toString(record.getLongThreadID()), record.getMessage()));
     }
 
 }

--- a/bots/cli/build.gradle
+++ b/bots/cli/build.gradle
@@ -95,8 +95,8 @@ images {
         options = ["--module-path", "plugins"]
         bundles = ['zip', 'tar.gz']
         jdk {
-            url = 'https://download.java.net/java/GA/jdk15.0.2/0d1cfde4252546c6931946de8db48ee2/7/GPL/openjdk-15.0.2_linux-x64_bin.tar.gz'
-            sha256 = '91ac6fc353b6bf39d995572b700e37a20e119a87034eeb939a6f24356fbcd207'
+            url = 'https://download.java.net/java/GA/jdk16/7863447f0ab643c585b9bdebf67c69db/36/GPL/openjdk-16_linux-x64_bin.tar.gz'
+            sha256 = 'e952958f16797ad7dc7cd8b724edd69ec7e0e0434537d80d6b5165193e33b931'
         }
     }
 }

--- a/bots/cli/src/main/java/org/openjdk/skara/bots/cli/BotConsoleHandler.java
+++ b/bots/cli/src/main/java/org/openjdk/skara/bots/cli/BotConsoleHandler.java
@@ -54,7 +54,7 @@ class BotConsoleHandler extends StreamHandler {
         }
 
         var level = levelAbbreviations.getOrDefault(record.getLevel().intValue(), "?");
-        System.out.println("[" + dateTimeFormatter.format(record.getInstant().truncatedTo(ChronoUnit.SECONDS)) + "][" + record.getThreadID() + "][" +
+        System.out.println("[" + dateTimeFormatter.format(record.getInstant().truncatedTo(ChronoUnit.SECONDS)) + "][" + record.getLongThreadID() + "][" +
                 level + "] " + record.getMessage());
         var exception = record.getThrown();
         if (exception != null) {

--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -80,8 +80,8 @@ images {
         launchers = ext.launchers
         bundles = ['zip', 'tar.gz']
         jdk {
-            url = 'https://download.java.net/java/GA/jdk15.0.2/0d1cfde4252546c6931946de8db48ee2/7/GPL/openjdk-15.0.2_windows-x64_bin.zip'
-            sha256 = 'ecbe7f32bc6bff2b6c8e9b68f19cbf4ddf54a492c918ba471f32d645cf1c5cf4'
+            url = 'https://download.java.net/java/GA/jdk16/7863447f0ab643c585b9bdebf67c69db/36/GPL/openjdk-16_windows-x64_bin.zip'
+            sha256 = 'a78bdeaad186297601edac6772d931224d7af6f682a43372e693c37020bd37d6'
         }
     }
 
@@ -91,8 +91,8 @@ images {
         man = 'cli/resources/man'
         bundles = ['zip', 'tar.gz']
         jdk {
-            url = 'https://download.java.net/java/GA/jdk15.0.2/0d1cfde4252546c6931946de8db48ee2/7/GPL/openjdk-15.0.2_linux-x64_bin.tar.gz'
-            sha256 = '91ac6fc353b6bf39d995572b700e37a20e119a87034eeb939a6f24356fbcd207'
+            url = 'https://download.java.net/java/GA/jdk16/7863447f0ab643c585b9bdebf67c69db/36/GPL/openjdk-16_linux-x64_bin.tar.gz'
+            sha256 = 'e952958f16797ad7dc7cd8b724edd69ec7e0e0434537d80d6b5165193e33b931'
         }
     }
 
@@ -102,8 +102,8 @@ images {
         man = 'cli/resources/man'
         bundles = ['zip', 'tar.gz']
         jdk {
-            url = 'https://download.java.net/java/GA/jdk15.0.2/0d1cfde4252546c6931946de8db48ee2/7/GPL/openjdk-15.0.2_osx-x64_bin.tar.gz'
-            sha256 = '578b17748f5a7d111474bc4c9b5a8a06b4a4aa1ba4a4bc3fef014e079ece7c74'
+            url = 'https://download.java.net/java/GA/jdk16/7863447f0ab643c585b9bdebf67c69db/36/GPL/openjdk-16_osx-x64_bin.tar.gz'
+            sha256 = '16f3e39a31e86f3f51b0b4035a37494a47ed3c4ead760eafc6afd7afdf2ad9f2'
         }
     }
 

--- a/deps.env
+++ b/deps.env
@@ -7,5 +7,5 @@ JDK_MACOS_X64_SHA256="578b17748f5a7d111474bc4c9b5a8a06b4a4aa1ba4a4bc3fef014e079e
 JDK_WINDOWS_X64_URL="https://download.java.net/java/GA/jdk15.0.2/0d1cfde4252546c6931946de8db48ee2/7/GPL/openjdk-15.0.2_windows-x64_bin.zip"
 JDK_WINDOWS_X64_SHA256="ecbe7f32bc6bff2b6c8e9b68f19cbf4ddf54a492c918ba471f32d645cf1c5cf4"
 
-GRADLE_URL="https://services.gradle.org/distributions/gradle-6.8.3-bin.zip"
-GRADLE_SHA256="7faa7198769f872826c8ef4f1450f839ec27f0b4d5d1e51bade63667cbccd205"
+GRADLE_URL="https://services.gradle.org/distributions/gradle-7.0-bin.zip"
+GRADLE_SHA256="eb8b89184261025b0430f5b2233701ff1377f96da1ef5e278af6ae8bac5cc305"

--- a/deps.env
+++ b/deps.env
@@ -1,11 +1,11 @@
-JDK_LINUX_X64_URL="https://download.java.net/java/GA/jdk15.0.2/0d1cfde4252546c6931946de8db48ee2/7/GPL/openjdk-15.0.2_linux-x64_bin.tar.gz"
-JDK_LINUX_X64_SHA256="91ac6fc353b6bf39d995572b700e37a20e119a87034eeb939a6f24356fbcd207"
+JDK_LINUX_X64_URL="https://download.java.net/java/GA/jdk16/7863447f0ab643c585b9bdebf67c69db/36/GPL/openjdk-16_linux-x64_bin.tar.gz"
+JDK_LINUX_X64_SHA256="e952958f16797ad7dc7cd8b724edd69ec7e0e0434537d80d6b5165193e33b931"
 
-JDK_MACOS_X64_URL="https://download.java.net/java/GA/jdk15.0.2/0d1cfde4252546c6931946de8db48ee2/7/GPL/openjdk-15.0.2_osx-x64_bin.tar.gz"
-JDK_MACOS_X64_SHA256="578b17748f5a7d111474bc4c9b5a8a06b4a4aa1ba4a4bc3fef014e079ece7c74"
+JDK_MACOS_X64_URL="https://download.java.net/java/GA/jdk16/7863447f0ab643c585b9bdebf67c69db/36/GPL/openjdk-16_osx-x64_bin.tar.gz"
+JDK_MACOS_X64_SHA256="16f3e39a31e86f3f51b0b4035a37494a47ed3c4ead760eafc6afd7afdf2ad9f2"
 
-JDK_WINDOWS_X64_URL="https://download.java.net/java/GA/jdk15.0.2/0d1cfde4252546c6931946de8db48ee2/7/GPL/openjdk-15.0.2_windows-x64_bin.zip"
-JDK_WINDOWS_X64_SHA256="ecbe7f32bc6bff2b6c8e9b68f19cbf4ddf54a492c918ba471f32d645cf1c5cf4"
+JDK_WINDOWS_X64_URL="https://download.java.net/java/GA/jdk16/7863447f0ab643c585b9bdebf67c69db/36/GPL/openjdk-16_windows-x64_bin.zip"
+JDK_WINDOWS_X64_SHA256="a78bdeaad186297601edac6772d931224d7af6f682a43372e693c37020bd37d6"
 
 GRADLE_URL="https://services.gradle.org/distributions/gradle-7.0-bin.zip"
 GRADLE_SHA256="eb8b89184261025b0430f5b2233701ff1377f96da1ef5e278af6ae8bac5cc305"

--- a/gradle/plugins/skara-images/src/main/java/org/openjdk/skara/gradle/images/ImagesPlugin.java
+++ b/gradle/plugins/skara-images/src/main/java/org/openjdk/skara/gradle/images/ImagesPlugin.java
@@ -132,9 +132,9 @@ public class ImagesPlugin implements Plugin<Project> {
                     } else {
                         task.getUrl().set("local");
                     }
-                    task.getToDir().set(buildDir.resolve("images"));
+                    var toDir = isLocal ? "local" : os + "-" + cpu;
+                    task.getToDir().set(buildDir.resolve("images").resolve(toDir));
                     task.getOS().set(os);
-                    task.getCPU().set(cpu);
                     task.getLaunchers().set(env.getLaunchers());
                     task.getModules().set(env.getModules());
                 });
@@ -143,9 +143,9 @@ public class ImagesPlugin implements Plugin<Project> {
                 project.getTasks().register(launchersTaskName, LaunchersTask.class, (task) -> {
                     task.getLaunchers().set(env.getLaunchers());
                     task.getOptions().set(env.getOptions());
-                    task.getToDir().set(buildDir.resolve("launchers"));
                     task.getOS().set(os);
-                    task.getCPU().set(cpu);
+                    var toDir = isLocal ? "local" : os + "-" + cpu;
+                    task.getToDir().set(buildDir.resolve("launchers").resolve(toDir));
                 });
 
                 var zipTaskName = "bundleZip" + subName;
@@ -166,7 +166,7 @@ public class ImagesPlugin implements Plugin<Project> {
                         });
                     }
 
-                    var subdir = os + "-" + cpu;
+                    var subdir = isLocal ? "local" : os + "-" + cpu;
                     task.from(buildDir.resolve("images").resolve(subdir), (s) -> {
                         s.into("image");
                     });
@@ -194,7 +194,7 @@ public class ImagesPlugin implements Plugin<Project> {
                         });
                     }
 
-                    var subdir = os + "-" + cpu;
+                    var subdir = isLocal ? "local" : os + "-" + cpu;
                     task.from(buildDir.resolve("images").resolve(subdir), (s) -> {
                         s.into("image");
                     });

--- a/gradle/plugins/skara-images/src/main/java/org/openjdk/skara/gradle/images/LaunchersTask.java
+++ b/gradle/plugins/skara-images/src/main/java/org/openjdk/skara/gradle/images/LaunchersTask.java
@@ -35,17 +35,15 @@ import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Comparator;
 
 public class LaunchersTask extends DefaultTask {
+    private final Property<String> os;
     private Property<Path> toDir;
-    private Property<String> os;
-    private Property<String> cpu;
     private MapProperty<String, String> launchers;
     private ListProperty<String> options;
 
     @Inject
     public LaunchersTask(ObjectFactory factory) {
-        toDir = factory.property(Path.class);
         os = factory.property(String.class);
-        cpu = factory.property(String.class);
+        toDir = factory.property(Path.class);
         launchers = factory.mapProperty(String.class, String.class);
         options = factory.listProperty(String.class);
     }
@@ -66,11 +64,6 @@ public class LaunchersTask extends DefaultTask {
     }
 
     @Input
-    Property<String> getCPU() {
-        return cpu;
-    }
-
-    @Input
     MapProperty<String, String> getLaunchers() {
         return launchers;
     }
@@ -84,7 +77,7 @@ public class LaunchersTask extends DefaultTask {
 
     @TaskAction
     void generate() throws IOException {
-        var dest = toDir.get().resolve(os.get() + "-" + cpu.get());
+        var dest = toDir.get();
         if (Files.isDirectory(dest)) {
             clearDirectory(dest);
         }

--- a/gradle/plugins/skara-images/src/main/java/org/openjdk/skara/gradle/images/LinkTask.java
+++ b/gradle/plugins/skara-images/src/main/java/org/openjdk/skara/gradle/images/LinkTask.java
@@ -41,7 +41,6 @@ import java.util.stream.Collectors;
 
 public class LinkTask extends DefaultTask {
     private final Property<String> os;
-    private final Property<String> cpu;
     private final Property<String> url;
     private final Property<Path> toDir;
     private final MapProperty<String, String> launchers;
@@ -52,7 +51,6 @@ public class LinkTask extends DefaultTask {
     @Inject
     public LinkTask(ObjectFactory factory) {
         os = factory.property(String.class);
-        cpu = factory.property(String.class);
         url = factory.property(String.class);
         toDir = factory.property(Path.class);
         launchers = factory.mapProperty(String.class, String.class);
@@ -69,11 +67,6 @@ public class LinkTask extends DefaultTask {
     @Input
     Property<String> getOS() {
         return os;
-    }
-
-    @Input
-    Property<String> getCPU() {
-        return cpu;
     }
 
     @Input
@@ -154,10 +147,11 @@ public class LinkTask extends DefaultTask {
         uniqueModules.addAll(modules.get());
         var allModules = new ArrayList<>(uniqueModules);
 
-        Files.createDirectories(toDir.get());
-        var dest = toDir.get().resolve(os.get() + "-" + cpu.get());
+        var dest = toDir.get();
         if (Files.exists(dest) && Files.isDirectory(dest)) {
             clearDirectory(dest);
+        } else {
+            Files.createDirectories(dest);
         }
 
         Collections.sort(modulePath);
@@ -182,7 +176,7 @@ public class LinkTask extends DefaultTask {
                                      .filter(p -> p.getFileName().toString().equals("java" + ext))
                                      .collect(Collectors.toList());
             if (javaLaunchers.size() != 1) {
-                throw new GradleException("Multiple or no java launchers generated for " + os.get() + "-" + cpu.get() + " image");
+                throw new GradleException("Multiple or no java launchers generated for " + os.get());
             }
             var java = javaLaunchers.get(0);
             project.exec((spec) -> {

--- a/gradle/plugins/skara-module/src/main/java/org/openjdk/skara/gradle/module/ModulePlugin.java
+++ b/gradle/plugins/skara-module/src/main/java/org/openjdk/skara/gradle/module/ModulePlugin.java
@@ -118,8 +118,7 @@ public class ModulePlugin implements Plugin<Project> {
                                     "-Djunit.jupiter.extensions.autodetection.enabled=true",
                                     "--module-path", classpath,
                                     "--add-modules", "ALL-MODULE-PATH",
-                                    "--patch-module", moduleName + "=" + outputDir,
-                                    "--illegal-access=deny"
+                                    "--patch-module", moduleName + "=" + outputDir
                             ));
 
                             var opens = extension.getOpens();


### PR DESCRIPTION
Hi all,

please review this patch that updates the JDK used for building and running Skara to JDK 16. As part of the update I had to remove `--illegal-access=deny` from Skara's module plugin and I also had use `LogRecord.getLongThreadId` instead of the (since JDK 16) deprecated method `LogRecord.getThreadId`.

Testing:
- [x] `make images` locally
- [x] `make test` locally

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1114/head:pull/1114` \
`$ git checkout pull/1114`

Update a local copy of the PR: \
`$ git checkout pull/1114` \
`$ git pull https://git.openjdk.java.net/skara pull/1114/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1114`

View PR using the GUI difftool: \
`$ git pr show -t 1114`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1114.diff">https://git.openjdk.java.net/skara/pull/1114.diff</a>

</details>
