### PR TITLE
1082: Add ide label and ide-support-dev to JDK repos

### DIFF
--- a/config/mailinglist/rules/jdk.json
+++ b/config/mailinglist/rules/jdk.json
@@ -501,6 +501,10 @@
             "test/jdk/sun/util/resources/cldr/",
             "test/jdk/tools/jlink/plugins/\\w*locales"
         ],
+        "ide-support": [
+            "bin/idea.sh",
+            "make/ide/"
+        ],
         "javadoc": [
             "make/data/docs-resources/resources",
             "make/jdk/src/classes/build/tools/taglet/",


### PR DESCRIPTION
Add automatic PR label "ide-support" for IDE related files. The rest of the configuration is done elsewhere.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1082](https://bugs.openjdk.java.net/browse/SKARA-1082): Add ide label and ide-support-dev to JDK repos


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Tim Bell](https://openjdk.java.net/census#tbell) (@tbell29552 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1189/head:pull/1189` \
`$ git checkout pull/1189`

Update a local copy of the PR: \
`$ git checkout pull/1189` \
`$ git pull https://git.openjdk.java.net/skara pull/1189/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1189`

View PR using the GUI difftool: \
`$ git pr show -t 1189`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1189.diff">https://git.openjdk.java.net/skara/pull/1189.diff</a>

</details>
