### PR TITLE
SKARA-1448

### DIFF
--- a/jbs/src/main/java/org/openjdk/skara/jbs/JdkVersion.java
+++ b/jbs/src/main/java/org/openjdk/skara/jbs/JdkVersion.java
@@ -32,7 +32,7 @@ public class JdkVersion implements Comparable<JdkVersion> {
     private final String opt;
     private final String build;
 
-    private final static Pattern jdkVersionPattern = Pattern.compile("(5\\.0|[1-9][0-9]?)(u([0-9]{1,3}))?$");
+    private final static Pattern jdkVersionPattern = Pattern.compile("(5\\.0|[1-9][0-9]?)(u([0-9]{1,3}))?(?:-(.*))?$");
     private final static Pattern hsxVersionPattern = Pattern.compile("(hs[1-9][0-9]{1,2})(\\.([0-9]{1,3}))?$");
     private final static Pattern embVersionPattern = Pattern.compile("(emb-[8-9])(u([0-9]{1,3}))?$");
     private final static Pattern ojVersionPattern = Pattern.compile("(openjdk[1-9][0-9]?)(u([0-9]{1,3}))?$");
@@ -55,6 +55,10 @@ public class JdkVersion implements Comparable<JdkVersion> {
                 finalComponents.add(legacyMatcher.group(1));
                 if (legacyMatcher.group(3) != null) {
                     finalComponents.add(legacyMatcher.group(3));
+                }
+                if (legacyMatcher.groupCount() > 3 && legacyMatcher.group(4) != null) {
+                    finalComponents.add(null);
+                    finalComponents.add(legacyMatcher.group(4));
                 }
                 break;
             }

--- a/jbs/src/test/java/org/openjdk/skara/jbs/BackportsTests.java
+++ b/jbs/src/test/java/org/openjdk/skara/jbs/BackportsTests.java
@@ -168,6 +168,12 @@ public class BackportsTests {
             assertEquals(Optional.empty(), Backports.findIssue(issue, JdkVersion.parse("13.3").orElseThrow()));
             assertEquals(issue, Backports.findIssue(issue, JdkVersion.parse("11.1-foo").orElseThrow()).orElseThrow());
 
+            backport.setProperty("fixVersions", JSON.array().add("openjfx17-pool"));
+            assertEquals(backport, Backports.findIssue(issue, JdkVersion.parse("openjfx17.0.1").orElseThrow()).orElseThrow());
+
+            backportFoo.setProperty("fixVersions", JSON.array().add("8-pool-foo"));
+            assertEquals(backportFoo, Backports.findIssue(issue, JdkVersion.parse("8u333-foo").orElseThrow()).orElseThrow());
+
             issue.setProperty("fixVersions", JSON.array().add("tbd"));
             assertEquals(issue, Backports.findIssue(issue, JdkVersion.parse("11.1").orElseThrow()).orElseThrow());
 
@@ -662,7 +668,7 @@ public class BackportsTests {
             var backports = new BackportManager(credentials, "8u291");
             backports.assertLabeled();
 
-            backports.addBackports("8u301", "8u281-b31");
+            backports.addBackports("8u301", "8u281/b31");
             backports.assertLabeled("8u301");
         }
     }

--- a/jbs/src/test/java/org/openjdk/skara/jbs/JdkVersionTests.java
+++ b/jbs/src/test/java/org/openjdk/skara/jbs/JdkVersionTests.java
@@ -133,4 +133,10 @@ public class JdkVersionTests {
         assertEquals(Optional.empty(), JdkVersion.parse(""));
         assertEquals(Optional.empty(), JdkVersion.parse("foobar7u"));
     }
+
+    @Test
+    void legacyOpt() {
+        assertEquals(List.of("8", "333"), from("8u333-foo").components());
+        assertEquals("foo", from("8u333-foo").opt().orElseThrow());
+    }
 }


### PR DESCRIPTION
This patch makes it possible to define specialized "pool" versions with suffixes for 8u in JBS, similar to how it's already possible for 11u+. For example: we could create a JBS `8-pool-foo` version that got consumed by commits with fixVersion `8u331-foo`.