### PR TITLE
1191: CommitCommentWorkItem overwhelms scheduler

### DIFF
--- a/bots/csr/src/main/java/org/openjdk/skara/bots/csr/CSRBot.java
+++ b/bots/csr/src/main/java/org/openjdk/skara/bots/csr/CSRBot.java
@@ -53,7 +53,7 @@ class CSRBot implements Bot, WorkItem {
             return true;
         }
 
-        return !repo.webUrl().equals(((CSRBot) other).repo.webUrl());
+        return !repo.isSame(((CSRBot) other).repo);
     }
 
     private String describe(PullRequest pr) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommandWorkItem.java
@@ -81,11 +81,10 @@ public class CommitCommandWorkItem implements WorkItem {
 
     @Override
     public boolean concurrentWith(WorkItem other) {
-        if (!(other instanceof CommitCommandWorkItem)) {
+        if (!(other instanceof CommitCommandWorkItem otherItem)) {
             return true;
         }
-        CommitCommandWorkItem otherItem = (CommitCommandWorkItem) other;
-        if (!bot.repo().webUrl().equals(otherItem.bot.repo().webUrl())) {
+        if (!bot.repo().isSame(otherItem.bot.repo())) {
             return true;
         }
         if (!commitComment.id().equals(otherItem.commitComment.id())) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommentsWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommentsWorkItem.java
@@ -49,7 +49,13 @@ class CommitCommentsWorkItem implements WorkItem {
 
     @Override
     public boolean concurrentWith(WorkItem other) {
-        return true;
+        if (!(other instanceof CommitCommentsWorkItem otherItem)) {
+            return true;
+        }
+        if (!repo.isSame(otherItem.repo)) {
+            return true;
+        }
+        return false;
     }
 
     private boolean isAncestor(ReadOnlyRepository repo, Hash ancestor, Hash descendant) {

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
@@ -131,4 +131,11 @@ public interface HostedRepository {
 
         return null;
     }
+
+    /**
+     * Returns true if this HostedRepository represents the same repo as the other.
+     */
+    default boolean isSame(HostedRepository other) {
+        return name().equals(other.name()) && forge().name().equals(other.forge().name());
+    }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
@@ -168,8 +168,6 @@ public interface PullRequest extends Issue {
      * Returns true if this PullRequest represents the same pull request as the other.
      */
     default boolean isSame(PullRequest other) {
-        return id().equals(other.id())
-                && repository().name().equals(other.repository().name())
-                && repository().forge().name().equals(other.repository().forge().name());
+        return id().equals(other.id()) && repository().isSame(other.repository());
     }
 }


### PR DESCRIPTION
Main goal if this patch is to fix the scheduling issue caused by CommitCommentsWorkItems::concurrentWith always returning true. To solve this a little nicer, I decided to expand on the idea I introduced a while back with PullRequest::isSame, and add the corresponding method to HostedRepository. This made implementing the ::concurrentWith methods cleaner IMO.

In addition to this, I decided to add two new gauges to the metrics collection, which would have made it much easier to discover this issue if we already had them. These gauges report the number of active and pending WorkItems we have respectively in the BotRunner, summarized per WorkItem type using labels. To achieve this as nicely as I could, I refactored the BotRunner a little bit, moving all adds and removes for the active and pending maps to specific methods.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1191](https://bugs.openjdk.java.net/browse/SKARA-1191): CommitCommentWorkItem overwhelms scheduler


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1223/head:pull/1223` \
`$ git checkout pull/1223`

Update a local copy of the PR: \
`$ git checkout pull/1223` \
`$ git pull https://git.openjdk.java.net/skara pull/1223/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1223`

View PR using the GUI difftool: \
`$ git pr show -t 1223`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1223.diff">https://git.openjdk.java.net/skara/pull/1223.diff</a>

</details>
