### PR TITLE
1133: Source branch for /backport PRs is outdated

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
@@ -125,7 +125,7 @@ public class BackportCommand implements CommandHandler {
                                    .materialize(targetRepo, localRepoDir);
                 var fetchHead = localRepo.fetch(bot.repo().url(), hash.hex(), false);
                 localRepo.checkout(targetBranch);
-                var head = localRepo.head();
+                var head = localRepo.fetch(targetRepo.url(), targetBranchName, false);
                 var backportBranch = localRepo.branch(head, backportBranchName);
                 localRepo.checkout(backportBranch);
                 var didApply = localRepo.cherryPick(fetchHead);


### PR DESCRIPTION
As mentioned in the JBS bug report for this bug, [SKARA-1080](https://bugs.openjdk.java.net/browse/SKARA-1080), which was fixed by PR #1188, was only a partial fix of the problem where the `/backport` command creates the local branch for the PR based off a stale copy of the target branch. The solution is to fetch the target branch from the target repo and base the patch off of that branch.

I didn't add any new tests for this case, so I'll file a follow-up issue.