### PR TITLE
983: Github commit links 404

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
@@ -257,9 +257,11 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
 
                 var existingComments = issue.comments();
                 var hashUrl = repository.webUrl(commit.hash()).toString();
+                // We used to store URLs with just the abbreviated hash, so need to check for both
+                var shortHashUrl = repository.webUrl(new Hash(commit.hash().abbreviate())).toString();
                 var alreadyPostedComment = existingComments.stream()
-                                                           .filter(comment -> comment.author().equals(issueProject.issueTracker().currentUser()))
-                                                           .anyMatch(comment -> comment.body().contains(hashUrl));
+                        .filter(comment -> comment.author().equals(issueProject.issueTracker().currentUser()))
+                        .anyMatch(comment -> comment.body().contains(hashUrl) || comment.body().contains(shortHashUrl));
                 if (!alreadyPostedComment) {
                     issue.addComment(commitNotification);
                 }

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
@@ -1052,6 +1052,7 @@ public class IssueNotifierTests {
             var issue = issueProject.createIssue("This is an issue", List.of("Indeed"), Map.of("issuetype", JSON.of("Enhancement")));
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", issue.id() + ": Fix that issue");
             localRepo.push(editHash, repo.url(), "master");
+
             // Add a comment for the fix with the old url hash format
             var lastCommit = localRepo.commits().stream().findFirst().orElseThrow();
             issue.addComment(CommitFormatters.toTextBrief(repo, lastCommit).replace(editHash.toString(), editHash.abbreviate()));

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -208,7 +208,7 @@ public class GitHubRepository implements HostedRepository {
 
     @Override
     public URI webUrl(Hash hash) {
-        var endpoint = "/" + repository + "/commit/" + hash.abbreviate();
+        var endpoint = "/" + repository + "/commit/" + hash;
         return gitHubHost.getWebURI(endpoint);
     }
 

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -199,7 +199,7 @@ public class GitLabRepository implements HostedRepository {
     @Override
     public URI webUrl(Hash hash) {
         return URIBuilder.base(gitLabHost.getUri())
-                         .setPath("/" + projectName + "/commit/" + hash.abbreviate())
+                         .setPath("/" + projectName + "/commit/" + hash)
                          .build();
     }
 


### PR DESCRIPTION
Sometimes our abbreviated commit web links on Github are not working. My guess is that this is caused by collisions. I think the correct fix here is to stop abbreviating commit hashes in links. Github internal links seem to always be full hashes, while pretty printing the link text with an abbreviation. We should adopt the same basic principle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-983](https://bugs.openjdk.java.net/browse/SKARA-983): Github commit links 404


### Reviewers
 * [Tim Bell](https://openjdk.java.net/census#tbell) (@tbell29552 - **Reviewer**) ⚠️ Review applies to 430499747d61c7e1f8fed34f6d3b9a9881abfd56
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**) ⚠️ Review applies to 430499747d61c7e1f8fed34f6d3b9a9881abfd56
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1136/head:pull/1136` \
`$ git checkout pull/1136`

Update a local copy of the PR: \
`$ git checkout pull/1136` \
`$ git pull https://git.openjdk.java.net/skara pull/1136/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1136`

View PR using the GUI difftool: \
`$ git pr show -t 1136`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1136.diff">https://git.openjdk.java.net/skara/pull/1136.diff</a>

</details>
