### PR TITLE
1352: Configure GithubHost as offline

### DIFF
--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunnerConfiguration.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunnerConfiguration.java
@@ -93,9 +93,11 @@ public class BotRunnerConfiguration {
                     } catch (IOException e) {
                         throw new ConfigurationError("Cannot find key file: " + keyFile);
                     }
-                } else {
+                } else if (github.contains("username")) {
                     var pat = new Credential(github.get("username").asString(), github.get("pat").asString());
                     ret.put(entry.name(), Forge.from("github", uri, pat, github.asObject()));
+                } else {
+                    ret.put(entry.name(), Forge.from("github", uri, github.asObject()));
                 }
             } else {
                 throw new ConfigurationError("Host " + entry.name());

--- a/forge/src/main/java/org/openjdk/skara/forge/Forge.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/Forge.java
@@ -59,7 +59,7 @@ public interface Forge extends Host {
     }
 
     static Forge from(String name, URI uri) {
-        return from(name, uri, (Credential) null);
+        return from(name, uri, null, null);
     }
 
     static Forge from(String name, URI uri, JSONObject configuration) {

--- a/forge/src/main/java/org/openjdk/skara/forge/Forge.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/Forge.java
@@ -59,7 +59,11 @@ public interface Forge extends Host {
     }
 
     static Forge from(String name, URI uri) {
-        return from(name, uri, null);
+        return from(name, uri, (Credential) null);
+    }
+
+    static Forge from(String name, URI uri, JSONObject configuration) {
+        return from(name, uri, null, configuration);
     }
 
     static Optional<Forge> from(URI uri, Credential credential, JSONObject configuration) {

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubForgeFactory.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubForgeFactory.java
@@ -53,6 +53,11 @@ public class GitHubForgeFactory implements ForgeFactory {
             webUriReplacement = configuration.get("weburl").get("replacement").asString();
         }
 
+        var offline = false;
+        if (configuration.contains("offline")) {
+            offline = configuration.get("offline").asBoolean();
+        }
+
         Set<String> orgs = new HashSet<>();
         if (configuration != null && configuration.contains("orgs")) {
             orgs = configuration.get("orgs")
@@ -72,7 +77,7 @@ public class GitHubForgeFactory implements ForgeFactory {
                 return new GitHubHost(uri, credential, webUriPattern, webUriReplacement, orgs);
             }
         } else {
-            return new GitHubHost(uri, webUriPattern, webUriReplacement, orgs);
+            return new GitHubHost(uri, webUriPattern, webUriReplacement, orgs, offline);
         }
     }
 }

--- a/forge/src/test/java/org/openjdk/skara/forge/github/GitHubHostTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/github/GitHubHostTests.java
@@ -39,7 +39,7 @@ class GitHubHostTests {
         try (var tempFolder = new TemporaryDirectory()) {
             var host = new GitHubHost(URIBuilder.base("http://www.example.com").build(),
                                       Pattern.compile("^(http://www.example.com)/test/(.*)$"), "$1/another/$2",
-                                      Set.of());
+                                      Set.of(), false);
             assertEquals(new URI("http://www.example.com/another/hello"), host.getWebURI("/test/hello"));
         }
     }
@@ -49,7 +49,7 @@ class GitHubHostTests {
         try (var tempFolder = new TemporaryDirectory()) {
             var host = new GitHubHost(URIBuilder.base("http://www.example.com").build(),
                                       Pattern.compile("^(http://www.example.com)/test/(.*)$"), "$1/another/$2",
-                                      Set.of());
+                                      Set.of(), false);
             assertEquals(new URI("http://www.example.com/another/hello"), host.getWebURI("/test/hello"));
             assertEquals(new URI("http://www.example.com/test/hello"), host.getWebURI("/test/hello", false));
         }


### PR DESCRIPTION
As a followup to [SKARA-1344](https://bugs.openjdk.java.net/browse/SKARA-1344), to better support the notifier to act through a mirror, we need another configuration option. When configuring a forge for the "originalrepository" option, we need to make it possible to not need to make any remote calls to that forge.

Currently, when Skara creates a HostedRepository from a forge, it will always make a call to validate and initiate things. At least for GithubRepositories, this call isn't strictly necessary (and one could argue that it should be possible to get around this for Gitlab as well). Most callers for Forge::repository do expect this validation however, so we do not want to change the default behavior.

I propose adding a new configure parameter to github forge, "offline", which defaults to false. If set to true, then it indicates that this forge is expected to be offline and the caller is not expected to try to perform any remote operations. This concept could certainly be expanded, but for now, the only thing we explicitly need to prevent is that validation/initialization when creating a repository. I would rather not spend more time implementing a more complete feature that is unlikely to be used.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1352](https://bugs.openjdk.java.net/browse/SKARA-1352): Configure GithubHost as offline


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1287/head:pull/1287` \
`$ git checkout pull/1287`

Update a local copy of the PR: \
`$ git checkout pull/1287` \
`$ git pull https://git.openjdk.java.net/skara pull/1287/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1287`

View PR using the GUI difftool: \
`$ git pr show -t 1287`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1287.diff">https://git.openjdk.java.net/skara/pull/1287.diff</a>

</details>
