### PR TITLE
991: Add 8u270 to the hgupdater exclusion list

### DIFF
--- a/jbs/src/main/java/org/openjdk/skara/jbs/Backports.java
+++ b/jbs/src/main/java/org/openjdk/skara/jbs/Backports.java
@@ -337,8 +337,11 @@ public class Backports {
 
         var version = fixVersion.get();
 
-        // 8u260 is a contingency release
+        // 8u260 and 8u270 are a contingency releases
         if (version.raw().equals("8u260")) {
+            return true;
+        }
+        if (version.raw().equals("8u270")) {
             return true;
         }
 

--- a/jbs/src/main/java/org/openjdk/skara/jbs/Backports.java
+++ b/jbs/src/main/java/org/openjdk/skara/jbs/Backports.java
@@ -337,7 +337,7 @@ public class Backports {
 
         var version = fixVersion.get();
 
-        // 8u260 and 8u270 are a contingency releases
+        // 8u260 and 8u270 are contingency releases
         if (version.raw().equals("8u260")) {
             return true;
         }

--- a/jbs/src/test/java/org/openjdk/skara/jbs/BackportsTests.java
+++ b/jbs/src/test/java/org/openjdk/skara/jbs/BackportsTests.java
@@ -780,4 +780,15 @@ public class BackportsTests {
             backports.assertLabeled("8u291", "8u301");
         }
     }
+
+    @Test
+    void test8u270(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo)) {
+            var backports = new BackportManager(credentials, "8u270");
+            backports.assertLabeled();
+
+            backports.addBackports("8u271", "8u281");
+            backports.assertLabeled("8u281");
+        }
+    }
 }


### PR DESCRIPTION
Add 8u270 as a special case release for hgupdate-sync labeling, just like 8u260.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-991](https://bugs.openjdk.java.net/browse/SKARA-991): Add 8u270 to the hgupdater exclusion list


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - no project role)
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1135/head:pull/1135` \
`$ git checkout pull/1135`

Update a local copy of the PR: \
`$ git checkout pull/1135` \
`$ git pull https://git.openjdk.java.net/skara pull/1135/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1135`

View PR using the GUI difftool: \
`$ git pr show -t 1135`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1135.diff">https://git.openjdk.java.net/skara/pull/1135.diff</a>

</details>
