### PR TITLE
1363: update-sync incorrect sync label

### DIFF
--- a/jbs/src/main/java/org/openjdk/skara/jbs/Backports.java
+++ b/jbs/src/main/java/org/openjdk/skara/jbs/Backports.java
@@ -223,26 +223,6 @@ public class Backports {
         return Optional.empty();
     }
 
-    private static boolean isFixed(Issue issue) {
-        if (issue.state() == Issue.State.OPEN) {
-            return false;
-        }
-        var resolution = issue.properties().get("resolution");
-        if (resolution == null || resolution.isNull()) {
-            return false;
-        }
-        var name = resolution.get("name");
-        if (name == null || name.isNull()) {
-            return false;
-        }
-
-        if (!name.asString().equals("Fixed")) {
-            return false;
-        }
-
-        return true;
-    }
-
     public static List<Issue> findBackports(Issue primary, boolean fixedOnly) {
         var links = primary.links();
         return links.stream()
@@ -250,7 +230,7 @@ public class Backports {
                     .filter(l -> l.relationship().isPresent())
                     .filter(l -> l.relationship().get().equals("backported by"))
                     .map(l -> l.issue().get())
-                    .filter(i -> !fixedOnly || isFixed(i))
+                    .filter(i -> !fixedOnly || i.isFixed())
                     // We used to filter out any issues not of 'backport' type here, but
                     // Jira allows linking of any issues with a 'backported by' link, so we
                     // have to accept them, even if it's weird.

--- a/test/src/main/java/org/openjdk/skara/test/TestIssue.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestIssue.java
@@ -158,7 +158,24 @@ public class TestIssue implements Issue {
         data.state = state;
         data.lastUpdate = ZonedDateTime.now();
         data.closedBy = user;
-        data.properties.put("resolution", JSON.object().put("name", JSON.of("Fixed")));
+        if (state == State.RESOLVED || state == State.CLOSED) {
+            data.properties.put("resolution", JSON.object().put("name", JSON.of("Fixed")));
+        }
+    }
+
+    /**
+     * This implementation mimics the JiraIssue definitions of isFixed and is
+     * needed to test Backports behavior.
+     */
+    @Override
+    public boolean isFixed() {
+        if (isResolved() || isClosed()) {
+            var resolution = data.properties.get("resolution");
+            if (!resolution.isNull()) {
+                return "Fixed".equals(resolution.get("name").asString());
+            }
+        }
+        return false;
     }
 
     @Override

--- a/test/src/main/java/org/openjdk/skara/test/TestIssue.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestIssue.java
@@ -164,8 +164,8 @@ public class TestIssue implements Issue {
     }
 
     /**
-     * This implementation mimics the JiraIssue definitions of isFixed and is
-     * needed to test Backports behavior.
+     * This implementation mimics the JiraIssue definition of isFixed and is
+     * needed to test handling of backports.
      */
     @Override
     public boolean isFixed() {


### PR DESCRIPTION
In SKARA-964, we fixed the labelsync bot to only consider "Fixed" issues when calculating label assignment. That fix only considered the backport issues and not the main bug. This fix tries to address this by applying the check for isFixed to the main bug as well.

While working on this, I also decided to refactor Backports a bit and remove the isFixed method from that class and instead use the newly introduced Issue::isFixed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1363](https://bugs.openjdk.java.net/browse/SKARA-1363): update-sync incorrect sync label


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1291/head:pull/1291` \
`$ git checkout pull/1291`

Update a local copy of the PR: \
`$ git checkout pull/1291` \
`$ git pull https://git.openjdk.java.net/skara pull/1291/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1291`

View PR using the GUI difftool: \
`$ git pr show -t 1291`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1291.diff">https://git.openjdk.java.net/skara/pull/1291.diff</a>

</details>
