### PR TITLE
1350: Altfixversions isn't checking Backport resolution

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
@@ -338,10 +338,10 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
         if (altFixVersions != null) {
             for (var altFixVersionString : altFixVersions.getOrDefault(branch.name(), List.of())) {
                 var altFixVersion = JdkVersion.parse(altFixVersionString).orElseThrow();
-                var backport = Backports.findIssue(issue, altFixVersion);
-                if (backport.isPresent()) {
-                    if (backport.get().isResolved()) {
-                        return backport;
+                var altBackport = Backports.findIssue(issue, altFixVersion);
+                if (altBackport.isPresent()) {
+                    if (altBackport.get().isFixed()) {
+                        return altBackport;
                     }
                 }
             }

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/Issue.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/Issue.java
@@ -135,6 +135,15 @@ public interface Issue {
     }
 
     /**
+     * By default this issue is considered fixed if it has been resolved.
+     * For specific implementations, this may require additional criteria,
+     * like not having been rejected.
+     */
+    default boolean isFixed() {
+        return isResolved();
+    }
+
+    /**
      * Set the state.
      * @param state Desired state
      */

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraIssue.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraIssue.java
@@ -181,6 +181,21 @@ public class JiraIssue implements Issue {
         }
     }
 
+    /**
+     * A Jira issue is considered fixed if it's either resolved or closed and
+     * the resolution is "Fixed".
+     */
+    @Override
+    public boolean isFixed() {
+        if (isResolved() || isClosed()) {
+            var resolution = json.get("fields").get("resolution");
+            if (!resolution.isNull()) {
+                return "Fixed".equals(resolution.get("name").asString());
+            }
+        }
+        return false;
+    }
+
     private Map<String, String> availableTransitions() {
         var transitions = request.get("/transitions").execute();
         return transitions.get("transitions").stream()


### PR DESCRIPTION
This patch fixes a flaw in the altfixversion feature. Currently a backport with an altfixversion is considered valid if the state is "resolved". There are two problems with this. It misses backports that are in state closed. It could also cause false positives by accepting backports that aren't set to resolution "Fixed".

To fix this, I've introduced a new method on the Issue interface "isFixed()". The default implementation (which will get used in testing) just delegates to isResolved(). For JiraIssue, it checks both the state and the resolution.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1350](https://bugs.openjdk.java.net/browse/SKARA-1350): Altfixversions isn't checking Backport resolution


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1286/head:pull/1286` \
`$ git checkout pull/1286`

Update a local copy of the PR: \
`$ git checkout pull/1286` \
`$ git pull https://git.openjdk.java.net/skara pull/1286/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1286`

View PR using the GUI difftool: \
`$ git pr show -t 1286`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1286.diff">https://git.openjdk.java.net/skara/pull/1286.diff</a>

</details>
