### PR TITLE
973: Include namespaces in census unification

### DIFF
--- a/bots/censussync/src/main/java/org/openjdk/skara/bots/censussync/CensusSyncUnifyBot.java
+++ b/bots/censussync/src/main/java/org/openjdk/skara/bots/censussync/CensusSyncUnifyBot.java
@@ -125,6 +125,15 @@ public class CensusSyncUnifyBot implements Bot, WorkItem {
 
                     file.println("</project>");
                 }
+                for (var namespace : census.namespaces()) {
+                    file.println("<namespace name=\"" + namespace.name() + "\">");
+                    for (var entry : namespace.entries()) {
+                        var id = entry.getKey();
+                        var contributor = entry.getValue();
+                        file.println("  <user id=\"" + id + "\" census=\"" + contributor.username() + "\" />");
+                    }
+                    file.println("</namespace>");
+                }
                 file.println("</census>");
             }
             toRepo.add(censusXML);

--- a/census/src/main/java/org/openjdk/skara/census/Census.java
+++ b/census/src/main/java/org/openjdk/skara/census/Census.java
@@ -173,7 +173,12 @@ public class Census {
             projects.add(Project.parse(ele, groups, contributors));
         }
 
-        return new Census(contributors, groups, projects, List.of(), version);
+        var namespaces = new ArrayList<Namespace>();
+        for (var ele : XML.children(census, "namespace")) {
+            namespaces.add(Namespace.parse(ele, contributors));
+        }
+
+        return new Census(contributors, groups, projects, namespaces, version);
     }
 
     private static Census parseSingleFile(Path p) throws IOException {

--- a/census/src/main/java/org/openjdk/skara/census/Namespace.java
+++ b/census/src/main/java/org/openjdk/skara/census/Namespace.java
@@ -27,6 +27,7 @@ import org.openjdk.skara.xml.XML;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.*;
+import org.w3c.dom.Element;
 
 public class Namespace {
     private final String name;
@@ -51,15 +52,22 @@ public class Namespace {
         return reverse.get(contributor);
     }
 
-    static Namespace parse(Path p, Map<String, Contributor> contributors) throws IOException {
-        var mapping = new HashMap<String, Contributor>();
-        var reverse = new HashMap<Contributor, String>();
+    public Set<Map.Entry<String, Contributor>> entries() {
+        return mapping.entrySet();
+    }
 
+    static Namespace parse(Path p, Map<String, Contributor> contributors) throws IOException {
         var document = XML.parse(p);
         var namespace = XML.child(document, "namespace");
-        var name = XML.attribute(namespace, "name");
+        return parse(namespace, contributors);
+    }
 
-        for (var user : XML.children(namespace, "user")) {
+    static Namespace parse(Element ele, Map<String, Contributor> contributors) throws IOException {
+        var mapping = new HashMap<String, Contributor>();
+        var reverse = new HashMap<Contributor, String>();
+        var name = XML.attribute(ele, "name");
+
+        for (var user : XML.children(ele, "user")) {
             var id = XML.attribute(user, "id");
             var to = XML.attribute(user, "census");
 

--- a/census/src/test/java/org/openjdk/skara/census/CensusTests.java
+++ b/census/src/test/java/org/openjdk/skara/census/CensusTests.java
@@ -144,6 +144,10 @@ class CensusTests {
             "    <person role=\"lead\" ref=\"user1\" />",
             "    <person role=\"committer\" ref=\"user2\" />",
             "  </project>",
+            "  <namespace name=\"reverse\" >",
+            "    <user id=\"1resu\" census=\"user1\" />",
+            "    <user id=\"2resu\" census=\"user2\" />",
+            "  </namespace>",
             "</census>");
         var tmpFile = Files.createTempFile("census", ".xml");
         Files.write(tmpFile, contents);
@@ -164,6 +168,10 @@ class CensusTests {
         assertEquals(List.of(expectedProject), census.projects());
 
         assertEquals(0, census.version().format());
+        assertEquals(1, census.namespaces().size());
+        assertEquals(2, census.namespace("reverse").entries().size());
+        assertEquals("user1", census.namespace("reverse").get("1resu").username());
+        assertEquals("user2", census.namespace("reverse").get("2resu").username());
 
         Files.delete(tmpFile);
     }


### PR DESCRIPTION
Hi all,

please review this patch that ensures that we include eventual namespaces when unifying a census from directory format to single-file format.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-973](https://bugs.openjdk.java.net/browse/SKARA-973): Include namespaces in census unification


### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1121/head:pull/1121` \
`$ git checkout pull/1121`

Update a local copy of the PR: \
`$ git checkout pull/1121` \
`$ git pull https://git.openjdk.java.net/skara pull/1121/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1121`

View PR using the GUI difftool: \
`$ git pr show -t 1121`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1121.diff">https://git.openjdk.java.net/skara/pull/1121.diff</a>

</details>
