### PR TITLE
1125: OpenJDK 7 backports incorrectly tagged with hgupdate-sync

### DIFF
--- a/jbs/src/main/java/org/openjdk/skara/jbs/JdkVersion.java
+++ b/jbs/src/main/java/org/openjdk/skara/jbs/JdkVersion.java
@@ -39,7 +39,7 @@ public class JdkVersion implements Comparable<JdkVersion> {
     private final static Pattern fxVersionPattern = Pattern.compile("(openjfx[1-9][0-9]?)(u([0-9]{1,3}))?$");
 
     // Match a version string symbolizing some future, but yet undefined, update of a major version
-    private final static Pattern futureUpdatePattern = Pattern.compile("([1-9][0-9]*u)(-([a-z0-9]+))?$");
+    private final static Pattern futureUpdatePattern = Pattern.compile("((openjdk)?[1-9][0-9]*u)(-([a-z0-9]+))?$");
 
     private final static Pattern prefixPattern = Pattern.compile("([a-z]+)([0-9.]+)$");
 
@@ -65,10 +65,10 @@ public class JdkVersion implements Comparable<JdkVersion> {
             var matcher = futureUpdatePattern.matcher(raw);
             if (matcher.matches()) {
                 finalComponents.add(matcher.group(1));
-                // Group 3 is the opt field
-                if (matcher.group(3) != null) {
+                // Group 4 is the opt field
+                if (matcher.group(4) != null) {
                     finalComponents.add(null);
-                    finalComponents.add(matcher.group(3));
+                    finalComponents.add(matcher.group(4));
                 }
             }
         }

--- a/jbs/src/test/java/org/openjdk/skara/jbs/BackportsTests.java
+++ b/jbs/src/test/java/org/openjdk/skara/jbs/BackportsTests.java
@@ -805,4 +805,15 @@ public class BackportsTests {
             backports.assertLabeled("16.0.2", "17");
         }
     }
+
+    @Test
+    void openjdk7u(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo)) {
+            var backports = new BackportManager(credentials, "17");
+            backports.assertLabeled();
+
+            backports.addBackports("openjdk7u", "7u321", "openjdk8u302", "openjdk8u312");
+            backports.assertLabeled("openjdk8u312");
+        }
+    }
 }

--- a/jbs/src/test/java/org/openjdk/skara/jbs/JdkVersionTests.java
+++ b/jbs/src/test/java/org/openjdk/skara/jbs/JdkVersionTests.java
@@ -78,6 +78,7 @@ public class JdkVersionTests {
         var jdk16uCpu = from("16u-cpu");
         assertEquals(List.of("16u"), jdk16uCpu.components());
         assertEquals("cpu", jdk16uCpu.opt().orElseThrow());
+        assertEquals(List.of("openjdk7u"), from("openjdk7u").components());
     }
 
     @Test
@@ -112,5 +113,6 @@ public class JdkVersionTests {
     void nonConforming() {
         assertEquals(Optional.empty(), JdkVersion.parse("bla"));
         assertEquals(Optional.empty(), JdkVersion.parse(""));
+        assertEquals(Optional.empty(), JdkVersion.parse("foobar7u"));
     }
 }


### PR DESCRIPTION
This patch makes "openjdk7u" a valid JdkVersion in the Skara version parser. This was preventing the SyncLabelBot from properly setting or removing the hgupdate-sync label on backports with this fixVersion.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1125](https://bugs.openjdk.java.net/browse/SKARA-1125): OpenJDK 7 backports incorrectly tagged with hgupdate-sync


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1215/head:pull/1215` \
`$ git checkout pull/1215`

Update a local copy of the PR: \
`$ git checkout pull/1215` \
`$ git pull https://git.openjdk.java.net/skara pull/1215/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1215`

View PR using the GUI difftool: \
`$ git pr show -t 1215`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1215.diff">https://git.openjdk.java.net/skara/pull/1215.diff</a>

</details>
