### PR TITLE
1325: Update Skara to recognize the FX 8uNNN-bXX tag format

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/OpenJDKTag.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/OpenJDKTag.java
@@ -53,6 +53,7 @@ public class OpenJDKTag {
      * hs24-b30    -> hs24     24               -b           30
      * hs23.6-b19  -> hs23.6   23.6     .6      -b           19
      * 11.1+22     -> 11.1     11.1     .1      +            22
+     * 8u321-b03   -> 8u321    8u321    u321    -b           3
      */
 
     private final static String legacyOpenJDKVersionPattern = "(jdk([0-9]{1,2}(u[0-9]{1,3})?))";
@@ -60,11 +61,13 @@ public class OpenJDKTag {
     private final static String legacyBuildPattern = "(-b)([0-9]{2,3})";
     private final static String OpenJDKVersionPattern = "(jdk-([0-9]+(\\.[0-9]){0,3}))(\\+)([0-9]+)";
     private final static String OpenJFXVersionPattern = "((?:jdk-){0,1}([1-9](?:(?:[0-9]*)(\\.(?:0|[1-9][0-9]*)){0,3})))(?:(\\+)([0-9]+)|(-ga))";
+    private final static String legacyOpenJFXVersionPattern = "(([0-9]{1,2}(u[0-9]{1,3})?))";
 
     private final static List<Pattern> tagPatterns = List.of(Pattern.compile(legacyOpenJDKVersionPattern + legacyBuildPattern),
                                                              Pattern.compile(legacyHSVersionPattern + legacyBuildPattern),
                                                              Pattern.compile(OpenJDKVersionPattern),
-                                                             Pattern.compile(OpenJFXVersionPattern));
+                                                             Pattern.compile(OpenJFXVersionPattern),
+                                                             Pattern.compile(legacyOpenJFXVersionPattern + legacyBuildPattern));
 
     /**
      * Attempts to create an OpenJDKTag instance from a general Tag.

--- a/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/OpenJDKTag.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/OpenJDKTag.java
@@ -61,7 +61,7 @@ public class OpenJDKTag {
     private final static String legacyBuildPattern = "(-b)([0-9]{2,3})";
     private final static String OpenJDKVersionPattern = "(jdk-([0-9]+(\\.[0-9]){0,3}))(\\+)([0-9]+)";
     private final static String OpenJFXVersionPattern = "((?:jdk-){0,1}([1-9](?:(?:[0-9]*)(\\.(?:0|[1-9][0-9]*)){0,3})))(?:(\\+)([0-9]+)|(-ga))";
-    private final static String legacyOpenJFXVersionPattern = "(([0-9]{1,2}(u[0-9]{1,3})?))";
+    private final static String legacyOpenJFXVersionPattern = "(([0-9](u[0-9]{1,3})?))";
 
     private final static List<Pattern> tagPatterns = List.of(Pattern.compile(legacyOpenJDKVersionPattern + legacyBuildPattern),
                                                              Pattern.compile(legacyHSVersionPattern + legacyBuildPattern),

--- a/vcs/src/test/java/org/openjdk/skara/vcs/openjdk/OpenJDKTagTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/openjdk/OpenJDKTagTests.java
@@ -111,4 +111,12 @@ class OpenJDKTagTests {
         assertEquals("12.1", jdkTag.version());
         assertTrue(jdkTag.buildNum().isEmpty());
     }
+
+    @Test
+    void parseLegacyJfxTags() {
+        var tag = new Tag("8u321-b03");
+        var jfxTag = OpenJDKTag.create(tag).orElseThrow();
+        assertEquals("8u321", jfxTag.version());
+        assertEquals(3, jfxTag.buildNum().orElseThrow());
+    }
 }


### PR DESCRIPTION
Add support for the legacy (8u) jfx tag format.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1325](https://bugs.openjdk.java.net/browse/SKARA-1325): Update Skara to recognize the FX 8uNNN-bXX tag format


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1279/head:pull/1279` \
`$ git checkout pull/1279`

Update a local copy of the PR: \
`$ git checkout pull/1279` \
`$ git pull https://git.openjdk.java.net/skara pull/1279/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1279`

View PR using the GUI difftool: \
`$ git pr show -t 1279`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1279.diff">https://git.openjdk.java.net/skara/pull/1279.diff</a>

</details>
