### PR TITLE
1274: The help message of the 'git-pr' sub-commamd misses the sub-command name

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrApply.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrApply.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,7 +68,7 @@ public class GitPrApply {
     );
 
     public static void main(String[] args) throws IOException {
-        var parser = new ArgumentParser("git-pr", flags, inputs);
+        var parser = new ArgumentParser("git-pr apply", flags, inputs);
         var arguments = parse(parser, args);
         var repo = getRepo();
         var uri = getURI(repo, arguments);

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrCheckout.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrCheckout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,7 +72,7 @@ public class GitPrCheckout {
     );
 
     public static void main(String[] args) throws IOException {
-        var parser = new ArgumentParser("git-pr", flags, inputs);
+        var parser = new ArgumentParser("git-pr checkout", flags, inputs);
         var arguments = parse(parser, args);
         var repo = getRepo();
         var uri = getURI(repo, arguments);

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrClose.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrClose.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,7 +64,7 @@ public class GitPrClose {
     );
 
     public static void main(String[] args) throws IOException, InterruptedException {
-        var parser = new ArgumentParser("git-pr", flags, inputs);
+        var parser = new ArgumentParser("git-pr close", flags, inputs);
         var arguments = parse(parser, args);
         var repo = getRepo();
         var uri = getURI(repo, arguments);

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrCreate.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrCreate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -130,7 +130,7 @@ public class GitPrCreate {
     }
 
     public static void main(String[] args) throws IOException, InterruptedException {
-        var parser = new ArgumentParser("git-pr", flags, inputs);
+        var parser = new ArgumentParser("git-pr create", flags, inputs);
         var arguments = parse(parser, args);
         var repo = getRepo();
         var uri = getURI(repo, arguments);

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrFetch.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrFetch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,7 +67,7 @@ public class GitPrFetch {
     );
 
     public static void main(String[] args) throws IOException {
-        var parser = new ArgumentParser("git-pr", flags, inputs);
+        var parser = new ArgumentParser("git-pr fetch", flags, inputs);
         var arguments = parse(parser, args);
         var repo = getRepo();
         var uri = getURI(repo, arguments);

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrHelp.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrHelp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -123,7 +123,7 @@ public class GitPrHelp {
                  .optional()
         );
 
-        var parser = new ArgumentParser("git-pr", flags, inputs);
+        var parser = new ArgumentParser("git-pr help", flags, inputs);
         var arguments = parser.parse(args);
         if (arguments.contains("version")) {
             System.out.println("git-pr version: " + Version.fromManifest().orElse("unknown"));

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrInfo.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -123,7 +123,7 @@ public class GitPrInfo {
     );
 
     public static void main(String[] args) throws IOException {
-        var parser = new ArgumentParser("git-pr", flags, inputs);
+        var parser = new ArgumentParser("git-pr info", flags, inputs);
         var arguments = parse(parser, args);
         var repo = getRepo();
         var uri = getURI(repo, arguments);

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrIntegrate.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrIntegrate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -75,7 +75,7 @@ public class GitPrIntegrate {
     );
 
     public static void main(String[] args) throws IOException, InterruptedException {
-        var parser = new ArgumentParser("git-pr", flags, inputs);
+        var parser = new ArgumentParser("git-pr integrate", flags, inputs);
         var arguments = parse(parser, args);
 
         var isAtomic = getSwitch("atomic", "integrate", arguments);

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrIssue.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrIssue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -79,7 +79,7 @@ public class GitPrIssue {
     );
 
     public static void main(String[] args) throws IOException, InterruptedException {
-        var parser = new ArgumentParser("git-pr", flags, inputs);
+        var parser = new ArgumentParser("git-pr issue", flags, inputs);
         var arguments = parse(parser, args);
         var repo = getRepo();
         var uri = getURI(repo, arguments);

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrList.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -111,7 +111,7 @@ public class GitPrList {
     }
 
     public static void main(String[] args) throws IOException {
-        var parser = new ArgumentParser("git-pr", flags, inputs);
+        var parser = new ArgumentParser("git-pr list", flags, inputs);
         var arguments = parse(parser, args);
         var repo = getRepo();
         var uri = getURI(repo, arguments);

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrReview.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrReview.java
@@ -74,7 +74,7 @@ public class GitPrReview {
     );
 
     public static void main(String[] args) throws IOException {
-        var parser = new ArgumentParser("git-pr", flags, inputs);
+        var parser = new ArgumentParser("git-pr review", flags, inputs);
         var arguments = parse(parser, args);
         var repo = getRepo();
         var uri = getURI(repo, arguments);

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrSet.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -110,7 +110,7 @@ public class GitPrSet {
     );
 
     public static void main(String[] args) throws IOException, InterruptedException {
-        var parser = new ArgumentParser("git-pr", flags, inputs);
+        var parser = new ArgumentParser("git-pr set", flags, inputs);
         var arguments = parse(parser, args);
         var repo = getRepo();
         var uri = getURI(repo, arguments);

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrShow.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrShow.java
@@ -71,7 +71,7 @@ public class GitPrShow {
     );
 
     public static void main(String[] args) throws IOException, InterruptedException {
-        var parser = new ArgumentParser("git-pr", flags, inputs);
+        var parser = new ArgumentParser("git-pr show", flags, inputs);
         var arguments = parse(parser, args);
         var repo = getRepo();
         var uri = getURI(repo, arguments);

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrSponsor.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrSponsor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,7 +63,7 @@ public class GitPrSponsor {
     );
 
     public static void main(String[] args) throws IOException, InterruptedException {
-        var parser = new ArgumentParser("git-pr", flags, inputs);
+        var parser = new ArgumentParser("git-pr sponsor", flags, inputs);
         var arguments = parse(parser, args);
         var repo = getRepo();
         var uri = getURI(repo, arguments);


### PR DESCRIPTION
Hi all,

This little patch fixes the help message when using the `git-pr` sub-command. For example:

Before this patch:

```
$ git-pr list -h

usage: git-pr [options] [<ID>] // <---- Here miss the `list`
      // Ignore the following output.
```

After this patch:

```
$ git-pr list -h
usage: git-pr list [options] [<ID>]
      // Ignore the following output.
```

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1274](https://bugs.openjdk.java.net/browse/SKARA-1274): The help message of the 'git-pr' sub-commamd misses the sub-command name


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1263/head:pull/1263` \
`$ git checkout pull/1263`

Update a local copy of the PR: \
`$ git checkout pull/1263` \
`$ git pull https://git.openjdk.java.net/skara pull/1263/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1263`

View PR using the GUI difftool: \
`$ git pr show -t 1263`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1263.diff">https://git.openjdk.java.net/skara/pull/1263.diff</a>

</details>
