### PR TITLE
bot: add readiness handler

### DIFF
--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
@@ -200,6 +200,7 @@ public class BotRunner {
     private final List<Bot> bots;
     private final ScheduledThreadPoolExecutor executor;
     private final BotWatchdog botWatchdog;
+    private volatile boolean isReady;
 
     private static final Logger log = Logger.getLogger("org.openjdk.skara.bot");
 
@@ -218,6 +219,11 @@ public class BotRunner {
 
         executor = new ScheduledThreadPoolExecutor(config.concurrency());
         botWatchdog = new BotWatchdog(Duration.ofMinutes(10));
+        isReady = false;
+    }
+
+    boolean isReady() {
+        return isReady;
     }
 
     private void checkPeriodicItems() {
@@ -298,6 +304,7 @@ public class BotRunner {
             }
         }
 
+        isReady = true;
         executor.scheduleAtFixedRate(this::itemWatchdog, 0,
                                      config.scheduledExecutionPeriod().toMillis(), TimeUnit.MILLISECONDS);
         executor.scheduleAtFixedRate(this::checkPeriodicItems, 0,

--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunnerConfiguration.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunnerConfiguration.java
@@ -391,7 +391,8 @@ public class BotRunnerConfiguration {
 
         Map<String, BiFunction<BotRunner, JSONObject, HttpHandler>> factories = Map.of(
             WebhookHandler.name(), WebhookHandler::create,
-            MetricsHandler.name(), MetricsHandler::create
+            MetricsHandler.name(), MetricsHandler::create,
+            ReadinessHandler.name(), ReadinessHandler::create
         );
         var contexts = new ArrayList<HttpContextConfiguration>();
         var port = config.get("http-server").get("port").asInt();

--- a/bot/src/main/java/org/openjdk/skara/bot/ReadinessHandler.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/ReadinessHandler.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bot;
+
+import org.openjdk.skara.json.JSONObject;
+
+import com.sun.net.httpserver.*;
+
+import java.io.IOException;
+import java.util.logging.Logger;
+
+class ReadinessHandler implements HttpHandler {
+    private static final Logger log = Logger.getLogger("org.openjdk.skara.bot");
+    private final BotRunner runner;
+
+    ReadinessHandler(BotRunner runner) {
+        this.runner = runner;
+    }
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+        if (runner.isReady()) {
+            exchange.sendResponseHeaders(200, 0);
+            exchange.getResponseBody().close();
+        } else {
+            exchange.sendResponseHeaders(404, 0);
+            exchange.getResponseBody().close();
+        }
+    }
+
+    static ReadinessHandler create(BotRunner runner, JSONObject configuration) {
+        return new ReadinessHandler(runner);
+    }
+
+    static String name() {
+        return "readiness";
+    }
+}


### PR DESCRIPTION
Hi all,

please review this patch that adds a "readiness" handler to the bot runner's HTTP server. A readiness handler can be used to automate deployments and are usually queried to see when a service is ready to do work. Typically listening on paths such a `/ready` the readiness can help automatic deployment software differentiate between the two states "started" and "ready to work". The "readiness" handler will return `200` when the bot runner is ready to work and `404` when it isn't.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1154/head:pull/1154` \
`$ git checkout pull/1154`

Update a local copy of the PR: \
`$ git checkout pull/1154` \
`$ git pull https://git.openjdk.java.net/skara pull/1154/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1154`

View PR using the GUI difftool: \
`$ git pr show -t 1154`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1154.diff">https://git.openjdk.java.net/skara/pull/1154.diff</a>

</details>
