### PR TITLE
1365: Draft PRs do not get extra time before auto closing

### DIFF
--- a/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestPrunerBot.java
+++ b/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestPrunerBot.java
@@ -40,7 +40,7 @@ class PullRequestPrunerBotWorkItem implements WorkItem {
 
     PullRequestPrunerBotWorkItem(PullRequest pr, Duration maxAge) {
         this.pr = pr;
-        this.maxAge = pr.isDraft() ? maxAge.multipliedBy(2) : maxAge;
+        this.maxAge = maxAge;
     }
 
     @Override
@@ -162,9 +162,10 @@ public class PullRequestPrunerBot implements Bot {
                                .flatMap(Function.identity())
                                .max(ZonedDateTime::compareTo).orElseThrow();
 
-        var oldestAllowed = ZonedDateTime.now().minus(currentMaxAge);
+        var actualMaxAge = pr.isDraft() ? currentMaxAge.multipliedBy(2) : currentMaxAge;
+        var oldestAllowed = ZonedDateTime.now().minus(actualMaxAge);
         if (latestAction.isBefore(oldestAllowed)) {
-            var item = new PullRequestPrunerBotWorkItem(pr, currentMaxAge);
+            var item = new PullRequestPrunerBotWorkItem(pr, actualMaxAge);
             ret.add(item);
         }
 


### PR DESCRIPTION
The PullRequestPrunerBot automatically closes PRs that have been inactive for too long. The maxAge is configurable, and we have it set to 28 days for most repos on Github. [SKARA-831](https://bugs.openjdk.java.net/browse/SKARA-831) tried to give draft PRs double the time before being auto closed. Unfortunately, that fix wasn't enough, as it only affects the printed message and not the actual age check.

I tried to add a unit test for this, but in the end I could find no reliable way to do this. I don't want to rely on timings. And the only other thing I could think of checking was the message printed -- but that was already "correct" so it would not verify this bug anyway.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1365](https://bugs.openjdk.java.net/browse/SKARA-1365): Draft PRs do not get extra time before auto closing


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1293/head:pull/1293` \
`$ git checkout pull/1293`

Update a local copy of the PR: \
`$ git checkout pull/1293` \
`$ git pull https://git.openjdk.java.net/skara pull/1293/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1293`

View PR using the GUI difftool: \
`$ git pr show -t 1293`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1293.diff">https://git.openjdk.java.net/skara/pull/1293.diff</a>

</details>
