### PR TITLE
1080: /backport command reports conflict even though there isn't any

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
@@ -122,7 +122,7 @@ public class BackportCommand implements CommandHandler {
                                               .resolve("fork");
                 var localRepo = bot.hostedRepositoryPool()
                                    .orElseThrow(() -> new IllegalStateException("Missing repository pool for PR bot"))
-                                   .materialize(fork, localRepoDir);
+                                   .materialize(targetRepo, localRepoDir);
                 var fetchHead = localRepo.fetch(bot.repo().url(), hash.hex(), false);
                 localRepo.checkout(targetBranch);
                 var head = localRepo.head();

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
@@ -23,7 +23,6 @@
 package org.openjdk.skara.bots.pr;
 
 import org.openjdk.skara.forge.HostedCommit;
-import org.openjdk.skara.forge.PullRequest;
 import org.openjdk.skara.issuetracker.Comment;
 import org.openjdk.skara.vcs.*;
 import org.openjdk.skara.vcs.openjdk.CommitMessageParsers;
@@ -114,7 +113,7 @@ public class BackportCommand implements CommandHandler {
                 return;
             }
             var fork = optionalFork.get();
-            Hash backportHash = null;
+            Hash backportHash;
             var backportBranchName = username + "-backport-" + hash.abbreviate();
             var hostedBackportBranch = fork.branches().stream().filter(b -> b.name().equals(backportBranchName)).findAny();
             if (hostedBackportBranch.isEmpty()) {
@@ -190,9 +189,7 @@ public class BackportCommand implements CommandHandler {
                 var reviewers = message.reviewers()
                                        .stream()
                                        .map(r -> censusInstance.census().contributor(r))
-                                       .map(c -> {
-                                           return c.fullName().isPresent() ? c.fullName().get() : c.username();
-                                       })
+                                       .map(c -> c.fullName().isPresent() ? c.fullName().get() : c.username())
                                        .collect(Collectors.toList());
                 var numReviewers = reviewers.size();
                 var listing = numReviewers == 1 ?

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportCommitCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportCommitCommandTests.java
@@ -23,7 +23,6 @@
 package org.openjdk.skara.bots.pr;
 
 import org.junit.jupiter.api.*;
-import org.openjdk.skara.issuetracker.Issue;
 import org.openjdk.skara.test.*;
 
 import java.io.IOException;

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportTests.java
@@ -29,7 +29,6 @@ import org.openjdk.skara.vcs.*;
 import org.openjdk.skara.vcs.openjdk.CommitMessageParsers;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.util.*;
 import java.util.regex.Pattern;
@@ -41,8 +40,7 @@ class BackportTests {
     @Test
     void simple(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
-             var tempFolder = new TemporaryDirectory();
-             var pushedFolder = new TemporaryDirectory()) {
+             var tempFolder = new TemporaryDirectory()) {
 
             var author = credentials.getHostedRepository();
             var integrator = credentials.getHostedRepository();
@@ -102,7 +100,7 @@ class BackportTests {
             assertLastCommentContains(pr, "This change now passes all *automated* pre-integration checks");
 
             // Integrate
-            var prAsCommitter = author.pullRequest(pr.id());
+            author.pullRequest(pr.id());
             pr.addComment("/integrate");
             TestBotRunner.runPeriodicItems(bot);
 
@@ -140,8 +138,7 @@ class BackportTests {
     @Test
     void withSummary(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
-             var tempFolder = new TemporaryDirectory();
-             var pushedFolder = new TemporaryDirectory()) {
+             var tempFolder = new TemporaryDirectory()) {
 
             var author = credentials.getHostedRepository();
             var integrator = credentials.getHostedRepository();
@@ -204,7 +201,7 @@ class BackportTests {
             assertLastCommentContains(pr, "This change now passes all *automated* pre-integration checks");
 
             // Integrate
-            var prAsCommitter = author.pullRequest(pr.id());
+            author.pullRequest(pr.id());
             pr.addComment("/integrate");
             TestBotRunner.runPeriodicItems(bot);
 
@@ -242,8 +239,7 @@ class BackportTests {
     @Test
     void withMultipleIssues(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
-             var tempFolder = new TemporaryDirectory();
-             var pushedFolder = new TemporaryDirectory()) {
+             var tempFolder = new TemporaryDirectory()) {
 
             var author = credentials.getHostedRepository();
             var integrator = credentials.getHostedRepository();
@@ -308,7 +304,7 @@ class BackportTests {
             assertLastCommentContains(pr, "This change now passes all *automated* pre-integration checks");
 
             // Integrate
-            var prAsCommitter = author.pullRequest(pr.id());
+            author.pullRequest(pr.id());
             pr.addComment("/integrate");
             TestBotRunner.runPeriodicItems(bot);
 
@@ -347,8 +343,7 @@ class BackportTests {
     @Test
     void nonExitingCommit(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
-             var tempFolder = new TemporaryDirectory();
-             var pushedFolder = new TemporaryDirectory()) {
+             var tempFolder = new TemporaryDirectory()) {
 
             var author = credentials.getHostedRepository();
             var integrator = credentials.getHostedRepository();
@@ -394,8 +389,7 @@ class BackportTests {
     @Test
     void prHeadCommit(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
-             var tempFolder = new TemporaryDirectory();
-             var pushedFolder = new TemporaryDirectory()) {
+             var tempFolder = new TemporaryDirectory()) {
 
             var author = credentials.getHostedRepository();
             var integrator = credentials.getHostedRepository();
@@ -463,8 +457,7 @@ class BackportTests {
     @Test
     void prAncestorOfHeadCommit(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
-             var tempFolder = new TemporaryDirectory();
-             var pushedFolder = new TemporaryDirectory()) {
+             var tempFolder = new TemporaryDirectory()) {
 
             var author = credentials.getHostedRepository();
             var integrator = credentials.getHostedRepository();
@@ -531,8 +524,7 @@ class BackportTests {
     @Test
     void cleanBackport(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
-             var tempFolder = new TemporaryDirectory(false);
-             var pushedFolder = new TemporaryDirectory(false)) {
+             var tempFolder = new TemporaryDirectory(false)) {
 
             var author = credentials.getHostedRepository();
             var integrator = credentials.getHostedRepository();
@@ -594,8 +586,7 @@ class BackportTests {
     @Test
     void fuzzyCleanBackport(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
-             var tempFolder = new TemporaryDirectory(false);
-             var pushedFolder = new TemporaryDirectory(false)) {
+             var tempFolder = new TemporaryDirectory(false)) {
 
             var author = credentials.getHostedRepository();
             var integrator = credentials.getHostedRepository();
@@ -665,8 +656,7 @@ class BackportTests {
     @Test
     void notCleanBackport(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
-             var tempFolder = new TemporaryDirectory(false);
-             var pushedFolder = new TemporaryDirectory(false)) {
+             var tempFolder = new TemporaryDirectory(false)) {
 
             var author = credentials.getHostedRepository();
             var integrator = credentials.getHostedRepository();
@@ -736,8 +726,7 @@ class BackportTests {
     @Test
     void notCleanBackportAdditionalFile(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
-             var tempFolder = new TemporaryDirectory(false);
-             var pushedFolder = new TemporaryDirectory(false)) {
+             var tempFolder = new TemporaryDirectory(false)) {
 
             var author = credentials.getHostedRepository();
             var integrator = credentials.getHostedRepository();
@@ -810,8 +799,7 @@ class BackportTests {
     @Test
     void cleanBackportFromCommitterCanBeIntegrated(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
-             var tempFolder = new TemporaryDirectory();
-             var pushedFolder = new TemporaryDirectory()) {
+             var tempFolder = new TemporaryDirectory()) {
 
             var author = credentials.getHostedRepository();
             var integrator = credentials.getHostedRepository();
@@ -869,7 +857,7 @@ class BackportTests {
             assertTrue(pr.labelNames().contains("backport"));
 
             // Integrate
-            var prAsCommitter = author.pullRequest(pr.id());
+            author.pullRequest(pr.id());
             pr.addComment("/integrate");
             TestBotRunner.runPeriodicItems(bot);
 
@@ -907,8 +895,7 @@ class BackportTests {
     @Test
     void cleanBackportFromAuthorCanBeIntegrated(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
-             var tempFolder = new TemporaryDirectory();
-             var pushedFolder = new TemporaryDirectory()) {
+             var tempFolder = new TemporaryDirectory()) {
 
             var author = credentials.getHostedRepository();
             var integrator = credentials.getHostedRepository();
@@ -1017,8 +1004,7 @@ class BackportTests {
     @Test
     void whitespaceInMiddle(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
-             var tempFolder = new TemporaryDirectory();
-             var pushedFolder = new TemporaryDirectory()) {
+             var tempFolder = new TemporaryDirectory()) {
 
             var author = credentials.getHostedRepository();
             var integrator = credentials.getHostedRepository();
@@ -1076,8 +1062,7 @@ class BackportTests {
     @Test
     void whitespaceAtEnd(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
-             var tempFolder = new TemporaryDirectory();
-             var pushedFolder = new TemporaryDirectory()) {
+             var tempFolder = new TemporaryDirectory()) {
 
             var author = credentials.getHostedRepository();
             var integrator = credentials.getHostedRepository();
@@ -1135,8 +1120,7 @@ class BackportTests {
     @Test
     void noWhitespace(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
-             var tempFolder = new TemporaryDirectory();
-             var pushedFolder = new TemporaryDirectory()) {
+             var tempFolder = new TemporaryDirectory()) {
 
             var author = credentials.getHostedRepository();
             var integrator = credentials.getHostedRepository();
@@ -1194,8 +1178,7 @@ class BackportTests {
     @Test
     void commitWithMismatchingIssueTitle(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
-             var tempFolder = new TemporaryDirectory();
-             var pushedFolder = new TemporaryDirectory()) {
+             var tempFolder = new TemporaryDirectory()) {
 
             var author = credentials.getHostedRepository();
             var integrator = credentials.getHostedRepository();
@@ -1255,7 +1238,7 @@ class BackportTests {
             assertLastCommentContains(pr, "This change now passes all *automated* pre-integration checks");
 
             // Integrate
-            var prAsCommitter = author.pullRequest(pr.id());
+            author.pullRequest(pr.id());
             pr.addComment("/integrate");
             TestBotRunner.runPeriodicItems(bot);
 
@@ -1293,8 +1276,7 @@ class BackportTests {
     @Test
     void badIssueInOriginal(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
-             var tempFolder = new TemporaryDirectory();
-             var pushedFolder = new TemporaryDirectory()) {
+             var tempFolder = new TemporaryDirectory()) {
 
             var author = credentials.getHostedRepository();
             var integrator = credentials.getHostedRepository();


### PR DESCRIPTION
This patch fixes a bug with the /backport commit command. It currently materializes the workspace where the cherry-picking is done from the wrong repository. It should be using the target repository, but instead it's using the "fork" (which is the repo from which we create the pull request if /backport is successful). 

In the tests, this wasn't handled at all. All the tests used the same hosted repository for the "fork" as the target. I introduced a separate "fork" repository in the tests where it would make a difference. 

I changed the backportDoesNotApply test so that it would fail without this fix. I also think I made it clearer why the backport shouldn't apply as well.

Finally I added a new test which verifies a situation very similar to the original issue reported.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1080](https://bugs.openjdk.java.net/browse/SKARA-1080): /backport command reports conflict even though there isn't any


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1188/head:pull/1188` \
`$ git checkout pull/1188`

Update a local copy of the PR: \
`$ git checkout pull/1188` \
`$ git pull https://git.openjdk.java.net/skara pull/1188/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1188`

View PR using the GUI difftool: \
`$ git pr show -t 1188`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1188.diff">https://git.openjdk.java.net/skara/pull/1188.diff</a>

</details>
