### PR TITLE
1061: The skara update command is broken for platforms without downloaded JDK

### DIFF
--- a/gradle/plugins/skara-images/src/main/java/org/openjdk/skara/gradle/images/LaunchersTask.java
+++ b/gradle/plugins/skara-images/src/main/java/org/openjdk/skara/gradle/images/LaunchersTask.java
@@ -92,16 +92,16 @@ public class LaunchersTask extends DefaultTask {
                 try (var w = Files.newBufferedWriter(file)) {
                     w.write("@echo off\r\n");
                     w.write("set DIR=%~dp0\r\n");
-                    w.write("set JAVA_HOME=%DIR%..\\image\r\n");
-                    w.write("\"%JAVA_HOME%\\bin\\java.exe\" %SKARA_JAVA_OPTS% " + optionString + " --module " + clazz + " %*\r\n");
+                    w.write("set JAVA_LAUNCHER=%DIR%..\\image\\bin\\java.exe\r\n");
+                    w.write("\"%JAVA_LAUNCHER%\" %SKARA_JAVA_OPTS% " + optionString + " --module " + clazz + " %*\r\n");
                 }
             } else {
                 var file = dest.resolve(filename);
                 try (var w = Files.newBufferedWriter(file)) {
                     w.write("#!/bin/sh\n");
                     w.write("DIR=$(dirname \"$0\")\n");
-                    w.write("export JAVA_HOME=\"${DIR}/../image\"\n");
-                    w.write("\"${JAVA_HOME}/bin/java\" $SKARA_JAVA_OPTS " + optionString + " --module " + clazz + " \"$@\"\n");
+                    w.write("JAVA_LAUNCHER=\"${DIR}/../image/bin/java\"\n");
+                    w.write("\"${JAVA_LAUNCHER}\" $SKARA_JAVA_OPTS " + optionString + " --module " + clazz + " \"$@\"\n");
                 }
                 if (file.getFileSystem().supportedFileAttributeViews().contains("posix")) {
                     var permissions = PosixFilePermissions.fromString("rwxr-xr-x");


### PR DESCRIPTION
This patch changes the CLI launcher scripts to no longer export JAVA_HOME. This is to prevent this exported variable from interfering with the "git skara update" command. The update command needs to be able to run Gradle. Gradle cannot run with the JAVA_HOME exported from the Skara CLI scripts. Whatever JAVA_HOME the user has needs to survive through to the Gradle invocation.

I'm not sure why JAVA_HOME was set here. It seems to have been around for a long time. I'm assuming it just happened to be written that way, but if anyone can think of a reason, that would be good. I'm running with this patch myself right now to try to catch any potential problems.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1061](https://bugs.openjdk.java.net/browse/SKARA-1061): The skara update command is broken for platforms without downloaded JDK


### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1174/head:pull/1174` \
`$ git checkout pull/1174`

Update a local copy of the PR: \
`$ git checkout pull/1174` \
`$ git pull https://git.openjdk.java.net/skara pull/1174/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1174`

View PR using the GUI difftool: \
`$ git pr show -t 1174`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1174.diff">https://git.openjdk.java.net/skara/pull/1174.diff</a>

</details>
