### PR TITLE
1437: Fix the OpenJDK official role name and pluralization

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewersCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewersCommand.java
@@ -131,11 +131,11 @@ public class ReviewersCommand implements CommandHandler {
         var updatedLimits = ReviewersTracker.updatedRoleLimits(censusInstance.configuration(), numReviewers, role);
         // The role name of the configuration should be changed to the official role name.
         var formatLimits = new LinkedHashMap<String, Integer>();
-        formatLimits.put("Lead", updatedLimits.get("lead"));
-        formatLimits.put("Reviewer", updatedLimits.get("reviewers"));
-        formatLimits.put("Committer", updatedLimits.get("committers"));
-        formatLimits.put("Author", updatedLimits.get("authors"));
-        formatLimits.put("Contributor", updatedLimits.get("contributors"));
+        formatLimits.put("[Lead%s](%s#project-lead)", updatedLimits.get("lead"));
+        formatLimits.put("[Reviewer%s](%s#reviewer)", updatedLimits.get("reviewers"));
+        formatLimits.put("[Committer%s](%s#committer)", updatedLimits.get("committers"));
+        formatLimits.put("[Author%s](%s#author)", updatedLimits.get("authors"));
+        formatLimits.put("[Contributor%s](%s#contributor)", updatedLimits.get("contributors"));
 
         reply.println(ReviewersTracker.setReviewersMarker(numReviewers, role));
         var totalRequired = formatLimits.values().stream().mapToInt(Integer::intValue).sum();
@@ -145,7 +145,7 @@ public class ReviewersCommand implements CommandHandler {
         // Create a helpful message regarding the required distribution (if applicable)
         var nonZeroDescriptions = formatLimits.entrySet().stream()
                 .filter(entry -> entry.getValue() > 0)
-                .map(entry -> entry.getValue() + " " + entry.getKey() + (entry.getValue() > 1 ? "s" : ""))
+                .map(entry -> entry.getValue() + " " + String.format(entry.getKey(), entry.getValue() > 1 ? "s" : "", "http://openjdk.java.net/bylaws"))
                 .collect(Collectors.toList());
         if (nonZeroDescriptions.size() > 0) {
             reply.print(" (with at least " + String.join(", ", nonZeroDescriptions) + ")");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewersCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewersCommand.java
@@ -30,6 +30,8 @@ import java.nio.file.Path;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static org.openjdk.skara.jcheck.ReviewersConfiguration.BYLAWS_URL;
+
 public class ReviewersCommand implements CommandHandler {
     private static final Map<String, String> roleMappings = Map.of(
             "lead", "lead",
@@ -145,7 +147,7 @@ public class ReviewersCommand implements CommandHandler {
         // Create a helpful message regarding the required distribution (if applicable)
         var nonZeroDescriptions = formatLimits.entrySet().stream()
                 .filter(entry -> entry.getValue() > 0)
-                .map(entry -> entry.getValue() + " " + String.format(entry.getKey(), entry.getValue() > 1 ? "s" : "", "http://openjdk.java.net/bylaws"))
+                .map(entry -> entry.getValue() + " " + String.format(entry.getKey(), entry.getValue() > 1 ? "s" : "", BYLAWS_URL))
                 .collect(Collectors.toList());
         if (nonZeroDescriptions.size() > 0) {
             reply.print(" (with at least " + String.join(", ", nonZeroDescriptions) + ")");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewersCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewersCommand.java
@@ -129,19 +129,26 @@ public class ReviewersCommand implements CommandHandler {
         }
 
         var updatedLimits = ReviewersTracker.updatedRoleLimits(censusInstance.configuration(), numReviewers, role);
+        // The role name of the configuration should be changed to the official role name.
+        var formatLimits = new LinkedHashMap<String, Integer>();
+        formatLimits.put("Lead", updatedLimits.get("lead"));
+        formatLimits.put("Reviewer", updatedLimits.get("reviewers"));
+        formatLimits.put("Committer", updatedLimits.get("committers"));
+        formatLimits.put("Author", updatedLimits.get("authors"));
+        formatLimits.put("Contributor", updatedLimits.get("contributors"));
 
         reply.println(ReviewersTracker.setReviewersMarker(numReviewers, role));
-        var totalRequired = updatedLimits.values().stream().mapToInt(Integer::intValue).sum();
+        var totalRequired = formatLimits.values().stream().mapToInt(Integer::intValue).sum();
         reply.print("The total number of required reviews for this PR (including the jcheck configuration " +
                     "and the last /reviewers command) is now set to " + totalRequired);
 
         // Create a helpful message regarding the required distribution (if applicable)
-        var nonZeroDescriptions = updatedLimits.entrySet().stream()
+        var nonZeroDescriptions = formatLimits.entrySet().stream()
                 .filter(entry -> entry.getValue() > 0)
-                .map(entry -> entry.getValue() + " of role " + entry.getKey())
+                .map(entry -> entry.getValue() + " " + entry.getKey() + (entry.getValue() > 1 ? "s" : ""))
                 .collect(Collectors.toList());
         if (nonZeroDescriptions.size() > 0) {
-            reply.print(" (with " + String.join(", ", nonZeroDescriptions) + ")");
+            reply.print(" (with at least " + String.join(", ", nonZeroDescriptions) + ")");
         }
 
         reply.println(".");

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ReviewersTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ReviewersTests.java
@@ -39,11 +39,11 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.openjdk.skara.bots.pr.PullRequestAsserts.assertLastCommentContains;
 
 public class ReviewersTests {
-    private static final String reviewersCommandFinallyOutput = "The total number of required reviews for this PR " +
-            "(including the jcheck configuration and the last /reviewers command) is now set to ";
+    private static final String REVIEWERS_COMMAND_OUTPUT = "The total number of required reviews for this PR " +
+            "(including the jcheck configuration and the last /reviewers command) is now set to %d (with at least %s).";
 
     private static final String REVIEW_PROGRESS_TEMPLATE = "Change must be properly reviewed (%d review%s required, with at least %s)";
-    private static final String ZERO_REVIEW_PROGRESS = "Change must be properly reviewed (no reviews required)";
+    private static final String ZERO_REVIEW_PROGRESS = "Change must be properly reviewed (no review required)";
 
     @Test
     void simple(TestInfo testInfo) throws IOException {
@@ -78,7 +78,7 @@ public class ReviewersTests {
 
             // The bot should reply with a help message
             assertLastCommentContains(reviewerPr,"is the number of required reviewers");
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 reviewer")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 Reviewer")));
 
             // Invalid syntax
             reviewerPr.addComment("/reviewers two");
@@ -86,49 +86,49 @@ public class ReviewersTests {
 
             // The bot should reply with a help message
             assertLastCommentContains(reviewerPr,"is the number of required reviewers");
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 reviewer")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 Reviewer")));
 
             // Too many
             reviewerPr.addComment("/reviewers 7001");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr,"Cannot increase the required number of reviewers above 10 (requested: 7001)");
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 reviewer")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 Reviewer")));
 
             // Too few
             reviewerPr.addComment("/reviewers -3");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr,"Cannot decrease the required number of reviewers below 0 (requested: -3)");
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 reviewer")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 Reviewer")));
 
             // Unknown role
             reviewerPr.addComment("/reviewers 2 penguins");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr,"Unknown role `penguins` specified");
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 reviewer")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 Reviewer")));
 
             // Set the number
             reviewerPr.addComment("/reviewers 2");
             TestBotRunner.runPeriodicItems(prBot);
 
             // The bot should reply with a success message
-            assertLastCommentContains(reviewerPr, reviewersCommandFinallyOutput + "2 (with 1 of role reviewers, 1 of role authors).");
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "s", "1 reviewer, 1 author")));
+            assertLastCommentContains(reviewerPr, String.format(REVIEWERS_COMMAND_OUTPUT, 2, "1 Reviewer, 1 Author"));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "s", "1 Reviewer, 1 Author")));
 
             // Set 2 of role committers
             reviewerPr.addComment("/reviewers 2 committer");
             TestBotRunner.runPeriodicItems(prBot);
 
             // The bot should reply with a success message
-            assertLastCommentContains(reviewerPr, reviewersCommandFinallyOutput + "2 (with 1 of role reviewers, 1 of role committers).");
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "s", "1 reviewer, 1 committer")));
+            assertLastCommentContains(reviewerPr, String.format(REVIEWERS_COMMAND_OUTPUT, 2, "1 Reviewer, 1 Committer"));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "s", "1 Reviewer, 1 Committer")));
 
             // Set 2 of role reviewers
             reviewerPr.addComment("/reviewers 2 reviewer");
             TestBotRunner.runPeriodicItems(prBot);
 
             // The bot should reply with a success message
-            assertLastCommentContains(reviewerPr, reviewersCommandFinallyOutput + "2 (with 2 of role reviewers).");
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "s", "2 reviewers")));
+            assertLastCommentContains(reviewerPr, String.format(REVIEWERS_COMMAND_OUTPUT, 2, "2 Reviewers"));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "s", "2 Reviewers")));
 
             // Approve it as another user
             reviewerPr.addReview(Review.Verdict.APPROVED, "Approved");
@@ -138,7 +138,7 @@ public class ReviewersTests {
             // The PR should not yet be considered as ready for review
             var updatedPr = author.pullRequest(pr.id());
             assertFalse(updatedPr.labelNames().contains("ready"));
-            assertTrue(updatedPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "s", "2 reviewers")));
+            assertTrue(updatedPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "s", "2 Reviewers")));
 
             // Now reduce the number of required reviewers
             reviewerPr.addComment("/reviewers 1");
@@ -148,14 +148,14 @@ public class ReviewersTests {
             // The PR should now be considered as ready for review
             updatedPr = author.pullRequest(pr.id());
             assertTrue(updatedPr.labelNames().contains("ready"));
-            assertTrue(updatedPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 reviewer")));
+            assertTrue(updatedPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 Reviewer")));
 
             // Now request that the lead reviews
             reviewerPr.addComment("/reviewers 1 lead");
             TestBotRunner.runPeriodicItems(prBot);
             TestBotRunner.runPeriodicItems(prBot);
-            assertLastCommentContains(reviewerPr, reviewersCommandFinallyOutput + "1 (with 1 of role lead).");
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 lead")));
+            assertLastCommentContains(reviewerPr, String.format(REVIEWERS_COMMAND_OUTPUT, 1, "1 Lead"));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 Lead")));
 
             // The PR should no longer be considered as ready for review
             updatedPr = author.pullRequest(pr.id());
@@ -165,8 +165,8 @@ public class ReviewersTests {
             reviewerPr.addComment("/reviewers 1");
             TestBotRunner.runPeriodicItems(prBot);
             TestBotRunner.runPeriodicItems(prBot);
-            assertLastCommentContains(reviewerPr, reviewersCommandFinallyOutput + "1 (with 1 of role reviewers).");
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 reviewer")));
+            assertLastCommentContains(reviewerPr,  String.format(REVIEWERS_COMMAND_OUTPUT, 1, "1 Reviewer"));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 Reviewer")));
 
             // The PR should now be considered as ready for review yet again
             updatedPr = author.pullRequest(pr.id());
@@ -206,8 +206,8 @@ public class ReviewersTests {
             TestBotRunner.runPeriodicItems(prBot);
 
             // The bot should reply with a success message
-            assertLastCommentContains(reviewerPr, reviewersCommandFinallyOutput + "2 (with 1 of role reviewers, 1 of role authors).");
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "s", "1 reviewer, 1 author")));
+            assertLastCommentContains(reviewerPr, String.format(REVIEWERS_COMMAND_OUTPUT, 2, "1 Reviewer, 1 Author"));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "s", "1 Reviewer, 1 Author")));
 
             // Approve it as another user
             reviewerPr.addReview(Review.Verdict.APPROVED, "Approved");
@@ -218,18 +218,18 @@ public class ReviewersTests {
             pr.addComment("/integrate");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr,"pull request has not yet been marked as ready for integration");
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "s", "1 reviewer, 1 author")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "s", "1 Reviewer, 1 Author")));
 
             // Relax the requirement
             reviewerPr.addComment("/reviewers 1");
             TestBotRunner.runPeriodicItems(prBot);
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 reviewer")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 Reviewer")));
 
             // It should now work fine
             pr.addComment("/integrate");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr,"Pushed as commit");
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 reviewer")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 Reviewer")));
         }
     }
 
@@ -264,38 +264,38 @@ public class ReviewersTests {
             reviewerPr.addReview(Review.Verdict.APPROVED, "Approved");
             TestBotRunner.runPeriodicItems(prBot);
             TestBotRunner.runPeriodicItems(prBot);
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 reviewer")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 Reviewer")));
 
             // Flag it as ready for integration
             pr.addComment("/integrate");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr,"now ready to be sponsored");
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 reviewer")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 Reviewer")));
 
             // Set the number
             reviewerPr.addComment("/reviewers 2");
             TestBotRunner.runPeriodicItems(prBot);
 
             // The bot should reply with a success message
-            assertLastCommentContains(reviewerPr, reviewersCommandFinallyOutput + "2 (with 1 of role reviewers, 1 of role authors).");
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "s", "1 reviewer, 1 author")));
+            assertLastCommentContains(reviewerPr, String.format(REVIEWERS_COMMAND_OUTPUT, 2, "1 Reviewer, 1 Author"));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "s", "1 Reviewer, 1 Author")));
 
             // It should not be possible to sponsor
             reviewerPr.addComment("/sponsor");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr,"PR has not yet been marked as ready for integration");
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "s", "1 reviewer, 1 author")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "s", "1 Reviewer, 1 Author")));
 
             // Relax the requirement
             reviewerPr.addComment("/reviewers 1");
             TestBotRunner.runPeriodicItems(prBot);
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 reviewer")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 Reviewer")));
 
             // It should now work fine
             reviewerPr.addComment("/sponsor");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr,"Pushed as commit");
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 reviewer")));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 Reviewer")));
         }
     }
 
@@ -329,8 +329,8 @@ public class ReviewersTests {
 
             // The bot should reply with a success message
             TestBotRunner.runPeriodicItems(prBot);
-            assertLastCommentContains(authorPR, reviewersCommandFinallyOutput + "2 (with 1 of role reviewers, 1 of role authors).");
-            assertTrue(authorPR.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "s", "1 reviewer, 1 author")));
+            assertLastCommentContains(authorPR, String.format(REVIEWERS_COMMAND_OUTPUT, 2, "1 Reviewer, 1 Author"));
+            assertTrue(authorPR.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "s", "1 Reviewer, 1 Author")));
         }
     }
 
@@ -366,20 +366,20 @@ public class ReviewersTests {
 
             // The bot should reply with a success message
             TestBotRunner.runPeriodicItems(prBot);
-            assertLastCommentContains(authorPR, reviewersCommandFinallyOutput + "2 (with 1 of role reviewers, 1 of role authors).");
-            assertTrue(authorPR.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "s", "1 reviewer, 1 author")));
+            assertLastCommentContains(authorPR, String.format(REVIEWERS_COMMAND_OUTPUT, 2, "1 Reviewer, 1 Author"));
+            assertTrue(authorPR.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "s", "1 Reviewer, 1 Author")));
             // The author should not be allowed to decrease even its own /reviewers command
             authorPR.addComment("/reviewers 1");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(authorPR, "Cannot decrease the number of required reviewers");
-            assertTrue(authorPR.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "s", "1 reviewer, 1 author")));
+            assertTrue(authorPR.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "s", "1 Reviewer, 1 Author")));
 
             // Reviewer should be allowed to decrease
             var reviewerPr = integrator.pullRequest(pr.id());
             reviewerPr.addComment("/reviewers 1");
             TestBotRunner.runPeriodicItems(prBot);
-            assertLastCommentContains(reviewerPr, reviewersCommandFinallyOutput + "1 (with 1 of role reviewers).");
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 reviewer")));
+            assertLastCommentContains(reviewerPr, String.format(REVIEWERS_COMMAND_OUTPUT, 1, "1 Reviewer"));
+            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 Reviewer")));
         }
     }
 
@@ -409,8 +409,8 @@ public class ReviewersTests {
             TestBotRunner.runPeriodicItems(prBot);
 
             var authorPR = author.pullRequest(pr.id());
-            assertLastCommentContains(authorPR, reviewersCommandFinallyOutput + "2 (with 1 of role reviewers, 1 of role authors).");
-            assertTrue(authorPR.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "s", "1 reviewer, 1 author")));
+            assertLastCommentContains(authorPR, String.format(REVIEWERS_COMMAND_OUTPUT, 2, "1 Reviewer, 1 Author"));
+            assertTrue(authorPR.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "s", "1 Reviewer, 1 Author")));
         }
     }
 
@@ -515,39 +515,29 @@ public class ReviewersTests {
     }
 
     private String getReviewersExpectedComment(int totalNum, int leadNum, int reviewerNum, int committerNum, int authorNum, int contributorNum) {
-        StringBuilder builder = new StringBuilder();
-        builder.append(reviewersCommandFinallyOutput);
-        builder.append(totalNum);
-        if (leadNum == 0 && reviewerNum == 0 && committerNum == 0 && authorNum == 0 && contributorNum == 0) {
-            builder.append(".");
-            return builder.toString();
-        }
-        builder.append(" (with");
         var list = new ArrayList<String>();
         var map = new LinkedHashMap<String, Integer>();
-        map.put("lead", leadNum);
-        map.put("reviewers", reviewerNum);
-        map.put("committers", committerNum);
-        map.put("authors", authorNum);
-        map.put("contributors", contributorNum);
+        map.put("Lead", leadNum);
+        map.put("Reviewer", reviewerNum);
+        map.put("Committer", committerNum);
+        map.put("Author", authorNum);
+        map.put("Contributor", contributorNum);
         for (var entry : map.entrySet()) {
             if (entry.getValue() > 0) {
-                list.add(" " + entry.getValue() + " of role " + entry.getKey());
+                list.add(entry.getValue() + " " + entry.getKey() + (entry.getValue() > 1 ? "s" : ""));
             }
         }
-        builder.append(String.join(",", list));
-        builder.append(").");
-        return builder.toString();
+        return String.format(REVIEWERS_COMMAND_OUTPUT, totalNum, String.join(", ", list));
     }
 
     private String getReviewersExpectedProgress(int totalNum, int leadNum, int reviewerNum, int committerNum, int authorNum, int contributorNum) {
         var requireList = new ArrayList<String>();
         var reviewRequirementMap = new LinkedHashMap<String, Integer>();
-        reviewRequirementMap.put("lead", leadNum);
-        reviewRequirementMap.put("reviewer", reviewerNum);
-        reviewRequirementMap.put("committer", committerNum);
-        reviewRequirementMap.put("author", authorNum);
-        reviewRequirementMap.put("contributor", contributorNum);
+        reviewRequirementMap.put("Lead", leadNum);
+        reviewRequirementMap.put("Reviewer", reviewerNum);
+        reviewRequirementMap.put("Committer", committerNum);
+        reviewRequirementMap.put("Author", authorNum);
+        reviewRequirementMap.put("Contributor", contributorNum);
         for (var reviewRequirement : reviewRequirementMap.entrySet()) {
             var requirementNum = reviewRequirement.getValue();
             if (requirementNum > 0) {
@@ -608,7 +598,7 @@ public class ReviewersTests {
 
             authorPR.addComment("/reviewers 2 reviewer");
             TestBotRunner.runPeriodicItems(prBot);
-            assertTrue(authorPR.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "s", "2 reviewers")));
+            assertTrue(authorPR.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "s", "2 Reviewers")));
 
             reviewerPr.addComment("/reviewers 0");
             TestBotRunner.runPeriodicItems(prBot);

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ReviewersTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ReviewersTests.java
@@ -39,8 +39,10 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.openjdk.skara.bots.pr.PullRequestAsserts.assertLastCommentContains;
 
 public class ReviewersTests {
-    private static final String REVIEWERS_COMMAND_OUTPUT = "The total number of required reviews for this PR " +
+    private static final String REVIEWERS_COMMENT_TEMPLATE = "The total number of required reviews for this PR " +
             "(including the jcheck configuration and the last /reviewers command) is now set to %d (with at least %s).";
+    private static final String ZERO_REVIEWER_COMMENT = "The total number of required reviews for this PR " +
+            "(including the jcheck configuration and the last /reviewers command) is now set to 0.";
 
     private static final String REVIEW_PROGRESS_TEMPLATE = "Change must be properly reviewed (%d review%s required, with at least %s)";
     private static final String ZERO_REVIEW_PROGRESS = "Change must be properly reviewed (no review required)";
@@ -78,7 +80,7 @@ public class ReviewersTests {
 
             // The bot should reply with a help message
             assertLastCommentContains(reviewerPr,"is the number of required reviewers");
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 Reviewer")));
+            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 1, 0, 0, 0)));
 
             // Invalid syntax
             reviewerPr.addComment("/reviewers two");
@@ -86,49 +88,49 @@ public class ReviewersTests {
 
             // The bot should reply with a help message
             assertLastCommentContains(reviewerPr,"is the number of required reviewers");
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 Reviewer")));
+            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 1, 0, 0, 0)));
 
             // Too many
             reviewerPr.addComment("/reviewers 7001");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr,"Cannot increase the required number of reviewers above 10 (requested: 7001)");
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 Reviewer")));
+            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 1, 0, 0, 0)));
 
             // Too few
             reviewerPr.addComment("/reviewers -3");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr,"Cannot decrease the required number of reviewers below 0 (requested: -3)");
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 Reviewer")));
+            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 1, 0, 0, 0)));
 
             // Unknown role
             reviewerPr.addComment("/reviewers 2 penguins");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr,"Unknown role `penguins` specified");
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 Reviewer")));
+            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 1, 0, 0, 0)));
 
             // Set the number
             reviewerPr.addComment("/reviewers 2");
             TestBotRunner.runPeriodicItems(prBot);
 
             // The bot should reply with a success message
-            assertLastCommentContains(reviewerPr, String.format(REVIEWERS_COMMAND_OUTPUT, 2, "1 Reviewer, 1 Author"));
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "s", "1 Reviewer, 1 Author")));
+            assertLastCommentContains(reviewerPr, getReviewersExpectedComment(0, 1, 0, 1, 0));
+            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 1, 0, 1, 0)));
 
             // Set 2 of role committers
             reviewerPr.addComment("/reviewers 2 committer");
             TestBotRunner.runPeriodicItems(prBot);
 
             // The bot should reply with a success message
-            assertLastCommentContains(reviewerPr, String.format(REVIEWERS_COMMAND_OUTPUT, 2, "1 Reviewer, 1 Committer"));
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "s", "1 Reviewer, 1 Committer")));
+            assertLastCommentContains(reviewerPr, getReviewersExpectedComment(0, 1, 1, 0, 0));
+            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 1, 1, 0, 0)));
 
             // Set 2 of role reviewers
             reviewerPr.addComment("/reviewers 2 reviewer");
             TestBotRunner.runPeriodicItems(prBot);
 
             // The bot should reply with a success message
-            assertLastCommentContains(reviewerPr, String.format(REVIEWERS_COMMAND_OUTPUT, 2, "2 Reviewers"));
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "s", "2 Reviewers")));
+            assertLastCommentContains(reviewerPr, getReviewersExpectedComment(0, 2, 0, 0, 0));
+            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 2, 0, 0, 0)));
 
             // Approve it as another user
             reviewerPr.addReview(Review.Verdict.APPROVED, "Approved");
@@ -138,7 +140,7 @@ public class ReviewersTests {
             // The PR should not yet be considered as ready for review
             var updatedPr = author.pullRequest(pr.id());
             assertFalse(updatedPr.labelNames().contains("ready"));
-            assertTrue(updatedPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "s", "2 Reviewers")));
+            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 2, 0, 0, 0)));
 
             // Now reduce the number of required reviewers
             reviewerPr.addComment("/reviewers 1");
@@ -148,14 +150,14 @@ public class ReviewersTests {
             // The PR should now be considered as ready for review
             updatedPr = author.pullRequest(pr.id());
             assertTrue(updatedPr.labelNames().contains("ready"));
-            assertTrue(updatedPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 Reviewer")));
+            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 1, 0, 0, 0)));
 
             // Now request that the lead reviews
             reviewerPr.addComment("/reviewers 1 lead");
             TestBotRunner.runPeriodicItems(prBot);
             TestBotRunner.runPeriodicItems(prBot);
-            assertLastCommentContains(reviewerPr, String.format(REVIEWERS_COMMAND_OUTPUT, 1, "1 Lead"));
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 Lead")));
+            assertLastCommentContains(reviewerPr, getReviewersExpectedComment(1, 0, 0, 0, 0));
+            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(1, 0, 0, 0, 0)));
 
             // The PR should no longer be considered as ready for review
             updatedPr = author.pullRequest(pr.id());
@@ -165,8 +167,8 @@ public class ReviewersTests {
             reviewerPr.addComment("/reviewers 1");
             TestBotRunner.runPeriodicItems(prBot);
             TestBotRunner.runPeriodicItems(prBot);
-            assertLastCommentContains(reviewerPr,  String.format(REVIEWERS_COMMAND_OUTPUT, 1, "1 Reviewer"));
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 Reviewer")));
+            assertLastCommentContains(reviewerPr, getReviewersExpectedComment(0, 1, 0, 0, 0));
+            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 1, 0, 0, 0)));
 
             // The PR should now be considered as ready for review yet again
             updatedPr = author.pullRequest(pr.id());
@@ -206,8 +208,8 @@ public class ReviewersTests {
             TestBotRunner.runPeriodicItems(prBot);
 
             // The bot should reply with a success message
-            assertLastCommentContains(reviewerPr, String.format(REVIEWERS_COMMAND_OUTPUT, 2, "1 Reviewer, 1 Author"));
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "s", "1 Reviewer, 1 Author")));
+            assertLastCommentContains(reviewerPr, getReviewersExpectedComment(0, 1, 0, 1, 0));
+            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 1, 0, 1, 0)));
 
             // Approve it as another user
             reviewerPr.addReview(Review.Verdict.APPROVED, "Approved");
@@ -218,18 +220,18 @@ public class ReviewersTests {
             pr.addComment("/integrate");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr,"pull request has not yet been marked as ready for integration");
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "s", "1 Reviewer, 1 Author")));
+            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 1, 0, 1, 0)));
 
             // Relax the requirement
             reviewerPr.addComment("/reviewers 1");
             TestBotRunner.runPeriodicItems(prBot);
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 Reviewer")));
+            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 1, 0, 0, 0)));
 
             // It should now work fine
             pr.addComment("/integrate");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr,"Pushed as commit");
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 Reviewer")));
+            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 1, 0, 0, 0)));
         }
     }
 
@@ -264,38 +266,38 @@ public class ReviewersTests {
             reviewerPr.addReview(Review.Verdict.APPROVED, "Approved");
             TestBotRunner.runPeriodicItems(prBot);
             TestBotRunner.runPeriodicItems(prBot);
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 Reviewer")));
+            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 1, 0, 0, 0)));
 
             // Flag it as ready for integration
             pr.addComment("/integrate");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr,"now ready to be sponsored");
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 Reviewer")));
+            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 1, 0, 0, 0)));
 
             // Set the number
             reviewerPr.addComment("/reviewers 2");
             TestBotRunner.runPeriodicItems(prBot);
 
             // The bot should reply with a success message
-            assertLastCommentContains(reviewerPr, String.format(REVIEWERS_COMMAND_OUTPUT, 2, "1 Reviewer, 1 Author"));
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "s", "1 Reviewer, 1 Author")));
+            assertLastCommentContains(reviewerPr, getReviewersExpectedComment(0, 1, 0, 1, 0));
+            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 1, 0, 1, 0)));
 
             // It should not be possible to sponsor
             reviewerPr.addComment("/sponsor");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr,"PR has not yet been marked as ready for integration");
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "s", "1 Reviewer, 1 Author")));
+            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 1, 0, 1, 0)));
 
             // Relax the requirement
             reviewerPr.addComment("/reviewers 1");
             TestBotRunner.runPeriodicItems(prBot);
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 Reviewer")));
+            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 1, 0, 0, 0)));
 
             // It should now work fine
             reviewerPr.addComment("/sponsor");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr,"Pushed as commit");
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 Reviewer")));
+            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 1, 0, 0, 0)));
         }
     }
 
@@ -329,8 +331,8 @@ public class ReviewersTests {
 
             // The bot should reply with a success message
             TestBotRunner.runPeriodicItems(prBot);
-            assertLastCommentContains(authorPR, String.format(REVIEWERS_COMMAND_OUTPUT, 2, "1 Reviewer, 1 Author"));
-            assertTrue(authorPR.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "s", "1 Reviewer, 1 Author")));
+            assertLastCommentContains(authorPR, getReviewersExpectedComment(0, 1, 0, 1, 0));
+            assertTrue(authorPR.body().contains(getReviewersExpectedProgress(0, 1, 0, 1, 0)));
         }
     }
 
@@ -366,20 +368,20 @@ public class ReviewersTests {
 
             // The bot should reply with a success message
             TestBotRunner.runPeriodicItems(prBot);
-            assertLastCommentContains(authorPR, String.format(REVIEWERS_COMMAND_OUTPUT, 2, "1 Reviewer, 1 Author"));
-            assertTrue(authorPR.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "s", "1 Reviewer, 1 Author")));
+            assertLastCommentContains(authorPR, getReviewersExpectedComment(0, 1, 0, 1, 0));
+            assertTrue(authorPR.body().contains(getReviewersExpectedProgress(0, 1, 0, 1, 0)));
             // The author should not be allowed to decrease even its own /reviewers command
             authorPR.addComment("/reviewers 1");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(authorPR, "Cannot decrease the number of required reviewers");
-            assertTrue(authorPR.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "s", "1 Reviewer, 1 Author")));
+            assertTrue(authorPR.body().contains(getReviewersExpectedProgress(0, 1, 0, 1, 0)));
 
             // Reviewer should be allowed to decrease
             var reviewerPr = integrator.pullRequest(pr.id());
             reviewerPr.addComment("/reviewers 1");
             TestBotRunner.runPeriodicItems(prBot);
-            assertLastCommentContains(reviewerPr, String.format(REVIEWERS_COMMAND_OUTPUT, 1, "1 Reviewer"));
-            assertTrue(reviewerPr.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 1, "", "1 Reviewer")));
+            assertLastCommentContains(reviewerPr, getReviewersExpectedComment(0, 1, 0, 0, 0));
+            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 1, 0, 0, 0)));
         }
     }
 
@@ -409,8 +411,8 @@ public class ReviewersTests {
             TestBotRunner.runPeriodicItems(prBot);
 
             var authorPR = author.pullRequest(pr.id());
-            assertLastCommentContains(authorPR, String.format(REVIEWERS_COMMAND_OUTPUT, 2, "1 Reviewer, 1 Author"));
-            assertTrue(authorPR.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "s", "1 Reviewer, 1 Author")));
+            assertLastCommentContains(authorPR, getReviewersExpectedComment(0, 1, 0, 1, 0));
+            assertTrue(authorPR.body().contains(getReviewersExpectedProgress(0, 1, 0, 1, 0)));
         }
     }
 
@@ -459,51 +461,46 @@ public class ReviewersTests {
 
             // test role contributor
             for (int i = 1; i <= 10; i++) {
-                var totalNum = Math.max(i, 5);
                 var contributorNum = (i < 6) ? 1 : i - 4;
                 verifyReviewersCommentAndProgress(reviewerPr, prBot, "/reviewers " + i + " contributor",
-                        getReviewersExpectedComment(totalNum, 1, 1, 1, 1, contributorNum),
-                        getReviewersExpectedProgress(totalNum, 1, 1, 1, 1, contributorNum));
+                        getReviewersExpectedComment(1, 1, 1, 1, contributorNum),
+                        getReviewersExpectedProgress(1, 1, 1, 1, contributorNum));
             }
 
             // test role author
             for (int i = 1; i <= 10; i++) {
-                var totalNum = Math.max(i, 5);
                 var contributorNum = (i < 5) ? 1 : 0;
                 var authorNum = (i < 5) ? 1 : i - 3;
                 verifyReviewersCommentAndProgress(reviewerPr, prBot, "/reviewers " + i + " author",
-                        getReviewersExpectedComment(totalNum, 1, 1, 1, authorNum, contributorNum),
-                        getReviewersExpectedProgress(totalNum, 1, 1, 1, authorNum, contributorNum));
+                        getReviewersExpectedComment(1, 1, 1, authorNum, contributorNum),
+                        getReviewersExpectedProgress(1, 1, 1, authorNum, contributorNum));
             }
 
             // test role committer
             for (int i = 1; i <= 10; i++) {
-                var totalNum = Math.max(i, 5);
                 var contributorNum = (i < 4) ? 1 : 0;
                 var authorNum = (i < 5) ? 1 : 0;
                 var committerNum = (i < 4) ? 1 : i - 2;
                 verifyReviewersCommentAndProgress(reviewerPr, prBot, "/reviewers " + i + " committer",
-                        getReviewersExpectedComment(totalNum, 1, 1, committerNum, authorNum, contributorNum),
-                        getReviewersExpectedProgress(totalNum, 1, 1, committerNum, authorNum, contributorNum));
+                        getReviewersExpectedComment(1, 1, committerNum, authorNum, contributorNum),
+                        getReviewersExpectedProgress(1, 1, committerNum, authorNum, contributorNum));
             }
 
             // test role reviewer
             for (int i = 1; i <= 10; i++) {
-                var totalNum = Math.max(i, 5);
                 var contributorNum = (i < 3) ? 1 : 0;
                 var authorNum = (i < 4) ? 1 : 0;
                 var committerNum = (i < 5) ? 1 : 0;
                 var reviewerNum = (i < 3) ? 1 : i - 1;
                 verifyReviewersCommentAndProgress(reviewerPr, prBot, "/reviewers " + i + " reviewer",
-                        getReviewersExpectedComment(totalNum, 1, reviewerNum, committerNum, authorNum, contributorNum),
-                        getReviewersExpectedProgress(totalNum, 1, reviewerNum, committerNum, authorNum, contributorNum));
-
+                        getReviewersExpectedComment(1, reviewerNum, committerNum, authorNum, contributorNum),
+                        getReviewersExpectedProgress(1, reviewerNum, committerNum, authorNum, contributorNum));
             }
 
             // test role lead
             verifyReviewersCommentAndProgress(reviewerPr, prBot, "/reviewers 1 lead",
-                    getReviewersExpectedComment(5, 1, 1, 1, 1, 1),
-                    getReviewersExpectedProgress(5, 1, 1, 1, 1, 1));
+                    getReviewersExpectedComment(1, 1, 1, 1, 1),
+                    getReviewersExpectedProgress(1, 1, 1, 1, 1));
         }
     }
 
@@ -514,40 +511,36 @@ public class ReviewersTests {
         assertTrue(reviewerPr.body().contains(expectedProgress));
     }
 
-    private String getReviewersExpectedComment(int totalNum, int leadNum, int reviewerNum, int committerNum, int authorNum, int contributorNum) {
-        var list = new ArrayList<String>();
-        var map = new LinkedHashMap<String, Integer>();
-        map.put("Lead", leadNum);
-        map.put("Reviewer", reviewerNum);
-        map.put("Committer", committerNum);
-        map.put("Author", authorNum);
-        map.put("Contributor", contributorNum);
-        for (var entry : map.entrySet()) {
-            if (entry.getValue() > 0) {
-                list.add(entry.getValue() + " " + entry.getKey() + (entry.getValue() > 1 ? "s" : ""));
-            }
-        }
-        return String.format(REVIEWERS_COMMAND_OUTPUT, totalNum, String.join(", ", list));
+    private String getReviewersExpectedComment(int leadNum, int reviewerNum, int committerNum, int authorNum, int contributorNum) {
+        return constructFromTemplate(REVIEWERS_COMMENT_TEMPLATE, ZERO_REVIEWER_COMMENT, leadNum, reviewerNum, committerNum, authorNum, contributorNum);
     }
 
-    private String getReviewersExpectedProgress(int totalNum, int leadNum, int reviewerNum, int committerNum, int authorNum, int contributorNum) {
+    private String getReviewersExpectedProgress(int leadNum, int reviewerNum, int committerNum, int authorNum, int contributorNum) {
+        return constructFromTemplate(REVIEW_PROGRESS_TEMPLATE, ZERO_REVIEW_PROGRESS, leadNum, reviewerNum, committerNum, authorNum, contributorNum);
+    }
+
+    private String constructFromTemplate(String template, String zeroTemplate, int leadNum, int reviewerNum, int committerNum, int authorNum, int contributorNum) {
+        var totalNum = leadNum + reviewerNum + committerNum + authorNum + contributorNum;
+        if (totalNum == 0) {
+            return zeroTemplate;
+        }
         var requireList = new ArrayList<String>();
         var reviewRequirementMap = new LinkedHashMap<String, Integer>();
-        reviewRequirementMap.put("Lead", leadNum);
-        reviewRequirementMap.put("Reviewer", reviewerNum);
-        reviewRequirementMap.put("Committer", committerNum);
-        reviewRequirementMap.put("Author", authorNum);
-        reviewRequirementMap.put("Contributor", contributorNum);
+        reviewRequirementMap.put("[Lead%s](%s#project-lead)", leadNum);
+        reviewRequirementMap.put("[Reviewer%s](%s#reviewer)", reviewerNum);
+        reviewRequirementMap.put("[Committer%s](%s#committer)", committerNum);
+        reviewRequirementMap.put("[Author%s](%s#author)", authorNum);
+        reviewRequirementMap.put("[Contributor%s](%s#contributor)", contributorNum);
         for (var reviewRequirement : reviewRequirementMap.entrySet()) {
             var requirementNum = reviewRequirement.getValue();
             if (requirementNum > 0) {
-                requireList.add(requirementNum+ " " + reviewRequirement.getKey() + (requirementNum > 1 ? "s" : ""));
+                requireList.add(requirementNum + " " + String.format(reviewRequirement.getKey(), requirementNum > 1 ? "s" : "", "http://openjdk.java.net/bylaws"));
             }
         }
-        if (totalNum == 0) {
-            return ZERO_REVIEW_PROGRESS;
+        if (template.equals(REVIEW_PROGRESS_TEMPLATE)) {
+            return String.format(template, totalNum, totalNum > 1 ? "s" : "", String.join(", ", requireList));
         } else {
-            return String.format(REVIEW_PROGRESS_TEMPLATE, totalNum, totalNum > 1 ? "s" : "", String.join(", ", requireList));
+            return String.format(template, totalNum, String.join(", ", requireList));
         }
     }
 
@@ -594,15 +587,15 @@ public class ReviewersTests {
 
             TestBotRunner.runPeriodicItems(prBot);
             var authorPR = author.pullRequest(pr.id());
-            assertTrue(authorPR.body().contains(ZERO_REVIEW_PROGRESS));
+            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 0, 0, 0, 0)));
 
             authorPR.addComment("/reviewers 2 reviewer");
             TestBotRunner.runPeriodicItems(prBot);
-            assertTrue(authorPR.body().contains(String.format(REVIEW_PROGRESS_TEMPLATE, 2, "s", "2 Reviewers")));
+            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 2, 0, 0, 0)));
 
             reviewerPr.addComment("/reviewers 0");
             TestBotRunner.runPeriodicItems(prBot);
-            assertTrue(reviewerPr.body().contains(ZERO_REVIEW_PROGRESS));
+            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 0, 0, 0, 0)));
         }
     }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ReviewersTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ReviewersTests.java
@@ -37,6 +37,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.openjdk.skara.bots.pr.PullRequestAsserts.assertLastCommentContains;
+import static org.openjdk.skara.jcheck.ReviewersConfiguration.BYLAWS_URL;
 
 public class ReviewersTests {
     private static final String REVIEWERS_COMMENT_TEMPLATE = "The total number of required reviews for this PR " +
@@ -534,7 +535,7 @@ public class ReviewersTests {
         for (var reviewRequirement : reviewRequirementMap.entrySet()) {
             var requirementNum = reviewRequirement.getValue();
             if (requirementNum > 0) {
-                requireList.add(requirementNum + " " + String.format(reviewRequirement.getKey(), requirementNum > 1 ? "s" : "", "http://openjdk.java.net/bylaws"));
+                requireList.add(requirementNum + " " + String.format(reviewRequirement.getKey(), requirementNum > 1 ? "s" : "", BYLAWS_URL));
             }
         }
         if (template.equals(REVIEW_PROGRESS_TEMPLATE)) {

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/ReviewersConfiguration.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/ReviewersConfiguration.java
@@ -30,6 +30,7 @@ import java.util.List;
 
 public class ReviewersConfiguration {
     static final ReviewersConfiguration DEFAULT = new ReviewersConfiguration(0, 1, 0, 0, 0, List.of("duke"), false);
+    public static final String BYLAWS_URL = "https://openjdk.java.net/bylaws";
 
     private final int lead;
     private final int reviewers;
@@ -94,7 +95,7 @@ public class ReviewersConfiguration {
             var requirementNum = reviewRequirement.getValue();
             if (requirementNum > 0) {
                 sum += requirementNum;
-                requireList.add(requirementNum + " " + String.format(reviewRequirement.getKey(), requirementNum > 1 ? "s" : "", "http://openjdk.java.net/bylaws"));
+                requireList.add(requirementNum + " " + String.format(reviewRequirement.getKey(), requirementNum > 1 ? "s" : "", BYLAWS_URL));
             }
         }
         if (sum == 0) {

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/ReviewersConfiguration.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/ReviewersConfiguration.java
@@ -85,16 +85,16 @@ public class ReviewersConfiguration {
         var reviewRequirementMap = new LinkedHashMap<String, Integer>();
         var requireList = new ArrayList<String>();
         var sum = 0;
-        reviewRequirementMap.put("Lead", lead);
-        reviewRequirementMap.put("Reviewer", reviewers);
-        reviewRequirementMap.put("Committer", committers);
-        reviewRequirementMap.put("Author", authors);
-        reviewRequirementMap.put("Contributor", contributors);
+        reviewRequirementMap.put("[Lead%s](%s#project-lead)", lead);
+        reviewRequirementMap.put("[Reviewer%s](%s#reviewer)", reviewers);
+        reviewRequirementMap.put("[Committer%s](%s#committer)", committers);
+        reviewRequirementMap.put("[Author%s](%s#author)", authors);
+        reviewRequirementMap.put("[Contributor%s](%s#contributor)", contributors);
         for (var reviewRequirement : reviewRequirementMap.entrySet()) {
             var requirementNum = reviewRequirement.getValue();
             if (requirementNum > 0) {
                 sum += requirementNum;
-                requireList.add(requirementNum + " " + reviewRequirement.getKey() + (requirementNum > 1 ? "s" : ""));
+                requireList.add(requirementNum + " " + String.format(reviewRequirement.getKey(), requirementNum > 1 ? "s" : "", "http://openjdk.java.net/bylaws"));
             }
         }
         if (sum == 0) {

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/ReviewersConfiguration.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/ReviewersConfiguration.java
@@ -85,11 +85,11 @@ public class ReviewersConfiguration {
         var reviewRequirementMap = new LinkedHashMap<String, Integer>();
         var requireList = new ArrayList<String>();
         var sum = 0;
-        reviewRequirementMap.put("lead", lead);
-        reviewRequirementMap.put("reviewer", reviewers);
-        reviewRequirementMap.put("committer", committers);
-        reviewRequirementMap.put("author", authors);
-        reviewRequirementMap.put("contributor", contributors);
+        reviewRequirementMap.put("Lead", lead);
+        reviewRequirementMap.put("Reviewer", reviewers);
+        reviewRequirementMap.put("Committer", committers);
+        reviewRequirementMap.put("Author", authors);
+        reviewRequirementMap.put("Contributor", contributors);
         for (var reviewRequirement : reviewRequirementMap.entrySet()) {
             var requirementNum = reviewRequirement.getValue();
             if (requirementNum > 0) {
@@ -98,7 +98,7 @@ public class ReviewersConfiguration {
             }
         }
         if (sum == 0) {
-            reviewRequirements = "no reviews required";
+            reviewRequirements = "no review required";
         } else {
             reviewRequirements = String.format("%d review%s required, with at least %s",
                     sum, sum > 1 ? "s" : "", String.join(", ", requireList));

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/ReviewersCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/ReviewersCheckTests.java
@@ -561,7 +561,7 @@ class ReviewersCheckTests {
     @Test
     void testReviewRequirements() throws IOException {
         // no review required.
-        var noReview = "no reviews required";
+        var noReview = "no review required";
         var conf = new ArrayList<>(CONFIGURATION);
         conf.add("reviewers = 0");
         assertEquals(noReview, JCheckConfiguration.parse(conf).checks().reviewers().getReviewRequirements());
@@ -573,24 +573,24 @@ class ReviewersCheckTests {
         // one review required.
         conf = new ArrayList<>(CONFIGURATION);
         conf.add("reviewers = 1");
-        assertEquals(String.format(hasReview, 1, "1 reviewer"),
+        assertEquals(String.format(hasReview, 1, "1 Reviewer"),
                 JCheckConfiguration.parse(conf).checks().reviewers().getReviewRequirements());
 
         conf = new ArrayList<>(CONFIGURATION);
         conf.add("committers = 1");
-        assertEquals(String.format(hasReview, 1, "1 committer"),
+        assertEquals(String.format(hasReview, 1, "1 Committer"),
                 JCheckConfiguration.parse(conf).checks().reviewers().getReviewRequirements());
 
         // two reviews required.
         conf = new ArrayList<>(CONFIGURATION);
         conf.add("reviewers = 1");
         conf.add("committers = 1");
-        assertEquals(String.format(hasReviews, 2, "1 reviewer, 1 committer"),
+        assertEquals(String.format(hasReviews, 2, "1 Reviewer, 1 Committer"),
                 JCheckConfiguration.parse(conf).checks().reviewers().getReviewRequirements());
 
         conf = new ArrayList<>(CONFIGURATION);
         conf.add("reviewers = 2");
-        assertEquals(String.format(hasReviews, 2, "2 reviewers"),
+        assertEquals(String.format(hasReviews, 2, "2 Reviewers"),
                 JCheckConfiguration.parse(conf).checks().reviewers().getReviewRequirements());
 
         // three reviews required.
@@ -598,18 +598,18 @@ class ReviewersCheckTests {
         conf.add("reviewers = 1");
         conf.add("committers = 1");
         conf.add("authors = 1");
-        assertEquals(String.format(hasReviews, 3, "1 reviewer, 1 committer, 1 author"),
+        assertEquals(String.format(hasReviews, 3, "1 Reviewer, 1 Committer, 1 Author"),
                 JCheckConfiguration.parse(conf).checks().reviewers().getReviewRequirements());
 
         conf = new ArrayList<>(CONFIGURATION);
         conf.add("reviewers = 1");
         conf.add("committers = 2");
-        assertEquals(String.format(hasReviews, 3, "1 reviewer, 2 committers"),
+        assertEquals(String.format(hasReviews, 3, "1 Reviewer, 2 Committers"),
                 JCheckConfiguration.parse(conf).checks().reviewers().getReviewRequirements());
 
         conf = new ArrayList<>(CONFIGURATION);
         conf.add("committers = 3");
-        assertEquals(String.format(hasReviews, 3, "3 committers"),
+        assertEquals(String.format(hasReviews, 3, "3 Committers"),
                 JCheckConfiguration.parse(conf).checks().reviewers().getReviewRequirements());
 
         // four reviews required.
@@ -618,25 +618,25 @@ class ReviewersCheckTests {
         conf.add("committers = 1");
         conf.add("authors = 1");
         conf.add("contributors = 1");
-        assertEquals(String.format(hasReviews, 4, "1 reviewer, 1 committer, 1 author, 1 contributor"),
+        assertEquals(String.format(hasReviews, 4, "1 Reviewer, 1 Committer, 1 Author, 1 Contributor"),
                 JCheckConfiguration.parse(conf).checks().reviewers().getReviewRequirements());
 
         conf = new ArrayList<>(CONFIGURATION);
         conf.add("reviewers = 1");
         conf.add("committers = 1");
         conf.add("authors = 2");
-        assertEquals(String.format(hasReviews, 4, "1 reviewer, 1 committer, 2 authors"),
+        assertEquals(String.format(hasReviews, 4, "1 Reviewer, 1 Committer, 2 Authors"),
                 JCheckConfiguration.parse(conf).checks().reviewers().getReviewRequirements());
 
         conf = new ArrayList<>(CONFIGURATION);
         conf.add("reviewers = 1");
         conf.add("authors = 3");
-        assertEquals(String.format(hasReviews, 4, "1 reviewer, 3 authors"),
+        assertEquals(String.format(hasReviews, 4, "1 Reviewer, 3 Authors"),
                 JCheckConfiguration.parse(conf).checks().reviewers().getReviewRequirements());
 
         conf = new ArrayList<>(CONFIGURATION);
         conf.add("authors = 4");
-        assertEquals(String.format(hasReviews, 4, "4 authors"),
+        assertEquals(String.format(hasReviews, 4, "4 Authors"),
                 JCheckConfiguration.parse(conf).checks().reviewers().getReviewRequirements());
 
         // five reviews required.
@@ -646,7 +646,7 @@ class ReviewersCheckTests {
         conf.add("committers = 1");
         conf.add("authors = 1");
         conf.add("contributors = 1");
-        assertEquals(String.format(hasReviews, 5, "1 lead, 1 reviewer, 1 committer, 1 author, 1 contributor"),
+        assertEquals(String.format(hasReviews, 5, "1 Lead, 1 Reviewer, 1 Committer, 1 Author, 1 Contributor"),
                 JCheckConfiguration.parse(conf).checks().reviewers().getReviewRequirements());
 
         conf = new ArrayList<>(CONFIGURATION);
@@ -654,25 +654,25 @@ class ReviewersCheckTests {
         conf.add("committers = 1");
         conf.add("authors = 1");
         conf.add("contributors = 2");
-        assertEquals(String.format(hasReviews, 5, "1 reviewer, 1 committer, 1 author, 2 contributors"),
+        assertEquals(String.format(hasReviews, 5, "1 Reviewer, 1 Committer, 1 Author, 2 Contributors"),
                 JCheckConfiguration.parse(conf).checks().reviewers().getReviewRequirements());
 
         conf = new ArrayList<>(CONFIGURATION);
         conf.add("reviewers = 1");
         conf.add("committers = 1");
         conf.add("contributors = 3");
-        assertEquals(String.format(hasReviews, 5, "1 reviewer, 1 committer, 3 contributors"),
+        assertEquals(String.format(hasReviews, 5, "1 Reviewer, 1 Committer, 3 Contributors"),
                 JCheckConfiguration.parse(conf).checks().reviewers().getReviewRequirements());
 
         conf = new ArrayList<>(CONFIGURATION);
         conf.add("reviewers = 1");
         conf.add("contributors = 4");
-        assertEquals(String.format(hasReviews, 5, "1 reviewer, 4 contributors"),
+        assertEquals(String.format(hasReviews, 5, "1 Reviewer, 4 Contributors"),
                 JCheckConfiguration.parse(conf).checks().reviewers().getReviewRequirements());
 
         conf = new ArrayList<>(CONFIGURATION);
         conf.add("contributors = 5");
-        assertEquals(String.format(hasReviews, 5, "5 contributors"),
+        assertEquals(String.format(hasReviews, 5, "5 Contributors"),
                 JCheckConfiguration.parse(conf).checks().reviewers().getReviewRequirements());
     }
 }

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/ReviewersCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/ReviewersCheckTests.java
@@ -41,6 +41,8 @@ import java.util.ArrayList;
 import java.time.ZonedDateTime;
 import java.io.IOException;
 
+import static org.openjdk.skara.jcheck.ReviewersConfiguration.BYLAWS_URL;
+
 class ReviewersCheckTests {
     private final Utilities utils = new Utilities();
 
@@ -690,7 +692,7 @@ class ReviewersCheckTests {
         for (var reviewRequirement : reviewRequirementMap.entrySet()) {
             var requirementNum = reviewRequirement.getValue();
             if (requirementNum > 0) {
-                requireList.add(requirementNum+ " " + String.format(reviewRequirement.getKey(), requirementNum > 1 ? "s" : "", "http://openjdk.java.net/bylaws"));
+                requireList.add(requirementNum+ " " + String.format(reviewRequirement.getKey(), requirementNum > 1 ? "s" : "", BYLAWS_URL));
             }
         }
         return String.format(hasReview, totalNum, totalNum > 1 ? "s" : "", String.join(", ", requireList));


### PR DESCRIPTION
Hi all,

This patch mainly fixes the following message:

1. Remove the pluralization if these is 0 reviewer. `no reviews required` --> `no review required`
2. Fix the official role name. eg: `reviewer` --> `Reviewer`, `committers` --> `Committers`
3. Unify the comment and the progress message. ` (with 1 of role reviewers)` --> `(with at least 1 Reviewer)`
4. Fix the pluralization of the comment. ` (with 1 of role reviewers)` --> `(with at least 1 Reviewer)` Note the pluralization.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [SKARA-1437](https://bugs.openjdk.java.net/browse/SKARA-1437): Fix the OpenJDK official role name and pluralization


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to [c5fc2924](https://git.openjdk.java.net/skara/pull/1319/files/c5fc292444e41b9584651ec357371486b6904807)
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**) ⚠️ Review applies to [0042b23c](https://git.openjdk.java.net/skara/pull/1319/files/0042b23cbfa7079cd6bf186cf128363928c6af1b)
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1319/head:pull/1319` \
`$ git checkout pull/1319`

Update a local copy of the PR: \
`$ git checkout pull/1319` \
`$ git pull https://git.openjdk.java.net/skara pull/1319/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1319`

View PR using the GUI difftool: \
`$ git pr show -t 1319`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1319.diff">https://git.openjdk.java.net/skara/pull/1319.diff</a>

</details>
