### PR TITLE
1011: Allow JDK fixVersion to be XXu-cpu

### DIFF
--- a/jbs/src/main/java/org/openjdk/skara/jbs/JdkVersion.java
+++ b/jbs/src/main/java/org/openjdk/skara/jbs/JdkVersion.java
@@ -38,6 +38,9 @@ public class JdkVersion implements Comparable<JdkVersion> {
     private final static Pattern ojVersionPattern = Pattern.compile("(openjdk[1-9][0-9]?)(u([0-9]{1,3}))?$");
     private final static Pattern fxVersionPattern = Pattern.compile("(openjfx[1-9][0-9]?)(u([0-9]{1,3}))?$");
 
+    // Match a version string symbolizing some future, but yet undefined, update of a major version
+    private final static Pattern futureUpdatePattern = Pattern.compile("([1-9][0-9]*u)(-([a-z0-9]+))?$");
+
     private final static Pattern prefixPattern = Pattern.compile("([a-z]+)([0-9.]+)$");
 
     private final static Pattern legacyPrefixPattern = Pattern.compile("^([^\\d]*)\\d+$");
@@ -54,6 +57,19 @@ public class JdkVersion implements Comparable<JdkVersion> {
                     finalComponents.add(legacyMatcher.group(3));
                 }
                 break;
+            }
+        }
+
+        // Check special placeholder versions
+        if (finalComponents.isEmpty()) {
+            var matcher = futureUpdatePattern.matcher(raw);
+            if (matcher.matches()) {
+                finalComponents.add(matcher.group(1));
+                // Group 3 is the opt field
+                if (matcher.group(3) != null) {
+                    finalComponents.add(null);
+                    finalComponents.add(matcher.group(3));
+                }
             }
         }
 

--- a/jbs/src/test/java/org/openjdk/skara/jbs/BackportsTests.java
+++ b/jbs/src/test/java/org/openjdk/skara/jbs/BackportsTests.java
@@ -791,4 +791,18 @@ public class BackportsTests {
             backports.assertLabeled("8u281");
         }
     }
+
+    /**
+     * Verify that a release such as 16u-cpu does not ever get labeled.
+     */
+    @Test
+    void uCpu(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo)) {
+            var backports = new BackportManager(credentials, "17");
+            backports.assertLabeled();
+
+            backports.addBackports("16", "16.0.2", "16u-cpu");
+            backports.assertLabeled("16.0.2", "17");
+        }
+    }
 }

--- a/jbs/src/test/java/org/openjdk/skara/jbs/JdkVersionTests.java
+++ b/jbs/src/test/java/org/openjdk/skara/jbs/JdkVersionTests.java
@@ -71,6 +71,15 @@ public class JdkVersionTests {
         assertEquals(List.of("openjfx17", "3", "4", "5", "6"), from("openjfx17.3.4.5.6").components());
     }
 
+
+    @Test
+    void futureUpdates() {
+        assertEquals(List.of("16u"), from("16u").components());
+        var jdk16uCpu = from("16u-cpu");
+        assertEquals(List.of("16u"), jdk16uCpu.components());
+        assertEquals("cpu", jdk16uCpu.opt().orElseThrow());
+    }
+
     @Test
     void order() {
         assertEquals(0, from("5.0u45").compareTo(from("5.0u45")));
@@ -93,10 +102,15 @@ public class JdkVersionTests {
     }
 
     @Test
+    void cpuOrder() {
+        assertEquals(-1, from("16").compareTo(from("16u-cpu")));
+        assertEquals(-1, from("16.0.2").compareTo(from("16u-cpu")));
+        assertEquals(1, from("17").compareTo(from("16u-cpu")));
+    }
+
+    @Test
     void nonConforming() {
         assertEquals(Optional.empty(), JdkVersion.parse("bla"));
         assertEquals(Optional.empty(), JdkVersion.parse(""));
-        assertEquals(Optional.empty(), JdkVersion.parse("12u-cpu"));
-        assertEquals(Optional.empty(), JdkVersion.parse("13u-open"));
     }
 }


### PR DESCRIPTION
We would like to be able to use fixVersions in JBS on the form "16u-cpu". This PR contains the necessary changes needed to the JdkVersion class to handle such versions. I'm also adding test cases to verify that it behaves as we want it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1011](https://bugs.openjdk.java.net/browse/SKARA-1011): Allow JDK fixVersion to be XXu-cpu


### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1144/head:pull/1144` \
`$ git checkout pull/1144`

Update a local copy of the PR: \
`$ git checkout pull/1144` \
`$ git pull https://git.openjdk.java.net/skara pull/1144/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1144`

View PR using the GUI difftool: \
`$ git pr show -t 1144`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1144.diff">https://git.openjdk.java.net/skara/pull/1144.diff</a>

</details>
