### PR TITLE
1040: Crash in webrev command

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitWebrev.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitWebrev.java
@@ -397,8 +397,11 @@ public class GitWebrev {
             if (path.equals(Path.of("-"))) {
                 var reader = new BufferedReader(new InputStreamReader(System.in));
                 files = reader.lines().map(Path::of).collect(Collectors.toList());
-            } else {
+            } else if (Files.exists(path) && !Files.isDirectory(path) && Files.isReadable(path)) {
                 files = Files.readAllLines(path).stream().map(Path::of).collect(Collectors.toList());
+            } else {
+                System.err.println(String.format("error: '%s' is not a readable file", path));
+                System.exit(1);
             }
         }
 


### PR DESCRIPTION
Validate the file input to GitWebrev.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1040](https://bugs.openjdk.java.net/browse/SKARA-1040): Crash in webrev command


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1199/head:pull/1199` \
`$ git checkout pull/1199`

Update a local copy of the PR: \
`$ git checkout pull/1199` \
`$ git pull https://git.openjdk.java.net/skara pull/1199/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1199`

View PR using the GUI difftool: \
`$ git pr show -t 1199`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1199.diff">https://git.openjdk.java.net/skara/pull/1199.diff</a>

</details>
