### PR TITLE
1242: The /clean command for backports is ignored

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -288,7 +288,7 @@ class CheckRun {
             pr.removeLabel("clean");
         }
 
-        return isClean;
+        return isClean || isCleanLabelManuallyAdded;
     }
 
     private Optional<HostedCommit> backportedFrom() {

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CleanCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CleanCommandTests.java
@@ -214,8 +214,10 @@ public class CleanCommandTests {
             // Use the "/clean" pull request command to mark the backport PR as clean
             pr.addComment("/clean");
             TestBotRunner.runPeriodicItems(bot);
-            assertTrue(pr.labelNames().contains("clean"));
-            assertLastCommentContains(pr, "This backport pull request is now marked as clean");
+            assertTrue(pr.labelNames().contains("clean"), "PR not marked clean");
+            assertTrue(pr.comments().stream()
+                    .anyMatch(c -> c.body().contains("This backport pull request is now marked as clean")));
+            assertTrue(pr.labelNames().contains("ready"), "PR not marked ready");
         }
     }
 


### PR DESCRIPTION
When dealing with backport pull requests, Skara tries to automatically determine if the backport is "clean". This automatic check is rather picky, so the user is supposed to be able to override this result with the command "/clean". Issuing the command works so far as the bot will react to it and add the "clean" label, but then it will ignore the label and still not consider the pull request clean.

This patch fixes this and updates the test to also verify that the pull request gets the "ready" label.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1242](https://bugs.openjdk.java.net/browse/SKARA-1242): The /clean command for backports is ignored


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1239/head:pull/1239` \
`$ git checkout pull/1239`

Update a local copy of the PR: \
`$ git checkout pull/1239` \
`$ git pull https://git.openjdk.java.net/skara pull/1239/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1239`

View PR using the GUI difftool: \
`$ git pr show -t 1239`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1239.diff">https://git.openjdk.java.net/skara/pull/1239.diff</a>

</details>
