### PR TITLE
1051: JCheck complains about issue already used

### DIFF
--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/DuplicateIssuesCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/DuplicateIssuesCheck.java
@@ -76,22 +76,21 @@ public class DuplicateIssuesCheck extends CommitCheck {
             var hashes = issuesToHashes.get(issue.id());
             if (hashes != null) {
                 // Check if any of the found hashes is an ancestor of the current commit
-                var duplicateHashes = new ArrayList<Hash>();
+                var ancestorHashes = new ArrayList<Hash>();
                 for (var hash : hashes) {
                     if (hash.equals(commit.hash())) {
-                        duplicateHashes.add(hash);
+                        ancestorHashes.add(hash);
                     } else {
                         try {
                             if (repo.isAncestor(hash, commit.hash())) {
-                                duplicateHashes.add(hash);
+                                ancestorHashes.add(hash);
                             }
                         } catch (IOException e) {
                             throw new UncheckedIOException(e);
                         }
                     }
                 }
-                // If more than one commit is found for the issue, we have duplicates
-                if (duplicateHashes.size() > 1) {
+                if (ancestorHashes.size() > 1) {
                     log.finer("issue: the JBS issue " + issue.toString() + " has been used in multiple commits");
                     var uniqueHashes = new ArrayList<>(new HashSet<>(hashes));
                     issues.add(new DuplicateIssuesIssue(issue, uniqueHashes, metadata));

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/DuplicateIssuesCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/DuplicateIssuesCheck.java
@@ -74,7 +74,7 @@ public class DuplicateIssuesCheck extends CommitCheck {
         var issues = new ArrayList<org.openjdk.skara.jcheck.Issue>();
         for (var issue : message.issues()) {
             var hashes = issuesToHashes.get(issue.id());
-            if (hashes != null) {
+            if (hashes != null && hashes.size() > 1) {
                 // Check if any of the found hashes is an ancestor of the current commit
                 var ancestorHashes = new ArrayList<Hash>();
                 for (var hash : hashes) {


### PR DESCRIPTION
The DuplicateIssuesCheck can sometimes report false positives when the same issueId has been used in separate branches. This patch fixes the check so that only commits that are ancestors of the commit being checked are considered.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1051](https://bugs.openjdk.java.net/browse/SKARA-1051): JCheck complains about issue already used


### Reviewers
 * [Tim Bell](https://openjdk.java.net/census#tbell) (@tbell29552 - **Reviewer**) ⚠️ Review applies to 1ca683816ddfda426b66d1401f4728a5e3ed582b
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1178/head:pull/1178` \
`$ git checkout pull/1178`

Update a local copy of the PR: \
`$ git checkout pull/1178` \
`$ git pull https://git.openjdk.java.net/skara pull/1178/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1178`

View PR using the GUI difftool: \
`$ git pr show -t 1178`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1178.diff">https://git.openjdk.java.net/skara/pull/1178.diff</a>

</details>
