### PR TITLE
1406: Two GitHub APIs don't return `patch` field when `per_page` argument exceeds 70

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -736,6 +736,7 @@ public class GitHubPullRequest implements PullRequest {
 
     @Override
     public Diff diff() {
+        // Need to specify an explicit per_page < 70 to guarantee that we get patch information in the result set.
         var files = request.get("pulls/" + json.get("number").toString() + "/files")
                            .param("per_page", "50")
                            .execute();

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -736,7 +736,9 @@ public class GitHubPullRequest implements PullRequest {
 
     @Override
     public Diff diff() {
-        var files = request.get("pulls/" + json.get("number").toString() + "/files").execute();
+        var files = request.get("pulls/" + json.get("number").toString() + "/files")
+                           .param("per_page", "50")
+                           .execute();
         var targetHash = repository.branchHash(targetRef());
         return repository.toDiff(targetHash, headHash(), files);
     }

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -456,6 +456,7 @@ public class GitHubRepository implements HostedRepository {
 
     @Override
     public Optional<HostedCommit> commit(Hash hash) {
+        // Need to specify an explicit per_page < 70 to guarantee that we get patch information in the result set.
         var o = request.get("commits/" + hash.hex())
                        .param("per_page", "50")
                        .onError(r -> Optional.of(JSON.of()))

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -457,6 +457,7 @@ public class GitHubRepository implements HostedRepository {
     @Override
     public Optional<HostedCommit> commit(Hash hash) {
         var o = request.get("commits/" + hash.hex())
+                       .param("per_page", "50")
                        .onError(r -> Optional.of(JSON.of()))
                        .execute();
         if (o.isNull()) {

--- a/forge/src/test/java/org/openjdk/skara/forge/github/GitHubRestApiTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/github/GitHubRestApiTests.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.forge.github;
+
+import org.junit.jupiter.api.*;
+import org.openjdk.skara.forge.Forge;
+import org.openjdk.skara.forge.HostedRepository;
+import org.openjdk.skara.host.Credential;
+import org.openjdk.skara.network.URIBuilder;
+import org.openjdk.skara.proxy.HttpProxy;
+import org.openjdk.skara.test.ManualTestSettings;
+import org.openjdk.skara.vcs.Diff;
+import org.openjdk.skara.vcs.DiffComparator;
+import org.openjdk.skara.vcs.Hash;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * To be able to run the tests, you need to remove or comment out the @Disabled annotation first.
+ */
+@Disabled("Manual")
+public class GitHubRestApiTests {
+    private static final String GITHUB_REST_URI = "https://github.com";
+    Forge githubHost;
+
+    @BeforeEach
+    void setupHost() throws IOException {
+        HttpProxy.setup();
+        var settings = ManualTestSettings.loadManualTestSettings();
+        // Here use the OAuth2 token. To use a GitHub App, please see ManualForgeTests#gitHubLabels.
+        var username = settings.getProperty("username");
+        var token = settings.getProperty("token");
+        var credential = new Credential(username, token);
+        var uri = URIBuilder.base(GITHUB_REST_URI).build();
+        githubHost = new GitHubForgeFactory().create(uri, credential, null);
+    }
+
+    @Test
+    void testDiffEqual() throws IOException {
+        var githubRepoOpt = githubHost.repository("openjdk/jfx");
+        assumeTrue(githubRepoOpt.isPresent());
+        var githubRepo = githubRepoOpt.get();
+
+        // Test the files number of a PR
+        var prDiffLittle = testDiffOfPullRequest(githubRepo, "756", 2);
+        var prDiffMiddle = testDiffOfPullRequest(githubRepo, "764", 105);
+        var prDiffLarge = testDiffOfPullRequest(githubRepo, "723", 3000); // Only 3000 files return
+
+        // Test the file number of a commit
+        var commitDiffLittle = testDiffOfCommit(githubRepo, new Hash("eb7fa5dd1c0911bca15576060691d884d29895a1"), 2);
+        var commitDiffMiddle = testDiffOfCommit(githubRepo, new Hash("b0f2521219efc1b0d0c45088736d5105712bc2c9"), 105);
+        var commitDiffLarge = testDiffOfCommit(githubRepo, new Hash("6f28d912024495278c4c35ab054bc2aab480b3e4"), 3000); // Only 3000 files return
+
+        // Test whether the diff is equal.
+        assertTrue(DiffComparator.areFuzzyEqual(commitDiffLittle, prDiffLittle));
+        assertTrue(DiffComparator.areFuzzyEqual(commitDiffMiddle, prDiffMiddle));
+        assertTrue(DiffComparator.areFuzzyEqual(commitDiffLarge, prDiffLarge));
+    }
+
+    Diff testDiffOfPullRequest(HostedRepository githubRepo, String prId, int expectedPatchesSize) {
+        var pr = githubRepo.pullRequest(prId);
+        var diff = pr.diff();
+        assertEquals(expectedPatchesSize, diff.patches().size());
+        return diff;
+    }
+
+    Diff testDiffOfCommit(HostedRepository githubRepo, Hash hash, int expectedPatchesSize) {
+        var commit = githubRepo.commit(hash);
+        assumeTrue(commit.isPresent());
+        assertEquals(1, commit.get().parentDiffs().size());
+        assertEquals(expectedPatchesSize, commit.get().parentDiffs().get(0).patches().size());
+        return commit.get().parentDiffs().get(0);
+    }
+}


### PR DESCRIPTION
Hi all,

When the bot checks whether a backport is clean, it would use the [get-a-commit](https://docs.github.com/en/rest/commits/commits#get-a-commit) api to get the patch files of the original commit and use the [list-pull-requests-files](https://docs.github.com/en/rest/pulls/pulls#list-pull-requests-files) api to get the patch files of the backport PR, and then compare them.

But the [get-a-commit](https://docs.github.com/en/rest/commits/commits#get-a-commit) api has the following drawbacks:

1. When the `per_page` argument exceeds 70, the files after 70th don't have the `patch` field. Please see the link [1] with `per_page` as 71, the final file, 71th, doesn't have the `patch` field. And the default `per_page` of this api is **300**, so if we don't provide a `per_page` and the total files number exceeds 70, we get the wrong result without `patch` field as well [2].
2. At most 3000 patch files of a commit are returned by the api. If the files number exceeds 3000, such as [3], the api returns only 3000 files. The class `RestRequest` gets the pagination information duplicately, but finally only get 3000 files. (The test case of this patch can prove it.)
3. If a patch file of the commit is too large (not exactly know the api how to judge "too large"), the api doesn't return the patch file as well. Please use the link [1] and find `modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/ChangeLog` or `modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/HTMLparser.c`, you can identify that they don't have the `patch` field.

The [list-pull-requests-files](https://docs.github.com/en/rest/pulls/pulls#list-pull-requests-files) api has the same drawbacks, but its default `per_page` is **30** instead of **300**, so the first drawback above doesn't happen in this api **now**.

This patch adds the `per_page` argument to these two api so that we can solve the first drawback. Note: considering the default `per_page` of the api [list-pull-requests-files](https://docs.github.com/en/rest/pulls/pulls#list-pull-requests-files) will change in the future (may exceed 70), it is good to also provide a explicit `per_page` for it.

I can't solve second and third drawbacks now. A possible alternative is using the media-type [5] `application/vnd.github.VERSION.diff` or `application/vnd.github.VERSION.patch` to get the meta `diff` or `patch` data and parse them. But the current paser classes `GitRawDiffParser` and `UnifiedDiffParser` can't parse such meta diff or patch (the format is not suitable). It needs many changes to the code about vcs, so I don't think it is a short term solution.

As a conclusion, this patch can solve the situations provided by kevin in SKARA-1332. But it can't identify the difference of the "too large" files and the files which exceeds 3000. Note: this shortcoming has already existed in SKARA and is not produced by this patch.

Best Regards,
-- Guoxiong

[1] https://api.github.com/repos/openjdk/jfx/commits/b0f2521219efc1b0d0c45088736d5105712bc2c9?&per_page=71
[2] https://api.github.com/repos/openjdk/jfx/commits/b0f2521219efc1b0d0c45088736d5105712bc2c9
[3] https://git.openjdk.java.net/jfx/commit/6f28d912024495278c4c35ab054bc2aab480b3e4
[4] https://api.github.com/repos/openjdk/jfx/commits/6f28d912024495278c4c35ab054bc2aab480b3e4
[5] https://docs.github.com/en/rest/overview/media-types#commits-commit-comparison-and-pull-requests

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1406](https://bugs.openjdk.java.net/browse/SKARA-1406): Two GitHub APIs don't return `patch` field when `per_page` argument exceeds 70


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1302/head:pull/1302` \
`$ git checkout pull/1302`

Update a local copy of the PR: \
`$ git checkout pull/1302` \
`$ git pull https://git.openjdk.java.net/skara pull/1302/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1302`

View PR using the GUI difftool: \
`$ git pr show -t 1302`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1302.diff">https://git.openjdk.java.net/skara/pull/1302.diff</a>

</details>
