### PR TITLE
1383: Add core-libs label to jdk.random files

### DIFF
--- a/config/mailinglist/rules/jdk.json
+++ b/config/mailinglist/rules/jdk.json
@@ -152,6 +152,7 @@
             "src/jdk.naming.dns/",
             "src/jdk.naming.rmi/",
             "src/jdk.nio.mapmode/",
+            "src/jdk.random/",
             "src/jdk.unsupported/",
             "src/jdk.xml.dom/",
             "src/jdk.zipfs/",


### PR DESCRIPTION
Currently no label is set on PRs touching jdk.random files. These PRs should be reviewed on core-libs mailing list.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1383](https://bugs.openjdk.java.net/browse/SKARA-1383): Add core-libs label to jdk.random files


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1295/head:pull/1295` \
`$ git checkout pull/1295`

Update a local copy of the PR: \
`$ git checkout pull/1295` \
`$ git pull https://git.openjdk.java.net/skara pull/1295/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1295`

View PR using the GUI difftool: \
`$ git pr show -t 1295`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1295.diff">https://git.openjdk.java.net/skara/pull/1295.diff</a>

</details>
