### PR TITLE
282: Make the review requirements more explicit in the progress list

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -27,7 +27,6 @@ import org.openjdk.skara.email.EmailAddress;
 import org.openjdk.skara.forge.*;
 import org.openjdk.skara.host.HostUser;
 import org.openjdk.skara.issuetracker.*;
-import org.openjdk.skara.jcheck.ReviewersCheck;
 import org.openjdk.skara.vcs.*;
 import org.openjdk.skara.vcs.openjdk.Issue;
 
@@ -469,11 +468,6 @@ class CheckRun {
 
     private String getChecksList(PullRequestCheckIssueVisitor visitor, boolean isCleanBackport, Map<String, Boolean> additionalProgresses) {
         var checks = isCleanBackport ? visitor.getReadyForReviewChecks() : visitor.getChecks();
-        var reviewRequirements = checkablePullRequest.getReviewRequirements();
-        if (checks.containsKey(ReviewersCheck.DESCRIPTION) && !"".equals(reviewRequirements)) {
-            checks.put(ReviewersCheck.DESCRIPTION + reviewRequirements, checks.get(ReviewersCheck.DESCRIPTION));
-            checks.remove(ReviewersCheck.DESCRIPTION);
-        }
         checks.putAll(additionalProgresses);
         return checks.entrySet().stream()
                 .map(entry -> "- [" + (entry.getValue() ? "x" : " ") + "] " + entry.getKey())

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -27,6 +27,7 @@ import org.openjdk.skara.email.EmailAddress;
 import org.openjdk.skara.forge.*;
 import org.openjdk.skara.host.HostUser;
 import org.openjdk.skara.issuetracker.*;
+import org.openjdk.skara.jcheck.ReviewersCheck;
 import org.openjdk.skara.vcs.*;
 import org.openjdk.skara.vcs.openjdk.Issue;
 
@@ -468,6 +469,11 @@ class CheckRun {
 
     private String getChecksList(PullRequestCheckIssueVisitor visitor, boolean isCleanBackport, Map<String, Boolean> additionalProgresses) {
         var checks = isCleanBackport ? visitor.getReadyForReviewChecks() : visitor.getChecks();
+        var reviewRequirements = checkablePullRequest.getReviewRequirements();
+        if (checks.containsKey(ReviewersCheck.DESCRIPTION) && !"".equals(reviewRequirements)) {
+            checks.put(ReviewersCheck.DESCRIPTION + reviewRequirements, checks.get(ReviewersCheck.DESCRIPTION));
+            checks.remove(ReviewersCheck.DESCRIPTION);
+        }
         checks.putAll(additionalProgresses);
         return checks.entrySet().stream()
                 .map(entry -> "- [" + (entry.getValue() ? "x" : " ") + "] " + entry.getKey())

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,11 +45,16 @@ public class CheckablePullRequest {
     private final boolean ignoreStaleReviews;
     private final List<String> confOverride;
 
+    // The review requirements is used by CheckRun#getChecksList to
+    // set the checkbox of the `Progress` in the PR body.
+    private String reviewRequirements;
+
     CheckablePullRequest(PullRequest pr, Repository localRepo, boolean ignoreStaleReviews,
             HostedRepository jcheckRepo, String jcheckName, String jcheckRef) {
         this.pr = pr;
         this.localRepo = localRepo;
         this.ignoreStaleReviews = ignoreStaleReviews;
+        reviewRequirements = "";
 
         if (jcheckRepo != null) {
             confOverride = jcheckRepo.fileContents(jcheckName, jcheckRef).lines().collect(Collectors.toList());
@@ -182,6 +187,34 @@ public class CheckablePullRequest {
         return new PullRequestCheckIssueVisitor(checks);
     }
 
+    String getReviewRequirements() {
+        return reviewRequirements;
+    }
+
+    private void setReviewRequirements(JCheckConfiguration conf) {
+        var reviewersConf = conf.checks().reviewers();
+        var requireList = new ArrayList<String>();
+        var sum = 0;
+        var reviewRequirementMap = new LinkedHashMap<String, Integer>();
+        reviewRequirementMap.put("lead", reviewersConf.lead());
+        reviewRequirementMap.put("reviewer", reviewersConf.reviewers());
+        reviewRequirementMap.put("committer", reviewersConf.committers());
+        reviewRequirementMap.put("author", reviewersConf.authors());
+        reviewRequirementMap.put("contributor", reviewersConf.contributors());
+        for (var reviewRequirement : reviewRequirementMap.entrySet()) {
+            var requirementNum = reviewRequirement.getValue();
+            if (requirementNum > 0) {
+                sum += requirementNum;
+                requireList.add(requirementNum+ " " + reviewRequirement.getKey() + (requirementNum > 1 ? "s" : ""));
+            }
+        }
+        if (sum == 0) {
+            reviewRequirements = " (no reviews required)";
+        } else {
+            reviewRequirements = String.format(" (%d reviews required, with at least %s)", sum, String.join(", ", requireList));
+        }
+    }
+
     void executeChecks(Hash localHash, CensusInstance censusInstance, PullRequestCheckIssueVisitor visitor, List<String> additionalConfiguration) throws IOException {
         Optional<JCheckConfiguration> conf;
         if (confOverride != null) {
@@ -192,6 +225,8 @@ public class CheckablePullRequest {
         if (conf.isEmpty()) {
             throw new RuntimeException("Failed to parse jcheck configuration at: " + targetHash() + " with extra: " + additionalConfiguration);
         }
+        // Set the review requirements for using in CheckRun#getChecksList
+        setReviewRequirements(conf.get());
         try (var issues = JCheck.check(localRepo, censusInstance.census(), CommitMessageParsers.v1, localHash,
                                        conf.get())) {
             for (var issue : issues) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
@@ -94,7 +94,7 @@ class PullRequestCheckIssueVisitor implements IssueVisitor {
 
     private String checkDescription(Check check) {
         if (check instanceof ReviewersCheck && configuration != null) {
-            return check.description() + configuration.checks().reviewers().getReviewRequirements();
+            return check.description() + " (" + configuration.checks().reviewers().getReviewRequirements() + ")";
         }
         return check.description();
     }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
@@ -93,7 +93,7 @@ class PullRequestCheckIssueVisitor implements IssueVisitor {
     }
 
     private String checkDescription(Check check) {
-        if (check instanceof ReviewersCheck) {
+        if (check instanceof ReviewersCheck && configuration != null) {
             return check.description() + configuration.checks().reviewers().getReviewRequirements();
         }
         return check.description();

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ReviewersTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ReviewersTests.java
@@ -42,6 +42,9 @@ public class ReviewersTests {
     private static final String reviewersCommandFinallyOutput = "The total number of required reviews for this PR " +
             "(including the jcheck configuration and the last /reviewers command) is now set to ";
 
+    private static final String reviewProgressTemplate = "Change must be properly reviewed (%d reviews required, with at least %s)";
+    private static final String zeroReviewProgress = "Change must be properly reviewed (no reviews required)";
+
     @Test
     void simple(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
@@ -75,6 +78,7 @@ public class ReviewersTests {
 
             // The bot should reply with a help message
             assertLastCommentContains(reviewerPr,"is the number of required reviewers");
+            assertTrue(reviewerPr.body().contains(String.format(reviewProgressTemplate, 1, "1 reviewer")));
 
             // Invalid syntax
             reviewerPr.addComment("/reviewers two");
@@ -82,21 +86,25 @@ public class ReviewersTests {
 
             // The bot should reply with a help message
             assertLastCommentContains(reviewerPr,"is the number of required reviewers");
+            assertTrue(reviewerPr.body().contains(String.format(reviewProgressTemplate, 1, "1 reviewer")));
 
             // Too many
             reviewerPr.addComment("/reviewers 7001");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr,"Cannot increase the required number of reviewers above 10 (requested: 7001)");
+            assertTrue(reviewerPr.body().contains(String.format(reviewProgressTemplate, 1, "1 reviewer")));
 
             // Too few
             reviewerPr.addComment("/reviewers -3");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr,"Cannot decrease the required number of reviewers below 0 (requested: -3)");
+            assertTrue(reviewerPr.body().contains(String.format(reviewProgressTemplate, 1, "1 reviewer")));
 
             // Unknown role
             reviewerPr.addComment("/reviewers 2 penguins");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr,"Unknown role `penguins` specified");
+            assertTrue(reviewerPr.body().contains(String.format(reviewProgressTemplate, 1, "1 reviewer")));
 
             // Set the number
             reviewerPr.addComment("/reviewers 2");
@@ -104,6 +112,7 @@ public class ReviewersTests {
 
             // The bot should reply with a success message
             assertLastCommentContains(reviewerPr, reviewersCommandFinallyOutput + "2 (with 1 of role reviewers, 1 of role authors).");
+            assertTrue(reviewerPr.body().contains(String.format(reviewProgressTemplate, 2, "1 reviewer, 1 author")));
 
             // Set 2 of role committers
             reviewerPr.addComment("/reviewers 2 committer");
@@ -111,6 +120,7 @@ public class ReviewersTests {
 
             // The bot should reply with a success message
             assertLastCommentContains(reviewerPr, reviewersCommandFinallyOutput + "2 (with 1 of role reviewers, 1 of role committers).");
+            assertTrue(reviewerPr.body().contains(String.format(reviewProgressTemplate, 2, "1 reviewer, 1 committer")));
 
             // Set 2 of role reviewers
             reviewerPr.addComment("/reviewers 2 reviewer");
@@ -118,6 +128,7 @@ public class ReviewersTests {
 
             // The bot should reply with a success message
             assertLastCommentContains(reviewerPr, reviewersCommandFinallyOutput + "2 (with 2 of role reviewers).");
+            assertTrue(reviewerPr.body().contains(String.format(reviewProgressTemplate, 2, "2 reviewers")));
 
             // Approve it as another user
             reviewerPr.addReview(Review.Verdict.APPROVED, "Approved");
@@ -127,6 +138,7 @@ public class ReviewersTests {
             // The PR should not yet be considered as ready for review
             var updatedPr = author.pullRequest(pr.id());
             assertFalse(updatedPr.labelNames().contains("ready"));
+            assertTrue(updatedPr.body().contains(String.format(reviewProgressTemplate, 2, "2 reviewers")));
 
             // Now reduce the number of required reviewers
             reviewerPr.addComment("/reviewers 1");
@@ -136,12 +148,14 @@ public class ReviewersTests {
             // The PR should now be considered as ready for review
             updatedPr = author.pullRequest(pr.id());
             assertTrue(updatedPr.labelNames().contains("ready"));
+            assertTrue(updatedPr.body().contains(String.format(reviewProgressTemplate, 1, "1 reviewer")));
 
             // Now request that the lead reviews
             reviewerPr.addComment("/reviewers 1 lead");
             TestBotRunner.runPeriodicItems(prBot);
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr, reviewersCommandFinallyOutput + "1 (with 1 of role lead).");
+            assertTrue(reviewerPr.body().contains(String.format(reviewProgressTemplate, 1, "1 lead")));
 
             // The PR should no longer be considered as ready for review
             updatedPr = author.pullRequest(pr.id());
@@ -152,6 +166,7 @@ public class ReviewersTests {
             TestBotRunner.runPeriodicItems(prBot);
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr, reviewersCommandFinallyOutput + "1 (with 1 of role reviewers).");
+            assertTrue(reviewerPr.body().contains(String.format(reviewProgressTemplate, 1, "1 reviewer")));
 
             // The PR should now be considered as ready for review yet again
             updatedPr = author.pullRequest(pr.id());
@@ -192,6 +207,7 @@ public class ReviewersTests {
 
             // The bot should reply with a success message
             assertLastCommentContains(reviewerPr, reviewersCommandFinallyOutput + "2 (with 1 of role reviewers, 1 of role authors).");
+            assertTrue(reviewerPr.body().contains(String.format(reviewProgressTemplate, 2, "1 reviewer, 1 author")));
 
             // Approve it as another user
             reviewerPr.addReview(Review.Verdict.APPROVED, "Approved");
@@ -202,15 +218,18 @@ public class ReviewersTests {
             pr.addComment("/integrate");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr,"pull request has not yet been marked as ready for integration");
+            assertTrue(reviewerPr.body().contains(String.format(reviewProgressTemplate, 2, "1 reviewer, 1 author")));
 
             // Relax the requirement
             reviewerPr.addComment("/reviewers 1");
             TestBotRunner.runPeriodicItems(prBot);
+            assertTrue(reviewerPr.body().contains(String.format(reviewProgressTemplate, 1, "1 reviewer")));
 
             // It should now work fine
             pr.addComment("/integrate");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr,"Pushed as commit");
+            assertTrue(reviewerPr.body().contains(String.format(reviewProgressTemplate, 1, "1 reviewer")));
         }
     }
 
@@ -245,11 +264,13 @@ public class ReviewersTests {
             reviewerPr.addReview(Review.Verdict.APPROVED, "Approved");
             TestBotRunner.runPeriodicItems(prBot);
             TestBotRunner.runPeriodicItems(prBot);
+            assertTrue(reviewerPr.body().contains(String.format(reviewProgressTemplate, 1, "1 reviewer")));
 
             // Flag it as ready for integration
             pr.addComment("/integrate");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr,"now ready to be sponsored");
+            assertTrue(reviewerPr.body().contains(String.format(reviewProgressTemplate, 1, "1 reviewer")));
 
             // Set the number
             reviewerPr.addComment("/reviewers 2");
@@ -257,20 +278,24 @@ public class ReviewersTests {
 
             // The bot should reply with a success message
             assertLastCommentContains(reviewerPr, reviewersCommandFinallyOutput + "2 (with 1 of role reviewers, 1 of role authors).");
+            assertTrue(reviewerPr.body().contains(String.format(reviewProgressTemplate, 2, "1 reviewer, 1 author")));
 
             // It should not be possible to sponsor
             reviewerPr.addComment("/sponsor");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr,"PR has not yet been marked as ready for integration");
+            assertTrue(reviewerPr.body().contains(String.format(reviewProgressTemplate, 2, "1 reviewer, 1 author")));
 
             // Relax the requirement
             reviewerPr.addComment("/reviewers 1");
             TestBotRunner.runPeriodicItems(prBot);
+            assertTrue(reviewerPr.body().contains(String.format(reviewProgressTemplate, 1, "1 reviewer")));
 
             // It should now work fine
             reviewerPr.addComment("/sponsor");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr,"Pushed as commit");
+            assertTrue(reviewerPr.body().contains(String.format(reviewProgressTemplate, 1, "1 reviewer")));
         }
     }
 
@@ -305,6 +330,7 @@ public class ReviewersTests {
             // The bot should reply with a success message
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(authorPR, reviewersCommandFinallyOutput + "2 (with 1 of role reviewers, 1 of role authors).");
+            assertTrue(authorPR.body().contains(String.format(reviewProgressTemplate, 2, "1 reviewer, 1 author")));
         }
     }
 
@@ -341,16 +367,19 @@ public class ReviewersTests {
             // The bot should reply with a success message
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(authorPR, reviewersCommandFinallyOutput + "2 (with 1 of role reviewers, 1 of role authors).");
+            assertTrue(authorPR.body().contains(String.format(reviewProgressTemplate, 2, "1 reviewer, 1 author")));
             // The author should not be allowed to decrease even its own /reviewers command
             authorPR.addComment("/reviewers 1");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(authorPR, "Cannot decrease the number of required reviewers");
+            assertTrue(authorPR.body().contains(String.format(reviewProgressTemplate, 2, "1 reviewer, 1 author")));
 
             // Reviewer should be allowed to decrease
             var reviewerPr = integrator.pullRequest(pr.id());
             reviewerPr.addComment("/reviewers 1");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr, reviewersCommandFinallyOutput + "1 (with 1 of role reviewers).");
+            assertTrue(reviewerPr.body().contains(String.format(reviewProgressTemplate, 1, "1 reviewer")));
         }
     }
 
@@ -381,6 +410,7 @@ public class ReviewersTests {
 
             var authorPR = author.pullRequest(pr.id());
             assertLastCommentContains(authorPR, reviewersCommandFinallyOutput + "2 (with 1 of role reviewers, 1 of role authors).");
+            assertTrue(authorPR.body().contains(String.format(reviewProgressTemplate, 2, "1 reviewer, 1 author")));
         }
     }
 
@@ -431,8 +461,9 @@ public class ReviewersTests {
             for (int i = 1; i <= 10; i++) {
                 var totalNum = Math.max(i, 5);
                 var contributorNum = (i < 6) ? 1 : i - 4;
-                verifyReviewersComment(reviewerPr, prBot, "/reviewers " + i + " contributor",
-                        getReviewersExpectedComment(totalNum, 1, 1, 1, 1, contributorNum));
+                verifyReviewersCommentAndProgress(reviewerPr, prBot, "/reviewers " + i + " contributor",
+                        getReviewersExpectedComment(totalNum, 1, 1, 1, 1, contributorNum),
+                        getReviewersExpectedProgress(totalNum, 1, 1, 1, 1, contributorNum));
             }
 
             // test role author
@@ -440,8 +471,9 @@ public class ReviewersTests {
                 var totalNum = Math.max(i, 5);
                 var contributorNum = (i < 5) ? 1 : 0;
                 var authorNum = (i < 5) ? 1 : i - 3;
-                verifyReviewersComment(reviewerPr, prBot, "/reviewers " + i + " author",
-                        getReviewersExpectedComment(totalNum, 1, 1, 1, authorNum, contributorNum));
+                verifyReviewersCommentAndProgress(reviewerPr, prBot, "/reviewers " + i + " author",
+                        getReviewersExpectedComment(totalNum, 1, 1, 1, authorNum, contributorNum),
+                        getReviewersExpectedProgress(totalNum, 1, 1, 1, authorNum, contributorNum));
             }
 
             // test role committer
@@ -450,8 +482,9 @@ public class ReviewersTests {
                 var contributorNum = (i < 4) ? 1 : 0;
                 var authorNum = (i < 5) ? 1 : 0;
                 var committerNum = (i < 4) ? 1 : i - 2;
-                verifyReviewersComment(reviewerPr, prBot, "/reviewers " + i + " committer",
-                        getReviewersExpectedComment(totalNum, 1, 1, committerNum, authorNum, contributorNum));
+                verifyReviewersCommentAndProgress(reviewerPr, prBot, "/reviewers " + i + " committer",
+                        getReviewersExpectedComment(totalNum, 1, 1, committerNum, authorNum, contributorNum),
+                        getReviewersExpectedProgress(totalNum, 1, 1, committerNum, authorNum, contributorNum));
             }
 
             // test role reviewer
@@ -461,21 +494,24 @@ public class ReviewersTests {
                 var authorNum = (i < 4) ? 1 : 0;
                 var committerNum = (i < 5) ? 1 : 0;
                 var reviewerNum = (i < 3) ? 1 : i - 1;
-                verifyReviewersComment(reviewerPr, prBot, "/reviewers " + i + " reviewer",
-                        getReviewersExpectedComment(totalNum, 1, reviewerNum, committerNum, authorNum, contributorNum));
+                verifyReviewersCommentAndProgress(reviewerPr, prBot, "/reviewers " + i + " reviewer",
+                        getReviewersExpectedComment(totalNum, 1, reviewerNum, committerNum, authorNum, contributorNum),
+                        getReviewersExpectedProgress(totalNum, 1, reviewerNum, committerNum, authorNum, contributorNum));
 
             }
 
             // test role lead
-            verifyReviewersComment(reviewerPr, prBot, "/reviewers 1 lead",
-                        getReviewersExpectedComment(5, 1, 1, 1, 1, 1));
+            verifyReviewersCommentAndProgress(reviewerPr, prBot, "/reviewers 1 lead",
+                    getReviewersExpectedComment(5, 1, 1, 1, 1, 1),
+                    getReviewersExpectedProgress(5, 1, 1, 1, 1, 1));
         }
     }
 
-    private void verifyReviewersComment(PullRequest reviewerPr, PullRequestBot prBot, String command, String expectedReply) throws IOException {
+    private void verifyReviewersCommentAndProgress(PullRequest reviewerPr, PullRequestBot prBot, String command, String expectedComment, String expectedProgress) throws IOException {
         reviewerPr.addComment(command);
         TestBotRunner.runPeriodicItems(prBot);
-        assertLastCommentContains(reviewerPr, expectedReply);
+        assertLastCommentContains(reviewerPr, expectedComment);
+        assertTrue(reviewerPr.body().contains(expectedProgress));
     }
 
     private String getReviewersExpectedComment(int totalNum, int leadNum, int reviewerNum, int committerNum, int authorNum, int contributorNum) {
@@ -502,5 +538,81 @@ public class ReviewersTests {
         builder.append(String.join(",", list));
         builder.append(").");
         return builder.toString();
+    }
+
+    private String getReviewersExpectedProgress(int totalNum, int leadNum, int reviewerNum, int committerNum, int authorNum, int contributorNum) {
+        var requireList = new ArrayList<String>();
+        var reviewRequirementMap = new LinkedHashMap<String, Integer>();
+        reviewRequirementMap.put("lead", leadNum);
+        reviewRequirementMap.put("reviewer", reviewerNum);
+        reviewRequirementMap.put("committer", committerNum);
+        reviewRequirementMap.put("author", authorNum);
+        reviewRequirementMap.put("contributor", contributorNum);
+        for (var reviewRequirement : reviewRequirementMap.entrySet()) {
+            var requirementNum = reviewRequirement.getValue();
+            if (requirementNum > 0) {
+                requireList.add(requirementNum+ " " + reviewRequirement.getKey() + (requirementNum > 1 ? "s" : ""));
+            }
+        }
+        if (totalNum == 0) {
+            return zeroReviewProgress;
+        } else {
+            return String.format(reviewProgressTemplate, totalNum, String.join(", ", requireList));
+        }
+    }
+
+    @Test
+    void testZeroReviewer(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var reviewer = credentials.getHostedRepository();
+            var bot = credentials.getHostedRepository();
+            var censusBuilder = credentials.getCensusBuilder()
+                    .addReviewer(reviewer.forge().currentUser().id())
+                    .addCommitter(author.forge().currentUser().id());
+            var prBot = PullRequestBot.newBuilder().repo(bot).censusRepo(censusBuilder.build()).build();
+
+            // Populate the projects repository
+            var localRepoFolder = tempFolder.path().resolve("localrepo");
+            var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Change the jcheck configuration
+            var confPath = localRepo.root().resolve(".jcheck/conf");
+            var defaultConf = Files.readString(confPath, StandardCharsets.UTF_8);
+            var newConf = defaultConf.replace("reviewers=1", """
+                                                    lead=0
+                                                    reviewers=0
+                                                    committers=0
+                                                    authors=0
+                                                    contributors=0
+                                                    ignore=duke
+                                                    """);
+            Files.writeString(confPath, newConf);
+            localRepo.add(confPath);
+            var confHash = localRepo.commit("Change conf", "duke", "duke@openjdk.org");
+            localRepo.push(confHash, author.url(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "123: This is a pull request", List.of(""));
+            var reviewerPr = reviewer.pullRequest(pr.id());
+
+            TestBotRunner.runPeriodicItems(prBot);
+            var authorPR = author.pullRequest(pr.id());
+            assertTrue(authorPR.body().contains(zeroReviewProgress));
+
+            authorPR.addComment("/reviewers 2 reviewer");
+            TestBotRunner.runPeriodicItems(prBot);
+            assertTrue(authorPR.body().contains(String.format(reviewProgressTemplate, 2, "2 reviewers")));
+
+            reviewerPr.addComment("/reviewers 0");
+            TestBotRunner.runPeriodicItems(prBot);
+            assertTrue(reviewerPr.body().contains(zeroReviewProgress));
+        }
     }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ReviewersTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ReviewersTests.java
@@ -42,8 +42,8 @@ public class ReviewersTests {
     private static final String reviewersCommandFinallyOutput = "The total number of required reviews for this PR " +
             "(including the jcheck configuration and the last /reviewers command) is now set to ";
 
-    private static final String reviewProgressTemplate = "Change must be properly reviewed (%d reviews required, with at least %s)";
-    private static final String zeroReviewProgress = "Change must be properly reviewed (no reviews required)";
+    private static final String REVIEW_PROGRESS_TEMPLATE = "Change must be properly reviewed (%d reviews required, with at least %s)";
+    private static final String ZERO_REVIEW_PROGRESS = "Change must be properly reviewed (no reviews required)";
 
     @Test
     void simple(TestInfo testInfo) throws IOException {
@@ -78,7 +78,7 @@ public class ReviewersTests {
 
             // The bot should reply with a help message
             assertLastCommentContains(reviewerPr,"is the number of required reviewers");
-            assertTrue(reviewerPr.body().contains(String.format(reviewProgressTemplate, 1, "1 reviewer")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "1 reviewer")));
 
             // Invalid syntax
             reviewerPr.addComment("/reviewers two");
@@ -86,25 +86,25 @@ public class ReviewersTests {
 
             // The bot should reply with a help message
             assertLastCommentContains(reviewerPr,"is the number of required reviewers");
-            assertTrue(reviewerPr.body().contains(String.format(reviewProgressTemplate, 1, "1 reviewer")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "1 reviewer")));
 
             // Too many
             reviewerPr.addComment("/reviewers 7001");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr,"Cannot increase the required number of reviewers above 10 (requested: 7001)");
-            assertTrue(reviewerPr.body().contains(String.format(reviewProgressTemplate, 1, "1 reviewer")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "1 reviewer")));
 
             // Too few
             reviewerPr.addComment("/reviewers -3");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr,"Cannot decrease the required number of reviewers below 0 (requested: -3)");
-            assertTrue(reviewerPr.body().contains(String.format(reviewProgressTemplate, 1, "1 reviewer")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "1 reviewer")));
 
             // Unknown role
             reviewerPr.addComment("/reviewers 2 penguins");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr,"Unknown role `penguins` specified");
-            assertTrue(reviewerPr.body().contains(String.format(reviewProgressTemplate, 1, "1 reviewer")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "1 reviewer")));
 
             // Set the number
             reviewerPr.addComment("/reviewers 2");
@@ -112,7 +112,7 @@ public class ReviewersTests {
 
             // The bot should reply with a success message
             assertLastCommentContains(reviewerPr, reviewersCommandFinallyOutput + "2 (with 1 of role reviewers, 1 of role authors).");
-            assertTrue(reviewerPr.body().contains(String.format(reviewProgressTemplate, 2, "1 reviewer, 1 author")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "1 reviewer, 1 author")));
 
             // Set 2 of role committers
             reviewerPr.addComment("/reviewers 2 committer");
@@ -120,7 +120,7 @@ public class ReviewersTests {
 
             // The bot should reply with a success message
             assertLastCommentContains(reviewerPr, reviewersCommandFinallyOutput + "2 (with 1 of role reviewers, 1 of role committers).");
-            assertTrue(reviewerPr.body().contains(String.format(reviewProgressTemplate, 2, "1 reviewer, 1 committer")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "1 reviewer, 1 committer")));
 
             // Set 2 of role reviewers
             reviewerPr.addComment("/reviewers 2 reviewer");
@@ -128,7 +128,7 @@ public class ReviewersTests {
 
             // The bot should reply with a success message
             assertLastCommentContains(reviewerPr, reviewersCommandFinallyOutput + "2 (with 2 of role reviewers).");
-            assertTrue(reviewerPr.body().contains(String.format(reviewProgressTemplate, 2, "2 reviewers")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "2 reviewers")));
 
             // Approve it as another user
             reviewerPr.addReview(Review.Verdict.APPROVED, "Approved");
@@ -138,7 +138,7 @@ public class ReviewersTests {
             // The PR should not yet be considered as ready for review
             var updatedPr = author.pullRequest(pr.id());
             assertFalse(updatedPr.labelNames().contains("ready"));
-            assertTrue(updatedPr.body().contains(String.format(reviewProgressTemplate, 2, "2 reviewers")));
+            assertTrue(updatedPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "2 reviewers")));
 
             // Now reduce the number of required reviewers
             reviewerPr.addComment("/reviewers 1");
@@ -148,14 +148,14 @@ public class ReviewersTests {
             // The PR should now be considered as ready for review
             updatedPr = author.pullRequest(pr.id());
             assertTrue(updatedPr.labelNames().contains("ready"));
-            assertTrue(updatedPr.body().contains(String.format(reviewProgressTemplate, 1, "1 reviewer")));
+            assertTrue(updatedPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "1 reviewer")));
 
             // Now request that the lead reviews
             reviewerPr.addComment("/reviewers 1 lead");
             TestBotRunner.runPeriodicItems(prBot);
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr, reviewersCommandFinallyOutput + "1 (with 1 of role lead).");
-            assertTrue(reviewerPr.body().contains(String.format(reviewProgressTemplate, 1, "1 lead")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "1 lead")));
 
             // The PR should no longer be considered as ready for review
             updatedPr = author.pullRequest(pr.id());
@@ -166,7 +166,7 @@ public class ReviewersTests {
             TestBotRunner.runPeriodicItems(prBot);
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr, reviewersCommandFinallyOutput + "1 (with 1 of role reviewers).");
-            assertTrue(reviewerPr.body().contains(String.format(reviewProgressTemplate, 1, "1 reviewer")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "1 reviewer")));
 
             // The PR should now be considered as ready for review yet again
             updatedPr = author.pullRequest(pr.id());
@@ -207,7 +207,7 @@ public class ReviewersTests {
 
             // The bot should reply with a success message
             assertLastCommentContains(reviewerPr, reviewersCommandFinallyOutput + "2 (with 1 of role reviewers, 1 of role authors).");
-            assertTrue(reviewerPr.body().contains(String.format(reviewProgressTemplate, 2, "1 reviewer, 1 author")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "1 reviewer, 1 author")));
 
             // Approve it as another user
             reviewerPr.addReview(Review.Verdict.APPROVED, "Approved");
@@ -218,18 +218,18 @@ public class ReviewersTests {
             pr.addComment("/integrate");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr,"pull request has not yet been marked as ready for integration");
-            assertTrue(reviewerPr.body().contains(String.format(reviewProgressTemplate, 2, "1 reviewer, 1 author")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "1 reviewer, 1 author")));
 
             // Relax the requirement
             reviewerPr.addComment("/reviewers 1");
             TestBotRunner.runPeriodicItems(prBot);
-            assertTrue(reviewerPr.body().contains(String.format(reviewProgressTemplate, 1, "1 reviewer")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "1 reviewer")));
 
             // It should now work fine
             pr.addComment("/integrate");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr,"Pushed as commit");
-            assertTrue(reviewerPr.body().contains(String.format(reviewProgressTemplate, 1, "1 reviewer")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "1 reviewer")));
         }
     }
 
@@ -264,13 +264,13 @@ public class ReviewersTests {
             reviewerPr.addReview(Review.Verdict.APPROVED, "Approved");
             TestBotRunner.runPeriodicItems(prBot);
             TestBotRunner.runPeriodicItems(prBot);
-            assertTrue(reviewerPr.body().contains(String.format(reviewProgressTemplate, 1, "1 reviewer")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "1 reviewer")));
 
             // Flag it as ready for integration
             pr.addComment("/integrate");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr,"now ready to be sponsored");
-            assertTrue(reviewerPr.body().contains(String.format(reviewProgressTemplate, 1, "1 reviewer")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "1 reviewer")));
 
             // Set the number
             reviewerPr.addComment("/reviewers 2");
@@ -278,24 +278,24 @@ public class ReviewersTests {
 
             // The bot should reply with a success message
             assertLastCommentContains(reviewerPr, reviewersCommandFinallyOutput + "2 (with 1 of role reviewers, 1 of role authors).");
-            assertTrue(reviewerPr.body().contains(String.format(reviewProgressTemplate, 2, "1 reviewer, 1 author")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "1 reviewer, 1 author")));
 
             // It should not be possible to sponsor
             reviewerPr.addComment("/sponsor");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr,"PR has not yet been marked as ready for integration");
-            assertTrue(reviewerPr.body().contains(String.format(reviewProgressTemplate, 2, "1 reviewer, 1 author")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "1 reviewer, 1 author")));
 
             // Relax the requirement
             reviewerPr.addComment("/reviewers 1");
             TestBotRunner.runPeriodicItems(prBot);
-            assertTrue(reviewerPr.body().contains(String.format(reviewProgressTemplate, 1, "1 reviewer")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "1 reviewer")));
 
             // It should now work fine
             reviewerPr.addComment("/sponsor");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr,"Pushed as commit");
-            assertTrue(reviewerPr.body().contains(String.format(reviewProgressTemplate, 1, "1 reviewer")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "1 reviewer")));
         }
     }
 
@@ -330,7 +330,7 @@ public class ReviewersTests {
             // The bot should reply with a success message
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(authorPR, reviewersCommandFinallyOutput + "2 (with 1 of role reviewers, 1 of role authors).");
-            assertTrue(authorPR.body().contains(String.format(reviewProgressTemplate, 2, "1 reviewer, 1 author")));
+            assertTrue(authorPR.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "1 reviewer, 1 author")));
         }
     }
 
@@ -367,19 +367,19 @@ public class ReviewersTests {
             // The bot should reply with a success message
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(authorPR, reviewersCommandFinallyOutput + "2 (with 1 of role reviewers, 1 of role authors).");
-            assertTrue(authorPR.body().contains(String.format(reviewProgressTemplate, 2, "1 reviewer, 1 author")));
+            assertTrue(authorPR.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "1 reviewer, 1 author")));
             // The author should not be allowed to decrease even its own /reviewers command
             authorPR.addComment("/reviewers 1");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(authorPR, "Cannot decrease the number of required reviewers");
-            assertTrue(authorPR.body().contains(String.format(reviewProgressTemplate, 2, "1 reviewer, 1 author")));
+            assertTrue(authorPR.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "1 reviewer, 1 author")));
 
             // Reviewer should be allowed to decrease
             var reviewerPr = integrator.pullRequest(pr.id());
             reviewerPr.addComment("/reviewers 1");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr, reviewersCommandFinallyOutput + "1 (with 1 of role reviewers).");
-            assertTrue(reviewerPr.body().contains(String.format(reviewProgressTemplate, 1, "1 reviewer")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "1 reviewer")));
         }
     }
 
@@ -410,7 +410,7 @@ public class ReviewersTests {
 
             var authorPR = author.pullRequest(pr.id());
             assertLastCommentContains(authorPR, reviewersCommandFinallyOutput + "2 (with 1 of role reviewers, 1 of role authors).");
-            assertTrue(authorPR.body().contains(String.format(reviewProgressTemplate, 2, "1 reviewer, 1 author")));
+            assertTrue(authorPR.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "1 reviewer, 1 author")));
         }
     }
 
@@ -555,9 +555,9 @@ public class ReviewersTests {
             }
         }
         if (totalNum == 0) {
-            return zeroReviewProgress;
+            return ZERO_REVIEW_PROGRESS;
         } else {
-            return String.format(reviewProgressTemplate, totalNum, String.join(", ", requireList));
+            return String.format(REVIEW_PROGRESS_TEMPLATE, totalNum, String.join(", ", requireList));
         }
     }
 
@@ -604,15 +604,15 @@ public class ReviewersTests {
 
             TestBotRunner.runPeriodicItems(prBot);
             var authorPR = author.pullRequest(pr.id());
-            assertTrue(authorPR.body().contains(zeroReviewProgress));
+            assertTrue(authorPR.body().contains(ZERO_REVIEW_PROGRESS));
 
             authorPR.addComment("/reviewers 2 reviewer");
             TestBotRunner.runPeriodicItems(prBot);
-            assertTrue(authorPR.body().contains(String.format(reviewProgressTemplate, 2, "2 reviewers")));
+            assertTrue(authorPR.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "2 reviewers")));
 
             reviewerPr.addComment("/reviewers 0");
             TestBotRunner.runPeriodicItems(prBot);
-            assertTrue(reviewerPr.body().contains(zeroReviewProgress));
+            assertTrue(reviewerPr.body().contains(ZERO_REVIEW_PROGRESS));
         }
     }
 }

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/ReviewersConfiguration.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/ReviewersConfiguration.java
@@ -24,8 +24,9 @@ package org.openjdk.skara.jcheck;
 
 import org.openjdk.skara.ini.Section;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class ReviewersConfiguration {
     static final ReviewersConfiguration DEFAULT = new ReviewersConfiguration(0, 1, 0, 0, 0, List.of("duke"), false);
@@ -37,6 +38,7 @@ public class ReviewersConfiguration {
     private final int contributors;
     private final List<String> ignore;
     private final boolean shouldCheckBackports;
+    private final String reviewRequirements;
 
     ReviewersConfiguration(int lead, int reviewers, int committers, int authors, int contributors, List<String> ignore, boolean shouldCheckBackports) {
         this.lead = lead;
@@ -46,6 +48,27 @@ public class ReviewersConfiguration {
         this.contributors = contributors;
         this.ignore = ignore;
         this.shouldCheckBackports = shouldCheckBackports;
+
+        var reviewRequirementMap = new LinkedHashMap<String, Integer>();
+        var requireList = new ArrayList<String>();
+        var sum = 0;
+        reviewRequirementMap.put("lead", lead);
+        reviewRequirementMap.put("reviewer", reviewers);
+        reviewRequirementMap.put("committer", committers);
+        reviewRequirementMap.put("author", authors);
+        reviewRequirementMap.put("contributor", contributors);
+        for (var reviewRequirement : reviewRequirementMap.entrySet()) {
+            var requirementNum = reviewRequirement.getValue();
+            if (requirementNum > 0) {
+                sum += requirementNum;
+                requireList.add(requirementNum+ " " + reviewRequirement.getKey() + (requirementNum > 1 ? "s" : ""));
+            }
+        }
+        if (sum == 0) {
+            reviewRequirements = " (no reviews required)";
+        } else {
+            reviewRequirements = String.format(" (%d reviews required, with at least %s)", sum, String.join(", ", requireList));
+        }
     }
 
     public int lead() {
@@ -74,6 +97,10 @@ public class ReviewersConfiguration {
 
     public boolean shouldCheckBackports() {
         return shouldCheckBackports;
+    }
+
+    public String getReviewRequirements() {
+        return reviewRequirements;
     }
 
     static String name() {

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/ReviewersConfiguration.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/ReviewersConfiguration.java
@@ -98,9 +98,9 @@ public class ReviewersConfiguration {
             }
         }
         if (sum == 0) {
-            reviewRequirements = " (no reviews required)";
+            reviewRequirements = "no reviews required";
         } else {
-            reviewRequirements = String.format(" (%d reviews required, with at least %s)", sum, String.join(", ", requireList));
+            reviewRequirements = String.format("%d reviews required, with at least %s", sum, String.join(", ", requireList));
         }
         return reviewRequirements;
     }

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/ReviewersConfiguration.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/ReviewersConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,7 @@ public class ReviewersConfiguration {
     private final int contributors;
     private final List<String> ignore;
     private final boolean shouldCheckBackports;
-    private final String reviewRequirements;
+    private String reviewRequirements;
 
     ReviewersConfiguration(int lead, int reviewers, int committers, int authors, int contributors, List<String> ignore, boolean shouldCheckBackports) {
         this.lead = lead;
@@ -48,27 +48,6 @@ public class ReviewersConfiguration {
         this.contributors = contributors;
         this.ignore = ignore;
         this.shouldCheckBackports = shouldCheckBackports;
-
-        var reviewRequirementMap = new LinkedHashMap<String, Integer>();
-        var requireList = new ArrayList<String>();
-        var sum = 0;
-        reviewRequirementMap.put("lead", lead);
-        reviewRequirementMap.put("reviewer", reviewers);
-        reviewRequirementMap.put("committer", committers);
-        reviewRequirementMap.put("author", authors);
-        reviewRequirementMap.put("contributor", contributors);
-        for (var reviewRequirement : reviewRequirementMap.entrySet()) {
-            var requirementNum = reviewRequirement.getValue();
-            if (requirementNum > 0) {
-                sum += requirementNum;
-                requireList.add(requirementNum+ " " + reviewRequirement.getKey() + (requirementNum > 1 ? "s" : ""));
-            }
-        }
-        if (sum == 0) {
-            reviewRequirements = " (no reviews required)";
-        } else {
-            reviewRequirements = String.format(" (%d reviews required, with at least %s)", sum, String.join(", ", requireList));
-        }
     }
 
     public int lead() {
@@ -100,6 +79,29 @@ public class ReviewersConfiguration {
     }
 
     public String getReviewRequirements() {
+        if (reviewRequirements != null && !"".equals(reviewRequirements)) {
+            return reviewRequirements;
+        }
+        var reviewRequirementMap = new LinkedHashMap<String, Integer>();
+        var requireList = new ArrayList<String>();
+        var sum = 0;
+        reviewRequirementMap.put("lead", lead);
+        reviewRequirementMap.put("reviewer", reviewers);
+        reviewRequirementMap.put("committer", committers);
+        reviewRequirementMap.put("author", authors);
+        reviewRequirementMap.put("contributor", contributors);
+        for (var reviewRequirement : reviewRequirementMap.entrySet()) {
+            var requirementNum = reviewRequirement.getValue();
+            if (requirementNum > 0) {
+                sum += requirementNum;
+                requireList.add(requirementNum+ " " + reviewRequirement.getKey() + (requirementNum > 1 ? "s" : ""));
+            }
+        }
+        if (sum == 0) {
+            reviewRequirements = " (no reviews required)";
+        } else {
+            reviewRequirements = String.format(" (%d reviews required, with at least %s)", sum, String.join(", ", requireList));
+        }
         return reviewRequirements;
     }
 

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/ReviewersCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/ReviewersCheckTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -556,5 +556,122 @@ class ReviewersCheckTests {
         assertEquals(commit, issue.commit());
         assertEquals(Severity.ERROR, issue.severity());
         assertEquals(check, issue.check());
+    }
+
+    @Test
+    void testReviewRequirements() throws IOException {
+        // no review required.
+        var noReview = " (no reviews required)";
+        var conf = new ArrayList<>(CONFIGURATION);
+        conf.add("reviewers = 0");
+        assertEquals(noReview, JCheckConfiguration.parse(conf).checks().reviewers().getReviewRequirements());
+
+        // review required template.
+        var hasReview = " (%d reviews required, with at least %s)";
+
+        // one review required.
+        conf = new ArrayList<>(CONFIGURATION);
+        conf.add("reviewers = 1");
+        assertEquals(String.format(hasReview, 1, "1 reviewer"),
+                JCheckConfiguration.parse(conf).checks().reviewers().getReviewRequirements());
+
+        conf = new ArrayList<>(CONFIGURATION);
+        conf.add("committers = 1");
+        assertEquals(String.format(hasReview, 1, "1 committer"),
+                JCheckConfiguration.parse(conf).checks().reviewers().getReviewRequirements());
+
+        // two reviews required.
+        conf = new ArrayList<>(CONFIGURATION);
+        conf.add("reviewers = 1");
+        conf.add("committers = 1");
+        assertEquals(String.format(hasReview, 2, "1 reviewer, 1 committer"),
+                JCheckConfiguration.parse(conf).checks().reviewers().getReviewRequirements());
+
+        conf = new ArrayList<>(CONFIGURATION);
+        conf.add("reviewers = 2");
+        assertEquals(String.format(hasReview, 2, "2 reviewers"),
+                JCheckConfiguration.parse(conf).checks().reviewers().getReviewRequirements());
+
+        // three reviews required.
+        conf = new ArrayList<>(CONFIGURATION);
+        conf.add("reviewers = 1");
+        conf.add("committers = 1");
+        conf.add("authors = 1");
+        assertEquals(String.format(hasReview, 3, "1 reviewer, 1 committer, 1 author"),
+                JCheckConfiguration.parse(conf).checks().reviewers().getReviewRequirements());
+
+        conf = new ArrayList<>(CONFIGURATION);
+        conf.add("reviewers = 1");
+        conf.add("committers = 2");
+        assertEquals(String.format(hasReview, 3, "1 reviewer, 2 committers"),
+                JCheckConfiguration.parse(conf).checks().reviewers().getReviewRequirements());
+
+        conf = new ArrayList<>(CONFIGURATION);
+        conf.add("committers = 3");
+        assertEquals(String.format(hasReview, 3, "3 committers"),
+                JCheckConfiguration.parse(conf).checks().reviewers().getReviewRequirements());
+
+        // four reviews required.
+        conf = new ArrayList<>(CONFIGURATION);
+        conf.add("reviewers = 1");
+        conf.add("committers = 1");
+        conf.add("authors = 1");
+        conf.add("contributors = 1");
+        assertEquals(String.format(hasReview, 4, "1 reviewer, 1 committer, 1 author, 1 contributor"),
+                JCheckConfiguration.parse(conf).checks().reviewers().getReviewRequirements());
+
+        conf = new ArrayList<>(CONFIGURATION);
+        conf.add("reviewers = 1");
+        conf.add("committers = 1");
+        conf.add("authors = 2");
+        assertEquals(String.format(hasReview, 4, "1 reviewer, 1 committer, 2 authors"),
+                JCheckConfiguration.parse(conf).checks().reviewers().getReviewRequirements());
+
+        conf = new ArrayList<>(CONFIGURATION);
+        conf.add("reviewers = 1");
+        conf.add("authors = 3");
+        assertEquals(String.format(hasReview, 4, "1 reviewer, 3 authors"),
+                JCheckConfiguration.parse(conf).checks().reviewers().getReviewRequirements());
+
+        conf = new ArrayList<>(CONFIGURATION);
+        conf.add("authors = 4");
+        assertEquals(String.format(hasReview, 4, "4 authors"),
+                JCheckConfiguration.parse(conf).checks().reviewers().getReviewRequirements());
+
+        // five reviews required.
+        conf = new ArrayList<>(CONFIGURATION);
+        conf.add("lead = 1");
+        conf.add("reviewers = 1");
+        conf.add("committers = 1");
+        conf.add("authors = 1");
+        conf.add("contributors = 1");
+        assertEquals(String.format(hasReview, 5, "1 lead, 1 reviewer, 1 committer, 1 author, 1 contributor"),
+                JCheckConfiguration.parse(conf).checks().reviewers().getReviewRequirements());
+
+        conf = new ArrayList<>(CONFIGURATION);
+        conf.add("reviewers = 1");
+        conf.add("committers = 1");
+        conf.add("authors = 1");
+        conf.add("contributors = 2");
+        assertEquals(String.format(hasReview, 5, "1 reviewer, 1 committer, 1 author, 2 contributors"),
+                JCheckConfiguration.parse(conf).checks().reviewers().getReviewRequirements());
+
+        conf = new ArrayList<>(CONFIGURATION);
+        conf.add("reviewers = 1");
+        conf.add("committers = 1");
+        conf.add("contributors = 3");
+        assertEquals(String.format(hasReview, 5, "1 reviewer, 1 committer, 3 contributors"),
+                JCheckConfiguration.parse(conf).checks().reviewers().getReviewRequirements());
+
+        conf = new ArrayList<>(CONFIGURATION);
+        conf.add("reviewers = 1");
+        conf.add("contributors = 4");
+        assertEquals(String.format(hasReview, 5, "1 reviewer, 4 contributors"),
+                JCheckConfiguration.parse(conf).checks().reviewers().getReviewRequirements());
+
+        conf = new ArrayList<>(CONFIGURATION);
+        conf.add("contributors = 5");
+        assertEquals(String.format(hasReview, 5, "5 contributors"),
+                JCheckConfiguration.parse(conf).checks().reviewers().getReviewRequirements());
     }
 }

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/ReviewersCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/ReviewersCheckTests.java
@@ -561,13 +561,13 @@ class ReviewersCheckTests {
     @Test
     void testReviewRequirements() throws IOException {
         // no review required.
-        var noReview = " (no reviews required)";
+        var noReview = "no reviews required";
         var conf = new ArrayList<>(CONFIGURATION);
         conf.add("reviewers = 0");
         assertEquals(noReview, JCheckConfiguration.parse(conf).checks().reviewers().getReviewRequirements());
 
         // review required template.
-        var hasReview = " (%d reviews required, with at least %s)";
+        var hasReview = "%d reviews required, with at least %s";
 
         // one review required.
         conf = new ArrayList<>(CONFIGURATION);


### PR DESCRIPTION
Hi all,

This patch adds the explicit review requirements, such as ` (2 reviews required, with at least 1 Reviewer).`, to the progress list and adds some test cases.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-282](https://bugs.openjdk.java.net/browse/SKARA-282): Make the review requirements more explicit in the progress list


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1305/head:pull/1305` \
`$ git checkout pull/1305`

Update a local copy of the PR: \
`$ git checkout pull/1305` \
`$ git pull https://git.openjdk.java.net/skara pull/1305/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1305`

View PR using the GUI difftool: \
`$ git pr show -t 1305`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1305.diff">https://git.openjdk.java.net/skara/pull/1305.diff</a>

</details>
