### PR TITLE
forge: fix GitHubRepository.createPullRequestUrl

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -525,7 +525,7 @@ public class GitHubRepository implements HostedRepository {
     @Override
     public URI createPullRequestUrl(HostedRepository target, String targetRef, String sourceRef) {
         var sourceGroup = repository.split("/")[0];
-        var endpoint = "/" + target.name() + "/" + targetRef + "..." + sourceGroup + ":" + sourceRef;
+        var endpoint = "/" + target.name() + "/pull/" + targetRef + "..." + sourceGroup + ":" + sourceRef;
         return gitHubHost.getWebURI(endpoint);
     }
 


### PR DESCRIPTION
Hi all,

please review this patch that fixes `GitHubRepository.createPullRequestUrl` (I had forgotten a `/pull/`) in the URL. Thanks to @RealCLanger for finding this!

Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - no project role)
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1145/head:pull/1145` \
`$ git checkout pull/1145`

Update a local copy of the PR: \
`$ git checkout pull/1145` \
`$ git pull https://git.openjdk.java.net/skara pull/1145/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1145`

View PR using the GUI difftool: \
`$ git pr show -t 1145`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1145.diff">https://git.openjdk.java.net/skara/pull/1145.diff</a>

</details>
