### PR TITLE
1056: Mirror service is no longer syncing tags

### DIFF
--- a/bots/mirror/src/main/java/org/openjdk/skara/bots/mirror/MirrorBot.java
+++ b/bots/mirror/src/main/java/org/openjdk/skara/bots/mirror/MirrorBot.java
@@ -34,6 +34,12 @@ import java.util.*;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
+/**
+ * The MirrorBot mirrors one HostedRepository to another. It can be configured
+ * to only mirror a specific set of branches, or everything (which also
+ * includes tags). When only mirroring a set of branches, the includeTags
+ * setting can be used to also include tags.
+ */
 class MirrorBot implements Bot, WorkItem {
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots");;
     private final Path storage;
@@ -41,17 +47,20 @@ class MirrorBot implements Bot, WorkItem {
     private final HostedRepository to;
     private final List<Branch> branches;
     private final boolean shouldMirrorEverything;
+    private final boolean includeTags;
 
     MirrorBot(Path storage, HostedRepository from, HostedRepository to) {
-        this(storage, from, to, List.of());
+        this(storage, from, to, List.of(), false);
     }
 
-    MirrorBot(Path storage, HostedRepository from, HostedRepository to, List<Branch> branches) {
+    MirrorBot(Path storage, HostedRepository from, HostedRepository to, List<Branch> branches,
+              boolean includeTags) {
         this.storage = storage;
         this.from = from;
         this.to = to;
         this.branches = branches;
         this.shouldMirrorEverything = branches.isEmpty();
+        this.includeTags = includeTags;
     }
 
     @Override
@@ -89,13 +98,14 @@ class MirrorBot implements Bot, WorkItem {
 
             if (shouldMirrorEverything) {
                 log.info("Pulling " + from.name());
-                repo.fetchAll(from.url(), false);
+                // Tags are always included when mirroring everything
+                repo.fetchAll(from.url(), true);
                 log.info("Pushing to " + to.name());
                 repo.pushAll(to.url());
             } else {
                 for (var branch : branches) {
-                    var fetchHead = repo.fetch(from.url(), branch.name(), false);
-                    repo.push(fetchHead, to.url(), branch.name());
+                    var fetchHead = repo.fetch(from.url(), branch.name(), includeTags);
+                    repo.push(fetchHead, to.url(), branch.name(), false, includeTags);
                 }
             }
 

--- a/bots/mirror/src/main/java/org/openjdk/skara/bots/mirror/MirrorBotFactory.java
+++ b/bots/mirror/src/main/java/org/openjdk/skara/bots/mirror/MirrorBotFactory.java
@@ -64,9 +64,10 @@ public class MirrorBotFactory implements BotFactory {
                                  .map(Branch::new)
                                  .collect(Collectors.toList());
 
+            var includeTags = repo.contains("tags") && repo.get("tags").asBoolean();
 
             log.info("Setting up mirroring from " + fromRepo.name() + "to " + toRepo.name());
-            bots.add(new MirrorBot(storage, fromRepo, toRepo, branches));
+            bots.add(new MirrorBot(storage, fromRepo, toRepo, branches, includeTags));
         }
         return bots;
     }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
@@ -55,7 +55,10 @@ public interface Repository extends ReadOnlyRepository {
     void fetchAllRemotes(boolean includeTags) throws IOException;
     void fetchRemote(String remote) throws IOException;
     void pushAll(URI uri) throws IOException;
-    void push(Hash hash, URI uri, String ref, boolean force) throws IOException;
+    default void push(Hash hash, URI uri, String ref, boolean force) throws IOException {
+        push(hash, uri, ref, force, false);
+    }
+    void push(Hash hash, URI uri, String ref, boolean force, boolean includeTags) throws IOException;
     void push(Branch branch, String remote, boolean setUpstream) throws IOException;
     void push(Tag tag, URI uri, boolean force) throws IOException;
     void clean() throws IOException;

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -585,14 +585,24 @@ public class GitRepository implements Repository {
     }
 
     @Override
-    public void push(Hash hash, URI uri, String ref, boolean force) throws IOException {
+    public void push(Hash hash, URI uri, String ref, boolean force, boolean includeTags) throws IOException {
+        var cmd = new ArrayList<String>();
+        cmd.addAll(List.of("git", "push"));
+
+        if (includeTags) {
+            cmd.add("--tags");
+        }
+
+        cmd.add(uri.toString());
+
         String refspec = force ? "+" : "";
         if (!ref.startsWith("refs/")) {
             ref = "refs/heads/" + ref;
         }
         refspec += hash.hex() + ":" + ref;
+        cmd.add(refspec);
 
-        try (var p = capture("git", "push", uri.toString(), refspec)) {
+        try (var p = capture(cmd)) {
             await(p);
         }
     }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -557,7 +557,8 @@ public class HgRepository implements Repository {
     }
 
     @Override
-    public void push(Hash hash, URI uri, String ref, boolean force) throws IOException {
+    public void push(Hash hash, URI uri, String ref, boolean force, boolean includeTags) throws IOException {
+        // ignore includeTags, hg always pushes tags
         var cmd = new ArrayList<>(List.of("hg", "push", "--rev=" + hash.hex()));
         if (force) {
             cmd.add("--force");


### PR DESCRIPTION
We currently have two modes of mirroring repositories using the MirrorBot, either a set of branches, or everything. When limiting branches, tags are excluded, and when mirroring everything, tags are included.

I'm adding a new configuration option "tags": true/false. The purpose is to be able to include tags when only mirroring a set of branches. Default is false (to mimic current behavior). I can't see a use case for being able to exclude tags in the all branches case, and implementing it would add quite a bit of complexity.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1056](https://bugs.openjdk.java.net/browse/SKARA-1056): Mirror service is no longer syncing tags


### Reviewers
 * [Tim Bell](https://openjdk.java.net/census#tbell) (@tbell29552 - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1177/head:pull/1177` \
`$ git checkout pull/1177`

Update a local copy of the PR: \
`$ git checkout pull/1177` \
`$ git pull https://git.openjdk.java.net/skara pull/1177/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1177`

View PR using the GUI difftool: \
`$ git pr show -t 1177`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1177.diff">https://git.openjdk.java.net/skara/pull/1177.diff</a>

</details>
