### PR TITLE
Do not print "Optional[repo name]" for backport PR command

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
@@ -84,13 +84,14 @@ public class BackportCommand implements CommandHandler {
         // otherwise cut off the namespace prefix before comparing with the forks
         // config.
         var includesNamespace = repoNameArg.contains("/");
-        var repoName = bot.forks().keySet().stream()
+        var repoNameOptional = bot.forks().keySet().stream()
                 .filter(s -> includesNamespace
                         ? s.equals(repoNameArg)
                         : s.substring(s.indexOf("/") + 1).equals(repoNameArg))
                 .findAny();
+        String repoName = repoNameOptional.orElse("<not found>");
 
-        var potentialTargetRepo = repoName.flatMap(forge::repository);
+        var potentialTargetRepo = repoNameOptional.flatMap(forge::repository);
         if (potentialTargetRepo.isEmpty()) {
             reply.println("@" + username + " the target repository `" + repoNameArg + "` is not a valid target for backports. ");
             reply.print("List of valid target repositories: ");


### PR DESCRIPTION
The sneaky `var` notation has caused a type problem. :-( `var repoName` was in fact `Optional<String>`, not `String`, so when printing this to the user, it was presented like this:

"Could not automatically backport 481a0456 to Optional[openjdk/jdk11u-dev] due to conflicts in the following files:"

The naming here is perhaps not my proudest moment, but I did not want to mess with the usage by `potentialTargetRepo` and so I wanted to keep the original value. I think the else-string will never actually show up, due to the isEmpty() check on potentialTargetRepo.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1232/head:pull/1232` \
`$ git checkout pull/1232`

Update a local copy of the PR: \
`$ git checkout pull/1232` \
`$ git pull https://git.openjdk.java.net/skara pull/1232/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1232`

View PR using the GUI difftool: \
`$ git pr show -t 1232`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1232.diff">https://git.openjdk.java.net/skara/pull/1232.diff</a>

</details>
