### PR TITLE
1144: Recreated tag causes HostedRepositoryPool to fail fetch

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepositoryPool.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepositoryPool.java
@@ -181,7 +181,7 @@ public class HostedRepositoryPool {
         var localClone = hostedRepositoryInstance.materializeClone(path, true, false);
         var remote = allowStale ? hostedRepositoryInstance.seedUri() : hostedRepository.url();
         log.info("Updating local repository from: " + remote);
-        var refHash = localClone.fetch(remote, "+" + ref + ":hostedrepositorypool");
+        var refHash = localClone.fetch(remote, "+" + ref + ":hostedrepositorypool", true, true);
         try {
             localClone.checkout(refHash, true);
         } catch (IOException e) {

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
@@ -44,7 +44,10 @@ public interface Repository extends ReadOnlyRepository {
     default Hash fetch(URI uri, String refspec) throws IOException {
         return fetch(uri, refspec, true);
     }
-    Hash fetch(URI uri, String refspec, boolean includeTags) throws IOException;
+    default Hash fetch(URI uri, String refspec, boolean includeTags) throws IOException {
+        return fetch(uri, refspec, includeTags, false);
+    }
+    Hash fetch(URI uri, String refspec, boolean includeTags, boolean forceUpdateTags) throws IOException;
     default void fetchAll(URI uri) throws IOException {
         fetchAll(uri, true);
     }
@@ -135,7 +138,10 @@ public interface Repository extends ReadOnlyRepository {
     default Tag tag(Hash hash, String tagName, String message, String authorName, String authorEmail) throws IOException {
         return tag(hash, tagName, message, authorName, authorEmail, null);
     }
-    Tag tag(Hash hash, String tagName, String message, String authorName, String authorEmail, ZonedDateTime date) throws IOException;
+    default Tag tag(Hash hash, String tagName, String message, String authorName, String authorEmail, ZonedDateTime date) throws IOException {
+        return tag(hash, tagName, message, authorName, authorEmail, date, false);
+    }
+    Tag tag(Hash hash, String tagName, String message, String authorName, String authorEmail, ZonedDateTime date, boolean force) throws IOException;
     Branch branch(Hash hash, String branchName) throws IOException;
     void prune(Branch branch, String remote) throws IOException;
     void delete(Branch b) throws IOException;

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -460,8 +460,8 @@ public class HgRepository implements Repository {
     }
 
     @Override
-    public Hash fetch(URI uri, String refspec, boolean includeTags) throws IOException {
-        // Ignore includeTags, Mercurial always fetches tags
+    public Hash fetch(URI uri, String refspec, boolean includeTags, boolean forceUpdateTags) throws IOException {
+        // Ignore includeTags and forceUpdateTags, Mercurial always fetches tags
         return fetch(uri != null ? uri.toString() : null, refspec);
     }
 
@@ -731,7 +731,7 @@ public class HgRepository implements Repository {
     }
 
     @Override
-    public Tag tag(Hash hash, String name, String message, String authorName, String authorEmail, ZonedDateTime date) throws IOException {
+    public Tag tag(Hash hash, String name, String message, String authorName, String authorEmail, ZonedDateTime date, boolean force) throws IOException {
         var user = authorEmail != null ?
             authorName + " <" + authorEmail + ">" :
             authorName;
@@ -743,6 +743,9 @@ public class HgRepository implements Repository {
         if (date != null) {
             cmd.add("--date");
             cmd.add(date.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+        }
+        if (force) {
+            cmd.add("--force");
         }
         cmd.add(name);
         try (var p = capture(cmd)) {


### PR DESCRIPTION
This patch makes it possible to force an update of a tag in a Repository as well as forcing fetching of an updated tag. This is then used in the HostedRepositoryPool to avoid errors when a tag has been updated in a repository, which is currently preventing bots from operating on such repositories.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1144](https://bugs.openjdk.java.net/browse/SKARA-1144): Recreated tag causes HostedRepositoryPool to fail fetch


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1210/head:pull/1210` \
`$ git checkout pull/1210`

Update a local copy of the PR: \
`$ git checkout pull/1210` \
`$ git pull https://git.openjdk.java.net/skara pull/1210/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1210`

View PR using the GUI difftool: \
`$ git pr show -t 1210`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1210.diff">https://git.openjdk.java.net/skara/pull/1210.diff</a>

</details>
