### PR TITLE
1280: Possible race condition when integrating PR could cause a spurious "Withdrawn" email

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
@@ -318,8 +318,8 @@ public class IntegrateCommand implements CommandHandler {
     }
 
     static void markIntegratedAndClosed(PullRequest pr, Hash hash, PrintWriter reply) {
-        pr.setState(PullRequest.State.CLOSED);
         pr.addLabel("integrated");
+        pr.setState(PullRequest.State.CLOSED);
         pr.removeLabel("ready");
         pr.removeLabel("rfr");
         if (pr.labelNames().contains("deferred")) {


### PR DESCRIPTION
Change the order of adding "integrated" label and closing a pull request to avoid a race with the mlbridge bot, which could otherwise mistakenly send out a "withdrawn" message for a PR that is in the process of being integrated.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1280](https://bugs.openjdk.java.net/browse/SKARA-1280): Possible race condition when integrating PR could cause a spurious "Withdrawn" email


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1259/head:pull/1259` \
`$ git checkout pull/1259`

Update a local copy of the PR: \
`$ git checkout pull/1259` \
`$ git pull https://git.openjdk.java.net/skara pull/1259/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1259`

View PR using the GUI difftool: \
`$ git pr show -t 1259`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1259.diff">https://git.openjdk.java.net/skara/pull/1259.diff</a>

</details>
