### PR TITLE
SKARA-1362: PR suggestion for fixing username is wrong

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -870,7 +870,7 @@ class CheckRun {
                           "\n\n" +
                           "```\n" +
                           "$ git checkout " + pr.sourceRef() + "\n" +
-                          "$ git commit -c user.name='Preferred Full Name' --allow-empty -m 'Update full name'\n" +
+                          "$ git commit --author='Preferred Full Name <you@example.com>' --allow-empty -m 'Update full name'\n" +
                           "$ git push\n" +
                           "```\n";
             pr.addComment(fullNameWarningMarker + "\n" + message);


### PR DESCRIPTION
The Skara PR bot warns when the Author name in the git commit doesn't match the preferred name in the GitHub profile. The recommended fix that the bot adds as a PR comment is wrong.

This PR fixes the message.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1362](https://bugs.openjdk.java.net/browse/SKARA-1362): PR suggestion for fixing username is wrong


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1290/head:pull/1290` \
`$ git checkout pull/1290`

Update a local copy of the PR: \
`$ git checkout pull/1290` \
`$ git pull https://git.openjdk.java.net/skara pull/1290/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1290`

View PR using the GUI difftool: \
`$ git pr show -t 1290`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1290.diff">https://git.openjdk.java.net/skara/pull/1290.diff</a>

</details>
