### PR TITLE
SKARA-1340: Correct email domain not always used when adding a contributor to a PR

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ContributorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ContributorCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -77,7 +77,8 @@ public class ContributorCommand implements CommandHandler {
         }
 
         if (contributor.fullName().isPresent()) {
-            return Optional.of(EmailAddress.from(contributor.fullName().get(), contributor.username() + "@openjdk.org"));
+            return Optional.of(EmailAddress.from(contributor.fullName().get(),
+                               contributor.username() + "@" + censusInstance.configuration().census().domain()));
         } else {
             return Optional.empty();
         }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ContributorTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ContributorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -264,7 +264,7 @@ class ContributorTests {
             TestBotRunner.runPeriodicItems(prBot);
 
             // The bot should reply
-            assertLastCommentContains(pr, "Contributor `Generated Committer 2 <integrationcommitter2@openjdk.org>` successfully added");
+            assertLastCommentContains(pr, "Contributor `Generated Committer 2 <integrationcommitter2@openjdk.java.net>` successfully added");
         }
     }
 
@@ -297,7 +297,7 @@ class ContributorTests {
             TestBotRunner.runPeriodicItems(prBot);
 
             // The bot should reply
-            assertLastCommentContains(pr, "Contributor `Generated Reviewer 1 <integrationreviewer1@openjdk.org>` successfully added");
+            assertLastCommentContains(pr, "Contributor `Generated Reviewer 1 <integrationreviewer1@openjdk.java.net>` successfully added");
         }
     }
 

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/CensusConfiguration.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/CensusConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@ import java.net.URI;
 
 public class CensusConfiguration {
     private static final CensusConfiguration DEFAULT =
-        new CensusConfiguration(0, "openjdk.org", URI.create("https://openjdk.java.net/census.xml"));
+        new CensusConfiguration(0, "localhost", URI.create("https://openjdk.java.net/census.xml"));
 
     private final int version;
     private final String domain;

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/CensusConfiguration.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/CensusConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@ import java.net.URI;
 
 public class CensusConfiguration {
     private static final CensusConfiguration DEFAULT =
-        new CensusConfiguration(0, "localhost", URI.create("https://openjdk.java.net/census.xml"));
+        new CensusConfiguration(0, "openjdk.org", URI.create("https://openjdk.java.net/census.xml"));
 
     private final int version;
     private final String domain;


### PR DESCRIPTION
Hi all,

The contributor command uses the static domain `openjdk.org` which causes this issue. This patch uses the domain of the configuration instead of the static `openjdk.org` and adjusts the test cases.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [SKARA-1340](https://bugs.openjdk.java.net/browse/SKARA-1340): Correct email domain not always used when adding a contributor to a PR


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1281/head:pull/1281` \
`$ git checkout pull/1281`

Update a local copy of the PR: \
`$ git checkout pull/1281` \
`$ git pull https://git.openjdk.java.net/skara pull/1281/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1281`

View PR using the GUI difftool: \
`$ git pr show -t 1281`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1281.diff">https://git.openjdk.java.net/skara/pull/1281.diff</a>

</details>
