### PR TITLE
1408: GitLabMergeRequest#reviews sometimes finds the wrong commit HASH

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabHost.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabHost.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -150,7 +150,7 @@ public class GitLabHost implements Forge {
         var id = o.get("id").asInt();
         var username = o.get("username").asString();
         var name = o.get("name").asString();
-        var email = o.get("email").asString();
+        var email = o.get("email") != null ? o.get("email").asString() : "";
         return HostUser.builder()
                        .id(id)
                        .username(username)

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,11 +87,11 @@ public class GitLabMergeRequest implements PullRequest {
             private ZonedDateTime date;
         }
 
-        var commits = request.get("commits").execute().stream()
+        var commits = request.get("versions").execute().stream()
                              .map(JSONValue::asObject)
                              .map(obj -> {
                                  var ret = new CommitDate();
-                                 ret.hash = new Hash(obj.get("id").asString());
+                                 ret.hash = new Hash(obj.get("head_commit_sha").asString());
                                  ret.date = ZonedDateTime.parse(obj.get("created_at").asString());
                                  return ret;
                              })

--- a/forge/src/test/java/org/openjdk/skara/forge/gitlab/GitLabRestApiTest.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/gitlab/GitLabRestApiTest.java
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 /**
  * To be able to run the tests, you need to remove or comment out the @Disabled annotation first.
  */
-//@Disabled("Manual")
+@Disabled("Manual")
 public class GitLabRestApiTest {
 
     @Test

--- a/forge/src/test/java/org/openjdk/skara/forge/gitlab/GitLabRestApiTest.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/gitlab/GitLabRestApiTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.forge.gitlab;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.openjdk.skara.host.Credential;
+import org.openjdk.skara.network.URIBuilder;
+import org.openjdk.skara.test.ManualTestSettings;
+import org.openjdk.skara.vcs.Hash;
+
+import java.io.IOException;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * To be able to run the tests, you need to remove or comment out the @Disabled annotation first.
+ */
+//@Disabled("Manual")
+public class GitLabRestApiTest {
+
+    @Test
+    void testReviews() throws IOException {
+        var settings = ManualTestSettings.loadManualTestSettings();
+        var username = settings.getProperty("gitlab.user");
+        var token = settings.getProperty("gitlab.pat");
+        var credential = new Credential(username, token);
+        var uri = URIBuilder.base(settings.getProperty("gitlab.uri")).build();
+        var gitLabHost = new GitLabHost("gitlab", uri, false, credential, Set.of());
+        var gitLabRepo = gitLabHost.repository(settings.getProperty("gitlab.repository")).orElseThrow();
+        var gitLabMergeRequest = gitLabRepo.pullRequest(settings.getProperty("gitlab.merge.request.id"));
+
+        var reviewList = gitLabMergeRequest.reviews();
+        var actualHash = reviewList.get(0).hash().orElse(new Hash(""));
+        assertEquals(settings.getProperty("gitlab.review.hash"), actualHash.hex());
+    }
+}


### PR DESCRIPTION
Hi all,

Please consider the following steps:

- the author creates "commit 1" locally (with hash "95f2d613cf392275075d7c87285845531f5fe827" [1])
- the author pushes it and creates a merge request in the Gitlab, then the Gitlab creates "version 1" [2] (its hash is the hash of "commit 1") which has the changed files of "commit 1"
- the author creates "commit 2" locally (with hash "99ca51edfa0063113a2236fce548ba453aee7275" [3])
- a reviewer approves the MR with the "**version 1**" in the Gitlab. Note: the "commit 2" is not pushed now.
- the author creates "commit 3" locally (with hash "50b119c4c325053b8151ea6e761a60d1acfbb746" [4]) Note: this step seems optional
- the author pushes the commits and the gitlab create "version 2" [5] (its hash is the hash of "commit 3") which has the changed files of "commit 1-3"

When we use the method `GitLabMergeRequest#reviews` to get the reviews list, we can see the review hash is the hash of the "commit 2" ("99ca51edfa0063113a2236fce548ba453aee7275"). But actually, the reviewer only approved "version 1" with hash of the "commit 1" ("95f2d613cf392275075d7c87285845531f5fe827").

This patch uses the `versions` list instead of all the `commits` list to fix the issue. And when I wrote a test case to verify it, I got a NPE and filed SKARA-1409 to record it. This patch also solves SKARA-1409 so that the reviewer can run the test locally.

You can use the following config to run the test:
```
gitlab.user=<your username in https://gitlab.com>
gitlab.pat=<your token in https://gitlab.com>

gitlab.uri=https://gitlab.com
gitlab.repository=35596381
gitlab.merge.request.id=2
gitlab.review.hash=95f2d613cf392275075d7c87285845531f5fe827
```

Note: this PR seems have git conflict with [SKARA-1407-PATCH](https://github.com/openjdk/skara/pull/1304). I will solve the conflict when one of them is integrated.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

[1] https://gitlab.com/lgxbslgx/test/-/merge_requests/2/diffs?commit_id=95f2d613cf392275075d7c87285845531f5fe827
[2] https://gitlab.com/lgxbslgx/test/-/merge_requests/2/diffs?diff_id=379883693
[3] https://gitlab.com/lgxbslgx/test/-/merge_requests/2/diffs?commit_id=99ca51edfa0063113a2236fce548ba453aee7275
[4] https://gitlab.com/lgxbslgx/test/-/merge_requests/2/diffs?commit_id=50b119c4c325053b8151ea6e761a60d1acfbb746
[5] https://gitlab.com/lgxbslgx/test/-/merge_requests/2/diffs?diff_id=379907777

---

/issue SKARA-1409

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issues
 * [SKARA-1408](https://bugs.openjdk.java.net/browse/SKARA-1408): GitLabMergeRequest#reviews sometimes finds the wrong commit HASH
 * [SKARA-1409](https://bugs.openjdk.java.net/browse/SKARA-1409): The GitLab 'list-users' api doesn't return 'email' field for normal users


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to 9217ff1e6922ccf05ce64e7c0b84539ac169bc6a


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1306/head:pull/1306` \
`$ git checkout pull/1306`

Update a local copy of the PR: \
`$ git checkout pull/1306` \
`$ git pull https://git.openjdk.java.net/skara pull/1306/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1306`

View PR using the GUI difftool: \
`$ git pr show -t 1306`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1306.diff">https://git.openjdk.java.net/skara/pull/1306.diff</a>

</details>
