### PR TITLE
1048: Missing integration comment causes mlbridge to throw exceptions

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
@@ -188,7 +188,8 @@ class ReviewArchive {
                         log.warning("Target commit for PR no longer exists, can't post or verify integration notice: " + hash.get());
                     }
                 } else {
-                    throw new RuntimeException("PR " + pr.webUrl() + " has integrated label but no integration comment");
+                    log.info("PR " + pr.webUrl() + " has integrated label but no integration comment, " +
+                            "can't post integration notice until it does");
                 }
             } else if (threadPrefix.equals("RFR")) {
                 var reply = ArchiveItem.closedNotice(pr, hostUserToEmailAuthor, parent, subjectPrefix);

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -336,12 +336,20 @@ class MailingListBridgeBotTests {
             // Add a comment quickly before integration - it should not be combined with the integration message
             pr.addComment("I will now integrate this PR");
 
-            // Now it has been integrated
+            // Mark it as integrated but skip adding the integration comment for now
             var ignoredPr = ignored.pullRequest(pr.id());
             ignoredPr.setBody("This has been integrated");
             ignoredPr.addLabel("integrated");
-            ignoredPr.addComment("Pushed as commit " + editHash + ".");
             ignoredPr.setState(Issue.State.CLOSED);
+
+            // Run another archive pass
+            TestBotRunner.runPeriodicItems(mlBot);
+
+            // Verify that no integration message was added to the archive
+            assertFalse(archiveContains(archiveFolder.path(), "Subject: Integrated:"));
+
+            // Add the integration comment
+            ignoredPr.addComment("Pushed as commit " + editHash + ".");
 
             // Run another archive pass
             TestBotRunner.runPeriodicItems(mlBot);


### PR DESCRIPTION
This patch changes the mlbridge bot to stop throwing errors when it encounters a PR marked as integrated but without the integration comment (which contains the information about the commit hash needed for the email). Instead, it's just logged and no action is taken. When the comment is eventually added, the bot will run again and the email will be sent.

The ordering of actions from the PR bot must unfortunately be like it is, with the comment added last.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1048](https://bugs.openjdk.java.net/browse/SKARA-1048): Missing integration comment causes mlbridge to throw exceptions


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1205/head:pull/1205` \
`$ git checkout pull/1205`

Update a local copy of the PR: \
`$ git checkout pull/1205` \
`$ git pull https://git.openjdk.java.net/skara pull/1205/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1205`

View PR using the GUI difftool: \
`$ git pr show -t 1205`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1205.diff">https://git.openjdk.java.net/skara/pull/1205.diff</a>

</details>
