### PR TITLE
1427: Remove unnecessary warning log message

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -141,9 +141,7 @@ class CheckRun {
             return Optional.empty();
         }
         var csr = csrLink(jbsIssue.get()).flatMap(Link::issue);
-        if (csr.isEmpty()) {
-            log.warning("The CSR issue of the issue " + issue + " does not exist");
-        } else {
+        if (csr.isPresent()) {
             return Issue.fromStringRelaxed(csr.get().id() + ": " + csr.get().title());
         }
         return Optional.empty();


### PR DESCRIPTION
The PR bot currently logs a warning about not finding a CSR for every PR. This seems unnecessary.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 reviews required, with at least 1 reviewer)

### Issue
 * [SKARA-1427](https://bugs.openjdk.java.net/browse/SKARA-1427): Remove unnecessary warning log message


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1316/head:pull/1316` \
`$ git checkout pull/1316`

Update a local copy of the PR: \
`$ git checkout pull/1316` \
`$ git pull https://git.openjdk.java.net/skara pull/1316/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1316`

View PR using the GUI difftool: \
`$ git pr show -t 1316`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1316.diff">https://git.openjdk.java.net/skara/pull/1316.diff</a>

</details>
