### PR TITLE
976: Do not send empty emails

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
@@ -114,7 +114,7 @@ class ArchiveWorkItem implements WorkItem {
         }
     }
 
-    private final static Pattern commandPattern = Pattern.compile("^\\s*/([A-Za-z]+).*$");
+    private static final Pattern commandPattern = Pattern.compile("^\\s*/([A-Za-z]+).*$", Pattern.MULTILINE | Pattern.DOTALL);
 
     private boolean ignoreComment(HostUser author, String body) {
         if (pr.repository().forge().currentUser().equals(author)) {
@@ -124,11 +124,12 @@ class ArchiveWorkItem implements WorkItem {
             return true;
         }
         // Check if this comment only contains command lines
-        var commandOnly = body.strip().lines()
-                              .map(commandPattern::matcher)
-                              .allMatch(Matcher::matches);
-        if (body.strip().lines().count() > 0 && commandOnly) {
-            return true;
+        var commandLineMatcher = commandPattern.matcher(body);
+        if (commandLineMatcher.find()) {
+            var filteredBody = commandLineMatcher.replaceAll("");
+            if (filteredBody.strip().isEmpty()) {
+                return true;
+            }
         }
         for (var ignoredCommentPattern : bot.ignoredComments()) {
             var ignoredCommentMatcher = ignoredCommentPattern.matcher(body);


### PR DESCRIPTION
Check for multiline commands when ignoring command-only comments.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-976](https://bugs.openjdk.java.net/browse/SKARA-976): Do not send empty emails


### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1128/head:pull/1128` \
`$ git checkout pull/1128`

Update a local copy of the PR: \
`$ git checkout pull/1128` \
`$ git pull https://git.openjdk.java.net/skara pull/1128/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1128`

View PR using the GUI difftool: \
`$ git pr show -t 1128`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1128.diff">https://git.openjdk.java.net/skara/pull/1128.diff</a>

</details>
