### PR TITLE
1012: Lots of "unhealthy" jdk repos found in scratch dirs

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepositoryPool.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepositoryPool.java
@@ -117,7 +117,7 @@ public class HostedRepositoryPool {
 
         private void removeOldClone(Path path, String reason) {
             if (Files.exists(path)) {
-                var preserved = path.resolveSibling(seed.getFileName().toString() + "-" + reason + "-" + UUID.randomUUID());
+                var preserved = path.resolveSibling(path.getFileName().toString() + "-" + reason + "-" + UUID.randomUUID());
                 log.severe("Invalid local repository detected (" + reason + ") - preserved in: " + preserved);
                 try {
                     Files.move(path, preserved);

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -1368,6 +1368,9 @@ public class GitRepository implements Repository {
         if (seed != null) {
             cmd.add("--reference-if-able");
             cmd.add(seed.toString());
+            // It's not safe to keep an alternates pointer back to the seed repo as we sometimes
+            // delete objects, which will cause clones to become corrupt.
+            cmd.add("--dissociate");
         }
         cmd.addAll(List.of(from.toString(), to.toString()));
         try (var p = capture(Path.of("").toAbsolutePath(), cmd)) {


### PR DESCRIPTION
Add --dissociate when cloning a repo using a seed. It's simply not safe to share objects between repos when we remove objects in the seed repo (which happens automatically behind the scenes when git GCs). This is documented in the git-clone man page. Changing this will increase disk usage some, but that's something we just have to live with.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1012](https://bugs.openjdk.java.net/browse/SKARA-1012): Lots of "unhealthy" jdk repos found in scratch dirs


### Reviewers
 * [Tim Bell](https://openjdk.java.net/census#tbell) (@tbell29552 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1146/head:pull/1146` \
`$ git checkout pull/1146`

Update a local copy of the PR: \
`$ git checkout pull/1146` \
`$ git pull https://git.openjdk.java.net/skara pull/1146/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1146`

View PR using the GUI difftool: \
`$ git pr show -t 1146`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1146.diff">https://git.openjdk.java.net/skara/pull/1146.diff</a>

</details>
