### PR TITLE
1407: GitLabMergeRequest#filesUrl returns wrong result

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -841,7 +841,16 @@ public class GitLabMergeRequest implements PullRequest {
 
     @Override
     public URI filesUrl(Hash hash) {
-        var endpoint = "/" + repository.name() + "/-/merge_requests/" + id() + "/diffs?commit_id=" + hash.hex();
-        return host.getWebUri(endpoint);
+        var versionId = request.get("versions").execute().stream()
+                               .filter(version -> hash.hex().equals(version.get("head_commit_sha").asString()))
+                               .map(version -> String.valueOf(version.get("id").asInt()))
+                               .findFirst();
+        String uri;
+        if (versionId.isEmpty()) {
+            uri = "/" + repository.name() + "/-/merge_requests/" + id() + "/diffs?commit_id=" + hash.hex();
+        } else {
+            uri = "/" + repository.name() + "/-/merge_requests/" + id() + "/diffs?diff_id=" + versionId.get();
+        }
+        return host.getWebUri(uri);
     }
 }

--- a/forge/src/test/java/org/openjdk/skara/forge/github/GitHubRestApiTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/github/GitHubRestApiTests.java
@@ -52,8 +52,8 @@ public class GitHubRestApiTests {
         HttpProxy.setup();
         var settings = ManualTestSettings.loadManualTestSettings();
         // Here use the OAuth2 token. To use a GitHub App, please see ManualForgeTests#gitHubLabels.
-        var username = settings.getProperty("username");
-        var token = settings.getProperty("token");
+        var username = settings.getProperty("github.user");
+        var token = settings.getProperty("github.pat");
         var credential = new Credential(username, token);
         var uri = URIBuilder.base(GITHUB_REST_URI).build();
         githubHost = new GitHubForgeFactory().create(uri, credential, null);

--- a/forge/src/test/java/org/openjdk/skara/forge/gitlab/GitLabRestApiTest.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/gitlab/GitLabRestApiTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.forge.gitlab;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.openjdk.skara.host.Credential;
+import org.openjdk.skara.network.URIBuilder;
+import org.openjdk.skara.test.ManualTestSettings;
+import org.openjdk.skara.vcs.Hash;
+
+import java.io.IOException;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * To be able to run the tests, you need to remove or comment out the @Disabled annotation first.
+ */
+@Disabled("Manual")
+public class GitLabRestApiTest {
+
+    @Test
+    void testFilesUrl() throws IOException {
+        var settings = ManualTestSettings.loadManualTestSettings();
+        var username = settings.getProperty("gitlab.user");
+        var token = settings.getProperty("gitlab.pat");
+        var credential = new Credential(username, token);
+        var uri = URIBuilder.base(settings.getProperty("gitlab.uri")).build();
+        var gitLabHost = new GitLabHost("gitlab", uri, false, credential, Set.of());
+        var gitLabRepo = gitLabHost.repository(settings.getProperty("gitlab.repository")).orElseThrow();
+        var gitLabMergeRequest = gitLabRepo.pullRequest(settings.getProperty("gitlab.merge.request.id"));
+
+        // Test a version hash
+        var versionUrl = gitLabMergeRequest.filesUrl(new Hash(settings.getProperty("gitlab.version.hash")));
+        assertEquals(settings.getProperty("gitlab.version.url"), versionUrl.toString());
+
+        // Test a non-version hash
+        var nonVersionUrl = gitLabMergeRequest.filesUrl(new Hash(settings.getProperty("gitlab.nonversion.hash")));
+        assertEquals(settings.getProperty("gitlab.nonversion.url"), nonVersionUrl.toString());
+    }
+}


### PR DESCRIPTION
Hi all,

The SKARA-744 [1][2] solved a problem about the link to the changes for just one commit. But it didn't solve the issue completely in GitLab. Please see the current issue [3] for more information.

This patch revises `GitLabMergeRequest#filesUrl` to return a `version url` if it exists which can represent the changed files **from the first commit to the provided commit HASH**. A corresponding test is added and a previous test is polished.

You can use the following config to run the new test `GitLabRestApiTest#testFilesUrl`:

```
gitlab.user=<your username in https://gitlab.com>
gitlab.pat=<your token in https://gitlab.com>

gitlab.uri=https://gitlab.com
gitlab.repository=35596381
gitlab.merge.request.id=1

gitlab.version.hash=60f39eb698e73cc2660f870667a54e7a53ee7018
gitlab.version.url=https://gitlab.com/lgxbslgx/test/-/merge_requests/1/diffs?diff_id=379601911
gitlab.nonversion.hash=c9b5a70790b13c3e7e182c9b83015f9f10d53df7
gitlab.nonversion.url=https://gitlab.com/lgxbslgx/test/-/merge_requests/1/diffs?commit_id=c9b5a70790b13c3e7e182c9b83015f9f10d53df7
```
Thanks for taking the time to review.

Best Regards,
-- Guoxiong

[1] https://bugs.openjdk.java.net/browse/SKARA-744
[2] https://git.openjdk.java.net/skara/commit/f16663b7
[3] https://bugs.openjdk.java.net/browse/SKARA-1407

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1407](https://bugs.openjdk.java.net/browse/SKARA-1407): GitLabMergeRequest#filesUrl returns wrong result


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1304/head:pull/1304` \
`$ git checkout pull/1304`

Update a local copy of the PR: \
`$ git checkout pull/1304` \
`$ git pull https://git.openjdk.java.net/skara pull/1304/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1304`

View PR using the GUI difftool: \
`$ git pr show -t 1304`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1304.diff">https://git.openjdk.java.net/skara/pull/1304.diff</a>

</details>
