### PR TITLE
1186: Backport command stopped working on Gitlab

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -579,9 +579,9 @@ public class GitLabRepository implements HostedRepository {
     @Override
     public void addCollaborator(HostUser user, boolean canPush) {
         var accessLevel = canPush ? "30" : "20";
-        var data = "user_id=" + user.id() + "&access_level=" + accessLevel;
         request.post("members")
-               .body(data)
+                .body("user_id", user.id())
+                .body("access_level", accessLevel)
                .execute();
     }
 

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -580,8 +580,8 @@ public class GitLabRepository implements HostedRepository {
     public void addCollaborator(HostUser user, boolean canPush) {
         var accessLevel = canPush ? "30" : "20";
         request.post("members")
-                .body("user_id", user.id())
-                .body("access_level", accessLevel)
+               .body("user_id", user.id())
+               .body("access_level", accessLevel)
                .execute();
     }
 


### PR DESCRIPTION
Our POST request to `<api-entry>/members` to add collaborators fails with status code 415 (Unsupported Media Type) on recent versions of Gitlab.

This is the only place in our Gitlab code where we do not send REST parameters as json, but as `&`-concatted raw data. I can't find any indication in the Gitlab API documentation that this is no longer supported, but otoh there is no reason to continue handling this method different from all other REST calls.

So I am fairly certain that this patch solves the problem (which makes sure we use json parameters here as everywhere else). However, I have not been able to test this. We have no tests that run on live instances of Gitlab, and the adhoc testing setup that I have used to not have a repo where backports are enabled (and I'm also a bit uncertain on how to properly configure that).

I believe the patch is likely to be low risk to accept it nevertheless, but I'd like input from Kevin or Erik on this assessment.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1186](https://bugs.openjdk.java.net/browse/SKARA-1186): Backport command stopped working on Gitlab


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**) ⚠️ Review applies to 853f533f5f8d0a780239186fb46d1dc6998dbe6d


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1229/head:pull/1229` \
`$ git checkout pull/1229`

Update a local copy of the PR: \
`$ git checkout pull/1229` \
`$ git pull https://git.openjdk.java.net/skara pull/1229/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1229`

View PR using the GUI difftool: \
`$ git pr show -t 1229`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1229.diff">https://git.openjdk.java.net/skara/pull/1229.diff</a>

</details>
