### PR TITLE
bot: add profile handler

### DIFF
--- a/bot/src/main/java/module-info.java
+++ b/bot/src/main/java/module-info.java
@@ -32,6 +32,7 @@ module org.openjdk.skara.bot {
     requires org.openjdk.skara.vcs;
     requires java.logging;
     requires jdk.httpserver;
+    requires jdk.jfr;
 
     exports org.openjdk.skara.bot;
 

--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunnerConfiguration.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunnerConfiguration.java
@@ -393,7 +393,8 @@ public class BotRunnerConfiguration {
             WebhookHandler.name(), WebhookHandler::create,
             MetricsHandler.name(), MetricsHandler::create,
             ReadinessHandler.name(), ReadinessHandler::create,
-            LivenessHandler.name(), LivenessHandler::create
+            LivenessHandler.name(), LivenessHandler::create,
+            ProfileHandler.name(), ProfileHandler::create
         );
         var contexts = new ArrayList<HttpContextConfiguration>();
         var port = config.get("http-server").get("port").asInt();

--- a/bot/src/main/java/org/openjdk/skara/bot/ProfileHandler.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/ProfileHandler.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bot;
+
+import org.openjdk.skara.json.JSONObject;
+
+import java.io.*;
+import java.nio.file.*;
+import java.util.*;
+import java.util.logging.*;
+import com.sun.net.httpserver.*;
+import jdk.jfr.*;
+import java.text.ParseException;
+import java.util.concurrent.locks.ReentrantLock;
+
+class ProfileHandler implements HttpHandler {
+    private static final Logger log = Logger.getLogger("org.openjdk.skara.bot");
+    private final Path configurationPath;
+    private final int maxDuration;
+    private final ReentrantLock lock = new ReentrantLock();
+
+    private ProfileHandler(Path configurationPath, int maxDuration) {
+        this.configurationPath = configurationPath;
+        this.maxDuration = maxDuration;
+    }
+
+    private static Map<String, String> parameters(HttpExchange exchange) {
+        var query = exchange.getRequestURI().getQuery();
+        var parts = query.split("&");
+        var result = new HashMap<String, String>();
+        for (var part : parts) {
+            var keyAndValue = part.split("=");
+            result.put(keyAndValue[0], keyAndValue[1]);
+        }
+        return result;
+    }
+
+    private void handleLocked(HttpExchange exchange) throws IOException {
+        var params = parameters(exchange);
+        var seconds = params.getOrDefault("seconds", "30");
+        var configurationName = params.getOrDefault("configuration", "profile");
+
+        Configuration configuration = null;
+        try {
+            configuration = Configuration.create(configurationPath);
+        } catch (ParseException e) {
+            log.log(Level.WARNING, "Could not get JFR configuration", e);
+            exchange.sendResponseHeaders(500, 0);
+            exchange.getResponseBody().close();
+        }
+
+        log.info("Profiling for " + seconds + " seconds with configuration " + configurationName);
+        var recording = new Recording(configuration);
+        recording.start();
+
+        try {
+            var duration = Integer.parseInt(seconds);
+            if (duration > maxDuration) {
+                duration = maxDuration;
+            }
+            Thread.sleep(duration * 1000);
+        } catch (InterruptedException e) {
+            log.log(Level.WARNING, "Thread interrupted when sleeping", e);
+            exchange.sendResponseHeaders(500, 0);
+            exchange.getResponseBody().close();
+        }
+
+        recording.stop();
+        var path = Files.createTempFile("recording", "jfr");
+        recording.dump(path);
+
+        var buffer = new byte[4096];
+        exchange.sendResponseHeaders(200, Files.size(path));
+        try (var output = exchange.getResponseBody(); var stream = Files.newInputStream(path)) {
+            while (true) {
+                var read = stream.read(buffer);
+                if (read == -1) {
+                    break;
+                }
+                output.write(buffer, 0, read);
+            }
+        } catch (Throwable t) {
+            log.log(Level.WARNING, "Could not send JFR recording", t);
+        } finally {
+            Files.deleteIfExists(path);
+        }
+    }
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+        // Only allow one recording at a time.
+        lock.lock();
+        try {
+            handleLocked(exchange);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    static ProfileHandler create(BotRunner runner, JSONObject configuration) {
+        var configurationPath = Path.of(configuration.get("configuration").asString());
+        var maxDuration = configuration.get("max-duration").asInt();
+        return new ProfileHandler(configurationPath, maxDuration);
+    }
+
+    static String name() {
+        return "profile";
+    }
+}

--- a/bot/src/main/java/org/openjdk/skara/bot/ProfileHandler.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/ProfileHandler.java
@@ -118,7 +118,7 @@ class ProfileHandler implements HttpHandler {
             return;
         }
         var authParts = authHeader.split(" ");
-        if (authParts.length != 2 || authParts[0].equals("token")) {
+        if (authParts.length != 2 || !authParts[0].equals("token")) {
             log.log(Level.WARNING, "Authorization HTTP header has wrong format");
             exchange.sendResponseHeaders(401, 0);
             exchange.getResponseBody().close();


### PR DESCRIPTION
Hi all,

please review this patch that adds a "profiling handler" typically listening on the `/profile` path. The profile handler will create a JFR recording that is sent as the reply to the HTTP request. The handler needs to configure a max duration (in seconds) for the recording and and a path to the `.jfc` configuration file. I made sure that only recording is allowed at a time to prevent too many requests to slow down the system too much.

Testing:
- [x] Tested locally on Linux x64 with various bots and configurations

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1164/head:pull/1164` \
`$ git checkout pull/1164`

Update a local copy of the PR: \
`$ git checkout pull/1164` \
`$ git pull https://git.openjdk.java.net/skara pull/1164/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1164`

View PR using the GUI difftool: \
`$ git pr show -t 1164`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1164.diff">https://git.openjdk.java.net/skara/pull/1164.diff</a>

</details>
