### PR TITLE
1196: Add extension points on RestRequest to support more REST authorization methods

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/JbsBackport.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/JbsBackport.java
@@ -41,7 +41,7 @@ public class JbsBackport {
 
     JbsBackport(URI uri, JbsVault vault) {
         if (vault != null) {
-            backportRequest = new RestRequest(backportRequest(uri), vault.authId(), () -> Arrays.asList("Cookie", vault.getCookie()));
+            backportRequest = new RestRequest(backportRequest(uri), vault.authId(), (r) -> Arrays.asList("Cookie", vault.getCookie()));
         } else {
             backportRequest = null;
         }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/JbsVault.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/JbsVault.java
@@ -51,7 +51,7 @@ public class JbsVault {
 
     JbsVault(URI vaultUri, String vaultToken, URI jiraUri) {
         authId = checksum(vaultToken);
-        request = new RestRequest(vaultUri, authId, () -> Arrays.asList(
+        request = new RestRequest(vaultUri, authId, (r) -> Arrays.asList(
                 "X-Vault-Token", vaultToken
         ));
         this.authProbe = URIBuilder.base(jiraUri).setPath("/rest/api/2/myself").build();
@@ -59,7 +59,7 @@ public class JbsVault {
 
     String getCookie() {
         if (cookie != null) {
-            var authProbeRequest = new RestRequest(authProbe, authId, () -> Arrays.asList("Cookie", cookie));
+            var authProbeRequest = new RestRequest(authProbe, authId, (r) -> Arrays.asList("Cookie", cookie));
             var res = authProbeRequest.get()
                                       .onError(error -> error.statusCode() >= 400 ? Optional.of(JSON.of("AUTH_ERROR")) : Optional.empty())
                                       .execute();

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubHost.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubHost.java
@@ -65,7 +65,7 @@ public class GitHubHost implements Forge {
                 .setPath("/")
                 .build();
 
-        request = new RestRequest(baseApi, application.authId(), () -> Arrays.asList(
+        request = new RestRequest(baseApi, application.authId(), (r) -> Arrays.asList(
                 "Authorization", "token " + getInstallationToken().orElseThrow(),
                 "Accept", "application/vnd.github.machine-man-preview+json",
                 "Accept", "application/vnd.github.antiope-preview+json",
@@ -76,7 +76,7 @@ public class GitHubHost implements Forge {
                 .appendSubDomain("api")
                 .setPath("/graphql")
                 .build();
-        graphQL = new RestRequest(graphQLAPI, application.authId(), () -> Arrays.asList(
+        graphQL = new RestRequest(graphQLAPI, application.authId(), (r) -> Arrays.asList(
                 "Authorization", "bearer " + getInstallationToken().orElseThrow(),
                 "Accept", "application/vnd.github.machine-man-preview+json",
                 "Accept", "application/vnd.github.antiope-preview+json",
@@ -106,7 +106,7 @@ public class GitHubHost implements Forge {
                                 .setPath("/")
                                 .build();
 
-        request = new RestRequest(baseApi, pat.username(), () -> Arrays.asList(
+        request = new RestRequest(baseApi, pat.username(), (r) -> Arrays.asList(
                 "Authorization", "token " + getInstallationToken().orElseThrow(),
                 "Accept", "application/vnd.github.machine-man-preview+json",
                 "Accept", "application/vnd.github.antiope-preview+json",
@@ -117,7 +117,7 @@ public class GitHubHost implements Forge {
                 .appendSubDomain("api")
                 .setPath("/graphql")
                 .build();
-        graphQL = new RestRequest(graphQLAPI, pat.username(), () -> Arrays.asList(
+        graphQL = new RestRequest(graphQLAPI, pat.username(), (r) -> Arrays.asList(
                 "Authorization", "bearer " + getInstallationToken().orElseThrow(),
                 "Accept", "application/vnd.github.machine-man-preview+json",
                 "Accept", "application/vnd.github.antiope-preview+json",

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -60,7 +60,7 @@ public class GitHubRepository implements HostedRepository {
                 .appendSubDomain("api")
                 .setPath("/repos/" + repository + "/")
                 .build();
-        request = new RestRequest(apiBase, gitHubHost.authId().orElse(null), () -> {
+        request = new RestRequest(apiBase, gitHubHost.authId().orElse(null), (r) -> {
             var headers = new ArrayList<>(List.of(
                 "Accept", "application/vnd.github.machine-man-preview+json",
                 "Accept", "application/vnd.github.antiope-preview+json",

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabHost.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabHost.java
@@ -56,7 +56,7 @@ public class GitLabHost implements Forge {
         var baseApi = URIBuilder.base(uri)
                                 .setPath("/api/v4/")
                                 .build();
-        request = new RestRequest(baseApi, pat.username(), () -> Arrays.asList("Private-Token", pat.password()));
+        request = new RestRequest(baseApi, pat.username(), (r) -> Arrays.asList("Private-Token", pat.password()));
     }
 
     GitLabHost(String name, URI uri, boolean useSsh, Set<String> groups) {

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -70,7 +70,7 @@ public class GitLabRepository implements HostedRepository {
                 .build();
 
         request = gitLabHost.getPat()
-                            .map(pat -> new RestRequest(baseApi, pat.username(), () -> Arrays.asList("Private-Token", pat.password())))
+                            .map(pat -> new RestRequest(baseApi, pat.username(), (r) -> Arrays.asList("Private-Token", pat.password())))
                             .orElseGet(() -> new RestRequest(baseApi));
 
         var urlPattern = URIBuilder.base(gitLabHost.getUri())

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraHost.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraHost.java
@@ -56,7 +56,7 @@ public class JiraHost implements IssueTracker {
         var baseApi = URIBuilder.base(uri)
                                 .setPath("/rest/api/2/")
                                 .build();
-        request = new RestRequest(baseApi, jiraVault.authId(), () -> Arrays.asList("Cookie", jiraVault.getCookie()));
+        request = new RestRequest(baseApi, jiraVault.authId(), (r) -> Arrays.asList("Cookie", jiraVault.getCookie()));
     }
 
     JiraHost(URI uri, JiraVault jiraVault, String visibilityRole, String securityLevel) {
@@ -66,7 +66,7 @@ public class JiraHost implements IssueTracker {
         var baseApi = URIBuilder.base(uri)
                                 .setPath("/rest/api/2/")
                                 .build();
-        request = new RestRequest(baseApi, jiraVault.authId(), () -> Arrays.asList("Cookie", jiraVault.getCookie()));
+        request = new RestRequest(baseApi, jiraVault.authId(), (r) -> Arrays.asList("Cookie", jiraVault.getCookie()));
     }
 
     URI getUri() {

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraVault.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraVault.java
@@ -51,7 +51,7 @@ class JiraVault {
 
     JiraVault(URI vaultUri, String vaultToken, URI jiraUri) {
         authId = checksum(vaultToken);
-        request = new RestRequest(vaultUri, authId, () -> Arrays.asList(
+        request = new RestRequest(vaultUri, authId, (r) -> Arrays.asList(
                 "X-Vault-Token", vaultToken
         ));
         this.authProbe = URIBuilder.base(jiraUri).setPath("/rest/api/2/myself").build();
@@ -59,7 +59,7 @@ class JiraVault {
 
     String getCookie() {
         if (cookie != null) {
-            var authProbeRequest = new RestRequest(authProbe, authId, () -> Arrays.asList("Cookie", cookie));
+            var authProbeRequest = new RestRequest(authProbe, authId, (r) -> Arrays.asList("Cookie", cookie));
             var res = authProbeRequest.get()
                     .onError(error -> error.statusCode() >= 400 ? Optional.of(JSON.of("AUTH_ERROR")) : Optional.empty())
                     .execute();

--- a/network/src/main/java/org/openjdk/skara/network/URIBuilder.java
+++ b/network/src/main/java/org/openjdk/skara/network/URIBuilder.java
@@ -137,6 +137,11 @@ public class URIBuilder {
         return this;
     }
 
+    public URIBuilder setQuery(String query) {
+        current.query = query;
+        return this;
+    }
+
     public URIBuilder setQuery(Map<String, String> parameters) {
         var query = parameters.entrySet().stream()
                 .map(p -> {

--- a/network/src/test/java/org/openjdk/skara/network/RestRequestTests.java
+++ b/network/src/test/java/org/openjdk/skara/network/RestRequestTests.java
@@ -304,8 +304,8 @@ class RestRequestTests {
     void cachedSeparateAuth() throws IOException {
         try (var receiver = new RestReceiver()) {
             var plainRequest = new RestRequest(receiver.getEndpoint());
-            var authRequest1 = new RestRequest(receiver.getEndpoint(), "id1", () -> List.of("user", "1"));
-            var authRequest2 = new RestRequest(receiver.getEndpoint(), "id2", () -> List.of("user", "2"));
+            var authRequest1 = new RestRequest(receiver.getEndpoint(), "id1", (r) -> List.of("user", "1"));
+            var authRequest2 = new RestRequest(receiver.getEndpoint(), "id2", (r) -> List.of("user", "2"));
 
             plainRequest.get("/test").execute();
             assertFalse(receiver.usedCached());


### PR DESCRIPTION
This patch adds and extends some extension points in the RestRequest API. The immediate use of these extensions are being implemented in a custom extension to Skara. There are 3 main changes:

1. The optional lambda that handles authorization headers for a request now has access to the HttpRequest.Builder, so that it may inspect existing headers. This is causing a lot of small changes throughout the code base, just adding the new parameter to any lambda implementing the FunctionalInterface.
2. Adding a new optional field to the QueryBuilder, naming a header where a sha256 hash of the request body will be stored. Requiring such a hash seems common enough to have built in support for it in Skara, but the name of the header seems to differ between API providers.
3. Adding another optional lambda which can override how pagination is handled. This gets access to the HttpResponse to extract any necessary data to generate an HttpRequest.Builder for accessing the next page.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1196](https://bugs.openjdk.java.net/browse/SKARA-1196): Add extension points on RestRequest to support more REST authorization methods


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1227/head:pull/1227` \
`$ git checkout pull/1227`

Update a local copy of the PR: \
`$ git checkout pull/1227` \
`$ git pull https://git.openjdk.java.net/skara pull/1227/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1227`

View PR using the GUI difftool: \
`$ git pr show -t 1227`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1227.diff">https://git.openjdk.java.net/skara/pull/1227.diff</a>

</details>
