### PR TITLE
Add census support for the issue notifier

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/PullRequestListener.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/PullRequestListener.java
@@ -26,17 +26,20 @@ import org.openjdk.skara.forge.PullRequest;
 import org.openjdk.skara.vcs.Hash;
 import org.openjdk.skara.vcs.openjdk.Issue;
 
+import java.nio.file.Path;
+
 public interface PullRequestListener {
-    default void onNewIssue(PullRequest pr, Issue issue) {
+    default void onNewIssue(PullRequest pr, Path scratchPath, Issue issue) {
     }
-    default void onRemovedIssue(PullRequest pr, Issue issue) {
+    default void onRemovedIssue(PullRequest pr, Path scratchPath, Issue issue) {
     }
-    default void onNewPullRequest(PullRequest pr) {
+    default void onNewPullRequest(PullRequest pr, Path scratchPath) {
     }
-    default void onIntegratedPullRequest(PullRequest pr, Hash hash) {
+    default void onIntegratedPullRequest(PullRequest pr, Path scratchPath, Hash hash) {
     }
-    default void onHeadChange(PullRequest pr, Hash oldHead) {
+    default void onHeadChange(PullRequest pr, Path scratchPath, Hash oldHead) {
     }
-    default void onStateChange(PullRequest pr, org.openjdk.skara.issuetracker.Issue.State oldState) {
+    default void onStateChange(PullRequest pr, Path scratchPath, org.openjdk.skara.issuetracker.Issue.State oldState) {
     }
+    String name();
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryListener.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryListener.java
@@ -26,16 +26,17 @@ import org.openjdk.skara.forge.HostedRepository;
 import org.openjdk.skara.vcs.*;
 import org.openjdk.skara.vcs.openjdk.OpenJDKTag;
 
+import java.nio.file.Path;
 import java.util.List;
 
 public interface RepositoryListener {
-    default void onNewCommits(HostedRepository repository, Repository localRepository, List<Commit> commits, Branch branch) throws NonRetriableException {
+    default void onNewCommits(HostedRepository repository, Repository localRepository, Path scratchPath, List<Commit> commits, Branch branch) throws NonRetriableException {
     }
-    default void onNewOpenJDKTagCommits(HostedRepository repository, Repository localRepository, List<Commit> commits, OpenJDKTag tag, Tag.Annotated annotated) throws NonRetriableException {
+    default void onNewOpenJDKTagCommits(HostedRepository repository, Repository localRepository, Path scratchPath, List<Commit> commits, OpenJDKTag tag, Tag.Annotated annotated) throws NonRetriableException {
     }
-    default void onNewTagCommit(HostedRepository repository, Repository localRepository, Commit commit, Tag tag, Tag.Annotated annotation) throws NonRetriableException {
+    default void onNewTagCommit(HostedRepository repository, Repository localRepository, Path scratchPath, Commit commit, Tag tag, Tag.Annotated annotation) throws NonRetriableException {
     }
-    default void onNewBranch(HostedRepository repository, Repository localRepository, List<Commit> commits, Branch parent, Branch branch) throws NonRetriableException {
+    default void onNewBranch(HostedRepository repository, Repository localRepository, Path scratchPath, List<Commit> commits, Branch parent, Branch branch) throws NonRetriableException {
     }
     String name();
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/comment/CommitCommentNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/comment/CommitCommentNotifier.java
@@ -28,6 +28,7 @@ import org.openjdk.skara.issuetracker.*;
 import org.openjdk.skara.vcs.*;
 import org.openjdk.skara.vcs.openjdk.CommitMessageParsers;
 
+import java.nio.file.Path;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -54,7 +55,7 @@ class CommitCommentNotifier implements Notifier, PullRequestListener {
     }
 
     @Override
-    public void onIntegratedPullRequest(PullRequest pr, Hash hash)  {
+    public void onIntegratedPullRequest(PullRequest pr, Path scratchPath, Hash hash)  {
         var repository = pr.repository();
         var commit = repository.commit(hash).orElseThrow(() ->
                 new IllegalStateException("Integrated commit " + hash +
@@ -77,5 +78,10 @@ class CommitCommentNotifier implements Notifier, PullRequestListener {
             }
         }
         repository.addCommitComment(hash, String.join("\n", comment));
+    }
+
+    @Override
+    public String name() {
+        return "commitcomment";
     }
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/CensusInstance.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/CensusInstance.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.notify.issue;
+
+import org.openjdk.skara.census.*;
+import org.openjdk.skara.forge.HostedRepository;
+import org.openjdk.skara.vcs.Repository;
+
+import java.io.*;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.Optional;
+
+class CensusInstance {
+    private final Namespace namespace;
+
+    private CensusInstance(Namespace namespace) {
+        this.namespace = namespace;
+    }
+
+    private static Repository initialize(HostedRepository repo, String ref, Path folder) {
+        try {
+            return Repository.materialize(folder, repo.url(), "+" + ref + ":" + "issue_census_" + repo.name());
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to retrieve census to " + folder, e);
+        }
+    }
+
+    private static Namespace namespace(Census census, String hostNamespace) {
+        var namespace = census.namespace(hostNamespace);
+        if (namespace == null) {
+            throw new RuntimeException("Namespace not found in census: " + hostNamespace);
+        }
+
+        return namespace;
+    }
+
+    static CensusInstance create(HostedRepository censusRepo, String censusRef, Path folder, String namespace) {
+        var repoName = censusRepo.url().getHost() + "/" + censusRepo.name();
+        var repoFolder = folder.resolve(URLEncoder.encode(repoName, StandardCharsets.UTF_8));
+        try {
+            var localRepo = Repository.get(repoFolder)
+                                      .or(() -> Optional.of(initialize(censusRepo, censusRef, repoFolder)))
+                                      .orElseThrow();
+            var hash = localRepo.fetch(censusRepo.url(), censusRef, false);
+            localRepo.checkout(hash, true);
+        } catch (IOException e) {
+            initialize(censusRepo, censusRef, repoFolder);
+        }
+
+        try {
+            var census = Census.parse(repoFolder);
+            var ns = namespace(census, namespace);
+            return new CensusInstance(ns);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Cannot parse census at " + repoFolder, e);
+        }
+    }
+
+    Namespace namespace() {
+        return namespace;
+    }
+}

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierBuilder.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierBuilder.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.skara.bots.notify.issue;
 
+import org.openjdk.skara.forge.HostedRepository;
 import org.openjdk.skara.issuetracker.IssueProject;
 
 import java.net.URI;
@@ -38,6 +39,9 @@ class IssueNotifierBuilder {
     private JbsVault vault = null;
     private boolean prOnly = true;
     private String buildName = null;
+    private HostedRepository censusRepository = null;
+    private String censusRef = null;
+    private String namespace = "openjdk.org";
 
     IssueNotifierBuilder issueProject(IssueProject issueProject) {
         this.issueProject = issueProject;
@@ -90,9 +94,25 @@ class IssueNotifierBuilder {
         return this;
     }
 
+    public IssueNotifierBuilder censusRepository(HostedRepository censusRepository) {
+        this.censusRepository = censusRepository;
+        return this;
+    }
+
+    public IssueNotifierBuilder censusRef(String censusRef) {
+        this.censusRef = censusRef;
+        return this;
+    }
+
+    public IssueNotifierBuilder namespace(String namespace) {
+        this.namespace = namespace;
+        return this;
+    }
+
     IssueNotifier build() {
         var jbsBackport = new JbsBackport(issueProject.webUrl(), vault);
         return new IssueNotifier(issueProject, reviewLink, reviewIcon, commitLink, commitIcon,
-                                 setFixVersion, fixVersions, jbsBackport, prOnly, buildName);
+                                 setFixVersion, fixVersions, jbsBackport, prOnly, buildName,
+                                 censusRepository, censusRef, namespace);
     }
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierFactory.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierFactory.java
@@ -88,6 +88,14 @@ public class IssueNotifierFactory implements NotifierFactory {
             builder.prOnly(notifierConfiguration.get("pronly").asBoolean());
         }
 
+        if (notifierConfiguration.contains("census")) {
+            builder.censusRepository(botConfiguration.repository(notifierConfiguration.get("census").asString()));
+            builder.censusRef(botConfiguration.repositoryRef(notifierConfiguration.get("census").asString()));
+        }
+        if (notifierConfiguration.contains("namespace")) {
+            builder.namespace(notifierConfiguration.get("namespace").asString());
+        }
+
         return builder.build();
     }
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/json/JsonNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/json/JsonNotifier.java
@@ -82,7 +82,7 @@ class JsonNotifier implements Notifier, RepositoryListener {
     }
 
     @Override
-    public void onNewCommits(HostedRepository repository, Repository localRepository, List<Commit> commits, Branch branch) throws NonRetriableException {
+    public void onNewCommits(HostedRepository repository, Repository localRepository, Path scratchPath, List<Commit> commits, Branch branch) throws NonRetriableException {
         try (var writer = new JsonWriter(path, repository.name())) {
             for (var commit : commits) {
                 var json = commitToChanges(repository, localRepository, commit, defaultBuild);
@@ -94,7 +94,7 @@ class JsonNotifier implements Notifier, RepositoryListener {
     }
 
     @Override
-    public void onNewOpenJDKTagCommits(HostedRepository repository, Repository localRepository, List<Commit> commits, OpenJDKTag tag, Tag.Annotated annotation) throws NonRetriableException {
+    public void onNewOpenJDKTagCommits(HostedRepository repository, Repository localRepository, Path scratchPath, List<Commit> commits, OpenJDKTag tag, Tag.Annotated annotation) throws NonRetriableException {
         if (tag.buildNum().isEmpty()) {
             return;
         }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/mailinglist/MailingListNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/mailinglist/MailingListNotifier.java
@@ -30,6 +30,7 @@ import org.openjdk.skara.vcs.*;
 import org.openjdk.skara.vcs.openjdk.OpenJDKTag;
 
 import java.io.*;
+import java.nio.file.Path;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.logging.Logger;
@@ -229,7 +230,7 @@ class MailingListNotifier implements Notifier, RepositoryListener {
     }
 
     @Override
-    public void onNewCommits(HostedRepository repository, Repository localRepository, List<Commit> commits, Branch branch) throws NonRetriableException {
+    public void onNewCommits(HostedRepository repository, Repository localRepository, Path scratchPath, List<Commit> commits, Branch branch) throws NonRetriableException {
         if (mode == Mode.PR) {
             commits = filterPrCommits(repository, localRepository, commits, branch);
         }
@@ -237,12 +238,12 @@ class MailingListNotifier implements Notifier, RepositoryListener {
     }
 
     @Override
-    public void onNewOpenJDKTagCommits(HostedRepository repository, Repository localRepository, List<Commit> commits, OpenJDKTag tag, Tag.Annotated annotation) throws NonRetriableException {
+    public void onNewOpenJDKTagCommits(HostedRepository repository, Repository localRepository, Path scratchPath, List<Commit> commits, OpenJDKTag tag, Tag.Annotated annotation) throws NonRetriableException {
         if (!reportNewTags) {
             return;
         }
         if (!reportNewBuilds) {
-            onNewTagCommit(repository, localRepository, commits.get(commits.size() - 1), tag.tag(), annotation);
+            onNewTagCommit(repository, localRepository, scratchPath, commits.get(commits.size() - 1), tag.tag(), annotation);
             return;
         }
         var writer = new StringWriter();
@@ -285,7 +286,7 @@ class MailingListNotifier implements Notifier, RepositoryListener {
     }
 
     @Override
-    public void onNewTagCommit(HostedRepository repository, Repository localRepository, Commit commit, Tag tag, Tag.Annotated annotation) throws NonRetriableException {
+    public void onNewTagCommit(HostedRepository repository, Repository localRepository, Path scratchPath, Commit commit, Tag tag, Tag.Annotated annotation) throws NonRetriableException {
         if (!reportNewTags) {
             return;
         }
@@ -337,7 +338,7 @@ class MailingListNotifier implements Notifier, RepositoryListener {
     }
 
     @Override
-    public void onNewBranch(HostedRepository repository, Repository localRepository, List<Commit> commits, Branch parent, Branch branch) throws NonRetriableException {
+    public void onNewBranch(HostedRepository repository, Repository localRepository, Path scratchPath, List<Commit> commits, Branch parent, Branch branch) throws NonRetriableException {
         if (!reportNewBranches) {
             return;
         }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifier.java
@@ -67,14 +67,14 @@ public class PullRequestBranchNotifier implements Notifier, PullRequestListener 
     }
 
     @Override
-    public void onNewPullRequest(PullRequest pr) {
+    public void onNewPullRequest(PullRequest pr, Path scratchPath) {
         if (pr.state() == Issue.State.OPEN) {
             pushBranch(pr);
         }
     }
 
     @Override
-    public void onStateChange(PullRequest pr, Issue.State oldState) {
+    public void onStateChange(PullRequest pr, Path scratchPath, Issue.State oldState) {
         if (pr.state() == Issue.State.CLOSED) {
             PreIntegrations.retargetDependencies(pr);
             deleteBranch(pr);
@@ -84,7 +84,12 @@ public class PullRequestBranchNotifier implements Notifier, PullRequestListener 
     }
 
     @Override
-    public void onHeadChange(PullRequest pr, Hash oldHead) {
+    public String name() {
+        return "pullrequestbranch";
+    }
+
+    @Override
+    public void onHeadChange(PullRequest pr, Path scratchPath, Hash oldHead) {
         if (pr.state() == Issue.State.OPEN) {
             pushBranch(pr);
         }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/slack/SlackNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/slack/SlackNotifier.java
@@ -32,6 +32,7 @@ import org.openjdk.skara.network.*;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.URI;
+import java.nio.file.Path;
 import java.util.List;
 import java.time.format.DateTimeFormatter;
 
@@ -53,7 +54,7 @@ class SlackNotifier implements Notifier, RepositoryListener, PullRequestListener
     }
 
     @Override
-    public void onNewPullRequest(PullRequest pr) {
+    public void onNewPullRequest(PullRequest pr, Path scratchPath) {
         if (prWebhook == null) {
             return;
         }
@@ -73,7 +74,7 @@ class SlackNotifier implements Notifier, RepositoryListener, PullRequestListener
     @Override
     public void onNewCommits(HostedRepository repository,
                              Repository localRepository,
-                             List<Commit> commits,
+                             Path scratchPath, List<Commit> commits,
                              Branch branch) throws NonRetriableException {
         if (commitWebhook == null) {
             return;

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdaterTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdaterTests.java
@@ -24,13 +24,13 @@ package org.openjdk.skara.bots.notify;
 
 import org.junit.jupiter.api.*;
 import org.openjdk.skara.forge.HostedRepository;
-import org.openjdk.skara.storage.StorageBuilder;
 import org.openjdk.skara.test.*;
 import org.openjdk.skara.vcs.Tag;
 import org.openjdk.skara.vcs.*;
 import org.openjdk.skara.vcs.openjdk.OpenJDKTag;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -50,8 +50,8 @@ public class UpdaterTests {
         }
 
         @Override
-        public void onNewCommits(HostedRepository repository, Repository localRepository, List<Commit> commits,
-                                  Branch branch) throws NonRetriableException {
+        public void onNewCommits(HostedRepository repository, Repository localRepository, Path scratchPath, List<Commit> commits,
+                                 Branch branch) throws NonRetriableException {
             updateCount++;
             if (shouldFail) {
                 if (idempotent) {
@@ -64,19 +64,19 @@ public class UpdaterTests {
 
         @Override
         public void onNewOpenJDKTagCommits(HostedRepository repository, Repository localRepository,
-         List<Commit> commits, OpenJDKTag tag, Tag.Annotated annotated) {
+                                           Path scratchPath, List<Commit> commits, OpenJDKTag tag, Tag.Annotated annotated) {
             throw new RuntimeException("unexpected");
         }
 
         @Override
-        public void onNewTagCommit(HostedRepository repository, Repository localRepository, Commit commit, Tag tag,
-         Tag.Annotated annotation) {
+        public void onNewTagCommit(HostedRepository repository, Repository localRepository, Path scratchPath, Commit commit, Tag tag,
+                                   Tag.Annotated annotation) {
             throw new RuntimeException("unexpected");
         }
 
         @Override
-        public void onNewBranch(HostedRepository repository, Repository localRepository, List<Commit> commits,
-         Branch parent, Branch branch) {
+        public void onNewBranch(HostedRepository repository, Repository localRepository, Path scratchPath, List<Commit> commits,
+                                Branch parent, Branch branch) {
             throw new RuntimeException("unexpected");
         }
 

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/IssueProject.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/IssueProject.java
@@ -22,7 +22,6 @@
  */
 package org.openjdk.skara.issuetracker;
 
-import org.openjdk.skara.host.HostUser;
 import org.openjdk.skara.json.JSONValue;
 
 import java.net.URI;
@@ -37,5 +36,4 @@ public interface IssueProject {
     List<Issue> issues();
     List<Issue> issues(ZonedDateTime updatedAfter);
     String name();
-    Optional<HostUser> findUser(String findBy);
 }

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraProject.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraProject.java
@@ -22,7 +22,6 @@
  */
 package org.openjdk.skara.issuetracker.jira;
 
-import org.openjdk.skara.host.HostUser;
 import org.openjdk.skara.issuetracker.*;
 import org.openjdk.skara.json.*;
 import org.openjdk.skara.network.*;
@@ -467,32 +466,5 @@ public class JiraProject implements IssueProject {
     @Override
     public String name() {
         return projectName.toUpperCase();
-    }
-
-    @Override
-    public Optional<HostUser> findUser(String findBy) {
-        var user = request.get("user/search")
-                          .param("username", findBy)
-                          .onError(r -> r.statusCode() == 404 ? Optional.of(JSON.object().put("NOT_FOUND", true)) : Optional.empty())
-                          .execute();
-        if (!user.isArray()) {
-            return Optional.empty();
-        }
-        if (user.asArray().size() == 0) {
-            log.info("No results returned for user query: " + findBy);
-            return Optional.empty();
-        }
-        if (user.asArray().size() > 1) {
-            log.severe("Multiple results returned for user query: " + findBy);
-            return Optional.empty();
-        }
-        var data = user.asArray().get(0);
-        var hostUser = HostUser.builder()
-                              .id(data.get("name").asString())
-                              .username(data.get("name").asString())
-                              .fullName(data.get("displayName").asString())
-                              .email(data.get("emailAddress").asString())
-                              .build();
-        return Optional.of(hostUser);
     }
 }

--- a/test/src/main/java/org/openjdk/skara/test/TestHost.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHost.java
@@ -22,7 +22,6 @@
  */
 package org.openjdk.skara.test;
 
-import org.openjdk.skara.email.EmailAddress;
 import org.openjdk.skara.forge.*;
 import org.openjdk.skara.host.HostUser;
 import org.openjdk.skara.issuetracker.*;
@@ -133,14 +132,6 @@ public class TestHost implements Forge, IssueTracker {
     public Optional<HostUser> user(String username) {
         return data.users.stream()
                          .filter(user -> user.username().equals(username))
-                         .findAny();
-    }
-
-    Optional<HostUser> findUser(String findBy) {
-        var findByLocalPart = EmailAddress.parse(findBy).localPart();
-        return data.users.stream()
-                         .filter(user -> user.username().equals(findBy) ||
-                                 user.username().equals(findByLocalPart))
                          .findAny();
     }
 

--- a/test/src/main/java/org/openjdk/skara/test/TestIssueProject.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestIssueProject.java
@@ -22,7 +22,6 @@
  */
 package org.openjdk.skara.test;
 
-import org.openjdk.skara.host.HostUser;
 import org.openjdk.skara.issuetracker.*;
 import org.openjdk.skara.json.JSONValue;
 import org.openjdk.skara.network.URIBuilder;
@@ -81,10 +80,5 @@ public class TestIssueProject implements IssueProject {
     @Override
     public String name() {
         return projectName.toUpperCase();
-    }
-
-    @Override
-    public Optional<HostUser> findUser(String findBy) {
-        return host.findUser(findBy);
     }
 }


### PR DESCRIPTION
Add census support for the issue notifier, to avoid having to hardcode openjdk.org.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1127/head:pull/1127` \
`$ git checkout pull/1127`

Update a local copy of the PR: \
`$ git checkout pull/1127` \
`$ git pull https://git.openjdk.java.net/skara pull/1127/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1127`

View PR using the GUI difftool: \
`$ git pr show -t 1127`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1127.diff">https://git.openjdk.java.net/skara/pull/1127.diff</a>

</details>
