### PR TITLE
SKARA-1304

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitFork.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitFork.java
@@ -173,8 +173,9 @@ public class GitFork {
         System.out.println("Creating fork of " + upstreamWebURI);
         var credentials = setupCredentials(upstreamWebURI);
 
-        // User Forge::from directly instead of ForgeUtils::from as any local repository
-        // here is not expected to be related to the remote
+        // Use Forge::from directly instead of ForgeUtils::from. ForgeUtils would
+        // try to update "forge.name" in the local repository based on this forge,
+        // and it's unlikely they are related.
         var gitForge = Forge.from(upstreamWebURI, credentials);
         if (gitForge.isEmpty()) {
             exit("error: could not connect to host " + upstreamWebURI.getHost());

--- a/cli/src/main/java/org/openjdk/skara/cli/GitFork.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitFork.java
@@ -23,6 +23,7 @@
 package org.openjdk.skara.cli;
 
 import org.openjdk.skara.args.*;
+import org.openjdk.skara.forge.Forge;
 import org.openjdk.skara.host.Credential;
 import org.openjdk.skara.proxy.HttpProxy;
 import org.openjdk.skara.vcs.Repository;
@@ -172,7 +173,9 @@ public class GitFork {
         System.out.println("Creating fork of " + upstreamWebURI);
         var credentials = setupCredentials(upstreamWebURI);
 
-        var gitForge = ForgeUtils.from(upstreamWebURI, credentials);
+        // User Forge::from directly instead of ForgeUtils::from as any local repository
+        // here is not expected to be related to the remote
+        var gitForge = Forge.from(upstreamWebURI, credentials);
         if (gitForge.isEmpty()) {
             exit("error: could not connect to host " + upstreamWebURI.getHost());
         }


### PR DESCRIPTION
This is a partial rework of the rather recent change to "git skara fork" and "git skara sync". That patch tried to protect the user from syncing changes to the wrong host unintentionally, but unfortunately, it turned out to make it a bit too hard.

With this patch I'm fixing some outright bugs as well as dialing back the protection a little bit. First the clear bugfixes:

1. When trying to figure out the official fork parent from the origin, setup and use credentials properly.
2. When forking and cloning a repository into a sub directory of an existing local repository, do not set the forge.name config in the existing local repository.

Behavioral changes:

1. Do not require --force when explicitly setting --to and/or --from. I believe that if you set those parameters, you are already explicit enough.
2. Do require --force whenever the derived to and from do not share the same hostname. This should better catch the sensitive situation when changes are likely to be going the wrong way.
3. Since looking up the fork parent from the origin forge is unreliable, only use it when possible and mostly for verification, and only use it as the last option for default from repo.

So to summarize, here is the expected behavior for choosing the repository from which to sync changes from (this now matches the existing documentation at https://wiki.openjdk.java.net/display/SKARA/git-sync).

1. The --from option if set either on the command line or configuration
2. A remote named "upstream"
3. The fork parent from the origin forge