### PR TITLE
1265: New CSR link warns that issue isn't open

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -544,7 +544,8 @@ class CheckRun {
                                 setExpiration(Duration.ofMinutes(10));
                             }
                             if (iss.get().state() != org.openjdk.skara.issuetracker.Issue.State.OPEN) {
-                                if (!pr.labelNames().contains("backport")) {
+                                if (!pr.labelNames().contains("backport") &&
+                                        (issueType == null || !"CSR".equals(issueType.asString()))) {
                                     progressBody.append(" ⚠️ Issue is not open.");
                                 }
                             }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -24,6 +24,7 @@ package org.openjdk.skara.bots.pr;
 
 import org.junit.jupiter.api.*;
 import org.openjdk.skara.forge.*;
+import org.openjdk.skara.issuetracker.Issue;
 import org.openjdk.skara.issuetracker.Link;
 import org.openjdk.skara.json.JSON;
 import org.openjdk.skara.test.*;
@@ -1171,6 +1172,20 @@ class CheckTests {
             assertTrue(pr.body().contains("### Issues"));
             assertTrue(pr.body().contains("The main issue"));
             assertTrue(pr.body().contains("The csr issue (**CSR**)"));
+
+            // Set the state of the csr issue to `closed`
+            csrIssue.setState(Issue.State.CLOSED);
+            // Push a commit to trigger the check which can update the PR body.
+            var newHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(newHash, author.url(), "edit", false);
+
+            // PR should have two issues
+            TestBotRunner.runPeriodicItems(checkBot);
+            assertTrue(pr.body().contains("### Issues"));
+            assertTrue(pr.body().contains("The main issue"));
+            assertTrue(pr.body().contains("The csr issue (**CSR**)"));
+            // The csr issue state don't need to be `open`.
+            assertFalse(pr.body().contains("Issue is not open"));
         }
     }
 


### PR DESCRIPTION
Hi all,

This little patch removes the unnecessary warning `Issue is not open.` which is end of the CSR link. And the test case is added.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1265](https://bugs.openjdk.java.net/browse/SKARA-1265): New CSR link warns that issue isn't open


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1249/head:pull/1249` \
`$ git checkout pull/1249`

Update a local copy of the PR: \
`$ git checkout pull/1249` \
`$ git pull https://git.openjdk.java.net/skara pull/1249/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1249`

View PR using the GUI difftool: \
`$ git pr show -t 1249`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1249.diff">https://git.openjdk.java.net/skara/pull/1249.diff</a>

</details>
