### PR TITLE
1197: Label changes from java.nio.** as nio

### DIFF
--- a/config/mailinglist/rules/jdk.json
+++ b/config/mailinglist/rules/jdk.json
@@ -518,6 +518,7 @@
             "test/micro/org/openjdk/bench/java/net/"
         ],
         "nio": [
+            "src/java.base/\\w+/classes/java/nio/",
             "src/java.base/\\w+/classes/sun/nio/",
             "src/java.base/\\w+/native/libnio/",
             "src/jdk.nio.mapmode/",


### PR DESCRIPTION
Please review this PR which adds a mailing list rule for New I/O (NIO). The change was tested as per https://mail.openjdk.java.net/pipermail/jdk-dev/2020-August/004662.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1197](https://bugs.openjdk.java.net/browse/SKARA-1197): Label changes from java.nio.** as nio


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1225/head:pull/1225` \
`$ git checkout pull/1225`

Update a local copy of the PR: \
`$ git checkout pull/1225` \
`$ git pull https://git.openjdk.java.net/skara pull/1225/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1225`

View PR using the GUI difftool: \
`$ git pr show -t 1225`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1225.diff">https://git.openjdk.java.net/skara/pull/1225.diff</a>

</details>
