### PR TITLE
Refactoring in preparation for SKARA-1146

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
@@ -40,6 +40,8 @@ import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.logging.Logger;
 
+import static org.openjdk.skara.issuetracker.jira.JiraProject.RESOLVED_IN_BUILD;
+
 class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener {
     private final IssueProject issueProject;
     private final boolean reviewLink;
@@ -315,9 +317,9 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
                     if (requestedVersion != null) {
                         if (buildName != null) {
                             // Check if the build name should be updated
-                            var oldBuild = issue.properties().getOrDefault("customfield_10006", JSON.of());
+                            var oldBuild = issue.properties().getOrDefault(RESOLVED_IN_BUILD, JSON.of());
                             if (BuildCompare.shouldReplace(buildName, oldBuild.asString())) {
-                                issue.setProperty("customfield_10006", JSON.of(buildName));
+                                issue.setProperty(RESOLVED_IN_BUILD, JSON.of(buildName));
                             } else {
                                 log.info("Not replacing build " + oldBuild.asString() + " with " + buildName + " for issue " + issue.id());
                             }
@@ -416,10 +418,10 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
                     }
 
                     // Check if the build name should be updated
-                    var oldBuild = issue.properties().getOrDefault("customfield_10006", JSON.of());
+                    var oldBuild = issue.properties().getOrDefault(RESOLVED_IN_BUILD, JSON.of());
                     var newBuild = "b" + String.format("%02d", tag.buildNum().get());
                     if (BuildCompare.shouldReplace(newBuild, oldBuild.asString())) {
-                        issue.setProperty("customfield_10006", JSON.of(newBuild));
+                        issue.setProperty(RESOLVED_IN_BUILD, JSON.of(newBuild));
                     } else {
                         log.info("Not replacing build " + oldBuild.asString() + " with " + newBuild + " for issue " + issue.id());
                     }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
@@ -405,8 +405,8 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
         }
     }
 
-    private String getRequestedVersion(Repository localRepository, Commit commit, String tagBranch) {
-        var requestedVersion = fixVersions != null ? fixVersions.getOrDefault(tagBranch, null) : null;
+    private String getRequestedVersion(Repository localRepository, Commit commit, String branch) {
+        var requestedVersion = fixVersions != null ? fixVersions.getOrDefault(branch, null) : null;
         if (requestedVersion == null) {
             try {
                 var conf = localRepository.lines(Path.of(".jcheck/conf"), commit.hash());

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/JbsBackport.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/JbsBackport.java
@@ -52,7 +52,6 @@ public class JbsBackport {
     private Issue createBackportIssue(Issue primary) {
         var finalProperties = new HashMap<>(primary.properties());
         finalProperties.put("issuetype", JSON.of("Backport"));
-        finalProperties.remove(RESOLVED_IN_BUILD);
 
         var backport = primary.project().createIssue(primary.title(), primary.body().lines().collect(Collectors.toList()), finalProperties);
 

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/JbsBackport.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/JbsBackport.java
@@ -30,6 +30,8 @@ import java.net.URI;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static org.openjdk.skara.issuetracker.jira.JiraProject.RESOLVED_IN_BUILD;
+
 public class JbsBackport {
     private final RestRequest backportRequest;
 
@@ -50,6 +52,7 @@ public class JbsBackport {
     private Issue createBackportIssue(Issue primary) {
         var finalProperties = new HashMap<>(primary.properties());
         finalProperties.put("issuetype", JSON.of("Backport"));
+        finalProperties.remove(RESOLVED_IN_BUILD);
 
         var backport = primary.project().createIssue(primary.title(), primary.body().lines().collect(Collectors.toList()), finalProperties);
 

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
@@ -39,11 +39,12 @@ import java.util.*;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.openjdk.skara.bots.notify.TestUtils.*;
 import static org.openjdk.skara.issuetracker.Issue.State.OPEN;
 import static org.openjdk.skara.issuetracker.Issue.State.RESOLVED;
+import static org.openjdk.skara.issuetracker.jira.JiraProject.RESOLVED_IN_BUILD;
+import static org.openjdk.skara.issuetracker.jira.JiraProject.SUBCOMPONENT;
 
 public class IssueNotifierTests {
     private static final String pullRequestTip = "A pull request was submitted for review.";
@@ -534,9 +535,9 @@ public class IssueNotifierTests {
 
             // As well as a fixVersion and a resolved in build
             assertEquals(Set.of("0.1"), fixVersions(updatedIssue1));
-            assertEquals("team", updatedIssue1.properties().get("customfield_10006").asString());
+            assertEquals("team", updatedIssue1.properties().get(RESOLVED_IN_BUILD).asString());
             assertEquals(Set.of("0.1"), fixVersions(updatedIssue2));
-            assertEquals("team", updatedIssue2.properties().get("customfield_10006").asString());
+            assertEquals("team", updatedIssue2.properties().get(RESOLVED_IN_BUILD).asString());
 
             // The issue should be assigned and resolved
             assertEquals(RESOLVED, updatedIssue1.state());
@@ -583,7 +584,7 @@ public class IssueNotifierTests {
 
             // As well as a fixVersion and a resolved in build
             assertEquals(Set.of("0.1"), fixVersions(updatedIssue));
-            assertEquals("team", updatedIssue.properties().get("customfield_10006").asString());
+            assertEquals("team", updatedIssue.properties().get(RESOLVED_IN_BUILD).asString());
 
             // The issue should be assigned and resolved
             assertEquals(RESOLVED, updatedIssue.state());
@@ -641,7 +642,7 @@ public class IssueNotifierTests {
 
             // As well as a fixVersion and a resolved in build
             assertEquals(Set.of("0.1"), fixVersions(updatedIssue));
-            assertEquals("team", updatedIssue.properties().get("customfield_10006").asString());
+            assertEquals("team", updatedIssue.properties().get(RESOLVED_IN_BUILD).asString());
 
             // The issue should be assigned and resolved
             assertEquals(RESOLVED, updatedIssue.state());
@@ -655,7 +656,7 @@ public class IssueNotifierTests {
             TestBotRunner.runPeriodicItems(notifyBot2);
 
             updatedIssue = issueProject.issue(issue.id()).orElseThrow();
-            assertEquals("master", updatedIssue.properties().get("customfield_10006").asString());
+            assertEquals("master", updatedIssue.properties().get(RESOLVED_IN_BUILD).asString());
 
             // Restore the history to simulate looking at another repository
             localRepo.fetch(repo.url(), "history");
@@ -665,7 +666,7 @@ public class IssueNotifierTests {
             TestBotRunner.runPeriodicItems(notifyBot3);
 
             updatedIssue = issueProject.issue(issue.id()).orElseThrow();
-            assertEquals("b04", updatedIssue.properties().get("customfield_10006").asString());
+            assertEquals("b04", updatedIssue.properties().get(RESOLVED_IN_BUILD).asString());
 
             // Restore the history to simulate looking at another repository
             localRepo.fetch(repo.url(), "history");
@@ -675,7 +676,7 @@ public class IssueNotifierTests {
             TestBotRunner.runPeriodicItems(notifyBot4);
 
             updatedIssue = issueProject.issue(issue.id()).orElseThrow();
-            assertEquals("b02", updatedIssue.properties().get("customfield_10006").asString());
+            assertEquals("b02", updatedIssue.properties().get(RESOLVED_IN_BUILD).asString());
 
             // Restore the history to simulate looking at another repository
             localRepo.fetch(repo.url(), "history");
@@ -685,7 +686,7 @@ public class IssueNotifierTests {
             TestBotRunner.runPeriodicItems(notifyBot5);
 
             updatedIssue = issueProject.issue(issue.id()).orElseThrow();
-            assertEquals("b02", updatedIssue.properties().get("customfield_10006").asString());
+            assertEquals("b02", updatedIssue.properties().get(RESOLVED_IN_BUILD).asString());
         }
     }
 
@@ -729,7 +730,7 @@ public class IssueNotifierTests {
 
             // As well as a fixVersion and a resolved in build
             assertEquals(Set.of("0.1"), fixVersions(updatedIssue));
-            assertEquals("team", updatedIssue.properties().get("customfield_10006").asString());
+            assertEquals("team", updatedIssue.properties().get(RESOLVED_IN_BUILD).asString());
 
             // The issue should be assigned and resolved
             assertEquals(RESOLVED, updatedIssue.state());
@@ -742,7 +743,7 @@ public class IssueNotifierTests {
 
             // The build should now be updated
             updatedIssue = issueProject.issue(issue.id()).orElseThrow();
-            assertEquals("b110", updatedIssue.properties().get("customfield_10006").asString());
+            assertEquals("b110", updatedIssue.properties().get(RESOLVED_IN_BUILD).asString());
 
             // Tag it again
             localRepo.tag(editHash, "jdk-16+10", "Third tag", "duke", "duke@openjdk.org");
@@ -751,7 +752,7 @@ public class IssueNotifierTests {
 
             // The build should now be updated
             updatedIssue = issueProject.issue(issue.id()).orElseThrow();
-            assertEquals("b10", updatedIssue.properties().get("customfield_10006").asString());
+            assertEquals("b10", updatedIssue.properties().get(RESOLVED_IN_BUILD).asString());
 
             // Tag it once again
             localRepo.tag(editHash, "jdk-16+8", "Fourth tag", "duke", "duke@openjdk.org");
@@ -760,7 +761,7 @@ public class IssueNotifierTests {
 
             // The build should now be updated
             updatedIssue = issueProject.issue(issue.id()).orElseThrow();
-            assertEquals("b08", updatedIssue.properties().get("customfield_10006").asString());
+            assertEquals("b08", updatedIssue.properties().get(RESOLVED_IN_BUILD).asString());
         }
     }
 
@@ -817,9 +818,9 @@ public class IssueNotifierTests {
 
             // As well as a fixVersion and a resolved in build
             assertEquals(Set.of("16.0.2"), fixVersions(updatedIssue));
-            assertEquals("team", updatedIssue.properties().get("customfield_10006").asString());
+            assertEquals("team", updatedIssue.properties().get(RESOLVED_IN_BUILD).asString());
             assertEquals(Set.of("16"), fixVersions(backportIssue));
-            assertEquals("team", backportIssue.properties().get("customfield_10006").asString());
+            assertEquals("team", backportIssue.properties().get(RESOLVED_IN_BUILD).asString());
 
             // The issue should be assigned and resolved
             assertEquals(RESOLVED, updatedIssue.state());
@@ -835,8 +836,8 @@ public class IssueNotifierTests {
             // The build should now be updated
             updatedIssue = issueProject.issue(issue.id()).orElseThrow();
             backportIssue = issueProject.issue(backportIssue.id()).orElseThrow();
-            assertEquals("b110", updatedIssue.properties().get("customfield_10006").asString());
-            assertEquals("b110", backportIssue.properties().get("customfield_10006").asString());
+            assertEquals("b110", updatedIssue.properties().get(RESOLVED_IN_BUILD).asString());
+            assertEquals("b110", backportIssue.properties().get(RESOLVED_IN_BUILD).asString());
 
             // Tag it again
             localRepo.tag(editHash, "jdk-16+10", "Third tag", "duke", "duke@openjdk.org");
@@ -846,8 +847,8 @@ public class IssueNotifierTests {
             // The build should now be updated
             updatedIssue = issueProject.issue(issue.id()).orElseThrow();
             backportIssue = issueProject.issue(backportIssue.id()).orElseThrow();
-            assertEquals("b10", updatedIssue.properties().get("customfield_10006").asString());
-            assertEquals("b10", backportIssue.properties().get("customfield_10006").asString());
+            assertEquals("b10", updatedIssue.properties().get(RESOLVED_IN_BUILD).asString());
+            assertEquals("b10", backportIssue.properties().get(RESOLVED_IN_BUILD).asString());
 
             // Tag it once again
             localRepo.tag(editHash, "jdk-16+8", "Fourth tag", "duke", "duke@openjdk.org");
@@ -857,8 +858,8 @@ public class IssueNotifierTests {
             // The build should now be updated
             updatedIssue = issueProject.issue(issue.id()).orElseThrow();
             backportIssue = issueProject.issue(backportIssue.id()).orElseThrow();
-            assertEquals("b08", updatedIssue.properties().get("customfield_10006").asString());
-            assertEquals("b08", backportIssue.properties().get("customfield_10006").asString());
+            assertEquals("b08", updatedIssue.properties().get(RESOLVED_IN_BUILD).asString());
+            assertEquals("b08", backportIssue.properties().get(RESOLVED_IN_BUILD).asString());
         }
     }
 
@@ -902,7 +903,7 @@ public class IssueNotifierTests {
 
             // As well as a fixVersion and a resolved in build
             assertEquals(Set.of("0.1"), fixVersions(updatedIssue));
-            assertEquals("team", updatedIssue.properties().get("customfield_10006").asString());
+            assertEquals("team", updatedIssue.properties().get(RESOLVED_IN_BUILD).asString());
 
             // The issue should be assigned and resolved
             assertEquals(RESOLVED, updatedIssue.state());
@@ -915,7 +916,7 @@ public class IssueNotifierTests {
 
             // The build should now be updated
             updatedIssue = issueProject.issue(issue.id()).orElseThrow();
-            assertEquals("b110", updatedIssue.properties().get("customfield_10006").asString());
+            assertEquals("b110", updatedIssue.properties().get(RESOLVED_IN_BUILD).asString());
 
             // Tag it again
             localRepo.tag(editHash, "jdk-16+10", "Third tag", "duke", "duke@openjdk.org");
@@ -937,7 +938,7 @@ public class IssueNotifierTests {
 
             // The build should not have been updated
             updatedIssue = issueProject.issue(issue.id()).orElseThrow();
-            assertEquals("b110", updatedIssue.properties().get("customfield_10006").asString());
+            assertEquals("b110", updatedIssue.properties().get(RESOLVED_IN_BUILD).asString());
 
             // Flag it as in need of retry
             processed.remove(processed.size() - 1);
@@ -952,7 +953,7 @@ public class IssueNotifierTests {
 
             // The build should have been updated by the retry
             updatedIssue = issueProject.issue(issue.id()).orElseThrow();
-            assertEquals("b10", updatedIssue.properties().get("customfield_10006").asString());
+            assertEquals("b10", updatedIssue.properties().get(RESOLVED_IN_BUILD).asString());
         }
     }
 
@@ -1240,9 +1241,10 @@ public class IssueNotifierTests {
 
             // Create an issue and commit a fix
             var issue = issueProject.createIssue("This is an issue", List.of("Indeed"),
-                                                 Map.of("issuetype", JSON.of("Enhancement"),
-                                                        "customfield_10008", JSON.of("java.io")
-                                                 ));
+                    Map.of("issuetype", JSON.of("Enhancement"),
+                            SUBCOMPONENT, JSON.of("java.io"),
+                            RESOLVED_IN_BUILD, JSON.of("b07")
+                    ));
             var level = issue.properties().get("security");
             issue.setProperty("fixVersions", JSON.array().add("13.0.1"));
             issue.setProperty("priority", JSON.of("1"));
@@ -1273,7 +1275,8 @@ public class IssueNotifierTests {
 
             // Custom properties should also propagate
             assertEquals("1", backport.properties().get("priority").asString());
-            assertEquals("java.io", backport.properties().get("customfield_10008").asString());
+            assertEquals("java.io", backport.properties().get(SUBCOMPONENT).asString());
+            assertFalse(backport.properties().containsKey(RESOLVED_IN_BUILD));
 
             // Labels should not
             assertEquals(0, backport.labelNames().size());

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
@@ -1276,7 +1276,6 @@ public class IssueNotifierTests {
             // Custom properties should also propagate
             assertEquals("1", backport.properties().get("priority").asString());
             assertEquals("java.io", backport.properties().get(SUBCOMPONENT).asString());
-            assertFalse(backport.properties().containsKey(RESOLVED_IN_BUILD));
 
             // Labels should not
             assertEquals(0, backport.labelNames().size());

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IssueCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IssueCommand.java
@@ -34,6 +34,8 @@ import java.util.*;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import static org.openjdk.skara.issuetracker.jira.JiraProject.SUBCOMPONENT;
+
 class InvalidIssue extends Exception {
     private String identifier;
     private String reason;
@@ -249,7 +251,7 @@ public class IssueCommand implements CommandHandler {
         var properties = new HashMap<String, JSONValue>();
         properties.put("components", JSON.array().add(JSON.of(component)));
         if (subComponent != null) {
-            properties.put("customfield_10008", JSON.of(subComponent));
+            properties.put(SUBCOMPONENT, JSON.of(subComponent));
         }
         if (priority != null) {
             properties.put("priority", JSON.of(priority));

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IssueTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IssueTests.java
@@ -34,6 +34,7 @@ import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.openjdk.skara.bots.pr.PullRequestAsserts.assertLastCommentContains;
+import static org.openjdk.skara.issuetracker.jira.JiraProject.SUBCOMPONENT;
 
 class IssueTests {
     @Test
@@ -567,7 +568,7 @@ class IssueTests {
             assertEquals("This is yet another pull request", issue.title());
             assertEquals("core-libs", issue.properties().get("components").asArray().get(0).asString());
             assertEquals("enhancement", issue.properties().get("issuetype").asString().toLowerCase());
-            assertEquals("java.io", issue.properties().get("customfield_10008").asString());
+            assertEquals("java.io", issue.properties().get(SUBCOMPONENT).asString());
         }
     }
 

--- a/bots/synclabel/src/test/java/org/openjdk/skara/bots/synclabel/SyncLabelBotTests.java
+++ b/bots/synclabel/src/test/java/org/openjdk/skara/bots/synclabel/SyncLabelBotTests.java
@@ -33,6 +33,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.openjdk.skara.issuetracker.Issue.State.RESOLVED;
+import static org.openjdk.skara.issuetracker.jira.JiraProject.RESOLVED_IN_BUILD;
 
 public class SyncLabelBotTests {
     private TestBotFactory testBotBuilder(IssueProject issueProject, Path storagePath) {
@@ -358,7 +359,7 @@ public class SyncLabelBotTests {
             var issue2 = credentials.createIssue(issueProject, "Issue 2");
             issue2.setProperty("fixVersions", JSON.array().add(JSON.of("8u271")));
             issue2.setProperty("issuetype", JSON.of("Backport"));
-            issue2.setProperty("customfield_10006", JSON.of("b33"));
+            issue2.setProperty(RESOLVED_IN_BUILD, JSON.of("b33"));
             issue2.setState(RESOLVED);
             issue1.addLink(Link.create(issue2, "backported by").build());
             TestBotRunner.runPeriodicItems(syncLabelBot);

--- a/issuetracker/src/main/java/module-info.java
+++ b/issuetracker/src/main/java/module-info.java
@@ -33,6 +33,7 @@ module org.openjdk.skara.issuetracker {
     requires java.logging;
 
     exports org.openjdk.skara.issuetracker;
+    exports org.openjdk.skara.issuetracker.jira;
 
     uses org.openjdk.skara.issuetracker.IssueTrackerFactory;
 

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraProject.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraProject.java
@@ -33,6 +33,10 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 public class JiraProject implements IssueProject {
+
+    public static final String RESOLVED_IN_BUILD = "customfield_10006";
+    public static final String SUBCOMPONENT = "customfield_10008";
+
     private final JiraHost jiraHost;
     private final String projectName;
     private final RestRequest request;
@@ -239,9 +243,9 @@ public class JiraProject implements IssueProject {
                 return Optional.of(new JSONArray(value.stream()
                                                       .map(obj -> obj.get("name"))
                                                       .collect(Collectors.toList())));
-            case "customfield_10006":
+            case RESOLVED_IN_BUILD:
                 return Optional.of(JSON.of(value.get("value").asString()));
-            case "customfield_10008":
+            case SUBCOMPONENT:
                 if (value.isString()) {
                     return Optional.of(value);
                 } // fall-through
@@ -286,7 +290,7 @@ public class JiraProject implements IssueProject {
             return value;
         }
 
-        if (name.equals("customfield_10006")) {
+        if (name.equals(RESOLVED_IN_BUILD)) {
             var editMeta = editMeta(forIssue);
             var valueToId = editMeta.get("fields").get(name).get("allowedValues").stream()
                                     .collect(Collectors.toMap(o -> o.get("value").asString(),
@@ -294,7 +298,7 @@ public class JiraProject implements IssueProject {
             return JSON.object().put("id", valueToId.get(value.asString()));
         }
 
-        if (!name.equals("customfield_10008")) {
+        if (!name.equals(SUBCOMPONENT)) {
             if (value.isObject()) {
                 if (value.asObject().contains("id")) {
                     return value.get("id");

--- a/jbs/src/main/java/org/openjdk/skara/jbs/Backports.java
+++ b/jbs/src/main/java/org/openjdk/skara/jbs/Backports.java
@@ -30,6 +30,8 @@ import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import java.util.stream.*;
 
+import static org.openjdk.skara.issuetracker.jira.JiraProject.RESOLVED_IN_BUILD;
+
 public class Backports {
     private final static Set<String> primaryTypes = Set.of("Bug", "New Feature", "Enhancement", "Task", "Sub-task");
     private final static Logger log = Logger.getLogger("org.openjdk.skara.bots.notify");
@@ -73,8 +75,8 @@ public class Backports {
             log.warning("Issue " + issue.id() + " has multiple valid fixVersions - ignoring");
             return Optional.empty();
         }
-        if (issue.properties().containsKey("customfield_10006")) {
-            return JdkVersion.parse(versionString.get(0), issue.properties().get("customfield_10006").asString());
+        if (issue.properties().containsKey(RESOLVED_IN_BUILD)) {
+            return JdkVersion.parse(versionString.get(0), issue.properties().get(RESOLVED_IN_BUILD).asString());
         } else {
             return JdkVersion.parse(versionString.get(0));
         }

--- a/jbs/src/test/java/org/openjdk/skara/jbs/BackportsTests.java
+++ b/jbs/src/test/java/org/openjdk/skara/jbs/BackportsTests.java
@@ -32,6 +32,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.openjdk.skara.issuetracker.jira.JiraProject.RESOLVED_IN_BUILD;
 
 public class BackportsTests {
     @Test
@@ -206,7 +207,7 @@ public class BackportsTests {
             }
             issue.setProperty("fixVersions", JSON.array().add(version));
             if (!resolvedInBuild.isEmpty()) {
-                issue.setProperty("customfield_10006", JSON.of(resolvedInBuild));
+                issue.setProperty(RESOLVED_IN_BUILD, JSON.of(resolvedInBuild));
             }
         }
 


### PR DESCRIPTION
While working on SKARA-1146, I felt that I needed to do some refactoring. To ease the review process, I've separated those changes into a separate PR. Nothing should change functionally from this change. Here is what I've done:

* Created String constants for the special custom fields we have in JBS.
* In IssueNotifier, created a method for finding the fixVersion for a branch. This code block is actually copied and sprinkled all over the code base, but for now, I will just unify the copies in the same class.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1270/head:pull/1270` \
`$ git checkout pull/1270`

Update a local copy of the PR: \
`$ git checkout pull/1270` \
`$ git pull https://git.openjdk.java.net/skara pull/1270/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1270`

View PR using the GUI difftool: \
`$ git pr show -t 1270`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1270.diff">https://git.openjdk.java.net/skara/pull/1270.diff</a>

</details>
