### PR TITLE
1320: Skara failing to create backport records for fixes synced into mainline

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierBuilder.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierBuilder.java
@@ -43,6 +43,7 @@ class IssueNotifierBuilder {
     private HostedRepository censusRepository = null;
     private String censusRef = null;
     private String namespace = "openjdk.org";
+    private boolean useHeadVersion = false;
 
     IssueNotifierBuilder issueProject(IssueProject issueProject) {
         this.issueProject = issueProject;
@@ -115,10 +116,15 @@ class IssueNotifierBuilder {
         return this;
     }
 
+    public IssueNotifierBuilder useHeadVersion(boolean useHeadVersion) {
+        this.useHeadVersion = useHeadVersion;
+        return this;
+    }
+
     IssueNotifier build() {
         var jbsBackport = new JbsBackport(issueProject.issueTracker().uri(), vault);
         return new IssueNotifier(issueProject, reviewLink, reviewIcon, commitLink, commitIcon,
                                  setFixVersion, fixVersions, altFixVersions, jbsBackport, prOnly, buildName,
-                                 censusRepository, censusRef, namespace);
+                                 censusRepository, censusRef, namespace, useHeadVersion);
     }
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierFactory.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierFactory.java
@@ -104,6 +104,10 @@ public class IssueNotifierFactory implements NotifierFactory {
             builder.namespace(notifierConfiguration.get("namespace").asString());
         }
 
+        if (notifierConfiguration.contains("headversion")) {
+            builder.useHeadVersion(notifierConfiguration.get("headversion").asBoolean());
+        }
+
         return builder.build();
     }
 }


### PR DESCRIPTION
When forward merging changes from jdk18 to mainline, we are no longer correctly creating backport entries for jdk19. This is because we switched from a Skara configuration for fixVersion to using the .jcheck/conf version from the repo in mainline. When Skara figures out the correct fixVersion from .jcheck/conf, it uses the file at the commit in question. In the case of a forward merge, that commit will have an outdated version in .jcheck/conf, as the commit is not a descendant of the version update change.

This change fixes this situation, by optionally (through a configuration parameter) have Skara use the HEAD version of .jcheck/conf (for the given branch) when resolving fixVersion for a commit. Some care needs to be taken when using this option, but essentially no more so than we already had to do when configuring the fixVersion in the Skara config.

The plan is to enable this option just for mainline jdk and jfx.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1320](https://bugs.openjdk.java.net/browse/SKARA-1320): Skara failing to create backport records for fixes synced into mainline


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1276/head:pull/1276` \
`$ git checkout pull/1276`

Update a local copy of the PR: \
`$ git checkout pull/1276` \
`$ git pull https://git.openjdk.java.net/skara pull/1276/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1276`

View PR using the GUI difftool: \
`$ git pr show -t 1276`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1276.diff">https://git.openjdk.java.net/skara/pull/1276.diff</a>

</details>
