### PR TITLE
bot: add metrics HTTP handler

### DIFF
--- a/bot/src/main/java/module-info.java
+++ b/bot/src/main/java/module-info.java
@@ -27,6 +27,7 @@ module org.openjdk.skara.bot {
     requires transitive org.openjdk.skara.forge;
     requires transitive org.openjdk.skara.json;
     requires transitive org.openjdk.skara.census;
+    requires transitive org.openjdk.skara.metrics;
     requires org.openjdk.skara.network;
     requires org.openjdk.skara.vcs;
     requires java.logging;

--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunnerConfiguration.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunnerConfiguration.java
@@ -390,7 +390,8 @@ public class BotRunnerConfiguration {
         }
 
         Map<String, BiFunction<BotRunner, JSONObject, HttpHandler>> factories = Map.of(
-            WebhookHandler.name(), WebhookHandler::create
+            WebhookHandler.name(), WebhookHandler::create,
+            MetricsHandler.name(), MetricsHandler::create
         );
         var contexts = new ArrayList<HttpContextConfiguration>();
         var port = config.get("http-server").get("port").asInt();

--- a/bot/src/main/java/org/openjdk/skara/bot/MetricsHandler.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/MetricsHandler.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bot;
+
+import com.sun.net.httpserver.*;
+import org.openjdk.skara.json.*;
+
+import org.openjdk.skara.metrics.*;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.logging.Logger;
+import java.time.ZonedDateTime;
+
+class MetricsHandler implements HttpHandler {
+    private static final Logger log = Logger.getLogger("org.openjdk.skara.bot");
+    private final Exporter exporter;
+
+    private MetricsHandler(Exporter exporter) {
+        this.exporter = exporter;
+    }
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+        var metrics = CollectorRegistry.defaultRegistry().scrape();
+        var response = exporter.export(metrics);
+        exchange.sendResponseHeaders(200, response.length());
+        var output = exchange.getResponseBody();
+        output.write(response.getBytes(StandardCharsets.UTF_8));
+        output.close();
+    }
+
+    static MetricsHandler create(BotRunner runner, JSONObject configuration) {
+        return new MetricsHandler(new PrometheusExporter());
+    }
+
+    static String name() {
+        return "metrics";
+    }
+}


### PR DESCRIPTION
Hi all,

please review this patch that adds an HTTP handler for metrics to the bot runner. Typically listening on the `/metrics` path the handler will return metrics according to Prometheus text format.

Testing:
- [x] Tested manually with a Prometheus instance on Linux x64

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1152/head:pull/1152` \
`$ git checkout pull/1152`

Update a local copy of the PR: \
`$ git checkout pull/1152` \
`$ git pull https://git.openjdk.java.net/skara pull/1152/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1152`

View PR using the GUI difftool: \
`$ git pr show -t 1152`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1152.diff">https://git.openjdk.java.net/skara/pull/1152.diff</a>

</details>
