### PR TITLE
1288: Adjust the implementation of the 'reviewers' command to match the documentation

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewersCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewersCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -97,6 +97,11 @@ public class ReviewersCommand implements CommandHandler {
             reply.println("Cannot increase the required number of reviewers above 10 (requested: " + numReviewers + ")");
             return;
         }
+        if (numReviewers < 0) {
+            showHelp(reply);
+            reply.println("Cannot decrease the required number of reviewers below 0 (requested: " + numReviewers + ")");
+            return;
+        }
 
         String role = "authors";
         if (splitArgs.length > 1) {
@@ -124,24 +129,19 @@ public class ReviewersCommand implements CommandHandler {
         }
 
         var updatedLimits = ReviewersTracker.updatedRoleLimits(censusInstance.configuration(), numReviewers, role);
-        if (updatedLimits.get(role) > numReviewers) {
-            showHelp(reply);
-            reply.println("Number of required reviewers of role " + role + " cannot be decreased below " + updatedLimits.get(role));
-            return;
-        }
 
         reply.println(ReviewersTracker.setReviewersMarker(numReviewers, role));
         var totalRequired = updatedLimits.values().stream().mapToInt(Integer::intValue).sum();
-        reply.print("The number of required reviews for this PR is now set to " + totalRequired);
+        reply.print("The total number of required reviews for this PR, " +
+                "which is combined by the configuration and the command, is now set to " + totalRequired);
 
         // Create a helpful message regarding the required distribution (if applicable)
         var nonZeroDescriptions = updatedLimits.entrySet().stream()
                 .filter(entry -> entry.getValue() > 0)
                 .map(entry -> entry.getValue() + " of role " + entry.getKey())
                 .collect(Collectors.toList());
-        if (nonZeroDescriptions.size() > 1) {
-            nonZeroDescriptions.remove(nonZeroDescriptions.size() - 1);
-            reply.print(" (with at least " + String.join(", ", nonZeroDescriptions) + ")");
+        if (nonZeroDescriptions.size() > 0) {
+            reply.print(" (with " + String.join(", ", nonZeroDescriptions) + ")");
         }
 
         reply.println(".");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewersCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewersCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -132,8 +132,8 @@ public class ReviewersCommand implements CommandHandler {
 
         reply.println(ReviewersTracker.setReviewersMarker(numReviewers, role));
         var totalRequired = updatedLimits.values().stream().mapToInt(Integer::intValue).sum();
-        reply.print("The total number of required reviews for this PR, " +
-                "which is combined by the configuration and the command, is now set to " + totalRequired);
+        reply.print("The total number of required reviews for this PR (including the jcheck configuration " +
+                    "and the last /reviewers command) is now set to " + totalRequired);
 
         // Create a helpful message regarding the required distribution (if applicable)
         var nonZeroDescriptions = updatedLimits.entrySet().stream()

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewersTracker.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewersTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,11 +60,11 @@ class ReviewersTracker {
                     break;
                 }
             } else {
+                // The new value cannot be lower than the value in '.jcheck/conf',
+                // because the '.jcheck/conf' file means the minimal reviewer requirement.
                 if (remainingAdditional > updatedLimits.get(r)) {
                     // Set the number for the lower roles to remove.
                     remainingRemovals = remainingAdditional - updatedLimits.get(r);
-                    // The new number of the reviewers should larger or equal than the requirement of the '.jcheck/conf' file.
-                    // Because the '.jcheck/conf' file means the minimal reviewer requirement.
                     updatedLimits.replace(r, remainingAdditional);
                 }
                 break;
@@ -83,7 +83,7 @@ class ReviewersTracker {
                 var originalVal = updatedLimits.get(r);
                 var removed = Math.max(0, originalVal - remainingRemovals);
                 updatedLimits.replace(r, removed);
-                remainingRemovals -= (originalVal - updatedLimits.get(r));
+                remainingRemovals -= (originalVal - removed);
             } else {
                 break;
             }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewersTracker.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewersTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,6 +51,7 @@ class ReviewersTracker {
 
         // Increase the required role level by the requested amount (while subtracting higher roles)
         var remainingAdditional = count;
+        var remainingRemovals = 0;
         var roles = new ArrayList<>(updatedLimits.keySet());
         for (var r : roles) {
             if (!r.equals(role)) {
@@ -59,19 +60,30 @@ class ReviewersTracker {
                     break;
                 }
             } else {
-                updatedLimits.replace(r, updatedLimits.get(r) + remainingAdditional);
+                if (remainingAdditional > updatedLimits.get(r)) {
+                    // Set the number for the lower roles to remove.
+                    remainingRemovals = remainingAdditional - updatedLimits.get(r);
+                    // The new number of the reviewers should larger or equal than the requirement of the '.jcheck/conf' file.
+                    // Because the '.jcheck/conf' file means the minimal reviewer requirement.
+                    updatedLimits.replace(r, remainingAdditional);
+                }
                 break;
             }
         }
 
+        if (remainingRemovals == 0) {
+            // Improve performance. If remainingRemovals is 0, don't need to decrease the lower roles.
+            return updatedLimits;
+        }
+
         // Decrease lower roles (if any) to avoid increasing the total count above the requested
         Collections.reverse(roles);
-        var remainingRemovals = count;
         for (var r : roles) {
             if (!r.equals(role)) {
-                var removed = Math.max(0, updatedLimits.get(r) - remainingRemovals);
+                var originalVal = updatedLimits.get(r);
+                var removed = Math.max(0, originalVal - remainingRemovals);
                 updatedLimits.replace(r, removed);
-                remainingRemovals -= removed;
+                remainingRemovals -= (originalVal - updatedLimits.get(r));
             } else {
                 break;
             }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ReviewersTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ReviewersTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,6 +39,9 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.openjdk.skara.bots.pr.PullRequestAsserts.assertLastCommentContains;
 
 public class ReviewersTests {
+    private static final String reviewersCommandFinallyOutput = "The total number of required reviews for this PR " +
+            "(including the jcheck configuration and the last /reviewers command) is now set to ";
+
     @Test
     void simple(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
@@ -100,24 +103,21 @@ public class ReviewersTests {
             TestBotRunner.runPeriodicItems(prBot);
 
             // The bot should reply with a success message
-            assertLastCommentContains(reviewerPr,"The total number of required reviews for this PR, " +
-                    "which is combined by the configuration and the command, is now set to 2 (with 1 of role reviewers, 1 of role authors).");
+            assertLastCommentContains(reviewerPr, reviewersCommandFinallyOutput + "2 (with 1 of role reviewers, 1 of role authors).");
 
             // Set 2 of role committers
             reviewerPr.addComment("/reviewers 2 committer");
             TestBotRunner.runPeriodicItems(prBot);
 
             // The bot should reply with a success message
-            assertLastCommentContains(reviewerPr,"The total number of required reviews for this PR, " +
-                    "which is combined by the configuration and the command, is now set to 2 (with 1 of role reviewers, 1 of role committers).");
+            assertLastCommentContains(reviewerPr, reviewersCommandFinallyOutput + "2 (with 1 of role reviewers, 1 of role committers).");
 
             // Set 2 of role reviewers
             reviewerPr.addComment("/reviewers 2 reviewer");
             TestBotRunner.runPeriodicItems(prBot);
 
             // The bot should reply with a success message
-            assertLastCommentContains(reviewerPr,"The total number of required reviews for this PR, " +
-                    "which is combined by the configuration and the command, is now set to 2 (with 2 of role reviewers).");
+            assertLastCommentContains(reviewerPr, reviewersCommandFinallyOutput + "2 (with 2 of role reviewers).");
 
             // Approve it as another user
             reviewerPr.addReview(Review.Verdict.APPROVED, "Approved");
@@ -141,8 +141,7 @@ public class ReviewersTests {
             reviewerPr.addComment("/reviewers 1 lead");
             TestBotRunner.runPeriodicItems(prBot);
             TestBotRunner.runPeriodicItems(prBot);
-            assertLastCommentContains(reviewerPr,"The total number of required reviews for this PR, " +
-                    "which is combined by the configuration and the command, is now set to 1 (with 1 of role lead).");
+            assertLastCommentContains(reviewerPr, reviewersCommandFinallyOutput + "1 (with 1 of role lead).");
 
             // The PR should no longer be considered as ready for review
             updatedPr = author.pullRequest(pr.id());
@@ -152,8 +151,7 @@ public class ReviewersTests {
             reviewerPr.addComment("/reviewers 1");
             TestBotRunner.runPeriodicItems(prBot);
             TestBotRunner.runPeriodicItems(prBot);
-            assertLastCommentContains(reviewerPr,"The total number of required reviews for this PR, " +
-                    "which is combined by the configuration and the command, is now set to 1 (with 1 of role reviewers).");
+            assertLastCommentContains(reviewerPr, reviewersCommandFinallyOutput + "1 (with 1 of role reviewers).");
 
             // The PR should now be considered as ready for review yet again
             updatedPr = author.pullRequest(pr.id());
@@ -193,8 +191,7 @@ public class ReviewersTests {
             TestBotRunner.runPeriodicItems(prBot);
 
             // The bot should reply with a success message
-            assertLastCommentContains(reviewerPr,"The total number of required reviews for this PR, " +
-                    "which is combined by the configuration and the command, is now set to 2 (with 1 of role reviewers, 1 of role authors).");
+            assertLastCommentContains(reviewerPr, reviewersCommandFinallyOutput + "2 (with 1 of role reviewers, 1 of role authors).");
 
             // Approve it as another user
             reviewerPr.addReview(Review.Verdict.APPROVED, "Approved");
@@ -259,8 +256,7 @@ public class ReviewersTests {
             TestBotRunner.runPeriodicItems(prBot);
 
             // The bot should reply with a success message
-            assertLastCommentContains(reviewerPr,"The total number of required reviews for this PR, " +
-                    "which is combined by the configuration and the command, is now set to 2 (with 1 of role reviewers, 1 of role authors).");
+            assertLastCommentContains(reviewerPr, reviewersCommandFinallyOutput + "2 (with 1 of role reviewers, 1 of role authors).");
 
             // It should not be possible to sponsor
             reviewerPr.addComment("/sponsor");
@@ -308,8 +304,7 @@ public class ReviewersTests {
 
             // The bot should reply with a success message
             TestBotRunner.runPeriodicItems(prBot);
-            assertLastCommentContains(authorPR,"The total number of required reviews for this PR, " +
-                    "which is combined by the configuration and the command, is now set to 2 (with 1 of role reviewers, 1 of role authors).");
+            assertLastCommentContains(authorPR, reviewersCommandFinallyOutput + "2 (with 1 of role reviewers, 1 of role authors).");
         }
     }
 
@@ -345,8 +340,7 @@ public class ReviewersTests {
 
             // The bot should reply with a success message
             TestBotRunner.runPeriodicItems(prBot);
-            assertLastCommentContains(authorPR,"The total number of required reviews for this PR, " +
-                    "which is combined by the configuration and the command, is now set to 2 (with 1 of role reviewers, 1 of role authors).");
+            assertLastCommentContains(authorPR, reviewersCommandFinallyOutput + "2 (with 1 of role reviewers, 1 of role authors).");
             // The author should not be allowed to decrease even its own /reviewers command
             authorPR.addComment("/reviewers 1");
             TestBotRunner.runPeriodicItems(prBot);
@@ -356,8 +350,7 @@ public class ReviewersTests {
             var reviewerPr = integrator.pullRequest(pr.id());
             reviewerPr.addComment("/reviewers 1");
             TestBotRunner.runPeriodicItems(prBot);
-            assertLastCommentContains(reviewerPr,"The total number of required reviews for this PR, " +
-                    "which is combined by the configuration and the command, is now set to 1 (with 1 of role reviewers).");
+            assertLastCommentContains(reviewerPr, reviewersCommandFinallyOutput + "1 (with 1 of role reviewers).");
         }
     }
 
@@ -387,8 +380,7 @@ public class ReviewersTests {
             TestBotRunner.runPeriodicItems(prBot);
 
             var authorPR = author.pullRequest(pr.id());
-            assertLastCommentContains(authorPR,"The total number of required reviews for this PR, " +
-                    "which is combined by the configuration and the command, is now set to 2 (with 1 of role reviewers, 1 of role authors).");
+            assertLastCommentContains(authorPR, reviewersCommandFinallyOutput + "2 (with 1 of role reviewers, 1 of role authors).");
         }
     }
 
@@ -488,8 +480,7 @@ public class ReviewersTests {
 
     private String getReviewersExpectedComment(int totalNum, int leadNum, int reviewerNum, int committerNum, int authorNum, int contributorNum) {
         StringBuilder builder = new StringBuilder();
-        builder.append("The total number of required reviews for this PR, " +
-                "which is combined by the configuration and the command, is now set to ");
+        builder.append(reviewersCommandFinallyOutput);
         builder.append(totalNum);
         if (leadNum == 0 && reviewerNum == 0 && committerNum == 0 && authorNum == 0 && contributorNum == 0) {
             builder.append(".");

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ReviewersTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ReviewersTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,12 +22,17 @@
  */
 package org.openjdk.skara.bots.pr;
 
+import org.openjdk.skara.forge.PullRequest;
 import org.openjdk.skara.forge.Review;
 import org.openjdk.skara.test.*;
 
 import org.junit.jupiter.api.*;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -83,7 +88,7 @@ public class ReviewersTests {
             // Too few
             reviewerPr.addComment("/reviewers -3");
             TestBotRunner.runPeriodicItems(prBot);
-            assertLastCommentContains(reviewerPr,"Number of required reviewers of role authors cannot be decreased below 0");
+            assertLastCommentContains(reviewerPr,"Cannot decrease the required number of reviewers below 0 (requested: -3)");
 
             // Unknown role
             reviewerPr.addComment("/reviewers 2 penguins");
@@ -95,7 +100,24 @@ public class ReviewersTests {
             TestBotRunner.runPeriodicItems(prBot);
 
             // The bot should reply with a success message
-            assertLastCommentContains(reviewerPr,"The number of required reviews for this PR is now set to 2 (with at least 1 of role reviewers).");
+            assertLastCommentContains(reviewerPr,"The total number of required reviews for this PR, " +
+                    "which is combined by the configuration and the command, is now set to 2 (with 1 of role reviewers, 1 of role authors).");
+
+            // Set 2 of role committers
+            reviewerPr.addComment("/reviewers 2 committer");
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // The bot should reply with a success message
+            assertLastCommentContains(reviewerPr,"The total number of required reviews for this PR, " +
+                    "which is combined by the configuration and the command, is now set to 2 (with 1 of role reviewers, 1 of role committers).");
+
+            // Set 2 of role reviewers
+            reviewerPr.addComment("/reviewers 2 reviewer");
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // The bot should reply with a success message
+            assertLastCommentContains(reviewerPr,"The total number of required reviews for this PR, " +
+                    "which is combined by the configuration and the command, is now set to 2 (with 2 of role reviewers).");
 
             // Approve it as another user
             reviewerPr.addReview(Review.Verdict.APPROVED, "Approved");
@@ -119,7 +141,8 @@ public class ReviewersTests {
             reviewerPr.addComment("/reviewers 1 lead");
             TestBotRunner.runPeriodicItems(prBot);
             TestBotRunner.runPeriodicItems(prBot);
-            assertLastCommentContains(reviewerPr,"The number of required reviews for this PR is now set to 1.");
+            assertLastCommentContains(reviewerPr,"The total number of required reviews for this PR, " +
+                    "which is combined by the configuration and the command, is now set to 1 (with 1 of role lead).");
 
             // The PR should no longer be considered as ready for review
             updatedPr = author.pullRequest(pr.id());
@@ -129,7 +152,8 @@ public class ReviewersTests {
             reviewerPr.addComment("/reviewers 1");
             TestBotRunner.runPeriodicItems(prBot);
             TestBotRunner.runPeriodicItems(prBot);
-            assertLastCommentContains(reviewerPr,"The number of required reviews for this PR is now set to 1.");
+            assertLastCommentContains(reviewerPr,"The total number of required reviews for this PR, " +
+                    "which is combined by the configuration and the command, is now set to 1 (with 1 of role reviewers).");
 
             // The PR should now be considered as ready for review yet again
             updatedPr = author.pullRequest(pr.id());
@@ -169,7 +193,8 @@ public class ReviewersTests {
             TestBotRunner.runPeriodicItems(prBot);
 
             // The bot should reply with a success message
-            assertLastCommentContains(reviewerPr,"The number of required reviews for this PR is now set to 2 (with at least 1 of role reviewers).");
+            assertLastCommentContains(reviewerPr,"The total number of required reviews for this PR, " +
+                    "which is combined by the configuration and the command, is now set to 2 (with 1 of role reviewers, 1 of role authors).");
 
             // Approve it as another user
             reviewerPr.addReview(Review.Verdict.APPROVED, "Approved");
@@ -234,7 +259,8 @@ public class ReviewersTests {
             TestBotRunner.runPeriodicItems(prBot);
 
             // The bot should reply with a success message
-            assertLastCommentContains(reviewerPr,"The number of required reviews for this PR is now set to 2 (with at least 1 of role reviewers).");
+            assertLastCommentContains(reviewerPr,"The total number of required reviews for this PR, " +
+                    "which is combined by the configuration and the command, is now set to 2 (with 1 of role reviewers, 1 of role authors).");
 
             // It should not be possible to sponsor
             reviewerPr.addComment("/sponsor");
@@ -282,7 +308,8 @@ public class ReviewersTests {
 
             // The bot should reply with a success message
             TestBotRunner.runPeriodicItems(prBot);
-            assertLastCommentContains(authorPR, "The number of required reviews for this PR is now set to 2 (with at least 1 of role reviewers).");
+            assertLastCommentContains(authorPR,"The total number of required reviews for this PR, " +
+                    "which is combined by the configuration and the command, is now set to 2 (with 1 of role reviewers, 1 of role authors).");
         }
     }
 
@@ -318,8 +345,8 @@ public class ReviewersTests {
 
             // The bot should reply with a success message
             TestBotRunner.runPeriodicItems(prBot);
-            assertLastCommentContains(authorPR, "The number of required reviews for this PR is now set to 2 (with at least 1 of role reviewers).");
-
+            assertLastCommentContains(authorPR,"The total number of required reviews for this PR, " +
+                    "which is combined by the configuration and the command, is now set to 2 (with 1 of role reviewers, 1 of role authors).");
             // The author should not be allowed to decrease even its own /reviewers command
             authorPR.addComment("/reviewers 1");
             TestBotRunner.runPeriodicItems(prBot);
@@ -329,7 +356,8 @@ public class ReviewersTests {
             var reviewerPr = integrator.pullRequest(pr.id());
             reviewerPr.addComment("/reviewers 1");
             TestBotRunner.runPeriodicItems(prBot);
-            assertLastCommentContains(authorPR, "The number of required reviews for this PR is now set to 1");
+            assertLastCommentContains(reviewerPr,"The total number of required reviews for this PR, " +
+                    "which is combined by the configuration and the command, is now set to 1 (with 1 of role reviewers).");
         }
     }
 
@@ -359,7 +387,129 @@ public class ReviewersTests {
             TestBotRunner.runPeriodicItems(prBot);
 
             var authorPR = author.pullRequest(pr.id());
-            assertLastCommentContains(authorPR,"The number of required reviews for this PR is now set to 2 (with at least 1 of role reviewers).");
+            assertLastCommentContains(authorPR,"The total number of required reviews for this PR, " +
+                    "which is combined by the configuration and the command, is now set to 2 (with 1 of role reviewers, 1 of role authors).");
         }
+    }
+
+    @Test
+    void complexCombinedConfigAndCommand(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var integrator = credentials.getHostedRepository();
+            var bot = credentials.getHostedRepository();
+
+            var censusBuilder = credentials.getCensusBuilder()
+                    .addReviewer(integrator.forge().currentUser().id())
+                    .addCommitter(author.forge().currentUser().id());
+            var prBot = PullRequestBot.newBuilder().repo(bot).censusRepo(censusBuilder.build()).build();
+
+            // Populate the projects repository
+            var localRepoFolder = tempFolder.path().resolve("localrepo");
+            var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Change the jcheck configuration
+            var confPath = localRepo.root().resolve(".jcheck/conf");
+            var defaultConf = Files.readString(confPath, StandardCharsets.UTF_8);
+            var newConf = defaultConf.replace("reviewers=1", """
+                                                    lead=1
+                                                    reviewers=1
+                                                    committers=1
+                                                    authors=1
+                                                    contributors=1
+                                                    ignore=duke
+                                                    """);
+            Files.writeString(confPath, newConf);
+            localRepo.add(confPath);
+            var confHash = localRepo.commit("Change conf", "duke", "duke@openjdk.org");
+            localRepo.push(confHash, author.url(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "123: This is a pull request");
+
+            var reviewerPr = integrator.pullRequest(pr.id());
+
+            // test role contributor
+            for (int i = 1; i <= 10; i++) {
+                var totalNum = Math.max(i, 5);
+                var contributorNum = (i < 6) ? 1 : i - 4;
+                verifyReviewersComment(reviewerPr, prBot, "/reviewers " + i + " contributor",
+                        getReviewersExpectedComment(totalNum, 1, 1, 1, 1, contributorNum));
+            }
+
+            // test role author
+            for (int i = 1; i <= 10; i++) {
+                var totalNum = Math.max(i, 5);
+                var contributorNum = (i < 5) ? 1 : 0;
+                var authorNum = (i < 5) ? 1 : i - 3;
+                verifyReviewersComment(reviewerPr, prBot, "/reviewers " + i + " author",
+                        getReviewersExpectedComment(totalNum, 1, 1, 1, authorNum, contributorNum));
+            }
+
+            // test role committer
+            for (int i = 1; i <= 10; i++) {
+                var totalNum = Math.max(i, 5);
+                var contributorNum = (i < 4) ? 1 : 0;
+                var authorNum = (i < 5) ? 1 : 0;
+                var committerNum = (i < 4) ? 1 : i - 2;
+                verifyReviewersComment(reviewerPr, prBot, "/reviewers " + i + " committer",
+                        getReviewersExpectedComment(totalNum, 1, 1, committerNum, authorNum, contributorNum));
+            }
+
+            // test role reviewer
+            for (int i = 1; i <= 10; i++) {
+                var totalNum = Math.max(i, 5);
+                var contributorNum = (i < 3) ? 1 : 0;
+                var authorNum = (i < 4) ? 1 : 0;
+                var committerNum = (i < 5) ? 1 : 0;
+                var reviewerNum = (i < 3) ? 1 : i - 1;
+                verifyReviewersComment(reviewerPr, prBot, "/reviewers " + i + " reviewer",
+                        getReviewersExpectedComment(totalNum, 1, reviewerNum, committerNum, authorNum, contributorNum));
+
+            }
+
+            // test role lead
+            verifyReviewersComment(reviewerPr, prBot, "/reviewers 1 lead",
+                        getReviewersExpectedComment(5, 1, 1, 1, 1, 1));
+        }
+    }
+
+    private void verifyReviewersComment(PullRequest reviewerPr, PullRequestBot prBot, String command, String expectedReply) throws IOException {
+        reviewerPr.addComment(command);
+        TestBotRunner.runPeriodicItems(prBot);
+        assertLastCommentContains(reviewerPr, expectedReply);
+    }
+
+    private String getReviewersExpectedComment(int totalNum, int leadNum, int reviewerNum, int committerNum, int authorNum, int contributorNum) {
+        StringBuilder builder = new StringBuilder();
+        builder.append("The total number of required reviews for this PR, " +
+                "which is combined by the configuration and the command, is now set to ");
+        builder.append(totalNum);
+        if (leadNum == 0 && reviewerNum == 0 && committerNum == 0 && authorNum == 0 && contributorNum == 0) {
+            builder.append(".");
+            return builder.toString();
+        }
+        builder.append(" (with");
+        var list = new ArrayList<String>();
+        var map = new LinkedHashMap<String, Integer>();
+        map.put("lead", leadNum);
+        map.put("reviewers", reviewerNum);
+        map.put("committers", committerNum);
+        map.put("authors", authorNum);
+        map.put("contributors", contributorNum);
+        for (var entry : map.entrySet()) {
+            if (entry.getValue() > 0) {
+                list.add(" " + entry.getValue() + " of role " + entry.getKey());
+            }
+        }
+        builder.append(String.join(",", list));
+        builder.append(").");
+        return builder.toString();
     }
 }


### PR DESCRIPTION
Hi all,

The `reviewers` command [documentation](https://wiki.openjdk.java.net/display/SKARA/Pull+Request+Commands#PullRequestCommands-/reviewers) states:

> Description
> Require that at least N users with given role (defaults to Author) review the pull request before it can be integrated. The requirements are in addition to the ones specified by the .jcheck/conf file.

But the implementation doesn't match the documentation now, especially the bug reported at [JDK-PULL-6752](https://github.com/openjdk/jdk/pull/6752) ([SKARA-1288](https://bugs.openjdk.java.net/browse/SKARA-1288) also recorded this bug).

This patch fixes the bug and revises the code to match the documentation.

The logic has small change(Please see the following code). In the past, the reviewer number of the role will be the sum of the `updatedLimits.get(r)` and `remainingAdditional`. But I don't know it meets our expectation. Because the higher roles can reduce the `remainingAdditional`, I think the remaining number should be only set to `updatedLimits` but not added to `updatedLimits`. This matches the documentation `Require that at least N users with given role (defaults to Author) review the pull request`, especially the key work `at least`.

```
-                updatedLimits.replace(r, updatedLimits.get(r) + remainingAdditional);
+                if (remainingAdditional > updatedLimits.get(r)) {
+                    // Set the number for the lower roles to remove.
+                    remainingRemovals = remainingAdditional - updatedLimits.get(r);
+                   // The new number of the reviewers should larger or equal than the requirement of the '.jcheck/conf' file.
+                    // Because the '.jcheck/conf' file means the minimal reviewer requirement.
+                   updatedLimits.replace(r, remainingAdditional);
+              }
```

The other code changes are listed below:
- add negative number check.
- remove the updated limits check. Because it is not needed after adding the negative number check.
- adjust the reply message, always output the concrete reviewers. Because the merged logic of jcheck config and user `reviewers` command is a little hard, we should let the user know the result directly instead of guessing the result.
- `decrease lower roles` in the method `ReviewersTracker#updatedRoleLimits` doesn't work as expected. I fix it.
- add more test cases.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1288](https://bugs.openjdk.java.net/browse/SKARA-1288): Adjust the implementation of the 'reviewers' command to match the documentation


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1262/head:pull/1262` \
`$ git checkout pull/1262`

Update a local copy of the PR: \
`$ git checkout pull/1262` \
`$ git pull https://git.openjdk.java.net/skara pull/1262/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1262`

View PR using the GUI difftool: \
`$ git pr show -t 1262`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1262.diff">https://git.openjdk.java.net/skara/pull/1262.diff</a>

</details>
