### PR TITLE
1397: Skara doesn't handle tags with more than 4 digits in version number

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/OpenJDKTag.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/OpenJDKTag.java
@@ -59,14 +59,13 @@ public class OpenJDKTag {
     private final static String legacyOpenJDKVersionPattern = "(jdk([0-9]{1,2}(u[0-9]{1,3})?))";
     private final static String legacyHSVersionPattern = "((hs[0-9]{1,2}(\\.[0-9]{1,3})?))";
     private final static String legacyBuildPattern = "(-b)([0-9]{2,3})";
-    private final static String OpenJDKVersionPattern = "(jdk-([0-9]+(\\.[0-9]){0,3}))(\\+)([0-9]+)";
-    private final static String OpenJFXVersionPattern = "((?:jdk-){0,1}([1-9](?:(?:[0-9]*)(\\.(?:0|[1-9][0-9]*)){0,3})))(?:(\\+)([0-9]+)|(-ga))";
+    // Version pattern matching project Verona (JEP 223) based versions
+    private final static String veronaVersionPattern = "((?:jdk-){0,1}([1-9](?:(?:[0-9]*)(\\.(?:0|[1-9][0-9]*)){0,6})))(?:(\\+)([0-9]+)|(-ga))";
     private final static String legacyOpenJFXVersionPattern = "(([0-9](u[0-9]{1,3})?))";
 
     private final static List<Pattern> tagPatterns = List.of(Pattern.compile(legacyOpenJDKVersionPattern + legacyBuildPattern),
                                                              Pattern.compile(legacyHSVersionPattern + legacyBuildPattern),
-                                                             Pattern.compile(OpenJDKVersionPattern),
-                                                             Pattern.compile(OpenJFXVersionPattern),
+                                                             Pattern.compile(veronaVersionPattern),
                                                              Pattern.compile(legacyOpenJFXVersionPattern + legacyBuildPattern));
 
     /**

--- a/vcs/src/test/java/org/openjdk/skara/vcs/openjdk/OpenJDKTagTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/openjdk/OpenJDKTagTests.java
@@ -119,4 +119,28 @@ class OpenJDKTagTests {
         assertEquals("8u321", jfxTag.version());
         assertEquals(3, jfxTag.buildNum().orElseThrow());
     }
+
+    @Test
+    void parse3DigitVersion() {
+        var tag = new Tag("jdk-11.0.15+1");
+        var jdkTag = OpenJDKTag.create(tag).orElseThrow();
+        assertEquals("11.0.15", jdkTag.version());
+        assertEquals(1, jdkTag.buildNum().orElseThrow());
+    }
+
+    @Test
+    void parse5DigitVersion() {
+        var tag = new Tag("jdk-11.0.15.0.3+1");
+        var jdkTag = OpenJDKTag.create(tag).orElseThrow();
+        assertEquals("11.0.15.0.3", jdkTag.version());
+        assertEquals(1, jdkTag.buildNum().orElseThrow());
+    }
+
+    @Test
+    void parse7DigitVersion() {
+        var tag = new Tag("jdk-11.0.15.0.3.4.5+1");
+        var jdkTag = OpenJDKTag.create(tag).orElseThrow();
+        assertEquals("11.0.15.0.3.4.5", jdkTag.version());
+        assertEquals(1, jdkTag.buildNum().orElseThrow());
+    }
 }


### PR DESCRIPTION
To be able to react to new tags, Skara needs to know how to parse our tag formats. For this we have the OpenJDKTag class. The current pattern for Verona based version numbers in this class is limited to tags with 4 digit version numbers. This becomes a problem when a JDK release uses more of the up to 7 possible version digits currently allowed in mainline since [JDK-8207849](https://bugs.openjdk.java.net/browse/JDK-8207849). 

This patch raises the limit to 7 digits to match what is currently possible in the JDK build. I'm also removing the redundant and incomplete "OpenJDKVersionPattern" which seemed to not serve any purpose as the existing OpenJFXVersionPattern covered everything for both JDK and JFX tags.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1397](https://bugs.openjdk.java.net/browse/SKARA-1397): Skara doesn't handle tags with more than 4 digits in version number


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1299/head:pull/1299` \
`$ git checkout pull/1299`

Update a local copy of the PR: \
`$ git checkout pull/1299` \
`$ git pull https://git.openjdk.java.net/skara pull/1299/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1299`

View PR using the GUI difftool: \
`$ git pr show -t 1299`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1299.diff">https://git.openjdk.java.net/skara/pull/1299.diff</a>

</details>
