### PR TITLE
SKARA-1194: Implement git webrev --no-comments option

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitWebrev.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitWebrev.java
@@ -259,7 +259,7 @@ public class GitWebrev {
             }
         }
 
-        var noComments = arguments.contains("no-comments");
+        var comments = !arguments.contains("no-comments");
 
         if (arguments.contains("base") && arguments.contains("rev")) {
             System.err.println("error: cannot combine --base and --rev options");
@@ -451,7 +451,7 @@ public class GitWebrev {
                   .version(version)
                   .files(files)
                   .similarity(similarity)
-                  .noComments(noComments)
+                  .comments(comments)
                   .generate(base, head);
         }
     }

--- a/cli/src/main/java/org/openjdk/skara/cli/GitWebrev.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitWebrev.java
@@ -259,6 +259,8 @@ public class GitWebrev {
             }
         }
 
+        var noComments = arguments.contains("no-comments");
+
         if (arguments.contains("base") && arguments.contains("rev")) {
             System.err.println("error: cannot combine --base and --rev options");
             System.exit(1);
@@ -449,6 +451,7 @@ public class GitWebrev {
                   .version(version)
                   .files(files)
                   .similarity(similarity)
+                  .noComments(noComments)
                   .generate(base, head);
         }
     }

--- a/webrev/src/main/java/org/openjdk/skara/webrev/AddedFileView.java
+++ b/webrev/src/main/java/org/openjdk/skara/webrev/AddedFileView.java
@@ -125,11 +125,13 @@ class AddedFileView implements FileView {
 
         if (patch.isTextual()) {
             w.write("<blockquote>\n");
-            w.write("  <pre>\n");
-            w.write(commits.stream()
-                           .map(formatter::format)
-                           .collect(Collectors.joining("\n")));
-            w.write("  </pre>\n");
+            if (!commits.isEmpty()) {
+                w.write("  <pre>\n");
+                w.write(commits.stream()
+                        .map(formatter::format)
+                        .collect(Collectors.joining("\n")));
+                w.write("  </pre>\n");
+            }
             w.write("  <span class=\"stat\">\n");
             w.write(stats.toString());
             w.write("  </span>");

--- a/webrev/src/main/java/org/openjdk/skara/webrev/ModifiedFileView.java
+++ b/webrev/src/main/java/org/openjdk/skara/webrev/ModifiedFileView.java
@@ -192,11 +192,13 @@ class ModifiedFileView implements FileView {
 
         if (patch.isTextual()) {
             w.write("<blockquote>\n");
-            w.write("  <pre>\n");
-            w.write(commits.stream()
-                           .map(formatter::format)
-                           .collect(Collectors.joining("\n")));
-            w.write("  </pre>\n");
+            if (!commits.isEmpty()) {
+                w.write("  <pre>\n");
+                w.write(commits.stream()
+                        .map(formatter::format)
+                        .collect(Collectors.joining("\n")));
+                w.write("  </pre>\n");
+            }
             w.write("  <span class=\"stat\">\n");
             w.write(stats.toString());
             w.write("  </span>");

--- a/webrev/src/main/java/org/openjdk/skara/webrev/RemovedFileView.java
+++ b/webrev/src/main/java/org/openjdk/skara/webrev/RemovedFileView.java
@@ -102,11 +102,13 @@ class RemovedFileView implements FileView {
 
         if (patch.isTextual()) {
             w.write("<blockquote>\n");
-            w.write("  <pre>\n");
-            w.write(commits.stream()
-                           .map(formatter::format)
-                           .collect(Collectors.joining("\n")));
-            w.write("  </pre>\n");
+            if (!commits.isEmpty()) {
+                w.write("  <pre>\n");
+                w.write(commits.stream()
+                        .map(formatter::format)
+                        .collect(Collectors.joining("\n")));
+                w.write("  </pre>\n");
+            }
             w.write("  <span class=\"stat\">\n");
             w.write(stats.toString());
             w.write("  </span>");

--- a/webrev/src/main/java/org/openjdk/skara/webrev/Webrev.java
+++ b/webrev/src/main/java/org/openjdk/skara/webrev/Webrev.java
@@ -84,6 +84,7 @@ public class Webrev {
         private String version;
         private List<Path> files = List.of();
         private int similarity = 90;
+        private boolean noComments;
 
         Builder(ReadOnlyRepository repository, Path output) {
             this.repository = repository;
@@ -159,6 +160,11 @@ public class Webrev {
 
         public Builder similarity(int similarity) {
             this.similarity = similarity;
+            return this;
+        }
+
+        public Builder noComments(boolean noComments) {
+            this.noComments = noComments;
             return this;
         }
 
@@ -384,7 +390,7 @@ public class Webrev {
                 var path = status.isDeleted() ?
                     patch.source().path().get() :
                     patch.target().path().get();
-                var commits = repository.commitMetadata(tailEnd, headHash, List.of(path));
+                var commits = noComments ? Collections.<CommitMetadata>emptyList() : repository.commitMetadata(tailEnd, headHash, List.of(path));
                 if (status.isModified() || status.isRenamed() || status.isCopied()) {
                     var nav = navigations.removeFirst();
                     fileViews.add(new ModifiedFileView(repository, tailEnd, head, commits, formatter, patch, output, nav));

--- a/webrev/src/main/java/org/openjdk/skara/webrev/Webrev.java
+++ b/webrev/src/main/java/org/openjdk/skara/webrev/Webrev.java
@@ -84,7 +84,7 @@ public class Webrev {
         private String version;
         private List<Path> files = List.of();
         private int similarity = 90;
-        private boolean noComments;
+        private boolean comments;
 
         Builder(ReadOnlyRepository repository, Path output) {
             this.repository = repository;
@@ -163,8 +163,8 @@ public class Webrev {
             return this;
         }
 
-        public Builder noComments(boolean noComments) {
-            this.noComments = noComments;
+        public Builder comments(boolean comments) {
+            this.comments = comments;
             return this;
         }
 
@@ -390,7 +390,7 @@ public class Webrev {
                 var path = status.isDeleted() ?
                     patch.source().path().get() :
                     patch.target().path().get();
-                var commits = noComments ? Collections.<CommitMetadata>emptyList() : repository.commitMetadata(tailEnd, headHash, List.of(path));
+                var commits = comments ? repository.commitMetadata(tailEnd, headHash, List.of(path)) : Collections.<CommitMetadata>emptyList();
                 if (status.isModified() || status.isRenamed() || status.isCopied()) {
                     var nav = navigations.removeFirst();
                     fileViews.add(new ModifiedFileView(repository, tailEnd, head, commits, formatter, patch, output, nav));


### PR DESCRIPTION
hg webrev had a `-C` / `--no-comments` option that skipped printing the comments for each file, i.e. commit messages. GitWebrev accepts the same option, but it does not seem to be implemented. Producing a webrev for a branch with a lot of commits looks badly then.

For example, current report with `-C`:

```
 ------ ------ ------ ------ --- New Patch Raw doc/panama_jextract.html

    8065b5cc: 8270898: update panama_jextract.md and panama_jextract.html files
    bedc58a3: 8257892: long double not handled by jextract
    2d966367: Consolidate all the various documents in the repository.
    3dc23ea0: 8253419: jextract should generate RuntimeHelper as a package private class
    52adf7f5: updating samples for CSupport->CLinker
    33cba7a0: adding tensorflow sample
    06675b1e: updating samples. changed constants class to use package constructor
    6809ef51: Samples update after 8249879. Added opengl sample
    abb6e377: updating samples for recent MemoryAccess changes.
    ebba5406: 8248710: jextract should not generate Cstring, Cpointer, Cint C-X utility classes
    45d41d75: * Fixed include path to be OS/SDK version independent
    ...

    992 lines changed; 992 ins; 0 del; 0 mod; 0 unchg
```

Fixed report with `-C`:

```
 ------ ------ ------ ------ --- New Patch Raw doc/panama_jextract.html

    992 lines changed; 992 ins; 0 del; 0 mod; 0 unchg 
```

Additional testing:
 - [x] Eyeballing the reports with/without `-C`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1194](https://bugs.openjdk.java.net/browse/SKARA-1194): Implement git webrev --no-comments option


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1224/head:pull/1224` \
`$ git checkout pull/1224`

Update a local copy of the PR: \
`$ git checkout pull/1224` \
`$ git pull https://git.openjdk.java.net/skara pull/1224/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1224`

View PR using the GUI difftool: \
`$ git pr show -t 1224`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1224.diff">https://git.openjdk.java.net/skara/pull/1224.diff</a>

</details>
