### PR TITLE
SKARA-1347: Enable binary check

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -263,7 +263,8 @@ class PullRequestCheckIssueVisitor implements IssueVisitor {
 
     @Override
     public void visit(BinaryIssue issue) {
-        log.fine("ignored: binary file");
+        addFailureMessage(issue.check(), "The binary file " + issue.path().toString() + " is not allowed in this repository.");
+        readyForReview = false;
     }
 
     @Override

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
@@ -263,7 +263,7 @@ class PullRequestCheckIssueVisitor implements IssueVisitor {
 
     @Override
     public void visit(BinaryIssue issue) {
-        addFailureMessage(issue.check(), "The binary file " + issue.path().toString() + " is not allowed in this repository.");
+        addFailureMessage(issue.check(), String.format("Binary files are not allowed (file: %s)", issue.path()));
         readyForReview = false;
     }
 

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/JCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/JCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -76,6 +76,7 @@ public class JCheck {
             new IssuesCheck(utils),
             new ExecutableCheck(),
             new SymlinkCheck(),
+            new BinaryCheck(),
             new ProblemListsCheck(repository)
         );
         repositoryChecks = List.of(


### PR DESCRIPTION
Hi all,

The binary check was not effective in the past. This patch fixes it to enable binary check.
Thanks for taking the time to reivew.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1347](https://bugs.openjdk.java.net/browse/SKARA-1347): Enable binary check


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1283/head:pull/1283` \
`$ git checkout pull/1283`

Update a local copy of the PR: \
`$ git checkout pull/1283` \
`$ git pull https://git.openjdk.java.net/skara pull/1283/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1283`

View PR using the GUI difftool: \
`$ git pr show -t 1283`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1283.diff">https://git.openjdk.java.net/skara/pull/1283.diff</a>

</details>
