### PR TITLE
941: Warn about required merge after dependent PR integration

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifier.java
@@ -83,7 +83,7 @@ public class PullRequestBranchNotifier implements Notifier, PullRequestListener 
                     The dependent pull request has now been integrated, and the target branch of this pull request \
                     has been updated. This means that changes from the dependent pull request can start to show up \
                     as belonging to this pull request, which may be confusing for reviewers. To remedy this situation, \
-                    simply merge the latest changes from the target branch into this pull request by running commands \
+                    simply merge the latest changes from the new target branch into this pull request by running commands \
                     similar to these in the local repository for your personal fork:
 
                     ```bash

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifier.java
@@ -85,7 +85,7 @@ public class PullRequestBranchNotifier implements Notifier, PullRequestListener 
                     as belonging to this pull request, which may be confusing for reviewers. To remedy this situation, \
                     simply merge the latest changes from the target branch into this pull request by running commands \
                     similar to these in the local repository for your personal fork:
-                    
+
                     ```bash
                     git checkout %s
                     git fetch %s %s

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifier.java
@@ -76,8 +76,26 @@ public class PullRequestBranchNotifier implements Notifier, PullRequestListener 
     @Override
     public void onStateChange(PullRequest pr, Path scratchPath, Issue.State oldState) {
         if (pr.state() == Issue.State.CLOSED) {
-            PreIntegrations.retargetDependencies(pr);
+            var retargetedDependencies = PreIntegrations.retargetDependencies(pr);
             deleteBranch(pr);
+            for (var retargeted : retargetedDependencies) {
+                retargeted.addComment("""
+                    The dependent pull request has now been integrated, and the target branch of this pull request \
+                    has been updated. This means that changes from the dependent pull request can start to show up \
+                    as belonging to this pull request, which may be confusing for reviewers. To remedy this situation, \
+                    simply merge the latest changes from the target branch into this pull request by running commands \
+                    similar to these in the local repository for your personal fork:
+                    
+                    ```bash
+                    git checkout %s
+                    git fetch %s %s
+                    git merge FETCH_HEAD
+                    # if there are conflicts, follow the instructions given by git merge
+                    git commit -m "Merge %s"
+                    git push
+                    ```
+                    """.formatted(pr.sourceRef(), pr.repository().webUrl(), pr.targetRef(), pr.targetRef()));
+            }
         } else {
             pushBranch(pr);
         }

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifierTests.java
@@ -232,6 +232,12 @@ public class PullRequestBranchNotifierTests {
             // The follow-up PR should have been retargeted
             followUpPr = repo.pullRequest(followUpPr.id());
             assertEquals("master", followUpPr.targetRef());
+
+            // Instructions on how to adapt to the newly integrated changes should have been posted
+            var lastComment = followUpPr.comments().get(followUpPr.comments().size() - 1);
+            assertTrue(lastComment.body().contains("The dependent pull request has now"), lastComment.body());
+            assertTrue(lastComment.body().contains("git checkout source"), lastComment.body());
+            assertTrue(lastComment.body().contains("git commit -m \"Merge master\""), lastComment.body());
         }
     }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/PreIntegrations.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PreIntegrations.java
@@ -22,7 +22,7 @@
  */
 package org.openjdk.skara.forge;
 
-import java.util.Optional;
+import java.util.*;
 
 public class PreIntegrations {
     public static Optional<String> dependentPullRequestId(PullRequest pr) {
@@ -42,15 +42,18 @@ public class PreIntegrations {
         return "pr/" + pr.id();
     }
 
-    public static void retargetDependencies(PullRequest pr) {
+    public static Collection<PullRequest> retargetDependencies(PullRequest pr) {
+        var ret = new ArrayList<PullRequest>();
         var dependentRef = preIntegrateBranch(pr);
 
         var candidates = pr.repository().pullRequests();
         for (var candidate : candidates) {
             if (candidate.targetRef().equals(dependentRef)) {
                 candidate.setTargetRef(pr.targetRef());
+                ret.add(candidate);
             }
         }
+        return ret;
     }
 
     public static boolean isPreintegrationBranch(String name) {


### PR DESCRIPTION
When a dependent PR has been integrated, post an instructional message on how to merge these changes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-941](https://bugs.openjdk.java.net/browse/SKARA-941): Warn about required merge after dependent PR integration


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to a8eec304d23cbf45c8ed41c46b7729532c563292


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1134/head:pull/1134` \
`$ git checkout pull/1134`

Update a local copy of the PR: \
`$ git checkout pull/1134` \
`$ git pull https://git.openjdk.java.net/skara pull/1134/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1134`

View PR using the GUI difftool: \
`$ git pr show -t 1134`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1134.diff">https://git.openjdk.java.net/skara/pull/1134.diff</a>

</details>
