### PR TITLE
forge: GitHubRepository.canPush might return 404

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -541,6 +541,9 @@ public class GitHubRepository implements HostedRepository {
     @Override
     public boolean canPush(HostUser user) {
         var permission = request.get("collaborators/" + user.username())
+                                .onError(r -> r.statusCode() == 404 ?
+                                                  Optional.of(JSON.object().put("permission", "none")) :
+                                                  Optional.empty())
                                 .execute()
                                 .get("permission")
                                 .asString();


### PR DESCRIPTION
Hi all,

please review this patch that makes `GitLabRepository.canPush` handle when the request returns a `404`. GitHub returns `404` when a user is not a collaborator in a repository.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1137/head:pull/1137` \
`$ git checkout pull/1137`

Update a local copy of the PR: \
`$ git checkout pull/1137` \
`$ git pull https://git.openjdk.java.net/skara pull/1137/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1137`

View PR using the GUI difftool: \
`$ git pr show -t 1137`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1137.diff">https://git.openjdk.java.net/skara/pull/1137.diff</a>

</details>
