### PR TITLE
1418: Dependent pull requests: inacurrate bot comment

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -94,7 +94,7 @@ public class PullRequestBranchNotifier implements Notifier, PullRequestListener 
                     git commit -m "Merge %s"
                     git push
                     ```
-                    """.formatted(pr.sourceRef(), pr.repository().webUrl(), pr.targetRef(), pr.targetRef()));
+                    """.formatted(retargeted.sourceRef(), pr.repository().webUrl(), pr.targetRef(), pr.targetRef()));
             }
         } else {
             pushBranch(pr);

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifierTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -291,7 +291,7 @@ public class PullRequestBranchNotifierTests {
             // Instructions on how to adapt to the newly integrated changes should have been posted
             var lastComment = followUpPr.comments().get(followUpPr.comments().size() - 1);
             assertTrue(lastComment.body().contains("The dependent pull request has now"), lastComment.body());
-            assertTrue(lastComment.body().contains("git checkout source"), lastComment.body());
+            assertTrue(lastComment.body().contains("git checkout followup"), lastComment.body());
             assertTrue(lastComment.body().contains("git commit -m \"Merge master\""), lastComment.body());
         }
     }


### PR DESCRIPTION
Hi all,

The patch fixes the comment when the dependent pull request was integrated and revises the corresponding test case.

Thanks for taking the time to  review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1418](https://bugs.openjdk.java.net/browse/SKARA-1418): Dependent pull requests: inacurrate bot comment


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1309/head:pull/1309` \
`$ git checkout pull/1309`

Update a local copy of the PR: \
`$ git checkout pull/1309` \
`$ git pull https://git.openjdk.java.net/skara pull/1309/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1309`

View PR using the GUI difftool: \
`$ git pr show -t 1309`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1309.diff">https://git.openjdk.java.net/skara/pull/1309.diff</a>

</details>
