### PR TITLE
1411: The JEP link warns that the issue isn't open

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -618,7 +618,7 @@ class CheckRun {
                             }
                             if (iss.get().state() != org.openjdk.skara.issuetracker.Issue.State.OPEN) {
                                 if (!pr.labelNames().contains("backport") &&
-                                        (issueType == null || !"CSR".equals(issueType.asString()))) {
+                                        (issueType == null || !List.of("CSR", "JEP").contains(issueType.asString()))) {
                                     progressBody.append(" ⚠️ Issue is not open.");
                                 }
                             }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -1252,6 +1252,22 @@ class CheckTests {
             assertTrue(pr.body().contains("### Issues"));
             assertTrue(pr.body().contains("The main issue"));
             assertTrue(pr.body().contains("The jep issue (**JEP**)"));
+
+            // Set the state of the jep issue to `Closed`.
+            jepIssue.setState(Issue.State.CLOSED);
+            jepIssue.setProperty("status", JSON.object().put("name", "Closed"));
+
+            // Push a commit to trigger the check which can update the PR body.
+            newHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(newHash, author.url(), "edit", false);
+
+            // PR should have two issues even though the jep issue has been Closed
+            TestBotRunner.runPeriodicItems(checkBot);
+            assertTrue(pr.body().contains("### Issues"));
+            assertTrue(pr.body().contains("The main issue"));
+            assertTrue(pr.body().contains("The jep issue (**JEP**)"));
+            // The jep issue state doesn't need to be `open`.
+            assertFalse(pr.body().contains("Issue is not open"));
         }
     }
 


### PR DESCRIPTION
Hi all,

The JEP link shouldn't warn that JEP issue isn't open. This is similar to the CSR link[1].

This patch excludes the JEP issue and adds a test case.
Thanks for taking the time to review.

Best Regards,
-- Guoxiong

[1] https://bugs.openjdk.java.net/browse/SKARA-1265