### PR TITLE
1070: An invalid /backport command target causes bot to fail endlessly

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
@@ -89,7 +89,9 @@ public class BackportCommand implements CommandHandler {
 
         var potentialTargetRepo = forge.repository(repoName);
         if (potentialTargetRepo.isEmpty()) {
-            reply.println("@" + username + " the target repository `" + repoName + "` does not exist");
+            reply.println("@" + username + " the target repository `" + repoName + "` does not exist. ");
+            reply.print("List of valid repositories: ");
+            reply.println(String.join(", ", bot.forkRepoNames()));
             return;
         }
         var targetRepo = potentialTargetRepo.get();
@@ -104,7 +106,14 @@ public class BackportCommand implements CommandHandler {
 
         try {
             var hash = commit.hash();
-            var fork = bot.writeableForkOf(targetRepo);
+            var optionalFork = bot.writeableForkOf(targetRepo);
+            if (optionalFork.isEmpty()) {
+                reply.print("@" + username + " [" + repoName + "](" + targetRepo.webUrl() + ") is not a valid target for backports. ");
+                reply.print("List of valid repositories: ");
+                reply.println(String.join(", ", bot.forkRepoNames()));
+                return;
+            }
+            var fork = optionalFork.get();
             Hash backportHash = null;
             var backportBranchName = username + "-backport-" + hash.abbreviate();
             var hostedBackportBranch = fork.branches().stream().filter(b -> b.name().equals(backportBranchName)).findAny();

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -277,12 +277,21 @@ class PullRequestBot implements Bot {
         return Optional.of(URI.create(censusLink.replace("{{contributor}}", contributor.username())));
     }
 
-    HostedRepository writeableForkOf(HostedRepository upstream) {
+    Optional<HostedRepository> writeableForkOf(HostedRepository upstream) {
         var fork = forks.get(upstream.name());
         if (fork == null) {
-            throw new IllegalArgumentException("No writeable fork for " + upstream.name());
+            return Optional.empty();
         }
-        return fork;
+        return Optional.of(fork);
+    }
+
+    /**
+     * Returns a list of all repo names that have a fork configured for them
+     */
+    List<String> forkRepoNames() {
+        return forks.keySet().stream()
+                .map(k -> k.substring(k.lastIndexOf('/') + 1))
+                .toList();
     }
 
     public boolean isAutoLabelled(PullRequest pr) {


### PR DESCRIPTION
If a user issues a /backport command on a commit on a repository that exists, but for which we haven't properly configured backports to work (they need a fork defined where the PR can be created from), we currently end up with endless failures. This patch adds handling of the situation by printing a helpful message for the user, which also includes a list of all valid repositories.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1070](https://bugs.openjdk.java.net/browse/SKARA-1070): An invalid /backport command target causes bot to fail endlessly


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1182/head:pull/1182` \
`$ git checkout pull/1182`

Update a local copy of the PR: \
`$ git checkout pull/1182` \
`$ git pull https://git.openjdk.java.net/skara pull/1182/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1182`

View PR using the GUI difftool: \
`$ git pr show -t 1182`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1182.diff">https://git.openjdk.java.net/skara/pull/1182.diff</a>

</details>
