### PR TITLE
1229: Skara Backports handling needs to handle non backport type as backport

### DIFF
--- a/jbs/src/main/java/org/openjdk/skara/jbs/Backports.java
+++ b/jbs/src/main/java/org/openjdk/skara/jbs/Backports.java
@@ -249,8 +249,9 @@ public class Backports {
                     .filter(l -> l.relationship().get().equals("backported by"))
                     .map(l -> l.issue().get())
                     .filter(i -> !fixedOnly || isFixed(i))
-                    .filter(i -> i.properties().containsKey("issuetype"))
-                    .filter(i -> i.properties().get("issuetype").asString().equals("Backport"))
+                    // We used to filter out any issues not of 'backport' type here, but
+                    // Jira allows linking of any issues with a 'backported by' link, so we
+                    // have to accept them, even if it's weird.
                     .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
This patch changes the Backports::findBackports method to no longer filter out issues that aren't of type "Backport" and just honor the "backported by" links as they are.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1229](https://bugs.openjdk.java.net/browse/SKARA-1229): Skara Backports handling needs to handle non backport type as backport


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1237/head:pull/1237` \
`$ git checkout pull/1237`

Update a local copy of the PR: \
`$ git checkout pull/1237` \
`$ git pull https://git.openjdk.java.net/skara pull/1237/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1237`

View PR using the GUI difftool: \
`$ git pr show -t 1237`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1237.diff">https://git.openjdk.java.net/skara/pull/1237.diff</a>

</details>
