### PR TITLE
1111: Backport command needs better matching of target repo

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
@@ -77,23 +77,29 @@ public class BackportCommand implements CommandHandler {
         }
 
         var forge = bot.repo().forge();
-        var repoName = parts[0].replace("http://", "")
+        var repoNameArg = parts[0].replace("http://", "")
                                .replace("https://", "")
                                .replace(forge.hostname() + "/", "");
-        var currentRepoName = bot.repo().name();
-        if (!currentRepoName.equals(repoName) && !repoName.contains("/")) {
-            var group = bot.repo().name().split("/")[0];
-            repoName = group + "/" + repoName;
-        }
+        // If the arg is given with a namespace prefix, look for an exact match,
+        // otherwise cut off the namespace prefix before comparing with the forks
+        // config.
+        var includesNamespace = repoNameArg.contains("/");
+        var repoName = bot.forks().keySet().stream()
+                .filter(s -> includesNamespace
+                        ? s.equals(repoNameArg)
+                        : s.substring(s.indexOf("/") + 1).equals(repoNameArg))
+                .findAny();
 
-        var potentialTargetRepo = forge.repository(repoName);
+        var potentialTargetRepo = repoName.flatMap(forge::repository);
         if (potentialTargetRepo.isEmpty()) {
-            reply.println("@" + username + " the target repository `" + repoName + "` does not exist. ");
-            reply.print("List of valid repositories: ");
-            reply.println(String.join(", ", bot.forkRepoNames()));
+            reply.println("@" + username + " the target repository `" + repoNameArg + "` is not a valid target for backports. ");
+            reply.print("List of valid target repositories: ");
+            reply.println(String.join(", ", bot.forks().keySet().stream().sorted().toList()) + ".");
+            reply.println("Supplying the organization/group prefix is optional.");
             return;
         }
         var targetRepo = potentialTargetRepo.get();
+        var fork = bot.forks().get(targetRepo.name());
 
         var targetBranchName = parts.length == 2 ? parts[1] : "master";
         var targetBranches = targetRepo.branches();
@@ -105,20 +111,12 @@ public class BackportCommand implements CommandHandler {
 
         try {
             var hash = commit.hash();
-            var optionalFork = bot.writeableForkOf(targetRepo);
-            if (optionalFork.isEmpty()) {
-                reply.print("@" + username + " [" + repoName + "](" + targetRepo.webUrl() + ") is not a valid target for backports. ");
-                reply.print("List of valid repositories: ");
-                reply.println(String.join(", ", bot.forkRepoNames()));
-                return;
-            }
-            var fork = optionalFork.get();
             Hash backportHash;
             var backportBranchName = username + "-backport-" + hash.abbreviate();
             var hostedBackportBranch = fork.branches().stream().filter(b -> b.name().equals(backportBranchName)).findAny();
             if (hostedBackportBranch.isEmpty()) {
                 var localRepoDir = scratchPath.resolve("backport-command")
-                                              .resolve(repoName)
+                                              .resolve(targetRepo.name())
                                               .resolve("fork");
                 var localRepo = bot.hostedRepositoryPool()
                                    .orElseThrow(() -> new IllegalStateException("Missing repository pool for PR bot"))
@@ -179,7 +177,7 @@ public class BackportCommand implements CommandHandler {
             body.add("> ");
             body.add("> this pull request contains a backport of commit " +
                       "[" + hash.abbreviate() + "](" + commit.url() + ") from the " +
-                      "[" + currentRepoName + "](" + bot.repo().webUrl() + ") repository.");
+                      "[" + bot.repo().name() + "](" + bot.repo().webUrl() + ") repository.");
             body.add(">");
             var info = "> The commit being backported was authored by " + commit.author().name() + " on " +
                         commit.committed().format(formatter);

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -278,20 +278,11 @@ class PullRequestBot implements Bot {
     }
 
     Optional<HostedRepository> writeableForkOf(HostedRepository upstream) {
-        var fork = forks.get(upstream.name());
-        if (fork == null) {
-            return Optional.empty();
-        }
-        return Optional.of(fork);
+        return Optional.ofNullable(forks.get(upstream.name()));
     }
 
-    /**
-     * Returns a list of all repo names that have a fork configured for them
-     */
-    List<String> forkRepoNames() {
-        return forks.keySet().stream()
-                .map(k -> k.substring(k.lastIndexOf('/') + 1))
-                .toList();
+    public Map<String, HostedRepository> forks() {
+        return forks;
     }
 
     public boolean isAutoLabelled(PullRequest pr) {

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportCommitCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportCommitCommandTests.java
@@ -94,7 +94,7 @@ public class BackportCommitCommandTests {
                                     .censusRepo(censusBuilder.build())
                                     .censusLink("https://census.com/{{contributor}}-profile")
                                     .seedStorage(seedFolder)
-                                    .forks(Map.of(author.name(), author))
+                                    .forks(Map.of(author.name(), author, "foobar/other-repo", author))
                                     .build();
 
             // Populate the projects repository
@@ -107,15 +107,15 @@ public class BackportCommitCommandTests {
             localRepo.push(editHash, author.url(), "edit");
 
             // Add a backport command
-            author.addCommitComment(editHash, "/backport non-existing-repo");
+            author.addCommitComment(editHash, "/backport foobar/non-existing-repo");
             TestBotRunner.runPeriodicItems(bot);
 
             var recentCommitComments = author.recentCommitComments();
             assertEquals(2, recentCommitComments.size());
             var botReply = recentCommitComments.get(0);
             assertTrue(botReply.body().contains("target repository"));
-            assertTrue(botReply.body().contains("does not exist"));
-            assertTrue(botReply.body().contains("List of valid repositories: test"));
+            assertTrue(botReply.body().contains("is not a valid target for backports"));
+            assertTrue(botReply.body().contains("List of valid target repositories: foobar/other-repo, test"));
             assertEquals(List.of(), author.pullRequests());
         }
     }
@@ -156,7 +156,7 @@ public class BackportCommitCommandTests {
             assertEquals(2, recentCommitComments.size());
             var botReply = recentCommitComments.get(0);
             assertTrue(botReply.body().contains("is not a valid target for backports"));
-            assertTrue(botReply.body().contains("List of valid repositories: other-repo"));
+            assertTrue(botReply.body().contains("List of valid target repositories: foobar/other-repo"));
             assertEquals(List.of(), author.pullRequests());
         }
     }

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
@@ -55,6 +55,10 @@ public interface HostedRepository {
     List<PullRequest> pullRequests(ZonedDateTime updatedAfter);
     List<PullRequest> findPullRequestsWithComment(String author, String body);
     Optional<PullRequest> parsePullRequestUrl(String url);
+
+    /**
+     * The full name of the repository, including any namespace/group/organization prefix
+     */
     String name();
     Optional<HostedRepository> parent();
     URI url();


### PR DESCRIPTION
This patch improves the /backport commit command, making it smarter when trying to find the target repository from the argument given by the user. Instead of trying to piece it together based on the namespace (organization/group) of the current repository, it goes straight to the forks configuration and tries to match the repo from there. We can only do backports if there is a valid fork configuration anyway.

In addition to this, I'm also changing the error message you get when you enter an invalid target repo. The list now includes the namespace prefix for each repo, and a note that supplying it is optional.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1111](https://bugs.openjdk.java.net/browse/SKARA-1111): Backport command needs better matching of target repo


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1204/head:pull/1204` \
`$ git checkout pull/1204`

Update a local copy of the PR: \
`$ git checkout pull/1204` \
`$ git pull https://git.openjdk.java.net/skara pull/1204/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1204`

View PR using the GUI difftool: \
`$ git pr show -t 1204`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1204.diff">https://git.openjdk.java.net/skara/pull/1204.diff</a>

</details>
