### PR TITLE
1395: The "Review applies to <commit>" link is misleading

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -490,9 +490,11 @@ class CheckRun {
                                    if (hash.isPresent()) {
                                        if (!hash.get().equals(pr.headHash())) {
                                            if (ignoreStaleReviews) {
-                                               entry += " 🔄 Re-review required (review applies to " + hash.get() + ")";
+                                               entry += " 🔄 Re-review required (review applies to [" + hash.get().abbreviate()
+                                                     + "](" + pr.filesUrl(hash.get()) + "))";
                                            } else {
-                                               entry += " ⚠️ Review applies to " + hash.get();
+                                               entry += " ⚠️ Review applies to [" + hash.get().abbreviate()
+                                                       + "](" + pr.filesUrl(hash.get()) + ")";
                                            }
                                        }
                                    } else {

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -231,7 +231,8 @@ class CheckTests {
             // Check that the review is flagged as stale
             TestBotRunner.runPeriodicItems(checkBot);
             authorPr = author.pullRequest(authorPr.id());
-            assertTrue(authorPr.body().contains("Review applies to"));
+            Pattern compilePattern = Pattern.compile(".*Review applies to \\[.*\\]\\(.*\\).*", Pattern.MULTILINE | Pattern.DOTALL);
+            assertTrue(compilePattern.matcher(authorPr.body()).matches());
 
             // Now we can approve it again
             reviewerPr.addReview(Review.Verdict.APPROVED, "Approved");


### PR DESCRIPTION
Hi all,

This trivial patch changes the `commit hash value` to a link which contains the changed files from the first commit of a PR to this `commit`. And the test case is adjusted.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1395](https://bugs.openjdk.java.net/browse/SKARA-1395): The "Review applies to <commit>" link is misleading


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1303/head:pull/1303` \
`$ git checkout pull/1303`

Update a local copy of the PR: \
`$ git checkout pull/1303` \
`$ git pull https://git.openjdk.java.net/skara pull/1303/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1303`

View PR using the GUI difftool: \
`$ git pr show -t 1303`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1303.diff">https://git.openjdk.java.net/skara/pull/1303.diff</a>

</details>
