### PR TITLE
1298: IssueNotifier removes and re-adds review links and comments

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/PullRequestWorkItem.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/PullRequestWorkItem.java
@@ -140,7 +140,8 @@ public class PullRequestWorkItem implements WorkItem {
         return "[\n" + String.join(",\n", entries) + "\n]";
     }
 
-    private final Pattern issuesBlockPattern = Pattern.compile("\\n\\n###? Issues?((?:\\n(?: \\* )?\\[.*)+)", Pattern.MULTILINE);
+    private final String lineSep = "(?:\\n|\\r|\\r\\n|\\n\\r)";
+    private final Pattern issuesBlockPattern = Pattern.compile(lineSep + lineSep + "###? Issues?((?:" + lineSep + "(?: \\* )?\\[.*)+)", Pattern.MULTILINE);
     private final Pattern issuePattern = Pattern.compile("^(?: \\* )?\\[(\\S+)]\\(.*\\): (.*$)", Pattern.MULTILINE);
 
     private Set<String> parseIssues() {

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
@@ -276,6 +276,42 @@ public class IssueNotifierTests {
             assertEquals(1, comments2.size());
             assertTrue(comments2.get(0).body().contains(pullRequestTip));
             assertTrue(comments2.get(0).body().contains(pr.webUrl().toString()));
+
+            // test line separator "\r"
+            pr.setBody("\r\r### Issues\r * [" + issue.id() + "](http://www.test.test/): The issue");
+            TestBotRunner.runPeriodicItems(notifyBot);
+
+            // Only the first issue should now contain a link to the PR and a comment which contains the link to the PR
+            links1 = issue.links();
+            assertEquals(1, links1.size());
+            assertEquals(pr.webUrl(), links1.get(0).uri().orElseThrow());
+            comments1 = issue.comments();
+            assertEquals(1, comments1.size());
+            assertTrue(comments1.get(0).body().contains(pullRequestTip));
+            assertTrue(comments1.get(0).body().contains(pr.webUrl().toString()));
+
+            links2 = issue2.links();
+            assertEquals(0, links2.size());
+            comments2 = issue2.comments();
+            assertEquals(0, comments2.size());
+
+            // test line separator "\r\n"
+            pr.setBody("\r\n\r\n### Issues\r\n * [" + issue2.id() + "](http://www.test2.test/): That other issue");
+            TestBotRunner.runPeriodicItems(notifyBot);
+
+            // Only the second issue should now contain a link to the PR and a comment which contains the link to the PR
+            links1 = issue.links();
+            assertEquals(0, links1.size());
+            comments1 = issue.comments();
+            assertEquals(0, comments1.size());
+
+            links2 = issue2.links();
+            assertEquals(1, links2.size());
+            assertEquals(pr.webUrl(), links2.get(0).uri().orElseThrow());
+            comments2 = issue2.comments();
+            assertEquals(1, comments2.size());
+            assertTrue(comments2.get(0).body().contains(pullRequestTip));
+            assertTrue(comments2.get(0).body().contains(pr.webUrl().toString()));
         }
     }
 


### PR DESCRIPTION
Hi all,

When the author of the PR modified the PR body, the Github will store the PR body by using its internal line separator instead of `\n`. The method `parseIssues` can't identify the line separator so that it can't find any issue.

This patch enhances the pattern to let it identify the `\r` as well and the corresponding test case is added.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1298](https://bugs.openjdk.java.net/browse/SKARA-1298): IssueNotifier removes and re-adds review links and comments


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1269/head:pull/1269` \
`$ git checkout pull/1269`

Update a local copy of the PR: \
`$ git checkout pull/1269` \
`$ git pull https://git.openjdk.java.net/skara pull/1269/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1269`

View PR using the GUI difftool: \
`$ git pr show -t 1269`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1269.diff">https://git.openjdk.java.net/skara/pull/1269.diff</a>

</details>
