### PR TITLE
metrics: add process metrics

### DIFF
--- a/metrics/src/main/java/module-info.java
+++ b/metrics/src/main/java/module-info.java
@@ -22,6 +22,7 @@
  */
 module org.openjdk.skara.metrics {
     requires java.management;
+    requires jdk.management;
     exports org.openjdk.skara.metrics;
 }
 

--- a/metrics/src/test/java/org/openjdk/skara/metrics/CollectorRegistryTests.java
+++ b/metrics/src/test/java/org/openjdk/skara/metrics/CollectorRegistryTests.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class CollectorRegistryTests {
     @Test
     void register() {
-        var registry = new CollectorRegistry(false);
+        var registry = new CollectorRegistry(false, false);
         var counter = Counter.name("counter").register(registry);
         var gauge = Gauge.name("gauge").register(registry);
         var metrics = registry.scrape();
@@ -45,7 +45,7 @@ class CollectorRegistryTests {
 
     @Test
     void unregister() {
-        var registry = new CollectorRegistry(false);
+        var registry = new CollectorRegistry(false, false);
         var counter = Counter.name("test").register(registry);
         assertEquals(1, registry.scrape().size());
         registry.unregister(counter);
@@ -54,7 +54,7 @@ class CollectorRegistryTests {
 
     @Test
     void hotspotMetrics() {
-        var registry = new CollectorRegistry(true);
+        var registry = new CollectorRegistry(true, false);
         var metrics = registry.scrape();
         var metricNames = metrics.stream().map(Metric::name).collect(Collectors.toSet());
         assertTrue(metricNames.contains("hotspot_memory_max"));
@@ -71,6 +71,13 @@ class CollectorRegistryTests {
         assertTrue(metricNames.contains("hotspot_memory_pool_init"));
         assertTrue(metricNames.contains("hotspot_classes_loaded"));
         assertTrue(metricNames.contains("hotspot_classes_unloaded"));
+    }
 
+    @Test
+    void processMetrics() {
+        var registry = new CollectorRegistry(false, true);
+        var metrics = registry.scrape();
+        var metricNames = metrics.stream().map(Metric::name).collect(Collectors.toSet());
+        assertTrue(metricNames.contains("process_start_time_seconds"));
     }
 }

--- a/metrics/src/test/java/org/openjdk/skara/metrics/CounterTests.java
+++ b/metrics/src/test/java/org/openjdk/skara/metrics/CounterTests.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class CounterTests {
     @Test
     void inc() {
-        var registry = new CollectorRegistry(false);
+        var registry = new CollectorRegistry(false, false);
         var counter = Counter.name("test").register(registry);
         assertEquals(0, counter.collect().get(0).value());
         counter.inc();
@@ -38,7 +38,7 @@ class CounterTests {
 
     @Test
     void incTwice() {
-        var registry = new CollectorRegistry(false);
+        var registry = new CollectorRegistry(false, false);
         var counter = Counter.name("test").register(registry);
         assertEquals(0, counter.collect().get(0).value());
         counter.inc();
@@ -52,7 +52,7 @@ class CounterTests {
 
     @Test
     void incWithValue() {
-        var registry = new CollectorRegistry(false);
+        var registry = new CollectorRegistry(false, false);
         var counter = Counter.name("test").register(registry);
         assertEquals(0, counter.collect().get(0).value());
         counter.inc(17);
@@ -61,7 +61,7 @@ class CounterTests {
 
     @Test
     void incWithValueMixedWithInc() {
-        var registry = new CollectorRegistry(false);
+        var registry = new CollectorRegistry(false, false);
         var counter = Counter.name("test").register(registry);
         assertEquals(0, counter.collect().get(0).value());
         counter.inc(17);
@@ -74,7 +74,7 @@ class CounterTests {
 
     @Test
     void incAndReset() {
-        var registry = new CollectorRegistry(false);
+        var registry = new CollectorRegistry(false, false);
         var counter = Counter.name("test").register(registry);
         assertEquals(0, counter.collect().get(0).value());
         counter.inc(17);
@@ -87,7 +87,7 @@ class CounterTests {
 
     @Test
     void oneLabel() {
-        var registry = new CollectorRegistry(false);
+        var registry = new CollectorRegistry(false, false);
         var counter = Counter.name("test").labels("a").register(registry);
         counter.labels("1").inc(17);
         assertEquals(1, counter.collect().size());
@@ -99,7 +99,7 @@ class CounterTests {
 
     @Test
     void twoLabels() {
-        var registry = new CollectorRegistry(false);
+        var registry = new CollectorRegistry(false, false);
         var counter = Counter.name("test").labels("a", "b").register(registry);
         counter.labels("1", "2").inc(17);
         assertEquals(1, counter.collect().size());
@@ -113,7 +113,7 @@ class CounterTests {
 
     @Test
     void threeLabels() {
-        var registry = new CollectorRegistry(false);
+        var registry = new CollectorRegistry(false, false);
         var counter = Counter.name("test").labels("a", "b", "c").register(registry);
         counter.labels("1", "2", "3").inc(17);
         assertEquals(1, counter.collect().size());
@@ -129,7 +129,7 @@ class CounterTests {
 
     @Test
     void threeLabelsIncAndReset() {
-        var registry = new CollectorRegistry(false);
+        var registry = new CollectorRegistry(false, false);
         var counter = Counter.name("test").labels("a", "b", "c").register(registry);
         counter.labels("1", "2", "3").inc();
         assertEquals(1, counter.collect().get(0).value());
@@ -143,7 +143,7 @@ class CounterTests {
 
     @Test
     void oneLabelMultiple() {
-        var registry = new CollectorRegistry(false);
+        var registry = new CollectorRegistry(false, false);
         var counter = Counter.name("test").labels("a").register(registry);
         counter.labels("1").inc(17);
         counter.labels("2").inc(19);

--- a/metrics/src/test/java/org/openjdk/skara/metrics/GaugeTests.java
+++ b/metrics/src/test/java/org/openjdk/skara/metrics/GaugeTests.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class GaugeTests {
     @Test
     void inc() {
-        var registry = new CollectorRegistry(false);
+        var registry = new CollectorRegistry(false, false);
         var gauge = Gauge.name("test").register(registry);
         gauge.inc();
         assertEquals(1, gauge.collect().get(0).value());
@@ -37,7 +37,7 @@ class GaugeTests {
 
     @Test
     void dec() {
-        var registry = new CollectorRegistry(false);
+        var registry = new CollectorRegistry(false, false);
         var gauge = Gauge.name("test").register(registry);
         gauge.inc();
         assertEquals(1, gauge.collect().get(0).value());
@@ -49,7 +49,7 @@ class GaugeTests {
 
     @Test
     void incWithValue() {
-        var registry = new CollectorRegistry(false);
+        var registry = new CollectorRegistry(false, false);
         var gauge = Gauge.name("test").register(registry);
         gauge.inc(17);
         assertEquals(17, gauge.collect().get(0).value());
@@ -57,7 +57,7 @@ class GaugeTests {
 
     @Test
     void decWithValue() {
-        var registry = new CollectorRegistry(false);
+        var registry = new CollectorRegistry(false, false);
         var gauge = Gauge.name("test").register(registry);
         gauge.dec(17);
         assertEquals(-17, gauge.collect().get(0).value());
@@ -65,7 +65,7 @@ class GaugeTests {
 
     @Test
     void incAndDecWithValue() {
-        var registry = new CollectorRegistry(false);
+        var registry = new CollectorRegistry(false, false);
         var gauge = Gauge.name("test").register(registry);
         gauge.inc(17);
         assertEquals(17, gauge.collect().get(0).value());
@@ -75,7 +75,7 @@ class GaugeTests {
 
     @Test
     void set() {
-        var registry = new CollectorRegistry(false);
+        var registry = new CollectorRegistry(false, false);
         var gauge = Gauge.name("test").register(registry);
         gauge.set(1337);
         assertEquals(1337, gauge.collect().get(0).value());
@@ -85,7 +85,7 @@ class GaugeTests {
 
     @Test
     void oneLabel() {
-        var registry = new CollectorRegistry(false);
+        var registry = new CollectorRegistry(false, false);
         var gauge = Gauge.name("test").labels("a").register(registry);
         gauge.labels("1").inc();
         assertEquals(1, gauge.collect().size());
@@ -97,7 +97,7 @@ class GaugeTests {
 
     @Test
     void oneLabelIncDecSet() {
-        var registry = new CollectorRegistry(false);
+        var registry = new CollectorRegistry(false, false);
         var gauge = Gauge.name("test").labels("a").register(registry);
         gauge.labels("1").inc(17);
         assertEquals(1, gauge.collect().size());
@@ -113,7 +113,7 @@ class GaugeTests {
 
     @Test
     void twoLabels() {
-        var registry = new CollectorRegistry(false);
+        var registry = new CollectorRegistry(false, false);
         var gauge = Gauge.name("test").labels("a", "b").register(registry);
         gauge.labels("1", "2").inc();
         assertEquals(1, gauge.collect().size());
@@ -127,7 +127,7 @@ class GaugeTests {
 
     @Test
     void twoLabelsIncDecSet() {
-        var registry = new CollectorRegistry(false);
+        var registry = new CollectorRegistry(false, false);
         var gauge = Gauge.name("test").labels("a", "b").register(registry);
         gauge.labels("1", "2").inc(17);
         assertEquals(1, gauge.collect().size());
@@ -145,7 +145,7 @@ class GaugeTests {
 
     @Test
     void threeLabels() {
-        var registry = new CollectorRegistry(false);
+        var registry = new CollectorRegistry(false, false);
         var gauge = Gauge.name("test").labels("a", "b", "c").register(registry);
         gauge.labels("1", "2", "3").inc();
         assertEquals(1, gauge.collect().size());
@@ -161,7 +161,7 @@ class GaugeTests {
 
     @Test
     void threeLabelsIncDecSet() {
-        var registry = new CollectorRegistry(false);
+        var registry = new CollectorRegistry(false, false);
         var gauge = Gauge.name("test").labels("a", "b", "c").register(registry);
         gauge.labels("1", "2", "3").inc(17);
         assertEquals(1, gauge.collect().size());


### PR DESCRIPTION
Hi all,

please review this patch that adds the [Prometheus recommended](https://prometheus.io/docs/instrumenting/writing_clientlibs/#process-metrics) `process_*` metrics. I've tested the implementation manually on a Linux x64 machine and opted to start by only implementing support for all metrics on Linux hosts.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1175/head:pull/1175` \
`$ git checkout pull/1175`

Update a local copy of the PR: \
`$ git checkout pull/1175` \
`$ git pull https://git.openjdk.java.net/skara pull/1175/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1175`

View PR using the GUI difftool: \
`$ git pr show -t 1175`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1175.diff">https://git.openjdk.java.net/skara/pull/1175.diff</a>

</details>
