### PR TITLE
1095: Ignore tags in pr branches when notifying

### DIFF
--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/RepositoryWorkItemTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/RepositoryWorkItemTests.java
@@ -1,0 +1,101 @@
+package org.openjdk.skara.bots.notify;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.openjdk.skara.forge.HostedRepository;
+import org.openjdk.skara.test.*;
+import org.openjdk.skara.vcs.*;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.openjdk.skara.bots.notify.TestUtils.createBranchStorage;
+import static org.openjdk.skara.bots.notify.TestUtils.createTagStorage;
+
+public class RepositoryWorkItemTests {
+
+    private static class TestNotifier implements RepositoryListener {
+
+        private final List<Tag> newTags = new ArrayList<>();
+
+        @Override
+        public void onNewTagCommit(HostedRepository repository, Repository localRepository,
+                                   Path scratchPath, Commit commit, Tag tag, Tag.Annotated annotation) {
+            newTags.add(tag);
+        }
+
+        @Override
+        public String name() {
+            return "test";
+        }
+
+        @Override
+        public boolean idempotent() {
+            return true;
+        }
+    }
+
+    /**
+     * Tests that the NotifierBot skips notifying on tags that only show up in
+     * pr branches.
+     */
+    @Test
+    void filterTagsInNonPrBranches(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var repo = credentials.getHostedRepository();
+            var repoFolder = tempFolder.path().resolve("repo");
+            var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
+            credentials.commitLock(localRepo);
+            localRepo.pushAll(repo.url());
+
+            var tagStorage = createTagStorage(repo);
+            var branchStorage = createBranchStorage(repo);
+            var storageFolder = tempFolder.path().resolve("storage");
+
+            var notifyBot = NotifyBot.newBuilder()
+                    .repository(repo)
+                    .storagePath(storageFolder)
+                    .branches(Pattern.compile("master"))
+                    .tagStorageBuilder(tagStorage)
+                    .branchStorageBuilder(branchStorage)
+                    .integratorId(repo.forge().currentUser().id())
+                    .build();
+            var testNotifier = new TestNotifier();
+            notifyBot.registerRepositoryListener(testNotifier);
+
+            // Create an initial tag to start history tracking. The notifier will never notify the first tag
+            var masterHash = localRepo.head();
+            localRepo.tag(masterHash, "initial-tag", "Tagging initial tag", "testauthor", "ta@none.none");
+            localRepo.push(masterHash, repo.url(), "master", false, true);
+
+            // Run bot to initialize notification history
+            TestBotRunner.runPeriodicItems(notifyBot);
+
+            // Create a "pr"-branch with a commit in it and tag that commit
+            var prBranchHash = CheckableRepository.appendAndCommit(localRepo, "Another line", "Change in pr branch");
+            localRepo.tag(prBranchHash, "pr-tag", "Tagging change in pr branch", "testauthor", "ta@none.none");
+            localRepo.push(prBranchHash, repo.url(), "pr/4711", false, true);
+
+            // Run the bot and verify that notifier is not called
+            TestBotRunner.runPeriodicItems(notifyBot);
+            assertTrue(testNotifier.newTags.isEmpty(), "Notifier called on pr branch: " + testNotifier.newTags);
+
+            // Create a commit in master branch and tag it
+            localRepo.checkout(masterHash);
+            var masterTaggedHash = CheckableRepository.appendAndCommit(localRepo, "Master line", "Change in master branch");
+            localRepo.tag(masterTaggedHash, "master-tag", "Tagging change in master branch", "testauthor", "ta@none.none");
+            localRepo.push(masterTaggedHash, repo.url(), "master", false, true);
+
+            // Run the bot and verify that notifier is called for master branch
+            TestBotRunner.runPeriodicItems(notifyBot);
+            assertEquals(testNotifier.newTags.size(), 1, "Notifier not called on master branch: " + testNotifier.newTags);
+            assertEquals("master-tag", testNotifier.newTags.get(0).name(), "Notified wrong tag");
+        }
+    }
+}


### PR DESCRIPTION
This patch for the Notify bot adds filtering when processing new tags. Only tags that appear in branches other than the PR branches are considered. Changes in PR branches are pending review and should not be included when sending email notifications or updating bugs. See bug for more details.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1095](https://bugs.openjdk.java.net/browse/SKARA-1095): Ignore tags in pr branches when notifying


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1193/head:pull/1193` \
`$ git checkout pull/1193`

Update a local copy of the PR: \
`$ git checkout pull/1193` \
`$ git pull https://git.openjdk.java.net/skara pull/1193/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1193`

View PR using the GUI difftool: \
`$ git pr show -t 1193`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1193.diff">https://git.openjdk.java.net/skara/pull/1193.diff</a>

</details>
