### PR TITLE
1129: [REDO] The mlbridge bot occasionally posts the same comments twice on Github

### DIFF
--- a/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestCloserBot.java
+++ b/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestCloserBot.java
@@ -86,10 +86,7 @@ class PullRequestCloserBotWorkItem implements WorkItem {
             return true;
         }
         PullRequestCloserBotWorkItem otherItem = (PullRequestCloserBotWorkItem)other;
-        if (!pr.id().equals(otherItem.pr.id())) {
-            return true;
-        }
-        if (!repository.name().equals(otherItem.repository.name())) {
+        if (!pr.isSame(otherItem.pr)) {
             return true;
         }
         return false;

--- a/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestPrunerBot.java
+++ b/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestPrunerBot.java
@@ -49,10 +49,7 @@ class PullRequestPrunerBotWorkItem implements WorkItem {
             return true;
         }
         PullRequestPrunerBotWorkItem otherItem = (PullRequestPrunerBotWorkItem) other;
-        if (!pr.id().equals(otherItem.pr.id())) {
-            return true;
-        }
-        if (!pr.repository().name().equals(otherItem.pr.repository().name())) {
+        if (!pr.isSame(otherItem.pr)) {
             return true;
         }
         return false;

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
@@ -70,10 +70,7 @@ class ArchiveWorkItem implements WorkItem {
             }
             return false;
         }
-        if (!pr.id().equals(otherArchiveItem.pr.id())) {
-            return true;
-        }
-        if (!bot.codeRepo().name().equals(otherArchiveItem.bot.codeRepo().name())) {
+        if (!pr.isSame(otherArchiveItem.pr)) {
             return true;
         }
         return false;

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/CommentPosterWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/CommentPosterWorkItem.java
@@ -55,7 +55,7 @@ public class CommentPosterWorkItem implements WorkItem {
             return true;
         }
         CommentPosterWorkItem otherItem = (CommentPosterWorkItem) other;
-        if (!pr.equals(otherItem.pr)) {
+        if (!pr.isSame(otherItem.pr)) {
             return true;
         }
         var otherItemIds = otherItem.newMessages.stream()

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/PullRequestWorkItem.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/PullRequestWorkItem.java
@@ -160,10 +160,7 @@ public class PullRequestWorkItem implements WorkItem {
             return true;
         }
         PullRequestWorkItem otherItem = (PullRequestWorkItem)other;
-        if (!pr.id().equals(otherItem.pr.id())) {
-            return true;
-        }
-        if (!pr.repository().name().equals(otherItem.pr.repository().name())) {
+        if (!pr.isSame(otherItem.pr)) {
             return true;
         }
         return false;

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestWorkItem.java
@@ -44,10 +44,7 @@ abstract class PullRequestWorkItem implements WorkItem {
             return true;
         }
         PullRequestWorkItem otherItem = (PullRequestWorkItem)other;
-        if (!pr.id().equals(otherItem.pr.id())) {
-            return true;
-        }
-        if (!pr.repository().name().equals(otherItem.pr.repository().name())) {
+        if (!pr.isSame(otherItem.pr)) {
             return true;
         }
         return false;

--- a/bots/submit/src/main/java/org/openjdk/skara/bots/submit/SubmitBotWorkItem.java
+++ b/bots/submit/src/main/java/org/openjdk/skara/bots/submit/SubmitBotWorkItem.java
@@ -58,10 +58,7 @@ public class SubmitBotWorkItem implements WorkItem {
         if (!executor.checkName().equals(otherItem.executor.checkName())) {
             return true;
         }
-        if (!pr.id().equals(otherItem.pr.id())) {
-            return true;
-        }
-        if (!bot.repository().name().equals(otherItem.bot.repository().name())) {
+        if (!pr.isSame(otherItem.pr)) {
             return true;
         }
         return false;

--- a/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestUpdateNeededWorkItem.java
+++ b/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestUpdateNeededWorkItem.java
@@ -54,10 +54,10 @@ public class TestUpdateNeededWorkItem implements WorkItem {
             return true;
         }
         var o = (TestUpdateNeededWorkItem) other;
-        if (!pr.repository().url().equals(o.pr.repository().url())) {
+        if (!pr.isSame(o.pr)) {
             return true;
         }
-        return !pr.id().equals(o.pr.id());
+        return false;
     }
 
     @Override

--- a/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestWorkItem.java
+++ b/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestWorkItem.java
@@ -71,10 +71,10 @@ public class TestWorkItem implements WorkItem {
             return true;
         }
         var o = (TestWorkItem) other;
-        if (!repository.url().equals(o.repository.url())) {
+        if (!pr.isSame(o.pr)) {
             return true;
         }
-        return !pr.id().equals(o.pr.id());
+        return false;
     }
 
 

--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
@@ -163,4 +163,13 @@ public interface PullRequest extends Issue {
     void setTargetRef(String targetRef);
 
     URI filesUrl(Hash hash);
+
+    /**
+     * Returns true if this PullRequest represents the same pull request as the other.
+     */
+    default boolean isSame(PullRequest other) {
+        return id().equals(other.id())
+                && repository().name().equals(other.repository().name())
+                && repository().forge().name().equals(other.repository().forge().name());
+    }
 }


### PR DESCRIPTION
Redo of SKARA-1058. The patch is exactly the same as I don't think it was the cause for SKARA-1128.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1129](https://bugs.openjdk.java.net/browse/SKARA-1129): [REDO] The mlbridge bot occasionally posts the same comments twice on Github


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1213/head:pull/1213` \
`$ git checkout pull/1213`

Update a local copy of the PR: \
`$ git checkout pull/1213` \
`$ git pull https://git.openjdk.java.net/skara pull/1213/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1213`

View PR using the GUI difftool: \
`$ git pr show -t 1213`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1213.diff">https://git.openjdk.java.net/skara/pull/1213.diff</a>

</details>
