### PR TITLE
1236: Add jcheck option to check for large binary files

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -262,8 +262,11 @@ class PullRequestCheckIssueVisitor implements IssueVisitor {
     }
 
     @Override
-    public void visit(BinaryIssue issue) {
-        log.fine("ignored: binary file");
+    public void visit(BinaryFileTooLargeIssue issue) {
+        addFailureMessage(issue.check(), "The size of the binary file `" + issue.path() + "` is " + issue.fileSize()
+                + (issue.fileSize() > 1 ? " Bytes" : " Byte") + ", which is larger than the limited file size: "
+                + issue.limitedFileSize() + (issue.limitedFileSize() > 1 ? " Bytes." : " Byte."));
+        readyForReview = false;
     }
 
     @Override

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
@@ -270,7 +270,7 @@ class PullRequestCheckIssueVisitor implements IssueVisitor {
     @Override
     public void visit(BinaryFileTooLargeIssue issue) {
         addFailureMessage(issue.check(), "The size of the binary file `" + issue.path() + "` is " + issue.fileSize()
-                + " Bytes, which is larger than the limited file size: "
+                + " Bytes, which is larger than the binary file size limit: "
                 + issue.maxSize() + (issue.maxSize() > 1 ? " Bytes." : " Byte."));
         readyForReview = false;
     }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
@@ -262,10 +262,16 @@ class PullRequestCheckIssueVisitor implements IssueVisitor {
     }
 
     @Override
+    public void visit(BinaryIssue issue) {
+        addFailureMessage(issue.check(), "The binary file " + issue.path().toString() + " is not allowed in this repository.");
+        readyForReview = false;
+    }
+
+    @Override
     public void visit(BinaryFileTooLargeIssue issue) {
         addFailureMessage(issue.check(), "The size of the binary file `" + issue.path() + "` is " + issue.fileSize()
-                + (issue.fileSize() > 1 ? " Bytes" : " Byte") + ", which is larger than the limited file size: "
-                + issue.limitedFileSize() + (issue.limitedFileSize() > 1 ? " Bytes." : " Byte."));
+                + " Bytes, which is larger than the limited file size: "
+                + issue.maxSize() + (issue.maxSize() > 1 ? " Bytes." : " Byte."));
         readyForReview = false;
     }
 

--- a/cli/src/main/java/org/openjdk/skara/cli/JCheckCLIVisitor.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/JCheckCLIVisitor.java
@@ -300,7 +300,7 @@ class JCheckCLIVisitor implements IssueVisitor {
     public void visit(BinaryFileTooLargeIssue i) {
         if (!ignore.contains(i.check().name())) {
             println(i, "The size of the binary file `" + i.path() + "` is " + i.fileSize()
-                    + " Bytes, which is larger than the limited file size: "
+                    + " Bytes, which is larger than the binary file size limit: "
                     + i.maxSize() + (i.maxSize() > 1 ? " Bytes." : " Byte."));
             hasDisplayedErrors = true;
         }

--- a/cli/src/main/java/org/openjdk/skara/cli/JCheckCLIVisitor.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/JCheckCLIVisitor.java
@@ -290,11 +290,18 @@ class JCheckCLIVisitor implements IssueVisitor {
         }
     }
 
+    public void visit(BinaryIssue i) {
+        if (!ignore.contains(i.check().name())) {
+            println(i, "The binary file " + i.path().toString() + " is not allowed in this repository.");
+            hasDisplayedErrors = true;
+        }
+    }
+
     public void visit(BinaryFileTooLargeIssue i) {
         if (!ignore.contains(i.check().name())) {
             println(i, "The size of the binary file `" + i.path() + "` is " + i.fileSize()
                     + (i.fileSize() > 1 ? " Bytes" : " Byte") + ", which is larger than the limited file size: "
-                    + i.limitedFileSize() + (i.limitedFileSize() > 1 ? " Bytes." : " Byte."));
+                    + i.maxSize() + (i.maxSize() > 1 ? " Bytes." : " Byte."));
             hasDisplayedErrors = true;
         }
     }

--- a/cli/src/main/java/org/openjdk/skara/cli/JCheckCLIVisitor.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/JCheckCLIVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -290,9 +290,11 @@ class JCheckCLIVisitor implements IssueVisitor {
         }
     }
 
-    public void visit(BinaryIssue i) {
+    public void visit(BinaryFileTooLargeIssue i) {
         if (!ignore.contains(i.check().name())) {
-            println(i, "adds binary file: " + i.path().toString());
+            println(i, "The size of the binary file `" + i.path() + "` is " + i.fileSize()
+                    + (i.fileSize() > 1 ? " Bytes" : " Byte") + ", which is larger than the limited file size: "
+                    + i.limitedFileSize() + (i.limitedFileSize() > 1 ? " Bytes." : " Byte."));
             hasDisplayedErrors = true;
         }
     }

--- a/cli/src/main/java/org/openjdk/skara/cli/JCheckCLIVisitor.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/JCheckCLIVisitor.java
@@ -300,7 +300,7 @@ class JCheckCLIVisitor implements IssueVisitor {
     public void visit(BinaryFileTooLargeIssue i) {
         if (!ignore.contains(i.check().name())) {
             println(i, "The size of the binary file `" + i.path() + "` is " + i.fileSize()
-                    + (i.fileSize() > 1 ? " Bytes" : " Byte") + ", which is larger than the limited file size: "
+                    + " Bytes, which is larger than the limited file size: "
                     + i.maxSize() + (i.maxSize() > 1 ? " Bytes." : " Byte."));
             hasDisplayedErrors = true;
         }

--- a/ini/src/main/java/org/openjdk/skara/ini/Section.java
+++ b/ini/src/main/java/org/openjdk/skara/ini/Section.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,8 +54,7 @@ public class Section {
 
     public Section(String name) {
         this.name = name;
-        // The BinaryConfiguration need a fixed iteration order.
-        this.entries = new LinkedHashMap<>();
+        this.entries = new HashMap<>();
         this.subsections = new HashMap<>();
     }
 

--- a/ini/src/main/java/org/openjdk/skara/ini/Section.java
+++ b/ini/src/main/java/org/openjdk/skara/ini/Section.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,7 +54,8 @@ public class Section {
 
     public Section(String name) {
         this.name = name;
-        this.entries = new HashMap<>();
+        // The BinaryConfiguration need a fixed iteration order.
+        this.entries = new LinkedHashMap<>();
         this.subsections = new HashMap<>();
     }
 

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/BinaryCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/BinaryCheck.java
@@ -45,13 +45,13 @@ public class BinaryCheck extends CommitCheck {
         for (var diff : commit.parentDiffs()) {
             for (var patch : diff.patches()) {
                 if (patch.isTextual()) {
+                    // Excluded the textual patch.
                     continue;
                 }
-                // Here, the file is surely binary.
-                if (!patch.status().isAdded() && !patch.status().isCopied()) {
+                if (patch.status().isDeleted()) {
+                    // Excluded the deleted file.
                     continue;
                 }
-                // Here, the binary file is newly added or copied.
                 if (maxSize == 0) {
                     // If the maxSize is not set or is set to 0, any binary file can't be added.
                     issues.add(new BinaryIssue(patch.target().path().get(), metadata));

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/BinaryCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/BinaryCheck.java
@@ -31,9 +31,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Iterator;
 import java.util.ArrayList;
-import java.util.Map;
 import java.util.logging.Logger;
-import java.util.regex.Pattern;
 
 public class BinaryCheck extends CommitCheck {
     private final Logger log = Logger.getLogger("org.openjdk.skara.jcheck.binary");

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/BinaryCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/BinaryCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,12 +23,17 @@
 package org.openjdk.skara.jcheck;
 
 import org.openjdk.skara.census.Census;
+import org.openjdk.skara.vcs.BinaryPatch;
 import org.openjdk.skara.vcs.Commit;
 import org.openjdk.skara.vcs.openjdk.CommitMessage;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Iterator;
 import java.util.ArrayList;
+import java.util.Map;
 import java.util.logging.Logger;
+import java.util.regex.Pattern;
 
 public class BinaryCheck extends CommitCheck {
     private final Logger log = Logger.getLogger("org.openjdk.skara.jcheck.binary");
@@ -36,18 +41,65 @@ public class BinaryCheck extends CommitCheck {
     @Override
     Iterator<Issue> check(Commit commit, CommitMessage message, JCheckConfiguration conf, Census census) {
         var metadata = CommitIssue.metadata(commit, message, conf, this);
+        var fileSizeLimits = conf.checks().binary().fileSizeLimits();
 
         var issues = new ArrayList<Issue>();
         for (var diff : commit.parentDiffs()) {
             for (var patch : diff.patches()) {
-                if (patch.isBinary() &&
-                    (patch.status().isAdded() || patch.status().isCopied())) {
-                    issues.add(new BinaryIssue(patch.target().path().get(), metadata));
+                if (patch.isTextual()) {
+                    continue;
+                }
+                // Here, the file is surely binary.
+                var binaryPatch = (BinaryPatch) patch;
+                var path =  binaryPatch.target().path().orElse(null);
+                var fileName = path != null ? path.getFileName().toString() : "";
+
+                long fileSize = 0;
+                boolean needCheck = false;
+
+                if (binaryPatch.status().isAdded()) {
+                    // This is a new-added file, so the BinaryHunk#inflatedSize of the first hunk should be the file size.
+                    fileSize = binaryPatch.hunks().get(0).inflatedSize();
+                    needCheck = true;
+                } else if (binaryPatch.status().isRenamed() || binaryPatch.status().isCopied()
+                        || binaryPatch.status().isModified() || binaryPatch.status().isUnmerged()) {
+                    // Use the file size in the file system.
+                    try {
+                        fileSize = path != null ? Files.size(path) : 0;
+                        needCheck = true;
+                    } catch (IOException e) {
+                        log.warning("The file '" + path + "' doesn't exist. ");
+                    }
+                }
+
+                // If the size of the binary file exceeds the limited size, the check should fail.
+                if (needCheck) {
+                    var excessSize = calculateExcessSize(fileSizeLimits, fileName, fileSize);
+                    if (excessSize > 0) {
+                        var limitedSize = fileSize - excessSize;
+                        log.info("The size of the binary file `" + path + "` is " + fileSize
+                                 + (fileSize > 1 ? " Bytes" : " Byte") + ", which is larger than the limited file size: "
+                                 + limitedSize + (limitedSize > 1 ? " Bytes." : " Byte."));
+                        issues.add(new BinaryFileTooLargeIssue(path, fileSize, limitedSize, metadata));
+                    }
                 }
             }
         }
-
         return issues.iterator();
+    }
+
+    /**
+     * Check whether the file size is exceeded and return the excess size.
+     * @return the value of (the file size - the limited size)
+     */
+    private long calculateExcessSize(Map<Pattern, Long> fileSizeLimits, String fileName, long fileSize) {
+        for (var entry : fileSizeLimits.entrySet()) {
+            if (entry.getKey().matcher(fileName).matches()) {
+                return fileSize - entry.getValue();
+            }
+        }
+        // the `fileSizeLimits` has no related limits about this file.
+        return 0;
     }
 
     @Override

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/BinaryConfiguration.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/BinaryConfiguration.java
@@ -39,6 +39,9 @@ public class BinaryConfiguration {
     }
 
     static BinaryConfiguration parse(Section s) {
+        if (s == null) {
+            return DEFAULT;
+        }
         Map<Pattern, Long> fileSizeLimits = new LinkedHashMap<>();
         for (var entry : s.entries()) {
             fileSizeLimits.put(Pattern.compile(entry.key()), SizeUtils.getSizeFromString(entry.value().asString()));

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/BinaryConfiguration.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/BinaryConfiguration.java
@@ -24,36 +24,28 @@ package org.openjdk.skara.jcheck;
 
 import org.openjdk.skara.ini.Section;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.regex.Pattern;
-
 public class BinaryConfiguration {
     static final BinaryConfiguration DEFAULT =
-            new BinaryConfiguration(new LinkedHashMap<>());
+            new BinaryConfiguration(0);
 
-    private final Map<Pattern, Long> fileSizeLimits;
+    private final long maxSize;
 
-    private BinaryConfiguration(Map<Pattern, Long> fileSizeLimits) {
-        this.fileSizeLimits = fileSizeLimits;
+    private BinaryConfiguration(long maxSize) {
+        this.maxSize = maxSize;
     }
 
     static BinaryConfiguration parse(Section s) {
         if (s == null) {
             return DEFAULT;
         }
-        Map<Pattern, Long> fileSizeLimits = new LinkedHashMap<>();
-        for (var entry : s.entries()) {
-            fileSizeLimits.put(Pattern.compile(entry.key()), SizeUtils.getSizeFromString(entry.value().asString()));
-        }
-        return new BinaryConfiguration(fileSizeLimits);
+        return new BinaryConfiguration(SizeUtils.getSizeFromString(s.get("max-size").asString()));
     }
 
     static String name() {
         return "binary";
     }
 
-    public Map<Pattern, Long> fileSizeLimits() {
-        return fileSizeLimits;
+    public long maxSize() {
+        return maxSize;
     }
 }

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/BinaryConfiguration.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/BinaryConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,22 +22,35 @@
  */
 package org.openjdk.skara.jcheck;
 
-import java.nio.file.Path;
+import org.openjdk.skara.ini.Section;
 
-public class BinaryIssue extends CommitIssue {
-    private final Path path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
 
-    BinaryIssue(Path path, CommitIssue.Metadata metadata) {
-        super(metadata);
-        this.path = path;
+public class BinaryConfiguration {
+    static final BinaryConfiguration DEFAULT =
+            new BinaryConfiguration(new LinkedHashMap<>());
+
+    private final Map<Pattern, Long> fileSizeLimits;
+
+    private BinaryConfiguration(Map<Pattern, Long> fileSizeLimits) {
+        this.fileSizeLimits = fileSizeLimits;
     }
 
-    public Path path() {
-        return path;
+    static BinaryConfiguration parse(Section s) {
+        Map<Pattern, Long> fileSizeLimits = new LinkedHashMap<>();
+        for (var entry : s.entries()) {
+            fileSizeLimits.put(Pattern.compile(entry.key()), SizeUtils.getSizeFromString(entry.value().asString()));
+        }
+        return new BinaryConfiguration(fileSizeLimits);
     }
 
-    @Override
-    public void accept(IssueVisitor v) {
-        v.visit(this);
+    static String name() {
+        return "binary";
+    }
+
+    public Map<Pattern, Long> fileSizeLimits() {
+        return fileSizeLimits;
     }
 }

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/BinaryFileTooLargeIssue.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/BinaryFileTooLargeIssue.java
@@ -27,13 +27,13 @@ import java.nio.file.Path;
 public class BinaryFileTooLargeIssue extends CommitIssue {
     private final Path path;
     private final long fileSize;
-    private final long limitedFileSize;
+    private final long maxSize;
 
-    BinaryFileTooLargeIssue(Path path, long fileSize, long limitedFileSize, CommitIssue.Metadata metadata) {
+    BinaryFileTooLargeIssue(Path path, long fileSize, long maxSize, CommitIssue.Metadata metadata) {
         super(metadata);
         this.path = path;
         this.fileSize = fileSize;
-        this.limitedFileSize = limitedFileSize;
+        this.maxSize = maxSize;
     }
 
     public Path path() {
@@ -44,8 +44,8 @@ public class BinaryFileTooLargeIssue extends CommitIssue {
         return fileSize;
     }
 
-    public long limitedFileSize() {
-        return limitedFileSize;
+    public long maxSize() {
+        return maxSize;
     }
 
     @Override

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/BinaryFileTooLargeIssue.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/BinaryFileTooLargeIssue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,26 +22,34 @@
  */
 package org.openjdk.skara.jcheck;
 
-public interface IssueVisitor {
-    void visit(TagIssue issue);
-    void visit(BranchIssue issue);
-    void visit(DuplicateIssuesIssue issue);
-    void visit(SelfReviewIssue issue);
-    void visit(TooFewReviewersIssue issue);
-    void visit(InvalidReviewersIssue issue);
-    void visit(MergeMessageIssue issue);
-    void visit(HgTagCommitIssue issue);
-    void visit(CommitterIssue issue);
-    void visit(CommitterNameIssue issue);
-    void visit(CommitterEmailIssue issue);
-    void visit(AuthorNameIssue issue);
-    void visit(AuthorEmailIssue issue);
-    void visit(WhitespaceIssue issue);
-    void visit(MessageIssue issue);
-    void visit(MessageWhitespaceIssue issue);
-    void visit(IssuesIssue issue);
-    void visit(ExecutableIssue issue);
-    void visit(BinaryFileTooLargeIssue issue);
-    void visit(SymlinkIssue issue);
-    void visit(ProblemListsIssue problemListIssue);
+import java.nio.file.Path;
+
+public class BinaryFileTooLargeIssue extends CommitIssue {
+    private final Path path;
+    private final long fileSize;
+    private final long limitedFileSize;
+
+    BinaryFileTooLargeIssue(Path path, long fileSize, long limitedFileSize, CommitIssue.Metadata metadata) {
+        super(metadata);
+        this.path = path;
+        this.fileSize = fileSize;
+        this.limitedFileSize = limitedFileSize;
+    }
+
+    public Path path() {
+        return path;
+    }
+
+    public long fileSize() {
+        return fileSize;
+    }
+
+    public long limitedFileSize() {
+        return limitedFileSize;
+    }
+
+    @Override
+    public void accept(IssueVisitor v) {
+        v.visit(this);
+    }
 }

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/BinaryFileTooLargeIssue.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/BinaryFileTooLargeIssue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/BinaryIssue.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/BinaryIssue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,27 +22,22 @@
  */
 package org.openjdk.skara.jcheck;
 
-public interface IssueVisitor {
-    void visit(TagIssue issue);
-    void visit(BranchIssue issue);
-    void visit(DuplicateIssuesIssue issue);
-    void visit(SelfReviewIssue issue);
-    void visit(TooFewReviewersIssue issue);
-    void visit(InvalidReviewersIssue issue);
-    void visit(MergeMessageIssue issue);
-    void visit(HgTagCommitIssue issue);
-    void visit(CommitterIssue issue);
-    void visit(CommitterNameIssue issue);
-    void visit(CommitterEmailIssue issue);
-    void visit(AuthorNameIssue issue);
-    void visit(AuthorEmailIssue issue);
-    void visit(WhitespaceIssue issue);
-    void visit(MessageIssue issue);
-    void visit(MessageWhitespaceIssue issue);
-    void visit(IssuesIssue issue);
-    void visit(ExecutableIssue issue);
-    void visit(BinaryIssue issue);
-    void visit(BinaryFileTooLargeIssue issue);
-    void visit(SymlinkIssue issue);
-    void visit(ProblemListsIssue problemListIssue);
+import java.nio.file.Path;
+
+public class BinaryIssue extends CommitIssue {
+    private final Path path;
+
+    BinaryIssue(Path path, CommitIssue.Metadata metadata) {
+        super(metadata);
+        this.path = path;
+    }
+
+    public Path path() {
+        return path;
+    }
+
+    @Override
+    public void accept(IssueVisitor v) {
+        v.visit(this);
+    }
 }

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/ChecksConfiguration.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/ChecksConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,7 @@ public class ChecksConfiguration {
                                 MergeConfiguration.DEFAULT,
                                 CommitterConfiguration.DEFAULT,
                                 IssuesConfiguration.DEFAULT,
+                                BinaryConfiguration.DEFAULT,
                                 ProblemListsConfiguration.DEFAULT);
 
     private final List<String> error;
@@ -45,6 +46,7 @@ public class ChecksConfiguration {
     private final MergeConfiguration merge;
     private final CommitterConfiguration committer;
     private final IssuesConfiguration issues;
+    private final BinaryConfiguration binary;
     private final ProblemListsConfiguration problemlists;
 
     ChecksConfiguration(List<String> error,
@@ -54,6 +56,7 @@ public class ChecksConfiguration {
                         MergeConfiguration merge,
                         CommitterConfiguration committer,
                         IssuesConfiguration issues,
+                        BinaryConfiguration binary,
                         ProblemListsConfiguration problemlists) {
         this.error = error;
         this.warning = warning;
@@ -62,6 +65,7 @@ public class ChecksConfiguration {
         this.merge = merge;
         this.committer = committer;
         this.issues = issues;
+        this.binary = binary;
         this.problemlists = problemlists;
     }
 
@@ -111,6 +115,10 @@ public class ChecksConfiguration {
         return issues;
     }
 
+    public BinaryConfiguration binary() {
+        return binary;
+    }
+
     public ProblemListsConfiguration problemlists() {
         return problemlists;
     }
@@ -132,7 +140,8 @@ public class ChecksConfiguration {
         var merge = MergeConfiguration.parse(s.subsection(MergeConfiguration.name()));
         var committer = CommitterConfiguration.parse(s.subsection(CommitterConfiguration.name()));
         var issues = IssuesConfiguration.parse(s.subsection(IssuesConfiguration.name()));
+        var binary = BinaryConfiguration.parse(s.subsection(BinaryConfiguration.name()));
         var problemlists = ProblemListsConfiguration.parse(s.subsection(ProblemListsConfiguration.name()));
-        return new ChecksConfiguration(error, warning, whitespace, reviewers, merge, committer, issues, problemlists);
+        return new ChecksConfiguration(error, warning, whitespace, reviewers, merge, committer, issues, binary, problemlists);
     }
 }

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/JCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/JCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -76,6 +76,7 @@ public class JCheck {
             new IssuesCheck(utils),
             new ExecutableCheck(),
             new SymlinkCheck(),
+            new BinaryCheck(),
             new ProblemListsCheck(repository)
         );
         repositoryChecks = List.of(

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/SizeUtils.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/SizeUtils.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.jcheck;
+
+import java.util.logging.Logger;
+
+public class SizeUtils {
+    private static final Logger log = Logger.getLogger("org.openjdk.skara.jcheck.sizeutils");
+
+    public static long getSizeFromString(String str) {
+        long size = 0;
+        String unit = "";
+        var sizeStr = str.toLowerCase();
+        if (sizeStr.endsWith("kb") || sizeStr.endsWith("mb") || sizeStr.endsWith("gb")) {
+            unit = sizeStr.substring(sizeStr.length() - 2);
+            sizeStr = sizeStr.substring(0, sizeStr.length() - 2);
+        } else if (sizeStr.endsWith("k") || sizeStr.endsWith("m") || sizeStr.endsWith("g") || sizeStr.endsWith("b")) {
+            unit = sizeStr.substring(sizeStr.length() - 1);
+            sizeStr = sizeStr.substring(0, sizeStr.length() - 1);
+        }
+        try {
+            size = Long.parseLong(sizeStr);
+        } catch (NumberFormatException exception) {
+            log.info("The string '" + str + "' can't be convert to a number. " + exception);
+            size = 0; // default 0
+        }
+        switch (unit) {
+            case "kb", "k" -> size *= 1024;
+            case "mb", "m" -> size *= 1024 * 1024;
+            case "gb", "g" -> size *= 1024 * 1024 * 1024;
+        }
+        return size;
+    }
+}

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/BinaryCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/BinaryCheckTests.java
@@ -123,17 +123,15 @@ class BinaryCheckTests {
         Files.deleteIfExists(path);
         Files.createFile(path);
         Files.write(path, List.of("testtest"));
-        for (var status : List.of(Status.from("M"), Status.from("U"), Status.from("R100"))) {
-            var commit = commit(binaryParentDiffs(path, status, 9, List.of("testtest")));
-            var message = message(commit);
-            var check = new BinaryCheck();
-            var issues = toList(check.check(commit, message, binaryNotAllowedConf, null));
-            assertEquals(0, issues.size());
-            issues = toList(check.check(commit, message, binaryAllowedConf, null));
-            assertEquals(0, issues.size());
-            issues = toList(check.check(commit, message, zeroMaxSizeConf, null));
-            assertEquals(0, issues.size());
-        }
+        var commit = commit(binaryParentDiffs(path, Status.from("D"), 9, List.of("testtest")));
+        var message = message(commit);
+        var check = new BinaryCheck();
+        var issues = toList(check.check(commit, message, binaryNotAllowedConf, null));
+        assertEquals(0, issues.size());
+        issues = toList(check.check(commit, message, binaryAllowedConf, null));
+        assertEquals(0, issues.size());
+        issues = toList(check.check(commit, message, zeroMaxSizeConf, null));
+        assertEquals(0, issues.size());
         Files.deleteIfExists(path);
     }
 
@@ -143,7 +141,7 @@ class BinaryCheckTests {
         Files.deleteIfExists(path);
         Files.createFile(path);
         Files.write(path, List.of("testtest"));
-        for (var status : List.of(Status.from("A"), Status.from("C100"))) {
+        for (var status : List.of(Status.from("A"), Status.from("C100"), Status.from("M"), Status.from("U"), Status.from("R100"))) {
             var commit = commit(binaryParentDiffs(path, status, 9, List.of("testtest")));
             var message = message(commit);
             var check = new BinaryCheck();
@@ -177,7 +175,7 @@ class BinaryCheckTests {
         Files.deleteIfExists(path);
         Files.createFile(path);
         Files.write(path, List.of("t"));
-        for (var status : List.of(Status.from("A"), Status.from("C100"))) {
+        for (var status : List.of(Status.from("A"), Status.from("C100"), Status.from("M"), Status.from("U"), Status.from("R100"))) {
             var commit = commit(binaryParentDiffs(path, status, 2, List.of("testtest")));
             var message = message(commit);
             var check = new BinaryCheck();
@@ -193,7 +191,7 @@ class BinaryCheckTests {
         Files.deleteIfExists(path);
         Files.createFile(path);
         Files.write(path, List.of("testtest"));
-        for (var status : List.of(Status.from("A"), Status.from("C100"))) {
+        for (var status : List.of(Status.from("A"), Status.from("C100"), Status.from("M"), Status.from("U"), Status.from("R100"))) {
             var commit = commit(binaryParentDiffs(path, status, 9, List.of("testtest")));
             var message = message(commit);
             var check = new BinaryCheck();

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/BinaryCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/BinaryCheckTests.java
@@ -118,7 +118,7 @@ class BinaryCheckTests {
     }
 
     @Test
-    void notAddOrCopyFileShouldPass() throws IOException {
+    void deletedFileShouldPass() throws IOException {
         Path path = Path.of("file.s");
         Files.deleteIfExists(path);
         Files.createFile(path);
@@ -191,7 +191,7 @@ class BinaryCheckTests {
         Files.deleteIfExists(path);
         Files.createFile(path);
         Files.write(path, List.of("testtest"));
-        for (var status : List.of(Status.from("A"), Status.from("C100"), Status.from("M"), Status.from("U"), Status.from("R100"))) {
+        for (var status : List.of(Status.from("A"), Status.from("M"), Status.from("U"))) {
             var commit = commit(binaryParentDiffs(path, status, 9, List.of("testtest")));
             var message = message(commit);
             var check = new BinaryCheck();

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/BinaryCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/BinaryCheckTests.java
@@ -147,7 +147,7 @@ class BinaryCheckTests {
             assertTrue(issues.get(0) instanceof BinaryFileTooLargeIssue);
             var issue = (BinaryFileTooLargeIssue) issues.get(0);
             assertEquals(path, issue.path());
-            assertEquals(9, issue.fileSize());
+            assertTrue(issue.fileSize() > issue.limitedFileSize());
             assertEquals(1, issue.limitedFileSize());
             assertEquals(commit, issue.commit());
             assertEquals(message, issue.message());

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/JCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/JCheckTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -229,7 +229,7 @@ class JCheckTests {
         }
 
         @Override
-        public void visit(BinaryIssue e) {
+        public void visit(BinaryFileTooLargeIssue e) {
             issues.add(e);
         }
 

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/JCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/JCheckTests.java
@@ -229,6 +229,11 @@ class JCheckTests {
         }
 
         @Override
+        public void visit(BinaryIssue e) {
+            issues.add(e);
+        }
+
+        @Override
         public void visit(BinaryFileTooLargeIssue e) {
             issues.add(e);
         }

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/SizeUtilsTest.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/SizeUtilsTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.jcheck;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.openjdk.skara.jcheck.SizeUtils.*;
+
+public class SizeUtilsTest {
+    @Test
+    void testGetSizeFromString() {
+        String[] simpleLowerStrList = new String[]{"1", "2b", "3k", "4m", "5g", "", "a", "ab", "ak", "am", "ag"};
+        String[] simpleUpperStrList = new String[]{"1", "2B", "3K", "4M", "5G", "", "A", "AB", "AK", "AM", "AG"};
+        long[] simpleSizeList = new long[]{1L, 2L, 3L * 1024, 4L * 1024 * 1024, 5L * 1024 * 1024 * 1024, 0, 0, 0, 0, 0, 0};
+        for (int i = 0; i < simpleSizeList.length; i++) {
+            assertEquals(simpleSizeList[i], getSizeFromString(simpleLowerStrList[i]));
+            assertEquals(simpleSizeList[i], getSizeFromString(simpleUpperStrList[i]));
+        }
+
+        String[] kiloStrList = new String[]{"1kb", "2Kb", "3kB", "4KB", "akb", "aKb", "akB", "aKB", "kb", "Kb", "kB", "KB"};
+        String[] mageStrList = new String[]{"1mb", "2Mb", "3mB", "4MB", "amb", "aMb", "amB", "aMB", "mb", "Mb", "mB", "MB"};
+        String[] gigaStrList = new String[]{"1gb", "2Gb", "3gB", "4GB", "agb", "aGb", "agB", "aGB", "gb", "Gb", "gB", "GB"};
+        long[] expectedSizeList = new long[]{1L, 2L, 3L, 4L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L};
+        for (int i = 0; i < expectedSizeList.length; i++) {
+            assertEquals(expectedSizeList[i] * 1024, getSizeFromString(kiloStrList[i]));
+            assertEquals(expectedSizeList[i] * 1024 * 1024, getSizeFromString(mageStrList[i]));
+            assertEquals(expectedSizeList[i] * 1024 * 1024 * 1024, getSizeFromString(gigaStrList[i]));
+        }
+    }
+}


### PR DESCRIPTION
Hi all,

This patch adds the large binary file check to the jcheck.

The corresponding configuration is like the following code. Each key/value in the `[checks "binary"]` is a mapper. The `key` means the file pattern and the `value` means the limited file size. For example, `.*\\.bin=200B` means the file which ends with `.bin` should not exceed 200 Bytes.

```
[checks]
error = binary

[checks "binary"]
.*\.bin=200B
.*\.o=1k
```

The limited file size can use one of these several units:  b(Byte), kb(KiloByte), mb(MegaByte), gb(GigaByte). The units is case insensitive, which means the `Kb`, `kB` and `KB` are equals to `kb(KiloByte)`. If the unit is not provided, it defauts to `b(Byte)`. And these is no a unit called `bit`.

The corresponding test cases are added.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [SKARA-1236](https://bugs.openjdk.java.net/browse/SKARA-1236): Add jcheck option to check for large binary files


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1247/head:pull/1247` \
`$ git checkout pull/1247`

Update a local copy of the PR: \
`$ git checkout pull/1247` \
`$ git pull https://git.openjdk.java.net/skara pull/1247/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1247`

View PR using the GUI difftool: \
`$ git pr show -t 1247`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1247.diff">https://git.openjdk.java.net/skara/pull/1247.diff</a>

</details>
