### PR TITLE
1390: Do not automatically assign the 'build' label to pull requests for IdealGraphVisualizer and LogCompilation

### DIFF
--- a/config/mailinglist/rules/jdk.json
+++ b/config/mailinglist/rules/jdk.json
@@ -6,7 +6,8 @@
             "bin/",
             "doc/",
             "make/",
-            "src/utils/",
+            "src/utils/hsdis/",
+            "src/utils/src/",
             "test/jdk/build/",
             "test/make/"
         ],


### PR DESCRIPTION
This change removes the mapping of `src/utils/IdealGraphVisualizer` and `src/utils/LogCompilation` to the `build` label to avoid sending irrelevant review emails to the `build-dev` mailing list. These tools are maintained by HotSpot compiler developers and already mapped to the `hotspot-compiler` label.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1390](https://bugs.openjdk.java.net/browse/SKARA-1390): Do not automatically assign the 'build' label to pull requests for IdealGraphVisualizer and LogCompilation


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1296/head:pull/1296` \
`$ git checkout pull/1296`

Update a local copy of the PR: \
`$ git checkout pull/1296` \
`$ git pull https://git.openjdk.java.net/skara pull/1296/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1296`

View PR using the GUI difftool: \
`$ git pr show -t 1296`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1296.diff">https://git.openjdk.java.net/skara/pull/1296.diff</a>

</details>
