### PR TITLE
1028: Skara notify bot fails to retry if JBS update fails at the wrong time

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryListener.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryListener.java
@@ -39,4 +39,10 @@ public interface RepositoryListener {
     default void onNewBranch(HostedRepository repository, Repository localRepository, Path scratchPath, List<Commit> commits, Branch parent, Branch branch) throws NonRetriableException {
     }
     String name();
+
+    /**
+     * Returns true if this listener can handle being called with the same
+     * data multiple times without generating multiple notifications
+     */
+    boolean idempotent();
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
@@ -383,4 +383,9 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
     public String name() {
         return "issue";
     }
+
+    @Override
+    public boolean idempotent() {
+        return true;
+    }
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/json/JsonNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/json/JsonNotifier.java
@@ -116,4 +116,9 @@ class JsonNotifier implements Notifier, RepositoryListener {
     public String name() {
         return "json";
     }
+
+    @Override
+    public boolean idempotent() {
+        return false;
+    }
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/mailinglist/MailingListNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/mailinglist/MailingListNotifier.java
@@ -380,4 +380,9 @@ class MailingListNotifier implements Notifier, RepositoryListener {
     public String name() {
         return "ml";
     }
+
+    @Override
+    public boolean idempotent() {
+        return false;
+    }
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/slack/SlackNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/slack/SlackNotifier.java
@@ -111,4 +111,9 @@ class SlackNotifier implements Notifier, RepositoryListener, PullRequestListener
     public String name() {
         return "slack";
     }
+
+    @Override
+    public boolean idempotent() {
+        return false;
+    }
 }

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdaterTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdaterTests.java
@@ -86,6 +86,11 @@ public class UpdaterTests {
         }
 
         @Override
+        public boolean idempotent() {
+            return idempotent;
+        }
+
+        @Override
         public void attachTo(Emitter e) {
             e.registerRepositoryListener(this);
         }


### PR DESCRIPTION
This patch makes the JBS notifier more resilient to failures. The Notify bot has to deal with different kinds of listeners, some which can handle repeated calls with the same notification (typically JBS) and some which can not (mail, slack). This is currently handled in a less than ideal way. 

Each notification is recorded in a history repo to avoid repeating it and limit reevaluation of potential notifications. If all listeners could handle repeat notifications, we would simply notify first, and update the history after. That would guarantee that every notification was eventually sent even if there was a failure. The problem is that we don't want any risk of things like emails being sent multiple times. So the current solution is to update the history first, and then notify the listener. If there is a recoverable failure, we then attempt to roll back. This works most of the time, but we have seen situations where bad timing causes JBS bugs to not be updated, requiring manual admin work to fix.

The solution I present here is a new property of the listener "idempotent". If true, the notifier will call the listener first and update history after. If false it will employ the old strategy (and attempt the rollback unless a NonRetriableException is thrown). The code gets quite messy so I tried to explain all this in a big class comment.

I didn't write any new tests for this as I can't think of a way to explicitly test the race with a failure. The exiting tests should be good enough.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1028](https://bugs.openjdk.java.net/browse/SKARA-1028): Skara notify bot fails to retry if JBS update fails at the wrong time


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1181/head:pull/1181` \
`$ git checkout pull/1181`

Update a local copy of the PR: \
`$ git checkout pull/1181` \
`$ git pull https://git.openjdk.java.net/skara pull/1181/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1181`

View PR using the GUI difftool: \
`$ git pr show -t 1181`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1181.diff">https://git.openjdk.java.net/skara/pull/1181.diff</a>

</details>
