### PR TITLE
1292: Empty commit message causes IndexOutOfBoundsException

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommentsWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommentsWorkItem.java
@@ -83,7 +83,7 @@ class CommitCommentsWorkItem implements WorkItem {
             var localBranches = remoteBranches.stream().map(b -> new Branch(b.name())).collect(Collectors.toList());
             var commitTitleToCommits = new HashMap<String, Set<Hash>>();
             for (var commit : localRepo.commitMetadataFor(localBranches)) {
-                var title = commit.message().get(0);
+                var title = commit.message().stream().findFirst().orElse("");
                 if (commitTitleToCommits.containsKey(title)) {
                     commitTitleToCommits.get(title).add(commit.hash());
                 } else {


### PR DESCRIPTION
This patch fixes an IndexOutOfBoundsException which occurs when a new repository is configured and it contains commits with an empty message. The message() here represents the commit message as a List<String> with one item for each line. If the message is empty, the list is empty. From what I can tell, returning an empty string in that case should work fine.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1292](https://bugs.openjdk.java.net/browse/SKARA-1292): Empty commit message causes IndexOutOfBoundsException


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1265/head:pull/1265` \
`$ git checkout pull/1265`

Update a local copy of the PR: \
`$ git checkout pull/1265` \
`$ git pull https://git.openjdk.java.net/skara pull/1265/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1265`

View PR using the GUI difftool: \
`$ git pr show -t 1265`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1265.diff">https://git.openjdk.java.net/skara/pull/1265.diff</a>

</details>
