### PR TITLE
930: Skara bot adds confusing comment to PR when CSR is needed

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CSRCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CSRCommand.java
@@ -45,12 +45,12 @@ public class CSRCommand implements CommandHandler {
 
     private static void jbsReply(PullRequest pr, PrintWriter writer) {
         writer.println("@" + pr.author().username() + " this pull request must refer to an issue in " +
-                      "[JBS](https://bugs.openjdk.java.net) to be able to link it to a CSR request. To refer this pull request to " +
+                      "[JBS](https://bugs.openjdk.java.net) to be able to link it to a [CSR](https://wiki.openjdk.java.net/display/csr/Main) request. To refer this pull request to " +
                       "an issue in JBS, please use the `/issue` command in a comment in this pull request.");
     }
 
     private static void linkReply(PullRequest pr, Issue issue, PrintWriter writer) {
-        writer.println("@" + pr.author().username() + " please create a CSR request and add link to it in " +
+        writer.println("@" + pr.author().username() + " please create a [CSR](https://wiki.openjdk.java.net/display/csr/Main) request for issue " +
                       "[" + issue.id() + "](" + issue.webUrl() + "). This pull request cannot be integrated until " +
                       "the CSR request is approved.");
     }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CSRTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CSRTests.java
@@ -174,7 +174,7 @@ class CSRTests {
                                           "[compatibility and specification](https://wiki.openjdk.java.net/display/csr/Main) " +
                                           "(CSR) request is needed for this pull request.");
             assertLastCommentContains(pr, "this pull request must refer to an issue in [JBS]");
-            assertLastCommentContains(pr, "to be able to link it to a CSR request. To refer this pull request to an issue in JBS");
+            assertLastCommentContains(pr, "To refer this pull request to an issue in JBS");
             assertTrue(pr.labelNames().contains("csr"));
         }
     }
@@ -296,7 +296,7 @@ class CSRTests {
                                           "[compatibility and specification](https://wiki.openjdk.java.net/display/csr/Main) " +
                                           "(CSR) request is needed for this pull request.");
             assertLastCommentContains(pr, "this pull request must refer to an issue in [JBS]");
-            assertLastCommentContains(pr, "to be able to link it to a CSR request. To refer this pull request to an issue in JBS");
+            assertLastCommentContains(pr, "to be able to link it to a [CSR](https://wiki.openjdk.java.net/display/csr/Main) request. To refer this pull request to an issue in JBS");
             assertTrue(pr.labelNames().contains("csr"));
         }
     }


### PR DESCRIPTION
Hi all,

please review this patch that slightly changes the wording in the message from the `/csr` command when the user has to create a CSR. When a CSR is created in JBS then it is automatically linked to the issue, so there is no need to instruct the user to link the CSR to an issue. I therefore just removed this part from the reply.

Testing:
- [x] `make test` passes locally on Linux x64

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-930](https://bugs.openjdk.java.net/browse/SKARA-930): Skara bot adds confusing comment to PR when CSR is needed


### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1119/head:pull/1119` \
`$ git checkout pull/1119`

Update a local copy of the PR: \
`$ git checkout pull/1119` \
`$ git pull https://git.openjdk.java.net/skara pull/1119/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1119`

View PR using the GUI difftool: \
`$ git pr show -t 1119`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1119.diff">https://git.openjdk.java.net/skara/pull/1119.diff</a>

</details>
