### PR TITLE
1042: Watchdog causing multiple restarts for mlbridge

### DIFF
--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
@@ -263,7 +263,7 @@ public class BotRunner {
         synchronized (executor) {
             for (var activeItem : active.entrySet()) {
                 var activeDuration = Duration.between(activeItem.getValue(), Instant.now());
-                if (activeDuration.compareTo(config.watchdogTimeout()) > 0) {
+                if (activeDuration.compareTo(config.watchdogWarnTimeout()) > 0) {
                     log.severe("Item " + activeItem.getKey() + " has been active more than " + activeDuration +
                                        " - this may be an error!");
                     // Reset the counter to avoid continuous reporting - once every watchdogTimeout is enough

--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
@@ -229,7 +229,7 @@ public class BotRunner {
         }
 
         executor = new ScheduledThreadPoolExecutor(config.concurrency());
-        botWatchdog = new BotWatchdog(Duration.ofMinutes(10));
+        botWatchdog = new BotWatchdog(config.watchdogTimeout());
         isReady = false;
     }
 
@@ -271,6 +271,7 @@ public class BotRunner {
                 }
             }
             // Inform the global watchdog that the scheduler is still executing items
+            log.fine("Pinging Watchdog");
             botWatchdog.ping();
         }
     }

--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
@@ -211,6 +211,7 @@ public class BotRunner {
     private final List<Bot> bots;
     private final ScheduledThreadPoolExecutor executor;
     private final BotWatchdog botWatchdog;
+    private final Duration watchdogWarnTimeout;
     private volatile boolean isReady;
 
     private static final Logger log = Logger.getLogger("org.openjdk.skara.bot");
@@ -230,6 +231,7 @@ public class BotRunner {
 
         executor = new ScheduledThreadPoolExecutor(config.concurrency());
         botWatchdog = new BotWatchdog(config.watchdogTimeout());
+        watchdogWarnTimeout = config.watchdogWarnTimeout();
         isReady = false;
     }
 
@@ -263,7 +265,7 @@ public class BotRunner {
         synchronized (executor) {
             for (var activeItem : active.entrySet()) {
                 var activeDuration = Duration.between(activeItem.getValue(), Instant.now());
-                if (activeDuration.compareTo(config.watchdogWarnTimeout()) > 0) {
+                if (activeDuration.compareTo(watchdogWarnTimeout) > 0) {
                     log.severe("Item " + activeItem.getKey() + " has been active more than " + activeDuration +
                                        " - this may be an error!");
                     // Reset the counter to avoid continuous reporting - once every watchdogTimeout is enough

--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunnerConfiguration.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunnerConfiguration.java
@@ -420,4 +420,13 @@ public class BotRunnerConfiguration {
             return Duration.parse(config.get("runner").get("watchdog").asString());
         }
     }
+
+    Duration watchdogWarnTimeout() {
+        if (!config.contains("runner") || !config.get("runner").contains("watchdog_warn")) {
+            log.info("No WorkItem watchdog_warn timeout defined, using watchdog value");
+            return watchdogTimeout();
+        } else {
+            return Duration.parse(config.get("runner").get("watchdog_warn").asString());
+        }
+    }
 }

--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunnerConfiguration.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunnerConfiguration.java
@@ -415,7 +415,7 @@ public class BotRunnerConfiguration {
     Duration watchdogTimeout() {
         if (!config.contains("runner") || !config.get("runner").contains("watchdog")) {
             log.info("No WorkItem watchdog timeout defined, using default value");
-            return Duration.ofHours(1);
+            return Duration.ofMinutes(30);
         } else {
             return Duration.parse(config.get("runner").get("watchdog").asString());
         }

--- a/bot/src/main/java/org/openjdk/skara/bot/BotWatchdog.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotWatchdog.java
@@ -27,6 +27,7 @@ import java.time.Duration;
 public class BotWatchdog {
     private final Thread watchThread;
     private final long maxWaitMillis;
+    private final Duration maxWait;
     private volatile boolean hasBeenPinged = false;
 
     private void threadMain() {
@@ -34,7 +35,7 @@ public class BotWatchdog {
             try {
                 Thread.sleep(maxWaitMillis);
                 if (!hasBeenPinged) {
-                    System.out.println("No watchdog ping detected - exiting...");
+                    System.out.println("No watchdog ping detected for " + maxWait + " - exiting...");
                     System.exit(1);
                 }
                 hasBeenPinged = false;
@@ -44,6 +45,7 @@ public class BotWatchdog {
     }
 
     BotWatchdog(Duration maxWait) {
+        this.maxWait = maxWait;
         maxWaitMillis = maxWait.toMillis();
         watchThread = new Thread(this::threadMain);
         watchThread.setName("BotWatchdog");

--- a/bot/src/test/java/org/openjdk/skara/bot/BotRunnerTests.java
+++ b/bot/src/test/java/org/openjdk/skara/bot/BotRunnerTests.java
@@ -313,7 +313,7 @@ class BotRunnerTests {
         var countdownLatch = new CountDownLatch(1);
         var item = new TestBlockedWorkItem(countdownLatch);
         var bot = new TestBot(item);
-        var runner = new BotRunner(config("{ \"runner\": { \"watchdog\": \"PT0.01S\", \"interval\": \"PT0.001S\" } }"), List.of(bot));
+        var runner = new BotRunner(config("{ \"runner\": { \"watchdog_warn\": \"PT0.01S\", \"interval\": \"PT0.001S\" } }"), List.of(bot));
 
         var errors = new ArrayList<String>();
         var log = Logger.getLogger("org.openjdk.skara.bot");

--- a/bots/cli/src/main/java/org/openjdk/skara/bots/cli/BotLauncher.java
+++ b/bots/cli/src/main/java/org/openjdk/skara/bots/cli/BotLauncher.java
@@ -163,20 +163,21 @@ public class BotLauncher {
 
         applyLogging(jsonConfig);
         var log = Logger.getLogger("org.openjdk.skara.bots.cli");
+        log.info("Starting BotLauncher");
 
         BotRunnerConfiguration runnerConfig = null;
         try {
             runnerConfig = BotRunnerConfiguration.parse(jsonConfig, jsonFile.getParent());
         } catch (ConfigurationError configurationError) {
-            System.out.println("Failed to parse configuration file: " + jsonFile);
-            System.out.println("Error message: " + configurationError.getMessage());
+            log.severe("Failed to parse configuration file: " + jsonFile
+                    + " error message: " + configurationError.getMessage());
             System.exit(1);
         }
 
         var botFactories = BotFactory.getBotFactories().stream()
                                      .collect(Collectors.toMap(BotFactory::name, Function.identity()));
         if (botFactories.size() == 0) {
-            System.out.println("Error: no bot factories found. Make sure the module path is correct. Exiting...");
+            log.severe("Error: no bot factories found. Make sure the module path is correct. Exiting...");
             System.exit(1);
         }
 

--- a/bots/cli/src/main/java/org/openjdk/skara/bots/cli/BotLauncher.java
+++ b/bots/cli/src/main/java/org/openjdk/skara/bots/cli/BotLauncher.java
@@ -171,6 +171,9 @@ public class BotLauncher {
         } catch (ConfigurationError configurationError) {
             log.severe("Failed to parse configuration file: " + jsonFile
                     + " error message: " + configurationError.getMessage());
+            // Also print directly as logging may not be setup
+            System.out.println("Failed to parse configuration file: " + jsonFile);
+            System.out.println("Error message: " + configurationError.getMessage());
             System.exit(1);
         }
 
@@ -178,6 +181,8 @@ public class BotLauncher {
                                      .collect(Collectors.toMap(BotFactory::name, Function.identity()));
         if (botFactories.size() == 0) {
             log.severe("Error: no bot factories found. Make sure the module path is correct. Exiting...");
+            // Also print directly as logging may not be setup
+            System.out.println("Error: no bot factories found. Make sure the module path is correct. Exiting...");
             System.exit(1);
         }
 


### PR DESCRIPTION
When starting certain bots with a fresh scratch area, we currently end up in a restart loop. This is because all the threads immediately get busy cloning repos, which starves out the watchdog pings for longer than the hard coded 10 minutes. This patch changes the watchdog to use the configuration setting "watchdog" for the restart timeout instead. This value is currently used for a log warning which is also driven by the watchdog, so to be able to still have separate values, I've introduced a new option "watchdog_warn" which can optionally be set for just the warning part.

In addition to this, I also added a bit more logging to make it easier to follow through logstash when watchdog pings occur, or when a new instance of a bot runner is started. Failure to start due to configuration errors are now also posted using proper logs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1042](https://bugs.openjdk.java.net/browse/SKARA-1042): Watchdog causing multiple restarts for mlbridge


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - Committer) ⚠️ Review applies to bb652d78e9a20946dd262d36a78cce5e8eff9854
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1157/head:pull/1157` \
`$ git checkout pull/1157`

Update a local copy of the PR: \
`$ git checkout pull/1157` \
`$ git pull https://git.openjdk.java.net/skara pull/1157/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1157`

View PR using the GUI difftool: \
`$ git pr show -t 1157`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1157.diff">https://git.openjdk.java.net/skara/pull/1157.diff</a>

</details>
