### PR TITLE
1153: Some emails still not posted as comments in PR

### DIFF
--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
@@ -251,7 +251,7 @@ public class BotRunner {
 
                     for (var pendingItem : pending.entrySet()) {
                         // If there are pending items of the same type that we cannot run concurrently with, replace them.
-                        if (pendingItem.getKey().getClass().equals(item.getClass()) && !pendingItem.getKey().concurrentWith(item)) {
+                        if (item.replaces(pendingItem.getKey())) {
                             log.finer("Discarding obsoleted item " + pendingItem.getKey() +
                                               " in favor of item " + item);
                             DISCARDED_COUNTER.labels(item.botName(), item.workItemName()).inc();

--- a/bot/src/main/java/org/openjdk/skara/bot/WorkItem.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/WorkItem.java
@@ -34,6 +34,15 @@ public interface WorkItem {
     boolean concurrentWith(WorkItem other);
 
     /**
+     * Returns true if this item should replace the other item in the queue. By default
+     * this is true if both items are of the same type, and cannot run concurrently with
+     * each other. In some cases we need a more specific condition.
+     */
+    default boolean replaces(WorkItem other) {
+        return this.getClass().equals(other.getClass()) && !concurrentWith(other);
+    }
+
+    /**
      * Execute the appropriate tasks with the provided scratch folder. Optionally return follow-up work items
      * that will be scheduled for execution.
      * @param scratchPath

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveReaderWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveReaderWorkItem.java
@@ -40,7 +40,7 @@ public class ArchiveReaderWorkItem implements WorkItem {
 
     @Override
     public String toString() {
-        return "ArchiveReaderWorkItem@" + list;
+        return "ArchiveReaderWorkItem@" + bot.repository().name();
     }
 
     @Override
@@ -53,6 +53,17 @@ public class ArchiveReaderWorkItem implements WorkItem {
             return true;
         }
         return false;
+    }
+
+    /**
+     * An ArchiveReaderWorkItem can't run concurrently with another item that shares the same
+     * MailingListReader, but it only replaces an item that acts on the same repository.
+     */
+    @Override
+    public boolean replaces(WorkItem other) {
+        return !concurrentWith(other)
+                && (other instanceof ArchiveReaderWorkItem archiveReaderWorkItem)
+                && bot.repository().name().equals(archiveReaderWorkItem.bot.repository().name());
     }
 
     @Override

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotFactory.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotFactory.java
@@ -122,6 +122,8 @@ public class MailingListBridgeBotFactory implements BotFactory {
                                                          .map(EmailAddress::localPart)
                                                          .collect(Collectors.toList());
 
+                // Reuse MailingListReaders with the exact same set of mailing lists between bots
+                // to benefit more from cached results.
                 if (!mailingListReaderMap.containsKey(listsForReading)) {
                     mailingListReaderMap.put(listsForReading, mailmanServer.getListReader(listsForReading.toArray(new String[0])));
                 }

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotFactory.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotFactory.java
@@ -24,7 +24,7 @@ package org.openjdk.skara.bots.mlbridge;
 
 import org.openjdk.skara.bot.*;
 import org.openjdk.skara.email.EmailAddress;
-import org.openjdk.skara.forge.HostedRepository;
+import org.openjdk.skara.mailinglist.MailingListReader;
 import org.openjdk.skara.network.URIBuilder;
 import org.openjdk.skara.json.*;
 import org.openjdk.skara.mailinglist.MailingListServerFactory;
@@ -89,8 +89,6 @@ public class MailingListBridgeBotFactory implements BotFactory {
         var archiveRef = configuration.repositoryRef(specific.get("archive").asString());
         var issueTracker = URIBuilder.base(specific.get("issues").asString()).build();
 
-        var allRepositories = new HashSet<HostedRepository>();
-
         var readyLabels = specific.get("ready").get("labels").stream()
                 .map(JSONValue::asString)
                 .collect(Collectors.toSet());
@@ -101,8 +99,11 @@ public class MailingListBridgeBotFactory implements BotFactory {
         var cooldown = specific.contains("cooldown") ? Duration.parse(specific.get("cooldown").asString()) : Duration.ofMinutes(1);
         var mailmanServer = MailingListServerFactory.createMailmanServer(listArchive, listSmtp, Duration.ZERO);
 
+        var mailingListReaderMap = new HashMap<List<String>, MailingListReader>();
+
         for (var repoConfig : specific.get("repositories").asArray()) {
             var repo = repoConfig.get("repository").asString();
+            var hostedRepository = configuration.repository(repo);
             var censusRepo = configuration.repository(repoConfig.get("census").asString());
             var censusRef = configuration.repositoryRef(repoConfig.get("census").asString());
 
@@ -120,7 +121,11 @@ public class MailingListBridgeBotFactory implements BotFactory {
                 var listsForReading = listNamesForReading.stream()
                                                          .map(EmailAddress::localPart)
                                                          .collect(Collectors.toList());
-                var bot = new MailingListArchiveReaderBot(from, mailmanServer.getListReader(listsForReading.toArray(new String[0])), allRepositories);
+
+                if (!mailingListReaderMap.containsKey(listsForReading)) {
+                    mailingListReaderMap.put(listsForReading, mailmanServer.getListReader(listsForReading.toArray(new String[0])));
+                }
+                var bot = new MailingListArchiveReaderBot(mailingListReaderMap.get(listsForReading), hostedRepository);
                 ret.add(bot);
             }
 
@@ -137,7 +142,7 @@ public class MailingListBridgeBotFactory implements BotFactory {
                                      repoConfig.get("webrevs").get("json").asBoolean();
 
             var botBuilder = MailingListBridgeBot.newBuilder().from(from)
-                                                 .repo(configuration.repository(repo))
+                                                 .repo(hostedRepository)
                                                  .archive(archiveRepo)
                                                  .archiveRef(archiveRef)
                                                  .censusRepo(censusRepo)
@@ -169,8 +174,6 @@ public class MailingListBridgeBotFactory implements BotFactory {
                 botBuilder.branchInSubject(Pattern.compile(repoConfig.get("branchname").asString()));
             }
             ret.add(botBuilder.build());
-
-            allRepositories.add(configuration.repository(repo));
         }
 
         return ret;

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBotTests.java
@@ -88,7 +88,7 @@ class MailingListArchiveReaderBotTests {
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(),
                                                                              Duration.ZERO);
             var mailmanList = mailmanServer.getListReader(listAddress.address());
-            var readerBot = new MailingListArchiveReaderBot(from, mailmanList, Set.of(archive));
+            var readerBot = new MailingListArchiveReaderBot(mailmanList, archive);
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -164,7 +164,7 @@ class MailingListArchiveReaderBotTests {
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(),
                                                                              Duration.ZERO);
             var mailmanList = mailmanServer.getListReader(listAddress.address());
-            var readerBot = new MailingListArchiveReaderBot(from, mailmanList, Set.of(archive));
+            var readerBot = new MailingListArchiveReaderBot(mailmanList, archive);
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -197,7 +197,7 @@ class MailingListArchiveReaderBotTests {
             var updated = pr.comments();
             assertEquals(2, updated.size());
 
-            var newReaderBot = new MailingListArchiveReaderBot(from, mailmanList, Set.of(archive));
+            var newReaderBot = new MailingListArchiveReaderBot(mailmanList, archive);
             TestBotRunner.runPeriodicItems(newReaderBot);
             TestBotRunner.runPeriodicItems(newReaderBot);
 
@@ -240,7 +240,7 @@ class MailingListArchiveReaderBotTests {
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(),
                                                                              Duration.ZERO);
             var mailmanList = mailmanServer.getListReader(listAddress.address());
-            var readerBot = new MailingListArchiveReaderBot(from, mailmanList, Set.of(archive));
+            var readerBot = new MailingListArchiveReaderBot(mailmanList, archive);
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -317,12 +317,6 @@ class MailingListArchiveReaderBotTests {
                     .webrevStorageBaseUri(webrevServer.uri())
                     .issueTracker(URIBuilder.base("http://issues.test/browse/").build())
                     .build();
-
-            // The mailing list as well
-            var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(),
-                    Duration.ZERO);
-            var mailmanList = mailmanServer.getListReader(listAddress.address());
-            var readerBot = new MailingListArchiveReaderBot(from, mailmanList, Set.of(archive));
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());

--- a/mailinglist/src/main/java/org/openjdk/skara/mailinglist/Mbox.java
+++ b/mailinglist/src/main/java/org/openjdk/skara/mailinglist/Mbox.java
@@ -97,9 +97,6 @@ public class Mbox {
             unhandledEmails = new ArrayList<>();
 
             for (var email : emailsToCheck) {
-                if (email.id().toString().contains("<VtLlAA6xMBK-6Ib-4SbkYZJssOuyqPl5Dr7kdiJUf6A=.9c549bc6-867f-4ba6-8727-efafe7cc18e2@github.com>")) {
-                    log.warning("Found first email of jdk#5300 in mbox");
-                }
                 if (!idToConversation.containsKey(email.id())) {
                     EmailAddress inReplyTo = findInReplyTo(idToMail, email);
                     if (inReplyTo != null) {


### PR DESCRIPTION
After fixing SKARA-1148, there were still some emails that weren't being posted as comments in PRs. The underlying cause this time was emails that Skara thinks it has sent, but they never were, so they weren't present in the mail archive. Emails sent in response to such missing emails have bad In-Reply-To headers as they point to emails that aren't in the archive. When the Mbox parser tries to piece together conversations, it fails to find the correct parents in these cases.

The reason we need to piece conversations together is to find the original RFR email, which contains the pull request link. This is how each email is associated with the correct pull request.

The fix for this is to also look at the References header as a backup. The References header contains the whole ancestor chain of email IDs, so using that, we can connect conversations regardless of missing emails in between, especially since we only really care about the first email in the conversation. Looking at the pipermail thread view, this is what it must be doing as it would otherwise fail miserably. I also tweaked the loops here to hopefully do a bit less work, which I think is worth it due to the pretty large number of emails being parsed here.

In addition to this small change to Mbox, I'm also tinkering with some other things that are related. These were things I stumbled over and needed to properly debug and test the issue. 

As I noted in SKARA-1148 already, the MailingListArchiveReaderBot is doing a lot of redundant work. I blame this on SKARA-843, where this bot was changed from one global instance to running one instance for each configured repository. There were two problems introduced with this change.

1. Each instance still has all the configured repositories, so every found conversation is evaluated against every repository in every instance. This creates an unnecessary N^2 complexity in number of configured repositories.
2. Each instance has its own MailingListReader, configured for exactly the set of mailing lists used for the repository. We have a lot of repositories that share the exact same mailing list config. This means that each of these instances will read all the archives for themselves, with no sharing of this data. The reader already does caching, so after the first time around, it's much faster. Still, the first time around we read jdk-updates-dev a pretty large number of times.

My solution for 1 is to only have one single repository in each MailingListArchiveReaderBot. This looks like a simple oversight in the previous patch. 

For 2, I make sure to only create one MailingListReader for each unique set of mailing lists. This will not remove all the redundant reads, but it will bring them down significantly. I also think it's the functionally correct solution as we will then only consider email threads on the relevant mailing lists for each repository, so less unnecessary (and potentially bad) cross evaluation between mailing lists and repositories that aren't configured as related.

To get 2 to actually work correctly, I needed to tweak the logic that protects us from running the wrong WorkItems concurrently. To be able to share MailingListReader between multiple WorkItems, we have WorkItem::concurrentWith. Unfortunately, this method was also used to detect duplicate WorkItems in the pending pool of the scheduler. This is correct in most cases, but not here. An ArchiveReaderWorkItem for jdk11u and jdk15u shares MailingListReader, but queueing one should not replace the other. To solve this I added another method WorkItem::replaces for this particular check (with a default method to preserve the current behavior for all other WorkItems).

Finally I also changed ArchiveReaderWorkItem::toString to print the repository name rather than the list of mailing lists. This made a lot more sense to me while debugging as we now create an instance per repository rather than based on mailinglists.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1153](https://bugs.openjdk.java.net/browse/SKARA-1153): Some emails still not posted as comments in PR


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**) ⚠️ Review applies to fda3fbb94e7e0cbcee2c250ffbc740e8fb5a41c1


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1214/head:pull/1214` \
`$ git checkout pull/1214`

Update a local copy of the PR: \
`$ git checkout pull/1214` \
`$ git pull https://git.openjdk.java.net/skara pull/1214/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1214`

View PR using the GUI difftool: \
`$ git pr show -t 1214`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1214.diff">https://git.openjdk.java.net/skara/pull/1214.diff</a>

</details>
