### PR TITLE
1085: Gitlab PR has bad link to patch file

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -549,7 +549,7 @@ class CheckRun {
     }
 
     private String reviewUsingDiffsHelp() {
-        var diffUrl = pr.repository().webUrl() + "/pull/" + pr.id() + ".diff";
+        var diffUrl = pr.repository().diffUrl(pr.id());
         return "Download this PR as a diff file: \\\n" +
                 "<a href=\"" + diffUrl + "\">" + diffUrl + "</a>\n";
     }

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
@@ -109,6 +109,11 @@ class InMemoryHostedRepository implements HostedRepository {
     }
 
     @Override
+    public URI diffUrl(String prId) {
+        return webUrl();
+    }
+
+    @Override
     public VCS repositoryType() {
         return null;
     }

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
@@ -64,6 +64,7 @@ public interface HostedRepository {
     URI webUrl(Branch branch);
     URI webUrl(Tag tag);
     URI webUrl(String baseRef, String headRef);
+    URI diffUrl(String prId);
     VCS repositoryType();
     String fileContents(String filename, String ref);
     String namespace();

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -219,6 +219,12 @@ public class GitHubRepository implements HostedRepository {
     }
 
     @Override
+    public URI diffUrl(String prId) {
+        var endpoint = "/" + repository + "/pull/" + prId + ".diff";
+        return gitHubHost.getWebURI(endpoint);
+    }
+
+    @Override
     public VCS repositoryType() {
         return VCS.GIT;
     }

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -212,8 +212,10 @@ public class GitLabRepository implements HostedRepository {
 
     @Override
     public URI diffUrl(String prId) {
+        // GitLab is too smart for it's own best and mangles URLs that contain a
+        // partial hit with the base MR, hence the double slash.
         return URIBuilder.base(gitLabHost.getUri())
-                .setPath("/" + projectName + "/-/merge_requests/" + prId + ".diff")
+                .setPath("/" + projectName + "/-/merge_requests//" + prId + ".diff")
                 .build();
     }
 

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -211,6 +211,13 @@ public class GitLabRepository implements HostedRepository {
     }
 
     @Override
+    public URI diffUrl(String prId) {
+        return URIBuilder.base(gitLabHost.getUri())
+                .setPath("/" + projectName + "/-/merge_requests/" + prId + ".diff")
+                .build();
+    }
+
+    @Override
     public VCS repositoryType() {
         return VCS.GIT;
     }

--- a/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
@@ -147,6 +147,11 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
     }
 
     @Override
+    public URI diffUrl(String prId) {
+        return webUrl();
+    }
+
+    @Override
     public VCS repositoryType() {
         return VCS.GIT;
     }


### PR DESCRIPTION
The link generated under the "Reviewing" header in a PR description works fine on Github, but on Gitlab, the link has a Github style form which does not work.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1085](https://bugs.openjdk.java.net/browse/SKARA-1085): Gitlab PR has bad link to patch file


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1191/head:pull/1191` \
`$ git checkout pull/1191`

Update a local copy of the PR: \
`$ git checkout pull/1191` \
`$ git pull https://git.openjdk.java.net/skara pull/1191/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1191`

View PR using the GUI difftool: \
`$ git pr show -t 1191`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1191.diff">https://git.openjdk.java.net/skara/pull/1191.diff</a>

</details>
