### PR TITLE
bot: add version handler

### DIFF
--- a/bot/build.gradle
+++ b/bot/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     implementation project(':json')
     implementation project(':census')
     implementation project(':metrics')
+    implementation project(':version')
 }
 
 publishing {

--- a/bot/src/main/java/module-info.java
+++ b/bot/src/main/java/module-info.java
@@ -30,6 +30,7 @@ module org.openjdk.skara.bot {
     requires transitive org.openjdk.skara.metrics;
     requires org.openjdk.skara.network;
     requires org.openjdk.skara.vcs;
+    requires org.openjdk.skara.version;
     requires java.logging;
     requires java.management;
     requires jdk.management;

--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunnerConfiguration.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunnerConfiguration.java
@@ -408,7 +408,8 @@ public class BotRunnerConfiguration {
             MetricsHandler.name(), MetricsHandler::create,
             ReadinessHandler.name(), ReadinessHandler::create,
             LivenessHandler.name(), LivenessHandler::create,
-            ProfileHandler.name(), ProfileHandler::create
+            ProfileHandler.name(), ProfileHandler::create,
+            VersionHandler.name(), VersionHandler::create
         );
         var contexts = new ArrayList<HttpContextConfiguration>();
         var port = config.get("http-server").get("port").asInt();

--- a/bot/src/main/java/org/openjdk/skara/bot/VersionHandler.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/VersionHandler.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bot;
+
+import org.openjdk.skara.json.JSONObject;
+import org.openjdk.skara.version.Version;
+
+import com.sun.net.httpserver.*;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.logging.Logger;
+
+class VersionHandler implements HttpHandler {
+    private static final Logger log = Logger.getLogger("org.openjdk.skara.bot");
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+        var version = Version.fromManifest();
+        if (version.isPresent()) {
+            var bytes = version.get().getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, bytes.length);
+            exchange.getResponseBody().write(bytes);
+            exchange.getResponseBody().close();
+        } else {
+            exchange.sendResponseHeaders(500, 0);
+            exchange.getResponseBody().close();
+        }
+    }
+
+    static VersionHandler create(BotRunner runner, JSONObject configuration) {
+        return new VersionHandler();
+    }
+
+    static String name() {
+        return "version";
+    }
+}


### PR DESCRIPTION
Hi all,

please review this patch that adds a version handler, typically listening on the path `/version`. This simple handler just returns the version of the running bots, useful for scripting or dashboards. Typical configuration:

```
{
  "http-server": {
    "/version": {
      "type": "version"
    }
  }
}
```

Example of usage:

```
$ curl http://localhost:8080/version
bd09ee70259733dc2e18577da6a36462c900dba3
```

Testing:
- [x] Tested locally on Linux x64

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to ead619b225ffbaf0f28c949f7b12fcd7b498072f


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1165/head:pull/1165` \
`$ git checkout pull/1165`

Update a local copy of the PR: \
`$ git checkout pull/1165` \
`$ git pull https://git.openjdk.java.net/skara pull/1165/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1165`

View PR using the GUI difftool: \
`$ git pr show -t 1165`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1165.diff">https://git.openjdk.java.net/skara/pull/1165.diff</a>

</details>
