### PR TITLE
1092: /backport commit command does not validate non existing repos

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/Forge.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/Forge.java
@@ -32,6 +32,14 @@ import java.util.stream.Collectors;
 
 public interface Forge extends Host {
     String name();
+
+    /**
+     * Gets a HostedRepository on this Forge. This method should verify that the
+     * repository exists.
+     * @param name Name of repository to get
+     * @return Optional containing the repository, or empty if the repository
+     *         does not exist on the Forge.
+     */
     Optional<HostedRepository> repository(String name);
     boolean supportsReviewBody();
     Optional<HostedCommit> search(Hash hash);

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -46,6 +46,11 @@ public class GitHubRepository implements HostedRepository {
     private JSONValue cachedJSON;
     private List<HostedBranch> branches;
 
+    GitHubRepository(GitHubHost gitHubHost, String repository, JSONValue json) {
+        this(gitHubHost, repository);
+        cachedJSON = json;
+    }
+
     GitHubRepository(GitHubHost gitHubHost, String repository) {
         this.gitHubHost = gitHubHost;
         this.repository = repository;
@@ -69,14 +74,14 @@ public class GitHubRepository implements HostedRepository {
             }
             return headers;
         });
-        this.cachedJSON = null;
         var urlPattern = gitHubHost.getWebURI("/" + repository + "/pull/").toString();
         pullRequestPattern = Pattern.compile(urlPattern + "(\\d+)");
     }
 
     private JSONValue json() {
         if (cachedJSON == null) {
-            cachedJSON = gitHubHost.getProjectInfo(repository);
+            cachedJSON = gitHubHost.getProjectInfo(repository)
+                    .orElseThrow(() -> new RuntimeException("Project not found: " + repository));
         }
         return cachedJSON;
     }

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -81,7 +81,7 @@ public class GitHubRepository implements HostedRepository {
     private JSONValue json() {
         if (cachedJSON == null) {
             cachedJSON = gitHubHost.getProjectInfo(repository)
-                    .orElseThrow(() -> new RuntimeException("Project not found: " + repository));
+                    .orElseThrow(() -> new RuntimeException("Repository not found: " + repository));
         }
         return cachedJSON;
     }

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabHost.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabHost.java
@@ -138,11 +138,8 @@ public class GitLabHost implements Forge {
 
     @Override
     public Optional<HostedRepository> repository(String name) {
-        try {
-            return Optional.of(new GitLabRepository(this, name));
-        } catch (Throwable t) {
-            return Optional.empty();
-        }
+        return getProjectInfo(name)
+                .map(jsonObject -> new GitLabRepository(this, jsonObject));
     }
 
     HostUser parseAuthorField(JSONValue json) {


### PR DESCRIPTION
This patch fixes inconsistencies with how Forge.repository(String) behaves for GitHub and GitLab. 

From what I can tell, this method is expected to return an Optional.empty() if the repository does not exist, and in the Gitlab case, this is what it does. For Github there is no actual check. In both cases, they call the hosted repository constructor (GitlabRepository and GithubRepository respectively) and expect an exception if it doesn't exist. In the case of Gitlab, the constructor will make a rest call to get information about the repository, while the Github variant does not. It seems this was changed for GitHub a long while back as an optimization, using lazy initialization: https://github.com/openjdk/skara/pull/296

I have rewritten this logic and aligned the behavior of Forge.repository(String) between GitHub and GitLab. Now they both will only return Optional.empty() if the rest call to get repository info returns 404. Any other RuntimeException or Error is just let through, as it should be. There are other ways a hosted repository can be created, where Optional is not used in the return value. In these cases we now have consistent throwing of a RuntimeException with the message "Project/Repository not found" (in the GitLab case directly as it's needed for constructing the object, and in the GitHub case when a method is called that triggers the lazy initialization). The assumption is that in these other code paths, the repository name does not originate from human input, but rather other query results, so a 404 is truly unexpected and should result in an exception.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1092](https://bugs.openjdk.java.net/browse/SKARA-1092): /backport commit command does not validate non existing repos


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1192/head:pull/1192` \
`$ git checkout pull/1192`

Update a local copy of the PR: \
`$ git checkout pull/1192` \
`$ git pull https://git.openjdk.java.net/skara pull/1192/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1192`

View PR using the GUI difftool: \
`$ git pr show -t 1192`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1192.diff">https://git.openjdk.java.net/skara/pull/1192.diff</a>

</details>
