### PR TITLE
1188: The pr/NNNN branches are not always deleted when a PR is closed

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/NotifyBot.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/NotifyBot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,7 +68,10 @@ public class NotifyBot implements Bot, Emitter {
 
     private boolean isOfInterest(PullRequest pr) {
         var labels = new HashSet<>(pr.labelNames());
-        if (!(labels.contains("rfr") || labels.contains("integrated"))) {
+        var branchExists = pr.repository().branches().stream()
+                            .map(HostedBranch::name)
+                            .anyMatch(name -> name.equals(PreIntegrations.preIntegrateBranch(pr)));
+        if (!(labels.contains("rfr") || labels.contains("integrated") || branchExists)) {
             log.fine("PR is not yet ready - needs either 'rfr' or 'integrated' label");
             return false;
         }


### PR DESCRIPTION
Hi all,

When a PR is ready for reviewing, the label `rfr` will be added and skara will create the branch `pr/NNNN` for it. 
If we convert the PR back to draft, the label `rfr` would be removed and the branch `pr/NNNN` won't be deleted. 
Then we close the PR, **the bot won't deleted the branch**.

The reason is that the following code checks the label `rfr` or `integrated` to decide whether the bot should remove the branch.

```
    private boolean isOfInterest(PullRequest pr) {
        var labels = new HashSet<>(pr.labelNames());
        if (!(labels.contains("rfr") || labels.contains("integrated"))) {
            log.fine("PR is not yet ready - needs either 'rfr' or 'integrated' label");
            return false;
        }
        // ignore......
    }
```

To solve this issue, this patch adds one situation about the branch existing or not. And the corresponding test is added.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1188](https://bugs.openjdk.java.net/browse/SKARA-1188): The pr/NNNN branches are not always deleted when a PR is closed


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1242/head:pull/1242` \
`$ git checkout pull/1242`

Update a local copy of the PR: \
`$ git checkout pull/1242` \
`$ git pull https://git.openjdk.java.net/skara pull/1242/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1242`

View PR using the GUI difftool: \
`$ git pr show -t 1242`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1242.diff">https://git.openjdk.java.net/skara/pull/1242.diff</a>

</details>
