### PR TITLE
1239: The backport command bot replies multiple `@username` unexpectedly

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
@@ -174,7 +174,7 @@ public class BackportCommand implements CommandHandler {
             var body = new ArrayList<String>();
             body.add("> Hi all,");
             body.add("> ");
-            body.add("> this pull request contains a backport of commit " +
+            body.add("> This pull request contains a backport of commit " +
                       "[" + hash.abbreviate() + "](" + commit.url() + ") from the " +
                       "[" + bot.repo().name() + "](" + bot.repo().webUrl() + ") repository.");
             body.add(">");
@@ -206,7 +206,7 @@ public class BackportCommand implements CommandHandler {
             var targetBranchWebUrl = targetRepo.webUrl(targetBranch);
             var backportBranchWebUrl = fork.webUrl(new Branch(backportBranchName));
             var backportWebUrl = fork.webUrl(backportHash);
-            reply.println("@" + command.user().username() + " the [backport](" + backportWebUrl + ")" +
+            reply.println("the [backport](" + backportWebUrl + ")" +
                           " was successfully created on the branch [" + backportBranchName + "](" +
                           backportBranchWebUrl + ") in my [personal fork](" + fork.webUrl() + ") of [" +
                           targetRepo.name() + "](" + targetRepo.webUrl() + "). To create a pull request " +

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportCommitCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportCommitCommandTests.java
@@ -75,6 +75,8 @@ public class BackportCommitCommandTests {
             assertTrue(botReply.body().contains("was successfully created"));
             assertTrue(botReply.body().contains("To create a pull request"));
             assertTrue(botReply.body().contains("with this backport"));
+            assertTrue(botReply.body().contains("@" + botReply.author().username()));
+            assertEquals(botReply.body().indexOf("@" + botReply.author().username()), botReply.body().lastIndexOf("@" + botReply.author().username()));
         }
     }
 


### PR DESCRIPTION
Hi all,

After [SKARA-1201](https://bugs.openjdk.java.net/browse/SKARA-1201), the backport command bot will reply multiple `@username` unexpectedly when we use command `/backport branch-name`.

Please see [this link](https://github.com/openjdk/jdk/commit/2b02b6f513b062261195ca1edd059d16abb7bec6) for the detailed messages. The bot replied two `@lgxbslgx` unexpectedly.

This patch fixes the issue and adds the corresponding test cases.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1239](https://bugs.openjdk.java.net/browse/SKARA-1239): The backport command bot replies multiple `@username` unexpectedly


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1238/head:pull/1238` \
`$ git checkout pull/1238`

Update a local copy of the PR: \
`$ git checkout pull/1238` \
`$ git pull https://git.openjdk.java.net/skara pull/1238/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1238`

View PR using the GUI difftool: \
`$ git pr show -t 1238`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1238.diff">https://git.openjdk.java.net/skara/pull/1238.diff</a>

</details>
