### PR TITLE
1036: Extend bot config files to support comments

### DIFF
--- a/bots/cli/src/main/java/org/openjdk/skara/bots/cli/BotLauncher.java
+++ b/bots/cli/src/main/java/org/openjdk/skara/bots/cli/BotLauncher.java
@@ -109,7 +109,7 @@ public class BotLauncher {
 
     private static JSONObject readConfiguration(Path jsonFile) {
         try {
-            return JSON.parse(Files.readString(jsonFile, StandardCharsets.UTF_8)).asObject();
+            return JWCC.parse(Files.readString(jsonFile, StandardCharsets.UTF_8)).asObject();
         } catch (IOException e) {
             throw new RuntimeException("Failed to open configuration file: " + jsonFile);
         }

--- a/json/src/main/java/org/openjdk/skara/json/JWCC.java
+++ b/json/src/main/java/org/openjdk/skara/json/JWCC.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.json;
+
+/**
+ * JWCC is JSON With Commas and Comments. In addition to supporting all of JSON
+ * JWCC also supports trailing commas and comments. Comments can be either
+ * until single-line or multi-line.
+ *
+ * Comments are stripped and are not present in the parsed result.
+ */
+public class JWCC {
+    public static JSONValue parse(String s) {
+        return new JSONParser(true, true).parse(s);
+    }
+}

--- a/json/src/test/java/org/openjdk/skara/json/JWCCTests.java
+++ b/json/src/test/java/org/openjdk/skara/json/JWCCTests.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.json;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+import java.util.stream.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class JWCCTests {
+    @Test
+    public void testSingleLineComment() {
+        var text = """
+                   // this is a comment before the object
+                   { // this is a comment after opening brace
+                     "foo": "bar" // this is a comment after field
+                   } // this is a comment after closening brace
+                   // this is a comment after the object
+                   """;
+        var json = JWCC.parse(text);
+        assertEquals("bar", json.get("foo").asString());
+    }
+
+    @Test
+    public void testSingleLineCommentAfterKey() {
+        var text = """
+                   {
+                     "foo": // comment
+                         "bar"
+                   }
+                   """;
+        var json = JWCC.parse(text);
+        assertEquals("bar", json.get("foo").asString());
+    }
+
+    @Test
+    public void testSingleLineCommentAfterKeyWithoutValue() {
+        var text = """
+                   {
+                     "foo": // comment
+                   }
+                   """;
+        assertThrows(IllegalStateException.class, () -> {
+            JWCC.parse(text);
+        });
+    }
+
+    @Test
+    public void testInlineComment() {
+        var text = """
+                   /*
+                    * This is a multi-line comment
+                    *
+                    */
+                   /*
+                    * This is another multi-line comment with JSON in it
+                    {
+                      "foo": 17
+                    }
+                    */
+                   /* small comment */ { /* another
+                   multi-line */
+                     /* before */ "foo" /* a comment */ : /* another comment */ "bar" /* so many comments */
+                   } /* after */
+                   /*
+                    * A final multi-line
+                    */
+                   """;
+        var json = JWCC.parse(text);
+        assertEquals("bar", json.get("foo").asString());
+    }
+
+    @Test
+    public void testInlineAndLineComment() {
+        var text = """
+                   /*
+                    * This is a multi-line comment
+                    * // with a line comment inside it
+                    */
+                   /*
+                    * This is another multi-line comment with JSON in it
+                    {
+                      "foo": 17
+                    }
+                    */
+                   /* small comment */ { // until end-of-line with closing brace }
+                     /* before */ "foo" /* a comment */ : /* another comment */ "bar" /////// end-of-line
+                   } /* after */ // end-of-line /* with in-line */
+                   /*
+                    * A final multi-line
+                    */
+                    // A final singe-line
+                   """;
+        var json = JWCC.parse(text);
+        assertEquals("bar", json.get("foo").asString());
+    }
+
+    @Test
+    public void testInlineAndLineCommentWithArray() {
+        var text = """
+                   /*
+                    * This is a multi-line comment
+                    * // with a line comment inside it
+                    */
+                   /*
+                    * This is another multi-line comment with JSON in it
+                    {
+                      "foo": 17
+                    }
+                    */
+                   /* small comment */ [ // until end-of-line with closing brace }
+                     /* before */ "foo" /* a comment */ , /* another comment */ "bar" /////// end-of-line
+                   ] /* after */ // end-of-line /* with in-line */
+                   /*
+                    * A final multi-line
+                    */
+                    // A final singe-line
+                   """;
+        var json = JWCC.parse(text);
+        assertEquals("foo", json.get(0).asString());
+        assertEquals("bar", json.get(1).asString());
+        assertEquals(2, json.asArray().size());
+    }
+
+    @Test
+    public void testTrailingComma() {
+        var text = """
+                   {
+                       "a": 1,
+                       "b": 2,
+                   }
+                   """;
+        var json = JWCC.parse(text);
+        assertEquals(1, json.get("a").asInt());
+        assertEquals(2, json.get("b").asInt());
+    }
+
+    @Test
+    public void testTrailingCommaWithLineComment() {
+        var text = """
+                   {
+                       "a": 1, // a comment
+                       "b": 2, // another comment
+                   }
+                   """;
+        var json = JWCC.parse(text);
+        assertEquals(1, json.get("a").asInt());
+        assertEquals(2, json.get("b").asInt());
+    }
+
+    @Test
+    public void testTrailingCommaWithInLineComment() {
+        var text = """
+                   {
+                       "a": 1, /* an in-line */
+                       "b": 2, /* another in-line */
+                   }
+                   """;
+        var json = JWCC.parse(text);
+        assertEquals(1, json.get("a").asInt());
+        assertEquals(2, json.get("b").asInt());
+    }
+
+    @Test
+    public void testTrailingOnSameLine() {
+        var text = """
+                   {
+                       "a": 1, "b": 2, /* in-line */ "c": 3,
+                   }
+                   """;
+        var json = JWCC.parse(text);
+        assertEquals(1, json.get("a").asInt());
+        assertEquals(2, json.get("b").asInt());
+        assertEquals(3, json.get("c").asInt());
+    }
+
+    @Test
+    public void testTrailingWithArray() {
+        var text = """
+                   [
+                       "a",
+                   ]
+                   """;
+        var json = JWCC.parse(text);
+        assertEquals("a", json.get(0).asString());
+    }
+
+    @Test
+    public void testTrailingWithMultipleArray() {
+        var text = """
+                   [
+                       "a",
+                       "b",
+                   ]
+                   """;
+        var json = JWCC.parse(text);
+        assertEquals("a", json.get(0).asString());
+        assertEquals("b", json.get(1).asString());
+    }
+}


### PR DESCRIPTION
Hi all,

please review this patch that extends the `JSON` parser to optionally allow both comments and trailing commas (i.e. [JWCC](https://nigeltao.github.io/blog/2021/json-with-commas-comments.html)). I also modified the bot launcher to now use JWCC for its configuration files instead of plain JSON (to allow comments and trailing commas). Note that no other code is updated to use JWCC, so all networking code etc. will still use regular old JSON.

I also added a bunch of tests for the new JWCC "mode".

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1036](https://bugs.openjdk.java.net/browse/SKARA-1036): Extend bot config files to support comments


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1159/head:pull/1159` \
`$ git checkout pull/1159`

Update a local copy of the PR: \
`$ git checkout pull/1159` \
`$ git pull https://git.openjdk.java.net/skara pull/1159/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1159`

View PR using the GUI difftool: \
`$ git pr show -t 1159`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1159.diff">https://git.openjdk.java.net/skara/pull/1159.diff</a>

</details>
