### PR TITLE
1166: New Gitlab version is causing "Initial paginated response no longer paginated" errors

### DIFF
--- a/network/src/main/java/org/openjdk/skara/network/RestRequest.java
+++ b/network/src/main/java/org/openjdk/skara/network/RestRequest.java
@@ -432,7 +432,7 @@ public class RestRequest {
 
             link = response.headers().firstValue("Link");
             links = parseLink(link.orElseThrow(
-                    () -> new RuntimeException("Initial paginated response no longer paginated")));
+                    () -> new UncheckedRestException("Initial paginated response no longer paginated for query: " + queryBuilder)));
 
             parsedResponse = parseResponse(response);
             ret.add(parsedResponse);


### PR DESCRIPTION
This patch changes the exception thrown when a paginated rest query suddenly returns a results without pages. Instead of a RuntimeException I'm throwing an UncheckedRestException, which makes the BotRunner treat it as a warning instead of logging SEVERE. The assumption is that this happens randomly, just like other rest call failures, and that most WorkItems will just have to be rerun at a later time.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1166](https://bugs.openjdk.java.net/browse/SKARA-1166): New Gitlab version is causing "Initial paginated response no longer paginated" errors


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1220/head:pull/1220` \
`$ git checkout pull/1220`

Update a local copy of the PR: \
`$ git checkout pull/1220` \
`$ git pull https://git.openjdk.java.net/skara pull/1220/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1220`

View PR using the GUI difftool: \
`$ git pr show -t 1220`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1220.diff">https://git.openjdk.java.net/skara/pull/1220.diff</a>

</details>
