### PR TITLE
SKARA-1306

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
@@ -394,7 +394,9 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
 
                     // Check if the build number should be updated
                     var tagVersion = JdkVersion.parse(tag.version());
-                    if (tagVersion.isPresent() && fixVersion.equals(tagVersion.get())) {
+                    // Ignore the opt string when comparing versions for match as the fixVersion can
+                    // have a suffix such as "-oracle" that isn't reflected in tags.
+                    if (tagVersion.isPresent() && fixVersion.components().equals(tagVersion.get().components())) {
                         var oldBuild = issue.properties().getOrDefault(RESOLVED_IN_BUILD, JSON.of());
                         var newBuild = "b" + String.format("%02d", tag.buildNum().get());
                         if (BuildCompare.shouldReplace(newBuild, oldBuild.asString())) {

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
@@ -815,7 +815,7 @@ public class IssueNotifierTests {
             var issueProject = credentials.getIssueProject();
             var storageFolder = tempFolder.path().resolve("storage");
             var jbsNotifierConfig = JSON.object().put("fixversions", JSON.object()
-                                                                         .put("master", "16")
+                                                                         .put("master", "16-foo")
                                                                          .put("other", "16.0.2"))
                                         .put("buildname", "team");
             var notifyBot = testBotBuilder(repo, issueProject, storageFolder, jbsNotifierConfig).create("notify", JSON.object());
@@ -855,7 +855,7 @@ public class IssueNotifierTests {
             // As well as a fixVersion and a resolved in build
             assertEquals(Set.of("16.0.2"), fixVersions(updatedIssue));
             assertEquals("team", updatedIssue.properties().get(RESOLVED_IN_BUILD).asString());
-            assertEquals(Set.of("16"), fixVersions(backportIssue));
+            assertEquals(Set.of("16-foo"), fixVersions(backportIssue));
             assertEquals("team", backportIssue.properties().get(RESOLVED_IN_BUILD).asString());
 
             // The issue should be assigned and resolved


### PR DESCRIPTION
In SKARA-1146 I made the IssueNotifier for build tags only update Resolved In Build in issues where the fixVersion of the issue/backport matches the version in the build tag. I missed taking fixversions of the format N-foo into account. This patch addresses this by comparing just the number components of the JdkVersions so ignoring the the "opt" part.

I chose to just adjust an existing test case to cover this case instead of creating a new one.