### PR TITLE
1291: NPE in org.openjdk.skara.issuetracker.Label.compareTo

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -45,7 +45,6 @@ public class GitLabMergeRequest implements PullRequest {
     private final GitLabHost host;
 
     private List<Label> labels;
-    private Map<String, Label> labelNameToLabel;
 
     GitLabMergeRequest(GitLabRepository repository, GitLabHost host, JSONValue jsonValue, RestRequest request) {
         this.repository = repository;
@@ -53,12 +52,9 @@ public class GitLabMergeRequest implements PullRequest {
         this.json = jsonValue;
         this.request = request.restrict("merge_requests/" + json.get("iid").toString() + "/");
 
-        labelNameToLabel = repository.labels()
-                                     .stream()
-                                     .collect(Collectors.toMap(l -> l.name(), l -> l));
         labels = json.get("labels")
                      .stream()
-                     .map(s -> labelNameToLabel.get(s.asString()))
+                     .map(s -> labelNameToLabel(s.asString()))
                      .sorted()
                      .collect(Collectors.toList());
     }
@@ -635,6 +631,21 @@ public class GitLabMergeRequest implements PullRequest {
                .execute();
     }
 
+    private Map<String, Label> labelNameToLabel;
+
+    /**
+     * Lookup a label from the repository labels. Initialize and refresh a cache
+     * of the repository labels lazily.
+     */
+    private Label labelNameToLabel(String labelName) {
+        if (labelNameToLabel == null || !labelNameToLabel.containsKey(labelName)) {
+            labelNameToLabel = repository.labels()
+                    .stream()
+                    .collect(Collectors.toMap(Label::name, l -> l));
+        }
+        return labelNameToLabel.get(labelName);
+    }
+
     @Override
     public void addLabel(String label) {
         labels = null;
@@ -668,7 +679,7 @@ public class GitLabMergeRequest implements PullRequest {
         request.put("")
                .body("labels", String.join(",", labels))
                .execute();
-        this.labels = labels.stream().map(l -> labelNameToLabel.get(l)).collect(Collectors.toList());
+        this.labels = labels.stream().map(this::labelNameToLabel).collect(Collectors.toList());
     }
 
     @Override
@@ -677,7 +688,9 @@ public class GitLabMergeRequest implements PullRequest {
             var currentJson = request.get("").execute().asObject();
             labels = currentJson.get("labels")
                                 .stream()
-                                .map(s -> labelNameToLabel.get(s.asString()))
+                                .map(s -> labelNameToLabel(s.asString()))
+                                // Avoid throwing NPE for unknown labels
+                                .filter(Objects::nonNull)
                                 .sorted()
                                 .collect(Collectors.toList());
         }


### PR DESCRIPTION
Recently, we have started seeing NPEs being thrown in org.openjdk.skara.issuetracker.Label::compareTo when called from GitLabMergeRequest::links. This seems to be caused by adding of labels while the GitLabMergeRequest object is active. The labelNameToLabel map is initiated in the constructor based on the repository labels. This may get outdated while the GitLabMergeRequest instance is still alive. 

This patch makes the initialization of the map lazy by wrapping all calls to the map in a private method. The map is re-initialized any time an element isn't found in it. I also added a filter on null labels before the sorting to avoid the NPE in case it still slips through.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1291](https://bugs.openjdk.java.net/browse/SKARA-1291): NPE in org.openjdk.skara.issuetracker.Label.compareTo


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1264/head:pull/1264` \
`$ git checkout pull/1264`

Update a local copy of the PR: \
`$ git checkout pull/1264` \
`$ git pull https://git.openjdk.java.net/skara pull/1264/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1264`

View PR using the GUI difftool: \
`$ git pr show -t 1264`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1264.diff">https://git.openjdk.java.net/skara/pull/1264.diff</a>

</details>
