### PR TITLE
1101: git webrev for mercurial should ignore config defaults for mercurial commands

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -195,7 +195,7 @@ public class HgRepository implements Repository {
 
     @Override
     public Optional<Hash> resolve(String ref) throws IOException {
-        try (var p = capture("hg", "log", "--rev=" + ref, "--template={node}\n")) {
+        try (var p = capture("hg", "--config", "defaults.log=", "log", "--rev=" + ref, "--template={node}\n")) {
             var res = p.await();
             if (res.status() == 0 && res.stdout().size() == 1) {
                 return Optional.of(new Hash(res.stdout().get(0)));


### PR DESCRIPTION
This patch adds --config defaults.log= to the mercurial command used to resolve a revset to a hash. Since this is a very particular use of the log command, we need to be in full control of all options passed to it.

There are likely several other situations like this that should be fixed, but I would rather not spend the time right now trying to implement a general overhaul for handling all of them.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1101](https://bugs.openjdk.java.net/browse/SKARA-1101): git webrev for mercurial should ignore config defaults for mercurial commands


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1197/head:pull/1197` \
`$ git checkout pull/1197`

Update a local copy of the PR: \
`$ git checkout pull/1197` \
`$ git pull https://git.openjdk.java.net/skara pull/1197/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1197`

View PR using the GUI difftool: \
`$ git pr show -t 1197`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1197.diff">https://git.openjdk.java.net/skara/pull/1197.diff</a>

</details>
