### PR TITLE
1201: Multiple command reply messages include 'HostUserDetails'

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
@@ -58,9 +58,8 @@ public class BackportCommand implements CommandHandler {
 
     @Override
     public void handle(PullRequestBot bot, HostedCommit commit, CensusInstance censusInstance, Path scratchPath, CommandInvocation command, List<Comment> allComments, PrintWriter reply) {
-        var username = command.user().username();
         if (censusInstance.contributor(command.user()).isEmpty()) {
-            reply.println("@" + username + " only OpenJDK [contributors](https://openjdk.java.net/bylaws#contributor) can use the `/backport` command");
+            reply.println("Only OpenJDK [contributors](https://openjdk.java.net/bylaws#contributor) can use the `/backport` command");
             return;
         }
 
@@ -92,7 +91,7 @@ public class BackportCommand implements CommandHandler {
 
         var potentialTargetRepo = repoName.flatMap(forge::repository);
         if (potentialTargetRepo.isEmpty()) {
-            reply.println("@" + username + " the target repository `" + repoNameArg + "` is not a valid target for backports. ");
+            reply.println("The target repository `" + repoNameArg + "` is not a valid target for backports. ");
             reply.print("List of valid target repositories: ");
             reply.println(String.join(", ", bot.forks().keySet().stream().sorted().toList()) + ".");
             reply.println("Supplying the organization/group prefix is optional.");
@@ -104,7 +103,7 @@ public class BackportCommand implements CommandHandler {
         var targetBranchName = parts.length == 2 ? parts[1] : "master";
         var targetBranches = targetRepo.branches();
         if (targetBranches.stream().noneMatch(b -> b.name().equals(targetBranchName))) {
-            reply.println("@" + username + " the target branch `" + targetBranchName + "` does not exist");
+            reply.println("The target branch `" + targetBranchName + "` does not exist");
             return;
         }
         var targetBranch = new Branch(targetBranchName);
@@ -112,7 +111,7 @@ public class BackportCommand implements CommandHandler {
         try {
             var hash = commit.hash();
             Hash backportHash;
-            var backportBranchName = username + "-backport-" + hash.abbreviate();
+            var backportBranchName = command.user().username() + "-backport-" + hash.abbreviate();
             var hostedBackportBranch = fork.branches().stream().filter(b -> b.name().equals(backportBranchName)).findAny();
             if (hostedBackportBranch.isEmpty()) {
                 var localRepoDir = scratchPath.resolve("backport-command")
@@ -128,7 +127,7 @@ public class BackportCommand implements CommandHandler {
                 var didApply = localRepo.cherryPick(fetchHead);
                 if (!didApply) {
                     var lines = new ArrayList<String>();
-                    lines.add("@" + username + " could **not** automatically backport `" + hash.abbreviate() + "` to " +
+                    lines.add("Could **not** automatically backport `" + hash.abbreviate() + "` to " +
                               "[" + repoName + "](" + targetRepo.webUrl() + ") due to conflicts in the following files:");
                     lines.add("");
                     var unmerged = localRepo.status()

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CleanCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CleanCommand.java
@@ -55,25 +55,24 @@ public class CleanCommand implements CommandHandler {
     @Override
     public void handle(PullRequestBot bot, PullRequest pr, CensusInstance censusInstance, Path scratchPath, CommandInvocation command, List<Comment> allComments, PrintWriter reply)
     {
-        var username = command.user().username();
         if (!censusInstance.isCommitter(command.user())) {
-            reply.println("@" + username + " only OpenJDK [Committers](https://openjdk.java.net/bylaws#committer) can use the `/clean` command");
+            reply.println("Only OpenJDK [Committers](https://openjdk.java.net/bylaws#committer) can use the `/clean` command");
             return;
         }
 
         if (!pr.labelNames().contains("backport") || CheckablePullRequest.findOriginalBackportHash(pr) == null) {
-            reply.println("@" + username + " can only mark [backport pull requests]" +
+            reply.println("Can only mark [backport pull requests]" +
                     "(https://wiki.openjdk.java.net/display/SKARA/Backports#Backports-BackportPullRequests)," +
                     " with an original hash, as clean");
             return;
         }
 
         if (pr.labelNames().contains("clean")) {
-            reply.println("@" + username + " this backport pull request is already marked as clean");
+            reply.println("This backport pull request is already marked as clean");
             return;
         }
 
         pr.addLabel("clean");
-        reply.println("@" + username + " this backport pull request is now marked as clean");
+        reply.println("This backport pull request is now marked as clean");
     }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommandWorkItem.java
@@ -120,6 +120,9 @@ public class CommitCommandWorkItem implements WorkItem {
         var printer = new PrintWriter(writer);
 
         printer.println(String.format(commandReplyMarker, command.id()));
+        printer.print("@");
+        printer.print(command.user().username());
+        printer.print(" ");
 
         var handler = command.handler();
         if (handler.isPresent()) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/OpenCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/OpenCommand.java
@@ -56,19 +56,18 @@ public class OpenCommand implements CommandHandler {
     @Override
     public void handle(PullRequestBot bot, PullRequest pr, CensusInstance censusInstance, Path scratchPath, CommandInvocation command, List<Comment> allComments, PrintWriter reply)
     {
-        var user = command.user();
-        if (!user.equals(pr.author())) {
-            reply.println("@" + user + " only the pull request author can set the pull request state to \"open\"");
+        if (!command.user().equals(pr.author())) {
+            reply.println("Only the pull request author can set the pull request state to \"open\"");
             return;
         }
 
         if (pr.isOpen()) {
-            reply.println("@" + user + " this pull request is already open");
+            reply.println("This pull request is already open");
             return;
 
         }
 
         pr.setState(Issue.State.OPEN);
-        reply.println("@" + user + " this pull request is now open");
+        reply.println("This pull request is now open");
     }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/TagCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/TagCommand.java
@@ -61,13 +61,12 @@ public class TagCommand implements CommandHandler {
     @Override
     public void handle(PullRequestBot bot, HostedCommit commit, CensusInstance censusInstance, Path scratchPath, CommandInvocation command, List<Comment> allComments, PrintWriter reply) {
         try {
-            var username = command.user().username();
             if (censusInstance.contributor(command.user()).isEmpty()) {
-                reply.println("@" + username + " only OpenJDK [contributors](https://openjdk.java.net/bylaws#contributor) can use the `/tag` command.");
+                reply.println("Only OpenJDK [contributors](https://openjdk.java.net/bylaws#contributor) can use the `/tag` command.");
                 return;
             }
-            if (!bot.integrators().contains(username)) {
-                reply.println("@" + username + " only integrators for this repository are allowed to use the `/tag` command.");
+            if (!bot.integrators().contains(command.user().username())) {
+                reply.println("Only integrators for this repository are allowed to use the `/tag` command.");
                 return;
             }
 
@@ -95,14 +94,14 @@ public class TagCommand implements CommandHandler {
                 var hash = localRepo.resolve(tagName).orElseThrow(() ->
                         new IllegalStateException("Cannot resolve tag with name " + tagName + " in repo " + bot.repo().name()));
                 var hashUrl = bot.repo().webUrl(hash);
-                reply.println("@" + username + " a tag with name `" + tagName + "` already exists that refers to commit [" + hash.abbreviate() + "](" + hashUrl + "].");
+                reply.println("A tag with name `" + tagName + "` already exists that refers to commit [" + hash.abbreviate() + "](" + hashUrl + "].");
                 return;
             }
 
             var jcheckConf = JCheckConfiguration.from(localRepo, commit.hash());
             var tagPattern = jcheckConf.isPresent() ? jcheckConf.get().repository().tags() : null;
             if (tagPattern != null && !tagName.matches(tagPattern)) {
-                reply.println("@" + username + " the given tag name `" + tagName + "` is not of the form `" + tagPattern + "`.");
+                reply.println("The given tag name `" + tagName + "` is not of the form `" + tagPattern + "`.");
                 return;
             }
 
@@ -112,7 +111,7 @@ public class TagCommand implements CommandHandler {
             var message = "Added tag " + tagName + " for changeset " + commit.hash().abbreviate();
             var tag = localRepo.tag(commit.hash(), tagName, message, contributor.username(), email);
             localRepo.push(tag, bot.repo().url(), false);
-            reply.println("@" + username + " the tag [" + tag.name() + "](" + bot.repo().webUrl(tag) + ") was successfully created.");
+            reply.println("The tag [" + tag.name() + "](" + bot.repo().webUrl(tag) + ") was successfully created.");
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }


### PR DESCRIPTION
Fixing this as the bug reporter suggested, by removing all explicit (broken or not) and duplicated constructions of "@" + username in the command replies, and adding a general @-mention in CommitCommands as well as PR Commands.