### PR TITLE
1396: Gitlab MR merged outside of Skara causes NPE in mlbridge

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -821,8 +821,17 @@ public class GitLabMergeRequest implements PullRequest {
         if (!isClosed()) {
             return Optional.empty();
         }
-
-        return Optional.of(host.parseAuthorObject(json.get("closed_by").asObject()));
+        JSONValue closedBy = json.get("closed_by");
+        // When MR is in what Skara considers "closed", it may also have been
+        // integrated directly in Gitlab. If so, the closed_by field will be
+        // null, and the merged_by field will be populated instead.
+        if (closedBy.isNull()) {
+            closedBy = json.get("merged_by");
+        }
+        if (closedBy.isNull()) {
+            return Optional.empty();
+        }
+        return Optional.of(host.parseAuthorObject(closedBy.asObject()));
     }
 
     @Override


### PR DESCRIPTION
If an MR is merged through Gitlab, without the use of Skara, we end up in a retry loop getting NPE in the mlbridge bot. This is caused by trying to extract the value of the "closed_by" field of the PR object. This patch adds a fallback to look at the "merged_by" field instead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1396](https://bugs.openjdk.java.net/browse/SKARA-1396): Gitlab MR merged outside of Skara causes NPE in mlbridge


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1298/head:pull/1298` \
`$ git checkout pull/1298`

Update a local copy of the PR: \
`$ git checkout pull/1298` \
`$ git pull https://git.openjdk.java.net/skara pull/1298/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1298`

View PR using the GUI difftool: \
`$ git pr show -t 1298`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1298.diff">https://git.openjdk.java.net/skara/pull/1298.diff</a>

</details>
