### PR TITLE
1375: Incorrect sync labels

### DIFF
--- a/jbs/src/main/java/org/openjdk/skara/jbs/Backports.java
+++ b/jbs/src/main/java/org/openjdk/skara/jbs/Backports.java
@@ -267,6 +267,9 @@ public class Backports {
                     if (numericUpdate == 1 || numericUpdate == 2) {
                         if (jdkVersion.opt().isPresent() && jdkVersion.opt().get().equals("oracle") && jdkVersion.components().size() > 4) {
                             ret.add(jdkVersion.feature() + "+bpr");
+                        } else if (numericFeature <= 11 && jdkVersion.resolvedInBuild().isPresent()
+                                && jdkVersion.resolvedInBuildNumber() > 30) {
+                            ret.add(jdkVersion.feature() + "+bpr");
                         } else {
                             ret.add(jdkVersion.feature() + "+updates-oracle");
                             ret.add(jdkVersion.feature() + "+updates-openjdk");
@@ -274,6 +277,9 @@ public class Backports {
                     } else if (numericUpdate > 2) {
                         if (jdkVersion.opt().isPresent() && jdkVersion.opt().get().equals("oracle")) {
                             if (jdkVersion.components().size() > 4) {
+                                ret.add(jdkVersion.feature()+ "+bpr");
+                            } else if (numericFeature <= 11 && numericUpdate == 3 && jdkVersion.resolvedInBuild().isPresent()
+                                    && jdkVersion.resolvedInBuildNumber() > 30) {
                                 ret.add(jdkVersion.feature()+ "+bpr");
                             } else {
                                 ret.add(jdkVersion.feature() + "+updates-oracle");
@@ -287,20 +293,18 @@ public class Backports {
                     ret.add(jdkVersion.feature() + "+updates-oracle");
                     ret.add(jdkVersion.feature() + "+updates-openjdk");
                 }
-            } else if (numericFeature == 7 || numericFeature == 8) {
+            } else if (numericFeature == 7 || numericFeature == 8 || numericFeature == 6) {
                 // For update releases, certain ranges of build numbers need special treatment
                 if (bprException(jdkVersion, numericFeature)) {
                     ret.add(jdkVersion.feature());
                 } else if (jdkVersion.interim().isPresent()) {
                     var resolvedInBuild = jdkVersion.resolvedInBuild();
                     if (resolvedInBuild.isPresent()) {
-                        if (!resolvedInBuild.get().equals("team")) { // Special case - team build resolved are ignored
-                            int resolvedInBuildNumber = jdkVersion.resolvedInBuildNumber();
-                            if (resolvedInBuildNumber < 30) {
-                                ret.add(jdkVersion.feature());
-                            } else if (resolvedInBuildNumber < 60) {
-                                ret.add(jdkVersion.feature() + "+bpr");
-                            }
+                        int resolvedInBuildNumber = jdkVersion.resolvedInBuildNumber();
+                        if (resolvedInBuildNumber < 30) {
+                            ret.add(jdkVersion.feature());
+                        } else if (resolvedInBuildNumber < 60) {
+                            ret.add(jdkVersion.feature() + "+bpr");
                         }
                     } else {
                         ret.add(jdkVersion.feature());

--- a/jbs/src/test/java/org/openjdk/skara/jbs/BackportsTests.java
+++ b/jbs/src/test/java/org/openjdk/skara/jbs/BackportsTests.java
@@ -400,13 +400,13 @@ public class BackportsTests {
             backports.assertLabeled();
 
             backports.addBackports("openjdk8u242/team", "openjdk8u232/master");
-            backports.assertLabeled();
+            backports.assertLabeled("openjdk8u242");
 
             backports.addBackports("8u261/b04", "8u251/b01", "8u241/b31", "8u231/b34");
-            backports.assertLabeled("8u261", "8u241");
+            backports.assertLabeled("openjdk8u242", "8u261", "8u241");
 
             backports.addBackports("emb-8u251/team", "7u261/b01");
-            backports.assertLabeled("8u261", "8u241");
+            backports.assertLabeled("openjdk8u242", "8u261", "8u241");
         }
     }
 
@@ -881,4 +881,36 @@ public class BackportsTests {
             backports.assertLabeled("8u5");
         }
     }
-}
+
+    @Test
+    void jdk6(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo)) {
+            var backports = new BackportManager(credentials, "11");
+            backports.assertLabeled();
+
+            backports.addBackports("6u201", "6u211");
+            backports.assertLabeled("6u211");
+        }
+    }
+
+    @Test
+    void jdk11_0_3_bpr(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo)) {
+            var backports = new BackportManager(credentials, "12");
+            backports.assertLabeled();
+
+            backports.addBackports("11.0.4-oracle", "11.0.4", "11.0.3-oracle/b31", "11.0.2/b31");
+            backports.assertLabeled("11.0.3-oracle");
+        }
+    }
+
+    @Test
+    void jdk11_0_3_bpr2(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo)) {
+            var backports = new BackportManager(credentials, "11.0.2.0.1-oracle");
+            backports.assertLabeled();
+
+            backports.addBackports("11.0.4-oracle", "11.0.3-oracle/b31");
+            backports.assertLabeled("11.0.3-oracle");
+        }
+    }}


### PR DESCRIPTION
This patch attempts to fix three reported issues with hgupdate-sync labels. 

* Backports for 6u should also be considered
* "Resolved in Build": "team" should not be ignored
* The b30+ is a bpr rule applies to releases up to 11.0.3

/issue add 1394,1382

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 reviews required, with at least 1 reviewer)

### Issues
 * [SKARA-1375](https://bugs.openjdk.java.net/browse/SKARA-1375): Incorrect sync labels
 * [SKARA-1394](https://bugs.openjdk.java.net/browse/SKARA-1394): sync-bot not adding sync label to openjdk releases
 * [SKARA-1382](https://bugs.openjdk.java.net/browse/SKARA-1382): sync-bot removing sync label from JDK 6 backport


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1313/head:pull/1313` \
`$ git checkout pull/1313`

Update a local copy of the PR: \
`$ git checkout pull/1313` \
`$ git pull https://git.openjdk.java.net/skara pull/1313/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1313`

View PR using the GUI difftool: \
`$ git pr show -t 1313`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1313.diff">https://git.openjdk.java.net/skara/pull/1313.diff</a>

</details>
