### PR TITLE
831: Longer time for autoclose on passive PRs

### DIFF
--- a/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestPrunerBot.java
+++ b/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestPrunerBot.java
@@ -40,7 +40,7 @@ class PullRequestPrunerBotWorkItem implements WorkItem {
 
     PullRequestPrunerBotWorkItem(PullRequest pr, Duration maxAge) {
         this.pr = pr;
-        this.maxAge = maxAge;
+        this.maxAge = pr.isDraft() ? maxAge.multipliedBy(2) : maxAge;
     }
 
     @Override
@@ -83,7 +83,8 @@ class PullRequestPrunerBotWorkItem implements WorkItem {
             if (lastComment.author().equals(pr.repository().forge().currentUser()) && lastComment.body().contains(noticeMarker)) {
                 var message = "@" + pr.author().username() + " This pull request has been inactive for more than " +
                         formatDuration(maxAge.multipliedBy(2)) + " and will now be automatically closed. If you would " +
-                        "like to continue working on this pull request in the future, feel free to reopen it!";
+                        "like to continue working on this pull request in the future, feel free to reopen it! This can be done " +
+                        "using the `/open` pull request command.";
                 log.fine("Posting prune message");
                 pr.addComment(message);
                 pr.setState(PullRequest.State.CLOSED);

--- a/bots/bridgekeeper/src/test/java/org/openjdk/skara/bots/bridgekeeper/PullRequestPrunerBotTests.java
+++ b/bots/bridgekeeper/src/test/java/org/openjdk/skara/bots/bridgekeeper/PullRequestPrunerBotTests.java
@@ -79,6 +79,10 @@ class PullRequestPrunerBotTests {
             // There should now be no open PRs
             var prs = author.pullRequests();
             assertEquals(0, prs.size());
+
+            // There should be a mention on how to reopen
+            var comment = pr.comments().get(pr.comments().size() - 1).body();
+            assertTrue(comment.contains("`/open`"), comment);
         }
     }
 


### PR DESCRIPTION
Wait longer before automatically trying to close draft pull requests. Also mention how to reopen a closed one.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-831](https://bugs.openjdk.java.net/browse/SKARA-831): Longer time for autoclose on passive PRs


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1131/head:pull/1131` \
`$ git checkout pull/1131`

Update a local copy of the PR: \
`$ git checkout pull/1131` \
`$ git pull https://git.openjdk.java.net/skara pull/1131/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1131`

View PR using the GUI difftool: \
`$ git pr show -t 1131`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1131.diff">https://git.openjdk.java.net/skara/pull/1131.diff</a>

</details>
