### PR TITLE
1072: Skara should validate the commit hash of a Backport PR

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -912,15 +912,17 @@ class CheckRun {
                 localHash = baseHash;
             }
             PullRequestCheckIssueVisitor visitor = checkablePullRequest.createVisitor(localHash);
-            if (!localHash.equals(baseHash)) {
+            if (localHash.equals(baseHash)) {
+                if (additionalErrors.isEmpty()) {
+                    additionalErrors = List.of("This PR contains no changes");
+                }
+            } else if (localHash.equals(PullRequestUtils.targetHash(pr, localRepo))) {
+                additionalErrors = List.of("This PR only contains changes already present in the target");
+            } else {
                 // Determine current status
                 var additionalConfiguration = AdditionalConfiguration.get(localRepo, localHash, pr.repository().forge().currentUser(), comments);
                 checkablePullRequest.executeChecks(localHash, censusInstance, visitor, additionalConfiguration);
                 additionalErrors = botSpecificChecks(localHash);
-            } else {
-                if (additionalErrors.isEmpty()) {
-                    additionalErrors = List.of("This PR contains no changes");
-                }
             }
             updateCheckBuilder(checkBuilder, visitor, additionalErrors);
             updateReadyForReview(visitor, additionalErrors);

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportTests.java
@@ -387,6 +387,75 @@ class BackportTests {
         }
     }
 
+    /**
+     * Tests that setting a backport title to points to the head commit of the PR
+     * itself is handled as an error.
+     */
+    @Test
+    void prHeadCommit(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory();
+             var pushedFolder = new TemporaryDirectory()) {
+
+            var author = credentials.getHostedRepository();
+            var integrator = credentials.getHostedRepository();
+            var reviewer = credentials.getHostedRepository();
+            var issues = credentials.getIssueProject();
+            var censusBuilder = credentials.getCensusBuilder()
+                    .addCommitter(author.forge().currentUser().id())
+                    .addReviewer(integrator.forge().currentUser().id())
+                    .addReviewer(reviewer.forge().currentUser().id());
+            var bot = PullRequestBot.newBuilder()
+                    .repo(integrator)
+                    .censusRepo(censusBuilder.build())
+                    .issueProject(issues)
+                    .build();
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            var releaseBranch = localRepo.branch(masterHash, "release");
+            localRepo.checkout(releaseBranch);
+            var newFile = localRepo.root().resolve("a_new_file.txt");
+            Files.writeString(newFile, "hello");
+            localRepo.add(newFile);
+            var issue1 = credentials.createIssue(issues, "An issue");
+            var issue1Number = issue1.id().split("-")[1];
+            var originalMessage = issue1Number + ": An issue\n" +
+                    "\n" +
+                    "Reviewed-by: integrationreviewer2";
+            var releaseHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.java.net");
+            localRepo.push(releaseHash, author.url(), "refs/heads/release", true);
+
+            // "backport" the new file to the master branch
+            localRepo.checkout(localRepo.defaultBranch());
+            var editBranch = localRepo.branch(masterHash, "edit");
+            localRepo.checkout(editBranch);
+            var newFile2 = localRepo.root().resolve("a_new_file.txt");
+            Files.writeString(newFile2, "hello");
+            localRepo.add(newFile2);
+            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.java.net");
+            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            // Create the backport with the hash from the PR branch
+            var pr = credentials.createPullRequest(author, "master", "edit", "Backport " + editHash.hex());
+
+            // The bot should detect the bad hash
+            // The bot should reply with a backport error
+            TestBotRunner.runPeriodicItems(bot);
+            assertLastCommentContains(pr, "<!-- backport error -->");
+            assertLastCommentContains(pr, ":warning:");
+            assertLastCommentContains(pr, "the given backport hash");
+            assertLastCommentContains(pr, "points to the head of your proposed change.");
+            assertFalse(pr.labelNames().contains("backport"));
+
+            // Re-running the bot should not cause any more error comments
+            TestBotRunner.runPeriodicItems(bot);
+            assertEquals(1, pr.comments().size());
+        }
+    }
+
     @Test
     void cleanBackport(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportTests.java
@@ -447,7 +447,7 @@ class BackportTests {
             assertLastCommentContains(pr, "<!-- backport error -->");
             assertLastCommentContains(pr, ":warning:");
             assertLastCommentContains(pr, "the given backport hash");
-            assertLastCommentContains(pr, "points to the head of your proposed change.");
+            assertLastCommentContains(pr, "is an ancestor of your proposed change.");
             assertFalse(pr.labelNames().contains("backport"));
 
             // Re-running the bot should not cause any more error comments


### PR DESCRIPTION
Add a check for "Backport <hash>" titles that the given hash isn't the head of the PR itself. If the user mistakenly uses that hash, Skara is very likely to get fooled into thinking the backport is clean.

While investigating this, I also discovered that the CheckWorkItem was inconsistent with not repeating "backport" errors, so I implemented a general mechanism for this, which guarantees that the same exact error message is never repeated. I believe this will be good enough, and certainly better than the existing behavior.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1072](https://bugs.openjdk.java.net/browse/SKARA-1072): Skara should validate the commit hash of a Backport PR


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**) ⚠️ Review applies to f0cfcfff9be706dabdb4fb3094515916fe909ca8


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1184/head:pull/1184` \
`$ git checkout pull/1184`

Update a local copy of the PR: \
`$ git checkout pull/1184` \
`$ git pull https://git.openjdk.java.net/skara pull/1184/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1184`

View PR using the GUI difftool: \
`$ git pr show -t 1184`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1184.diff">https://git.openjdk.java.net/skara/pull/1184.diff</a>

</details>
