### PR TITLE
pr: markdown fixes for /backport

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
@@ -173,7 +173,7 @@ public class BackportCommand implements CommandHandler {
                       "[" + hash.abbreviate() + "](" + commit.url() + ") from the " +
                       "[" + currentRepoName + "](" + bot.repo().webUrl() + ") repository.");
             body.add(">");
-            var info = "The commit being backported was authored by " + commit.author().name() + " on " +
+            var info = "> The commit being backported was authored by " + commit.author().name() + " on " +
                         commit.committed().format(formatter);
             if (message.reviewers().isEmpty()) {
                 info += " and had no reviewers";
@@ -182,11 +182,7 @@ public class BackportCommand implements CommandHandler {
                                        .stream()
                                        .map(r -> censusInstance.census().contributor(r))
                                        .map(c -> {
-                                           var link = "[" + c.username() + "](https://openjdk.java.net/census#" +
-                                                      c.username() + ")";
-                                           return c.fullName().isPresent() ?
-                                                    c.fullName().get() + " (" + link + ")" :
-                                                    link;
+                                           return c.fullName().isPresent() ? c.fullName().get() : c.username();
                                        })
                                        .collect(Collectors.toList());
                 var numReviewers = reviewers.size();
@@ -221,6 +217,7 @@ public class BackportCommand implements CommandHandler {
                           "\n" +
                           String.join("\n", body) +
                           "\n" +
+                          "\n" +
                           "If you need to update the [source branch](" + backportBranchWebUrl + ") of the pull " +
                           "then run the following commands in a local clone of your personal fork of " +
                           "[" + targetRepo.name() + "](" + targetRepo.webUrl() + "):\n" +
@@ -231,7 +228,7 @@ public class BackportCommand implements CommandHandler {
                           "# make changes\n" +
                           "$ git add paths/to/changed/files\n" +
                           "$ git commit --message 'Describe additional changes made'\n" +
-                          "$ git push\n" +
+                          "$ git push " + fork.webUrl() + " " + backportBranchName + "\n" +
                           "```");
         } catch (IOException e) {
             throw new UncheckedIOException(e);


### PR DESCRIPTION
Hi all,

please review this patch that contains minor markdown fixes for the `/backport` command.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1126/head:pull/1126` \
`$ git checkout pull/1126`

Update a local copy of the PR: \
`$ git checkout pull/1126` \
`$ git pull https://git.openjdk.java.net/skara pull/1126/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1126`

View PR using the GUI difftool: \
`$ git pr show -t 1126`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1126.diff">https://git.openjdk.java.net/skara/pull/1126.diff</a>

</details>
