### PR TITLE
1308: CSRBot only reacts to approved CSR if PR is touched

### DIFF
--- a/bots/csr/src/main/java/org/openjdk/skara/bots/csr/CSRBot.java
+++ b/bots/csr/src/main/java/org/openjdk/skara/bots/csr/CSRBot.java
@@ -70,10 +70,6 @@ class CSRBot implements Bot, WorkItem {
         var prs = repo.pullRequests();
 
         for (var pr : prs) {
-            if (!cache.needsUpdate(pr)) {
-                continue;
-            }
-
             var issue = org.openjdk.skara.vcs.openjdk.Issue.fromStringRelaxed(pr.title());
             if (issue.isEmpty()) {
                 log.info("No issue found in title for " + describe(pr));

--- a/bots/csr/src/main/java/org/openjdk/skara/bots/csr/CSRBot.java
+++ b/bots/csr/src/main/java/org/openjdk/skara/bots/csr/CSRBot.java
@@ -25,7 +25,6 @@ package org.openjdk.skara.bots.csr;
 import org.openjdk.skara.bot.*;
 import org.openjdk.skara.forge.HostedRepository;
 import org.openjdk.skara.forge.PullRequest;
-import org.openjdk.skara.forge.PullRequestUpdateCache;
 import org.openjdk.skara.issuetracker.IssueProject;
 import org.openjdk.skara.issuetracker.Issue;
 import org.openjdk.skara.issuetracker.Link;
@@ -39,12 +38,10 @@ class CSRBot implements Bot, WorkItem {
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots");;
     private final HostedRepository repo;
     private final IssueProject project;
-    private final PullRequestUpdateCache cache;
 
     CSRBot(HostedRepository repo, IssueProject project) {
         this.repo = repo;
         this.project = project;
-        this.cache = new PullRequestUpdateCache();
     }
 
     @Override


### PR DESCRIPTION
When a CSR issue is approved, any associated PR is only updated once someone touches the PR. The CSRBot will not evaluate anything about a PR unless there is a change to the PR. Since a CSR issue update only happens in JBS, the CSRBot cannot be limited by PR updates, it needs to check Jira for changes.

This patch removes the use of the PullRequestUpdateCache to limit when the bot evaluates a PR. If this turns out to generate too much load on JBS, we will have to implement a limiter in some way, but I don't think it will be a big issue in practice.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1308](https://bugs.openjdk.java.net/browse/SKARA-1308): CSRBot only reacts to approved CSR if PR is touched


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1274/head:pull/1274` \
`$ git checkout pull/1274`

Update a local copy of the PR: \
`$ git checkout pull/1274` \
`$ git pull https://git.openjdk.java.net/skara pull/1274/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1274`

View PR using the GUI difftool: \
`$ git pr show -t 1274`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1274.diff">https://git.openjdk.java.net/skara/pull/1274.diff</a>

</details>
