### PR TITLE
1029: Skara bot should prevent integration of PR with incorrect issue type

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -195,6 +195,19 @@ class CheckRun {
                             ret.add("Title mismatch between PR and JBS for issue " + issueString);
                             setExpiration(Duration.ofMinutes(10));
                         }
+
+                        var properties = iss.get().properties();
+                        if (!properties.containsKey("issuetype")) {
+                            var issueString = "[" + iss.get().id() + "](" + iss.get().webUrl() + ")";
+                            ret.add("Issue " + issueString + " does not contain property `issuetype`");
+                            setExpiration(Duration.ofMinutes(10));
+                        } else {
+                            var issueType = properties.get("issuetype").asString();
+                            if (!primaryTypes.contains(issueType)) {
+                                ret.add("Issue of type `" + issueType + "` is not allowed for integrations");
+                                setExpiration(Duration.ofMinutes(10));
+                            }
+                        }
                     } else {
                         log.warning("Failed to retrieve information on issue " + currentIssue.id());
                         setExpiration(Duration.ofMinutes(10));
@@ -477,10 +490,6 @@ class CheckRun {
                                 if (!pr.labelNames().contains("backport")) {
                                     progressBody.append(" ⚠️ Issue is not open.");
                                 }
-                            }
-                            if (properties.containsKey("issuetype") && !primaryTypes.contains(properties.get("issuetype").asString())) {
-                                progressBody.append(" ⚠️ Unexpected issue type `").append(properties.get("issuetype").asString()).append("`.");
-                                setExpiration(Duration.ofMinutes(10));
                             }
                             progressBody.append("\n");
                         } else {

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -970,7 +970,7 @@ class CheckTests {
             var masterHash = localRepo.resolve("master").orElseThrow();
             localRepo.push(masterHash, author.url(), "master", true);
 
-            var issue1 = issues.createIssue("My first issue", List.of("Hello"), Map.of());
+            var issue1 = issues.createIssue("My first issue", List.of("Hello"), Map.of("issuetype", JSON.of("Bug")));
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
@@ -990,7 +990,7 @@ class CheckTests {
             assertTrue(pr.body().contains("My first issue"));
 
             // Change the issue
-            var issue2 = issues.createIssue("My second issue", List.of("Body"), Map.of());
+            var issue2 = issues.createIssue("My second issue", List.of("Body"), Map.of("issuetype", JSON.of("Bug")));
             pr.setTitle(issue2.id() + ": This is a pull request");
 
             // Check the status again
@@ -1067,7 +1067,7 @@ class CheckTests {
             var masterHash = localRepo.resolve("master").orElseThrow();
             localRepo.push(masterHash, author.url(), "master", true);
 
-            var issue1 = issues.createIssue("My first issue", List.of("Hello"), Map.of());
+            var issue1 = issues.createIssue("My first issue", List.of("Hello"), Map.of("issuetype", JSON.of("Bug")));
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
@@ -1087,7 +1087,7 @@ class CheckTests {
             assertTrue(pr.body().contains("My first issue"));
 
             // Change the issue
-            var issue2 = issues.createIssue("My second issue", List.of("Body"), Map.of());
+            var issue2 = issues.createIssue("My second issue", List.of("Body"), Map.of("issuetype", JSON.of("Bug")));
             pr.setTitle(issue2.id() + ": This is a pull request");
 
             // Check the status again
@@ -1507,8 +1507,8 @@ class CheckTests {
 
             var bug = issues.createIssue("My first bug", List.of("A bug"),
                                          Map.of("issuetype", JSON.of("Bug")));
-            var feature = issues.createIssue("My first feature", List.of("A feature"),
-                                             Map.of("issuetype", JSON.of("Backport")));
+            var backport = issues.createIssue("My first feature", List.of("A feature"),
+                                              Map.of("issuetype", JSON.of("Backport")));
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -1531,17 +1531,17 @@ class CheckTests {
             assertEquals(CheckStatus.SUCCESS, bugCheck.status());
 
             // Make a change with a corresponding PR
-            var featureHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(featureHash, author.url(), "feature", true);
-            var featurePR = credentials.createPullRequest(author, "master", "feature",
-                                                          feature.id() + ": My first feature", true);
+            var backportHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(backportHash, author.url(), "backport", true);
+            var backportPR = credentials.createPullRequest(author, "master", "backport",
+                                                           backport.id() + ": My first backport", true);
 
             // Check the status
             TestBotRunner.runPeriodicItems(checkBot);
-            assertTrue(featurePR.body().contains(feature.id()));
-            assertTrue(featurePR.body().contains("My first feature"));
-            assertTrue(featurePR.body().contains("## Issue\n"));
-            assertTrue(featurePR.body().contains("Unexpected issue type"));
+            assertTrue(backportPR.body().contains(backport.id()));
+            assertTrue(backportPR.body().contains("My first feature"));
+            assertTrue(backportPR.body().contains("### Integration blocker"));
+            assertTrue(backportPR.body().contains("Issue of type `Backport` is not allowed for integrations"));
         }
     }
 

--- a/test/src/main/java/org/openjdk/skara/test/HostCredentials.java
+++ b/test/src/main/java/org/openjdk/skara/test/HostCredentials.java
@@ -378,7 +378,7 @@ public class HostCredentials implements AutoCloseable {
     }
 
     public Issue createIssue(IssueProject issueProject, String title) {
-        var issue = issueProject.createIssue(title, List.of(), Map.of());
+        var issue = issueProject.createIssue(title, List.of(), Map.of("issuetype", JSON.of("Bug")));
         issuesToBeClosed.add(issue);
         return issue;
     }


### PR DESCRIPTION
Hi all,

please review this patch that makes using a issue of type other than "Bug", "Enhancement", "Task", "Sub-task" or "New Feature" an integration blocker. We currently issue a warning, this warning has now been changed to an integration blocker.

Testing:
- [x] Updated a number of unit tests

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1029](https://bugs.openjdk.java.net/browse/SKARA-1029): Skara bot should prevent integration of PR with incorrect issue type


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - Committer)
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1162/head:pull/1162` \
`$ git checkout pull/1162`

Update a local copy of the PR: \
`$ git checkout pull/1162` \
`$ git pull https://git.openjdk.java.net/skara pull/1162/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1162`

View PR using the GUI difftool: \
`$ git pr show -t 1162`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1162.diff">https://git.openjdk.java.net/skara/pull/1162.diff</a>

</details>
