### PR TITLE
1243: BotRunnerTests may fail intermittently

### DIFF
--- a/bot/src/test/java/org/openjdk/skara/bot/BotRunnerTests.java
+++ b/bot/src/test/java/org/openjdk/skara/bot/BotRunnerTests.java
@@ -306,6 +306,7 @@ class BotRunnerTests {
         var item6 = new TestWorkItemChild(i -> false, "Item 6");
         var item7 = new TestWorkItemChild(i -> false, "Item 7");
         var bot = new TestBot(item1, item2, item3, item4, item5, item6, item7);
+
         var config = config("{\"runner\": { \"concurrency\": 1 } }");
         var runner = new BotRunner(config, List.of(bot));
 

--- a/bot/src/test/java/org/openjdk/skara/bot/BotRunnerTests.java
+++ b/bot/src/test/java/org/openjdk/skara/bot/BotRunnerTests.java
@@ -284,7 +284,9 @@ class BotRunnerTests {
         var item3 = new TestWorkItem(i -> false, "Item 3");
         var item4 = new TestWorkItem(i -> false, "Item 4");
         var bot = new TestBot(item1, item2, item3, item4);
-        var runner = new BotRunner(config(), List.of(bot));
+
+        var config = config("{\"runner\": { \"concurrency\": 1 } }");
+        var runner = new BotRunner(config, List.of(bot));
 
         runner.runOnce(Duration.ofSeconds(10));
 
@@ -304,7 +306,8 @@ class BotRunnerTests {
         var item6 = new TestWorkItemChild(i -> false, "Item 6");
         var item7 = new TestWorkItemChild(i -> false, "Item 7");
         var bot = new TestBot(item1, item2, item3, item4, item5, item6, item7);
-        var runner = new BotRunner(config(), List.of(bot));
+        var config = config("{\"runner\": { \"concurrency\": 1 } }");
+        var runner = new BotRunner(config, List.of(bot));
 
         runner.runOnce(Duration.ofSeconds(10));
 


### PR DESCRIPTION
There is a potential race causing intermittent failures in the BotRunnerTests. This patch reduces concurrency to 1 for the executor in the affected tests. I believe the tests are still verifying the core behavior as intended even without parallel execution.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1243](https://bugs.openjdk.java.net/browse/SKARA-1243): BotRunnerTests may fail intermittently


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1240/head:pull/1240` \
`$ git checkout pull/1240`

Update a local copy of the PR: \
`$ git checkout pull/1240` \
`$ git pull https://git.openjdk.java.net/skara pull/1240/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1240`

View PR using the GUI difftool: \
`$ git pr show -t 1240`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1240.diff">https://git.openjdk.java.net/skara/pull/1240.diff</a>

</details>
