### PR TITLE
1270: Allow different 'issues' urls for different repositories in mlbridge configuration

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotFactory.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotFactory.java
@@ -87,7 +87,7 @@ public class MailingListBridgeBotFactory implements BotFactory {
 
         var archiveRepo = configuration.repository(specific.get("archive").asString());
         var archiveRef = configuration.repositoryRef(specific.get("archive").asString());
-        var issueTracker = URIBuilder.base(specific.get("issues").asString()).build();
+        var globalIssueTracker = URIBuilder.base(specific.get("issues").asString()).build();
 
         var readyLabels = specific.get("ready").get("labels").stream()
                 .map(JSONValue::asString)
@@ -106,6 +106,11 @@ public class MailingListBridgeBotFactory implements BotFactory {
             var hostedRepository = configuration.repository(repo);
             var censusRepo = configuration.repository(repoConfig.get("census").asString());
             var censusRef = configuration.repositoryRef(repoConfig.get("census").asString());
+
+            var issueTracker = globalIssueTracker;
+            if (repoConfig.contains("issues")) {
+                issueTracker = URIBuilder.base(repoConfig.get("issues").asString()).build();
+            }
 
             Map<String, String> headers = repoConfig.contains("headers") ?
                     repoConfig.get("headers").fields().stream()


### PR DESCRIPTION
The 'issues' URL in the mlbridge configuration is currently global for all repositories. We need to be able to configure different Jira instances for different repositories.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1270](https://bugs.openjdk.java.net/browse/SKARA-1270): Allow different 'issues' urls for different repositories in mlbridge configuration


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1254/head:pull/1254` \
`$ git checkout pull/1254`

Update a local copy of the PR: \
`$ git checkout pull/1254` \
`$ git pull https://git.openjdk.java.net/skara pull/1254/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1254`

View PR using the GUI difftool: \
`$ git pr show -t 1254`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1254.diff">https://git.openjdk.java.net/skara/pull/1254.diff</a>

</details>
