### PR TITLE
1063: Lower log severity on HTTP errors

### DIFF
--- a/network/src/main/java/org/openjdk/skara/network/RestRequest.java
+++ b/network/src/main/java/org/openjdk/skara/network/RestRequest.java
@@ -198,7 +198,7 @@ public class RestRequest {
 
         @Override
         public String toString() {
-            return "type: " + queryType +
+            return "QueryBuilder: type: " + queryType +
                     ", endpoint: " + endpoint +
                     ", body: " + composedBody();
         }

--- a/network/src/main/java/org/openjdk/skara/network/RestRequest.java
+++ b/network/src/main/java/org/openjdk/skara/network/RestRequest.java
@@ -40,9 +40,9 @@ public class RestRequest {
         Counter.name("skara_http_requests")
                .labels("method")
                .register();
-    private final static Counter.WithOneLabel responseCounter =
+    private final static Counter.WithTwoLabels responseCounter =
         Counter.name("skara_http_responses")
-               .labels("code")
+               .labels("code", "error_handled")
                .register();
 
     private enum RequestType {
@@ -195,6 +195,13 @@ public class RestRequest {
         public String executeUnparsed() throws IOException {
             return RestRequest.this.executeUnparsed(this);
         }
+
+        @Override
+        public String toString() {
+            return "type: " + queryType +
+                    ", endpoint: " + endpoint +
+                    ", body: " + composedBody();
+        }
     }
 
     private final URI apiBase;
@@ -313,9 +320,10 @@ public class RestRequest {
                     return transformed;
                 }
             }
-            log.warning(queryBuilder.toString());
-            log.warning(response.body());
-            throw new RuntimeException("Request returned bad status: " + response.statusCode());
+            log.warning("Request returned bad status: " + response.statusCode());
+            log.info(queryBuilder.toString());
+            log.info(response.body());
+            throw new UncheckedRestException("Request returned bad status: " + response.statusCode());
         } else {
             return Optional.empty();
         }
@@ -392,8 +400,8 @@ public class RestRequest {
                                     queryBuilder.params, queryBuilder.headers, queryBuilder.isJSON());
         requestCounter.labels(queryBuilder.queryType.toString()).inc();
         var response = sendRequest(request);
-        responseCounter.labels(Integer.toString(response.statusCode())).inc();
         var errorTransform = transformBadResponse(response, queryBuilder);
+        responseCounter.labels(Integer.toString(response.statusCode()), Boolean.toString(errorTransform.isPresent())).inc();
         if (errorTransform.isPresent()) {
             return errorTransform.get();
         }
@@ -412,10 +420,12 @@ public class RestRequest {
         while (links.containsKey("next") && ret.size() < queryBuilder.maxPages) {
             var uri = URI.create(links.get("next"));
             request = getHttpRequestBuilder(uri).GET();
+            requestCounter.labels(queryBuilder.queryType.toString()).inc();
             response = sendRequest(request);
 
             // If an error occurs during paginated parsing, we have to discard all previous data
             errorTransform = transformBadResponse(response, queryBuilder);
+            responseCounter.labels(Integer.toString(response.statusCode()), Boolean.toString(errorTransform.isPresent())).inc();
             if (errorTransform.isPresent()) {
                 return errorTransform.get();
             }
@@ -433,7 +443,9 @@ public class RestRequest {
     private String executeUnparsed(QueryBuilder queryBuilder) throws IOException {
         var request = createRequest(queryBuilder.queryType, queryBuilder.endpoint, queryBuilder.composedBody(),
                                     queryBuilder.params, queryBuilder.headers, queryBuilder.isJSON());
+        requestCounter.labels(queryBuilder.queryType.toString()).inc();
         var response = sendRequest(request);
+        responseCounter.labels(Integer.toString(response.statusCode()), Boolean.toString(false)).inc();
         if (response.statusCode() >= 400) {
             throw new IOException("Bad response: " + response.statusCode());
         }

--- a/network/src/main/java/org/openjdk/skara/network/UncheckedRestException.java
+++ b/network/src/main/java/org/openjdk/skara/network/UncheckedRestException.java
@@ -1,0 +1,13 @@
+package org.openjdk.skara.network;
+
+/**
+ * Specialized RuntimeException thrown when a REST call receives a response code
+ * >=400 that isn't handled. When catching this, details about the failed call
+ * has already been logged.
+ */
+public class UncheckedRestException extends RuntimeException {
+
+    public UncheckedRestException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
The Skara bots currently log all HTTP errors as SEVERE. With the log configuration we use, this results in admin alarms being sent whenever this happens (with some throttling). Now that we have metrics, we should instead leverage those and rely on alarms from our metrics gathering system instead. Typically HTTP errors aren't severe on their own, but if we get a lot of them, across multiple bot runners, then we need to react.

This patch does the following:

1. Introduces a new specific exception which the RestRequest class throws when a bad HTTP response code is received.
2. Changes the logging behavior in the BotRunner when this new exception is caught.
3. Improves the logging of bad RestRequests so we actually log the request (instead of just the class name of the RequestBuilder).
4. Adds a new label on the skara_http_response counter to track if an error code was handled or not. We have a defined way of handling a bad HTTP response, and if this was used, we shouldn't send alarms as it's expected behavior.
5. Applies the http counters in two places where they were currently missing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1063](https://bugs.openjdk.java.net/browse/SKARA-1063): Lower log severity on HTTP errors


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1180/head:pull/1180` \
`$ git checkout pull/1180`

Update a local copy of the PR: \
`$ git checkout pull/1180` \
`$ git pull https://git.openjdk.java.net/skara pull/1180/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1180`

View PR using the GUI difftool: \
`$ git pr show -t 1180`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1180.diff">https://git.openjdk.java.net/skara/pull/1180.diff</a>

</details>
