### PR TITLE
1360: SKARA-1352 is missing null check

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubForgeFactory.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubForgeFactory.java
@@ -48,22 +48,25 @@ public class GitHubForgeFactory implements ForgeFactory {
     public Forge create(URI uri, Credential credential, JSONObject configuration) {
         Pattern webUriPattern = null;
         String webUriReplacement = null;
-        if (configuration != null && configuration.contains("weburl")) {
-            webUriPattern = Pattern.compile(configuration.get("weburl").get("pattern").asString());
-            webUriReplacement = configuration.get("weburl").get("replacement").asString();
-        }
-
         var offline = false;
-        if (configuration.contains("offline")) {
-            offline = configuration.get("offline").asBoolean();
-        }
-
         Set<String> orgs = new HashSet<>();
-        if (configuration != null && configuration.contains("orgs")) {
-            orgs = configuration.get("orgs")
-                                .stream()
-                                .map(JSONValue::asString)
-                                .collect(Collectors.toSet());
+
+        if (configuration != null) {
+            if (configuration.contains("weburl")) {
+                webUriPattern = Pattern.compile(configuration.get("weburl").get("pattern").asString());
+                webUriReplacement = configuration.get("weburl").get("replacement").asString();
+            }
+
+            if (configuration.contains("offline")) {
+                offline = configuration.get("offline").asBoolean();
+            }
+
+            if (configuration.contains("orgs")) {
+                orgs = configuration.get("orgs")
+                    .stream()
+                    .map(JSONValue::asString)
+                    .collect(Collectors.toSet());
+            }
         }
 
         if (credential != null) {


### PR DESCRIPTION
The recent fix for [SKARA-1352](https://bugs.openjdk.java.net/browse/SKARA-1352) ("Configure GithubHost as offline") is missing a null check for the configuration object.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1360](https://bugs.openjdk.java.net/browse/SKARA-1360): SKARA-1352 is missing null check


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1289/head:pull/1289` \
`$ git checkout pull/1289`

Update a local copy of the PR: \
`$ git checkout pull/1289` \
`$ git pull https://git.openjdk.java.net/skara pull/1289/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1289`

View PR using the GUI difftool: \
`$ git pr show -t 1289`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1289.diff">https://git.openjdk.java.net/skara/pull/1289.diff</a>

</details>
