### PR TITLE
1400: GitlabMergeRequest sometimes associates reviews with the wrong commit

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -95,8 +95,13 @@ public class GitLabMergeRequest implements PullRequest {
                                  ret.date = ZonedDateTime.parse(obj.get("created_at").asString());
                                  return ret;
                              })
-                             .sorted(Comparator.comparing(cd -> cd.date))
-                             .collect(Collectors.toList());
+                             .collect(Collectors.toCollection(ArrayList::new));
+        // Commits are returned in reverse chronological order. We want them
+        // primarily in chronological order based on the "created_at" date
+        // and secondary in the reverse order they originally came in. We can
+        // trust that List::sort is stable.
+        Collections.reverse(commits);
+        commits.sort(Comparator.comparing(cd -> cd.date));
 
         // It's possible to create a merge request without any commits
         if (commits.size() == 0) {


### PR DESCRIPTION
GitlabMergeRequset::reviews can sometimes associate a review with the wrong commit. This can happen if multiple commits have the same "created_at" date (the date the commit was pushed to gitlab). In this case, sorting on date will leave the older commit last. When later comparing the date of each commit with the date of a review note, the older commit gets picked.

The consequence of this is that a review can end up stuck with "Re-review required" if the repository requires new reviews for new commits.

This patch fixes this by first reversing the order of the commits and then trusting the stable sort to keep any commits considered equal in the correct (reversed) order.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1400](https://bugs.openjdk.java.net/browse/SKARA-1400): GitlabMergeRequest sometimes associates reviews with the wrong commit


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1300/head:pull/1300` \
`$ git checkout pull/1300`

Update a local copy of the PR: \
`$ git checkout pull/1300` \
`$ git pull https://git.openjdk.java.net/skara pull/1300/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1300`

View PR using the GUI difftool: \
`$ git pr show -t 1300`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1300.diff">https://git.openjdk.java.net/skara/pull/1300.diff</a>

</details>
