### PR TITLE
713: Rename git/pr-approve to git-pr-review

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,9 +52,9 @@ public class GitPr {
             Command.name("integrate")
                     .helptext("integrate a pull request")
                     .main(GitPrIntegrate::main),
-            Command.name("approve")
-                    .helptext("approve a pull request")
-                    .main(GitPrApprove::main),
+            Command.name("review")
+                    .helptext("review a pull request")
+                    .main(GitPrReview::main),
             Command.name("create")
                     .helptext("create a pull request")
                     .main(GitPrCreate::main),

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrHelp.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrHelp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@ import org.openjdk.skara.cli.Logging;
 
 import java.util.*;
 import java.util.logging.Level;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class GitPrHelp {
@@ -64,7 +63,7 @@ public class GitPrHelp {
         commands.put("checkout", Pair.of(GitPrCheckout.inputs, GitPrCheckout.flags));
         commands.put("apply", Pair.of(GitPrApply.inputs, GitPrApply.flags));
         commands.put("integrate", Pair.of(GitPrIntegrate.inputs, GitPrIntegrate.flags));
-        commands.put("approve", Pair.of(GitPrApprove.inputs, GitPrApprove.flags));
+        commands.put("review", Pair.of(GitPrReview.inputs, GitPrReview.flags));
         commands.put("create", Pair.of(GitPrCreate.inputs, GitPrCreate.flags));
         commands.put("close", Pair.of(GitPrClose.inputs, GitPrClose.flags));
         commands.put("set", Pair.of(GitPrSet.inputs, GitPrSet.flags));

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrReview.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrReview.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@ import static org.openjdk.skara.cli.pr.Utils.*;
 import java.io.IOException;
 import java.util.List;
 
-public class GitPrApprove {
+public class GitPrReview {
     static final List<Flag> flags = List.of(
         Option.shortcut("u")
               .fullname("username")
@@ -45,8 +45,13 @@ public class GitPrApprove {
         Option.shortcut("m")
               .fullname("message")
               .describe("TEXT")
-              .helptext("Message to author as part of approval (e.g. \"Looks good!\")")
+              .helptext("Message to author as part of review (e.g. \"Looks good!\")")
               .optional(),
+        Option.shortcut("t")
+              .fullname("type")
+              .describe("TEXT")
+              .helptext("Select the review type: 'approve' or 'request-changes' or 'comment'")
+              .required(),
         Switch.shortcut("")
               .fullname("verbose")
               .helptext("Turn on verbose output")
@@ -80,6 +85,40 @@ public class GitPrApprove {
         var message = arguments.contains("message") ?
             arguments.get("message").asString() :
             null;
-        pr.addReview(Review.Verdict.APPROVED, message);
+        var type = arguments.get("type").asString();
+        checkType(type, parser);
+        if ("approve".equals(type)) {
+            pr.addReview(Review.Verdict.APPROVED, message);
+        } else if ("request-changes".equals(type)) {
+            checkMessage(message, type, parser);
+            pr.addReview(Review.Verdict.DISAPPROVED, message);
+        } else if ("comment".equals(type)) {
+            checkMessage(message, type, parser);
+            pr.addReview(Review.Verdict.NONE, message);
+        }
+    }
+
+    /**
+     * The message can't be null if the type is `request-change` or `comment`.
+     */
+    public static void checkMessage(String message, String type, ArgumentParser parser) {
+        if (message == null) {
+            System.err.println("error: the option 'message' missed. Need to provide the 'message' if the 'type' is '" + type + "'.");
+            parser.showUsage();
+            System.exit(1);
+        }
+    }
+
+    /**
+     * The type need to be `approve` or `request-change` or `comment`.
+     */
+    public static void checkType(String type, ArgumentParser parser) {
+        if ("approve".equals(type) || "request-changes".equals(type) || "comment".equals(type)) {
+            return;
+        }
+        System.err.println("error: incorrect review 'type': '" + type
+                + "'. Supported review types:  \"approve\", \"request-changes\" or \"comment\".");
+        parser.showUsage();
+        System.exit(1);
     }
 }


### PR DESCRIPTION
Hi all,

This patch changes the command `git pr approve` to `git pr review` and adds the option `type` to identify the review type `approve`, `request-changes` or `comment`.

I tested this patch in [PR1](https://github.com/openjdk/skara/pull/1) mistakenly. Apology for the wrong operation. And I can't find the right place to test the `git pr` command now.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-713](https://bugs.openjdk.java.net/browse/SKARA-713): Rename git/pr-approve to git-pr-review


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1256/head:pull/1256` \
`$ git checkout pull/1256`

Update a local copy of the PR: \
`$ git checkout pull/1256` \
`$ git pull https://git.openjdk.java.net/skara pull/1256/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1256`

View PR using the GUI difftool: \
`$ git pr show -t 1256`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1256.diff">https://git.openjdk.java.net/skara/pull/1256.diff</a>

</details>
