### PR TITLE
1422: Remove the need to type `JEP-` or `jep-` prefix in `jep` command

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/JEPCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/JEPCommand.java
@@ -63,7 +63,7 @@ public class JEPCommand implements CommandHandler {
                 """);
     }
 
-    private Optional<Issue> getJepIssue(String args, PullRequestBot bot, PrintWriter reply) {
+    private Optional<Issue> getJepIssue(String args, PullRequestBot bot) {
         Optional<Issue> jbsIssue = Optional.empty();
         var upperArgs = args.toUpperCase();
         if (upperArgs.startsWith("JEP-")) {
@@ -76,10 +76,6 @@ public class JEPCommand implements CommandHandler {
                 // For example, if we have a `JEP-12345` (its issue ID is not `JDK-12345`) and an issue `JDK-12345`,
                 // when typing `/jep 12345`, the bot firstly parses it as `JEP-12345` instead of `JDK-12345`.
                 jbsIssue = bot.issueProject().jepIssue(args);
-                if (jbsIssue.isEmpty()) {
-                    reply.println("The JEP issue of the JEP argument `" + args + "` was not found. " +
-                            "We will treat the argument `" + args + "` as an issue ID.");
-                }
             }
             if (jbsIssue.isEmpty()) {
                 // Handle the issue ID
@@ -114,7 +110,7 @@ public class JEPCommand implements CommandHandler {
         }
 
         // Get the issue
-        var jbsIssueOpt = getJepIssue(args, bot, reply);
+        var jbsIssueOpt = getJepIssue(args, bot);
         if (jbsIssueOpt.isEmpty()) {
             reply.println("The JEP issue was not found. Please make sure you have entered it correctly.");
             showHelp(reply);

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/JEPCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/JEPCommand.java
@@ -50,19 +50,16 @@ public class JEPCommand implements CommandHandler {
                  * `/jep unneeded`
 
                 Some examples:
-
+                 * `/jep 123`
                  * `/jep JDK-1234567`
                  * `/jep 1234567`
                  * `/jep jep-123`
                  * `/jep JEP-123`
-                 * `/jep 123`
                  * `/jep unneeded`
 
                 Note:
-                The prefix (`JDK-`, `JEP-` or `jep-` in the above examples) is optional.
-                The bot firstly treats the ID without prefix as a JEP ID.
-                If not found, the bot then treats the ID without prefix as an issue ID.
-                The issue type in any case must be `JEP`.
+                The prefix (i.e. `JDK-`, `JEP-` or `jep-`) is optional. If the argument is given without prefix, \
+                it will be tried first as a JEP ID and second as an issue ID. The issue type must be `JEP`.
                 """);
     }
 
@@ -96,7 +93,7 @@ public class JEPCommand implements CommandHandler {
     public void handle(PullRequestBot bot, PullRequest pr, CensusInstance censusInstance, Path scratchPath, CommandInvocation command,
                        List<Comment> allComments, PrintWriter reply, List<String> labelsToAdd, List<String> labelsToRemove) {
         if (!pr.author().equals(command.user()) && !censusInstance.isReviewer(command.user())) {
-            reply.println("only the pull request author and [Reviewers](https://openjdk.java.net/bylaws#reviewer) are allowed to use the `jep` command.");
+            reply.println("Only the pull request author and [Reviewers](https://openjdk.java.net/bylaws#reviewer) are allowed to use the `jep` command.");
             return;
         }
 
@@ -147,13 +144,13 @@ public class JEPCommand implements CommandHandler {
         reply.println(String.format(jepMarker, jepNumber, jbsIssue.id(), jbsIssue.title()));
         if ("Targeted".equals(issueStatus) || "Integrated".equals(issueStatus) ||
             "Completed".equals(issueStatus) || ("Closed".equals(issueStatus) && "Delivered".equals(resolutionName))) {
-            reply.println("the JEP for this pull request, [JEP-" + jepNumber + "](" + jbsIssue.webUrl() + "), has already been targeted.");
+            reply.println("The JEP for this pull request, [JEP-" + jepNumber + "](" + jbsIssue.webUrl() + "), has already been targeted.");
             if (labelNames.contains(JEP_LABEL)) {
                 labelsToRemove.add(JEP_LABEL);
             }
         } else {
             // The current issue status may be "Draft", "Submitted", "Candidate", "Proposed to Target", "Proposed to Drop" or "Closed without Delivered"
-            reply.println("this pull request will not be integrated until the [JEP-" + jepNumber
+            reply.println("This pull request will not be integrated until the [JEP-" + jepNumber
                     + "](" + jbsIssue.webUrl() + ")" + " has been targeted.");
             if (!labelNames.contains(JEP_LABEL)) {
                 labelsToAdd.add(JEP_LABEL);

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/JEPCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/JEPCommandTests.java
@@ -83,7 +83,7 @@ public class JEPCommandTests {
             // Verify the behavior
             TestBotRunner.runPeriodicItems(prBot);
             assertTrue(pr.labelNames().contains(JEPCommand.JEP_LABEL));
-            assertLastCommentContains(pr, "this pull request will not be integrated until the [JEP-");
+            assertLastCommentContains(pr, "This pull request will not be integrated until the [JEP-");
             assertLastCommentContains(pr, "has been targeted.");
             assertTrue(pr.body().contains("- [ ] Change requires a JEP request to be targeted"));
 
@@ -102,7 +102,7 @@ public class JEPCommandTests {
             // Verify the behavior
             TestBotRunner.runPeriodicItems(prBot);
             assertTrue(pr.labelNames().contains(JEPCommand.JEP_LABEL));
-            assertLastCommentContains(pr, "this pull request will not be integrated until the [JEP-");
+            assertLastCommentContains(pr, "This pull request will not be integrated until the [JEP-");
             assertLastCommentContains(pr, "has been targeted.");
             assertTrue(pr.body().contains("- [ ] Change requires a JEP request to be targeted"));
 
@@ -121,7 +121,7 @@ public class JEPCommandTests {
             // Verify the behavior
             TestBotRunner.runPeriodicItems(prBot);
             assertTrue(pr.labelNames().contains(JEPCommand.JEP_LABEL));
-            assertLastCommentContains(pr, "this pull request will not be integrated until the [JEP-");
+            assertLastCommentContains(pr, "This pull request will not be integrated until the [JEP-");
             assertLastCommentContains(pr, "has been targeted.");
             assertTrue(pr.body().contains("- [ ] Change requires a JEP request to be targeted"));
 
@@ -140,7 +140,7 @@ public class JEPCommandTests {
             // Verify the behavior
             TestBotRunner.runPeriodicItems(prBot);
             assertTrue(pr.labelNames().contains(JEPCommand.JEP_LABEL));
-            assertLastCommentContains(pr, "this pull request will not be integrated until the [JEP-");
+            assertLastCommentContains(pr, "This pull request will not be integrated until the [JEP-");
             assertLastCommentContains(pr, "has been targeted.");
             assertTrue(pr.body().contains("- [ ] Change requires a JEP request to be targeted"));
 
@@ -159,7 +159,7 @@ public class JEPCommandTests {
             // Verify the behavior
             TestBotRunner.runPeriodicItems(prBot);
             assertFalse(pr.labelNames().contains(JEPCommand.JEP_LABEL));
-            assertLastCommentContains(pr, "the JEP for this pull request, [JEP-");
+            assertLastCommentContains(pr, "The JEP for this pull request, [JEP-");
             assertLastCommentContains(pr, "has already been targeted.");
             assertTrue(pr.body().contains("- [x] Change requires a JEP request to be targeted"));
 
@@ -180,7 +180,7 @@ public class JEPCommandTests {
             assertFalse(pr.labelNames().contains(JEPCommand.JEP_LABEL));
             assertLastCommentContains(pr, "The JEP issue of the JEP argument `3` was not found.");
             assertLastCommentContains(pr, "We will treat the argument `3` as an issue ID.");
-            assertLastCommentContains(pr, "the JEP for this pull request, [JEP-");
+            assertLastCommentContains(pr, "The JEP for this pull request, [JEP-");
             assertLastCommentContains(pr, "has already been targeted.");
             assertTrue(pr.body().contains("- [x] Change requires a JEP request to be targeted"));
 
@@ -199,7 +199,7 @@ public class JEPCommandTests {
             // Verify the behavior
             TestBotRunner.runPeriodicItems(prBot);
             assertTrue(pr.labelNames().contains(JEPCommand.JEP_LABEL));
-            assertLastCommentContains(pr, "this pull request will not be integrated until the [JEP-");
+            assertLastCommentContains(pr, "This pull request will not be integrated until the [JEP-");
             assertLastCommentContains(pr, "has been targeted.");
             assertTrue(pr.body().contains("- [ ] Change requires a JEP request to be targeted"));
         }
@@ -248,7 +248,7 @@ public class JEPCommandTests {
             // Verify the behavior
             TestBotRunner.runPeriodicItems(prBot);
             assertFalse(pr.labelNames().contains(JEPCommand.JEP_LABEL));
-            assertLastCommentContains(pr, "only the pull request author and [Reviewers]" +
+            assertLastCommentContains(pr, "Only the pull request author and [Reviewers]" +
                     "(https://openjdk.java.net/bylaws#reviewer) are allowed to use the `jep` command.");
 
             // Require jep by the PR author
@@ -257,7 +257,7 @@ public class JEPCommandTests {
             // Verify the behavior
             TestBotRunner.runPeriodicItems(prBot);
             assertTrue(pr.labelNames().contains(JEPCommand.JEP_LABEL));
-            assertLastCommentContains(pr, "this pull request will not be integrated until the [JEP-");
+            assertLastCommentContains(pr, "This pull request will not be integrated until the [JEP-");
             assertLastCommentContains(pr, "has been targeted.");
             assertTrue(pr.body().contains("- [ ] Change requires a JEP request to be targeted"));
 
@@ -267,7 +267,7 @@ public class JEPCommandTests {
             // Verify the behavior
             TestBotRunner.runPeriodicItems(prBot);
             assertTrue(pr.labelNames().contains(JEPCommand.JEP_LABEL));
-            assertLastCommentContains(pr, "this pull request will not be integrated until the [JEP-");
+            assertLastCommentContains(pr, "This pull request will not be integrated until the [JEP-");
             assertLastCommentContains(pr, "has been targeted.");
             assertTrue(pr.body().contains("- [ ] Change requires a JEP request to be targeted"));
 
@@ -277,7 +277,7 @@ public class JEPCommandTests {
             // Verify the behavior
             TestBotRunner.runPeriodicItems(prBot);
             assertTrue(pr.labelNames().contains(JEPCommand.JEP_LABEL));
-            assertLastCommentContains(pr, "only the pull request author and [Reviewers]" +
+            assertLastCommentContains(pr, "Only the pull request author and [Reviewers]" +
                     "(https://openjdk.java.net/bylaws#reviewer) are allowed to use the `jep` command.");
             assertTrue(pr.body().contains("- [ ] Change requires a JEP request to be targeted"));
 
@@ -332,6 +332,9 @@ public class JEPCommandTests {
             assertEquals(3, pr.comments().size());
             assertLastCommentContains(pr, "Command syntax:");
             assertLastCommentContains(pr, "Some examples:");
+            // Test the symbol `\` of the text block
+            assertLastCommentContains(pr, "The prefix (i.e. `JDK-`, `JEP-` or `jep-`) is optional. If the argument is given without prefix, "
+                    + "it will be tried first as a JEP ID and second as an issue ID. The issue type must be `JEP`.");
             assertFalse(pr.body().contains("Change requires a JEP request to be targeted"));
 
             // Require jep with blank space
@@ -343,6 +346,9 @@ public class JEPCommandTests {
             assertEquals(5, pr.comments().size());
             assertLastCommentContains(pr, "Command syntax:");
             assertLastCommentContains(pr, "Some examples:");
+            // Test the symbol `\` of the text block
+            assertLastCommentContains(pr, "The prefix (i.e. `JDK-`, `JEP-` or `jep-`) is optional. If the argument is given without prefix, "
+                    + "it will be tried first as a JEP ID and second as an issue ID. The issue type must be `JEP`.");
             assertFalse(pr.body().contains("Change requires a JEP request to be targeted"));
 
             // Require jep with wrong jep prefix
@@ -443,7 +449,7 @@ public class JEPCommandTests {
                 TestBotRunner.runPeriodicItems(prBot);
                 assertTrue(pr.labelNames().contains(JEPCommand.JEP_LABEL));
                 assertEquals(i * 2 + 1, pr.comments().size());
-                assertLastCommentContains(pr, "this pull request will not be integrated until the [JEP-");
+                assertLastCommentContains(pr, "This pull request will not be integrated until the [JEP-");
                 assertLastCommentContains(pr, "has been targeted.");
                 assertTrue(pr.body().contains("- [ ] Change requires a JEP request to be targeted"));
             }
@@ -454,7 +460,7 @@ public class JEPCommandTests {
                 TestBotRunner.runPeriodicItems(prBot);
                 assertFalse(pr.labelNames().contains(JEPCommand.JEP_LABEL));
                 assertEquals(i * 2 + 1, pr.comments().size());
-                assertLastCommentContains(pr, "the JEP for this pull request, [JEP-");
+                assertLastCommentContains(pr, "The JEP for this pull request, [JEP-");
                 assertLastCommentContains(pr, "has already been targeted.");
                 assertTrue(pr.body().contains("- [x] Change requires a JEP request to be targeted"));
             }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/JEPCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/JEPCommandTests.java
@@ -178,8 +178,6 @@ public class JEPCommandTests {
             // Verify the behavior
             TestBotRunner.runPeriodicItems(prBot);
             assertFalse(pr.labelNames().contains(JEPCommand.JEP_LABEL));
-            assertLastCommentContains(pr, "The JEP issue of the JEP argument `3` was not found.");
-            assertLastCommentContains(pr, "We will treat the argument `3` as an issue ID.");
             assertLastCommentContains(pr, "The JEP for this pull request, [JEP-");
             assertLastCommentContains(pr, "has already been targeted.");
             assertTrue(pr.body().contains("- [x] Change requires a JEP request to be targeted"));
@@ -368,8 +366,6 @@ public class JEPCommandTests {
             TestBotRunner.runPeriodicItems(prBot);
             assertFalse(pr.labelNames().contains(JEPCommand.JEP_LABEL));
             assertEquals(9, pr.comments().size());
-            assertLastCommentContains(pr, "The JEP issue of the JEP argument `1` was not found.");
-            assertLastCommentContains(pr, "We will treat the argument `1` as an issue ID.");
             assertLastCommentContains(pr, "The issue `TEST-1` is not a JEP. Please make sure you have entered it correctly.");
             assertFalse(pr.body().contains("Change requires a JEP request to be targeted"));
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/JEPCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/JEPCommandTests.java
@@ -134,6 +134,25 @@ public class JEPCommandTests {
             assertLastCommentContains(pr, "determined that the JEP request is not needed for this pull request.");
             assertFalse(pr.body().contains("Change requires a JEP request to be targeted"));
 
+            // Require jep with strange jep prefix
+            pr.addComment("/jep jEP-123");
+
+            // Verify the behavior
+            TestBotRunner.runPeriodicItems(prBot);
+            assertTrue(pr.labelNames().contains(JEPCommand.JEP_LABEL));
+            assertLastCommentContains(pr, "this pull request will not be integrated until the [JEP-");
+            assertLastCommentContains(pr, "has been targeted.");
+            assertTrue(pr.body().contains("- [ ] Change requires a JEP request to be targeted"));
+
+            // Not require jep
+            prAsReviewer.addComment("/jep unneeded");
+
+            // Verify the behavior
+            TestBotRunner.runPeriodicItems(prBot);
+            assertFalse(pr.labelNames().contains(JEPCommand.JEP_LABEL));
+            assertLastCommentContains(pr, "determined that the JEP request is not needed for this pull request.");
+            assertFalse(pr.body().contains("Change requires a JEP request to be targeted"));
+
             // Require jep by using `issue-id`(<ProjectName>-<id>)
             pr.addComment("/jep TEST-3");
 
@@ -159,9 +178,30 @@ public class JEPCommandTests {
             // Verify the behavior
             TestBotRunner.runPeriodicItems(prBot);
             assertFalse(pr.labelNames().contains(JEPCommand.JEP_LABEL));
+            assertLastCommentContains(pr, "The JEP issue of the JEP argument `3` was not found.");
+            assertLastCommentContains(pr, "We will treat the argument `3` as an issue ID.");
             assertLastCommentContains(pr, "the JEP for this pull request, [JEP-");
             assertLastCommentContains(pr, "has already been targeted.");
             assertTrue(pr.body().contains("- [x] Change requires a JEP request to be targeted"));
+
+            // Not require jep
+            prAsReviewer.addComment("/jep unneeded");
+
+            // Verify the behavior
+            TestBotRunner.runPeriodicItems(prBot);
+            assertFalse(pr.labelNames().contains(JEPCommand.JEP_LABEL));
+            assertLastCommentContains(pr, "determined that the JEP request is not needed for this pull request.");
+            assertFalse(pr.body().contains("Change requires a JEP request to be targeted"));
+
+            // Require jep with right JEP ID without prefix
+            pr.addComment("/jep 123");
+
+            // Verify the behavior
+            TestBotRunner.runPeriodicItems(prBot);
+            assertTrue(pr.labelNames().contains(JEPCommand.JEP_LABEL));
+            assertLastCommentContains(pr, "this pull request will not be integrated until the [JEP-");
+            assertLastCommentContains(pr, "has been targeted.");
+            assertTrue(pr.body().contains("- [ ] Change requires a JEP request to be targeted"));
         }
     }
 
@@ -315,14 +355,16 @@ public class JEPCommandTests {
             assertLastCommentContains(pr, "The JEP issue was not found. Please make sure you have entered it correctly.");
             assertFalse(pr.body().contains("Change requires a JEP request to be targeted"));
 
-            // Require jep with wrong jep prefix
-            pr.addComment("/jep jEP-123");
+            // Require jep with wrong jep id without prefix
+            pr.addComment("/jep 1");
 
             // Verify the behavior
             TestBotRunner.runPeriodicItems(prBot);
             assertFalse(pr.labelNames().contains(JEPCommand.JEP_LABEL));
             assertEquals(9, pr.comments().size());
-            assertLastCommentContains(pr, "The JEP issue was not found. Please make sure you have entered it correctly.");
+            assertLastCommentContains(pr, "The JEP issue of the JEP argument `1` was not found.");
+            assertLastCommentContains(pr, "We will treat the argument `1` as an issue ID.");
+            assertLastCommentContains(pr, "The issue `TEST-1` is not a JEP. Please make sure you have entered it correctly.");
             assertFalse(pr.body().contains("Change requires a JEP request to be targeted"));
 
             // Require jep with wrong project prefix
@@ -352,16 +394,6 @@ public class JEPCommandTests {
             TestBotRunner.runPeriodicItems(prBot);
             assertFalse(pr.labelNames().contains(JEPCommand.JEP_LABEL));
             assertEquals(15, pr.comments().size());
-            assertLastCommentContains(pr, "The issue `TEST-1` is not a JEP. Please make sure you have entered it correctly.");
-            assertFalse(pr.body().contains("Change requires a JEP request to be targeted"));
-
-            // Require jep with wrong issue type
-            pr.addComment("/jep 1");
-
-            // Verify the behavior
-            TestBotRunner.runPeriodicItems(prBot);
-            assertFalse(pr.labelNames().contains(JEPCommand.JEP_LABEL));
-            assertEquals(17, pr.comments().size());
             assertLastCommentContains(pr, "The issue `TEST-1` is not a JEP. Please make sure you have entered it correctly.");
             assertFalse(pr.body().contains("Change requires a JEP request to be targeted"));
         }


### PR DESCRIPTION
Hi all,

This patch permits the strange grammer like `/jep jEP-123` and removes the need of the `JEP-` or `jep-` prefix.
When the prefix (`JDK-`, `JEP-` or others) is not provided, the bot treats it as a JEP ID firstly.
If the issue is not found, the bot then treats it as an issue ID.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 reviews required, with at least 1 reviewer)

### Issue
 * [SKARA-1422](https://bugs.openjdk.java.net/browse/SKARA-1422): Remove the need to type `JEP-` or `jep-` prefix in `jep` command


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1311/head:pull/1311` \
`$ git checkout pull/1311`

Update a local copy of the PR: \
`$ git checkout pull/1311` \
`$ git pull https://git.openjdk.java.net/skara pull/1311/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1311`

View PR using the GUI difftool: \
`$ git pr show -t 1311`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1311.diff">https://git.openjdk.java.net/skara/pull/1311.diff</a>

</details>
