### PR TITLE
Improve "git sync" and "git fork" resilience

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitFork.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitFork.java
@@ -212,20 +212,20 @@ public class GitFork {
                 repo.addRemote("upstream", upstreamWebURI.toString());
             }
             System.out.println("done");
+        }
 
-            if (getSwitch("sync")) {
-                if (!isDryRun) {
-                    GitSync.sync(repo, new String[] {"--from", "upstream", "--to", "origin", "--fast-forward"});
-                }
+        if (getSwitch("sync")) {
+            if (!isDryRun) {
+                GitSync.sync(repo, new String[] {"--from", "upstream", "--to", "origin", "--fast-forward"});
             }
+        }
 
-            var setupPrePushHooksOption = getSwitch("setup-pre-push-hook");
-            if (setupPrePushHooksOption) {
-                if (!isDryRun) {
-                    var res = GitJCheck.run(repo, new String[] {"--setup-pre-push-hook"});
-                    if (res != 0) {
-                        System.exit(res);
-                    }
+        var setupPrePushHooksOption = getSwitch("setup-pre-push-hook");
+        if (setupPrePushHooksOption) {
+            if (!isDryRun) {
+                var res = GitJCheck.run(repo, new String[] {"--setup-pre-push-hook"});
+                if (res != 0) {
+                    System.exit(res);
                 }
             }
         }

--- a/cli/src/main/java/org/openjdk/skara/cli/GitFork.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitFork.java
@@ -247,19 +247,10 @@ public class GitFork {
     }
 
     private URI getCloneURI(URI originWebURI) {
-        boolean useSSH = getSwitch("ssh");
-        if (getOption("host") != null) {
-            if (useSSH) {
-                return URI.create("ssh://git@" + originWebURI.getHost() + originWebURI.getPath() + ".git");
-            } else {
-                return URI.create("https://" + originWebURI.getHost() + originWebURI.getPath());
-            }
+        if (getSwitch("ssh")) {
+            return URI.create("ssh://git@" + originWebURI.getHost() + originWebURI.getPath() + ".git");
         } else {
-            if (useSSH) {
-                return URI.create("ssh://git@" + originWebURI.getHost() + originWebURI.getPath() + ".git");
-            } else {
-                return originWebURI;
-            }
+            return originWebURI;
         }
     }
 
@@ -357,11 +348,7 @@ public class GitFork {
                         .optional(),
                 Switch.shortcut("")
                         .fullname("ssh")
-                        .helptext("Use the ssh:// protocol when cloning")
-                        .optional(),
-                Switch.shortcut("")
-                        .fullname("https")
-                        .helptext("Use the https:// protocol when cloning")
+                        .helptext("Use the ssh:// protocol when cloning (instead of https)")
                         .optional(),
                 Switch.shortcut("")
                         .fullname("sync")

--- a/cli/src/main/java/org/openjdk/skara/cli/GitSync.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitSync.java
@@ -213,6 +213,14 @@ public class GitSync {
                     System.exit(1);
                 }
             }
+        } else {
+            // Repo is badly configured, fix it unless instructed not to
+            if (!arguments.contains("no-remote")) {
+                System.out.println("Setting 'upstream' remote to " + sourceParentURI);
+                if (!isDryRun) {
+                    repo.addRemote("upstream", sourceParentURI.toString());
+                }
+            }
         }
 
         // Find pull source as given by command line options
@@ -457,6 +465,10 @@ public class GitSync {
                   .fullname("fast-forward")
                   .helptext("Fast forward all local branches where possible")
                   .optional(),
+            Switch.shortcut("N")
+                   .fullname("no-remote")
+                   .helptext("Do not add an additional git remote")
+                   .optional(),
             Switch.shortcut("n")
                    .fullname("dry-run")
                    .helptext("Only simulate behavior, do no actual changes")

--- a/cli/src/main/java/org/openjdk/skara/cli/GitSync.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitSync.java
@@ -465,7 +465,7 @@ public class GitSync {
                   .fullname("fast-forward")
                   .helptext("Fast forward all local branches where possible")
                   .optional(),
-            Switch.shortcut("N")
+            Switch.shortcut("")
                    .fullname("no-remote")
                    .helptext("Do not add an additional git remote")
                    .optional(),

--- a/cli/src/main/java/org/openjdk/skara/cli/GitSync.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitSync.java
@@ -62,7 +62,11 @@ public class GitSync {
             if (remotes.contains(name)) {
                 return Remote.toURI(repo.pullPath(name));
             } else {
-                return Remote.toURI(name);
+                try {
+                    return Remote.toURI(name);
+                } catch (IOException e) {
+                    die(name + " is not a known git remote, nor a proper git URI");
+                }
             }
         }
         return null;
@@ -285,6 +289,10 @@ public class GitSync {
         if (arguments.contains("verbose") || arguments.contains("debug")) {
             var level = arguments.contains("debug") ? Level.FINER : Level.FINE;
             Logging.setup(level);
+        }
+
+        if (isDryRun) {
+            System.out.println("Running in dry-run mode. No actual changes will be performed");
         }
 
         HttpProxy.setup();

--- a/cli/src/main/java/org/openjdk/skara/cli/GitSync.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitSync.java
@@ -506,7 +506,7 @@ public class GitSync {
                 die("no repository found at " + cwd)
         );
 
-        GitSync syncer = new GitSync(repo, parseArguments(args));
-        syncer.sync();
+        GitSync commandExecutor = new GitSync(repo, parseArguments(args));
+        commandExecutor.sync();
     }
 }

--- a/cli/src/main/java/org/openjdk/skara/cli/GitSync.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitSync.java
@@ -75,6 +75,11 @@ public class GitSync {
         return lines.size() == 1 ? lines.get(0) : null;
     }
 
+    public static void sync(Repository repo, String[] args) throws IOException, InterruptedException {
+        GitSync syncer = new GitSync(repo, parseArguments(args));
+        syncer.sync();
+    }
+
     public void sync() throws IOException, InterruptedException {
         if (arguments.contains("version")) {
             System.out.println("git-sync version: " + Version.fromManifest().orElse("unknown"));

--- a/cli/src/main/java/org/openjdk/skara/cli/GitSync.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitSync.java
@@ -496,8 +496,8 @@ public class GitSync {
     }
 
     public static void sync(Repository repo, String[] args) throws IOException, InterruptedException {
-        GitSync syncer = new GitSync(repo, parseArguments(args));
-        syncer.sync();
+        GitSync commandExecutor = new GitSync(repo, parseArguments(args));
+        commandExecutor.sync();
     }
 
     public static void main(String[] args) throws IOException, InterruptedException {


### PR DESCRIPTION
The Skara CLI tools `git sync` and `git fork` are very much appreciated, but they are not fully designed to make sure you get the intended result. Part of this problem is that they are too general, and part is that they are too dumb. :-)

These changes make sure that `git sync` always syncs between your personal fork, and the upstream repository (determined by the Git Forge provider as the "parent" repo you created your fork from), and `git fork` always sets up your repository for such `git sync` usage.

If you really know what you are doing, you *can* still use `git sync` to sync between fully unrelated repos using the `--to` and `--from` arguments, but this is highly discouraged (and will require the `--force` flag as well, to be accepted).

Before syncing, `git sync` will check that you have a proper `origin` and `upstream` remote configured, and that the upstream is consistent with what the Git Forge provider says. If the `upstream` remote is missing, it will be configured for you (unless `--no-remote` is given).

`git fork` will now always set the `upstream` remote (unless given `--no-remote`).

If these sounds like obvious behavior, it is worth noting what happened before. If `upstream` was missing, `git sync` had no idea what to do. `git fork` had a second, undocumented *) mode, in which you could run `git fork` without any arguments in a directory that already contained a checked out repo. That would create a personal fork of that repo on the Git Forge provider, but it would still keep `origin` as the upstream repo URI, and instead add a `fork` remote for the newly created personal fork. This mode of operation was barely supported (and broken) on `git sync`. The backwards way of naming the remotes could lead to no end of troubles. 

*) I say "undocumented" since there is no explicit documentation about this feature that I could found. However, the "upstream URI" argument to `git fork` is documented as "optional" (but all other documentation assumes that it is present, so the behavior when omitted is not specified).

When implementing these fixes, it was clear that the code was in desperate need of a massive cleanup. There were dead code, code duplication, unclear logic, misleading names, etc... So in the end the code is so different from what I started from that a side-by-side comparison might be impossible. You can see individual changes in the separate commits, or you can review the new version of the files as were they new additions. These refactorings also uncovered a bug in `git fork`, where adding `--no-remote` would disable `--sync` and `--setup-pre-push-hooks`. I fixed that also.

Unfortunately, we still don't have a testing story for our CLI tools. :-( I have however done extensive ad-hoc testing, with all possible combinations of flags, etc.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1226/head:pull/1226` \
`$ git checkout pull/1226`

Update a local copy of the PR: \
`$ git checkout pull/1226` \
`$ git pull https://git.openjdk.java.net/skara pull/1226/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1226`

View PR using the GUI difftool: \
`$ git pr show -t 1226`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1226.diff">https://git.openjdk.java.net/skara/pull/1226.diff</a>

</details>
