### PR TITLE
635: Add census link for credited reviewers

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -400,9 +400,9 @@ class CheckRun {
             // The HostUser is not null and the Contributor is null
             ret.append("@");
             ret.append(user.username());
-            ret.append(" (Unknown ");
-            ret.append(censusInstance.project().fullName());
-            ret.append(" username and role)");
+            ret.append(" (no known ");
+            ret.append(censusInstance.namespace().name());
+            ret.append(" user name / role)");
         } else {
             // The HostUser is null and the Contributor is not null
             ret.append(contributorLink(contributor));


### PR DESCRIPTION
Hi all,

This patch uses the full name and the census link of the credited reviewer so that the `### Reviewers` part can be clearer.

For example, the [PR-6562](https://github.com/openjdk/jdk/pull/6562) has a credited reviewer which is shown as `jbhateja - Committer  Added manually`. 

After this patch, it will show: `Jatin Bhateja - Committer  Added manually`. The full name `Jatin Bhateja` will replace the username `jbhateja`.

If these is a census link, it will show: `[Jatin Bhateja](https://openjdk.java.net/census#jbhateja) - Committer  Added manually`.

And the test cases are added.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-635](https://bugs.openjdk.java.net/browse/SKARA-635): Add census link for credited reviewers


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1252/head:pull/1252` \
`$ git checkout pull/1252`

Update a local copy of the PR: \
`$ git checkout pull/1252` \
`$ git pull https://git.openjdk.java.net/skara pull/1252/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1252`

View PR using the GUI difftool: \
`$ git pr show -t 1252`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1252.diff">https://git.openjdk.java.net/skara/pull/1252.diff</a>

</details>
