### PR TITLE
1003: GitHubRepository.restrictAccess sends incomplete query

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
@@ -162,7 +162,7 @@ public class BackportCommand implements CommandHandler {
             if (!fork.canPush(command.user())) {
                 fork.addCollaborator(command.user(), true);
             }
-            fork.restrictPushAccess(new Branch(backportBranchName), List.of(command.user()));
+            fork.restrictPushAccess(new Branch(backportBranchName), command.user());
 
             var message = CommitMessageParsers.v1.parse(commit);
             var formatter = DateTimeFormatter.ofPattern("d MMM uuuu");

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
@@ -216,7 +216,7 @@ class InMemoryHostedRepository implements HostedRepository {
     }
 
     @Override
-    public void restrictPushAccess(Branch branch, List<HostUser> users) {
+    public void restrictPushAccess(Branch branch, HostUser user) {
     }
 
     @Override

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
@@ -88,7 +88,7 @@ public interface HostedRepository {
                              String sourceRef);
     void addCollaborator(HostUser user, boolean canPush);
     boolean canPush(HostUser user);
-    void restrictPushAccess(Branch branch, List<HostUser> users);
+    void restrictPushAccess(Branch branch, HostUser users);
     List<Label> labels();
 
     default PullRequest createPullRequest(HostedRepository target,

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -551,13 +551,19 @@ public class GitHubRepository implements HostedRepository {
     }
 
     @Override
-    public void restrictPushAccess(Branch branch, List<HostUser> users) {
-        var usernames = JSON.array();
-        for (var user : users) {
-            usernames.add(user.username());
-        }
-        var query = JSON.object()
-                        .put("restrictions", JSON.object().put("users", usernames));
+    public void restrictPushAccess(Branch branch, HostUser user) {
+        var restrictions =
+            JSON.object()
+                .put("users", JSON.array().add(user.username()))
+                .put("teams", JSON.array())
+                .put("apps", JSON.array());
+        var query =
+            JSON.object()
+                .put("required_status_checks", JSON.of())
+                .put("enforce_admins", JSON.of())
+                .put("required_pull_request_reviews", JSON.of())
+                .put("restrictions", restrictions);
+
         request.put("branches/" + branch.name() + "/protection")
                .body(query)
                .execute();

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -589,7 +589,7 @@ public class GitLabRepository implements HostedRepository {
     }
 
     @Override
-    public void restrictPushAccess(Branch branch, List<HostUser> users) {
+    public void restrictPushAccess(Branch branch, HostUser user) {
         // Not possible to implement using GitLab Community Edition.
         // Must work around in admin web UI using groups.
     }

--- a/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
@@ -304,7 +304,7 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
     }
 
     @Override
-    public void restrictPushAccess(Branch branch, List<HostUser> users) {
+    public void restrictPushAccess(Branch branch, HostUser user) {
         // Not possible to simulate
     }
 


### PR DESCRIPTION
Hi all,

please review this patch which sends the correct JSON data to GitHub's branch protection endpoint. I also changed the API of `restrictPushAccess` to make it more clear that only the supplied `HostUser` can push to the given branch afterwards.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1003](https://bugs.openjdk.java.net/browse/SKARA-1003): GitHubRepository.restrictAccess sends incomplete query


### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1141/head:pull/1141` \
`$ git checkout pull/1141`

Update a local copy of the PR: \
`$ git checkout pull/1141` \
`$ git pull https://git.openjdk.java.net/skara pull/1141/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1141`

View PR using the GUI difftool: \
`$ git pr show -t 1141`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1141.diff">https://git.openjdk.java.net/skara/pull/1141.diff</a>

</details>
