### PR TITLE
bot: modularize HTTP server

### DIFF
--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/bot/src/main/java/org/openjdk/skara/bot/WebhookHandler.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/WebhookHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Hi all,

please review this patch that modularizes the bot HTTP server. The HTTP server featured by the bot runner is currently only used to process webhooks, but I have coming patches that extends it with other functionality. This refactoring make the bot runner start the actual server and then handlers can be configured in a configuration file. A minimal configuration file looks like:

```json
{
    "scratch": {
        "path": "/tmp/skara/scratch"
    },
    "storage": {
        "path": "/tmp/skara/storage"
    },
    "runner": {
        "interval": "PT10S",
        "watchdog": "PT30M",
        "concurrency": 2
    },
    "log": {
        "console": {
            "level": "FINER"
        }
    },
    "http-server": {
        "port": 8080,
        "/api": {
            "type": "webhook"
        }
   }
}
```

Using the above configuration stored in `config.json` the bot runner can then be started as:

```
$ make bots
$ ./bots/bin/bin/skara-bots $PWD/config.json
```

The HTTP server can be then be queried using e.g. `curl`:

```
$ curl --verbose --request POST --data '{"foo": "bar"}'  http://localhost:8080/api
Note: Unnecessary use of -X or --request, POST is already inferred.
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 127.0.0.1:8080...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8080 (#0)
> POST /api HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.68.0
> Accept: */*
> Content-Length: 14
> Content-Type: application/x-www-form-urlencoded
>
} [14 bytes data]
* upload completely sent off: 14 out of 14 bytes
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Date: Wed, 12 May 2021 07:18:50 GMT
< Content-length: 2
<
{ [2 bytes data]
100    16  100     2  100    14     66    466 --:--:-- --:--:-- --:--:--   533
* Connection #0 to host localhost left intact
{}
```

I also updated the webhook handler to return `404` if the supplied data cannot be parsed as valid JSON.

Testing:
- [x] Tested manually on Linux x64

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to c7966cc86db1587cc15ab0be1774ba0dba1c931f


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1149/head:pull/1149` \
`$ git checkout pull/1149`

Update a local copy of the PR: \
`$ git checkout pull/1149` \
`$ git pull https://git.openjdk.java.net/skara pull/1149/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1149`

View PR using the GUI difftool: \
`$ git pr show -t 1149`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1149.diff">https://git.openjdk.java.net/skara/pull/1149.diff</a>

</details>
