### PR TITLE
bot: add Bot.name and WorkItem.botName

### DIFF
--- a/bot/src/main/java/org/openjdk/skara/bot/Bot.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/Bot.java
@@ -31,4 +31,5 @@ public interface Bot {
     default List<WorkItem> processWebHook(JSONValue body) {
         return List.of();
     };
+    String name();
 }

--- a/bot/src/main/java/org/openjdk/skara/bot/WorkItem.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/WorkItem.java
@@ -41,6 +41,8 @@ public interface WorkItem {
      */
     Collection<WorkItem> run(Path scratchPath);
 
+    String botName();
+
     /**
      * The BotRunner will catch <code>RuntimeException</code>s, implementing this method allows a WorkItem to
      * perform additional cleanup if necessary (avoiding the need for catching and rethrowing the exception).

--- a/bot/src/test/java/org/openjdk/skara/bot/BotRunnerTests.java
+++ b/bot/src/test/java/org/openjdk/skara/bot/BotRunnerTests.java
@@ -72,6 +72,11 @@ class TestWorkItem implements WorkItem {
     public String toString() {
         return description != null ? description : super.toString();
     }
+
+    @Override
+    public String botName() {
+        return "test-bot";
+    }
 }
 
 class TestWorkItemChild extends TestWorkItem {
@@ -120,6 +125,11 @@ class TestBlockedWorkItem implements WorkItem {
         System.out.println("Done waiting");
         return List.of();
     }
+
+    @Override
+    public String botName() {
+        return "test-blocked";
+    }
 }
 
 class TestBot implements Bot {
@@ -143,6 +153,11 @@ class TestBot implements Bot {
         } else {
             return itemSupplier.get();
         }
+    }
+
+    @Override
+    public String name() {
+        return "test-bot";
     }
 }
 

--- a/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/BridgekeeperBotFactory.java
+++ b/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/BridgekeeperBotFactory.java
@@ -29,9 +29,10 @@ import java.time.Duration;
 import java.util.*;
 
 public class BridgekeeperBotFactory implements BotFactory {
+    static final String NAME = "bridgekeeper";
     @Override
     public String name() {
-        return "bridgekeeper";
+        return NAME;
     }
 
     @Override

--- a/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestCloserBot.java
+++ b/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestCloserBot.java
@@ -110,6 +110,11 @@ class PullRequestCloserBotWorkItem implements WorkItem {
     public String toString() {
         return "PullRequestCloserBotWorkItem@" + repository.name() + "#" + pr.id();
     }
+
+    @Override
+    public String botName() {
+        return BridgekeeperBotFactory.NAME;
+    }
 }
 
 public class PullRequestCloserBot implements Bot {
@@ -139,5 +144,10 @@ public class PullRequestCloserBot implements Bot {
         }
 
         return ret;
+    }
+
+    @Override
+    public String name() {
+        return BridgekeeperBotFactory.NAME;
     }
 }

--- a/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestPrunerBot.java
+++ b/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestPrunerBot.java
@@ -106,6 +106,11 @@ class PullRequestPrunerBotWorkItem implements WorkItem {
     public String toString() {
         return "PullRequestPrunerBotWorkItem@" + pr.repository().name() + "#" + pr.id();
     }
+
+    @Override
+    public String botName() {
+        return BridgekeeperBotFactory.NAME;
+    }
 }
 
 public class PullRequestPrunerBot implements Bot {
@@ -162,5 +167,10 @@ public class PullRequestPrunerBot implements Bot {
         }
 
         return ret;
+    }
+
+    @Override
+    public String name() {
+        return BridgekeeperBotFactory.NAME;
     }
 }

--- a/bots/censussync/src/main/java/org/openjdk/skara/bots/censussync/CensusSyncBotFactory.java
+++ b/bots/censussync/src/main/java/org/openjdk/skara/bots/censussync/CensusSyncBotFactory.java
@@ -31,9 +31,10 @@ import java.util.logging.Logger;
 public class CensusSyncBotFactory implements BotFactory {
     private static final Logger log = Logger.getLogger("org.openjdk.skara.bots");
 
+    static final String NAME = "censussync";
     @Override
     public String name() {
-        return "censussync";
+        return NAME;
     }
 
     @Override

--- a/bots/censussync/src/main/java/org/openjdk/skara/bots/censussync/CensusSyncSplitBot.java
+++ b/bots/censussync/src/main/java/org/openjdk/skara/bots/censussync/CensusSyncSplitBot.java
@@ -251,4 +251,14 @@ public class CensusSyncSplitBot implements Bot, WorkItem {
         }
         return List.of();
     }
+
+    @Override
+    public String name() {
+        return CensusSyncBotFactory.NAME;
+    }
+
+    @Override
+    public String botName() {
+        return name();
+    }
 }

--- a/bots/censussync/src/main/java/org/openjdk/skara/bots/censussync/CensusSyncUnifyBot.java
+++ b/bots/censussync/src/main/java/org/openjdk/skara/bots/censussync/CensusSyncUnifyBot.java
@@ -145,4 +145,14 @@ public class CensusSyncUnifyBot implements Bot, WorkItem {
         }
         return List.of();
     }
+
+    @Override
+    public String name() {
+        return CensusSyncBotFactory.NAME;
+    }
+
+    @Override
+    public String botName() {
+        return name();
+    }
 }

--- a/bots/checkout/src/main/java/org/openjdk/skara/bots/checkout/CheckoutBot.java
+++ b/bots/checkout/src/main/java/org/openjdk/skara/bots/checkout/CheckoutBot.java
@@ -154,4 +154,14 @@ public class CheckoutBot implements Bot, WorkItem {
         }
         return List.of();
     }
+
+    @Override
+    public String name() {
+        return CheckoutBotFactory.NAME;
+    }
+
+    @Override
+    public String botName() {
+        return name();
+    }
 }

--- a/bots/checkout/src/main/java/org/openjdk/skara/bots/checkout/CheckoutBotFactory.java
+++ b/bots/checkout/src/main/java/org/openjdk/skara/bots/checkout/CheckoutBotFactory.java
@@ -34,9 +34,10 @@ import java.util.logging.Logger;
 public class CheckoutBotFactory implements BotFactory {
     private static final Logger log = Logger.getLogger("org.openjdk.skara.bots");
 
+    static final String NAME = "checkout";
     @Override
     public String name() {
-        return "checkout";
+        return NAME;
     }
 
     @Override

--- a/bots/cli/src/test/java/org/openjdk/skara/bots/cli/LoggingBot.java
+++ b/bots/cli/src/test/java/org/openjdk/skara/bots/cli/LoggingBot.java
@@ -80,4 +80,14 @@ public class LoggingBot implements Bot, WorkItem {
         runnable.accept(logger);
         return List.of();
     }
+
+    @Override
+    public String name() {
+        return "logging";
+    }
+
+    @Override
+    public String botName() {
+        return name();
+    }
 }

--- a/bots/csr/src/main/java/org/openjdk/skara/bots/csr/CSRBot.java
+++ b/bots/csr/src/main/java/org/openjdk/skara/bots/csr/CSRBot.java
@@ -142,4 +142,14 @@ class CSRBot implements Bot, WorkItem {
     public List<WorkItem> getPeriodicItems() {
         return List.of(this);
     }
+
+    @Override
+    public String botName() {
+        return name();
+    }
+
+    @Override
+    public String name() {
+        return CSRBotFactory.NAME;
+    }
 }

--- a/bots/csr/src/main/java/org/openjdk/skara/bots/csr/CSRBotFactory.java
+++ b/bots/csr/src/main/java/org/openjdk/skara/bots/csr/CSRBotFactory.java
@@ -31,9 +31,10 @@ import java.util.logging.Logger;
 public class CSRBotFactory implements BotFactory {
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots");;
 
+    static final String NAME = "csr";
     @Override
     public String name() {
-        return "csr";
+        return NAME;
     }
 
     @Override

--- a/bots/forward/src/main/java/org/openjdk/skara/bots/forward/ForwardBot.java
+++ b/bots/forward/src/main/java/org/openjdk/skara/bots/forward/ForwardBot.java
@@ -103,4 +103,14 @@ class ForwardBot implements Bot, WorkItem {
     public List<WorkItem> getPeriodicItems() {
         return List.of(this);
     }
+
+    @Override
+    public String name() {
+        return ForwardBotFactory.NAME;
+    }
+
+    @Override
+    public String botName() {
+        return name();
+    }
 }

--- a/bots/forward/src/main/java/org/openjdk/skara/bots/forward/ForwardBotFactory.java
+++ b/bots/forward/src/main/java/org/openjdk/skara/bots/forward/ForwardBotFactory.java
@@ -34,9 +34,10 @@ import java.util.logging.Logger;
 public class ForwardBotFactory implements BotFactory {
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots");;
 
+    static final String NAME = "forward";
     @Override
     public String name() {
-        return "forward";
+        return NAME;
     }
 
     @Override

--- a/bots/hgbridge/src/main/java/org/openjdk/skara/bots/hgbridge/JBridgeBot.java
+++ b/bots/hgbridge/src/main/java/org/openjdk/skara/bots/hgbridge/JBridgeBot.java
@@ -144,4 +144,15 @@ public class JBridgeBot implements Bot, WorkItem {
         }
         return List.of();
     }
+
+    @Override
+    public String name() {
+        return JBridgeBotFactory.NAME;
+    }
+
+    @Override
+    public String botName() {
+        return name();
+    }
+
 }

--- a/bots/hgbridge/src/main/java/org/openjdk/skara/bots/hgbridge/JBridgeBotFactory.java
+++ b/bots/hgbridge/src/main/java/org/openjdk/skara/bots/hgbridge/JBridgeBotFactory.java
@@ -41,9 +41,10 @@ public class JBridgeBotFactory implements BotFactory {
         return ret;
     }
 
+    static final String NAME = "hgbridge";
     @Override
     public String name() {
-        return "hgbridge";
+        return NAME;
     }
 
     @Override

--- a/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
+++ b/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
@@ -607,4 +607,14 @@ class MergeBot implements Bot, WorkItem {
     public List<WorkItem> getPeriodicItems() {
         return List.of(this);
     }
+
+    @Override
+    public String name() {
+        return MergeBotFactory.NAME;
+    }
+
+    @Override
+    public String botName() {
+        return name();
+    }
 }

--- a/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBotFactory.java
+++ b/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBotFactory.java
@@ -37,9 +37,10 @@ import java.util.logging.Logger;
 public class MergeBotFactory implements BotFactory {
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots");;
 
+    static final String NAME = "merge";
     @Override
     public String name() {
-        return "merge";
+        return NAME;
     }
 
     private static MergeBot.Spec.Frequency.Interval toInterval(String s) {

--- a/bots/mirror/src/main/java/org/openjdk/skara/bots/mirror/MirrorBot.java
+++ b/bots/mirror/src/main/java/org/openjdk/skara/bots/mirror/MirrorBot.java
@@ -119,4 +119,14 @@ class MirrorBot implements Bot, WorkItem {
     public List<WorkItem> getPeriodicItems() {
         return List.of(this);
     }
+
+    @Override
+    public String botName() {
+        return name();
+    }
+
+    @Override
+    public String name() {
+        return MirrorBotFactory.NAME;
+    }
 }

--- a/bots/mirror/src/main/java/org/openjdk/skara/bots/mirror/MirrorBotFactory.java
+++ b/bots/mirror/src/main/java/org/openjdk/skara/bots/mirror/MirrorBotFactory.java
@@ -34,9 +34,10 @@ import java.util.logging.Logger;
 public class MirrorBotFactory implements BotFactory {
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots");;
 
+    static final String NAME = "mirror";
     @Override
     public String name() {
-        return "mirror";
+        return NAME;
     }
 
     @Override

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveReaderWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveReaderWorkItem.java
@@ -64,4 +64,9 @@ public class ArchiveReaderWorkItem implements WorkItem {
         }
         return List.of();
     }
+
+    @Override
+    public String botName() {
+        return MailingListBridgeBotFactory.NAME;
+    }
 }

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
@@ -406,4 +406,9 @@ class ArchiveWorkItem implements WorkItem {
     public void handleRuntimeException(RuntimeException e) {
         exceptionConsumer.accept(e);
     }
+
+    @Override
+    public String botName() {
+        return MailingListBridgeBotFactory.NAME;
+    }
 }

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/CommentPosterWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/CommentPosterWorkItem.java
@@ -95,4 +95,9 @@ public class CommentPosterWorkItem implements WorkItem {
     public void handleRuntimeException(RuntimeException e) {
         errorHandler.accept(e);
     }
+
+    @Override
+    public String botName() {
+        return MailingListBridgeBotFactory.NAME;
+    }
 }

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBot.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBot.java
@@ -144,4 +144,9 @@ public class MailingListArchiveReaderBot implements Bot {
 
         return ret;
     }
+
+    @Override
+    public String name() {
+        return MailingListBridgeBotFactory.NAME;
+    }
 }

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBot.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBot.java
@@ -219,4 +219,9 @@ public class MailingListBridgeBot implements Bot {
 
         return ret;
     }
+
+    @Override
+    public String name() {
+        return MailingListBridgeBotFactory.NAME;
+    }
 }

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotFactory.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotFactory.java
@@ -36,9 +36,10 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class MailingListBridgeBotFactory implements BotFactory {
+    static final String NAME = "mlbridge";
     @Override
     public String name() {
-        return "mlbridge";
+        return NAME;
     }
 
     private MailingListConfiguration parseList(JSONObject configuration) {

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/NotifyBot.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/NotifyBot.java
@@ -143,4 +143,9 @@ public class NotifyBot implements Bot, Emitter {
 
         return ret;
     }
+
+    @Override
+    public String name() {
+        return NotifyBotFactory.NAME;
+    }
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/NotifyBotFactory.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/NotifyBotFactory.java
@@ -36,9 +36,10 @@ import java.util.stream.Collectors;
 public class NotifyBotFactory implements BotFactory {
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots");;
 
+    static final String NAME = "notify";
     @Override
     public String name() {
-        return "notify";
+        return NAME;
     }
 
     private JSONObject combineConfiguration(JSONObject global, JSONObject specific) {

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/PullRequestWorkItem.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/PullRequestWorkItem.java
@@ -272,4 +272,9 @@ public class PullRequestWorkItem implements WorkItem {
     public void handleRuntimeException(RuntimeException e) {
         errorHandler.accept(e);
     }
+
+    @Override
+    public String botName() {
+        return NotifyBotFactory.NAME;
+    }
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryWorkItem.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryWorkItem.java
@@ -303,4 +303,9 @@ public class RepositoryWorkItem implements WorkItem {
     public String toString() {
         return "RepositoryWorkItem@" + repository.name();
     }
+
+    @Override
+    public String botName() {
+        return NotifyBotFactory.NAME;
+    }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommandWorkItem.java
@@ -184,4 +184,9 @@ public class CommitCommandWorkItem implements WorkItem {
     public String toString() {
         return "CommitCommandWorkItem@" + bot.repo().name() + ":" + commitComment.commit().abbreviate();
     }
+
+    @Override
+    public String botName() {
+        return PullRequestBotFactory.NAME;
+    }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommentsWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommentsWorkItem.java
@@ -105,4 +105,9 @@ class CommitCommentsWorkItem implements WorkItem {
     public String toString() {
         return "CommitCommentsWorkItem@" + repo.name();
     }
+
+    @Override
+    public String botName() {
+        return PullRequestBotFactory.NAME;
+    }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -300,4 +300,9 @@ class PullRequestBot implements Bot {
     public Set<String> integrators() {
         return integrators;
     }
+
+    @Override
+    public String name() {
+        return PullRequestBotFactory.NAME;
+    }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
@@ -32,9 +32,10 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class PullRequestBotFactory implements BotFactory {
+    static final String NAME = "pr";
     @Override
     public String name() {
-        return "pr";
+        return NAME;
     }
 
     @Override

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestWorkItem.java
@@ -57,4 +57,9 @@ abstract class PullRequestWorkItem implements WorkItem {
     public final void handleRuntimeException(RuntimeException e) {
         errorHandler.accept(e);
     }
+
+    @Override
+    public String botName() {
+        return bot.name();
+    }
 }

--- a/bots/submit/src/main/java/org/openjdk/skara/bots/submit/SubmitBot.java
+++ b/bots/submit/src/main/java/org/openjdk/skara/bots/submit/SubmitBot.java
@@ -51,4 +51,9 @@ public class SubmitBot implements Bot {
     HostedRepository repository() {
         return repository;
     }
+
+    @Override
+    public String name() {
+        return SubmitBotFactory.NAME;
+    }
 }

--- a/bots/submit/src/main/java/org/openjdk/skara/bots/submit/SubmitBotFactory.java
+++ b/bots/submit/src/main/java/org/openjdk/skara/bots/submit/SubmitBotFactory.java
@@ -31,9 +31,10 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class SubmitBotFactory implements BotFactory {
+    static final String NAME = "submit";
     @Override
     public String name() {
-        return "submit";
+        return NAME;
     }
 
     @Override

--- a/bots/submit/src/main/java/org/openjdk/skara/bots/submit/SubmitBotWorkItem.java
+++ b/bots/submit/src/main/java/org/openjdk/skara/bots/submit/SubmitBotWorkItem.java
@@ -101,4 +101,9 @@ public class SubmitBotWorkItem implements WorkItem {
 
         return List.of();
     }
+
+    @Override
+    public String botName() {
+        return SubmitBotFactory.NAME;
+    }
 }

--- a/bots/synclabel/src/main/java/org/openjdk/skara/bots/synclabel/SyncLabelBot.java
+++ b/bots/synclabel/src/main/java/org/openjdk/skara/bots/synclabel/SyncLabelBot.java
@@ -82,4 +82,9 @@ public class SyncLabelBot implements Bot {
         }
         return ret;
     }
+
+    @Override
+    public String name() {
+        return SyncLabelBotFactory.NAME;
+    }
 }

--- a/bots/synclabel/src/main/java/org/openjdk/skara/bots/synclabel/SyncLabelBotFactory.java
+++ b/bots/synclabel/src/main/java/org/openjdk/skara/bots/synclabel/SyncLabelBotFactory.java
@@ -31,9 +31,10 @@ import java.util.regex.Pattern;
 public class SyncLabelBotFactory implements BotFactory {
     private static final Logger log = Logger.getLogger("org.openjdk.skara.bots");
 
+    static final String NAME = "synclabel";
     @Override
     public String name() {
-        return "synclabel";
+        return NAME;
     }
 
     @Override

--- a/bots/synclabel/src/main/java/org/openjdk/skara/bots/synclabel/SyncLabelBotFindMainIssueWorkItem.java
+++ b/bots/synclabel/src/main/java/org/openjdk/skara/bots/synclabel/SyncLabelBotFindMainIssueWorkItem.java
@@ -70,4 +70,8 @@ public class SyncLabelBotFindMainIssueWorkItem implements WorkItem {
         return "SyncLabelBotFindMainIssueWorkItem@" + issueId;
     }
 
+    @Override
+    public String botName() {
+        return SyncLabelBotFactory.NAME;
+    }
 }

--- a/bots/synclabel/src/main/java/org/openjdk/skara/bots/synclabel/SyncLabelBotUpdateLabelWorkItem.java
+++ b/bots/synclabel/src/main/java/org/openjdk/skara/bots/synclabel/SyncLabelBotUpdateLabelWorkItem.java
@@ -92,4 +92,9 @@ public class SyncLabelBotUpdateLabelWorkItem implements WorkItem {
 
         return List.of();
     }
+
+    @Override
+    public String botName() {
+        return SyncLabelBotFactory.NAME;
+    }
 }

--- a/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestBot.java
+++ b/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestBot.java
@@ -138,4 +138,9 @@ public class TestBot implements Bot {
 
         return ret;
     }
+
+    @Override
+    public String name() {
+        return "test";
+    }
 }

--- a/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestBotFactory.java
+++ b/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestBotFactory.java
@@ -34,9 +34,10 @@ import java.util.stream.Collectors;
 import java.net.URI;
 
 public class TestBotFactory implements BotFactory {
+    static final String NAME = "test";
     @Override
     public String name() {
-        return "test";
+        return NAME;
     }
 
     @Override

--- a/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestUpdateNeededWorkItem.java
+++ b/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestUpdateNeededWorkItem.java
@@ -102,4 +102,8 @@ public class TestUpdateNeededWorkItem implements WorkItem {
         return "TestUpdateNeededWorkItem@" + pr.repository().name() + "#" + pr.id();
     }
 
+    @Override
+    public String botName() {
+        return TestBotFactory.NAME;
+    }
 }

--- a/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestWorkItem.java
+++ b/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestWorkItem.java
@@ -460,4 +460,9 @@ public class TestWorkItem implements WorkItem {
     public String toString() {
         return "TestWorkItem@" + pr.repository().name() + "#" + pr.id();
     }
+
+    @Override
+    public String botName() {
+        return TestBotFactory.NAME;
+    }
 }

--- a/bots/testinfo/src/main/java/org/openjdk/skara/bots/testinfo/TestInfoBot.java
+++ b/bots/testinfo/src/main/java/org/openjdk/skara/bots/testinfo/TestInfoBot.java
@@ -66,4 +66,9 @@ public class TestInfoBot implements Bot {
         }
         return ret;
     }
+
+    @Override
+    public String name() {
+        return TestInfoBotFactory.NAME;
+    }
 }

--- a/bots/testinfo/src/main/java/org/openjdk/skara/bots/testinfo/TestInfoBotFactory.java
+++ b/bots/testinfo/src/main/java/org/openjdk/skara/bots/testinfo/TestInfoBotFactory.java
@@ -30,9 +30,10 @@ import java.util.logging.Logger;
 public class TestInfoBotFactory implements BotFactory {
     private static final Logger log = Logger.getLogger("org.openjdk.skara.bots");
 
+    static final String NAME = "testinfo";
     @Override
     public String name() {
-        return "testinfo";
+        return NAME;
     }
 
     @Override

--- a/bots/testinfo/src/main/java/org/openjdk/skara/bots/testinfo/TestInfoBotWorkItem.java
+++ b/bots/testinfo/src/main/java/org/openjdk/skara/bots/testinfo/TestInfoBotWorkItem.java
@@ -127,4 +127,9 @@ public class TestInfoBotWorkItem implements WorkItem {
 
         return List.of();
     }
+
+    @Override
+    public String botName() {
+        return TestInfoBotFactory.NAME;
+    }
 }

--- a/bots/topological/src/main/java/org/openjdk/skara/bots/topological/TopologicalBot.java
+++ b/bots/topological/src/main/java/org/openjdk/skara/bots/topological/TopologicalBot.java
@@ -184,4 +184,14 @@ class TopologicalBot implements Bot, WorkItem {
     public List<WorkItem> getPeriodicItems() {
         return List.of(this);
     }
+
+    @Override
+    public String botName() {
+        return name();
+    }
+
+    @Override
+    public String name() {
+        return TopologicalBotFactory.NAME;
+    }
 }

--- a/bots/topological/src/main/java/org/openjdk/skara/bots/topological/TopologicalBotFactory.java
+++ b/bots/topological/src/main/java/org/openjdk/skara/bots/topological/TopologicalBotFactory.java
@@ -35,9 +35,10 @@ import java.util.stream.Collectors;
 public class TopologicalBotFactory implements BotFactory {
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots");
 
+    static final String NAME = "topological";
     @Override
     public String name() {
-        return "topological";
+        return NAME;
     }
 
     @Override


### PR DESCRIPTION
Hi all,

please review this patch that adds the methods `Bot.name` and `WorkItem.botName`. These methods are useful when adding metrics to code that deals with Bots and WorkItems (one often wants to create a `"bot"` label). I opted to add `static final` variables to the factories to ensure that names ending up as label values matches the names in the configuration files.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1151/head:pull/1151` \
`$ git checkout pull/1151`

Update a local copy of the PR: \
`$ git checkout pull/1151` \
`$ git pull https://git.openjdk.java.net/skara pull/1151/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1151`

View PR using the GUI difftool: \
`$ git pr show -t 1151`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1151.diff">https://git.openjdk.java.net/skara/pull/1151.diff</a>

</details>
