### PR TITLE
1026: Skara bot doesn't update Progress checklist for clean backports to show that it is properly reviewed

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -340,10 +340,11 @@ class CheckRun {
         }
     }
 
-    private String getChecksList(PullRequestCheckIssueVisitor visitor) {
-        return visitor.getChecks().entrySet().stream()
-                      .map(entry -> "- [" + (entry.getValue() ? "x" : " ") + "] " + entry.getKey())
-                      .collect(Collectors.joining("\n"));
+    private String getChecksList(PullRequestCheckIssueVisitor visitor, boolean isCleanBackport) {
+        var checks = isCleanBackport ? visitor.getReadyForReviewChecks() : visitor.getChecks();
+        return checks.entrySet().stream()
+                .map(entry -> "- [" + (entry.getValue() ? "x" : " ") + "] " + entry.getKey())
+                .collect(Collectors.joining("\n"));
     }
 
     private String warningListToText(List<String> additionalErrors) {
@@ -417,11 +418,12 @@ class CheckRun {
     }
 
     private String getStatusMessage(List<Comment> comments, List<Review> reviews, PullRequestCheckIssueVisitor visitor,
-                                    List<String> additionalErrors, List<String> integrationBlockers) {
+                                    List<String> additionalErrors, List<String> integrationBlockers,
+                                    boolean isCleanBackport) {
         var progressBody = new StringBuilder();
         progressBody.append("---------\n");
         progressBody.append("### Progress\n");
-        progressBody.append(getChecksList(visitor));
+        progressBody.append(getChecksList(visitor, isCleanBackport));
 
         var allAdditionalErrors = Stream.concat(visitor.hiddenMessages().stream(), additionalErrors.stream())
                                         .sorted()
@@ -917,7 +919,7 @@ class CheckRun {
             var integrationBlockers = botSpecificIntegrationBlockers();
 
             // Calculate and update the status message if needed
-            var statusMessage = getStatusMessage(comments, activeReviews, visitor, additionalErrors, integrationBlockers);
+            var statusMessage = getStatusMessage(comments, activeReviews, visitor, additionalErrors, integrationBlockers, isCleanBackport);
             var updatedBody = updateStatusMessage(statusMessage);
             var title = pr.title();
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
@@ -68,6 +68,9 @@ class PullRequestCheckIssueVisitor implements IssueVisitor {
                            .collect(Collectors.toList());
     }
 
+    /**
+     * Get all the displayed checks with results.
+     */
     Map<String, Boolean> getChecks() {
         return enabledChecks.stream()
                             .filter(check -> displayedChecks.contains(check.getClass()))
@@ -75,6 +78,10 @@ class PullRequestCheckIssueVisitor implements IssueVisitor {
                                                       check -> !failedChecks.containsKey(check.getClass())));
     }
 
+    /**
+     * Get all the displayed checks with results that were used to decide if this change is ready for
+     * review.
+     */
     Map<String, Boolean> getReadyForReviewChecks() {
         return enabledChecks.stream()
                             .filter(check -> displayedChecks.contains(check.getClass()))

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
@@ -75,6 +75,13 @@ class PullRequestCheckIssueVisitor implements IssueVisitor {
                                                       check -> !failedChecks.containsKey(check.getClass())));
     }
 
+    Map<String, Boolean> getReadyForReviewChecks() {
+        return enabledChecks.stream()
+                            .filter(check -> displayedChecks.contains(check.getClass()))
+                            .filter(check -> !(check instanceof ReviewersCheck))
+                            .collect(Collectors.toMap(Check::description,
+                                                      check -> !failedChecks.containsKey(check.getClass())));
+    }
 
     List<CheckAnnotation> getAnnotations() { return annotations; }
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportTests.java
@@ -24,6 +24,7 @@ package org.openjdk.skara.bots.pr;
 
 import org.junit.jupiter.api.*;
 import org.openjdk.skara.forge.*;
+import org.openjdk.skara.jcheck.ReviewersCheck;
 import org.openjdk.skara.test.*;
 import org.openjdk.skara.vcs.*;
 import org.openjdk.skara.vcs.openjdk.CommitMessageParsers;
@@ -577,6 +578,7 @@ class BackportTests {
             assertTrue(backportComment.contains("<!-- backport " + releaseHash.hex() + " -->"));
             assertEquals(issue1Number + ": An issue", pr.title());
             assertTrue(pr.labelNames().contains("backport"));
+            assertFalse(pr.body().contains(ReviewersCheck.DESCRIPTION), "Reviewer requirement found in pr body");
 
             // The bot should have added the "clean" label
             assertTrue(pr.labelNames().contains("clean"));

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportTests.java
@@ -719,6 +719,7 @@ class BackportTests {
             assertTrue(backportComment.contains("<!-- backport " + upstreamHash.hex() + " -->"));
             assertEquals(issue2Number + ": Another issue", pr.title());
             assertTrue(pr.labelNames().contains("backport"));
+            assertTrue(pr.body().contains(ReviewersCheck.DESCRIPTION), "Reviewer requirement not found in pr body");
 
             // The bot should not have added the "clean" label
             assertFalse(pr.labelNames().contains("clean"));

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/ReviewersCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/ReviewersCheck.java
@@ -36,6 +36,7 @@ import java.util.stream.Collectors;
 import java.util.logging.Logger;
 
 public class ReviewersCheck extends CommitCheck {
+    public static final String DESCRIPTION = "Change must be properly reviewed";
     private final Logger log = Logger.getLogger("org.openjdk.skara.jcheck.reviewers");
     private final Utilities utils;
 
@@ -169,6 +170,6 @@ public class ReviewersCheck extends CommitCheck {
 
     @Override
     public String description() {
-        return "Change must be properly reviewed";
+        return DESCRIPTION;
     }
 }


### PR DESCRIPTION
When a backport is considered clean, no review is required. This should be reflected in the progress list in the PR body. This patch simply removes the "Change must be properly reviewed" line in that case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1026](https://bugs.openjdk.java.net/browse/SKARA-1026): Skara bot doesn't update Progress checklist for clean backports to show that it is properly reviewed


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1198/head:pull/1198` \
`$ git checkout pull/1198`

Update a local copy of the PR: \
`$ git checkout pull/1198` \
`$ git pull https://git.openjdk.java.net/skara pull/1198/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1198`

View PR using the GUI difftool: \
`$ git pr show -t 1198`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1198.diff">https://git.openjdk.java.net/skara/pull/1198.diff</a>

</details>
