### PR TITLE
1004: Skara bots fail to parse openjfx11.0.12 version

### DIFF
--- a/jbs/src/main/java/org/openjdk/skara/jbs/JdkVersion.java
+++ b/jbs/src/main/java/org/openjdk/skara/jbs/JdkVersion.java
@@ -38,6 +38,8 @@ public class JdkVersion implements Comparable<JdkVersion> {
     private final static Pattern ojVersionPattern = Pattern.compile("(openjdk[1-9][0-9]?)(u([0-9]{1,3}))?$");
     private final static Pattern fxVersionPattern = Pattern.compile("(openjfx[1-9][0-9]?)(u([0-9]{1,3}))?$");
 
+    private final static Pattern prefixPattern = Pattern.compile("([a-z]+)([0-9.]+)$");
+
     private final static Pattern legacyPrefixPattern = Pattern.compile("^([^\\d]*)\\d+$");
 
     private static List<String> splitComponents(String raw) {
@@ -63,6 +65,12 @@ public class JdkVersion implements Comparable<JdkVersion> {
                 optional = raw.substring(optionalStart + 1);
                 raw = raw.substring(0, optionalStart);
             }
+            var prefixMatcher = prefixPattern.matcher(raw);
+            String prefix = null;
+            if (prefixMatcher.matches()) {
+                prefix = prefixMatcher.group(1);
+                raw = prefixMatcher.group(2);
+            }
 
             finalComponents.addAll(Arrays.asList(raw.split("\\.")));
 
@@ -72,6 +80,10 @@ public class JdkVersion implements Comparable<JdkVersion> {
             if (optional != null) {
                 finalComponents.add(null);
                 finalComponents.add(optional);
+            }
+
+            if (prefix != null) {
+                finalComponents.set(0, prefix + finalComponents.get(0));
             }
         }
 

--- a/jbs/src/test/java/org/openjdk/skara/jbs/JdkVersionTests.java
+++ b/jbs/src/test/java/org/openjdk/skara/jbs/JdkVersionTests.java
@@ -66,6 +66,12 @@ public class JdkVersionTests {
     }
 
     @Test
+    void openjfx11() {
+        assertEquals(List.of("openjfx11", "0", "12"), from("openjfx11.0.12").components());
+        assertEquals(List.of("openjfx17", "3", "4", "5", "6"), from("openjfx17.3.4.5.6").components());
+    }
+
+    @Test
     void order() {
         assertEquals(0, from("5.0u45").compareTo(from("5.0u45")));
         assertEquals(0, from("11.0.3").compareTo(from("11.0.3")));
@@ -83,6 +89,7 @@ public class JdkVersionTests {
         assertEquals(-1, from("emb-8u71").compareTo(from("emb-8u170")));
         assertEquals(-1, from("openjdk7").compareTo(from("openjdk7u42")));
         assertEquals(-1, from("hs22.4").compareTo(from("hs23")));
+        assertEquals(-1, from("openjfx11.0.12").compareTo(from("openjfx17.3.4.5.6")));
     }
 
     @Test


### PR DESCRIPTION
This patch adds the ability to parse prefixes for JEP322 versions in JBS. One typical such prefix is openjfx, but I chose to not enumerate valid ones here but instead accept any prefix matching [a-z]+.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1004](https://bugs.openjdk.java.net/browse/SKARA-1004): Skara bots fail to parse openjfx11.0.12 version


### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)
 * [Tim Bell](https://openjdk.java.net/census#tbell) (@tbell29552 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1142/head:pull/1142` \
`$ git checkout pull/1142`

Update a local copy of the PR: \
`$ git checkout pull/1142` \
`$ git pull https://git.openjdk.java.net/skara pull/1142/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1142`

View PR using the GUI difftool: \
`$ git pr show -t 1142`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1142.diff">https://git.openjdk.java.net/skara/pull/1142.diff</a>

</details>
