### PR TITLE
934: Bots incorrectly assigned "build" label despite no obvious matching rule

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequestUtils.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequestUtils.java
@@ -186,8 +186,12 @@ public class PullRequestUtils {
         var ret = new HashSet<Path>();
         var changes = localRepo.diff(baseHash(pr, localRepo), pr.headHash());
         for (var patch : changes.patches()) {
-            patch.target().path().ifPresent(ret::add);
-            patch.source().path().ifPresent(ret::add);
+            if (patch.status().isDeleted() || patch.status().isRenamed()) {
+                patch.source().path().ifPresent(ret::add);
+            }
+            if (!patch.status().isDeleted()) {
+                patch.target().path().ifPresent(ret::add);
+            }
         }
         return ret;
     }


### PR DESCRIPTION
When determining the set of file names to evaluate for determining label assignment, only include the source name for deletions and renames (and not for copies, for example).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-934](https://bugs.openjdk.java.net/browse/SKARA-934): Bots incorrectly assigned "build" label despite no obvious matching rule


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1118/head:pull/1118` \
`$ git checkout pull/1118`

Update a local copy of the PR: \
`$ git checkout pull/1118` \
`$ git pull https://git.openjdk.java.net/skara pull/1118/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1118`

View PR using the GUI difftool: \
`$ git pr show -t 1118`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1118.diff">https://git.openjdk.java.net/skara/pull/1118.diff</a>

</details>
