### PR TITLE
1053: Github check in conclusion "stale" not handled

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/pr/Utils.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/Utils.java
@@ -140,6 +140,8 @@ class Utils {
             return "FAILED";
         } else if (checkStatus == CheckStatus.CANCELLED) {
             return "CANCELLED";
+        } else if (checkStatus == CheckStatus.STALE) {
+            return "STALE";
         }
 
         return "UNKNOWN";

--- a/forge/src/main/java/org/openjdk/skara/forge/CheckBuilder.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/CheckBuilder.java
@@ -142,6 +142,12 @@ public class CheckBuilder {
         return this;
     }
 
+    public CheckBuilder stale() {
+        status = CheckStatus.STALE;
+        completedAt = ZonedDateTime.now();
+        return this;
+    }
+
     public Check build() {
         return new Check(name, hash, status, startedAt, completedAt, metadata, title, summary, annotations, details);
     }

--- a/forge/src/main/java/org/openjdk/skara/forge/CheckStatus.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/CheckStatus.java
@@ -27,5 +27,6 @@ public enum CheckStatus {
     SUCCESS,
     FAILURE,
     CANCELLED,
-    SKIPPED
+    SKIPPED,
+    STALE
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -407,12 +407,14 @@ public class GitHubPullRequest implements PullRequest {
                             var completed = c.get("status").asString().equals("completed");
                             if (completed) {
                                 var conclusion = c.get("conclusion").asString();
-                                var completedAt = ZonedDateTime.parse(c.get("completed_at").asString());
+                                String completedAtString = c.get("completed_at").asString();
+                                var completedAt = completedAtString != null ? ZonedDateTime.parse(completedAtString) : null;
                                 switch (conclusion) {
                                     case "cancelled" -> checkBuilder.cancel(completedAt);
                                     case "success" -> checkBuilder.complete(true, completedAt);
                                     case "action_required", "failure", "neutral" -> checkBuilder.complete(false, completedAt);
                                     case "skipped" -> checkBuilder.skipped(completedAt);
+                                    case "stale" -> checkBuilder.stale();
                                     default -> throw new IllegalStateException("Unexpected conclusion: " + conclusion);
                                 }
                             }

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -407,7 +407,7 @@ public class GitHubPullRequest implements PullRequest {
                             var completed = c.get("status").asString().equals("completed");
                             if (completed) {
                                 var conclusion = c.get("conclusion").asString();
-                                String completedAtString = c.get("completed_at").asString();
+                                var completedAtString = c.get("completed_at").asString();
                                 var completedAt = completedAtString != null ? ZonedDateTime.parse(completedAtString) : null;
                                 switch (conclusion) {
                                     case "cancelled" -> checkBuilder.cancel(completedAt);


### PR DESCRIPTION
This patch adds handling of the "stale" github check result. A stale result does not have a completed_at time, so we need to handle that this field can be null.

I tried to look through the code to see if there were any places where we would need to react to this new result, but could only find one that seemed relevant.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1053](https://bugs.openjdk.java.net/browse/SKARA-1053): Github check in conclusion "stale" not handled


### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**) ⚠️ Review applies to 907a2c8a15f0d3780d9a7957e002dd10234c7191


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1172/head:pull/1172` \
`$ git checkout pull/1172`

Update a local copy of the PR: \
`$ git checkout pull/1172` \
`$ git pull https://git.openjdk.java.net/skara pull/1172/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1172`

View PR using the GUI difftool: \
`$ git pr show -t 1172`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1172.diff">https://git.openjdk.java.net/skara/pull/1172.diff</a>

</details>
