### PR TITLE
965: hgupdate-sync mistakenly added to 16.0.2 backport record

### DIFF
--- a/jbs/src/main/java/org/openjdk/skara/jbs/Backports.java
+++ b/jbs/src/main/java/org/openjdk/skara/jbs/Backports.java
@@ -233,8 +233,12 @@ public class Backports {
                 if (jdkVersion.update().isPresent()) {
                     var numericUpdate = Integer.parseInt(jdkVersion.update().get());
                     if (numericUpdate == 1 || numericUpdate == 2) {
-                        ret.add(jdkVersion.feature() + "+updates-oracle");
-                        ret.add(jdkVersion.feature() + "+updates-openjdk");
+                        if (jdkVersion.opt().isPresent() && jdkVersion.opt().get().equals("oracle") && jdkVersion.components().size() > 4) {
+                            ret.add(jdkVersion.feature() + "+bpr");
+                        } else {
+                            ret.add(jdkVersion.feature() + "+updates-oracle");
+                            ret.add(jdkVersion.feature() + "+updates-openjdk");
+                        }
                     } else if (numericUpdate > 2) {
                         if (jdkVersion.opt().isPresent() && jdkVersion.opt().get().equals("oracle")) {
                             if (jdkVersion.components().size() > 4) {

--- a/jbs/src/test/java/org/openjdk/skara/jbs/BackportsTests.java
+++ b/jbs/src/test/java/org/openjdk/skara/jbs/BackportsTests.java
@@ -754,4 +754,15 @@ public class BackportsTests {
             backports.assertLabeled();
         }
     }
+
+    @Test
+    void testBpr(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo)) {
+            var backports = new BackportManager(credentials, "17");
+            backports.assertLabeled();
+
+            backports.addBackports("16.0.2", "16.0.1.0.1-oracle", "11.0.12-oracle", "11.0.11.0.1-oracle", "8u301", "8u291", "8u281");
+            backports.assertLabeled("8u291", "8u301");
+        }
+    }
 }


### PR DESCRIPTION
A BPR release stream can start before update version 3, so check for that as well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-965](https://bugs.openjdk.java.net/browse/SKARA-965): hgupdate-sync mistakenly added to 16.0.2 backport record


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - no project role) ⚠️ Review applies to 9854c60d4158034228c374c5acf4b86f15acd8ed
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1116/head:pull/1116` \
`$ git checkout pull/1116`

Update a local copy of the PR: \
`$ git checkout pull/1116` \
`$ git pull https://git.openjdk.java.net/skara pull/1116/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1116`

View PR using the GUI difftool: \
`$ git pr show -t 1116`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1116.diff">https://git.openjdk.java.net/skara/pull/1116.diff</a>

</details>
