### PR TITLE
1091: "PR body must not be empty" check pointless for clean backports

### DIFF
--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportTests.java
@@ -568,7 +568,7 @@ class BackportTests {
             localRepo.add(newFile2);
             var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.java.net");
             localRepo.push(editHash, author.url(), "refs/heads/edit", true);
-            var pr = credentials.createPullRequest(author, "master", "edit", "Backport " + releaseHash.hex());
+            var pr = credentials.createPullRequest(author, "master", "edit", "Backport " + releaseHash.hex(), List.of());
 
             // The bot should reply with a backport message
             TestBotRunner.runPeriodicItems(bot);
@@ -579,6 +579,7 @@ class BackportTests {
             assertEquals(issue1Number + ": An issue", pr.title());
             assertTrue(pr.labelNames().contains("backport"));
             assertFalse(pr.body().contains(ReviewersCheck.DESCRIPTION), "Reviewer requirement found in pr body");
+            assertFalse(pr.body().contains(CheckRun.MSG_EMPTY_BODY), "Body not empty requirement found in pr body");
 
             // The bot should have added the "clean" label
             assertTrue(pr.labelNames().contains("clean"));

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -662,12 +662,12 @@ class CheckTests {
             assertEquals(1, checks.size());
             var check = checks.get("jcheck");
             assertEquals(CheckStatus.FAILURE, check.status());
-            assertTrue(check.summary().orElseThrow().contains("The pull request body must not be empty."));
+            assertTrue(check.summary().orElseThrow().contains(CheckRun.MSG_EMPTY_BODY));
 
             // Additional errors should be displayed in the body
             var updatedPr = author.pullRequest(pr.id());
             assertTrue(updatedPr.body().contains("## Error"));
-            assertTrue(updatedPr.body().contains("The pull request body must not be empty."));
+            assertTrue(updatedPr.body().contains(CheckRun.MSG_EMPTY_BODY));
 
             // There should be an indicator of where the pr body should be entered
             assertTrue(updatedPr.body().contains("Replace this text with a description of your pull request"));
@@ -687,7 +687,7 @@ class CheckTests {
             // The additional errors should be gone
             updatedPr = author.pullRequest(pr.id());
             assertFalse(updatedPr.body().contains("## Error"));
-            assertFalse(updatedPr.body().contains("The pull request body must not be empty."));
+            assertFalse(updatedPr.body().contains(CheckRun.MSG_EMPTY_BODY));
 
             // And no new helper marker
             assertFalse(updatedPr.body().contains("Replace this text with a description of your pull request"));


### PR DESCRIPTION
This patch removes the requirement to write something in the PR body for clean backports. Most of the time there really is nothing to add in that case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1091](https://bugs.openjdk.java.net/browse/SKARA-1091): "PR body must not be empty" check pointless for clean backports


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1201/head:pull/1201` \
`$ git checkout pull/1201`

Update a local copy of the PR: \
`$ git checkout pull/1201` \
`$ git pull https://git.openjdk.java.net/skara pull/1201/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1201`

View PR using the GUI difftool: \
`$ git pr show -t 1201`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1201.diff">https://git.openjdk.java.net/skara/pull/1201.diff</a>

</details>
