### PR TITLE
1455: Github closed action may not contain an actor

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveItem.java
@@ -266,7 +266,7 @@ class ArchiveItem {
     }
 
     static ArchiveItem closedNotice(PullRequest pr, HostUserToEmailAuthor hostUserToEmailAuthor, ArchiveItem parent, String subjectPrefix) {
-        var closedBy = pr.closedBy().orElseThrow(() -> new RuntimeException("PR is not closed by anyone: " + pr.id()));
+        var closedBy = pr.closedBy().orElse(pr.author());
         return new ArchiveItem(parent, "cn", pr.updatedAt(), pr.updatedAt(), closedBy, Map.of("PR-Closed-Notice", "0"),
                                () -> String.format("%sWithdrawn: %s", subjectPrefix, pr.title()),
                                () -> ArchiveMessages.composeReplyHeader(parent.createdAt(), hostUserToEmailAuthor.author(parent.author())),


### PR DESCRIPTION
As described in the bug, pr.closedBy() may (consistently) return empty on Github in some cases. Rather than getting stuck retrying endlessly, I think we should just add a fallback.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1455](https://bugs.openjdk.java.net/browse/SKARA-1455): Github closed action may not contain an actor


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - no project role)
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1323/head:pull/1323` \
`$ git checkout pull/1323`

Update a local copy of the PR: \
`$ git checkout pull/1323` \
`$ git pull https://git.openjdk.java.net/skara pull/1323/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1323`

View PR using the GUI difftool: \
`$ git pr show -t 1323`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1323.diff">https://git.openjdk.java.net/skara/pull/1323.diff</a>

</details>
