### PR TITLE
1000: mlbridge stuck failing on closed PR targeting a branch that no longer exists

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
@@ -271,6 +271,14 @@ class ArchiveWorkItem implements WorkItem {
             }
         }
 
+        // If the PR is closed and the target ref no longer exists, we cannot process it
+        if (pr.isClosed()) {
+            if (pr.repository().branches().stream().noneMatch(n -> n.name().equals(pr.targetRef()))) {
+                log.warning("Target branch of PR '" + pr.targetRef() + "' no longer exists, cannot process further");
+                return List.of();
+            }
+        }
+
         // Also inspect comments before making the first post
         var comments = pr.comments();
         if (sentMails.isEmpty()) {

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
@@ -179,9 +179,13 @@ class ReviewArchive {
                 var hash = findIntegratedHash();
                 if (hash.isPresent()) {
                     var commit = localRepo.lookup(hash.get());
-                    if (!hasLegacyIntegrationNotice(localRepo, commit.orElseThrow())) {
-                        var reply = ArchiveItem.integratedNotice(pr, localRepo, commit.orElseThrow(), hostUserToEmailAuthor, parent, subjectPrefix);
-                        generated.add(reply);
+                    if (commit.isPresent()) {
+                        if (!hasLegacyIntegrationNotice(localRepo, commit.get())) {
+                            var reply = ArchiveItem.integratedNotice(pr, localRepo, commit.get(), hostUserToEmailAuthor, parent, subjectPrefix);
+                            generated.add(reply);
+                        }
+                    } else {
+                        log.warning("Target commit for PR no longer exists, can't post or verify integration notice: " + hash.get());
                     }
                 } else {
                     throw new RuntimeException("PR " + pr.webUrl() + " has integrated label but no integration comment");


### PR DESCRIPTION
This patch fixes two related issues in mlbridge where the bot would fail with exception (and subsequently retry indefinitely while spamming admins with alarms) if the target branch or the integrated change of a PR no longer exists. My conclusion on how to fix this is to simply log a warning if either of these cases are detected and stop processing more.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1000](https://bugs.openjdk.java.net/browse/SKARA-1000): mlbridge stuck failing on closed PR targeting a branch that no longer exists


### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1161/head:pull/1161` \
`$ git checkout pull/1161`

Update a local copy of the PR: \
`$ git checkout pull/1161` \
`$ git pull https://git.openjdk.java.net/skara pull/1161/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1161`

View PR using the GUI difftool: \
`$ git pr show -t 1161`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1161.diff">https://git.openjdk.java.net/skara/pull/1161.diff</a>

</details>
