### PR TITLE
bot: add liveness handler

### DIFF
--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
@@ -237,6 +237,10 @@ public class BotRunner {
         return isReady;
     }
 
+    boolean isHealthy() {
+        return true;
+    }
+
     private void checkPeriodicItems() {
         try (var __ = new LogContext("work_id", String.valueOf(workIdCounter.incrementAndGet()))) {
             log.log(Level.FINE, "Starting of checking for periodic items", TaskPhases.BEGIN);

--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunnerConfiguration.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunnerConfiguration.java
@@ -392,7 +392,8 @@ public class BotRunnerConfiguration {
         Map<String, BiFunction<BotRunner, JSONObject, HttpHandler>> factories = Map.of(
             WebhookHandler.name(), WebhookHandler::create,
             MetricsHandler.name(), MetricsHandler::create,
-            ReadinessHandler.name(), ReadinessHandler::create
+            ReadinessHandler.name(), ReadinessHandler::create,
+            LivenessHandler.name(), LivenessHandler::create
         );
         var contexts = new ArrayList<HttpContextConfiguration>();
         var port = config.get("http-server").get("port").asInt();

--- a/bot/src/main/java/org/openjdk/skara/bot/LivenessHandler.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/LivenessHandler.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bot;
+
+import org.openjdk.skara.json.JSONObject;
+
+import com.sun.net.httpserver.*;
+
+import java.io.IOException;
+import java.util.logging.Logger;
+
+class LivenessHandler implements HttpHandler {
+    private static final Logger log = Logger.getLogger("org.openjdk.skara.bot");
+    private final BotRunner runner;
+
+    LivenessHandler(BotRunner runner) {
+        this.runner = runner;
+    }
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+        if (runner.isHealthy()) {
+            exchange.sendResponseHeaders(200, 0);
+            exchange.getResponseBody().close();
+        } else {
+            exchange.sendResponseHeaders(500, 0);
+            exchange.getResponseBody().close();
+        }
+    }
+
+    static LivenessHandler create(BotRunner runner, JSONObject configuration) {
+        return new LivenessHandler(runner);
+    }
+
+    static String name() {
+        return "liveness";
+    }
+}


### PR DESCRIPTION
Hi all,

please review this patch that adds a liveness handler to the bot runner's HTTP server. The liveness handler, typically acting on the `/healthz` path, returns `200` if everything is well and `500` otherwise.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1155/head:pull/1155` \
`$ git checkout pull/1155`

Update a local copy of the PR: \
`$ git checkout pull/1155` \
`$ git pull https://git.openjdk.java.net/skara pull/1155/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1155`

View PR using the GUI difftool: \
`$ git pr show -t 1155`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1155.diff">https://git.openjdk.java.net/skara/pull/1155.diff</a>

</details>
