### PR TITLE
997: Email notifications are not sent to alias if binary change is commented in Gitlab

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
@@ -369,15 +369,21 @@ class ArchiveMessages {
 
         // Add some context to the first post
         if (reviewComment.parent().isEmpty()) {
-            body.append(reviewComment.path()).append(" line ").append(reviewComment.line()).append(":\n\n");
-            try {
-                var contents = pr.repository().fileContents(reviewComment.path(), reviewComment.hash().hex()).lines().collect(Collectors.toList());
-                for (int i = Math.max(0, reviewComment.line() - 3); i < Math.min(contents.size(), reviewComment.line()); ++i) {
-                    body.append("> ").append(i + 1).append(": ").append(contents.get(i)).append("\n");
+            body.append(reviewComment.path());
+            if (reviewComment.line() > 0) {
+                body.append(" line ").append(reviewComment.line());
+            }
+            body.append(":\n\n");
+            if (reviewComment.line() > 0) {
+                try {
+                    var contents = pr.repository().fileContents(reviewComment.path(), reviewComment.hash().hex()).lines().collect(Collectors.toList());
+                    for (int i = Math.max(0, reviewComment.line() - 3); i < Math.min(contents.size(), reviewComment.line()); ++i) {
+                        body.append("> ").append(i + 1).append(": ").append(contents.get(i)).append("\n");
+                    }
+                    body.append("\n");
+                } catch (RuntimeException e) {
+                    body.append("> (failed to retrieve contents of file, check the PR for context)\n");
                 }
-                body.append("\n");
-            } catch (RuntimeException e) {
-                body.append("> (failed to retrieve contents of file, check the PR for context)\n");
             }
         }
         body.append(filterCommentsAndCommands(reviewComment.body()));

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -791,7 +791,7 @@ class MailingListBridgeBotTests {
             assertTrue(archiveContains(archiveFolder.path(), "This is now ready"));
             assertTrue(archiveContains(archiveFolder.path(), "Review comment"));
             assertTrue(archiveContains(archiveFolder.path(), "> This is now ready"));
-            assertTrue(archiveContains(archiveFolder.path(), reviewFile.toString()));
+            assertTrue(archiveContains(archiveFolder.path(), reviewFile + " line 2:"));
             assertFalse(archiveContains(archiveFolder.path(), "Don't mind me"));
 
             // The mailing list as well
@@ -821,6 +821,16 @@ class MailingListBridgeBotTests {
                 assertEquals(noreplyAddress(archive), newMail.author().address());
                 assertEquals(listAddress, newMail.sender());
             }
+
+            // Add a file comment (on line 0)
+            var fileComment = pr.addReviewComment(masterHash, editHash, reviewFile.toString(), 0, "File review comment");
+            TestBotRunner.runPeriodicItems(mlBot);
+            listServer.processIncoming();
+
+            // The archive should contain the additional comment
+            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            assertTrue(archiveContains(archiveFolder.path(), "File review comment"));
+            assertTrue(archiveContains(archiveFolder.path(), reviewFile + ":"));
         }
     }
 

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -210,15 +210,25 @@ public class GitLabMergeRequest implements PullRequest {
         String path;
         Hash hash;
 
-        // Is the comment on the old or the new version of the file?
-        if (note.get("position").get("new_line").isNull()) {
-            line = note.get("position").get("old_line").asInt();
-            path = note.get("position").get("old_path").asString();
-            hash = new Hash(note.get("position").get("start_sha").asString());
+        var position = note.get("position");
+        // Is this a line comment?
+        if (position.get("new_line") != null) {
+            // Is the comment on the old or the new version of the file?
+            if (position.get("new_line").isNull()) {
+                line = position.get("old_line").asInt();
+                path = position.get("old_path").asString();
+                hash = new Hash(position.get("start_sha").asString());
+            } else {
+                line = position.get("new_line").asInt();
+                path = position.get("new_path").asString();
+                hash = new Hash(position.get("head_sha").asString());
+            }
         } else {
-            line = note.get("position").get("new_line").asInt();
-            path = note.get("position").get("new_path").asString();
-            hash = new Hash(note.get("position").get("head_sha").asString());
+            // This comment does not have a line. Gitlab seems to only allow file comments
+            // on the new file
+            line = 0;
+            path = position.get("new_path").asString();
+            hash = new Hash(position.get("head_sha").asString());
         }
 
         var comment = new ReviewComment(parent,

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -212,6 +212,8 @@ public class GitLabMergeRequest implements PullRequest {
 
         var position = note.get("position");
         // Is this a line comment?
+        // For line comments, this field is always set, either to a value or null, but
+        // for file comments there is no new_line field at all.
         if (position.get("new_line") != null) {
             // Is the comment on the old or the new version of the file?
             if (position.get("new_line").isNull()) {


### PR DESCRIPTION
This fixes an NPE when parsing a review comment from Gitlab on a binary file. Such a comment does not have a line, and I picked the value 0 to signal that. I also updated the email formatting of such comments to skip showing line numbers and quotes from the file.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-997](https://bugs.openjdk.java.net/browse/SKARA-997): Email notifications are not sent to alias if binary change is commented in Gitlab


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1190/head:pull/1190` \
`$ git checkout pull/1190`

Update a local copy of the PR: \
`$ git checkout pull/1190` \
`$ git pull https://git.openjdk.java.net/skara pull/1190/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1190`

View PR using the GUI difftool: \
`$ git pr show -t 1190`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1190.diff">https://git.openjdk.java.net/skara/pull/1190.diff</a>

</details>
