### PR TITLE
1079: Support ability to defer and delegate timing of an integration

### DIFF
--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrateTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrateTests.java
@@ -1357,8 +1357,7 @@ class IntegrateTests {
             assertEquals(1, undeferred, "Missing undeferred message");
             assertFalse(authorPr.labelNames().contains("deferred"));
 
-            // Try integrating as another committer, which should fails since the PR is currently not deferred
-            // Try to integrate by committer
+            // Try integrating as another committer, which should fail since the PR is currently not deferred
             var integratorPr = integrator.pullRequest(authorPr.id());
             integratorPr.addComment("/integrate");
             TestBotRunner.runPeriodicItems(mergeBot);

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrateTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrateTests.java
@@ -44,14 +44,13 @@ class IntegrateTests {
              var tempFolder = new TemporaryDirectory();
              var pushedFolder = new TemporaryDirectory()) {
 
+            var botUser = credentials.getHostedRepository();
             var author = credentials.getHostedRepository();
-            var integrator = credentials.getHostedRepository();
             var reviewer = credentials.getHostedRepository();
             var censusBuilder = credentials.getCensusBuilder()
                                            .addCommitter(author.forge().currentUser().id())
-                                           .addReviewer(integrator.forge().currentUser().id())
                                            .addReviewer(reviewer.forge().currentUser().id());
-            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
+            var mergeBot = PullRequestBot.newBuilder().repo(botUser).censusRepo(censusBuilder.build()).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -65,8 +64,8 @@ class IntegrateTests {
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Approve it as another user
-            var approvalPr = integrator.pullRequest(pr.id());
-            approvalPr.addReview(Review.Verdict.APPROVED, "Approved");
+            var reviewerPr = reviewer.pullRequest(pr.id());
+            reviewerPr.addReview(Review.Verdict.APPROVED, "Approved");
 
             // The bot should reply with integration message
             TestBotRunner.runPeriodicItems(mergeBot);
@@ -234,7 +233,7 @@ class IntegrateTests {
             TestBotRunner.runPeriodicItems(mergeBot);
 
             // The bot should reply with an error message
-            assertLastCommentContains(pr, "PR has not yet been marked as ready for integration");
+            assertLastCommentContains(pr, "pull request has not yet been marked as ready for integration");
         }
     }
 
@@ -651,7 +650,7 @@ class IntegrateTests {
 
             // The bot should reply with an error message
             TestBotRunner.runPeriodicItems(mergeBot);
-            assertLastCommentContains(pr, "PR has not yet been marked as ready for integration");
+            assertLastCommentContains(pr, "pull request has not yet been marked as ready for integration");
         }
     }
 
@@ -1294,6 +1293,105 @@ class IntegrateTests {
             assertFalse(pr.labelNames().contains("ready"), "ready label not removed");
             assertFalse(pr.labelNames().contains("rfr"), "rfr label not removed");
             assertTrue(pr.labelNames().contains("integrated"), "integrated label not added");
+        }
+    }
+
+    @Test
+    void defer(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory();
+             var pushedFolder = new TemporaryDirectory()) {
+
+            var botUser = credentials.getHostedRepository();
+            var author = credentials.getHostedRepository();
+            var reviewer = credentials.getHostedRepository();
+            var badIntegrator = credentials.getHostedRepository();
+            var integrator = credentials.getHostedRepository();
+            var censusBuilder = credentials.getCensusBuilder()
+                    .addCommitter(author.forge().currentUser().id())
+                    .addReviewer(reviewer.forge().currentUser().id())
+                    .addAuthor(badIntegrator.forge().currentUser().id())
+                    .addCommitter(integrator.forge().currentUser().id());
+            var mergeBot = PullRequestBot.newBuilder().repo(botUser).censusRepo(censusBuilder.build()).build();
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            var authorPr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
+
+            // Approve it as another user
+            var reviewerPr = reviewer.pullRequest(authorPr.id());
+            reviewerPr.addReview(Review.Verdict.APPROVED, "Approved");
+
+            // Issue /integrate defer command and verify the PR gets deferred
+            authorPr.addComment("/integrate defer");
+            TestBotRunner.runPeriodicItems(mergeBot);
+            var deferred = authorPr.comments().stream()
+                    .filter(comment -> comment.body().contains("Integration of this pull request has been deferred"))
+                    .count();
+            assertEquals(1, deferred, "Missing deferred message");
+            assertTrue(authorPr.labelNames().contains("deferred"));
+
+            // Try to integrate by non committer
+            var badIntegratorPr = badIntegrator.pullRequest(authorPr.id());
+            badIntegratorPr.addComment("/integrate");
+            TestBotRunner.runPeriodicItems(mergeBot);
+            var onlyCommitters = authorPr.comments().stream()
+                    .filter(comment -> comment.body()
+                            .contains("Only project committers are allowed to issue the `integrate` command on a deferred pull request."))
+                    .count();
+            assertEquals(1, onlyCommitters, "Missing error about only committers can integrate");
+
+            // Issue /integrate undefer and verify the PR is no longer deferred
+            authorPr.addComment("/integrate undefer");
+            TestBotRunner.runPeriodicItems(mergeBot);
+            var undeferred = authorPr.comments().stream()
+                    .filter(comment -> comment.body().contains("Integration of this pull request is no longer deferred and may only be integrated by the author"))
+                    .count();
+            assertEquals(1, undeferred, "Missing undeferred message");
+            assertFalse(authorPr.labelNames().contains("deferred"));
+
+            // Defer again
+            authorPr.addComment("/integrate defer");
+            TestBotRunner.runPeriodicItems(mergeBot);
+            assertTrue(authorPr.labelNames().contains("deferred"));
+
+            // Try to issue /integrate with an invalid command for a non author
+            var integratorPr = integrator.pullRequest(authorPr.id());
+            integratorPr.addComment("/integrate auto");
+            TestBotRunner.runPeriodicItems(mergeBot);
+            var invalid = authorPr.comments().stream()
+                    .filter(comment -> comment.body().contains("Only the author"))
+                    .count();
+            assertEquals(1, invalid, "Missing error message");
+
+            // Try to integrate by committer
+            integratorPr.addComment("/integrate");
+            TestBotRunner.runPeriodicItems(mergeBot);
+
+            // The change should now be present on the master branch
+            var pushedRepo = Repository.materialize(pushedFolder.path(), author.url(), "master");
+            assertTrue(CheckableRepository.hasBeenEdited(pushedRepo));
+
+            var headHash = pushedRepo.resolve("HEAD").orElseThrow();
+            var headCommit = pushedRepo.commits(headHash.hex() + "^.." + headHash.hex()).asList().get(0);
+
+            // Author and committer should be the same
+            assertEquals("Generated Committer 1", headCommit.author().name());
+            assertEquals("integrationcommitter1@openjdk.java.net", headCommit.author().email());
+            assertEquals("Generated Committer 4", headCommit.committer().name());
+            assertEquals("integrationcommitter4@openjdk.java.net", headCommit.committer().email());
+            assertTrue(authorPr.labelNames().contains("integrated"));
+
+            // Ready label should have been removed
+            assertFalse(authorPr.labelNames().contains("ready"));
+            assertFalse(authorPr.labelNames().contains("deferred"));
         }
     }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PreIntegrateTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PreIntegrateTests.java
@@ -92,7 +92,7 @@ public class PreIntegrateTests {
             // Try to integrate it
             followUpPr.addComment("/integrate");
             TestBotRunner.runPeriodicItems(mergeBot);
-            assertLastCommentContains(followUpPr, "This PR has not yet been marked as ready for integration");
+            assertLastCommentContains(followUpPr, "This pull request has not yet been marked as ready for integration");
 
             // Push something unrelated to the target
             localRepo.checkout(masterHash, true);

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ReviewersTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ReviewersTests.java
@@ -179,7 +179,7 @@ public class ReviewersTests {
             // It should not be possible to integrate yet
             pr.addComment("/integrate");
             TestBotRunner.runPeriodicItems(prBot);
-            assertLastCommentContains(reviewerPr,"PR has not yet been marked as ready for integration");
+            assertLastCommentContains(reviewerPr,"pull request has not yet been marked as ready for integration");
 
             // Relax the requirement
             reviewerPr.addComment("/reviewers 1");

--- a/test/src/main/java/org/openjdk/skara/test/HostCredentials.java
+++ b/test/src/main/java/org/openjdk/skara/test/HostCredentials.java
@@ -187,7 +187,8 @@ public class HostCredentials implements AutoCloseable {
                 HostUser.create(1, "user1", "User Number 1"),
                 HostUser.create(2, "user2", "User Number 2"),
                 HostUser.create(3, "user3", "User Number 3"),
-                HostUser.create(4, "user4", "User Number 4")
+                HostUser.create(4, "user4", "User Number 4"),
+                HostUser.create(5, "user5", "User Number 5")
         );
 
         private TestHost createHost(int userIndex) {


### PR DESCRIPTION
Here is my first stab at implementing a way for a PR author to defer integration to another committer. The usecase for this is if the timing of the integration is important, but the author may not be available to issue the /integrate command at the desired time. 

Here is how it works: There are two new arguments to the /integrate command "defer" and "undefer". If the author of a PR issues "/integrate defer", the PR enters the deferred state (which is marked by the label "deferred"). This enables any committer to issue "/integrate" to actually perform the integration. When a PR is integrated by someone other than the author, then that person gets attributed in the Git committer field, just like when a change is sponsored. The author can revert this ability at any time before integration happens by issuing "/integrate undefer".

This is similar to how sponsoring a change works, but not quite the same. When setting up for being sponsored, the /integrate command will run all the checks and record the specific hash that the author wishes to commit. I skipped this kind of rigorous book keeping here as I think it is more likely to get in the way in the desired usecase. The whole point is that timing is important and the author is not available, so better to leave things more open in my opinion.

I'm open to informed suggestions on how this could potentially be improved on a conceptual level.

When writing the test, I based it on the simpleMerge test already present. It took some work to properly understand what was happening in that test, and to make it clearer (at least to me), I have renamed and reorganized things a little bit. In these tests, the HostedRepository instances ("author", "integrator", "reviewer" etc) represent users and are used to create PR test instances (or views) which the test can use to interact with the PR as different users. To make this clearer, I introduced the botUser explicitly as that is also a user that sometimes issues commands and interacts with a PR, and used that for things that the bot is doing. I also changed some other users around so that they perform the role for which they are named (reviewer reviews, not the integrator).

When composing the messages that the bot will print back in comments, I noticed that "PR" and "pull request" were used interchangeably. I decided to standardize on "pull request".

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1079](https://bugs.openjdk.java.net/browse/SKARA-1079): Support ability to defer and delegate timing of an integration


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1221/head:pull/1221` \
`$ git checkout pull/1221`

Update a local copy of the PR: \
`$ git checkout pull/1221` \
`$ git pull https://git.openjdk.java.net/skara pull/1221/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1221`

View PR using the GUI difftool: \
`$ git pr show -t 1221`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1221.diff">https://git.openjdk.java.net/skara/pull/1221.diff</a>

</details>
