### PR TITLE
Add SKARA_JAVA_OPTS env variable to launchers

### DIFF
--- a/gradle/plugins/skara-images/src/main/java/org/openjdk/skara/gradle/images/LaunchersTask.java
+++ b/gradle/plugins/skara-images/src/main/java/org/openjdk/skara/gradle/images/LaunchersTask.java
@@ -93,7 +93,7 @@ public class LaunchersTask extends DefaultTask {
                     w.write("@echo off\r\n");
                     w.write("set DIR=%~dp0\r\n");
                     w.write("set JAVA_HOME=%DIR%..\\image\r\n");
-                    w.write("\"%JAVA_HOME%\\bin\\java.exe\" " + optionString + " --module " + clazz + " %*\r\n");
+                    w.write("\"%JAVA_HOME%\\bin\\java.exe\" %SKARA_JAVA_OPTS% " + optionString + " --module " + clazz + " %*\r\n");
                 }
             } else {
                 var file = dest.resolve(filename);
@@ -101,7 +101,7 @@ public class LaunchersTask extends DefaultTask {
                     w.write("#!/bin/sh\n");
                     w.write("DIR=$(dirname \"$0\")\n");
                     w.write("export JAVA_HOME=\"${DIR}/../image\"\n");
-                    w.write("\"${JAVA_HOME}/bin/java\" " + optionString + " --module " + clazz + " \"$@\"\n");
+                    w.write("\"${JAVA_HOME}/bin/java\" $SKARA_JAVA_OPTS " + optionString + " --module " + clazz + " \"$@\"\n");
                 }
                 if (file.getFileSystem().supportedFileAttributeViews().contains("posix")) {
                     var permissions = PosixFilePermissions.fromString("rwxr-xr-x");


### PR DESCRIPTION
This change adds the possibility of adding java options used when running a Skara image (such as the bots) though the environment variable SKARA_JAVA_OPTS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - Committer)
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1158/head:pull/1158` \
`$ git checkout pull/1158`

Update a local copy of the PR: \
`$ git checkout pull/1158` \
`$ git pull https://git.openjdk.java.net/skara pull/1158/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1158`

View PR using the GUI difftool: \
`$ git pr show -t 1158`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1158.diff">https://git.openjdk.java.net/skara/pull/1158.diff</a>

</details>
