### PR TITLE
1031: Declare Skara 1.0

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -25,7 +25,7 @@
 project=skara
 repository=skara
 jbs=skara
-version=0.9
+version=1.0
 
 [checks]
 error=author,reviewers,whitespace


### PR DESCRIPTION
This patch updates the version field in .jcheck/conf to 1.0. We do this to declare that Skara is now considered feature complete and will go into maintenance mode. We will continue to fix issues, but we will not be focusing on any new features in the foreseeable future.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1031](https://bugs.openjdk.java.net/browse/SKARA-1031): Declare Skara 1.0


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - no project role)
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1176/head:pull/1176` \
`$ git checkout pull/1176`

Update a local copy of the PR: \
`$ git checkout pull/1176` \
`$ git pull https://git.openjdk.java.net/skara pull/1176/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1176`

View PR using the GUI difftool: \
`$ git pr show -t 1176`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1176.diff">https://git.openjdk.java.net/skara/pull/1176.diff</a>

</details>
