### PR TITLE
956: Skara bot is continually trying to process the same PR command

### DIFF
--- a/network/src/main/java/org/openjdk/skara/network/RestRequestCache.java
+++ b/network/src/main/java/org/openjdk/skara/network/RestRequestCache.java
@@ -217,6 +217,14 @@ enum RestRequestCache {
             }
             try (var ignored = new LockWithTimeout(authLock)) {
                 return client.send(finalRequest, HttpResponse.BodyHandlers.ofString());
+            } finally {
+                // Invalidate any related GET caches
+                var postUriString = unauthenticatedRequest.uri().toString();
+                for (var cachedResponse : cachedResponses.keySet()) {
+                    if (cachedResponse.unauthenticatedRequest.uri().toString().startsWith(postUriString)) {
+                        cachedUpdated.put(cachedResponse, Instant.now().minus(Duration.ofDays(1)));
+                    }
+                }
             }
         }
     }

--- a/network/src/test/java/org/openjdk/skara/network/RestRequestTests.java
+++ b/network/src/test/java/org/openjdk/skara/network/RestRequestTests.java
@@ -269,6 +269,38 @@ class RestRequestTests {
     }
 
     @Test
+    void cacheFlush() throws IOException {
+        try (var receiver = new RestReceiver()) {
+            var request = new RestRequest(receiver.getEndpoint());
+            request.get("/test").execute();
+            assertFalse(receiver.usedCached());
+            request.post("/test").execute();
+            request.get("/test").execute();
+            assertFalse(receiver.usedCached());
+            var anotherRequest = new RestRequest(receiver.getEndpoint());
+            request.post("/test").execute();
+            anotherRequest.get("/test").execute();
+            assertFalse(receiver.usedCached());
+        }
+    }
+
+    @Test
+    void cacheFlushPartial() throws IOException {
+        try (var receiver = new RestReceiver()) {
+            var request = new RestRequest(receiver.getEndpoint());
+            request.get("/test?1").execute();
+            assertFalse(receiver.usedCached());
+            request.get("/test?1").execute();
+            assertTrue(receiver.usedCached());
+            request.post("/test").execute();
+            request.get("/test?1").execute();
+            assertFalse(receiver.usedCached());
+            request.get("/test?1").execute();
+            assertTrue(receiver.usedCached());
+        }
+    }
+
+    @Test
     void cachedSeparateAuth() throws IOException {
         try (var receiver = new RestReceiver()) {
             var plainRequest = new RestRequest(receiver.getEndpoint());


### PR DESCRIPTION
Invalidate related GET cache entries when performing a non-GET request, to ensure that we for example always retrieve an updated list of comments after posting a new one.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-956](https://bugs.openjdk.java.net/browse/SKARA-956): Skara bot is continually trying to process the same PR command


### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1129/head:pull/1129` \
`$ git checkout pull/1129`

Update a local copy of the PR: \
`$ git checkout pull/1129` \
`$ git pull https://git.openjdk.java.net/skara pull/1129/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1129`

View PR using the GUI difftool: \
`$ git pr show -t 1129`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1129.diff">https://git.openjdk.java.net/skara/pull/1129.diff</a>

</details>
