### PR TITLE
Fix NPE in 'notes' filter after SKARA-1316

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -405,11 +405,12 @@ public class GitLabRepository implements HostedRepository {
                       .param("after", fourDaysAgo.format(formatter))
                       .execute()
                       .stream()
-                      .filter(o -> o.contains("target_type") &&
-                                   o.get("target_type").asString().equals("Note"))
                       .filter(o -> o.contains("note") &&
                                    o.get("note").contains("noteable_type") &&
                                    o.get("note").get("noteable_type").asString().equals("Commit"))
+                      .filter(o -> o.contains("target_type") &&
+                                   !o.get("target_type").isNull() &&
+                                   o.get("target_type").asString().equals("Note"))
                       .filter(o -> o.contains("author") &&
                                    o.get("author").contains("id") &&
                                    !excludeAuthors.contains(o.get("author").get("id").asInt()))


### PR DESCRIPTION
The fix for SKARA-1316 resulted in NPE in several cases. It appears the field "target_type" is often explicitly set to null. To mitigate this, I added a null check and moved this filter a bit lower in the order (so we only apply it to notes that are a bit closer to what we want).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1277/head:pull/1277` \
`$ git checkout pull/1277`

Update a local copy of the PR: \
`$ git checkout pull/1277` \
`$ git pull https://git.openjdk.java.net/skara pull/1277/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1277`

View PR using the GUI difftool: \
`$ git pr show -t 1277`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1277.diff">https://git.openjdk.java.net/skara/pull/1277.diff</a>

</details>
