### PR TITLE
1281: Jcheck fails to run due to IllegalStateException

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
@@ -156,7 +156,7 @@ class PullRequestCheckIssueVisitor implements IssueVisitor {
 
     @Override
     public void visit(HgTagCommitIssue e) {
-        throw new IllegalStateException("Hg tag commit issue - should not happen");
+        log.fine("ignored: invalid tag commit");
     }
 
     @Override


### PR DESCRIPTION
This patch changes the reaction on a hg-tags jcheck failure in a PR from throwing IllegalStateException to just ignore with a log message. This is restoring the behavior to before [423](https://github.com/openjdk/skara/pull/423) for this particular check. See bug description for a more in depth explanation why this is needed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1281](https://bugs.openjdk.java.net/browse/SKARA-1281): Jcheck fails to run due to IllegalStateException


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1258/head:pull/1258` \
`$ git checkout pull/1258`

Update a local copy of the PR: \
`$ git checkout pull/1258` \
`$ git pull https://git.openjdk.java.net/skara pull/1258/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1258`

View PR using the GUI difftool: \
`$ git pr show -t 1258`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1258.diff">https://git.openjdk.java.net/skara/pull/1258.diff</a>

</details>
