### PR TITLE
1428: New reviews message always adds plural 's'

### DIFF
--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ReviewersTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ReviewersTests.java
@@ -42,7 +42,7 @@ public class ReviewersTests {
     private static final String reviewersCommandFinallyOutput = "The total number of required reviews for this PR " +
             "(including the jcheck configuration and the last /reviewers command) is now set to ";
 
-    private static final String REVIEW_PROGRESS_TEMPLATE = "Change must be properly reviewed (%d reviews required, with at least %s)";
+    private static final String REVIEW_PROGRESS_TEMPLATE = "Change must be properly reviewed (%d review%s required, with at least %s)";
     private static final String ZERO_REVIEW_PROGRESS = "Change must be properly reviewed (no reviews required)";
 
     @Test
@@ -78,7 +78,7 @@ public class ReviewersTests {
 
             // The bot should reply with a help message
             assertLastCommentContains(reviewerPr,"is the number of required reviewers");
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "1 reviewer")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 reviewer")));
 
             // Invalid syntax
             reviewerPr.addComment("/reviewers two");
@@ -86,25 +86,25 @@ public class ReviewersTests {
 
             // The bot should reply with a help message
             assertLastCommentContains(reviewerPr,"is the number of required reviewers");
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "1 reviewer")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 reviewer")));
 
             // Too many
             reviewerPr.addComment("/reviewers 7001");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr,"Cannot increase the required number of reviewers above 10 (requested: 7001)");
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "1 reviewer")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 reviewer")));
 
             // Too few
             reviewerPr.addComment("/reviewers -3");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr,"Cannot decrease the required number of reviewers below 0 (requested: -3)");
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "1 reviewer")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 reviewer")));
 
             // Unknown role
             reviewerPr.addComment("/reviewers 2 penguins");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr,"Unknown role `penguins` specified");
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "1 reviewer")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 reviewer")));
 
             // Set the number
             reviewerPr.addComment("/reviewers 2");
@@ -112,7 +112,7 @@ public class ReviewersTests {
 
             // The bot should reply with a success message
             assertLastCommentContains(reviewerPr, reviewersCommandFinallyOutput + "2 (with 1 of role reviewers, 1 of role authors).");
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "1 reviewer, 1 author")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "s", "1 reviewer, 1 author")));
 
             // Set 2 of role committers
             reviewerPr.addComment("/reviewers 2 committer");
@@ -120,7 +120,7 @@ public class ReviewersTests {
 
             // The bot should reply with a success message
             assertLastCommentContains(reviewerPr, reviewersCommandFinallyOutput + "2 (with 1 of role reviewers, 1 of role committers).");
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "1 reviewer, 1 committer")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "s", "1 reviewer, 1 committer")));
 
             // Set 2 of role reviewers
             reviewerPr.addComment("/reviewers 2 reviewer");
@@ -128,7 +128,7 @@ public class ReviewersTests {
 
             // The bot should reply with a success message
             assertLastCommentContains(reviewerPr, reviewersCommandFinallyOutput + "2 (with 2 of role reviewers).");
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "2 reviewers")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "s", "2 reviewers")));
 
             // Approve it as another user
             reviewerPr.addReview(Review.Verdict.APPROVED, "Approved");
@@ -138,7 +138,7 @@ public class ReviewersTests {
             // The PR should not yet be considered as ready for review
             var updatedPr = author.pullRequest(pr.id());
             assertFalse(updatedPr.labelNames().contains("ready"));
-            assertTrue(updatedPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "2 reviewers")));
+            assertTrue(updatedPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "s", "2 reviewers")));
 
             // Now reduce the number of required reviewers
             reviewerPr.addComment("/reviewers 1");
@@ -148,14 +148,14 @@ public class ReviewersTests {
             // The PR should now be considered as ready for review
             updatedPr = author.pullRequest(pr.id());
             assertTrue(updatedPr.labelNames().contains("ready"));
-            assertTrue(updatedPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "1 reviewer")));
+            assertTrue(updatedPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 reviewer")));
 
             // Now request that the lead reviews
             reviewerPr.addComment("/reviewers 1 lead");
             TestBotRunner.runPeriodicItems(prBot);
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr, reviewersCommandFinallyOutput + "1 (with 1 of role lead).");
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "1 lead")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 lead")));
 
             // The PR should no longer be considered as ready for review
             updatedPr = author.pullRequest(pr.id());
@@ -166,7 +166,7 @@ public class ReviewersTests {
             TestBotRunner.runPeriodicItems(prBot);
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr, reviewersCommandFinallyOutput + "1 (with 1 of role reviewers).");
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "1 reviewer")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 reviewer")));
 
             // The PR should now be considered as ready for review yet again
             updatedPr = author.pullRequest(pr.id());
@@ -207,7 +207,7 @@ public class ReviewersTests {
 
             // The bot should reply with a success message
             assertLastCommentContains(reviewerPr, reviewersCommandFinallyOutput + "2 (with 1 of role reviewers, 1 of role authors).");
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "1 reviewer, 1 author")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "s", "1 reviewer, 1 author")));
 
             // Approve it as another user
             reviewerPr.addReview(Review.Verdict.APPROVED, "Approved");
@@ -218,18 +218,18 @@ public class ReviewersTests {
             pr.addComment("/integrate");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr,"pull request has not yet been marked as ready for integration");
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "1 reviewer, 1 author")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "s", "1 reviewer, 1 author")));
 
             // Relax the requirement
             reviewerPr.addComment("/reviewers 1");
             TestBotRunner.runPeriodicItems(prBot);
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "1 reviewer")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 reviewer")));
 
             // It should now work fine
             pr.addComment("/integrate");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr,"Pushed as commit");
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "1 reviewer")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 reviewer")));
         }
     }
 
@@ -264,13 +264,13 @@ public class ReviewersTests {
             reviewerPr.addReview(Review.Verdict.APPROVED, "Approved");
             TestBotRunner.runPeriodicItems(prBot);
             TestBotRunner.runPeriodicItems(prBot);
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "1 reviewer")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 reviewer")));
 
             // Flag it as ready for integration
             pr.addComment("/integrate");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr,"now ready to be sponsored");
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "1 reviewer")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 reviewer")));
 
             // Set the number
             reviewerPr.addComment("/reviewers 2");
@@ -278,24 +278,24 @@ public class ReviewersTests {
 
             // The bot should reply with a success message
             assertLastCommentContains(reviewerPr, reviewersCommandFinallyOutput + "2 (with 1 of role reviewers, 1 of role authors).");
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "1 reviewer, 1 author")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "s", "1 reviewer, 1 author")));
 
             // It should not be possible to sponsor
             reviewerPr.addComment("/sponsor");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr,"PR has not yet been marked as ready for integration");
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "1 reviewer, 1 author")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "s", "1 reviewer, 1 author")));
 
             // Relax the requirement
             reviewerPr.addComment("/reviewers 1");
             TestBotRunner.runPeriodicItems(prBot);
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "1 reviewer")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 reviewer")));
 
             // It should now work fine
             reviewerPr.addComment("/sponsor");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr,"Pushed as commit");
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "1 reviewer")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 reviewer")));
         }
     }
 
@@ -330,7 +330,7 @@ public class ReviewersTests {
             // The bot should reply with a success message
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(authorPR, reviewersCommandFinallyOutput + "2 (with 1 of role reviewers, 1 of role authors).");
-            assertTrue(authorPR.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "1 reviewer, 1 author")));
+            assertTrue(authorPR.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "s", "1 reviewer, 1 author")));
         }
     }
 
@@ -367,19 +367,19 @@ public class ReviewersTests {
             // The bot should reply with a success message
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(authorPR, reviewersCommandFinallyOutput + "2 (with 1 of role reviewers, 1 of role authors).");
-            assertTrue(authorPR.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "1 reviewer, 1 author")));
+            assertTrue(authorPR.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "s", "1 reviewer, 1 author")));
             // The author should not be allowed to decrease even its own /reviewers command
             authorPR.addComment("/reviewers 1");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(authorPR, "Cannot decrease the number of required reviewers");
-            assertTrue(authorPR.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "1 reviewer, 1 author")));
+            assertTrue(authorPR.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "s", "1 reviewer, 1 author")));
 
             // Reviewer should be allowed to decrease
             var reviewerPr = integrator.pullRequest(pr.id());
             reviewerPr.addComment("/reviewers 1");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr, reviewersCommandFinallyOutput + "1 (with 1 of role reviewers).");
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "1 reviewer")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 reviewer")));
         }
     }
 
@@ -410,7 +410,7 @@ public class ReviewersTests {
 
             var authorPR = author.pullRequest(pr.id());
             assertLastCommentContains(authorPR, reviewersCommandFinallyOutput + "2 (with 1 of role reviewers, 1 of role authors).");
-            assertTrue(authorPR.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "1 reviewer, 1 author")));
+            assertTrue(authorPR.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "s", "1 reviewer, 1 author")));
         }
     }
 
@@ -557,7 +557,7 @@ public class ReviewersTests {
         if (totalNum == 0) {
             return ZERO_REVIEW_PROGRESS;
         } else {
-            return String.format(REVIEW_PROGRESS_TEMPLATE, totalNum, String.join(", ", requireList));
+            return String.format(REVIEW_PROGRESS_TEMPLATE, totalNum, totalNum > 1 ? "s" : "", String.join(", ", requireList));
         }
     }
 
@@ -608,7 +608,7 @@ public class ReviewersTests {
 
             authorPR.addComment("/reviewers 2 reviewer");
             TestBotRunner.runPeriodicItems(prBot);
-            assertTrue(authorPR.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "2 reviewers")));
+            assertTrue(authorPR.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "s", "2 reviewers")));
 
             reviewerPr.addComment("/reviewers 0");
             TestBotRunner.runPeriodicItems(prBot);

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/ReviewersConfiguration.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/ReviewersConfiguration.java
@@ -94,13 +94,14 @@ public class ReviewersConfiguration {
             var requirementNum = reviewRequirement.getValue();
             if (requirementNum > 0) {
                 sum += requirementNum;
-                requireList.add(requirementNum+ " " + reviewRequirement.getKey() + (requirementNum > 1 ? "s" : ""));
+                requireList.add(requirementNum + " " + reviewRequirement.getKey() + (requirementNum > 1 ? "s" : ""));
             }
         }
         if (sum == 0) {
             reviewRequirements = "no reviews required";
         } else {
-            reviewRequirements = String.format("%d reviews required, with at least %s", sum, String.join(", ", requireList));
+            reviewRequirements = String.format("%d review%s required, with at least %s",
+                    sum, sum > 1 ? "s" : "", String.join(", ", requireList));
         }
         return reviewRequirements;
     }

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/ReviewersCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/ReviewersCheckTests.java
@@ -567,7 +567,8 @@ class ReviewersCheckTests {
         assertEquals(noReview, JCheckConfiguration.parse(conf).checks().reviewers().getReviewRequirements());
 
         // review required template.
-        var hasReview = "%d reviews required, with at least %s";
+        var hasReview = "%d review required, with at least %s";
+        var hasReviews = "%d reviews required, with at least %s";
 
         // one review required.
         conf = new ArrayList<>(CONFIGURATION);
@@ -584,12 +585,12 @@ class ReviewersCheckTests {
         conf = new ArrayList<>(CONFIGURATION);
         conf.add("reviewers = 1");
         conf.add("committers = 1");
-        assertEquals(String.format(hasReview, 2, "1 reviewer, 1 committer"),
+        assertEquals(String.format(hasReviews, 2, "1 reviewer, 1 committer"),
                 JCheckConfiguration.parse(conf).checks().reviewers().getReviewRequirements());
 
         conf = new ArrayList<>(CONFIGURATION);
         conf.add("reviewers = 2");
-        assertEquals(String.format(hasReview, 2, "2 reviewers"),
+        assertEquals(String.format(hasReviews, 2, "2 reviewers"),
                 JCheckConfiguration.parse(conf).checks().reviewers().getReviewRequirements());
 
         // three reviews required.
@@ -597,18 +598,18 @@ class ReviewersCheckTests {
         conf.add("reviewers = 1");
         conf.add("committers = 1");
         conf.add("authors = 1");
-        assertEquals(String.format(hasReview, 3, "1 reviewer, 1 committer, 1 author"),
+        assertEquals(String.format(hasReviews, 3, "1 reviewer, 1 committer, 1 author"),
                 JCheckConfiguration.parse(conf).checks().reviewers().getReviewRequirements());
 
         conf = new ArrayList<>(CONFIGURATION);
         conf.add("reviewers = 1");
         conf.add("committers = 2");
-        assertEquals(String.format(hasReview, 3, "1 reviewer, 2 committers"),
+        assertEquals(String.format(hasReviews, 3, "1 reviewer, 2 committers"),
                 JCheckConfiguration.parse(conf).checks().reviewers().getReviewRequirements());
 
         conf = new ArrayList<>(CONFIGURATION);
         conf.add("committers = 3");
-        assertEquals(String.format(hasReview, 3, "3 committers"),
+        assertEquals(String.format(hasReviews, 3, "3 committers"),
                 JCheckConfiguration.parse(conf).checks().reviewers().getReviewRequirements());
 
         // four reviews required.
@@ -617,25 +618,25 @@ class ReviewersCheckTests {
         conf.add("committers = 1");
         conf.add("authors = 1");
         conf.add("contributors = 1");
-        assertEquals(String.format(hasReview, 4, "1 reviewer, 1 committer, 1 author, 1 contributor"),
+        assertEquals(String.format(hasReviews, 4, "1 reviewer, 1 committer, 1 author, 1 contributor"),
                 JCheckConfiguration.parse(conf).checks().reviewers().getReviewRequirements());
 
         conf = new ArrayList<>(CONFIGURATION);
         conf.add("reviewers = 1");
         conf.add("committers = 1");
         conf.add("authors = 2");
-        assertEquals(String.format(hasReview, 4, "1 reviewer, 1 committer, 2 authors"),
+        assertEquals(String.format(hasReviews, 4, "1 reviewer, 1 committer, 2 authors"),
                 JCheckConfiguration.parse(conf).checks().reviewers().getReviewRequirements());
 
         conf = new ArrayList<>(CONFIGURATION);
         conf.add("reviewers = 1");
         conf.add("authors = 3");
-        assertEquals(String.format(hasReview, 4, "1 reviewer, 3 authors"),
+        assertEquals(String.format(hasReviews, 4, "1 reviewer, 3 authors"),
                 JCheckConfiguration.parse(conf).checks().reviewers().getReviewRequirements());
 
         conf = new ArrayList<>(CONFIGURATION);
         conf.add("authors = 4");
-        assertEquals(String.format(hasReview, 4, "4 authors"),
+        assertEquals(String.format(hasReviews, 4, "4 authors"),
                 JCheckConfiguration.parse(conf).checks().reviewers().getReviewRequirements());
 
         // five reviews required.
@@ -645,7 +646,7 @@ class ReviewersCheckTests {
         conf.add("committers = 1");
         conf.add("authors = 1");
         conf.add("contributors = 1");
-        assertEquals(String.format(hasReview, 5, "1 lead, 1 reviewer, 1 committer, 1 author, 1 contributor"),
+        assertEquals(String.format(hasReviews, 5, "1 lead, 1 reviewer, 1 committer, 1 author, 1 contributor"),
                 JCheckConfiguration.parse(conf).checks().reviewers().getReviewRequirements());
 
         conf = new ArrayList<>(CONFIGURATION);
@@ -653,25 +654,25 @@ class ReviewersCheckTests {
         conf.add("committers = 1");
         conf.add("authors = 1");
         conf.add("contributors = 2");
-        assertEquals(String.format(hasReview, 5, "1 reviewer, 1 committer, 1 author, 2 contributors"),
+        assertEquals(String.format(hasReviews, 5, "1 reviewer, 1 committer, 1 author, 2 contributors"),
                 JCheckConfiguration.parse(conf).checks().reviewers().getReviewRequirements());
 
         conf = new ArrayList<>(CONFIGURATION);
         conf.add("reviewers = 1");
         conf.add("committers = 1");
         conf.add("contributors = 3");
-        assertEquals(String.format(hasReview, 5, "1 reviewer, 1 committer, 3 contributors"),
+        assertEquals(String.format(hasReviews, 5, "1 reviewer, 1 committer, 3 contributors"),
                 JCheckConfiguration.parse(conf).checks().reviewers().getReviewRequirements());
 
         conf = new ArrayList<>(CONFIGURATION);
         conf.add("reviewers = 1");
         conf.add("contributors = 4");
-        assertEquals(String.format(hasReview, 5, "1 reviewer, 4 contributors"),
+        assertEquals(String.format(hasReviews, 5, "1 reviewer, 4 contributors"),
                 JCheckConfiguration.parse(conf).checks().reviewers().getReviewRequirements());
 
         conf = new ArrayList<>(CONFIGURATION);
         conf.add("contributors = 5");
-        assertEquals(String.format(hasReview, 5, "5 contributors"),
+        assertEquals(String.format(hasReviews, 5, "5 contributors"),
                 JCheckConfiguration.parse(conf).checks().reviewers().getReviewRequirements());
     }
 }


### PR DESCRIPTION
The new message for listing review requirements in the progress list always adds a plural 's' regardless of the number of reviews required. We should change this so that it's only added when there are 2 or more reviews required.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 reviews required, with at least 1 reviewer)

### Issue
 * [SKARA-1428](https://bugs.openjdk.java.net/browse/SKARA-1428): New reviews message always adds plural 's'


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Guoxiong Li](https://openjdk.java.net/census#gli) (@lgxbslgx - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1317/head:pull/1317` \
`$ git checkout pull/1317`

Update a local copy of the PR: \
`$ git checkout pull/1317` \
`$ git pull https://git.openjdk.java.net/skara pull/1317/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1317`

View PR using the GUI difftool: \
`$ git pr show -t 1317`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1317.diff">https://git.openjdk.java.net/skara/pull/1317.diff</a>

</details>
