### PR TITLE
Log warning on wrapped UncheckedRestException

### DIFF
--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
@@ -196,7 +196,13 @@ public class BotRunner {
                     item.handleRuntimeException(e);
                 } catch (RuntimeException e) {
                     EXCEPTIONS_COUNTER.labels(item.botName(), item.workItemName(), e.getClass().getName()).inc();
-                    log.log(Level.SEVERE, "Exception during item execution (" + item + "): " + e.getMessage(), e);
+                    if (e.getCause() instanceof UncheckedRestException) {
+                        // Log as WARNING to avoid triggering alarms. Failed REST calls are tracked
+                        // using metrics.
+                        log.log(Level.WARNING, "RestException during item execution (" + item + ")", e.getCause());
+                    } else {
+                        log.log(Level.SEVERE, "Exception during item execution (" + item + "): " + e.getMessage(), e);
+                    }
                     item.handleRuntimeException(e);
                 } finally {
                     log.log(Level.FINE, "Item " + item + " is now done", TaskPhases.END);


### PR DESCRIPTION
In SKARA-1063, I introduced UncheckedRestException in order to avoid logging for errors that are very likely transient, and that are tracked with metrics as well. In some cases, specifically when running Jcheck in a bot, we end up wrapping that exception in a RuntimeException, which in turn causes us to log an error instead of warning. 

This patch tries to fix this by also checking nested exceptions in when catching RuntimeException in the BotRunner.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1292/head:pull/1292` \
`$ git checkout pull/1292`

Update a local copy of the PR: \
`$ git checkout pull/1292` \
`$ git pull https://git.openjdk.java.net/skara pull/1292/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1292`

View PR using the GUI difftool: \
`$ git pr show -t 1292`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1292.diff">https://git.openjdk.java.net/skara/pull/1292.diff</a>

</details>
