### PR TITLE
SKARA-1069

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
@@ -223,7 +223,10 @@ public class PullRequestCommandWorkItem extends PullRequestWorkItem {
         var command = nextCommand.get();
         log.info("Processing command: " + command.id() + " - " + command.name());
 
-        if (!pr.labelNames().contains("integrated")) {
+        // We can't trust just the integrated label as that gets set before the commit comment.
+        // If marked as integrated but there is no commit comment, any integrate command needs
+        // to run again to correct the state of the PR.
+        if (!pr.labelNames().contains("integrated") || resultingCommitHash(comments).isEmpty()) {
             processCommand(pr, census, scratchPath.resolve("pr").resolve("command"), command, comments, false);
             // Must re-fetch PR after running the command, the command might have updated the PR
             var updatedPR = pr.repository().pullRequest(pr.id());

--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequestUtils.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequestUtils.java
@@ -163,6 +163,11 @@ public class PullRequestUtils {
         return localRepo;
     }
 
+    public static boolean isAncestorOfTarget(Repository localRepo, Hash hash) throws IOException {
+        Optional<Hash> targetHash = localRepo.resolve("prutils_targetref");
+        return localRepo.isAncestor(hash, targetHash.orElseThrow());
+    }
+
     public static boolean isMerge(PullRequest pr) {
         return pr.title().startsWith("Merge");
     }

--- a/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
@@ -24,6 +24,7 @@ package org.openjdk.skara.test;
 
 import org.openjdk.skara.forge.*;
 import org.openjdk.skara.host.*;
+import org.openjdk.skara.issuetracker.Comment;
 import org.openjdk.skara.issuetracker.IssueProject;
 import org.openjdk.skara.network.URIBuilder;
 import org.openjdk.skara.vcs.Diff;
@@ -261,5 +262,9 @@ public class TestPullRequest extends TestIssue implements PullRequest {
     @Override
     public URI filesUrl(Hash hash) {
         return URI.create(webUrl().toString() + "/files/" + hash.hex());
+    }
+
+    public void removeComment(Comment comment) {
+        data.comments.remove(comment);
     }
 }


### PR DESCRIPTION
This change adds a new transaction step when integrating a PR, to better handle if the bot gets interrupted mid integration. Currently, if the change is pushed and the bot is interrupted before closing, changing labels or adding the final "commit pushed" comment, the PR can end up in a limbo state.

The new step is another comment "Going to push commit as ..." which gets added right before the git push command is run. Using this comment, it's now possible to automatically recover if the bot gets interrupted. The integration command checks for any such comments and if found, checks if the commit hash is present in the target. If it is, the PR was already pushed, and the command will just close it out as normal.

I also decided to move the output of any rebase command to this prepush comment, so we don't risk losing it. 