### PR TITLE
1296: ArchiveWorkItem throws repeated exceptions after force push to PR

### DIFF
--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
@@ -958,7 +958,7 @@ class MergeTests {
             localRepo.merge(otherHash);
             var mergeHash = localRepo.commit("Merge commit", "some", "some@one");
             localRepo.push(mergeHash, author.url(), "edit", true);
-            var pr = credentials.createPullRequest(author, "master", "edit", "Merge " + author.name() + "xyz" + ":other");
+            var pr = credentials.createPullRequest(author, "master", "edit", "Merge " + TestHost.NON_EXISTING_REPO + ":other");
 
             // Approve it as another user
             var approvalPr = integrator.pullRequest(pr.id());
@@ -978,7 +978,7 @@ class MergeTests {
             assertEquals(1, error, () -> pr.comments().stream().map(Comment::body).collect(Collectors.joining("\n\n")));
 
             var check = pr.checks(mergeHash).get("jcheck");
-            assertEquals("- Could not find project `" + author.name() + "xyz` - check that it is correct.", check.summary().orElseThrow());
+            assertEquals("- Could not find project `" + TestHost.NON_EXISTING_REPO + "` - check that it is correct.", check.summary().orElseThrow());
         }
     }
 
@@ -1078,7 +1078,7 @@ class MergeTests {
             localRepo.merge(otherHash);
             var mergeHash = localRepo.commit("Merge commit", "some", "some@one");
             localRepo.push(mergeHash, author.url(), "edit", true);
-            var pr = credentials.createPullRequest(author, "master", "edit", "Merge otherxyz");
+            var pr = credentials.createPullRequest(author, "master", "edit", "Merge " + TestHost.NON_EXISTING_REPO);
 
             // Approve it as another user
             var approvalPr = integrator.pullRequest(pr.id());
@@ -1098,7 +1098,7 @@ class MergeTests {
             assertEquals(1, error, () -> pr.comments().stream().map(Comment::body).collect(Collectors.joining("\n\n")));
 
             var check = pr.checks(mergeHash).get("jcheck");
-            assertEquals("- Could not find project `otherxyz` - check that it is correct.", check.summary().orElseThrow());
+            assertEquals("- Could not find project `" + TestHost.NON_EXISTING_REPO + "` - check that it is correct.", check.summary().orElseThrow());
         }
     }
 

--- a/test/src/main/java/org/openjdk/skara/test/TestHost.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHost.java
@@ -39,6 +39,13 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 public class TestHost implements Forge, IssueTracker {
+
+    /**
+     * If test needs to name a repository that should not exist on the TestHost,
+     * use this as the name of the repository.
+     */
+    public static final String NON_EXISTING_REPO = "non-existing-repo";
+
     private final int currentUser;
     private HostData data;
     private final Logger log = Logger.getLogger("org.openjdk.skara.test");
@@ -112,13 +119,12 @@ public class TestHost implements Forge, IssueTracker {
     @Override
     public Optional<HostedRepository> repository(String name) {
         Repository localRepository;
+        if (NON_EXISTING_REPO.equals(name)) {
+            return Optional.empty();
+        }
         if (data.repositories.containsKey(name)) {
             localRepository = data.repositories.get(name);
         } else {
-            if (data.repositories.size() > 0) {
-                log.warning("A test host can only manage a single repository - reporting " + name + " as not found");
-                return Optional.empty();
-            }
             localRepository = createLocalRepository();
             data.repositories.put(name, localRepository);
         }


### PR DESCRIPTION
The mlbridge bot sometimes fails handling of force-pushed changes to a PR. This patch tries to fix this.

When the previous head hash of a PR has been replaced with a force push, that hash will not automatically be present in the local repository that the bot uses to generate diffs. Sometimes it will be present if the bot happens to execute in the same scratch area as where the PR was processed before. Before this patch, the code assumes that the previous hash is present in the local repo.

I'm attacking this from two sides. I'm adding a method that tries to pull in the missing hash if needed. This may or may not succeed depending on if the server allows pulling of arbitrary hashes or not (my local git does not, but I believe github does). It can also fail if the hash has been GCd on the server. If the hash is, or has been made present in the local repo, we can proceed as before. If getting the hash was unsuccessful, I'm changing the email message to explain that incremental views of the changes are unavailable, and we only try to produce the full webrev.

To test this properly, I tried to adapt an existing test. However, while working with that test, I discovered that it wasn't really doing what (at least I) expected it to do. As I explained in a bug comment, TestCredentials::getHostedRepository, will return HostedRepository objects with the same backing Git repository in all of them. This was causing weird and unexpected behavior as changes for the main PR repo as well as the webrev and mail archive repos all ended up jumbled in the same repository, making it impossible to actually control the setup for the test. To handle this I added the ability to create multiple named repositories for a TestHost, and use it in the two tests affected by this change. I also found two other tests that relied on there only being one repo per TestHost (and fixed them). I believe a followup is necessary to try to fix the remaining tests for at least mlbridge as I suspect more of them are likely to have issues.

I added caching of the supplier results in ArchiveItem. The suppliers here are potentially calling out to remote URLs as well as running multiple git commands to generate the body and footer. I noticed that at least the body() method was called twice, so figured it would be good to only make these costly operations once.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1296](https://bugs.openjdk.java.net/browse/SKARA-1296): ArchiveWorkItem throws repeated exceptions after force push to PR


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1267/head:pull/1267` \
`$ git checkout pull/1267`

Update a local copy of the PR: \
`$ git checkout pull/1267` \
`$ git pull https://git.openjdk.java.net/skara pull/1267/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1267`

View PR using the GUI difftool: \
`$ git pr show -t 1267`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1267.diff">https://git.openjdk.java.net/skara/pull/1267.diff</a>

</details>
