### PR TITLE
1052: Memory leak in RestRequestCache

### DIFF
--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
@@ -36,6 +36,7 @@ import java.util.logging.*;
 import java.util.stream.Collectors;
 
 import com.sun.net.httpserver.*;
+import org.openjdk.skara.network.RestRequest;
 
 class BotRunnerError extends RuntimeException {
     BotRunnerError(String msg) {
@@ -328,6 +329,8 @@ public class BotRunner {
         executor.scheduleAtFixedRate(this::itemWatchdog, 0,
                                      config.scheduledExecutionPeriod().toMillis(), TimeUnit.MILLISECONDS);
         executor.scheduleAtFixedRate(this::checkPeriodicItems, 0,
+                                     config.scheduledExecutionPeriod().toMillis(), TimeUnit.MILLISECONDS);
+        executor.scheduleAtFixedRate(RestRequest::evictOldCacheData, 0,
                                      config.scheduledExecutionPeriod().toMillis(), TimeUnit.MILLISECONDS);
 
         try {

--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
@@ -326,12 +326,14 @@ public class BotRunner {
         }
 
         isReady = true;
-        executor.scheduleAtFixedRate(this::itemWatchdog, 0,
-                                     config.scheduledExecutionPeriod().toMillis(), TimeUnit.MILLISECONDS);
-        executor.scheduleAtFixedRate(this::checkPeriodicItems, 0,
-                                     config.scheduledExecutionPeriod().toMillis(), TimeUnit.MILLISECONDS);
-        executor.scheduleAtFixedRate(RestRequest::evictOldCacheData, 0,
-                                     config.scheduledExecutionPeriod().toMillis(), TimeUnit.MILLISECONDS);
+
+        var schedulingInterval = config.scheduledExecutionPeriod().toMillis();
+        executor.scheduleAtFixedRate(this::itemWatchdog, 0, schedulingInterval, TimeUnit.MILLISECONDS);
+        executor.scheduleAtFixedRate(this::checkPeriodicItems, 0, schedulingInterval, TimeUnit.MILLISECONDS);
+
+        var cacheEvictionInterval = config.cacheEvictionInterval().toMillis();
+        executor.scheduleAtFixedRate(RestRequest::evictOldCacheData, cacheEvictionInterval,
+                cacheEvictionInterval, TimeUnit.MILLISECONDS);
 
         try {
             executor.awaitTermination(timeout.toMillis(), TimeUnit.MILLISECONDS);

--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunnerConfiguration.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunnerConfiguration.java
@@ -320,6 +320,20 @@ public class BotRunnerConfiguration {
     }
 
     /**
+     * The amount of time to wait between runs of the RestResponseCache evictions.
+     * @return
+     */
+    Duration cacheEvictionInterval() {
+        if (!config.contains("runner") || !config.get("runner").contains("cache_eviction_interval")) {
+            var defaultValue = Duration.ofMinutes(5);
+            log.info("No cache eviction interval defined, using default value " + defaultValue);
+            return defaultValue;
+        } else {
+            return Duration.parse(config.get("runner").get("cache_eviction_interval").asString());
+        }
+    }
+
+    /**
      * Number of WorkItems to execute in parallel.
      * @return
      */

--- a/network/src/main/java/org/openjdk/skara/network/RestRequest.java
+++ b/network/src/main/java/org/openjdk/skara/network/RestRequest.java
@@ -479,4 +479,8 @@ public class RestRequest {
     public QueryBuilder delete() {
         return delete(null);
     }
+
+    public static void evictOldCacheData() {
+        RestRequestCache.INSTANCE.evictOldData();
+    }
 }


### PR DESCRIPTION
This patch adds a regularly scheduled cache eviction call to the RestRequestCache.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1052](https://bugs.openjdk.java.net/browse/SKARA-1052): Memory leak in RestRequestCache


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - Committer)
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1167/head:pull/1167` \
`$ git checkout pull/1167`

Update a local copy of the PR: \
`$ git checkout pull/1167` \
`$ git pull https://git.openjdk.java.net/skara pull/1167/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1167`

View PR using the GUI difftool: \
`$ git pr show -t 1167`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1167.diff">https://git.openjdk.java.net/skara/pull/1167.diff</a>

</details>
