### PR TITLE
1456: hgupdate-sync labeling ignores suffix on 8u releases

### DIFF
--- a/jbs/src/main/java/org/openjdk/skara/jbs/Backports.java
+++ b/jbs/src/main/java/org/openjdk/skara/jbs/Backports.java
@@ -315,7 +315,7 @@ public class Backports {
      * @return
      */
     private static List<String> releaseStreams(JdkVersion jdkVersion) {
-        var ret = new ArrayList<String>();
+        List<String> ret = new ArrayList<String>();
         try {
             var featureFamilyMatcher = featureFamilyPattern.matcher(jdkVersion.feature());
             if (!featureFamilyMatcher.matches()) {
@@ -381,6 +381,17 @@ public class Backports {
             }
         } catch (NumberFormatException e) {
             log.info("Cannot determine release streams for version: " + jdkVersion + " (" + e + ")");
+        }
+        // For any arbitrary opt string that we haven't already handled explicitly,
+        // let them represent their own release stream.
+        if (jdkVersion.opt().isPresent()) {
+            String opt = jdkVersion.opt().get();
+            if (!opt.equals("oracle")) {
+                var plusOpt = "+" + opt;
+                ret = ret.stream()
+                        .map(r -> r + plusOpt)
+                        .collect(Collectors.toList());
+            }
         }
         return ret;
     }

--- a/jbs/src/main/java/org/openjdk/skara/jbs/Backports.java
+++ b/jbs/src/main/java/org/openjdk/skara/jbs/Backports.java
@@ -383,7 +383,7 @@ public class Backports {
             log.info("Cannot determine release streams for version: " + jdkVersion + " (" + e + ")");
         }
         // For any arbitrary opt string that we haven't already handled explicitly,
-        // let them represent their own release stream.
+        // we let them represent their own respective release streams.
         if (jdkVersion.opt().isPresent()) {
             String opt = jdkVersion.opt().get();
             if (!opt.equals("oracle")) {

--- a/jbs/src/test/java/org/openjdk/skara/jbs/BackportsTests.java
+++ b/jbs/src/test/java/org/openjdk/skara/jbs/BackportsTests.java
@@ -520,18 +520,7 @@ public class BackportsTests {
     }
 
     @Test
-    void labelTest8255226_1(TestInfo testInfo) throws IOException {
-        try (var credentials = new HostCredentials(testInfo)) {
-            var backports = new BackportManager(credentials, "16");
-            backports.assertLabeled();
-
-            backports.addBackports("15-pool", "11-pool", "8-pool", "7-pool");
-            backports.assertLabeled("16", "15-pool");
-        }
-    }
-
-    @Test
-    void labelTest8255226_2(TestInfo testInfo) throws IOException {
+    void labelTest8255226(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo)) {
             var backports = new BackportManager(credentials, "16");
             backports.assertLabeled();
@@ -978,4 +967,16 @@ public class BackportsTests {
             backports.addBackports("11.0.4-oracle", "11.0.3-oracle/b31");
             backports.assertLabeled("11.0.3-oracle");
         }
-    }}
+    }
+
+    @Test
+    void jdk8u_foo(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo)) {
+            var backports = new BackportManager(credentials, "8u341");
+            backports.assertLabeled();
+
+            backports.addBackports("8u333-foo", "8u345-foo", "8u351");
+            backports.assertLabeled("8u345-foo", "8u351");
+        }
+    }
+}


### PR DESCRIPTION
This patch adds a new concept to the hgupdate-sync label logic, which I had naively thought was already there. Any version string with an "opt" part (basically a -suffix) gets treated as a separate release stream. I think this makes sense and is easily understood, but I'm looking for more eyes and thoughts on this.

While working on it, an existing test started failing. I ended up removing it as I can't see how that test is relevant or even correct. AFAIK we never accept X-pool as fixVersion when an issue is resolved, and hgupdate-sync should only be considered for resolved or closed bugs. I think this test was based on trying to mimic the old labeler and happened to find a mislabeled set of bugs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1456](https://bugs.openjdk.java.net/browse/SKARA-1456): hgupdate-sync labeling ignores suffix on 8u releases


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1324/head:pull/1324` \
`$ git checkout pull/1324`

Update a local copy of the PR: \
`$ git checkout pull/1324` \
`$ git pull https://git.openjdk.java.net/skara pull/1324/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1324`

View PR using the GUI difftool: \
`$ git pr show -t 1324`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1324.diff">https://git.openjdk.java.net/skara/pull/1324.diff</a>

</details>
