### PR TITLE
1189: Update mapping so the Hotspot Style Guide is reviewed on hotspot-dev

### DIFF
--- a/config/mailinglist/rules/jdk.json
+++ b/config/mailinglist/rules/jdk.json
@@ -225,6 +225,7 @@
             "test/micro/org/openjdk/bench/vm/lang/"
         ],
         "hotspot": [
+            "doc/hotspot-.*",
             "src/hotspot/share/prims/",
             "src/hotspot/share/utilities/",
             "test/hotspot/gtest/utilities/",


### PR DESCRIPTION
This will add review target list hotspot-dev for doc/hotspot-style and doc/hotspot-unit-tests.

Since there is no exclude mechanism in the mailing list selection, it is not easy to exclude these from the build-dev target. In this case, I think it's okay to cross-post to build-dev (I like to keep track of documentation changes :)) but in the long term I think the mailing list rules should benefit from having an exclusion system to exclude certain subparts of a directory tree (not just in this case).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1189](https://bugs.openjdk.java.net/browse/SKARA-1189): Update mapping so the Hotspot Style Guide is reviewed on hotspot-dev


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1230/head:pull/1230` \
`$ git checkout pull/1230`

Update a local copy of the PR: \
`$ git checkout pull/1230` \
`$ git pull https://git.openjdk.java.net/skara pull/1230/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1230`

View PR using the GUI difftool: \
`$ git pr show -t 1230`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1230.diff">https://git.openjdk.java.net/skara/pull/1230.diff</a>

</details>
