### PR TITLE
build: update to JUnit 5.8.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ echo "export MANPATH=\$MANPATH":$PWD/build/bin/man >> ~/.bashrc
 
 ## Testing
 
-[JUnit](https://junit.org/junit5/) 5.6.2 or later is required to run the unit
+[JUnit](https://junit.org/junit5/) 5.8.2 or later is required to run the unit
 tests. To run the tests, execute following command from the source tree root:
 
 ```bash

--- a/build.gradle
+++ b/build.gradle
@@ -53,12 +53,12 @@ configure(subprojects.findAll() { it.name != 'bots' }) {
     }
 
     dependencies {
-        testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.1'
-        testImplementation 'org.junit.jupiter:junit-jupiter-params:5.7.1'
-        testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.1'
+        testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
+        testImplementation 'org.junit.jupiter:junit-jupiter-params:5.8.2'
+        testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
         // Force Gradle to load the JUnit Platform Launcher from the module-path, as
         // configured in buildSrc/.../ModulePlugin.java -- see SKARA-69 for details.
-        testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.7.1'
+        testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.8.2'
     }
 
     tasks.withType(JavaCompile).configureEach {


### PR DESCRIPTION
This patch that updates JUnit Jupiter to 5.8.2 and JUnit Platform to 1.8.2.

PS: The text at https://github.com/openjdk/skara#testing reading "_JUnit 5.6.2 or later is required to run the unit tests._" seems to be out of date. Shouldn't it read like: "A recent version of JUnit 5 is..."?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1260/head:pull/1260` \
`$ git checkout pull/1260`

Update a local copy of the PR: \
`$ git checkout pull/1260` \
`$ git pull https://git.openjdk.java.net/skara pull/1260/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1260`

View PR using the GUI difftool: \
`$ git pr show -t 1260`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1260.diff">https://git.openjdk.java.net/skara/pull/1260.diff</a>

</details>
