### PR TITLE
1283: Test failures with Mercurial 6.0

### DIFF
--- a/vcs/src/main/resources/ext.py
+++ b/vcs/src/main/resources/ext.py
@@ -67,7 +67,7 @@ def _match_exact(root, cwd, files, badfn=None):
     """
     Wrapper for mercurial.match.exact that ignores some arguments based on the used version
     """
-    if mercurial.util.version().startswith(b"5"):
+    if mercurial.util.version().split(b".")[0] >= b"5":
         return mercurial.match.exact(files, badfn)
     else:
         return mercurial.match.exact(root, cwd, files, badfn)

--- a/vcs/src/main/resources/ext.py
+++ b/vcs/src/main/resources/ext.py
@@ -67,7 +67,7 @@ def _match_exact(root, cwd, files, badfn=None):
     """
     Wrapper for mercurial.match.exact that ignores some arguments based on the used version
     """
-    if mercurial.util.version().split(b".")[0] >= b"5":
+    if int(mercurial.util.version().split(b".")[0]) >= 5:
         return mercurial.match.exact(files, badfn)
     else:
         return mercurial.match.exact(root, cwd, files, badfn)


### PR DESCRIPTION
Adjust ext.py to handle Mercurial versions 6.0+.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1283](https://bugs.openjdk.java.net/browse/SKARA-1283): Test failures with Mercurial 6.0


### Reviewers
 * [Christian Stein](https://openjdk.java.net/census#cstein) (@sormuras - no project role)
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1261/head:pull/1261` \
`$ git checkout pull/1261`

Update a local copy of the PR: \
`$ git checkout pull/1261` \
`$ git pull https://git.openjdk.java.net/skara pull/1261/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1261`

View PR using the GUI difftool: \
`$ git pr show -t 1261`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1261.diff">https://git.openjdk.java.net/skara/pull/1261.diff</a>

</details>
