### PR TITLE
286: Add a link to CSR in the PR's first comment

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -123,21 +123,24 @@ class CheckRun {
     }
 
     private Optional<Issue> getCsrIssue(Issue issue) {
-        var jbsIssue = issueProject().issue(issue.shortId());
-        if (jbsIssue.isEmpty()) {
-            return Optional.empty();
-        }
-        org.openjdk.skara.issuetracker.Issue csr = null;
-        for (var link : jbsIssue.get().links()) {
-            var relationship = link.relationship();
-            if (relationship.isPresent() && relationship.get().equals("csr for")) {
-                csr = link.issue().orElseThrow(
-                        () -> new IllegalStateException("Link with title 'csr for' does not contain issue")
-                );
+        var issueProject = issueProject();
+        if (issueProject != null) {
+            var jbsIssue = issueProject.issue(issue.shortId());
+            if (jbsIssue.isEmpty()) {
+                return Optional.empty();
             }
-        }
-        if (csr != null) {
-            return Issue.fromStringRelaxed(csr.id() + ": " + csr.title());
+            org.openjdk.skara.issuetracker.Issue csr = null;
+            for (var link : jbsIssue.get().links()) {
+                var relationship = link.relationship();
+                if (relationship.isPresent() && relationship.get().equals("csr for")) {
+                    csr = link.issue().orElseThrow(
+                            () -> new IllegalStateException("Link with title 'csr for' does not contain issue")
+                    );
+                }
+            }
+            if (csr != null) {
+                return Issue.fromStringRelaxed(csr.id() + ": " + csr.title());
+            }
         }
         return Optional.empty();
     }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -136,13 +136,13 @@ class CheckRun {
         org.openjdk.skara.issuetracker.Issue csr = null;
         for (var link : jbsIssue.get().links()) {
             var relationship = link.relationship();
-            if (relationship.isPresent() && relationship.get().equals("csr for")) {
-                csr = link.issue().orElse(null);
-                if (csr == null) {
-                    log.warning("The CSR " + link + " of the issue " + issue + " does not exist");
-                }
+            if (relationship.isEmpty() || !relationship.get().equals("csr for")) {
+                continue;
             }
-            if (csr != null) {
+            csr = link.issue().orElse(null);
+            if (csr == null) {
+                log.warning("The CSR " + link + " of the issue " + issue + " does not exist");
+            } else {
                 break;
             }
         }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -136,6 +136,9 @@ class CheckRun {
                 var relationship = link.relationship();
                 if (relationship.isPresent() && relationship.get().equals("csr for")) {
                     csr = link.issue().orElse(null);
+                    if (csr == null) {
+                        log.warning("The CSR " + link + " of the issue " + issue + " does not exist");
+                    }
                 }
             }
             if (csr != null) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -126,24 +126,28 @@ class CheckRun {
 
     private Optional<Issue> getCsrIssue(Issue issue) {
         var issueProject = issueProject();
-        if (issueProject != null) {
-            var jbsIssue = issueProject.issue(issue.shortId());
-            if (jbsIssue.isEmpty()) {
-                return Optional.empty();
-            }
-            org.openjdk.skara.issuetracker.Issue csr = null;
-            for (var link : jbsIssue.get().links()) {
-                var relationship = link.relationship();
-                if (relationship.isPresent() && relationship.get().equals("csr for")) {
-                    csr = link.issue().orElse(null);
-                    if (csr == null) {
-                        log.warning("The CSR " + link + " of the issue " + issue + " does not exist");
-                    }
+        if (issueProject == null) {
+            return Optional.empty();
+        }
+        var jbsIssue = issueProject.issue(issue.shortId());
+        if (jbsIssue.isEmpty()) {
+            return Optional.empty();
+        }
+        org.openjdk.skara.issuetracker.Issue csr = null;
+        for (var link : jbsIssue.get().links()) {
+            var relationship = link.relationship();
+            if (relationship.isPresent() && relationship.get().equals("csr for")) {
+                csr = link.issue().orElse(null);
+                if (csr == null) {
+                    log.warning("The CSR " + link + " of the issue " + issue + " does not exist");
                 }
             }
             if (csr != null) {
-                return Issue.fromStringRelaxed(csr.id() + ": " + csr.title());
+                break;
             }
+        }
+        if (csr != null) {
+            return Issue.fromStringRelaxed(csr.id() + ": " + csr.title());
         }
         return Optional.empty();
     }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -1160,7 +1160,7 @@ class CheckTests {
             assertTrue(pr.body().contains("### Issue"));
             assertFalse(pr.body().contains("### Issues"));
             assertTrue(pr.body().contains("The main issue"));
-            assertFalse(pr.body().contains("The csr issue"));
+            assertFalse(pr.body().contains("The csr issue (**CSR**)"));
 
             // Require CSR
             mainIssue.addLink(Link.create(csrIssue, "csr for").build());
@@ -1170,7 +1170,7 @@ class CheckTests {
             TestBotRunner.runPeriodicItems(checkBot);
             assertTrue(pr.body().contains("### Issues"));
             assertTrue(pr.body().contains("The main issue"));
-            assertTrue(pr.body().contains("The csr issue"));
+            assertTrue(pr.body().contains("The csr issue (**CSR**)"));
         }
     }
 


### PR DESCRIPTION
Hi all,

This patch adds a link to the csr in the PR's first comment under **Issue**.
And the corresponding test is added.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-286](https://bugs.openjdk.java.net/browse/SKARA-286): Add a link to CSR in the PR's first comment


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**) ⚠️ Review applies to c023b808f42b88c96cc90714467a701c8478c705
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1244/head:pull/1244` \
`$ git checkout pull/1244`

Update a local copy of the PR: \
`$ git checkout pull/1244` \
`$ git pull https://git.openjdk.java.net/skara pull/1244/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1244`

View PR using the GUI difftool: \
`$ git pr show -t 1244`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1244.diff">https://git.openjdk.java.net/skara/pull/1244.diff</a>

</details>
