### PR TITLE
1102: Document minimum required JDK version 16 for Skara

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ external Git source code hosting providers are available:
 
 ## Building
 
-[JDK 14](http://jdk.java.net/14/) or later and [Gradle](https://gradle.org/)
-6.6 or later is required for building. To build the project on macOS or
+[JDK 16](http://jdk.java.net/16/) or later and [Gradle](https://gradle.org/)
+7.0 or later is required for building. To build the project on macOS or
 GNU/Linux x64, just run the following command from the source tree root:
 
 ```bash
@@ -69,7 +69,7 @@ also want to build the bot images run `sh gradlew images` on GNU/Linux or
 
 If you want to build on an operating system other than GNU/Linux, macOS or
 Windows _or_ if you want to build on a CPU architecture other than x64, then
-ensure that you have JDK 14 or later installed locally and JAVA_HOME set to
+ensure that you have JDK 16 or later installed locally and JAVA_HOME set to
 point to it. You can then run the following command from the source tree root:
 
 ```bash
@@ -84,8 +84,8 @@ tree root.
 If you don't want the build to automatically download any dependencies, then
 you must ensure that you have installed the following software locally:
 
-- JDK 14 or later
-- Gradle 6.6 or later
+- JDK 16 or later
+- Gradle 7.0 or later
 
 To create a build then run the command:
 
@@ -224,7 +224,7 @@ or IDE.
 If you choose to use [IntelliJ IDEA](https://www.jetbrains.com/idea/) as your
 IDE when working on Skara you can simply open the root folder and the project
 should be automatically imported. You will need to configure a Platform SDK that
-is JDK 14 or above. Either set this up manually, or [build](#building) once from
+is JDK 16 or above. Either set this up manually, or [build](#building) once from
 the terminal, which will download a suitable JDK. Configure IntelliJ to use it
 at `File → Project Structure → Platform Settings → SDKs → + → Add JDK...` and
 browse to the downloaded JDK found in `<skara-folder>/.jdk/`. For example, on

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ the terminal, which will download a suitable JDK. Configure IntelliJ to use it
 at `File → Project Structure → Platform Settings → SDKs → + → Add JDK...` and
 browse to the downloaded JDK found in `<skara-folder>/.jdk/`. For example, on
 macOS, select the
-`<skara-folder>/.jdk/openjdk-15.0.1_osx-x64_bin/jdk-15.0.1.jdk/Contents/Home`
+`<skara-folder>/.jdk/openjdk-16_osx-x64_bin/jdk-16.jdk/Contents/Home`
 folder.
 
 ### Vim

--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,10 @@ configure(subprojects.findAll() { it.name != 'bots' }) {
         testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.7.1'
     }
 
+    tasks.withType(JavaCompile).configureEach {
+        options.release.set(16)
+    }
+
     compileJava.options.encoding = 'UTF-8'
     compileTestJava.options.encoding = 'UTF-8'
 


### PR DESCRIPTION
Change documentation to reflect that Skara now requires JDK 16 to build.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1102](https://bugs.openjdk.java.net/browse/SKARA-1102): Document minimum required JDK version 16 for Skara


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - no project role) ⚠️ Review applies to 35fa6b8c76c0870a8fbf1f1167040d03995ef16d


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1195/head:pull/1195` \
`$ git checkout pull/1195`

Update a local copy of the PR: \
`$ git checkout pull/1195` \
`$ git pull https://git.openjdk.java.net/skara pull/1195/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1195`

View PR using the GUI difftool: \
`$ git pr show -t 1195`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1195.diff">https://git.openjdk.java.net/skara/pull/1195.diff</a>

</details>
