### PR TITLE
980: Update log level of thrown exceptions

### DIFF
--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
@@ -167,7 +167,7 @@ public class BotRunner {
                     try {
                         head.get();
                     } catch (InterruptedException | ExecutionException e) {
-                        log.log(Level.WARNING,"Exception during queue drain", e);
+                        log.log(Level.WARNING, "Exception during queue drain", e);
                     }
                 } else {
                     log.finest("Queue is now empty");

--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
@@ -83,9 +83,8 @@ public class BotRunner {
                 try {
                     followUpItems = item.run(scratchPath);
                 } catch (RuntimeException e) {
-                    log.severe("Exception during item execution (" + item + "): " + e.getMessage());
+                    log.log(Level.SEVERE, "Exception during item execution (" + item + "): " + e.getMessage(), e);
                     item.handleRuntimeException(e);
-                    log.throwing(item.toString(), "run", e);
                 } finally {
                     log.log(Level.FINE, "Item " + item + " is now done", TaskPhases.END);
                 }
@@ -168,8 +167,7 @@ public class BotRunner {
                     try {
                         head.get();
                     } catch (InterruptedException | ExecutionException e) {
-                        log.warning("Exception during queue drain");
-                        log.throwing("BotRunner", "drain", e);
+                        log.log(Level.WARNING,"Exception during queue drain", e);
                     }
                 } else {
                     log.finest("Queue is now empty");
@@ -188,8 +186,7 @@ public class BotRunner {
             try {
                 Thread.sleep(1);
             } catch (InterruptedException e) {
-                log.warning("Exception during queue drain");
-                log.throwing("BotRunner", "drain", e);
+                log.log(Level.WARNING, "Exception during queue drain", e);
             }
         }
 
@@ -231,8 +228,7 @@ public class BotRunner {
                     }
                 }
             } catch (RuntimeException e) {
-                log.severe("Exception during periodic item checking: " + e.getMessage());
-                log.throwing("BotRunner", "checkPeriodicItems", e);
+                log.log(Level.SEVERE, "Exception during periodic item checking: " + e.getMessage(), e);
             } finally {
                 log.log(Level.FINE, "Done checking periodic items", TaskPhases.END);
             }
@@ -267,8 +263,7 @@ public class BotRunner {
                     }
                 }
             } catch (RuntimeException e) {
-                log.severe("Exception during rest request processing: " + e.getMessage());
-                log.throwing("BotRunner", "processRestRequest", e);
+                log.log(Level.SEVERE, "Exception during rest request processing: " + e.getMessage(), e);
             } finally {
                 log.log(Level.FINE, "Done processing incoming rest request", TaskPhases.END);
             }
@@ -289,8 +284,7 @@ public class BotRunner {
             try {
                 restReceiver = new RestReceiver(config.restReceiverPort().get(), this::processRestRequest);
             } catch (IOException e) {
-                log.warning("Failed to create RestReceiver");
-                log.throwing("BotRunner", "run", e);
+                log.log(Level.WARNING, "Failed to create RestReceiver", e);
             }
         }
 

--- a/bot/src/main/java/org/openjdk/skara/bot/BotTaskAggregationHandler.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotTaskAggregationHandler.java
@@ -92,8 +92,7 @@ public abstract class BotTaskAggregationHandler extends StreamHandler {
             }
         }
         catch (RuntimeException e) {
-            log.severe("Exception during task notification posting: " + e.getMessage());
-            log.throwing("BotTaskAggregationHandler", "publish", e);
+            log.log(Level.SEVERE, "Exception during task notification posting: " + e.getMessage(), e);
         } finally {
             threadEntry.isPublishing = false;
         }

--- a/bot/src/main/java/org/openjdk/skara/bot/RestReceiver.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/RestReceiver.java
@@ -29,6 +29,7 @@ import java.io.*;
 import java.net.*;
 import java.nio.charset.StandardCharsets;
 import java.util.function.Consumer;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 class RestReceiver {
@@ -53,8 +54,7 @@ class RestReceiver {
                 var parsedInput = JSON.parse(input);
                 consumer.accept(parsedInput);
             } catch (RuntimeException e) {
-                log.warning("Failed to parse incoming request: " + input);
-                log.throwing("RestReceiver", "Handler", e);
+                log.log(Level.WARNING, "Failed to parse incoming request: " + input, e);
             }
         }
     }

--- a/bots/cli/src/main/java/org/openjdk/skara/bots/cli/BotSlackHandler.java
+++ b/bots/cli/src/main/java/org/openjdk/skara/bots/cli/BotSlackHandler.java
@@ -100,8 +100,7 @@ class BotSlackHandler extends BotTaskAggregationHandler {
 
             webhook.post("").body(query).executeUnparsed();
         } catch (RuntimeException | IOException e) {
-            log.warning("Exception during slack notification posting: " + e.getMessage());
-            log.throwing("BotSlackHandler", "publish", e);
+            log.log(Level.WARNING, "Exception during slack notification posting: " + e.getMessage(), e);
         }
     }
 

--- a/bots/cli/src/test/java/org/openjdk/skara/bots/cli/BotLogstashHandlerTests.java
+++ b/bots/cli/src/test/java/org/openjdk/skara/bots/cli/BotLogstashHandlerTests.java
@@ -45,6 +45,7 @@ class BotLogstashHandlerTests {
             handler.setFuturesCollection(futures);
 
             var record = new LogRecord(Level.INFO, "Hello");
+            record.setLoggerName("my.logger");
             handler.publish(record);
 
             for (Future<HttpResponse<Void>> future : futures) {
@@ -53,8 +54,9 @@ class BotLogstashHandlerTests {
 
             var requests = receiver.getRequests();
             assertEquals(1, requests.size(), requests.toString());
-            assertTrue(requests.get(0).get("message").asString().contains("Hello"));
-            assertTrue(requests.get(0).get("level").asString().contains(Level.INFO.getName()));
+            assertEquals("Hello", requests.get(0).get("message").asString());
+            assertEquals(Level.INFO.getName(), requests.get(0).get("level").asString());
+            assertEquals("my.logger", requests.get(0).get("logger_name").asString());
         }
     }
 

--- a/bots/hgbridge/src/main/java/org/openjdk/skara/bots/hgbridge/JBridgeBot.java
+++ b/bots/hgbridge/src/main/java/org/openjdk/skara/bots/hgbridge/JBridgeBot.java
@@ -30,6 +30,7 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.util.*;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class JBridgeBot implements Bot, WorkItem {
@@ -128,8 +129,7 @@ public class JBridgeBot implements Bot, WorkItem {
                         repo.pushAll(destination.url());
                         storage.resolve(successfulPushMarker).toFile().createNewFile();
                     } catch (IOException e) {
-                        log.severe("Failed to push to " + destination.url());
-                        log.throwing("JBridgeBot", "run", e);
+                        log.log(Level.SEVERE, "Failed to push to " + destination.url(), e);
                         lastException = e;
                     }
                 } else {

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryWorkItem.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryWorkItem.java
@@ -290,7 +290,7 @@ public class RepositoryWorkItem implements WorkItem {
                 }
             }
             if (!errors.isEmpty()) {
-                errors.forEach(error -> log.throwing("RepositoryWorkItem", "run", error));
+                errors.forEach(error -> log.log(Level.WARNING, error.getMessage(), error));
                 throw new RuntimeException("Errors detected when processing repository notifications", errors.get(0));
             }
         } catch (IOException e) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
@@ -30,6 +30,7 @@ import java.io.*;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.*;
+import java.util.logging.Level;
 import java.util.stream.Stream;
 import java.util.stream.Collectors;
 import java.util.logging.Logger;
@@ -214,8 +215,7 @@ public class IntegrateCommand implements CommandHandler {
                 reply.println("No push attempt will be made.");
             }
         } catch (IOException | CommitFailure e) {
-            log.severe("An error occurred during integration (" + pr.webUrl() + "): " + e.getMessage());
-            log.throwing("IntegrateCommand", "handle", e);
+            log.log(Level.SEVERE, "An error occurred during integration (" + pr.webUrl() + "): " + e.getMessage(), e);
             reply.println("An unexpected error occurred during integration. No push attempt will be made. " +
                                   "The error has been logged and will be investigated. It is possible that this error " +
                                   "is caused by a transient issue; feel free to retry the operation.");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
@@ -30,6 +30,7 @@ import java.io.*;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.*;
+import java.util.logging.Level;
 import java.util.stream.Stream;
 import java.util.stream.Collectors;
 import java.util.logging.Logger;
@@ -156,8 +157,7 @@ public class SponsorCommand implements CommandHandler {
                 reply.println("No push attempt will be made.");
             }
         } catch (IOException | CommitFailure e) {
-            log.severe("An error occurred during sponsored integration (" + pr.webUrl() + "): " + e.getMessage());
-            log.throwing("SponsorCommand", "handle", e);
+            log.log(Level.SEVERE, "An error occurred during sponsored integration (" + pr.webUrl() + "): " + e.getMessage(), e);
             reply.println("An unexpected error occurred during sponsored integration. No push attempt will be made. " +
                                   "The error has been logged and will be investigated. It is possible that this error " +
                                   "is caused by a transient issue; feel free to retry the operation.");

--- a/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestUpdateNeededWorkItem.java
+++ b/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestUpdateNeededWorkItem.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class TestUpdateNeededWorkItem implements WorkItem {
@@ -68,8 +69,7 @@ public class TestUpdateNeededWorkItem implements WorkItem {
             log.info("Getting test jobs for " + desc);
             jobs = ci.jobsFor(pr);
         } catch (IOException e) {
-            log.info("Could not retrieve test jobs for PR: " + desc);
-            log.throwing("TestBot", "getPeriodicItems", e);
+            log.log(Level.INFO, "Could not retrieve test jobs for PR: " + desc, e);
         }
 
         if (!jobs.isEmpty()) {

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepositoryPool.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepositoryPool.java
@@ -29,6 +29,7 @@ import java.net.URI;
 import java.nio.file.*;
 import java.time.*;
 import java.util.*;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class HostedRepositoryPool {
@@ -121,8 +122,7 @@ public class HostedRepositoryPool {
                 try {
                     Files.move(path, preserved);
                 } catch (IOException e) {
-                    log.severe("Failed to preserve old clone at " + path);
-                    log.throwing("HostedRepositoryInstance", "preserveOldClone", e);
+                    log.log(Level.SEVERE, "Failed to preserve old clone at " + path, e);
                 } finally {
                     if (Files.exists(path)) {
                         clearDirectory(path);

--- a/storage/src/main/java/org/openjdk/skara/storage/HostedRepositoryStorage.java
+++ b/storage/src/main/java/org/openjdk/skara/storage/HostedRepositoryStorage.java
@@ -28,6 +28,7 @@ import org.openjdk.skara.vcs.*;
 import java.io.*;
 import java.nio.file.*;
 import java.util.*;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 class HostedRepositoryStorage<T> implements Storage<T> {
@@ -73,8 +74,7 @@ class HostedRepositoryStorage<T> implements Storage<T> {
                     Repository localRepository = Repository.init(localStorage, repository.repositoryType());
                     if (!localRepository.isEmpty()) {
                         // If the materialization failed but the local repository already contains data, do not initialize the ref
-                        log.warning("Materialization into existing local repository failed");
-                        log.throwing("HostedRepositoryStorage", "tryMaterialize", e2);
+                        log.log(Level.WARNING, "Materialization into existing local repository failed", e2);
                         lastException = e2;
                         retryCount++;
                         continue;


### PR DESCRIPTION
This patch updates (almost) all uses of log.throwing() to log.log() so that we can include any exception in a log message of the appropriate level. This became necessary as we started logging each log message individually to logstash, so the FINER level logs from log.throwing() were no longer included. 

In addition to this, I'm also adding stack_trace and logger_name as fields in the logstash logging entries.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-980](https://bugs.openjdk.java.net/browse/SKARA-980): Update log level of thrown exceptions


### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**) ⚠️ Review applies to 00c22590665787bb9967b923cefa2faacfa6923e


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1132/head:pull/1132` \
`$ git checkout pull/1132`

Update a local copy of the PR: \
`$ git checkout pull/1132` \
`$ git pull https://git.openjdk.java.net/skara pull/1132/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1132`

View PR using the GUI difftool: \
`$ git pr show -t 1132`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1132.diff">https://git.openjdk.java.net/skara/pull/1132.diff</a>

</details>
