### PR TITLE
1206: Skara: TagCommand creates malformed Markdown link

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/TagCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/TagCommand.java
@@ -94,7 +94,7 @@ public class TagCommand implements CommandHandler {
                 var hash = localRepo.resolve(tagName).orElseThrow(() ->
                         new IllegalStateException("Cannot resolve tag with name " + tagName + " in repo " + bot.repo().name()));
                 var hashUrl = bot.repo().webUrl(hash);
-                reply.println("A tag with name `" + tagName + "` already exists that refers to commit [" + hash.abbreviate() + "](" + hashUrl + "].");
+                reply.println("A tag with name `" + tagName + "` already exists that refers to commit [" + hash.abbreviate() + "](" + hashUrl + ").");
                 return;
             }
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/TagCommitCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/TagCommitCommandTests.java
@@ -213,7 +213,7 @@ public class TagCommitCommandTests {
             assertEquals(4, recentCommitComments.size());
             botReply = recentCommitComments.get(0);
             assertTrue(botReply.body().contains("A tag with name `v1.0` already exists"));
-            assertTrue(botReply.body().matches("[.*](.*)"));
+            assertTrue(botReply.body().matches("(.|\n)*\\[.*\\]\\(.*\\)(.|\n)*"));
         }
     }
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/TagCommitCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/TagCommitCommandTests.java
@@ -33,7 +33,9 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
+import java.util.regex.Pattern;
 import java.util.*;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 public class TagCommitCommandTests {
@@ -213,7 +215,8 @@ public class TagCommitCommandTests {
             assertEquals(4, recentCommitComments.size());
             botReply = recentCommitComments.get(0);
             assertTrue(botReply.body().contains("A tag with name `v1.0` already exists"));
-            assertTrue(botReply.body().matches("(.|\n)*\\[.*\\]\\(.*\\)(.|\n)*"));
+            Pattern compilePattern = Pattern.compile(".*\\[.*\\]\\(.*\\).*", Pattern.MULTILINE | Pattern.DOTALL);
+            assertTrue(compilePattern.matcher(botReply.body()).matches());
         }
     }
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/TagCommitCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/TagCommitCommandTests.java
@@ -213,6 +213,7 @@ public class TagCommitCommandTests {
             assertEquals(4, recentCommitComments.size());
             botReply = recentCommitComments.get(0);
             assertTrue(botReply.body().contains("A tag with name `v1.0` already exists"));
+            assertTrue(botReply.body().matches("[.*](.*)"));
         }
     }
 


### PR DESCRIPTION
Hi all,

This little patch fixes the malformed link and adds the corresponding test case.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1206](https://bugs.openjdk.java.net/browse/SKARA-1206): Skara: TagCommand creates malformed Markdown link


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1241/head:pull/1241` \
`$ git checkout pull/1241`

Update a local copy of the PR: \
`$ git checkout pull/1241` \
`$ git pull https://git.openjdk.java.net/skara pull/1241/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1241`

View PR using the GUI difftool: \
`$ git pr show -t 1241`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1241.diff">https://git.openjdk.java.net/skara/pull/1241.diff</a>

</details>
