### PR TITLE
974: Add retry logic to mlbridge when pushing

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
@@ -221,7 +221,21 @@ class WebrevStorage {
                     // where some of the files have already been committed. Ignore it and continue.
                     continue;
                 }
-                localStorage.push(hash, remote, storageRef);
+                var retryCount = 0;
+                while (true) {
+                    try {
+                        localStorage.push(hash, remote, storageRef);
+                        break;
+                    } catch (IOException e) {
+                        retryCount++;
+                        if (retryCount > 5) {
+                            throw e;
+                        }
+                        var updated = localStorage.fetch(remote, storageRef);
+                        localStorage.rebase(updated, author.fullName().orElseThrow(), author.address());
+                        hash = localStorage.head();
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
If pushing a webrev to the archive should fail, it is commonly caused by a concurrent push for another webrev. Try to rebase a few times to avoid throwing an error.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-974](https://bugs.openjdk.java.net/browse/SKARA-974): Add retry logic to mlbridge when pushing


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1130/head:pull/1130` \
`$ git checkout pull/1130`

Update a local copy of the PR: \
`$ git checkout pull/1130` \
`$ git pull https://git.openjdk.java.net/skara pull/1130/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1130`

View PR using the GUI difftool: \
`$ git pr show -t 1130`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1130.diff">https://git.openjdk.java.net/skara/pull/1130.diff</a>

</details>
