### PR TITLE
1329: incorrect hgupdate label for JDK 7 updates

### DIFF
--- a/jbs/src/test/java/org/openjdk/skara/jbs/BackportsTests.java
+++ b/jbs/src/test/java/org/openjdk/skara/jbs/BackportsTests.java
@@ -837,4 +837,37 @@ public class BackportsTests {
             backports.assertLabeled("openjdk8u312");
         }
     }
+
+    @Test
+    void jdk7u40(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo)) {
+            var backports = new BackportManager(credentials, "17");
+            backports.assertLabeled();
+
+            backports.addBackports("7u40/b31", "7u45", "8u60");
+            backports.assertLabeled("7u45");
+        }
+    }
+
+    @Test
+    void jdk8u26(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo)) {
+            var backports = new BackportManager(credentials, "17");
+            backports.assertLabeled();
+
+            backports.addBackports("8u26/b31", "8u30");
+            backports.assertLabeled("8u30");
+        }
+    }
+
+    @Test
+    void bpr7and8(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo)) {
+            var backports = new BackportManager(credentials, "17");
+            backports.assertLabeled();
+
+            backports.addBackports("8u291", "8u281/b30", "7u300/b30", "7u310");
+            backports.assertLabeled();
+        }
+    }
 }


### PR DESCRIPTION
This patch adds special handling of Backports for a couple of historic releases where we have 30 or more builds (and no BPRs).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1329](https://bugs.openjdk.java.net/browse/SKARA-1329): incorrect hgupdate label for JDK 7 updates


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1280/head:pull/1280` \
`$ git checkout pull/1280`

Update a local copy of the PR: \
`$ git checkout pull/1280` \
`$ git pull https://git.openjdk.java.net/skara pull/1280/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1280`

View PR using the GUI difftool: \
`$ git pr show -t 1280`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1280.diff">https://git.openjdk.java.net/skara/pull/1280.diff</a>

</details>
