### PR TITLE
964: Should only consider Fixed bugs for hgupdate-sync

### DIFF
--- a/bots/csr/src/test/java/org/openjdk/skara/bots/csr/CSRBotTests.java
+++ b/bots/csr/src/test/java/org/openjdk/skara/bots/csr/CSRBotTests.java
@@ -43,9 +43,9 @@ class CSRBotTests {
             var issues = credentials.getIssueProject();
             var issue = issues.createIssue("This is an issue", List.of(), Map.of());
 
-            var csr = issues.createIssue("This is an approved CSR", List.of(), Map.of("resolution",
-                                                                                      JSON.object().put("name", "Approved")));
+            var csr = issues.createIssue("This is an approved CSR", List.of(), Map.of());
             csr.setState(Issue.State.CLOSED);
+            csr.setProperty("resolution", JSON.object().put("name", "Approved"));
             issue.addLink(Link.create(csr, "csr for").build());
 
             var bot = new CSRBot(repo, issues);

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CSRTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CSRTests.java
@@ -105,9 +105,9 @@ class CSRTests {
             var issues = credentials.getIssueProject();
             var issue = issues.createIssue("This is an issue", List.of(), Map.of());
 
-            var csr = issues.createIssue("This is an approved CSR", List.of(), Map.of("resolution",
-                                                                                      JSON.object().put("name", "Approved")));
+            var csr = issues.createIssue("This is an approved CSR", List.of(), Map.of());
             csr.setState(Issue.State.CLOSED);
+            csr.setProperty("resolution", JSON.object().put("name", "Approved"));
             issue.addLink(Link.create(csr, "csr for").build());
 
             var censusBuilder = credentials.getCensusBuilder()

--- a/jbs/src/test/java/org/openjdk/skara/jbs/BackportsTests.java
+++ b/jbs/src/test/java/org/openjdk/skara/jbs/BackportsTests.java
@@ -185,6 +185,10 @@ public class BackportsTests {
         private void setState(Issue issue, String version) {
             if (version.endsWith("#open")) {
                 version = version.substring(0, version.length() - 5);
+            } else if (version.endsWith("#wontfix")) {
+                version = version.substring(0, version.length() - 8);
+                issue.setState(Issue.State.RESOLVED);
+                issue.setProperty("resolution", JSON.object().put("name", JSON.of("Won't Fix")));
             } else {
                 issue.setState(Issue.State.RESOLVED);
             }
@@ -752,6 +756,17 @@ public class BackportsTests {
 
             backports.addBackports("14u-cpu", "14.0.2", "13.0.7", "11.0.9-oracle", "11.0.9");
             backports.assertLabeled();
+        }
+    }
+
+    @Test
+    void wontFix(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo)) {
+            var backports = new BackportManager(credentials, "14");
+            backports.assertLabeled();
+
+            backports.addBackports("15", "13.0.7", "11.0.12-oracle", "11.0.11-oracle#wontfix", "11.0.10");
+            backports.assertLabeled("15");
         }
     }
 }

--- a/test/src/main/java/org/openjdk/skara/test/TestIssue.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestIssue.java
@@ -24,7 +24,7 @@ package org.openjdk.skara.test;
 
 import org.openjdk.skara.host.HostUser;
 import org.openjdk.skara.issuetracker.*;
-import org.openjdk.skara.json.JSONValue;
+import org.openjdk.skara.json.*;
 import org.openjdk.skara.network.URIBuilder;
 
 import java.net.URI;
@@ -150,6 +150,7 @@ public class TestIssue implements Issue {
         data.state = state;
         data.lastUpdate = ZonedDateTime.now();
         data.closedBy = user;
+        data.properties.put("resolution", JSON.object().put("name", JSON.of("Fixed")));
     }
 
     @Override


### PR DESCRIPTION
When deciding which issues should receive the hgupdate-sync label, only consider resolved issues that also have a resolution of "Fixed".

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-964](https://bugs.openjdk.java.net/browse/SKARA-964): Should only consider Fixed bugs for hgupdate-sync


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - no project role) ⚠️ Review applies to 2d0bf4cec9add72e2d1e49a94d57e388fde967f9
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to 2d0bf4cec9add72e2d1e49a94d57e388fde967f9


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1115/head:pull/1115` \
`$ git checkout pull/1115`

Update a local copy of the PR: \
`$ git checkout pull/1115` \
`$ git pull https://git.openjdk.java.net/skara pull/1115/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1115`

View PR using the GUI difftool: \
`$ git pr show -t 1115`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1115.diff">https://git.openjdk.java.net/skara/pull/1115.diff</a>

</details>
