### PR TITLE
1001: CommentPosterWorkItem@openjdk/jdk#3425

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/BridgedComment.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/BridgedComment.java
@@ -39,7 +39,7 @@ public class BridgedComment {
     private final ZonedDateTime created;
 
     private final static String bridgedMailMarker = "<!-- Bridged id (%s) -->";
-    private final static Pattern bridgedMailId = Pattern.compile("^<!-- Bridged id \\(([=\\w]+)\\) -->");
+    final static Pattern bridgedMailId = Pattern.compile("^<!-- Bridged id \\(([=+/\\w]+)\\) -->");
     private final static Pattern bridgedSender = Pattern.compile("Mailing list message from \\[(.*?)]\\(mailto:(\\S+)\\)");
 
     private BridgedComment(String body, EmailAddress messageId, HostUser author, ZonedDateTime created) {

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/BridgedCommentTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/BridgedCommentTests.java
@@ -1,8 +1,6 @@
 package org.openjdk.skara.bots.mlbridge;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.openjdk.skara.issuetracker.Comment;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/BridgedCommentTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/BridgedCommentTests.java
@@ -1,0 +1,23 @@
+package org.openjdk.skara.bots.mlbridge;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.openjdk.skara.issuetracker.Comment;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class BridgedCommentTests {
+
+    @Test
+    public void bridgeMailPattern() {
+        assertFalse(BridgedComment.bridgedMailId.matcher("foo").find());
+        assertFalse(BridgedComment.bridgedMailId.matcher("<-- foo -->").find());
+        assertTrue(BridgedComment.bridgedMailId.matcher("<!-- Bridged id (foo=) -->").find());
+        assertTrue(BridgedComment.bridgedMailId.matcher("<!-- Bridged id (PEEzNDJBNUQwLTM" +
+                "4MjItNEM2Ni05MDc4LUY5QThDOTA2NTRBNkBjYmZpZGRsZS5jb20+RnJvbSB0aGUgQ1NSIHJldmlldzo=) -->").find());
+
+        var matcher = BridgedComment.bridgedMailId.matcher("<!-- Bridged id (fo+/o=) -->");
+        assertTrue(matcher.find());
+        assertEquals("fo+/o=", matcher.group(1));
+    }
+}


### PR DESCRIPTION
The mlbridge is currently spamming a PR with duplicated mail comments. This is caused by a regexp that fails to identify a comment as a bridged comment. The identification in this case is a Base64 encoded string that we generated. The regexp is missing + and / as valid characters in such a string. This change adds them and also adds a test, which includes the particular string that is currently causing the failure in production.

I need to get this deployed ASAP.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1001](https://bugs.openjdk.java.net/browse/SKARA-1001): CommentPosterWorkItem@openjdk/jdk#3425


### Reviewers
 * [Tim Bell](https://openjdk.java.net/census#tbell) (@tbell29552 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1139/head:pull/1139` \
`$ git checkout pull/1139`

Update a local copy of the PR: \
`$ git checkout pull/1139` \
`$ git pull https://git.openjdk.java.net/skara pull/1139/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1139`

View PR using the GUI difftool: \
`$ git pr show -t 1139`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1139.diff">https://git.openjdk.java.net/skara/pull/1139.diff</a>

</details>
