### PR TITLE
1145: NPE in GitHubPullRequest::reviews

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveItem.java
@@ -334,15 +334,20 @@ class ArchiveItem {
         return lastRevisionItem;
     }
 
-    static ArchiveItem findRevisionItem(List<ArchiveItem> generated, Hash hash) {
+    private static ArchiveItem findRevisionItem(List<ArchiveItem> generated, Hash hash) {
         // Parent is revision update mail with the hash
         ArchiveItem lastRevisionItem = generated.get(0);
-        for (var item : generated) {
-            if (item.id().startsWith("ha")) {
-                lastRevisionItem = item;
-            }
-            if (item.id().equals("ha" + hash.hex())) {
-                return item;
+        // If no hash is given, that means the commit for the review/comment no longer exists.
+        // This means that no properly valid parent exists, but as we need to return one, just
+        // return the first element.
+        if (hash != null) {
+            for (var item : generated) {
+                if (item.id().startsWith("ha")) {
+                    lastRevisionItem = item;
+                }
+                if (item.id().equals("ha" + hash.hex())) {
+                    return item;
+                }
             }
         }
         return lastRevisionItem;
@@ -358,7 +363,7 @@ class ArchiveItem {
     }
 
     static ArchiveItem findParent(List<ArchiveItem> generated, Review review) {
-        return findRevisionItem(generated, review.hash());
+        return findRevisionItem(generated, review.hash().orElse(null));
     }
 
     static ArchiveItem findParent(List<ArchiveItem> generated, List<ReviewComment> reviewComments, ReviewComment reviewComment) {
@@ -379,7 +384,7 @@ class ArchiveItem {
         }
 
         if (previousComment == null) {
-            return findRevisionItem(generated, reviewComment.hash());
+            return findRevisionItem(generated, reviewComment.hash().orElse(null));
         } else {
             var mentionedParent = findLastMention(reviewComment.body(), eligible);
             if (mentionedParent.isPresent()) {

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
@@ -374,9 +374,9 @@ class ArchiveMessages {
                 body.append(" line ").append(reviewComment.line());
             }
             body.append(":\n\n");
-            if (reviewComment.line() > 0) {
+            if (reviewComment.hash().isPresent() && reviewComment.line() > 0) {
                 try {
-                    var contents = pr.repository().fileContents(reviewComment.path(), reviewComment.hash().hex()).lines().collect(Collectors.toList());
+                    var contents = pr.repository().fileContents(reviewComment.path(), reviewComment.hash().get().hex()).lines().collect(Collectors.toList());
                     for (int i = Math.max(0, reviewComment.line() - 3); i < Math.min(contents.size(), reviewComment.line()); ++i) {
                         body.append("> ").append(i + 1).append(": ").append(contents.get(i)).append("\n");
                     }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -360,12 +360,17 @@ class CheckRun {
                                .filter(review -> review.verdict() == Review.Verdict.APPROVED)
                                .map(review -> {
                                    var entry = " * " + formatReviewer(review.reviewer());
-                                   if (!review.hash().equals(pr.headHash())) {
-                                       if (ignoreStaleReviews) {
-                                           entry += " 🔄 Re-review required (review applies to " + review.hash() + ")";
-                                       } else {
-                                           entry += " ⚠️ Review applies to " + review.hash();
+                                   var hash = review.hash();
+                                   if (hash.isPresent()) {
+                                       if (!hash.get().equals(pr.headHash())) {
+                                           if (ignoreStaleReviews) {
+                                               entry += " 🔄 Re-review required (review applies to " + hash.get() + ")";
+                                           } else {
+                                               entry += " ⚠️ Review applies to " + hash.get();
+                                           }
                                        }
+                                   } else {
+                                       entry += " 🔄 Re-review required (review applies to a commit that is no longer present)";
                                    }
                                    return entry;
                                })

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -75,7 +75,8 @@ class CheckWorkItem extends PullRequestWorkItem {
         try {
             var approverString = reviews.stream()
                                         .filter(review -> review.verdict() == Review.Verdict.APPROVED)
-                                        .map(review -> encodeReviewer(review.reviewer(), censusInstance) + review.hash().hex())
+                                        .filter(review -> review.hash().isPresent())
+                                        .map(review -> encodeReviewer(review.reviewer(), censusInstance) + review.hash().orElseThrow().hex())
                                         .sorted()
                                         .collect(Collectors.joining());
             var commentString = comments.stream()

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
@@ -60,7 +60,10 @@ public class CheckablePullRequest {
 
     private String commitMessage(Hash head, List<Review> activeReviews, Namespace namespace, boolean manualReviewers, Hash original) throws IOException {
         var eligibleReviews = activeReviews.stream()
-                                           .filter(review -> !ignoreStaleReviews || review.hash().equals(pr.headHash()))
+                                           // Reviews without a hash are never valid as they referred to no longer
+                                           // existing commits.
+                                           .filter(review -> review.hash().isPresent())
+                                           .filter(review -> !ignoreStaleReviews || review.hash().orElseThrow().equals(pr.headHash()))
                                            .filter(review -> review.verdict() == Review.Verdict.APPROVED)
                                            .collect(Collectors.toList());
         var reviewers = PullRequestUtils.reviewerNames(eligibleReviews, namespace);

--- a/forge/src/main/java/org/openjdk/skara/forge/Review.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/Review.java
@@ -58,7 +58,7 @@ public class Review {
     }
 
     /**
-     * The hash for the commit for which this review was created. Can be null if the commit
+     * The hash for the commit for which this review was created. Can be empty if the commit
      * no longer exists.
      */
     public Optional<Hash> hash() {

--- a/forge/src/main/java/org/openjdk/skara/forge/Review.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/Review.java
@@ -57,8 +57,12 @@ public class Review {
         return verdict;
     }
 
-    public Hash hash() {
-        return hash;
+    /**
+     * The hash for the commit for which this review was created. Can be null if the commit
+     * no longer exists.
+     */
+    public Optional<Hash> hash() {
+        return Optional.ofNullable(hash);
     }
 
     public int id() {

--- a/forge/src/main/java/org/openjdk/skara/forge/ReviewComment.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/ReviewComment.java
@@ -50,8 +50,12 @@ public class ReviewComment extends Comment {
         return Optional.ofNullable(parent);
     }
 
-    public Hash hash() {
-        return hash;
+    /**
+     * The hash for the commit for which this review comment was created. Can be null if the commit
+     * no longer exists.
+     */
+    public Optional<Hash> hash() {
+        return Optional.ofNullable(hash);
     }
 
     public String path() {

--- a/forge/src/main/java/org/openjdk/skara/forge/ReviewComment.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/ReviewComment.java
@@ -51,7 +51,7 @@ public class ReviewComment extends Comment {
     }
 
     /**
-     * The hash for the commit for which this review comment was created. Can be null if the commit
+     * The hash for the commit for which this review comment was created. Can be empty if the commit
      * no longer exists.
      */
     public Optional<Hash> hash() {

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -87,7 +87,11 @@ public class GitHubPullRequest implements PullRequest {
                              .filter(obj -> !(obj.get("state").asString().equals("COMMENTED") && obj.get("body").asString().isEmpty()))
                              .map(obj -> {
                                  var reviewer = host.parseUserField(obj);
-                                 var hash = new Hash(obj.get("commit_id").asString());
+                                 var commitId = obj.get("commit_id");
+                                 Hash hash = null;
+                                 if (commitId != null) {
+                                     hash = new Hash(commitId.asString());
+                                 }
                                  Review.Verdict verdict;
                                  switch (obj.get("state").asString()) {
                                      case "APPROVED":
@@ -190,7 +194,11 @@ public class GitHubPullRequest implements PullRequest {
         var threadId = parent == null ? reviewJson.get("id").toString() : parent.threadId();
 
         int line = reviewJson.get("original_line").asInt();
-        var hash = new Hash(reviewJson.get("original_commit_id").asString());
+        var originalCommitId = reviewJson.get("original_commit_id");
+        Hash hash = null;
+        if (originalCommitId != null) {
+            hash = new Hash(originalCommitId.asString());
+        }
         var path = reviewJson.get("path").asString();
 
         if (reviewJson.get("side").asString().equals("LEFT")) {

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -120,7 +120,7 @@ public class GitLabMergeRequest implements PullRequest {
                                    var createdAt = ZonedDateTime.parse(obj.get("created_at").asString());
 
                                    // Find the latest commit that isn't created after our review
-                                   var hash = commits.get(0).hash;
+                                   Hash hash = null;
                                    for (var cd : commits) {
                                        if (createdAt.isAfter(cd.date)) {
                                            hash = cd.hash;

--- a/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
@@ -125,7 +125,7 @@ public class TestPullRequest extends TestIssue implements PullRequest {
         if (parent.parent().isPresent()) {
             throw new RuntimeException("Can only reply to top-level review comments");
         }
-        var comment = new ReviewComment(parent, parent.threadId(), parent.hash(), parent.path(), parent.line(), String.valueOf(data.reviewComments.size()), body, user, ZonedDateTime.now(), ZonedDateTime.now());
+        var comment = new ReviewComment(parent, parent.threadId(), parent.hash().orElseThrow(), parent.path(), parent.line(), String.valueOf(data.reviewComments.size()), body, user, ZonedDateTime.now(), ZonedDateTime.now());
         data.reviewComments.add(comment);
         data.lastUpdate = ZonedDateTime.now();
         return comment;


### PR DESCRIPTION
The core of this change is to fix an NPE in GitHubPullRequest::reviews, which happens when a commit that a review refers to no longer exists (presumably because of a rebase or forced update of the review branch). The introduction of a possible null value in Review::hash has some ripple effects however, so this gets a bit more complicated.

I've opted to wrap the return value of Review::hash and ReviewComment::hash with Optional to properly force every caller to handle the situation. I haven't seen this happen for ReviewComment, but I would be surprised if the same thing didn't apply there from the GitHub side.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1145](https://bugs.openjdk.java.net/browse/SKARA-1145): NPE in GitHubPullRequest::reviews


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**) ⚠️ Review applies to dcbc4f1cb0c672f0d9735f81d8661acff4cb9b97


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1211/head:pull/1211` \
`$ git checkout pull/1211`

Update a local copy of the PR: \
`$ git checkout pull/1211` \
`$ git pull https://git.openjdk.java.net/skara pull/1211/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1211`

View PR using the GUI difftool: \
`$ git pr show -t 1211`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1211.diff">https://git.openjdk.java.net/skara/pull/1211.diff</a>

</details>
