### PR TITLE
1423: Clarfiy doc for /contributor command

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ContributorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ContributorCommand.java
@@ -28,7 +28,6 @@ import org.openjdk.skara.forge.PullRequest;
 import org.openjdk.skara.issuetracker.Comment;
 
 import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.regex.Pattern;

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ContributorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ContributorCommand.java
@@ -43,7 +43,6 @@ public class ContributorCommand implements CommandHandler {
         reply.println(" * `/contributor add duke`");
         reply.println(" * `/contributor add J. Duke <duke@openjdk.org>`");
         reply.println();
-        reply.println("Note:");
         reply.println("User names can only be used for users in the census associated with this repository. " +
                 "For other contributors you need to supply the full name and email address.");
     }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ContributorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ContributorCommand.java
@@ -28,6 +28,7 @@ import org.openjdk.skara.forge.PullRequest;
 import org.openjdk.skara.issuetracker.Comment;
 
 import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.regex.Pattern;
@@ -41,26 +42,34 @@ public class ContributorCommand implements CommandHandler {
         reply.println(" * `/contributor add @openjdk-bot`");
         reply.println(" * `/contributor add duke`");
         reply.println(" * `/contributor add J. Duke <duke@openjdk.org>`");
+        reply.println();
+        reply.println("Note:");
+        reply.println("User names can only be used for users in the census associated with this repository." +
+                "For other contributors you need to supply the full name and email address.");
     }
 
-    private Optional<EmailAddress> parseUser(String user, PullRequest pr, CensusInstance censusInstance) {
+    private Optional<EmailAddress> parseUser(String user, PullRequest pr, CensusInstance censusInstance, PrintWriter reply) {
         user = user.strip();
         if (user.isEmpty()) {
+            reply.println("Username parameter is empty.");
             return Optional.empty();
         }
         Contributor contributor;
         if (user.charAt(0) == '@') {
             var platformUser = pr.repository().forge().user(user.substring(1));
             if (platformUser.isEmpty()) {
+                reply.println("`" + user + "` is not a valid user in this repository.");
                 return Optional.empty();
             }
             contributor = censusInstance.namespace().get(platformUser.get().id());
             if (contributor == null) {
+                reply.println("`" + user + "` was not found in the census.");
                 return Optional.empty();
             }
         } else if (!user.contains("@")) {
             contributor = censusInstance.census().contributor(user);
             if (contributor == null) {
+                reply.println("`" + user + "` was not found in the census.");
                 return Optional.empty();
             }
         } else {
@@ -69,9 +78,11 @@ public class ContributorCommand implements CommandHandler {
                 if (email.fullName().isPresent()) {
                     return Optional.of(email);
                 } else {
+                    reply.println("`" + user + "` is not a valid name and email string.");
                     return Optional.empty();
                 }
             } catch (RuntimeException e) {
+                reply.println("`" + user + "` is not a valid name and email string.");
                 return Optional.empty();
             }
         }
@@ -79,6 +90,7 @@ public class ContributorCommand implements CommandHandler {
         if (contributor.fullName().isPresent()) {
             return Optional.of(EmailAddress.from(contributor.fullName().get(), contributor.username() + "@openjdk.org"));
         } else {
+            reply.println("`" + user + "` does not have a full name recorded in the census.");
             return Optional.empty();
         }
     }
@@ -96,9 +108,8 @@ public class ContributorCommand implements CommandHandler {
             return;
         }
 
-        var contributor = parseUser(matcher.group(2), pr, censusInstance);
+        var contributor = parseUser(matcher.group(2), pr, censusInstance, reply);
         if (contributor.isEmpty()) {
-            reply.println("Could not parse `" + matcher.group(2) + "` as a valid contributor.");
             showHelp(pr, reply);;
             return;
         }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ContributorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ContributorCommand.java
@@ -44,7 +44,7 @@ public class ContributorCommand implements CommandHandler {
         reply.println(" * `/contributor add J. Duke <duke@openjdk.org>`");
         reply.println();
         reply.println("Note:");
-        reply.println("User names can only be used for users in the census associated with this repository." +
+        reply.println("User names can only be used for users in the census associated with this repository. " +
                 "For other contributors you need to supply the full name and email address.");
     }
 
@@ -110,6 +110,7 @@ public class ContributorCommand implements CommandHandler {
 
         var contributor = parseUser(matcher.group(2), pr, censusInstance, reply);
         if (contributor.isEmpty()) {
+            reply.println();
             showHelp(pr, reply);;
             return;
         }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ContributorTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ContributorTests.java
@@ -211,27 +211,27 @@ class ContributorTests {
             // Use an invalid full name
             pr.addComment("/contributor add Moo <Foo.Bar (at) host.com>");
             TestBotRunner.runPeriodicItems(prBot);
-            assertLastCommentContains(pr, "Could not parse `Moo <Foo.Bar (at) host.com>` as a valid contributor");
+            assertLastCommentContains(pr, "`Moo <Foo.Bar (at) host.com>` was not found in the census.");
 
             // Empty platform id
             pr.addComment("/contributor add @");
             TestBotRunner.runPeriodicItems(prBot);
-            assertLastCommentContains(pr, "Could not parse `@` as a valid contributor");
+            assertLastCommentContains(pr, "`@` is not a valid user in this repository.");
 
             // Unknown platform id
             pr.addComment("/contributor add @someone");
             TestBotRunner.runPeriodicItems(prBot);
-            assertLastCommentContains(pr, "Could not parse `@someone` as a valid contributor");
+            assertLastCommentContains(pr, "`@someone` is not a valid user in this repository.");
 
             // Unknown openjdk user
             pr.addComment("/contributor add someone");
             TestBotRunner.runPeriodicItems(prBot);
-            assertLastCommentContains(pr, "Could not parse `someone` as a valid contributor");
+            assertLastCommentContains(pr, "`someone` was not found in the census.");
 
             // No full name
             pr.addComment("/contributor add some@one");
             TestBotRunner.runPeriodicItems(prBot);
-            assertLastCommentContains(pr, "Could not parse `some@one` as a valid contributor");
+            assertLastCommentContains(pr, "`some@one` is not a valid name and email string.");
         }
     }
 


### PR DESCRIPTION
This patch improves the help text and the error messages for the /contributor command.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 reviews required, with at least 1 reviewer)

### Issue
 * [SKARA-1423](https://bugs.openjdk.java.net/browse/SKARA-1423): Clarfiy doc for /contributor command


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**) ⚠️ Review applies to [28f617bb](https://git.openjdk.java.net/skara/pull/1314/files/28f617bbd906403ed3527ec35bff3f02967ab773)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1314/head:pull/1314` \
`$ git checkout pull/1314`

Update a local copy of the PR: \
`$ git checkout pull/1314` \
`$ git pull https://git.openjdk.java.net/skara pull/1314/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1314`

View PR using the GUI difftool: \
`$ git pr show -t 1314`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1314.diff">https://git.openjdk.java.net/skara/pull/1314.diff</a>

</details>
