### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ also want to build the bot images run `sh gradlew images` on GNU/Linux or
 
 If you want to build on an operating system other than GNU/Linux, macOS or
 Windows _or_ if you want to build on a CPU architecture other than x64, then
-ensure that you have JDK 14 or later installed locally. You can then run the
-following command from the source tree root:
+ensure that you have JDK 14 or later installed locally and JAVA_HOME set to
+point to it. You can then run the following command from the source tree root:
 
 ```bash
 $ sh gradlew


### PR DESCRIPTION
This patch updates the readme to clarify that you need to set JAVA_HOME when building Skara on a platform other than Linux, Windows and Macos x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - Committer)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - no project role)
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1173/head:pull/1173` \
`$ git checkout pull/1173`

Update a local copy of the PR: \
`$ git checkout pull/1173` \
`$ git pull https://git.openjdk.java.net/skara pull/1173/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1173`

View PR using the GUI difftool: \
`$ git pr show -t 1173`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1173.diff">https://git.openjdk.java.net/skara/pull/1173.diff</a>

</details>
