### PR TITLE
1356: Notifer option to only interact with PRs

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
@@ -66,6 +66,8 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
     // repository but still generate links to the original. Only works for notifications
     // on repository, not pull requests.
     private final HostedRepository originalRepository;
+    // If true, Issues will be resolved on a PR integration event.
+    private final boolean resolveFromPr;
 
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots.notify");
 
@@ -75,7 +77,7 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
                   boolean setFixVersion, Map<String, String> fixVersions, Map<String, List<String>> altFixVersions,
                   JbsBackport jbsBackport, boolean prOnly, boolean repoOnly, String buildName,
                   HostedRepository censusRepository, String censusRef, String namespace, boolean useHeadVersion,
-                  HostedRepository originalRepository) {
+                  HostedRepository originalRepository, boolean resolveFromPr) {
         this.issueProject = issueProject;
         this.reviewLink = reviewLink;
         this.reviewIcon = reviewIcon;
@@ -93,6 +95,7 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
         this.namespace = namespace;
         this.useHeadVersion = useHeadVersion;
         this.originalRepository = originalRepository;
+        this.resolveFromPr = resolveFromPr;
     }
 
     static IssueNotifierBuilder newBuilder() {
@@ -175,8 +178,8 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
                 issue.addLink(linkBuilder.build());
             }
 
-            // If prOnly is false, this is instead done when processing commits
-            if (prOnly) {
+            // Resolving issues can happen either here or when processing commits
+            if (resolveFromPr) {
                 if (issue.state() == Issue.State.OPEN) {
                     issue.setState(Issue.State.RESOLVED);
                     if (issue.assignees().isEmpty()) {

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
@@ -66,7 +66,8 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
     // repository but still generate links to the original. Only works for notifications
     // on repository, not pull requests.
     private final HostedRepository originalRepository;
-    // If true, Issues will be resolved on a PR integration event.
+    // Controls whether the notifier should try to resolve issues. Only valid when
+    // pronly is true.
     private final boolean resolve;
 
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots.notify");

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
@@ -67,7 +67,7 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
     // on repository, not pull requests.
     private final HostedRepository originalRepository;
     // If true, Issues will be resolved on a PR integration event.
-    private final boolean resolveFromPr;
+    private final boolean resolve;
 
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots.notify");
 
@@ -77,7 +77,7 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
                   boolean setFixVersion, Map<String, String> fixVersions, Map<String, List<String>> altFixVersions,
                   JbsBackport jbsBackport, boolean prOnly, boolean repoOnly, String buildName,
                   HostedRepository censusRepository, String censusRef, String namespace, boolean useHeadVersion,
-                  HostedRepository originalRepository, boolean resolveFromPr) {
+                  HostedRepository originalRepository, boolean resolve) {
         this.issueProject = issueProject;
         this.reviewLink = reviewLink;
         this.reviewIcon = reviewIcon;
@@ -95,7 +95,7 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
         this.namespace = namespace;
         this.useHeadVersion = useHeadVersion;
         this.originalRepository = originalRepository;
-        this.resolveFromPr = resolveFromPr;
+        this.resolve = resolve;
     }
 
     static IssueNotifierBuilder newBuilder() {
@@ -178,8 +178,8 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
                 issue.addLink(linkBuilder.build());
             }
 
-            // Resolving issues can happen either here or when processing commits
-            if (resolveFromPr) {
+            // If prOnly is false, this is instead done when processing commits
+            if (prOnly && resolve) {
                 if (issue.state() == Issue.State.OPEN) {
                     issue.setState(Issue.State.RESOLVED);
                     if (issue.assignees().isEmpty()) {

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierBuilder.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierBuilder.java
@@ -46,6 +46,7 @@ class IssueNotifierBuilder {
     private String namespace = "openjdk.org";
     private boolean useHeadVersion = false;
     private HostedRepository originalRepository;
+    private boolean resolveFromPr = true;
 
     IssueNotifierBuilder issueProject(IssueProject issueProject) {
         this.issueProject = issueProject;
@@ -73,7 +74,6 @@ class IssueNotifierBuilder {
     }
 
     public IssueNotifierBuilder setFixVersion(boolean setFixVersion) {
-        prOnly = false;
         this.setFixVersion = setFixVersion;
         return this;
     }
@@ -133,10 +133,16 @@ class IssueNotifierBuilder {
         return this;
     }
 
+    public IssueNotifierBuilder resolveFromPr(boolean resolveFromPr) {
+        this.resolveFromPr = resolveFromPr;
+        return this;
+    }
+
     IssueNotifier build() {
         var jbsBackport = new JbsBackport(issueProject.issueTracker().uri(), vault);
         return new IssueNotifier(issueProject, reviewLink, reviewIcon, commitLink, commitIcon,
                 setFixVersion, fixVersions, altFixVersions, jbsBackport, prOnly,
-                repoOnly, buildName, censusRepository, censusRef, namespace, useHeadVersion, originalRepository);
+                repoOnly, buildName, censusRepository, censusRef, namespace, useHeadVersion, originalRepository,
+                resolveFromPr);
     }
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierBuilder.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierBuilder.java
@@ -46,7 +46,7 @@ class IssueNotifierBuilder {
     private String namespace = "openjdk.org";
     private boolean useHeadVersion = false;
     private HostedRepository originalRepository;
-    private boolean resolveFromPr = true;
+    private boolean resolve = true;
 
     IssueNotifierBuilder issueProject(IssueProject issueProject) {
         this.issueProject = issueProject;
@@ -74,6 +74,7 @@ class IssueNotifierBuilder {
     }
 
     public IssueNotifierBuilder setFixVersion(boolean setFixVersion) {
+        prOnly = false;
         this.setFixVersion = setFixVersion;
         return this;
     }
@@ -133,9 +134,17 @@ class IssueNotifierBuilder {
         return this;
     }
 
-    public IssueNotifierBuilder resolveFromPr(boolean resolveFromPr) {
-        this.resolveFromPr = resolveFromPr;
+    public IssueNotifierBuilder resolve(boolean resolve) {
+        this.resolve = resolve;
         return this;
+    }
+
+    public boolean prOnly() {
+        return prOnly;
+    }
+
+    public boolean resolve() {
+        return resolve;
     }
 
     IssueNotifier build() {
@@ -143,6 +152,6 @@ class IssueNotifierBuilder {
         return new IssueNotifier(issueProject, reviewLink, reviewIcon, commitLink, commitIcon,
                 setFixVersion, fixVersions, altFixVersions, jbsBackport, prOnly,
                 repoOnly, buildName, censusRepository, censusRef, namespace, useHeadVersion, originalRepository,
-                resolveFromPr);
+                resolve);
     }
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierFactory.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierFactory.java
@@ -64,8 +64,6 @@ public class IssueNotifierFactory implements NotifierFactory {
 
         if (notifierConfiguration.contains("fixversions")) {
             builder.setFixVersion(true);
-            builder.prOnly(false);
-            builder.resolveFromPr(false);
             builder.fixVersions(notifierConfiguration.get("fixversions").fields().stream()
                                                       .collect(Collectors.toMap(JSONObject.Field::name,
                                                                                 f -> f.value().asString())));
@@ -98,8 +96,11 @@ public class IssueNotifierFactory implements NotifierFactory {
             builder.prOnly(notifierConfiguration.get("pronly").asBoolean());
         }
 
-        if (notifierConfiguration.contains("resolvefrompr")) {
-            builder.resolveFromPr(notifierConfiguration.get("resolvefrompr").asBoolean());
+        if (notifierConfiguration.contains("resolve")) {
+            builder.resolve(notifierConfiguration.get("resolve").asBoolean());
+            if (!builder.resolve() && !builder.prOnly()) {
+                throw new RuntimeException("Cannot disable resolve when pronly is false");
+            }
         }
 
         if (notifierConfiguration.contains("repoonly")) {

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierFactory.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierFactory.java
@@ -64,6 +64,8 @@ public class IssueNotifierFactory implements NotifierFactory {
 
         if (notifierConfiguration.contains("fixversions")) {
             builder.setFixVersion(true);
+            builder.prOnly(false);
+            builder.resolveFromPr(false);
             builder.fixVersions(notifierConfiguration.get("fixversions").fields().stream()
                                                       .collect(Collectors.toMap(JSONObject.Field::name,
                                                                                 f -> f.value().asString())));
@@ -94,6 +96,10 @@ public class IssueNotifierFactory implements NotifierFactory {
 
         if (notifierConfiguration.contains("pronly")) {
             builder.prOnly(notifierConfiguration.get("pronly").asBoolean());
+        }
+
+        if (notifierConfiguration.contains("resolvefrompr")) {
+            builder.resolveFromPr(notifierConfiguration.get("resolvefrompr").asBoolean());
         }
 
         if (notifierConfiguration.contains("repoonly")) {


### PR DESCRIPTION
The "pronly" option was introduced in [SKARA-445](https://bugs.openjdk.java.net/browse/SKARA-445) with the intention of support running just a PR based IssueNotifier, which includes resolving issues when a PR is integrated.

We need to run an IssueNotifier without it trying to resolve issues and without reacting to repo events. To support this, I've introduced a new config parameter on IssueNotifier: "resolve". Since we only need this when pronly is true, I didn't bother implementing support for that case and instead added a validation check in the factory so we don't accidentally try to run with an unsupported configuration.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1356](https://bugs.openjdk.java.net/browse/SKARA-1356): Notifer option to only interact with PRs


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**) ⚠️ Review applies to f795c61f3cf2ae762b6a9b9bad8f1b10f4397bd6
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**) ⚠️ Review applies to f795c61f3cf2ae762b6a9b9bad8f1b10f4397bd6


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1288/head:pull/1288` \
`$ git checkout pull/1288`

Update a local copy of the PR: \
`$ git checkout pull/1288` \
`$ git pull https://git.openjdk.java.net/skara pull/1288/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1288`

View PR using the GUI difftool: \
`$ git pr show -t 1288`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1288.diff">https://git.openjdk.java.net/skara/pull/1288.diff</a>

</details>
