### PR TITLE
metrics: add metrics for HotSpot

### DIFF
--- a/metrics/src/main/java/module-info.java
+++ b/metrics/src/main/java/module-info.java
@@ -21,6 +21,7 @@
  * questions.
  */
 module org.openjdk.skara.metrics {
+    requires java.management;
     exports org.openjdk.skara.metrics;
 }
 

--- a/metrics/src/main/java/org/openjdk/skara/metrics/CollectorRegistry.java
+++ b/metrics/src/main/java/org/openjdk/skara/metrics/CollectorRegistry.java
@@ -25,10 +25,18 @@ package org.openjdk.skara.metrics;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryType;
+import java.lang.management.MemoryUsage;
 
 public final class CollectorRegistry {
-    private static final CollectorRegistry DEFAULT = new CollectorRegistry();
+    private static final CollectorRegistry DEFAULT = new CollectorRegistry(true);
     private final ConcurrentLinkedQueue<Collector> collectors = new ConcurrentLinkedQueue<>();
+    private final boolean includeHotspotMetrics;
+
+    public CollectorRegistry(boolean includeHotspotMetrics) {
+        this.includeHotspotMetrics = includeHotspotMetrics;
+    }
 
     public void register(Collector c) {
         collectors.add(c);
@@ -38,10 +46,78 @@ public final class CollectorRegistry {
         collectors.remove(c);
     }
 
+    private static List<Metric> memoryUsageMetrics(String prefix, List<Metric.Label> labels, MemoryUsage usage) {
+        var result = new ArrayList<Metric>();
+        var max = usage.getMax();
+        if (max != -1) {
+            result.add(new Metric(Metric.Type.GAUGE, prefix + "_max", labels, max));
+        }
+        result.add(new Metric(Metric.Type.GAUGE, prefix + "_used", labels, usage.getUsed()));
+        result.add(new Metric(Metric.Type.GAUGE, prefix + "_committed", labels, usage.getCommitted()));
+        var init = usage.getInit();
+        if (init != -1) {
+            result.add(new Metric(Metric.Type.GAUGE, prefix + "_init", labels, init));
+        }
+        return result;
+    }
+
+    private static List<Metric> hotspotMetrics() {
+        var result = new ArrayList<Metric>();
+
+        var memoryMXBean = ManagementFactory.getMemoryMXBean();
+        var heapUsage = memoryMXBean.getHeapMemoryUsage();
+        var heapLabels = List.of(new Metric.Label("type", MemoryType.HEAP.toString()));
+        result.addAll(memoryUsageMetrics("hotspot_memory", heapLabels, heapUsage));
+
+        var nonHeapUsage = memoryMXBean.getNonHeapMemoryUsage();
+        var nonHeapLabels = List.of(new Metric.Label("type", MemoryType.NON_HEAP.toString()));
+        result.addAll(memoryUsageMetrics("hotspot_memory", nonHeapLabels, nonHeapUsage));
+
+        var numThreads = ManagementFactory.getThreadMXBean().getThreadCount();
+        result.add(new Metric(Metric.Type.GAUGE, "hotspot_threads", List.of(), numThreads));
+
+        var uptime = ManagementFactory.getRuntimeMXBean().getUptime();
+        result.add(new Metric(Metric.Type.COUNTER, "hotspot_uptime", List.of(), uptime));
+
+        for (var gcMXBean : ManagementFactory.getGarbageCollectorMXBeans()) {
+            var labels = List.of(new Metric.Label("gc_name", gcMXBean.getName()));
+
+            var gcCount = gcMXBean.getCollectionCount();
+            result.add(new Metric(Metric.Type.COUNTER, "hotspot_gc_count", labels, gcCount));
+
+            var gcTime = gcMXBean.getCollectionTime() / 1000.0;
+            result.add(new Metric(Metric.Type.COUNTER, "hotspot_gc_time", labels, gcTime));
+        }
+
+        for (var memoryPoolMXBean : ManagementFactory.getMemoryPoolMXBeans()) {
+            var labels = List.of(new Metric.Label("memory_pool_name", memoryPoolMXBean.getName()),
+                                 new Metric.Label("memory_pool_type", memoryPoolMXBean.getType().toString()));
+            var usage = memoryPoolMXBean.getUsage();
+            result.addAll(memoryUsageMetrics("hotspot_memory_pool", labels, usage));
+        }
+
+        var compilationMXBean = ManagementFactory.getCompilationMXBean();
+        if (compilationMXBean.isCompilationTimeMonitoringSupported()) {
+            var compilationTime = ManagementFactory.getCompilationMXBean().getTotalCompilationTime();
+            result.add(new Metric(Metric.Type.COUNTER, "hotspot_compilation_time", List.of(), compilationTime));
+        }
+
+        var classLoadingMXBean = ManagementFactory.getClassLoadingMXBean();
+        var totalLoadedClasses = classLoadingMXBean.getTotalLoadedClassCount();
+        result.add(new Metric(Metric.Type.COUNTER, "hotspot_classes_loaded", List.of(), totalLoadedClasses));
+        var totalUnloadedClasses = classLoadingMXBean.getTotalLoadedClassCount();
+        result.add(new Metric(Metric.Type.COUNTER, "hotspot_classes_unloaded", List.of(), totalUnloadedClasses));
+
+        return result;
+    }
+
     public List<Metric> scrape() {
         var result = new ArrayList<Metric>();
         for (var collector : collectors) {
             result.addAll(collector.collect());
+        }
+        if (includeHotspotMetrics) {
+            result.addAll(hotspotMetrics());
         }
         return result;
     }

--- a/metrics/src/test/java/org/openjdk/skara/metrics/CollectorRegistryTests.java
+++ b/metrics/src/test/java/org/openjdk/skara/metrics/CollectorRegistryTests.java
@@ -25,13 +25,14 @@ package org.openjdk.skara.metrics;
 import org.junit.jupiter.api.*;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class CollectorRegistryTests {
     @Test
     void register() {
-        var registry = new CollectorRegistry();
+        var registry = new CollectorRegistry(false);
         var counter = Counter.name("counter").register(registry);
         var gauge = Gauge.name("gauge").register(registry);
         var metrics = registry.scrape();
@@ -44,10 +45,32 @@ class CollectorRegistryTests {
 
     @Test
     void unregister() {
-        var registry = new CollectorRegistry();
+        var registry = new CollectorRegistry(false);
         var counter = Counter.name("test").register(registry);
         assertEquals(1, registry.scrape().size());
         registry.unregister(counter);
         assertEquals(0, registry.scrape().size());
+    }
+
+    @Test
+    void hotspotMetrics() {
+        var registry = new CollectorRegistry(true);
+        var metrics = registry.scrape();
+        var metricNames = metrics.stream().map(Metric::name).collect(Collectors.toSet());
+        assertTrue(metricNames.contains("hotspot_memory_max"));
+        assertTrue(metricNames.contains("hotspot_memory_used"));
+        assertTrue(metricNames.contains("hotspot_memory_committed"));
+        assertTrue(metricNames.contains("hotspot_memory_init"));
+        assertTrue(metricNames.contains("hotspot_threads"));
+        assertTrue(metricNames.contains("hotspot_uptime"));
+        assertTrue(metricNames.contains("hotspot_gc_count"));
+        assertTrue(metricNames.contains("hotspot_gc_time"));
+        assertTrue(metricNames.contains("hotspot_memory_pool_max"));
+        assertTrue(metricNames.contains("hotspot_memory_pool_used"));
+        assertTrue(metricNames.contains("hotspot_memory_pool_committed"));
+        assertTrue(metricNames.contains("hotspot_memory_pool_init"));
+        assertTrue(metricNames.contains("hotspot_classes_loaded"));
+        assertTrue(metricNames.contains("hotspot_classes_unloaded"));
+
     }
 }

--- a/metrics/src/test/java/org/openjdk/skara/metrics/CounterTests.java
+++ b/metrics/src/test/java/org/openjdk/skara/metrics/CounterTests.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class CounterTests {
     @Test
     void inc() {
-        var registry = new CollectorRegistry();
+        var registry = new CollectorRegistry(false);
         var counter = Counter.name("test").register(registry);
         assertEquals(0, counter.collect().get(0).value());
         counter.inc();
@@ -38,7 +38,7 @@ class CounterTests {
 
     @Test
     void incTwice() {
-        var registry = new CollectorRegistry();
+        var registry = new CollectorRegistry(false);
         var counter = Counter.name("test").register(registry);
         assertEquals(0, counter.collect().get(0).value());
         counter.inc();
@@ -52,7 +52,7 @@ class CounterTests {
 
     @Test
     void incWithValue() {
-        var registry = new CollectorRegistry();
+        var registry = new CollectorRegistry(false);
         var counter = Counter.name("test").register(registry);
         assertEquals(0, counter.collect().get(0).value());
         counter.inc(17);
@@ -61,7 +61,7 @@ class CounterTests {
 
     @Test
     void incWithValueMixedWithInc() {
-        var registry = new CollectorRegistry();
+        var registry = new CollectorRegistry(false);
         var counter = Counter.name("test").register(registry);
         assertEquals(0, counter.collect().get(0).value());
         counter.inc(17);
@@ -74,7 +74,7 @@ class CounterTests {
 
     @Test
     void incAndReset() {
-        var registry = new CollectorRegistry();
+        var registry = new CollectorRegistry(false);
         var counter = Counter.name("test").register(registry);
         assertEquals(0, counter.collect().get(0).value());
         counter.inc(17);
@@ -87,7 +87,7 @@ class CounterTests {
 
     @Test
     void oneLabel() {
-        var registry = new CollectorRegistry();
+        var registry = new CollectorRegistry(false);
         var counter = Counter.name("test").labels("a").register(registry);
         counter.labels("1").inc(17);
         assertEquals(1, counter.collect().size());
@@ -99,7 +99,7 @@ class CounterTests {
 
     @Test
     void twoLabels() {
-        var registry = new CollectorRegistry();
+        var registry = new CollectorRegistry(false);
         var counter = Counter.name("test").labels("a", "b").register(registry);
         counter.labels("1", "2").inc(17);
         assertEquals(1, counter.collect().size());
@@ -113,7 +113,7 @@ class CounterTests {
 
     @Test
     void threeLabels() {
-        var registry = new CollectorRegistry();
+        var registry = new CollectorRegistry(false);
         var counter = Counter.name("test").labels("a", "b", "c").register(registry);
         counter.labels("1", "2", "3").inc(17);
         assertEquals(1, counter.collect().size());
@@ -129,7 +129,7 @@ class CounterTests {
 
     @Test
     void threeLabelsIncAndReset() {
-        var registry = new CollectorRegistry();
+        var registry = new CollectorRegistry(false);
         var counter = Counter.name("test").labels("a", "b", "c").register(registry);
         counter.labels("1", "2", "3").inc();
         assertEquals(1, counter.collect().get(0).value());
@@ -143,7 +143,7 @@ class CounterTests {
 
     @Test
     void oneLabelMultiple() {
-        var registry = new CollectorRegistry();
+        var registry = new CollectorRegistry(false);
         var counter = Counter.name("test").labels("a").register(registry);
         counter.labels("1").inc(17);
         counter.labels("2").inc(19);

--- a/metrics/src/test/java/org/openjdk/skara/metrics/GaugeTests.java
+++ b/metrics/src/test/java/org/openjdk/skara/metrics/GaugeTests.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class GaugeTests {
     @Test
     void inc() {
-        var registry = new CollectorRegistry();
+        var registry = new CollectorRegistry(false);
         var gauge = Gauge.name("test").register(registry);
         gauge.inc();
         assertEquals(1, gauge.collect().get(0).value());
@@ -37,7 +37,7 @@ class GaugeTests {
 
     @Test
     void dec() {
-        var registry = new CollectorRegistry();
+        var registry = new CollectorRegistry(false);
         var gauge = Gauge.name("test").register(registry);
         gauge.inc();
         assertEquals(1, gauge.collect().get(0).value());
@@ -49,7 +49,7 @@ class GaugeTests {
 
     @Test
     void incWithValue() {
-        var registry = new CollectorRegistry();
+        var registry = new CollectorRegistry(false);
         var gauge = Gauge.name("test").register(registry);
         gauge.inc(17);
         assertEquals(17, gauge.collect().get(0).value());
@@ -57,7 +57,7 @@ class GaugeTests {
 
     @Test
     void decWithValue() {
-        var registry = new CollectorRegistry();
+        var registry = new CollectorRegistry(false);
         var gauge = Gauge.name("test").register(registry);
         gauge.dec(17);
         assertEquals(-17, gauge.collect().get(0).value());
@@ -65,7 +65,7 @@ class GaugeTests {
 
     @Test
     void incAndDecWithValue() {
-        var registry = new CollectorRegistry();
+        var registry = new CollectorRegistry(false);
         var gauge = Gauge.name("test").register(registry);
         gauge.inc(17);
         assertEquals(17, gauge.collect().get(0).value());
@@ -75,7 +75,7 @@ class GaugeTests {
 
     @Test
     void set() {
-        var registry = new CollectorRegistry();
+        var registry = new CollectorRegistry(false);
         var gauge = Gauge.name("test").register(registry);
         gauge.set(1337);
         assertEquals(1337, gauge.collect().get(0).value());
@@ -85,7 +85,7 @@ class GaugeTests {
 
     @Test
     void oneLabel() {
-        var registry = new CollectorRegistry();
+        var registry = new CollectorRegistry(false);
         var gauge = Gauge.name("test").labels("a").register(registry);
         gauge.labels("1").inc();
         assertEquals(1, gauge.collect().size());
@@ -97,7 +97,7 @@ class GaugeTests {
 
     @Test
     void oneLabelIncDecSet() {
-        var registry = new CollectorRegistry();
+        var registry = new CollectorRegistry(false);
         var gauge = Gauge.name("test").labels("a").register(registry);
         gauge.labels("1").inc(17);
         assertEquals(1, gauge.collect().size());
@@ -113,7 +113,7 @@ class GaugeTests {
 
     @Test
     void twoLabels() {
-        var registry = new CollectorRegistry();
+        var registry = new CollectorRegistry(false);
         var gauge = Gauge.name("test").labels("a", "b").register(registry);
         gauge.labels("1", "2").inc();
         assertEquals(1, gauge.collect().size());
@@ -127,7 +127,7 @@ class GaugeTests {
 
     @Test
     void twoLabelsIncDecSet() {
-        var registry = new CollectorRegistry();
+        var registry = new CollectorRegistry(false);
         var gauge = Gauge.name("test").labels("a", "b").register(registry);
         gauge.labels("1", "2").inc(17);
         assertEquals(1, gauge.collect().size());
@@ -145,7 +145,7 @@ class GaugeTests {
 
     @Test
     void threeLabels() {
-        var registry = new CollectorRegistry();
+        var registry = new CollectorRegistry(false);
         var gauge = Gauge.name("test").labels("a", "b", "c").register(registry);
         gauge.labels("1", "2", "3").inc();
         assertEquals(1, gauge.collect().size());
@@ -161,7 +161,7 @@ class GaugeTests {
 
     @Test
     void threeLabelsIncDecSet() {
-        var registry = new CollectorRegistry();
+        var registry = new CollectorRegistry(false);
         var gauge = Gauge.name("test").labels("a", "b", "c").register(registry);
         gauge.labels("1", "2", "3").inc(17);
         assertEquals(1, gauge.collect().size());


### PR DESCRIPTION
Hi all,

please review this patch that adds some default metrics for HotSpot to the default `CollectorRegistry` in the `metrics` package.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1160/head:pull/1160` \
`$ git checkout pull/1160`

Update a local copy of the PR: \
`$ git checkout pull/1160` \
`$ git pull https://git.openjdk.java.net/skara pull/1160/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1160`

View PR using the GUI difftool: \
`$ git pr show -t 1160`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1160.diff">https://git.openjdk.java.net/skara/pull/1160.diff</a>

</details>
