### PR TITLE
1049: Watchdog should change health status to unhealthy

### DIFF
--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
@@ -213,6 +213,7 @@ public class BotRunner {
     private final BotWatchdog botWatchdog;
     private final Duration watchdogWarnTimeout;
     private volatile boolean isReady;
+    private volatile boolean isHealthy;
 
     private static final Logger log = Logger.getLogger("org.openjdk.skara.bot");
 
@@ -230,9 +231,10 @@ public class BotRunner {
         }
 
         executor = new ScheduledThreadPoolExecutor(config.concurrency());
-        botWatchdog = new BotWatchdog(config.watchdogTimeout());
+        botWatchdog = new BotWatchdog(config.watchdogTimeout(), () -> isHealthy = false);
         watchdogWarnTimeout = config.watchdogWarnTimeout();
         isReady = false;
+        isHealthy = true;
     }
 
     boolean isReady() {
@@ -240,7 +242,7 @@ public class BotRunner {
     }
 
     boolean isHealthy() {
-        return true;
+        return isHealthy;
     }
 
     private void checkPeriodicItems() {

--- a/bot/src/main/java/org/openjdk/skara/bot/BotWatchdog.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotWatchdog.java
@@ -28,6 +28,7 @@ public class BotWatchdog {
     private final Thread watchThread;
     private final long maxWaitMillis;
     private final Duration maxWait;
+    private final Runnable callBack;
     private volatile boolean hasBeenPinged = false;
 
     private void threadMain() {
@@ -36,6 +37,7 @@ public class BotWatchdog {
                 Thread.sleep(maxWaitMillis);
                 if (!hasBeenPinged) {
                     System.out.println("No watchdog ping detected for " + maxWait + " - exiting...");
+                    callBack.run();
                     System.exit(1);
                 }
                 hasBeenPinged = false;
@@ -44,8 +46,9 @@ public class BotWatchdog {
         }
     }
 
-    BotWatchdog(Duration maxWait) {
+    BotWatchdog(Duration maxWait, Runnable callBack) {
         this.maxWait = maxWait;
+        this.callBack = callBack;
         maxWaitMillis = maxWait.toMillis();
         watchThread = new Thread(this::threadMain);
         watchThread.setName("BotWatchdog");


### PR DESCRIPTION
This patch adds a callback for the Watchdog, which is used to flip the isHealthy status to false when the watchdog triggers. This will help us to more quickly discover when a bot runner isn't working if System.exit() isn't working (which happened today).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1049](https://bugs.openjdk.java.net/browse/SKARA-1049): Watchdog should change health status to unhealthy


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - Committer)
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1163/head:pull/1163` \
`$ git checkout pull/1163`

Update a local copy of the PR: \
`$ git checkout pull/1163` \
`$ git pull https://git.openjdk.java.net/skara pull/1163/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1163`

View PR using the GUI difftool: \
`$ git pr show -t 1163`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1163.diff">https://git.openjdk.java.net/skara/pull/1163.diff</a>

</details>
