### PR TITLE
1311: Pull Request not closed automatically

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -234,7 +234,9 @@ class CheckWorkItem extends PullRequestWorkItem {
         if (!currentCheckValid(census, comments, activeReviews, labels)) {
             if (labels.contains("integrated")) {
                 log.info("Skipping check of integrated PR");
-                return List.of();
+                // We still need to make sure any commands get run or are able to finish a
+                // previously interrupted run
+                return List.of(new PullRequestCommandWorkItem(bot, pr, errorHandler));
             }
 
             var backportHashMatcher = BACKPORT_HASH_TITLE_PATTERN.matcher(pr.title());

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
@@ -318,6 +318,8 @@ public class IntegrateCommand implements CommandHandler {
     }
 
     static void markIntegratedAndClosed(PullRequest pr, Hash hash, PrintWriter reply) {
+        // Note that the order of operations here is tested in IntegrateTests::retryAfterInterrupt
+        // so any change here requires careful update of that test
         pr.addLabel("integrated");
         pr.setState(PullRequest.State.CLOSED);
         pr.removeLabel("ready");


### PR DESCRIPTION
If an integration gets interrupted or fails at the wrong time, a PR may end up in a state where it gets stuck without ever being closed. I fixed this by making sure we give any commit commands the chance to run even when a PR is marked as integrated.

I've also extended the test to verify recovering from interruption at each of the steps we take when integrating.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1311](https://bugs.openjdk.java.net/browse/SKARA-1311): Pull Request not closed automatically


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1278/head:pull/1278` \
`$ git checkout pull/1278`

Update a local copy of the PR: \
`$ git checkout pull/1278` \
`$ git pull https://git.openjdk.java.net/skara pull/1278/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1278`

View PR using the GUI difftool: \
`$ git pr show -t 1278`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1278.diff">https://git.openjdk.java.net/skara/pull/1278.diff</a>

</details>
