### PR TITLE
1316: Review comment on a commit triggers error in CommitCommentsWorkItem

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -405,6 +405,8 @@ public class GitLabRepository implements HostedRepository {
                       .param("after", fourDaysAgo.format(formatter))
                       .execute()
                       .stream()
+                      .filter(o -> o.contains("target_type") &&
+                                   o.get("target_type").asString().equals("Note"))
                       .filter(o -> o.contains("note") &&
                                    o.get("note").contains("noteable_type") &&
                                    o.get("note").get("noteable_type").asString().equals("Commit"))


### PR DESCRIPTION
Add additional filtering of notes when looking for comments on commits on Gitlab, to avoid picking up comments on other things, such as MR diffs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1316](https://bugs.openjdk.java.net/browse/SKARA-1316): Review comment on a commit triggers error in CommitCommentsWorkItem


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1275/head:pull/1275` \
`$ git checkout pull/1275`

Update a local copy of the PR: \
`$ git checkout pull/1275` \
`$ git pull https://git.openjdk.java.net/skara pull/1275/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1275`

View PR using the GUI difftool: \
`$ git pr show -t 1275`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1275.diff">https://git.openjdk.java.net/skara/pull/1275.diff</a>

</details>
