### PR TITLE
1293: The Skara bot should not add review links or comments to CSR issues

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/PullRequestWorkItem.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/PullRequestWorkItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/PullRequestWorkItem.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/PullRequestWorkItem.java
@@ -141,7 +141,7 @@ public class PullRequestWorkItem implements WorkItem {
     }
 
     private final Pattern issuesBlockPattern = Pattern.compile("\\n\\n###? Issues?((?:\\n(?: \\* )?\\[.*)+)", Pattern.MULTILINE);
-    private final Pattern issuePattern = Pattern.compile("^(?: \\* )?\\[(\\S+)]\\(.*\\): .*$", Pattern.MULTILINE);
+    private final Pattern issuePattern = Pattern.compile("^(?: \\* )?\\[(\\S+)]\\(.*\\): (.*$)", Pattern.MULTILINE);
 
     private Set<String> parseIssues() {
         var issuesBlockMatcher = issuesBlockPattern.matcher(pr.body());
@@ -150,6 +150,7 @@ public class PullRequestWorkItem implements WorkItem {
         }
         var issueMatcher = issuePattern.matcher(issuesBlockMatcher.group(1));
         return issueMatcher.results()
+                           .filter(mr -> !mr.group(2).endsWith(" (**CSR**)"))
                            .map(mo -> mo.group(1))
                            .collect(Collectors.toSet());
     }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
@@ -220,12 +220,11 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
     }
 
     private String pullRequestToTextBrief(PullRequest pr) {
-        var writer = new StringWriter();
-        var printer = new PrintWriter(writer);
-        printer.println(pullRequestTip + "\n");
-        printer.println("URL: " + pr.webUrl().toString());
-        printer.println("Date: " + pr.createdAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss +0000")));
-        return writer.toString();
+        var builder = new StringBuilder();
+        builder.append(pullRequestTip).append("\n");
+        builder.append("URL: ").append(pr.webUrl().toString()).append("\n");
+        builder.append("Date: ").append(pr.createdAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss +0000")));
+        return builder.toString();
     }
 
     @Override


### PR DESCRIPTION
Hi all,

Currently, the review link and comment will be added to the CSR issue because the method `PullRequestWorkItem::parseIssues` get the all the issues from the PR body. This patch excludes the CSR issue and adds a corresponding test case.

And the method `IssueNotifier::pullRequestToTextBrief` creates the following comment body in the jira, because the method `println` prints the line seperator according to the bot server OS. But it seems that the jira can't identify this line seperator. So I adjust this method bu using the class `StringBuilder` instead of `PrintWriter`.

```
A pull request was submitted for review.

URL: https://git.openjdk.java.net/jfx/pull/548 Date: 2021-06-28 12:13:44 +0000
```

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1293](https://bugs.openjdk.java.net/browse/SKARA-1293): The Skara bot should not add review links or comments to CSR issues


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1266/head:pull/1266` \
`$ git checkout pull/1266`

Update a local copy of the PR: \
`$ git checkout pull/1266` \
`$ git pull https://git.openjdk.java.net/skara pull/1266/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1266`

View PR using the GUI difftool: \
`$ git pr show -t 1266`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1266.diff">https://git.openjdk.java.net/skara/pull/1266.diff</a>

</details>
