### PR TITLE
1424: CheckRun fails to evaluate jol#24

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
@@ -82,6 +82,19 @@ public interface ReadOnlyRepository {
     boolean isHealthy() throws IOException;
     boolean isEmpty() throws IOException;
     boolean isClean() throws IOException;
+
+    /**
+     * Finds the hash of the merge-base commit for the two given hashes. Returns
+     * empty if the two hashes do not share any history.
+     */
+    default Optional<Hash> mergeBaseOptional(Hash first, Hash second) throws IOException {
+        return Optional.of(mergeBase(first, second));
+    }
+
+    /**
+     * Finds the hash of the merge base commit for the two given hashes. Throws
+     * IOException if it can't be found.
+     */
     Hash mergeBase(Hash first, Hash second) throws IOException;
     boolean isAncestor(Hash ancestor, Hash descendant) throws IOException;
     Optional<Hash> resolve(String ref) throws IOException;


### PR DESCRIPTION
CheckRun, which is part of the PullRequestBot, is currently failing to evaluate https://github.com/openjdk/jol/pull/24. The failure happens in PullRequestUtils::containsForeignMerge where we are looking for merges in the PR branch which bring in commits that aren't descendants of the main merge parent. If this test is positive, the bot adds a comment with a warning.

The problem is that GitRepository::mergeBase doesn't differentiate between the git command failing with an error and when it just can't find a merge-base. For this check, a non existent merge-base should qualify for a positive test.

I'm refactoring Repository::mergeBase into two methods, one that returns an Optional, which will be empty when a merge-base can't be found. I've also gone through all callers to identify when the new method should be used to properly tell this situation apart.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 reviews required, with at least 1 reviewer)

### Issue
 * [SKARA-1424](https://bugs.openjdk.java.net/browse/SKARA-1424): CheckRun fails to evaluate jol#24


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1312/head:pull/1312` \
`$ git checkout pull/1312`

Update a local copy of the PR: \
`$ git checkout pull/1312` \
`$ git pull https://git.openjdk.java.net/skara pull/1312/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1312`

View PR using the GUI difftool: \
`$ git pr show -t 1312`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1312.diff">https://git.openjdk.java.net/skara/pull/1312.diff</a>

</details>
