### PR TITLE
1344: Support notifications operating on a repository mirror

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierBuilder.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierBuilder.java
@@ -39,11 +39,13 @@ class IssueNotifierBuilder {
     private Map<String, List<String>> altFixVersions = null;
     private JbsVault vault = null;
     private boolean prOnly = true;
+    private boolean repoOnly = false;
     private String buildName = null;
     private HostedRepository censusRepository = null;
     private String censusRef = null;
     private String namespace = "openjdk.org";
     private boolean useHeadVersion = false;
+    private HostedRepository originalRepository;
 
     IssueNotifierBuilder issueProject(IssueProject issueProject) {
         this.issueProject = issueProject;
@@ -96,6 +98,11 @@ class IssueNotifierBuilder {
         return this;
     }
 
+    public IssueNotifierBuilder repoOnly(boolean repoOnly) {
+        this.repoOnly = repoOnly;
+        return this;
+    }
+
     public IssueNotifierBuilder buildName(String buildName) {
         this.buildName = buildName;
         return this;
@@ -121,10 +128,15 @@ class IssueNotifierBuilder {
         return this;
     }
 
+    public IssueNotifierBuilder originalRepository(HostedRepository originalRepository) {
+        this.originalRepository = originalRepository;
+        return this;
+    }
+
     IssueNotifier build() {
         var jbsBackport = new JbsBackport(issueProject.issueTracker().uri(), vault);
         return new IssueNotifier(issueProject, reviewLink, reviewIcon, commitLink, commitIcon,
-                                 setFixVersion, fixVersions, altFixVersions, jbsBackport, prOnly, buildName,
-                                 censusRepository, censusRef, namespace, useHeadVersion);
+                setFixVersion, fixVersions, altFixVersions, jbsBackport, prOnly,
+                repoOnly, buildName, censusRepository, censusRef, namespace, useHeadVersion, originalRepository);
     }
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierFactory.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierFactory.java
@@ -96,6 +96,10 @@ public class IssueNotifierFactory implements NotifierFactory {
             builder.prOnly(notifierConfiguration.get("pronly").asBoolean());
         }
 
+        if (notifierConfiguration.contains("repoonly")) {
+            builder.repoOnly(notifierConfiguration.get("repoonly").asBoolean());
+        }
+
         if (notifierConfiguration.contains("census")) {
             builder.censusRepository(botConfiguration.repository(notifierConfiguration.get("census").asString()));
             builder.censusRef(botConfiguration.repositoryRef(notifierConfiguration.get("census").asString()));
@@ -106,6 +110,10 @@ public class IssueNotifierFactory implements NotifierFactory {
 
         if (notifierConfiguration.contains("headversion")) {
             builder.useHeadVersion(notifierConfiguration.get("headversion").asBoolean());
+        }
+
+        if (notifierConfiguration.contains("originalrepository")) {
+            builder.originalRepository(botConfiguration.repository(notifierConfiguration.get("originalrepository").asString()));
         }
 
         return builder.build();

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/TestUtils.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/TestUtils.java
@@ -40,4 +40,18 @@ public class TestUtils {
         return new StorageBuilder<PullRequestState>("prissues.txt")
                 .remoteRepository(repository, "history", "Duke", "duke@openjdk.java.net", "Updated prissues");
     }
+
+    // Test implementation of a RepositoryListener that does nothing
+    public static class NullRepositoryListener implements RepositoryListener {
+
+        @Override
+        public String name() {
+            return "null";
+        }
+
+        @Override
+        public boolean idempotent() {
+            return true;
+        }
+    }
 }

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/comment/CommitCommentNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/comment/CommitCommentNotifierTests.java
@@ -60,6 +60,8 @@ public class CommitCommentNotifierTests {
                                      .prStateStorageBuilder(prStateStorage)
                                      .integratorId(repo.forge().currentUser().id())
                                      .build();
+            // Register a RepositoryListener to make history initialize on the first run
+            notifyBot.registerRepositoryListener(new NullRepositoryListener());
             var notifier = new CommitCommentNotifier(issueProject);
             notifier.attachTo(notifyBot);
 
@@ -127,6 +129,8 @@ public class CommitCommentNotifierTests {
                                      .prStateStorageBuilder(prStateStorage)
                                      .integratorId(repo.forge().currentUser().id())
                                      .build();
+            // Register a RepositoryListener to make history initialize on the first run
+            notifyBot.registerRepositoryListener(new NullRepositoryListener());
             var notifier = new CommitCommentNotifier(issueProject);
             notifier.attachTo(notifyBot);
 
@@ -194,6 +198,8 @@ public class CommitCommentNotifierTests {
                     .prStateStorageBuilder(prStateStorage)
                     .integratorId(repo.forge().currentUser().id())
                     .build();
+            // Register a RepositoryListener to make history initialize on the first run
+            notifyBot.registerRepositoryListener(new NullRepositoryListener());
             var notifier = new CommitCommentNotifier(issueProject);
             notifier.attachTo(notifyBot);
 


### PR DESCRIPTION
We would like to move some NotifierBot configurations to operate off of a mirror of a repo instead of the original repo. In order to support this I would like to add these two new configuration options in the issue notifier:

1. "originalrepository": Setting this implies that the repo the notifier is operating on is a mirror, and this original repo should be used for any links generated in notifications.
2. "repoonly": Similar to the existing "pronly", this limits what kind of notifications the notifier acts on. This is needed to be able to separate the PR event based notifications from the repo event based notifications. PRs aren't mirrored so those can't be moved to operate from the mirror.

When implementing repoonly, I also changed the NotifyBot to only return WorkItems for either pr or repo if there are actually listeners registered for them respectively. This caused some seemingly unrelated tests to fail, as they were relying on the side effect of running the RepositoryWorkItem with nothing to do. To combat this, I've introduced a mock NullRepositoryListener for these tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1344](https://bugs.openjdk.java.net/browse/SKARA-1344): Support notifications operating on a repository mirror


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1285/head:pull/1285` \
`$ git checkout pull/1285`

Update a local copy of the PR: \
`$ git checkout pull/1285` \
`$ git pull https://git.openjdk.java.net/skara pull/1285/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1285`

View PR using the GUI difftool: \
`$ git pr show -t 1285`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1285.diff">https://git.openjdk.java.net/skara/pull/1285.diff</a>

</details>
