### PR TITLE
SKARA-971: Stop clumping up logs in logstash

### DIFF
--- a/bot/src/main/java/org/openjdk/skara/bot/LogContext.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/LogContext.java
@@ -1,0 +1,50 @@
+package org.openjdk.skara.bot;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Logger;
+
+/**
+ * A LogContext is used to temporarily add extra log metadata in the current thread.
+ * It should be initiated with a try-with-resources construct. The variable itself
+ * is never used, we only want the controlled automatic close at the end of the try
+ * block. Typically name the variable __. Example:
+ *
+ * try (var __ = new LogContext("foo", "bar")) {
+ *     // some code that logs stuff
+ * }
+ */
+public class LogContext implements AutoCloseable {
+    private static final Logger log = Logger.getLogger("org.openjdk.skara.bot");
+    private final Map<String, String> context = new HashMap<>();
+
+    public LogContext(String key, String value) {
+        this.init(Map.of(key, value));
+    }
+
+    public LogContext(Map<String, String> ctx) {
+        this.init(ctx);
+    }
+
+    private void init(Map<String, String> newContext) {
+        for (var entry : newContext.entrySet()) {
+            String currentValue = LogContextMap.get(entry.getKey());
+            if (currentValue != null) {
+                if (!currentValue.equals(entry.getValue())) {
+                    log.severe("Tried to override the current LogContext value: " + currentValue
+                            + " for " + entry.getKey() + " with a different value: " + entry.getValue());
+                }
+            } else {
+                this.context.put(entry.getKey(), entry.getValue());
+                LogContextMap.put(entry.getKey(), entry.getValue());
+            }
+        }
+
+    }
+
+    public void close() {
+        this.context.forEach((key, value) -> {
+            LogContextMap.remove(key);
+        });
+    }
+}

--- a/bot/src/main/java/org/openjdk/skara/bot/LogContextMap.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/LogContextMap.java
@@ -7,7 +7,7 @@ import java.util.Set;
 
 /**
  * This class holds a static thread local hashmap to store temporary log
- * metadata which our custom LogStreamers can pick up and include in log
+ * metadata which our custom StreamHandlers can pick up and include in log
  * messages.
  */
 public class LogContextMap {

--- a/bot/src/main/java/org/openjdk/skara/bot/LogContextMap.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/LogContextMap.java
@@ -1,0 +1,48 @@
+package org.openjdk.skara.bot;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * This class holds a static thread local hashmap to store temporary log
+ * metadata which our custom LogStreamers can pick up and include in log
+ * messages.
+ */
+public class LogContextMap {
+
+    private static final ThreadLocal<HashMap<String, String>> threadContextMap = new ThreadLocal<>();
+
+    public static void put(String key, String value) {
+        if (threadContextMap.get() == null) {
+            threadContextMap.set(new HashMap<>());
+        }
+        var map = threadContextMap.get();
+        map.put(key, value);
+    }
+
+    public static String get(String key) {
+        if (threadContextMap.get() != null) {
+            return threadContextMap.get().get(key);
+        } else {
+            return null;
+        }
+    }
+
+    public static String remove(String key) {
+        if (threadContextMap.get() != null) {
+            return threadContextMap.get().remove(key);
+        } else {
+            return null;
+        }
+    }
+
+    public static Set<Map.Entry<String, String>> entrySet() {
+        if (threadContextMap.get() != null) {
+            return threadContextMap.get().entrySet();
+        } else {
+            return Collections.emptySet();
+        }
+    }
+}

--- a/bot/src/test/java/org/openjdk/skara/bot/LogContextTests.java
+++ b/bot/src/test/java/org/openjdk/skara/bot/LogContextTests.java
@@ -1,0 +1,19 @@
+package org.openjdk.skara.bot;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class LogContextTests {
+
+    @Test
+    public void simple() {
+        String key = "keyname";
+        assertNull(LogContextMap.get(key), "Key " + key + " already present in context");
+        try (var __ = new LogContext(key, "value")) {
+            assertEquals("value", LogContextMap.get(key), "Context property not set");
+        }
+        assertNull(LogContextMap.get(key), "Context property not removed");
+    }
+}

--- a/bots/cli/src/main/java/module-info.java
+++ b/bots/cli/src/main/java/module-info.java
@@ -33,6 +33,7 @@ module org.openjdk.skara.bots.cli {
     requires org.openjdk.skara.network;
     requires org.openjdk.skara.version;
 
+    requires java.net.http;
     requires java.sql;
 
     exports org.openjdk.skara.bots.cli;

--- a/bots/cli/src/main/java/org/openjdk/skara/bots/cli/BotLauncher.java
+++ b/bots/cli/src/main/java/org/openjdk/skara/bots/cli/BotLauncher.java
@@ -22,7 +22,7 @@
  */
 package org.openjdk.skara.bots.cli;
 
-import java.time.LocalDate;
+import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import org.openjdk.skara.args.*;
@@ -44,7 +44,7 @@ import java.util.stream.*;
 
 public class BotLauncher {
     private static Logger log;
-    private static final LocalDate START_TIME = LocalDate.now();
+    private static final Instant START_TIME = Instant.now();
 
     private static void applyLogging(JSONObject config) {
         LogManager.getLogManager().reset();
@@ -102,7 +102,7 @@ public class BotLauncher {
             var dateTimeFormatter = DateTimeFormatter.ISO_INSTANT
                     .withLocale(Locale.getDefault())
                     .withZone(ZoneId.systemDefault());
-            handler.addExtraField("instance_start_time", START_TIME.format(dateTimeFormatter));
+            handler.addExtraField("instance_start_time", dateTimeFormatter.format(START_TIME));
             log.addHandler(handler);
         }
     }

--- a/bots/cli/src/main/java/org/openjdk/skara/bots/cli/BotLogstashHandler.java
+++ b/bots/cli/src/main/java/org/openjdk/skara/bots/cli/BotLogstashHandler.java
@@ -78,7 +78,7 @@ public class BotLogstashHandler extends StreamHandler {
             query.put("level_value", level.intValue());
             query.put("message", message);
 
-            for (Map.Entry<String, String> entry : LogContextMap.entrySet()) {
+            for (var entry : LogContextMap.entrySet()) {
                 query.put(entry.getKey(), entry.getValue());
             }
 

--- a/bots/cli/src/main/java/org/openjdk/skara/bots/cli/BotLogstashHandler.java
+++ b/bots/cli/src/main/java/org/openjdk/skara/bots/cli/BotLogstashHandler.java
@@ -100,6 +100,7 @@ public class BotLogstashHandler extends StreamHandler {
                 .POST(HttpRequest.BodyPublishers.ofString(query.toString()))
                 .build();
         var future = httpClient.sendAsync(httpRequest, HttpResponse.BodyHandlers.discarding());
+        // Save futures in optional collection when running tests.
         if (futures != null) {
             futures.add(future);
         }


### PR DESCRIPTION
I would like to change how we send logs to logstash so each log message is stored as an individual document. To make this more practical, we need to add some more meta data to each message so we can properly filter them. I suggest adding the following:

instance_start_time: An ISO_INSTANT time stamp string indicating when this JVM instance was started.
work_id: A running counter generated ID for each work item, rest request or periodic check, which was previously clumped up in one log message.
work_item: For work items, store the item toString()

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-971](https://bugs.openjdk.java.net/browse/SKARA-971): Stop clumping up logs in logstash


### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**) ⚠️ Review applies to f1ec8ffd7dfe9d930d994a7e1ee7c1f5d9038fcd


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1120/head:pull/1120` \
`$ git checkout pull/1120`

Update a local copy of the PR: \
`$ git checkout pull/1120` \
`$ git pull https://git.openjdk.java.net/skara pull/1120/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1120`

View PR using the GUI difftool: \
`$ git pr show -t 1120`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1120.diff">https://git.openjdk.java.net/skara/pull/1120.diff</a>

</details>
