### PR TITLE
1275: An unknown sub-command gives a confusing error message

### DIFF
--- a/args/src/main/java/org/openjdk/skara/args/MultiCommandParser.java
+++ b/args/src/main/java/org/openjdk/skara/args/MultiCommandParser.java
@@ -33,8 +33,9 @@ public class MultiCommandParser {
     private final String programName;
     private final String defaultCommand;
     private final Map<String, Command> subCommands;
+    private final boolean defaultCommandWarningEnabled;
 
-    public MultiCommandParser(String programName, List<Command> commands) {
+    public MultiCommandParser(String programName, List<Command> commands, boolean defaultCommandWarningEnabled) {
         var defaults = commands.stream().filter(Default.class::isInstance).collect(Collectors.toList());
         if (defaults.size() != 1) {
             throw new IllegalArgumentException("Expecting exactly one default command");
@@ -46,6 +47,7 @@ public class MultiCommandParser {
                                    .collect(Collectors.toMap(
                                            Command::name,
                                            Function.identity()));
+        this.defaultCommandWarningEnabled = defaultCommandWarningEnabled;
         if (!commands.stream().anyMatch(c -> c.name().equals("help"))) {
             this.subCommands.put("help", helpCommand());
         }
@@ -62,7 +64,7 @@ public class MultiCommandParser {
                 var forwardedArgs = Arrays.copyOfRange(args, 1, args.length);
                 return () -> p.main(forwardedArgs);
             }
-            if (!"git-webrev".equals(programName) && !"git webrev".equals(programName)) {
+            if (defaultCommandWarningEnabled) {
                 System.err.println("warning: unknown sub-command: " + args[0]);
                 System.err.println("the default sub-command '" + defaultCommand +
                         "' will be executed with the arguments " + Arrays.toString(args) + "\n");

--- a/args/src/main/java/org/openjdk/skara/args/MultiCommandParser.java
+++ b/args/src/main/java/org/openjdk/skara/args/MultiCommandParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,6 +62,10 @@ public class MultiCommandParser {
                 var forwardedArgs = Arrays.copyOfRange(args, 1, args.length);
                 return () -> p.main(forwardedArgs);
             }
+            System.err.println("Can't find the sub-command '" + args[0] +
+                    "', the default sub-command '" + defaultCommand + "' will be executed.");
+            System.err.println("The arguments " + Arrays.toString(args) +
+                    " will be passed to the default sub-command.\n");
         }
         return () -> subCommands.get(defaultCommand).main(args);
     }

--- a/args/src/main/java/org/openjdk/skara/args/MultiCommandParser.java
+++ b/args/src/main/java/org/openjdk/skara/args/MultiCommandParser.java
@@ -62,10 +62,11 @@ public class MultiCommandParser {
                 var forwardedArgs = Arrays.copyOfRange(args, 1, args.length);
                 return () -> p.main(forwardedArgs);
             }
-            System.err.println("Can't find the sub-command '" + args[0] +
-                    "', the default sub-command '" + defaultCommand + "' will be executed.");
-            System.err.println("The arguments " + Arrays.toString(args) +
-                    " will be passed to the default sub-command.\n");
+            if (!"git-webrev".equals(programName) && !"git webrev".equals(programName)) {
+                System.err.println("warning: unknown sub-command: " + args[0]);
+                System.err.println("the default sub-command '" + defaultCommand +
+                        "' will be executed with the arguments " + Arrays.toString(args) + "\n");
+            }
         }
         return () -> subCommands.get(defaultCommand).main(args);
     }

--- a/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitPr.java
@@ -106,7 +106,7 @@ public class GitPr {
     public static void main(String[] args) throws Exception {
         HttpProxy.setup();
 
-        var parser = new MultiCommandParser("git pr", commands);
+        var parser = new MultiCommandParser("git pr", commands, true);
         var command = parser.parse(args);
         command.execute();
     }

--- a/cli/src/main/java/org/openjdk/skara/cli/GitWebrev.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitWebrev.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -503,7 +503,7 @@ public class GitWebrev {
                 );
         HttpProxy.setup();
 
-        var parser = new MultiCommandParser("git webrev", commands);
+        var parser = new MultiCommandParser("git webrev", commands, false);
         var command = parser.parse(args);
         command.execute();
     }

--- a/cli/src/main/java/org/openjdk/skara/cli/SkaraDebug.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/SkaraDebug.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,7 +56,7 @@ public class SkaraDebug {
 
         HttpProxy.setup();
 
-        var parser = new MultiCommandParser("skara debug", commands);
+        var parser = new MultiCommandParser("skara debug", commands, true);
         var command = parser.parse(args);
         command.execute();
     }


### PR DESCRIPTION
Hi all,

When using the unknown command, the client will output the unexpected message. For example:

```
$ git-pr lis 123

error: unexpected input: 123
usage: git-pr [options] [<COMMAND>]
	-h, --help      Show help
	    --verbose   Turn on verbose output
	    --debug     Turn on debugging output
	    --version   Print the version of this tool
```

When the client can't identify the sub-command `git-pr lis`, it will execute the default command `git-pr help` and will pass `lis 123` as the argument to the `git-pr help` command. And the `git-pr help` can resolve only one argument, which is `lis` in this example, so it would output `error: unexpected input: 123`.

This patch will output more information to the user:

```
$ git-pr lis 123

Can't find the sub-command 'lis', the default sub-command 'help' will be executed.
The arguments [lis, 123] will be passed to the default sub-command.

error: unexpected input: 123
usage: git-pr [options] [<COMMAND>]
	-h, --help      Show help
	    --verbose   Turn on verbose output
	    --debug     Turn on debugging output
	    --version   Print the version of this tool
```

The added information can let the user know why the following output is shown.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1275](https://bugs.openjdk.java.net/browse/SKARA-1275): An unknown sub-command gives a confusing error message


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1257/head:pull/1257` \
`$ git checkout pull/1257`

Update a local copy of the PR: \
`$ git checkout pull/1257` \
`$ git pull https://git.openjdk.java.net/skara pull/1257/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1257`

View PR using the GUI difftool: \
`$ git pr show -t 1257`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1257.diff">https://git.openjdk.java.net/skara/pull/1257.diff</a>

</details>
