### PR TITLE
1068: [Backport] Bot finds original commit in wrong repository

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubHost.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubHost.java
@@ -351,9 +351,9 @@ public class GitHubHost implements Forge {
 
     @Override
     public Optional<HostedCommit> search(Hash hash) {
-        var orgsToSearch = orgs.stream().map(o -> "org:" + o).collect(Collectors.joining("+"));
+        var orgsToSearch = orgs.stream().map(o -> "org:" + o).collect(Collectors.joining(" "));
         if (!orgsToSearch.isEmpty()) {
-            orgsToSearch = "+" + orgsToSearch;
+            orgsToSearch = " " + orgsToSearch;
         }
         var result = runSearch("commits", "hash:" + hash.hex() + orgsToSearch);
         var items = result.get("items").asArray();

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabHost.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabHost.java
@@ -232,6 +232,11 @@ public class GitLabHost implements Forge {
             var ids = request.get("groups/" + group + "/projects")
                                   .execute()
                                   .stream()
+                                  // When searching for a commit, there may be hits in multiple repositories.
+                                  // There is no good way of knowing for sure which repository we would rather
+                                  // get the commit from, but a reasonable default is to go by the shortest
+                                  // path name as that is most likely the main repository of the project.
+                                  .sorted(Comparator.comparing(o -> o.get("path").asString().length()))
                                   .map(o -> o.get("id").asInt())
                                   .collect(Collectors.toList());
             for (var id : ids) {


### PR DESCRIPTION
When the PR bot searches for the original commit for a backport it's more or less random from which repository it will be found. Whatever it finds is posted as a link in a PR comment, and if it points to something weird, that can be confusing (though not strictly incorrect as the change will be the exact same regardless of which repo it is in).

The search feature already has what looks to be a configurable way to limit searching to a set of organizations. Unfortunately, that feature was never used and is currently broken for Github (for Gitlab it's already in use as it's required for the search method we use). Because of this, we usually pick a match from adoptium or SAP today. This patch fixes this for Github (where the query separator is space, not '+'), and I intend to limit the organizations to "openjdk" when deploying this fix.

In addition to this, it would be nice if the exact repo that gets picked is the "correct" one. Unfortunately, there is no really good definition of what the correct repo would be in all cases, and it would be even trickier to implement this in a good way. As an approximate workaround, I've added sorting on repository name length, so we always pick the repo with the shortest name. I believe this will at least give us a better answer than "random" in most cases for a relatively modest cost in performance.

I have experimented with this patch in staging with the playground repo and the behavior I've seen so far is good.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1068](https://bugs.openjdk.java.net/browse/SKARA-1068): [Backport] Bot finds original commit in wrong repository


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1203/head:pull/1203` \
`$ git checkout pull/1203`

Update a local copy of the PR: \
`$ git checkout pull/1203` \
`$ git pull https://git.openjdk.java.net/skara pull/1203/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1203`

View PR using the GUI difftool: \
`$ git pr show -t 1203`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1203.diff">https://git.openjdk.java.net/skara/pull/1203.diff</a>

</details>
