### PR TITLE
1419: The Skara PR bot should not block on a JEP if not enabled for a repo

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CSRCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CSRCommand.java
@@ -64,7 +64,7 @@ public class CSRCommand implements CommandHandler {
     @Override
     public void handle(PullRequestBot bot, PullRequest pr, CensusInstance censusInstance, Path scratchPath, CommandInvocation command, List<Comment> allComments, PrintWriter reply) {
         if (!bot.enableCsr()) {
-            reply.println("this repository is not allowed to use the `csr` command.");
+            reply.println("This repository has not been configured to use the `csr` command.");
             return;
         }
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/JEPCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/JEPCommand.java
@@ -80,7 +80,7 @@ public class JEPCommand implements CommandHandler {
     public void handle(PullRequestBot bot, PullRequest pr, CensusInstance censusInstance, Path scratchPath, CommandInvocation command,
                        List<Comment> allComments, PrintWriter reply, List<String> labelsToAdd, List<String> labelsToRemove) {
         if (!bot.enableJep()) {
-            reply.println("this repository is not allowed to use the `jep` command.");
+            reply.println("This repository has not been configured to use the `jep` command.");
             return;
         }
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/JEPCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/JEPCommand.java
@@ -79,6 +79,11 @@ public class JEPCommand implements CommandHandler {
     @Override
     public void handle(PullRequestBot bot, PullRequest pr, CensusInstance censusInstance, Path scratchPath, CommandInvocation command,
                        List<Comment> allComments, PrintWriter reply, List<String> labelsToAdd, List<String> labelsToRemove) {
+        if (!bot.enableJep()) {
+            reply.println("this repository is not allowed to use the `jep` command.");
+            return;
+        }
+
         if (!pr.author().equals(command.user()) && !censusInstance.isReviewer(command.user())) {
             reply.println("only the pull request author and [Reviewers](https://openjdk.java.net/bylaws#reviewer) are allowed to use the `jep` command.");
             return;

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -64,6 +64,7 @@ class PullRequestBot implements Bot {
     private final Set<String> integrators;
     private final Set<Integer> excludeCommitCommentsFrom;
     private final boolean enableCsr;
+    private final boolean enableJep;
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots.pr");
 
     private Instant lastFullUpdate;
@@ -76,7 +77,7 @@ class PullRequestBot implements Bot {
                    boolean ignoreStaleReviews, Pattern allowedTargetBranches,
                    Path seedStorage, HostedRepository confOverrideRepo, String confOverrideName,
                    String confOverrideRef, String censusLink, Map<String, HostedRepository> forks,
-                   Set<String> integrators, Set<Integer> excludeCommitCommentsFrom, boolean enableCsr) {
+                   Set<String> integrators, Set<Integer> excludeCommitCommentsFrom, boolean enableCsr, boolean enableJep) {
         remoteRepo = repo;
         this.censusRepo = censusRepo;
         this.censusRef = censusRef;
@@ -100,6 +101,7 @@ class PullRequestBot implements Bot {
         this.integrators = integrators;
         this.excludeCommitCommentsFrom = excludeCommitCommentsFrom;
         this.enableCsr = enableCsr;
+        this.enableJep = enableJep;
 
         autoLabelled = new HashSet<>();
         scheduledRechecks = new ConcurrentHashMap<>();
@@ -281,6 +283,10 @@ class PullRequestBot implements Bot {
 
     public boolean enableCsr() {
         return enableCsr;
+    }
+
+    public boolean enableJep() {
+        return enableJep;
     }
 
     Optional<HostedRepository> writeableForkOf(HostedRepository upstream) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
@@ -51,6 +51,7 @@ public class PullRequestBotBuilder {
     private String confOverrideRef = Branch.defaultFor(VCS.GIT).name();
     private String censusLink = null;
     private boolean enableCsr = false;
+    private boolean enableJep = false;
     private Map<String, HostedRepository> forks = Map.of();
     private Set<String> integrators = Set.of();
     private Set<Integer> excludeCommitCommentsFrom = Set.of();
@@ -158,6 +159,11 @@ public class PullRequestBotBuilder {
         return this;
     }
 
+    public PullRequestBotBuilder enableJep(boolean enableJep) {
+        this.enableJep = enableJep;
+        return this;
+    }
+
     public PullRequestBotBuilder forks(Map<String, HostedRepository> forks) {
         this.forks = forks;
         return this;
@@ -179,6 +185,6 @@ public class PullRequestBotBuilder {
                                   blockingCheckLabels, readyLabels, twoReviewersLabels, twentyFourHoursLabels,
                                   readyComments, issueProject, ignoreStaleReviews,
                                   allowedTargetBranches, seedStorage, confOverrideRepo, confOverrideName,
-                                  confOverrideRef, censusLink, forks, integrators, excludeCommitCommentsFrom, enableCsr);
+                                  confOverrideRef, censusLink, forks, integrators, excludeCommitCommentsFrom, enableCsr, enableJep);
     }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
@@ -161,6 +161,9 @@ public class PullRequestBotFactory implements BotFactory {
             if (repo.value().contains("csr")) {
                 botBuilder.enableCsr(repo.value().get("csr").asBoolean());
             }
+            if (repo.value().contains("jep")) {
+                botBuilder.enableJep(repo.value().get("jep").asBoolean());
+            }
 
             ret.add(botBuilder.build());
         }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CSRTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CSRTests.java
@@ -669,7 +669,7 @@ class CSRTests {
                     .enableCsr(false).censusRepo(censusBuilder.build()).build();
             pr.addComment("/csr");
             TestBotRunner.runPeriodicItems(disableCsrBot);
-            assertLastCommentContains(pr, "this repository is not allowed to use the `csr` command.");
+            assertLastCommentContains(pr, "This repository has not been configured to use the `csr` command.");
             assertFalse(pr.labelNames().contains("csr"));
 
             // Test the pull request bot with csr enable

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -1203,7 +1203,7 @@ class CheckTests {
                     .addAuthor(author.forge().currentUser().id())
                     .addReviewer(reviewer.forge().currentUser().id());
             var checkBot = PullRequestBot.newBuilder().repo(bot).issueProject(issueProject)
-                    .censusRepo(censusBuilder.build()).build();
+                    .censusRepo(censusBuilder.build()).enableJep(true).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(),

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/JEPCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/JEPCommandTests.java
@@ -428,4 +428,49 @@ public class JEPCommandTests {
             }
         }
     }
+
+    @Test
+    void testEnableJepConfig(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var bot = credentials.getHostedRepository();
+            var issueProject = credentials.getIssueProject();
+            var censusBuilder = credentials.getCensusBuilder()
+                    .addAuthor(author.forge().currentUser().id());
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(),
+                    Path.of("appendable.txt"), Set.of("issues"), null);
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            var mainIssue = issueProject.createIssue("The main issue", List.of("main"), Map.of("issuetype", JSON.of("Bug")));
+            var jepIssue = issueProject.createIssue("The jep issue", List.of("Jep body"),
+                    Map.of("issuetype", JSON.of("JEP"), "status", JSON.object().put("name", "Submitted"), JEP_NUMBER, JSON.of("123")));
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", mainIssue.id() + ": " + mainIssue.title());
+
+            // Test the PR bot with jep disable
+            var disableJepBot = PullRequestBot.newBuilder().repo(bot).issueProject(issueProject)
+                            .enableJep(false).censusRepo(censusBuilder.build()).build();
+            pr.addComment("/jep TEST-2");
+            TestBotRunner.runPeriodicItems(disableJepBot);
+            assertLastCommentContains(pr, "This repository has not been configured to use the `jep` command.");
+            assertFalse(pr.labelNames().contains(JEPCommand.JEP_LABEL));
+            assertFalse(pr.body().contains("- [ ] Change requires a JEP request to be targeted"));
+
+            // Test the PR bot with jep enable
+            var enableJepBot = PullRequestBot.newBuilder().repo(bot).issueProject(issueProject)
+                    .enableJep(true).censusRepo(censusBuilder.build()).build();
+            pr.addComment("/jep TEST-2");
+            TestBotRunner.runPeriodicItems(enableJepBot);
+            assertLastCommentContains(pr, "pull request will not be integrated until the");
+            assertTrue(pr.labelNames().contains(JEPCommand.JEP_LABEL));
+            assertTrue(pr.body().contains("- [ ] Change requires a JEP request to be targeted"));
+        }
+    }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/JEPCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/JEPCommandTests.java
@@ -53,7 +53,7 @@ public class JEPCommandTests {
                     .addAuthor(author.forge().currentUser().id())
                     .addReviewer(reviewer.forge().currentUser().id());
             var prBot = PullRequestBot.newBuilder().repo(bot).issueProject(issueProject)
-                    .censusRepo(censusBuilder.build()).build();
+                    .censusRepo(censusBuilder.build()).enableJep(true).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(),
@@ -179,7 +179,7 @@ public class JEPCommandTests {
                     .addCommitter(committer.forge().currentUser().id())
                     .addReviewer(reviewer.forge().currentUser().id());
             var prBot = PullRequestBot.newBuilder().repo(bot).issueProject(issueProject)
-                    .censusRepo(censusBuilder.build()).build();
+                    .censusRepo(censusBuilder.build()).enableJep(true).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(),
@@ -262,7 +262,7 @@ public class JEPCommandTests {
             var censusBuilder = credentials.getCensusBuilder()
                     .addAuthor(author.forge().currentUser().id());
             var prBot = PullRequestBot.newBuilder().repo(bot).issueProject(issueProject)
-                    .censusRepo(censusBuilder.build()).build();
+                    .censusRepo(censusBuilder.build()).enableJep(true).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(),
@@ -377,7 +377,7 @@ public class JEPCommandTests {
             var censusBuilder = credentials.getCensusBuilder()
                     .addAuthor(author.forge().currentUser().id());
             var prBot = PullRequestBot.newBuilder().repo(bot).issueProject(issueProject)
-                    .censusRepo(censusBuilder.build()).build();
+                    .censusRepo(censusBuilder.build()).enableJep(true).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(),


### PR DESCRIPTION
Hi all,

If a repository doesn't support JEP and someone issues the `/jep` command in the PR of this repo, the bot should replies a comment instead of blocking the PR. This patch adds a jep config to the PR bot and adjusts the test cases.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 reviews required, with at least 1 reviewer)

### Issue
 * [SKARA-1419](https://bugs.openjdk.java.net/browse/SKARA-1419): The Skara PR bot should not block on a JEP if not enabled for a repo


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1310/head:pull/1310` \
`$ git checkout pull/1310`

Update a local copy of the PR: \
`$ git checkout pull/1310` \
`$ git pull https://git.openjdk.java.net/skara pull/1310/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1310`

View PR using the GUI difftool: \
`$ git pr show -t 1310`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1310.diff">https://git.openjdk.java.net/skara/pull/1310.diff</a>

</details>
