### PR TITLE
Refactor and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ external Git source code hosting providers are available:
 
 ## Building
 
-[JDK 15](http://jdk.java.net/15/) or later and [Gradle](https://gradle.org/)
+[JDK 14](http://jdk.java.net/14/) or later and [Gradle](https://gradle.org/)
 6.6 or later is required for building. To build the project on macOS or
 GNU/Linux x64, just run the following command from the source tree root:
 
@@ -69,7 +69,7 @@ also want to build the bot images run `sh gradlew images` on GNU/Linux or
 
 If you want to build on an operating system other than GNU/Linux, macOS or
 Windows _or_ if you want to build on a CPU architecture other than x64, then
-ensure that you have JDK 15 or later installed locally and JAVA_HOME set to
+ensure that you have JDK 14 or later installed locally and JAVA_HOME set to
 point to it. You can then run the following command from the source tree root:
 
 ```bash
@@ -84,7 +84,7 @@ tree root.
 If you don't want the build to automatically download any dependencies, then
 you must ensure that you have installed the following software locally:
 
-- JDK 15 or later
+- JDK 14 or later
 - Gradle 6.6 or later
 
 To create a build then run the command:
@@ -224,7 +224,7 @@ or IDE.
 If you choose to use [IntelliJ IDEA](https://www.jetbrains.com/idea/) as your
 IDE when working on Skara you can simply open the root folder and the project
 should be automatically imported. You will need to configure a Platform SDK that
-is JDK 15 or above. Either set this up manually, or [build](#building) once from
+is JDK 14 or above. Either set this up manually, or [build](#building) once from
 the terminal, which will download a suitable JDK. Configure IntelliJ to use it
 at `File → Project Structure → Platform Settings → SDKs → + → Add JDK...` and
 browse to the downloaded JDK found in `<skara-folder>/.jdk/`. For example, on

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ external Git source code hosting providers are available:
 
 ## Building
 
-[JDK 14](http://jdk.java.net/14/) or later and [Gradle](https://gradle.org/)
+[JDK 15](http://jdk.java.net/15/) or later and [Gradle](https://gradle.org/)
 6.6 or later is required for building. To build the project on macOS or
 GNU/Linux x64, just run the following command from the source tree root:
 
@@ -69,7 +69,7 @@ also want to build the bot images run `sh gradlew images` on GNU/Linux or
 
 If you want to build on an operating system other than GNU/Linux, macOS or
 Windows _or_ if you want to build on a CPU architecture other than x64, then
-ensure that you have JDK 14 or later installed locally and JAVA_HOME set to
+ensure that you have JDK 15 or later installed locally and JAVA_HOME set to
 point to it. You can then run the following command from the source tree root:
 
 ```bash
@@ -84,7 +84,7 @@ tree root.
 If you don't want the build to automatically download any dependencies, then
 you must ensure that you have installed the following software locally:
 
-- JDK 14 or later
+- JDK 15 or later
 - Gradle 6.6 or later
 
 To create a build then run the command:
@@ -224,7 +224,7 @@ or IDE.
 If you choose to use [IntelliJ IDEA](https://www.jetbrains.com/idea/) as your
 IDE when working on Skara you can simply open the root folder and the project
 should be automatically imported. You will need to configure a Platform SDK that
-is JDK 14 or above. Either set this up manually, or [build](#building) once from
+is JDK 15 or above. Either set this up manually, or [build](#building) once from
 the terminal, which will download a suitable JDK. Configure IntelliJ to use it
 at `File → Project Structure → Platform Settings → SDKs → + → Add JDK...` and
 browse to the downloaded JDK found in `<skara-folder>/.jdk/`. For example, on

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveItem.java
@@ -78,7 +78,7 @@ class ArchiveItem {
         }
 
         try {
-            localRepo.merge(PullRequestUtils.targetHash(pr, localRepo));
+            localRepo.merge(PullRequestUtils.targetHash(localRepo));
             // No problem means no conflict
             return Optional.empty();
         } catch (IOException e) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -58,11 +58,8 @@ class CheckRun {
     private static final String outdatedHelpMarker = "<!-- PullRequestBot outdated help comment -->";
     private static final String sourceBranchWarningMarker = "<!-- PullRequestBot source branch warning comment -->";
     private static final String mergeCommitWarningMarker = "<!-- PullRequestBot merge commit warning comment -->";
-    private static final String emptyPrBodyMarker = """
-            <!--
-            Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
-            If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-            -->""";
+    private static final String emptyPrBodyMarker = "<!--\nReplace this text with a description of your pull request (also remove the surrounding HTML comment markers).\n" +
+            "If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.\n-->";
     private static final String fullNameWarningMarker = "<!-- PullRequestBot full name warning comment -->";
     private final static Set<String> primaryTypes = Set.of("Bug", "New Feature", "Enhancement", "Task", "Sub-task");
     private final Set<String> newLabels;

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -35,7 +35,6 @@ import java.time.*;
 import java.util.*;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.*;
 
 class CheckRun {
@@ -59,10 +58,12 @@ class CheckRun {
     private static final String outdatedHelpMarker = "<!-- PullRequestBot outdated help comment -->";
     private static final String sourceBranchWarningMarker = "<!-- PullRequestBot source branch warning comment -->";
     private static final String mergeCommitWarningMarker = "<!-- PullRequestBot merge commit warning comment -->";
-    private static final String emptyPrBodyMarker = "<!--\nReplace this text with a description of your pull request (also remove the surrounding HTML comment markers).\n" +
-            "If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.\n-->";
+    private static final String emptyPrBodyMarker = """
+            <!--
+            Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
+            If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
+            -->""";
     private static final String fullNameWarningMarker = "<!-- PullRequestBot full name warning comment -->";
-    private static final Pattern BACKPORT_PATTERN = Pattern.compile("<!-- backport ([0-9a-z]{40}) -->");
     private final static Set<String> primaryTypes = Set.of("Bug", "New Feature", "Enhancement", "Task", "Sub-task");
     private final Set<String> newLabels;
 
@@ -138,7 +139,7 @@ class CheckRun {
     }
 
     // Additional bot-specific checks that are not handled by JCheck
-    private List<String> botSpecificChecks(Hash finalHash) throws IOException {
+    private List<String> botSpecificChecks() {
         var ret = new ArrayList<String>();
 
         if (bodyWithoutStatus().isBlank()) {
@@ -291,19 +292,10 @@ class CheckRun {
     }
 
     private Optional<HostedCommit> backportedFrom() {
-        var botUser = pr.repository().forge().currentUser();
-        var backportLines = pr.comments()
-                              .stream()
-                              .filter(c -> c.author().equals(botUser))
-                              .flatMap(c -> Stream.of(c.body().split("\n")))
-                              .map(l -> BACKPORT_PATTERN.matcher(l))
-                              .filter(Matcher::find)
-                              .collect(Collectors.toList());
-        if (backportLines.isEmpty()) {
+        var hash = checkablePullRequest.findOriginalBackportHash();
+        if (hash == null) {
             return Optional.empty();
         }
-
-        var hash = new Hash(backportLines.get(0).group(1));
         var commit = pr.repository().forge().search(hash);
         if (commit.isEmpty()) {
             throw new IllegalStateException("Backport comment for PR " + pr.id() + " contains bad hash: " + hash.hex());
@@ -339,7 +331,7 @@ class CheckRun {
             ret.append(contributor.fullName().orElse(contributor.username()));
             if (censusLink.isPresent()) {
                 ret.append("](");
-                ret.append(censusLink.get().toString());
+                ret.append(censusLink.get());
                 ret.append(")");
             }
             ret.append(" (@");
@@ -475,7 +467,6 @@ class CheckRun {
                     try {
                         var iss = issueProject.issue(currentIssue.shortId());
                         if (iss.isPresent()) {
-                            var properties = iss.get().properties();
                             progressBody.append("[");
                             progressBody.append(iss.get().id());
                             progressBody.append("](");
@@ -594,16 +585,11 @@ class CheckRun {
     }
 
     private String verdictToString(Review.Verdict verdict) {
-        switch (verdict) {
-            case APPROVED:
-                return "changes are approved";
-            case DISAPPROVED:
-                return "more changes needed";
-            case NONE:
-                return "comment added";
-            default:
-                throw new RuntimeException("Unknown verdict: " + verdict);
-        }
+        return switch (verdict) {
+            case APPROVED -> "changes are approved";
+            case DISAPPROVED -> "more changes needed";
+            case NONE -> "comment added";
+        };
     }
 
     private void updateReviewedMessages(List<Comment> comments, List<Review> reviews) {
@@ -636,7 +622,7 @@ class CheckRun {
 
         try {
             var hasContributingFile =
-                !localRepo.files(PullRequestUtils.targetHash(pr, localRepo), Path.of("CONTRIBUTING.md")).isEmpty();
+                !localRepo.files(checkablePullRequest.targetHash(), Path.of("CONTRIBUTING.md")).isEmpty();
             if (hasContributingFile) {
                 message.append("\n\nℹ️ This project also has non-automated pre-integration requirements. Please see the file ");
                 message.append("[CONTRIBUTING.md](https://github.com/");
@@ -724,7 +710,6 @@ class CheckRun {
 
         if (!censusInstance.isCommitter(pr.author())) {
             message.append("\n");
-            var contributor = censusInstance.namespace().get(pr.author().id());
             message.append("As you do not have [Committer](https://openjdk.java.net/bylaws#committer) status in ");
             message.append("[this project](https://openjdk.java.net/census#");
             message.append(censusInstance.project().name());
@@ -811,7 +796,7 @@ class CheckRun {
         }
     }
 
-    private void addSourceBranchWarningComment(List<Comment> comments) throws IOException {
+    private void addSourceBranchWarningComment(List<Comment> comments) {
         var existing = findComment(comments, sourceBranchWarningMarker);
         if (existing.isPresent()) {
             // Only add the comment once per PR
@@ -822,7 +807,7 @@ class CheckRun {
             "a branch with the same name as the source branch for this pull request (`" + branch + "`) " +
             "is present in the [target repository](" + pr.repository().nonTransformedWebUrl() + "). " +
             "If you eventually integrate this pull request then the branch `" + branch + "` " +
-            "in your [personal fork](" + pr.sourceRepository().get().nonTransformedWebUrl() + ") will diverge once you sync " +
+            "in your [personal fork](" + pr.sourceRepository().orElseThrow().nonTransformedWebUrl() + ") will diverge once you sync " +
             "your personal fork with the upstream repository.\n" +
             "\n" +
             "To avoid this situation, create a new branch for your changes and reset the `" + branch + "` branch. " +
@@ -911,18 +896,18 @@ class CheckRun {
                 additionalErrors = List.of(e.getMessage());
                 localHash = baseHash;
             }
-            PullRequestCheckIssueVisitor visitor = checkablePullRequest.createVisitor(localHash);
+            PullRequestCheckIssueVisitor visitor = checkablePullRequest.createVisitor();
             if (localHash.equals(baseHash)) {
                 if (additionalErrors.isEmpty()) {
                     additionalErrors = List.of("This PR contains no changes");
                 }
-            } else if (localHash.equals(PullRequestUtils.targetHash(pr, localRepo))) {
+            } else if (localHash.equals(checkablePullRequest.targetHash())) {
                 additionalErrors = List.of("This PR only contains changes already present in the target");
             } else {
                 // Determine current status
                 var additionalConfiguration = AdditionalConfiguration.get(localRepo, localHash, pr.repository().forge().currentUser(), comments);
                 checkablePullRequest.executeChecks(localHash, censusInstance, visitor, additionalConfiguration);
-                additionalErrors = botSpecificChecks(localHash);
+                additionalErrors = botSpecificChecks();
             }
             updateCheckBuilder(checkBuilder, visitor, additionalErrors);
             updateReadyForReview(visitor, additionalErrors);


### PR DESCRIPTION
I have been working quite a bit in the area of the Integrate and SponsorCommand classes recently, and while doing so noted that they have a lot of duplicate code. Some of that I fixed, but I didn't want to include unrelated refactoring and cleanup in a functional change, so here is a separate change with just that. Nothing should change from a functional perspective. This change only touches a limited set of classes where I had noted specific issues. Here is a breakdown of the changes.

1. Moved logic for finding the original change hash in a backport PR to the CheckablePullRequest class. All three locations where this was done already had an instance of this class, and that class has all the data needed for the operation, so seemed like a decent fit.
2. Put a lazily initialized wrapper of PullRequestUtils.targetHash(localRepo) in CheckablePullRequest. This method is called quite often, and each time it results in running a git command to resolve the hash from the ref name. When browsing logs, this git command is sprinkled all over the place so reducing it will improve both performance and log browsing. Unfortunately I can't figure out a good way to completely reduce it as PullRequestUtils is a static class and it calls this method quite a bit itself.
3. Moved a duplicate piece of code (for running and reacting to jcheck checks) in IntegrateCommand.handle() and SponsorCommand.handle() to a new static method in IntegrateCommand. I still didn't dare dabbling in a super class. 
4. Removed all dead parameters and variables that I could find in these classes.
5. Applied some other Intellij suggested code fixes, like removing exceptions never thrown and unneeded calls to toString(). I also let it convert a switch statements to the new fancy switch expression, which looks a lot better.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1185/head:pull/1185` \
`$ git checkout pull/1185`

Update a local copy of the PR: \
`$ git checkout pull/1185` \
`$ git pull https://git.openjdk.java.net/skara pull/1185/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1185`

View PR using the GUI difftool: \
`$ git pr show -t 1185`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1185.diff">https://git.openjdk.java.net/skara/pull/1185.diff</a>

</details>
