### PR TITLE
1065: New prometheus labels have illegal characters

### DIFF
--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
@@ -61,13 +61,13 @@ public class BotRunner {
 
     private class RunnableWorkItem implements Runnable {
         private static final Counter.WithThreeLabels EXCEPTIONS_COUNTER =
-            Counter.name("skara_runner_exceptions").labels("bot", "work-item", "exception").register();
+            Counter.name("skara_runner_exceptions").labels("bot", "work_item", "exception").register();
         private static final Gauge.WithTwoLabels CPU_TIME_GAUGE =
-            Gauge.name("skara_runner_cpu_time").labels("bot", "work-item").register();
+            Gauge.name("skara_runner_cpu_time").labels("bot", "work_item").register();
         private static final Gauge.WithTwoLabels USER_TIME_GAUGE =
-            Gauge.name("skara_runner_user_time").labels("bot", "work-item").register();
+            Gauge.name("skara_runner_user_time").labels("bot", "work_item").register();
         private static final Gauge.WithTwoLabels ALLOCATED_BYTES_GAUGE =
-            Gauge.name("skara_runner_allocated_bytes").labels("bot", "work-item").register();
+            Gauge.name("skara_runner_allocated_bytes").labels("bot", "work_item").register();
 
         private final WorkItem item;
 
@@ -232,9 +232,9 @@ public class BotRunner {
     private final Deque<Path> scratchPaths;
 
     private static final Counter.WithTwoLabels SCHEDULED_COUNTER =
-        Counter.name("skara_runner_scheduled").labels("bot", "work-item").register();
+        Counter.name("skara_runner_scheduled").labels("bot", "work_item").register();
     private static final Counter.WithTwoLabels DISCARDED_COUNTER =
-        Counter.name("skara_runner_discarded").labels("bot", "work-item").register();
+        Counter.name("skara_runner_discarded").labels("bot", "work_item").register();
 
     private void submitOrSchedule(WorkItem item) {
         SCHEDULED_COUNTER.labels(item.botName(), item.workItemName()).inc();


### PR DESCRIPTION
This patch changes the metrics label name work-item to work_item. In prometheus, dash '-' is not a valid character for label names.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1065](https://bugs.openjdk.java.net/browse/SKARA-1065): New prometheus labels have illegal characters


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1179/head:pull/1179` \
`$ git checkout pull/1179`

Update a local copy of the PR: \
`$ git checkout pull/1179` \
`$ git pull https://git.openjdk.java.net/skara pull/1179/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1179`

View PR using the GUI difftool: \
`$ git pr show -t 1179`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1179.diff">https://git.openjdk.java.net/skara/pull/1179.diff</a>

</details>
