### PR TITLE
1030: Lots of "uncleanable" repos found in scratch dirs

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepositoryPool.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepositoryPool.java
@@ -116,6 +116,7 @@ public class HostedRepositoryPool {
             log.info("Using seed folder " + seed + " when cloning into " + path + " from " + remote + (bare ? " (bare)" : ""));
             var tmpClonePath = path.resolveSibling(path.getFileName() + CLONE_TMP_SUFFIX);
             if (Files.exists(tmpClonePath)) {
+                log.fine("Found previous clone attempt " + tmpClonePath + " - deleting");
                 clearDirectory(tmpClonePath);
             }
             Repository.clone(remote, tmpClonePath, bare, seed);

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepositoryPool.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepositoryPool.java
@@ -33,6 +33,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class HostedRepositoryPool {
+    private static final String CLONE_TMP_SUFFIX = ".clone-tmp";
+
     private final Path seedStorage;
     private final Logger log = Logger.getLogger("org.openjdk.skara.forge");
 
@@ -112,7 +114,13 @@ public class HostedRepositoryPool {
             refreshSeed(true);
             var remote = allowStale ? seedUri() : hostedRepository.url();
             log.info("Using seed folder " + seed + " when cloning into " + path + " from " + remote + (bare ? " (bare)" : ""));
-            return Repository.clone(remote, path, bare, seed);
+            var tmpClonePath = path.resolveSibling(path.getFileName() + CLONE_TMP_SUFFIX);
+            if (Files.exists(tmpClonePath)) {
+                clearDirectory(tmpClonePath);
+            }
+            Repository.clone(remote, tmpClonePath, bare, seed);
+            Files.move(tmpClonePath, path);
+            return Repository.get(path).orElseThrow();
         }
 
         private void removeOldClone(Path path, String reason) {


### PR DESCRIPTION
This patch tries to fix a problem where bots will often generate "uncleanable" repos in the scratch area. This is often caused by the initial clone of the repo being interrupted for some reason (usually bot restart). By cloning into a temp dir and then moving in place, we can easily tell if an existing scratch repo was fully cloned or not.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1030](https://bugs.openjdk.java.net/browse/SKARA-1030): Lots of "uncleanable" repos found in scratch dirs


### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1156/head:pull/1156` \
`$ git checkout pull/1156`

Update a local copy of the PR: \
`$ git checkout pull/1156` \
`$ git pull https://git.openjdk.java.net/skara pull/1156/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1156`

View PR using the GUI difftool: \
`$ git pr show -t 1156`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1156.diff">https://git.openjdk.java.net/skara/pull/1156.diff</a>

</details>
