### PR TITLE
1252: Improve the output message about the command `csr`

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CSRCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CSRCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,7 +58,7 @@ public class CSRCommand implements CommandHandler {
     @Override
     public void handle(PullRequestBot bot, PullRequest pr, CensusInstance censusInstance, Path scratchPath, CommandInvocation command, List<Comment> allComments, PrintWriter reply) {
         if (!pr.author().equals(command.user()) && !censusInstance.isReviewer(command.user())) {
-            reply.println("only the pull request author and [Reviewers](https://openjdk.java.net/bylaws#reviewer) are allowed to require a CSR.");
+            reply.println("only the pull request author and [Reviewers](https://openjdk.java.net/bylaws#reviewer) are allowed to use the `csr` command.");
             return;
         }
 


### PR DESCRIPTION
Hi all,

Currently, when a user, who is not the author of the pr and is not a reviewer, uses the command `/csr unneeded`, the bot will output the message `only the pull request author and [Reviewers](https://openjdk.java.net/bylaws#reviewer) are allowed to require a CSR.`. The message is good when meeting the command `/csr` or `/csr needed` but it is not good when meeting the command `/csr unneeded` or `/csr uneeded`.

This patch changes the message `are allowed to require a CSR` to `are allowed to use the csr command` and adds the corresponding test cases.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1252](https://bugs.openjdk.java.net/browse/SKARA-1252): Improve the output message about the command `csr`


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1243/head:pull/1243` \
`$ git checkout pull/1243`

Update a local copy of the PR: \
`$ git checkout pull/1243` \
`$ git pull https://git.openjdk.java.net/skara pull/1243/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1243`

View PR using the GUI difftool: \
`$ git pr show -t 1243`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1243.diff">https://git.openjdk.java.net/skara/pull/1243.diff</a>

</details>
