### PR TITLE
1019: IssueNotifier fails if there are extra branches in a repo

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
@@ -352,13 +352,16 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
                         }
                     }
                     if (requestedVersion == null) {
-                        throw new RuntimeException("Failed to determine requested fixVersion for " + issue.id());
+                        log.info("Cannot update \"Resolved In Build\" for issue: " + issue.id() + ", branch: "
+                                + tagBranch + " - no fixVersion configured");
+                        continue;
                     }
                     var fixVersion = JdkVersion.parse(requestedVersion).orElseThrow();
                     var existing = Backports.findIssue(issue, fixVersion);
                     if (existing.isEmpty()) {
-                        log.severe("Cannot find a properly resolved issue for: " + issue.id() + " - will not update resolved in build");
-                        return;
+                        log.info("Cannot update \"Resolved in Build\" for issue: " + issue.id() + ", branch: "
+                                + tagBranch + " - no suitable backport found");
+                        continue;
                     } else {
                         issue = existing.get();
                     }

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
@@ -691,6 +691,8 @@ public class IssueNotifierTests {
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", issue.id() + ": Fix that issue", "Duke", authorEmailAddress);
             localRepo.push(editHash, repo.url(), "master");
             localRepo.push(editHash, repo.url(), "other");
+            // Add an extra branch that is not configured with any fixVersion
+            localRepo.push(editHash, repo.url(), "extra");
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The changeset should be reflected in a comment in the issue and in a new backport


### PR DESCRIPTION
This change makes the notifier bot more lenient when finding branches without fixVersions configured, or when those fixVersions do not have backports in the issue tracker, when processing new tags. Currently either of these cases will cause the rest of the commits affected by a tag to never get processed. See bug for more details.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1019](https://bugs.openjdk.java.net/browse/SKARA-1019): IssueNotifier fails if there are extra branches in a repo


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - no project role)
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1147/head:pull/1147` \
`$ git checkout pull/1147`

Update a local copy of the PR: \
`$ git checkout pull/1147` \
`$ git pull https://git.openjdk.java.net/skara pull/1147/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1147`

View PR using the GUI difftool: \
`$ git pr show -t 1147`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1147.diff">https://git.openjdk.java.net/skara/pull/1147.diff</a>

</details>
