### PR TITLE
1449: Changing the original hash in a backport PR doesn't work

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
@@ -275,14 +275,15 @@ public class CheckablePullRequest {
 
     static Hash findOriginalBackportHash(PullRequest pr) {
         var botUser = pr.repository().forge().currentUser();
-        var backportLines = pr.comments()
+        return pr.comments()
                 .stream()
                 .filter(c -> c.author().equals(botUser))
                 .flatMap(c -> Stream.of(c.body().split("\n")))
                 .map(BACKPORT_PATTERN::matcher)
                 .filter(Matcher::find)
-                .collect(Collectors.toList());
-        return backportLines.isEmpty() ? null : new Hash(backportLines.get(0).group(1));
+                .reduce((first, second) -> second)
+                .map(l -> new Hash(l.group(1)))
+                .orElse(null);
     }
 
     // Lazily initiated

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportTests.java
@@ -1445,4 +1445,135 @@ class BackportTests {
             assertEquals(List.of(), message.additional());
         }
     }
+
+    /**
+     * Tests that the correct original hash is used if the PR is updated with a new
+     * "Backport HASH" title
+     */
+    @Test
+    void updateOriginal(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+
+            var author = credentials.getHostedRepository();
+            var integrator = credentials.getHostedRepository();
+            var reviewer = credentials.getHostedRepository();
+            var issues = credentials.getIssueProject();
+            var censusBuilder = credentials.getCensusBuilder()
+                    .addCommitter(author.forge().currentUser().id())
+                    .addReviewer(integrator.forge().currentUser().id())
+                    .addReviewer(reviewer.forge().currentUser().id());
+            var bot = PullRequestBot.newBuilder()
+                    .repo(integrator)
+                    .censusRepo(censusBuilder.build())
+                    .issueProject(issues)
+                    .build();
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            var releaseBranch = localRepo.branch(masterHash, "release");
+            localRepo.checkout(releaseBranch);
+            var newFile = localRepo.root().resolve("a_new_file.txt");
+            Files.writeString(newFile, "hello");
+            localRepo.add(newFile);
+            var issue1 = credentials.createIssue(issues, "An issue");
+            var issue1Number = issue1.id().split("-")[1];
+            var originalMessage = issue1Number + ": An issue\n" +
+                    "\n" +
+                    "Reviewed-by: integrationreviewer2";
+            var releaseHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.java.net");
+            localRepo.push(releaseHash, author.url(), "refs/heads/release", true);
+
+            // Create the same fix in another release branch
+            var releaseBranch2 = localRepo.branch(masterHash, "release2");
+            localRepo.checkout(releaseBranch2);
+            var newFile2 = localRepo.root().resolve("a_new_file.txt");
+            Files.writeString(newFile2, "hello2");
+            localRepo.add(newFile);
+            var releaseHash2 = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.java.net");
+            localRepo.push(releaseHash2, author.url(), "refs/heads/release2", true);
+
+            // "backport" the new file to the master branch
+            localRepo.checkout(localRepo.defaultBranch());
+            var editBranch = localRepo.branch(masterHash, "edit");
+            localRepo.checkout(editBranch);
+            var newFile3 = localRepo.root().resolve("a_new_file.txt");
+            Files.writeString(newFile3, "hello");
+            localRepo.add(newFile3);
+            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.java.net");
+            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "Backport " + releaseHash.hex());
+
+            // The bot should reply with a backport message
+            TestBotRunner.runPeriodicItems(bot);
+            var backportComment = pr.comments().get(0).body();
+            assertTrue(backportComment.contains("This backport pull request has now been updated with issue"));
+            assertTrue(backportComment.contains("<!-- backport " + releaseHash.hex() + " -->"));
+            assertEquals(issue1Number + ": An issue", pr.title());
+            assertTrue(pr.labelNames().contains("backport"));
+            assertTrue(pr.labelNames().contains("clean"));
+            var mergeReadyComment = pr.comments().get(1).body();
+            assertTrue(mergeReadyComment.contains("This change now passes all *automated* pre-integration checks"));
+
+            // Update the PR title and use the hash from release2 instead
+            pr.setTitle("Backport " + releaseHash2.hex());
+
+            // The bot should reply with a backport message
+            TestBotRunner.runPeriodicItems(bot);
+            var backportComment2 = pr.comments().get(2).body();
+            assertTrue(backportComment2.contains("This backport pull request has now been updated with issue"));
+            assertTrue(backportComment2.contains("<!-- backport " + releaseHash2.hex() + " -->"));
+            assertEquals(issue1Number + ": An issue", pr.title());
+            assertTrue(pr.labelNames().contains("backport"));
+            // The backport is no longer clean as the release2 version of the change was different
+            assertFalse(pr.labelNames().contains("clean"));
+            mergeReadyComment = pr.comments().get(1).body();
+            assertTrue(mergeReadyComment.contains("This change is no longer ready for integration - check the PR body for details"));
+
+            // Approve PR and re-run bot
+            var prAsReviewer = reviewer.pullRequest(pr.id());
+            prAsReviewer.addReview(Review.Verdict.APPROVED, "Looks good");
+            TestBotRunner.runPeriodicItems(bot);
+            mergeReadyComment = pr.comments().get(1).body();
+            assertTrue(mergeReadyComment.contains("This change now passes all *automated* pre-integration checks"));
+
+            // Integrate
+            author.pullRequest(pr.id());
+            pr.addComment("/integrate");
+            TestBotRunner.runPeriodicItems(bot);
+
+            // Find the commit
+            assertLastCommentContains(pr, "Pushed as commit");
+
+            String hex = null;
+            var comment = pr.comments().get(pr.comments().size() - 1);
+            var lines = comment.body().split("\n");
+            var pattern = Pattern.compile(".* Pushed as commit ([0-9a-z]{40}).*");
+            for (var line : lines) {
+                var m = pattern.matcher(line);
+                if (m.matches()) {
+                    hex = m.group(1);
+                    break;
+                }
+            }
+            assertNotNull(hex);
+            assertEquals(40, hex.length());
+            localRepo.checkout(localRepo.defaultBranch());
+            localRepo.pull(author.url().toString(), "master", false);
+            var commit = localRepo.lookup(new Hash(hex)).orElseThrow();
+
+            var message = CommitMessageParsers.v1.parse(commit);
+            assertEquals(1, message.issues().size());
+            assertEquals("An issue", message.issues().get(0).description());
+            assertEquals(List.of("integrationreviewer3"), message.reviewers());
+            // Verify that the correct original hash is present in the commit message
+            assertEquals(Optional.of(releaseHash2), message.original());
+            assertEquals(List.of(), message.contributors());
+            assertEquals(List.of(), message.summaries());
+            assertEquals(List.of(), message.additional());
+        }
+    }
 }


### PR DESCRIPTION
If a user tries to change the original hash for a backport PR, by changing the title to "Backport HASH", it appears to work, but in reality, several things behind the scenes do not. The logic for finding the original commit will always just return the first hash that was set and ignores any updates/changes. This affects the clean evaluation and the commit message.

This patch changes the method for finding the original hash so that the last one is returned instead. A new test is added to verify this functionality, both for the clean evaluation as well as the final commit message.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [SKARA-1449](https://bugs.openjdk.java.net/browse/SKARA-1449): Changing the original hash in a backport PR doesn't work


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1321/head:pull/1321` \
`$ git checkout pull/1321`

Update a local copy of the PR: \
`$ git checkout pull/1321` \
`$ git pull https://git.openjdk.java.net/skara pull/1321/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1321`

View PR using the GUI difftool: \
`$ git pr show -t 1321`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1321.diff">https://git.openjdk.java.net/skara/pull/1321.diff</a>

</details>
