### PR TITLE
596: Allow short-hand syntax for /label command

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,11 +29,13 @@ import java.io.*;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 public class LabelCommand implements CommandHandler {
     private final String commandName;
 
-    private static final Pattern argumentPattern = Pattern.compile("(?:(add|remove)\\s+)?((?:[A-Za-z0-9_@.-]+[\\s,]*)+)");
+    private static final Pattern argumentPattern = Pattern.compile("(?:(add|remove)\\s+)((?:[A-Za-z0-9_@.-]+[\\s,]*)+)");
+    private static final Pattern shortArgumentPattern = Pattern.compile("((?:[-+]?[A-Za-z0-9_@.-]+[\\s,]*)+)");
     private static final Pattern ignoredSuffixes = Pattern.compile("^(.*)(?:-dev(?:@openjdk.java.net)?)$");
 
     LabelCommand() {
@@ -45,8 +47,10 @@ public class LabelCommand implements CommandHandler {
     }
 
     private void showHelp(LabelConfiguration labelConfiguration, PrintWriter reply) {
-        reply.println("Usage: `/" + commandName + "` <add|remove> [label[, label, ...]]` where `label` is an additional classification that should " +
-                              "be applied to this PR. These labels are valid:");
+        reply.println("Usage: `/" + commandName + " <add|remove> [label[, label, ...]]` " +
+                      "or `/" + commandName + " [<+|->label[, <+|->label, ...]]` " +
+                      "where `label` is an additional classification that should " +
+                      "be applied to this PR. These labels are valid:");
         labelConfiguration.allowed().forEach(label -> reply.println(" * `" + label + "`"));
     }
 
@@ -58,49 +62,109 @@ public class LabelCommand implements CommandHandler {
         }
 
         var argumentMatcher = argumentPattern.matcher(command.args());
-        if (!argumentMatcher.matches()) {
-            showHelp(bot.labelConfiguration(), reply);
-            return;
-        }
-
-        var labels = argumentMatcher.group(2).split("[\\s,]+");
-        for (int i = 0; i < labels.length; ++i) {
-            var label = labels[i];
-            var ignoredSuffixMatcher = ignoredSuffixes.matcher(label);
-            if (ignoredSuffixMatcher.matches()) {
-                label = ignoredSuffixMatcher.group(1);
-                labels[i] = label;
-            }
-            if (!bot.labelConfiguration().allowed().contains(label)) {
-                reply.println("The label `" + label + "` is not a valid label. These labels are valid:");
-                bot.labelConfiguration().allowed().forEach(l -> reply.println(" * `" + l + "`"));
-                return;
-            }
-        }
-        if (labels.length == 0) {
+        var shortArgumentMatcher = shortArgumentPattern.matcher(command.args());
+        if (!argumentMatcher.matches() && !shortArgumentMatcher.matches()) {
             showHelp(bot.labelConfiguration(), reply);
             return;
         }
         var currentLabels = new HashSet<>(pr.labelNames());
-        if (argumentMatcher.group(1) == null || argumentMatcher.group(1).equals("add")) {
-            for (var label : labels) {
-                if (!currentLabels.contains(label)) {
-                    pr.addLabel(label);
-                    reply.println(LabelTracker.addLabelMarker(label));
-                    reply.println("The `" + label + "` label was successfully added.");
-                } else {
-                    reply.println("The `" + label + "` label was already applied.");
-                }
+
+        if (argumentMatcher.matches()) {
+            var labels =  Arrays.stream(argumentMatcher.group(2).split("[\\s,]+")).collect(Collectors.toList());
+            if (labels.size() == 0) {
+                showHelp(bot.labelConfiguration(), reply);
+                return;
             }
-        } else if (argumentMatcher.group(1).equals("remove")) {
-            for (var label : labels) {
-                if (currentLabels.contains(label)) {
-                    pr.removeLabel(label);
-                    reply.println(LabelTracker.removeLabelMarker(label));
-                    reply.println("The `" + label + "` label was successfully removed.");
+            var invalidLabels = verifyLabels(labels, bot);
+            if (!invalidLabels.isEmpty()) {
+                printInvalidLabels(invalidLabels, bot, reply);
+                return;
+            }
+            if (argumentMatcher.group(1).equals("add")) {
+                addLabels(labels, currentLabels, pr, reply);
+            } else if (argumentMatcher.group(1).equals("remove")) {
+                removeLabels(labels, currentLabels, pr, reply);
+            }
+            return;
+        }
+
+        if (shortArgumentMatcher.matches()) {
+            var labels = Arrays.stream(shortArgumentMatcher.group(1).split("[\\s,]+")).collect(Collectors.toList());
+            if (labels.size() == 0 || "add".equals(labels.get(0)) || "remove".equals(labels.get(0))) {
+                // The comparison of the `add and `remove` is to solve this situation: `/label add +label1, -label2`.
+                showHelp(bot.labelConfiguration(), reply);
+                return;
+            }
+            var labelsToAdd = new ArrayList<String>();
+            var labelsToRemove = new ArrayList<String>();
+            labels.forEach(label -> {
+                if (label.startsWith("-")) {
+                    labelsToRemove.add(label.substring(1).strip());
+                } else if (label.startsWith("+")){
+                    labelsToAdd.add(label.substring(1).strip());
                 } else {
-                    reply.println("The `" + label + "` label was not set.");
+                    labelsToAdd.add(label.strip());
                 }
+            });
+
+            var invalidLabels = verifyLabels(labelsToAdd, bot);
+            invalidLabels.addAll(verifyLabels(labelsToRemove, bot));
+            if (!invalidLabels.isEmpty()) {
+                printInvalidLabels(invalidLabels, bot, reply);
+                return;
+            }
+
+            addLabels(labelsToAdd, currentLabels, pr, reply);
+            removeLabels(labelsToRemove, currentLabels, pr, reply);
+        }
+    }
+
+    private void printInvalidLabels(List<String> invalidLabels, PullRequestBot bot, PrintWriter reply) {
+        reply.println(""); // Intentionally blank line.
+        invalidLabels.forEach(label -> reply.println("The label `" + label + "` is not a valid label."));
+        reply.println("These labels are valid:");
+        bot.labelConfiguration().allowed().forEach(l -> reply.println(" * `" + l + "`"));
+    }
+
+    /**
+     * Verify whether the labels are valid, return the invalid labels.
+     */
+    private List<String> verifyLabels(List<String> labels, PullRequestBot bot) {
+        List<String> invalidLabels = new ArrayList<>();
+        for (int i = 0; i < labels.size(); ++i) {
+            var label = labels.get(i);
+            var ignoredSuffixMatcher = ignoredSuffixes.matcher(label);
+            if (ignoredSuffixMatcher.matches()) {
+                label = ignoredSuffixMatcher.group(1);
+                labels.set(i, label);
+            }
+            if (!bot.labelConfiguration().allowed().contains(label)) {
+                invalidLabels.add(label);
+            }
+        }
+        return invalidLabels;
+    }
+
+    private void addLabels(List<String> labelsToAdd,Set<String> currentLabels, PullRequest pr, PrintWriter reply) {
+        for (var label : labelsToAdd) {
+            if (!currentLabels.contains(label)) {
+                pr.addLabel(label);
+                reply.println(LabelTracker.addLabelMarker(label));
+                reply.println("The `" + label + "` label was successfully added.");
+            } else {
+                reply.println("The `" + label + "` label was already applied.");
+            }
+        }
+    }
+
+    private void removeLabels(List<String> labelsToRemove,Set<String> currentLabels, PullRequest pr, PrintWriter reply) {
+        for (var label : labelsToRemove) {
+            if (currentLabels.contains(label)) {
+                pr.removeLabel(label);
+                reply.println(LabelTracker.removeLabelMarker(label));
+                reply.println("The `" + label + "` label was successfully removed.");
+            } else {
+                reply.println("The `" + label + "` label was not set.");
             }
         }
     }


### PR DESCRIPTION
Hi all,

This patch adds the short-hand syntax for `/label` command. The short-hand syntax makes the users easily add and remove the labels in one comment.

Some example:
```
Add a label: `/label +labelName`
Remove a label: `/label -labelName`
Mixed: `/label +labelName, -labelName2`
Mixed: `/label labelName, +labelName2, -labelName3`
```

And the test cases are added.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-596](https://bugs.openjdk.java.net/browse/SKARA-596): Allow short-hand syntax for /label command


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1255/head:pull/1255` \
`$ git checkout pull/1255`

Update a local copy of the PR: \
`$ git checkout pull/1255` \
`$ git pull https://git.openjdk.java.net/skara pull/1255/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1255`

View PR using the GUI difftool: \
`$ git pr show -t 1255`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1255.diff">https://git.openjdk.java.net/skara/pull/1255.diff</a>

</details>
