### PR TITLE
998: Backport fails for jdk15u-dev

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -540,7 +540,7 @@ public class GitHubRepository implements HostedRepository {
 
     @Override
     public boolean canPush(HostUser user) {
-        var permission = request.get("collaborators/" + user.username())
+        var permission = request.get("collaborators/" + user.username() + "/permission")
                                 .onError(r -> r.statusCode() == 404 ?
                                                   Optional.of(JSON.object().put("permission", "none")) :
                                                   Optional.empty())


### PR DESCRIPTION
Hi all,

please review this patch that fixes the REST endpoint used by `GitHubRepository.canPush`.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-998](https://bugs.openjdk.java.net/browse/SKARA-998): Backport fails for jdk15u-dev


### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1140/head:pull/1140` \
`$ git checkout pull/1140`

Update a local copy of the PR: \
`$ git checkout pull/1140` \
`$ git pull https://git.openjdk.java.net/skara pull/1140/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1140`

View PR using the GUI difftool: \
`$ git pr show -t 1140`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1140.diff">https://git.openjdk.java.net/skara/pull/1140.diff</a>

</details>
