### PR TITLE
bot: add performance metrics for work items

### DIFF
--- a/bot/src/main/java/module-info.java
+++ b/bot/src/main/java/module-info.java
@@ -31,6 +31,8 @@ module org.openjdk.skara.bot {
     requires org.openjdk.skara.network;
     requires org.openjdk.skara.vcs;
     requires java.logging;
+    requires java.management;
+    requires jdk.management;
     requires jdk.httpserver;
 
     exports org.openjdk.skara.bot;

--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
@@ -150,11 +150,11 @@ public class BotRunner {
                     -1L : stopAllocatedBytes - startAllocatedBytes;
 
                 if (cpuTimeNs != -1L) {
-                    double cpuTimeSeconds = cpuTimeNs / 1_000_000.0;
+                    double cpuTimeSeconds = cpuTimeNs / 1_000_000_000.0;
                     CPU_TIME_GAUGE.labels(item.botName(), item.workItemName()).set(cpuTimeSeconds);
                 }
                 if (userTimeNs != -1L) {
-                    double userTimeSeconds = userTimeNs / 1_000_000.0;
+                    double userTimeSeconds = userTimeNs / 1_000_000_000.0;
                     USER_TIME_GAUGE.labels(item.botName(), item.workItemName()).set(userTimeSeconds);
                 }
                 if (allocatedBytes != -1L) {

--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
@@ -57,8 +57,8 @@ public class BotRunner {
     private AtomicInteger workIdCounter = new AtomicInteger();
 
     private class RunnableWorkItem implements Runnable {
-        private static final Counter.WithOneLabel EXCEPTIONS_COUNTER =
-            Counter.name("skara_runner_exceptions").labels("bot").register();
+        private static final Counter.WithTwoLabels EXCEPTIONS_COUNTER =
+            Counter.name("skara_runner_exceptions").labels("bot", "work-item").register();
         private final WorkItem item;
 
         RunnableWorkItem(WorkItem wrappedItem) {
@@ -89,7 +89,7 @@ public class BotRunner {
                 try {
                     followUpItems = item.run(scratchPath);
                 } catch (RuntimeException e) {
-                    EXCEPTIONS_COUNTER.labels(item.botName()).inc();
+                    EXCEPTIONS_COUNTER.labels(item.botName(), item.workItemName()).inc();
                     log.log(Level.SEVERE, "Exception during item execution (" + item + "): " + e.getMessage(), e);
                     item.handleRuntimeException(e);
                 } finally {
@@ -137,13 +137,13 @@ public class BotRunner {
     private final Map<WorkItem, Instant> active;
     private final Deque<Path> scratchPaths;
 
-    private static final Counter.WithOneLabel SCHEDULED_COUNTER =
-        Counter.name("skara_runner_scheduled").labels("bot").register();
-    private static final Counter.WithOneLabel DISCARDED_COUNTER =
-        Counter.name("skara_runner_discarded").labels("bot").register();
+    private static final Counter.WithTwoLabels SCHEDULED_COUNTER =
+        Counter.name("skara_runner_scheduled").labels("bot", "work-item").register();
+    private static final Counter.WithTwoLabels DISCARDED_COUNTER =
+        Counter.name("skara_runner_discarded").labels("bot", "work-item").register();
 
     private void submitOrSchedule(WorkItem item) {
-        SCHEDULED_COUNTER.labels(item.botName()).inc();
+        SCHEDULED_COUNTER.labels(item.botName(), item.workItemName()).inc();
         synchronized (executor) {
             for (var activeItem : active.keySet()) {
                 if (!activeItem.concurrentWith(item)) {
@@ -153,7 +153,7 @@ public class BotRunner {
                         if (pendingItem.getKey().getClass().equals(item.getClass()) && !pendingItem.getKey().concurrentWith(item)) {
                             log.finer("Discarding obsoleted item " + pendingItem.getKey() +
                                               " in favor of item " + item);
-                            DISCARDED_COUNTER.labels(item.botName()).inc();
+                            DISCARDED_COUNTER.labels(item.botName(), item.workItemName()).inc();
                             pending.remove(pendingItem.getKey());
                             // There can't be more than one
                             break;

--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
@@ -57,8 +57,8 @@ public class BotRunner {
     private AtomicInteger workIdCounter = new AtomicInteger();
 
     private class RunnableWorkItem implements Runnable {
-        private static final Counter.WithTwoLabels EXCEPTIONS_COUNTER =
-            Counter.name("skara_runner_exceptions").labels("bot", "work-item").register();
+        private static final Counter.WithThreeLabels EXCEPTIONS_COUNTER =
+            Counter.name("skara_runner_exceptions").labels("bot", "work-item", "exception").register();
         private final WorkItem item;
 
         RunnableWorkItem(WorkItem wrappedItem) {
@@ -89,7 +89,7 @@ public class BotRunner {
                 try {
                     followUpItems = item.run(scratchPath);
                 } catch (RuntimeException e) {
-                    EXCEPTIONS_COUNTER.labels(item.botName(), item.workItemName()).inc();
+                    EXCEPTIONS_COUNTER.labels(item.botName(), item.workItemName(), e.getClass().getName()).inc();
                     log.log(Level.SEVERE, "Exception during item execution (" + item + "): " + e.getMessage(), e);
                     item.handleRuntimeException(e);
                 } finally {

--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
@@ -24,7 +24,7 @@ package org.openjdk.skara.bot;
 
 import java.util.concurrent.atomic.AtomicInteger;
 import org.openjdk.skara.json.JSONValue;
-import org.openjdk.skara.metrics.Counter;
+import org.openjdk.skara.metrics.*;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -34,6 +34,8 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.logging.*;
 import java.util.stream.Collectors;
+import java.lang.management.ManagementFactory;
+import com.sun.management.ThreadMXBean;
 
 import com.sun.net.httpserver.*;
 
@@ -59,6 +61,13 @@ public class BotRunner {
     private class RunnableWorkItem implements Runnable {
         private static final Counter.WithThreeLabels EXCEPTIONS_COUNTER =
             Counter.name("skara_runner_exceptions").labels("bot", "work-item", "exception").register();
+        private static final Gauge.WithTwoLabels CPU_TIME_GAUGE =
+            Gauge.name("skara_runner_cpu_time").labels("bot", "work-item").register();
+        private static final Gauge.WithTwoLabels USER_TIME_GAUGE =
+            Gauge.name("skara_runner_user_time").labels("bot", "work-item").register();
+        private static final Gauge.WithTwoLabels ALLOCATED_BYTES_GAUGE =
+            Gauge.name("skara_runner_allocated_bytes").labels("bot", "work-item").register();
+
         private final WorkItem item;
 
         RunnableWorkItem(WorkItem wrappedItem) {
@@ -69,8 +78,92 @@ public class BotRunner {
             return item;
         }
 
+        private static Optional<ThreadMXBean> getThreadMXBean() {
+            var bean = ManagementFactory.getThreadMXBean();
+            return bean instanceof ThreadMXBean ?
+                Optional.of((ThreadMXBean) bean) : Optional.empty();
+        }
+
+        private static void enableThreadCpuTime() {
+            var bean = getThreadMXBean();
+            if (bean.get().isCurrentThreadCpuTimeSupported() && !bean.get().isThreadCpuTimeEnabled()) {
+                bean.get().setThreadCpuTimeEnabled(true);
+            }
+        }
+
+        private static long getCurrentThreadCpuTime() {
+            var bean = getThreadMXBean();
+            if (bean.isEmpty()) {
+                return -1L;
+            }
+            return bean.get().isCurrentThreadCpuTimeSupported()?
+                bean.get().getCurrentThreadCpuTime() :
+                -1L;
+        }
+
+        private static long getCurrentThreadUserTime() {
+            var bean = getThreadMXBean();
+            if (bean.isEmpty()) {
+                return -1L;
+            }
+            return bean.get().isCurrentThreadCpuTimeSupported()?
+                bean.get().getCurrentThreadUserTime() :
+                -1L;
+        }
+
+        private static long getCurrentThreadAllocatedBytes() {
+            var bean = getThreadMXBean();
+            if (bean.isEmpty()) {
+                return -1L;
+            }
+
+            if (!bean.get().isThreadAllocatedMemorySupported()) {
+                return -1L;
+            }
+
+            if (!bean.get().isThreadAllocatedMemoryEnabled()) {
+                bean.get().setThreadAllocatedMemoryEnabled(true);
+            }
+
+            return bean.get().getCurrentThreadAllocatedBytes();
+        }
+
         @Override
         public void run() {
+            enableThreadCpuTime();
+            long startCpuTimeNs = getCurrentThreadCpuTime();
+            long startUserTimeNs = getCurrentThreadUserTime();
+            long startAllocatedBytes = getCurrentThreadAllocatedBytes();
+
+            try {
+                runMeasured();
+            } finally {
+                long stopCpuTimeNs = getCurrentThreadCpuTime();
+                long stopUserTimeNs = getCurrentThreadUserTime();
+                long stopAllocatedBytes = getCurrentThreadAllocatedBytes();
+
+                var cpuTimeNs = (startCpuTimeNs == -1L && stopCpuTimeNs == -1L)?
+                    -1L : stopCpuTimeNs - startCpuTimeNs;
+                var userTimeNs = (startUserTimeNs == -1L && stopUserTimeNs == -1L)?
+                    -1L : stopUserTimeNs - startUserTimeNs;
+                var allocatedBytes = (startAllocatedBytes == -1L && stopAllocatedBytes == -1L)?
+                    -1L : stopAllocatedBytes - startAllocatedBytes;
+
+                if (cpuTimeNs != -1L) {
+                    double cpuTimeSeconds = cpuTimeNs / 1_000_000.0;
+                    CPU_TIME_GAUGE.labels(item.botName(), item.workItemName()).set(cpuTimeSeconds);
+                }
+                if (userTimeNs != -1L) {
+                    double userTimeSeconds = userTimeNs / 1_000_000.0;
+                    USER_TIME_GAUGE.labels(item.botName(), item.workItemName()).set(userTimeSeconds);
+                }
+                if (allocatedBytes != -1L) {
+                    ALLOCATED_BYTES_GAUGE.labels(item.botName(), item.workItemName()).set(allocatedBytes);
+                }
+            }
+        }
+
+        private void runMeasured() {
             Path scratchPath;
 
             synchronized (executor) {

--- a/bot/src/main/java/org/openjdk/skara/bot/WorkItem.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/WorkItem.java
@@ -42,6 +42,7 @@ public interface WorkItem {
     Collection<WorkItem> run(Path scratchPath);
 
     String botName();
+    String workItemName();
 
     /**
      * The BotRunner will catch <code>RuntimeException</code>s, implementing this method allows a WorkItem to

--- a/bot/src/test/java/org/openjdk/skara/bot/BotRunnerTests.java
+++ b/bot/src/test/java/org/openjdk/skara/bot/BotRunnerTests.java
@@ -77,6 +77,11 @@ class TestWorkItem implements WorkItem {
     public String botName() {
         return "test-bot";
     }
+
+    @Override
+    public String workItemName() {
+        return botName();
+    }
 }
 
 class TestWorkItemChild extends TestWorkItem {
@@ -129,6 +134,11 @@ class TestBlockedWorkItem implements WorkItem {
     @Override
     public String botName() {
         return "test-blocked";
+    }
+
+    @Override
+    public String workItemName() {
+        return botName();
     }
 }
 

--- a/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestCloserBot.java
+++ b/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestCloserBot.java
@@ -115,6 +115,11 @@ class PullRequestCloserBotWorkItem implements WorkItem {
     public String botName() {
         return BridgekeeperBotFactory.NAME;
     }
+
+    @Override
+    public String workItemName() {
+        return "closer";
+    }
 }
 
 public class PullRequestCloserBot implements Bot {

--- a/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestPrunerBot.java
+++ b/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestPrunerBot.java
@@ -111,6 +111,11 @@ class PullRequestPrunerBotWorkItem implements WorkItem {
     public String botName() {
         return BridgekeeperBotFactory.NAME;
     }
+
+    @Override
+    public String workItemName() {
+        return "pruner";
+    }
 }
 
 public class PullRequestPrunerBot implements Bot {

--- a/bots/censussync/src/main/java/org/openjdk/skara/bots/censussync/CensusSyncSplitBot.java
+++ b/bots/censussync/src/main/java/org/openjdk/skara/bots/censussync/CensusSyncSplitBot.java
@@ -261,4 +261,9 @@ public class CensusSyncSplitBot implements Bot, WorkItem {
     public String botName() {
         return name();
     }
+
+    @Override
+    public String workItemName() {
+        return "split";
+    }
 }

--- a/bots/censussync/src/main/java/org/openjdk/skara/bots/censussync/CensusSyncUnifyBot.java
+++ b/bots/censussync/src/main/java/org/openjdk/skara/bots/censussync/CensusSyncUnifyBot.java
@@ -155,4 +155,9 @@ public class CensusSyncUnifyBot implements Bot, WorkItem {
     public String botName() {
         return name();
     }
+
+    @Override
+    public String workItemName() {
+        return "unitfy";
+    }
 }

--- a/bots/checkout/src/main/java/org/openjdk/skara/bots/checkout/CheckoutBot.java
+++ b/bots/checkout/src/main/java/org/openjdk/skara/bots/checkout/CheckoutBot.java
@@ -164,4 +164,9 @@ public class CheckoutBot implements Bot, WorkItem {
     public String botName() {
         return name();
     }
+
+    @Override
+    public String workItemName() {
+        return botName();
+    }
 }

--- a/bots/cli/src/test/java/org/openjdk/skara/bots/cli/LoggingBot.java
+++ b/bots/cli/src/test/java/org/openjdk/skara/bots/cli/LoggingBot.java
@@ -90,4 +90,9 @@ public class LoggingBot implements Bot, WorkItem {
     public String botName() {
         return name();
     }
+
+    @Override
+    public String workItemName() {
+        return botName();
+    }
 }

--- a/bots/csr/src/main/java/org/openjdk/skara/bots/csr/CSRBot.java
+++ b/bots/csr/src/main/java/org/openjdk/skara/bots/csr/CSRBot.java
@@ -144,6 +144,11 @@ class CSRBot implements Bot, WorkItem {
     }
 
     @Override
+    public String workItemName() {
+        return botName();
+    }
+
+    @Override
     public String botName() {
         return name();
     }

--- a/bots/forward/src/main/java/org/openjdk/skara/bots/forward/ForwardBot.java
+++ b/bots/forward/src/main/java/org/openjdk/skara/bots/forward/ForwardBot.java
@@ -113,4 +113,9 @@ class ForwardBot implements Bot, WorkItem {
     public String botName() {
         return name();
     }
+
+    @Override
+    public String workItemName() {
+        return botName();
+    }
 }

--- a/bots/hgbridge/src/main/java/org/openjdk/skara/bots/hgbridge/JBridgeBot.java
+++ b/bots/hgbridge/src/main/java/org/openjdk/skara/bots/hgbridge/JBridgeBot.java
@@ -155,4 +155,8 @@ public class JBridgeBot implements Bot, WorkItem {
         return name();
     }
 
+    @Override
+    public String workItemName() {
+        return botName();
+    }
 }

--- a/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
+++ b/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
@@ -617,4 +617,9 @@ class MergeBot implements Bot, WorkItem {
     public String botName() {
         return name();
     }
+
+    @Override
+    public String workItemName() {
+        return botName();
+    }
 }

--- a/bots/mirror/src/main/java/org/openjdk/skara/bots/mirror/MirrorBot.java
+++ b/bots/mirror/src/main/java/org/openjdk/skara/bots/mirror/MirrorBot.java
@@ -121,6 +121,11 @@ class MirrorBot implements Bot, WorkItem {
     }
 
     @Override
+    public String workItemName() {
+        return botName();
+    }
+
+    @Override
     public String botName() {
         return name();
     }

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveReaderWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveReaderWorkItem.java
@@ -69,4 +69,9 @@ public class ArchiveReaderWorkItem implements WorkItem {
     public String botName() {
         return MailingListBridgeBotFactory.NAME;
     }
+
+    @Override
+    public String workItemName() {
+        return "archive-reader";
+    }
 }

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
@@ -419,4 +419,9 @@ class ArchiveWorkItem implements WorkItem {
     public String botName() {
         return MailingListBridgeBotFactory.NAME;
     }
+
+    @Override
+    public String workItemName() {
+        return "archive";
+    }
 }

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/CommentPosterWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/CommentPosterWorkItem.java
@@ -100,4 +100,9 @@ public class CommentPosterWorkItem implements WorkItem {
     public String botName() {
         return MailingListBridgeBotFactory.NAME;
     }
+
+    @Override
+    public String workItemName() {
+        return "comment-poster";
+    }
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/PullRequestWorkItem.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/PullRequestWorkItem.java
@@ -277,4 +277,9 @@ public class PullRequestWorkItem implements WorkItem {
     public String botName() {
         return NotifyBotFactory.NAME;
     }
+
+    @Override
+    public String workItemName() {
+        return "pr";
+    }
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryWorkItem.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryWorkItem.java
@@ -308,4 +308,9 @@ public class RepositoryWorkItem implements WorkItem {
     public String botName() {
         return NotifyBotFactory.NAME;
     }
+
+    @Override
+    public String workItemName() {
+        return "repository";
+    }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -318,4 +318,9 @@ class CheckWorkItem extends PullRequestWorkItem {
         var updatedPR = pr.repository().pullRequest(pr.id());
         return List.of(new PullRequestCommandWorkItem(bot, updatedPR, errorHandler));
     }
+
+    @Override
+    public String workItemName() {
+        return "check";
+    }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommandWorkItem.java
@@ -189,4 +189,9 @@ public class CommitCommandWorkItem implements WorkItem {
     public String botName() {
         return PullRequestBotFactory.NAME;
     }
+
+    @Override
+    public String workItemName() {
+        return "commit-command";
+    }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommentsWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommentsWorkItem.java
@@ -110,4 +110,9 @@ class CommitCommentsWorkItem implements WorkItem {
     public String botName() {
         return PullRequestBotFactory.NAME;
     }
+
+    @Override
+    public String workItemName() {
+        return "commit-comments";
+    }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
@@ -173,4 +173,9 @@ public class LabelerWorkItem extends PullRequestWorkItem {
         }
         return List.of();
     }
+
+    @Override
+    public String workItemName() {
+        return "labeler";
+    }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
@@ -240,4 +240,9 @@ public class PullRequestCommandWorkItem extends PullRequestWorkItem {
     public String toString() {
         return "PullRequestCommandWorkItem@" + pr.repository().name() + "#" + pr.id();
     }
+
+    @Override
+    public String workItemName() {
+        return "pr-command";
+    }
 }

--- a/bots/submit/src/main/java/org/openjdk/skara/bots/submit/SubmitBotWorkItem.java
+++ b/bots/submit/src/main/java/org/openjdk/skara/bots/submit/SubmitBotWorkItem.java
@@ -106,4 +106,9 @@ public class SubmitBotWorkItem implements WorkItem {
     public String botName() {
         return SubmitBotFactory.NAME;
     }
+
+    @Override
+    public String workItemName() {
+        return botName();
+    }
 }

--- a/bots/synclabel/src/main/java/org/openjdk/skara/bots/synclabel/SyncLabelBotFindMainIssueWorkItem.java
+++ b/bots/synclabel/src/main/java/org/openjdk/skara/bots/synclabel/SyncLabelBotFindMainIssueWorkItem.java
@@ -74,4 +74,9 @@ public class SyncLabelBotFindMainIssueWorkItem implements WorkItem {
     public String botName() {
         return SyncLabelBotFactory.NAME;
     }
+
+    @Override
+    public String workItemName() {
+        return "find-main-issue";
+    }
 }

--- a/bots/synclabel/src/main/java/org/openjdk/skara/bots/synclabel/SyncLabelBotUpdateLabelWorkItem.java
+++ b/bots/synclabel/src/main/java/org/openjdk/skara/bots/synclabel/SyncLabelBotUpdateLabelWorkItem.java
@@ -97,4 +97,9 @@ public class SyncLabelBotUpdateLabelWorkItem implements WorkItem {
     public String botName() {
         return SyncLabelBotFactory.NAME;
     }
+
+    @Override
+    public String workItemName() {
+        return "update-label";
+    }
 }

--- a/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestUpdateNeededWorkItem.java
+++ b/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestUpdateNeededWorkItem.java
@@ -106,4 +106,9 @@ public class TestUpdateNeededWorkItem implements WorkItem {
     public String botName() {
         return TestBotFactory.NAME;
     }
+
+    @Override
+    public String workItemName() {
+        return "updater";
+    }
 }

--- a/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestWorkItem.java
+++ b/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestWorkItem.java
@@ -465,4 +465,9 @@ public class TestWorkItem implements WorkItem {
     public String botName() {
         return TestBotFactory.NAME;
     }
+
+    @Override
+    public String workItemName() {
+        return "command";
+    }
 }

--- a/bots/testinfo/src/main/java/org/openjdk/skara/bots/testinfo/TestInfoBotWorkItem.java
+++ b/bots/testinfo/src/main/java/org/openjdk/skara/bots/testinfo/TestInfoBotWorkItem.java
@@ -132,4 +132,9 @@ public class TestInfoBotWorkItem implements WorkItem {
     public String botName() {
         return TestInfoBotFactory.NAME;
     }
+
+    @Override
+    public String workItemName() {
+        return botName();
+    }
 }

--- a/bots/topological/src/main/java/org/openjdk/skara/bots/topological/TopologicalBot.java
+++ b/bots/topological/src/main/java/org/openjdk/skara/bots/topological/TopologicalBot.java
@@ -186,6 +186,11 @@ class TopologicalBot implements Bot, WorkItem {
     }
 
     @Override
+    public String workItemName() {
+        return botName();
+    }
+
+    @Override
     public String botName() {
         return name();
     }


### PR DESCRIPTION
Hi all,

please review this patch that adds runtime performance metrics for work items. I have added three new gauges:

- `skara_runner_cpu_time`
- `skara_runner_user_time`
- `skara_runner_allocated_bytes`

All three are per work item and make use of the `ThreadMXBean` to set the gauges. We can use the methods in `ThreadMXBean` because the `Runnable` that is running on a thread in the thread pool cannot be preempted or moved to another thread, i.e. it will have the same "carrier" thread for its whole execution.

Testing:
- [x] Manual testing on Linux x64 using the mirror bot

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to 497d1bca0b230ef93ab6be683f03f18dace66810


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1171/head:pull/1171` \
`$ git checkout pull/1171`

Update a local copy of the PR: \
`$ git checkout pull/1171` \
`$ git pull https://git.openjdk.java.net/skara pull/1171/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1171`

View PR using the GUI difftool: \
`$ git pr show -t 1171`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1171.diff">https://git.openjdk.java.net/skara/pull/1171.diff</a>

</details>
