### PR TITLE
1345: sync-bot removing hgupdate-sync label from 8u5 backport

### DIFF
--- a/jbs/src/main/java/org/openjdk/skara/jbs/Backports.java
+++ b/jbs/src/main/java/org/openjdk/skara/jbs/Backports.java
@@ -308,9 +308,10 @@ public class Backports {
                     ret.add(jdkVersion.feature() + "+updates-openjdk");
                 }
             } else if (numericFeature == 7 || numericFeature == 8) {
+                // For update releases, certain ranges of build numbers need special treatment
                 if (bprException(jdkVersion, numericFeature)) {
                     ret.add(jdkVersion.feature());
-                } else {
+                } else if (jdkVersion.interim().isPresent()) {
                     var resolvedInBuild = jdkVersion.resolvedInBuild();
                     if (resolvedInBuild.isPresent()) {
                         if (!resolvedInBuild.get().equals("team")) { // Special case - team build resolved are ignored
@@ -324,6 +325,8 @@ public class Backports {
                     } else {
                         ret.add(jdkVersion.feature());
                     }
+                } else {
+                    ret.add(jdkVersion.feature());
                 }
             } else {
                 log.warning("Ignoring issue with unknown version: " + jdkVersion);

--- a/jbs/src/test/java/org/openjdk/skara/jbs/BackportsTests.java
+++ b/jbs/src/test/java/org/openjdk/skara/jbs/BackportsTests.java
@@ -870,4 +870,15 @@ public class BackportsTests {
             backports.assertLabeled();
         }
     }
+
+    @Test
+    void jdk8ub130(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo)) {
+            var backports = new BackportManager(credentials, "8/b130");
+            backports.assertLabeled();
+
+            backports.addBackports("9", "7u111", "openjdk7u", "6u121", "8u5");
+            backports.assertLabeled("8u5");
+        }
+    }
 }


### PR DESCRIPTION
This patch fixes an issue in the synclabel bot. For update releases of 8 and 7, we have special ranges of build numbers that are used for special releases. These need to be, and are, handled separately in the synclabel bot. These ranges only apply to update releases however, and not the main feature releases, where the actual build numbers used went well into these ranges. 

Added a test that mimics the example mislabeled set of bugs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1345](https://bugs.openjdk.java.net/browse/SKARA-1345): sync-bot removing hgupdate-sync label from 8u5 backport


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1284/head:pull/1284` \
`$ git checkout pull/1284`

Update a local copy of the PR: \
`$ git checkout pull/1284` \
`$ git pull https://git.openjdk.java.net/skara pull/1284/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1284`

View PR using the GUI difftool: \
`$ git pr show -t 1284`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1284.diff">https://git.openjdk.java.net/skara/pull/1284.diff</a>

</details>
