### PR TITLE
1434: Testissue#addLink doesn't generate the right relationship for the reversed link

### DIFF
--- a/issuetracker/src/test/java/org/openjdk/skara/issuetracker/IssueTrackerTests.java
+++ b/issuetracker/src/test/java/org/openjdk/skara/issuetracker/IssueTrackerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -122,7 +122,7 @@ class IssueTrackerTests {
             issue1.setBody("This is now the body");
 
             var issue2 = credentials.createIssue(project, "Test issue 2");
-            var link = Link.create(issue1, "duplicated by").build();
+            var link = Link.create(issue1, "duplicates").build();
             issue2.addLink(link);
 
             var links = issue2.links();

--- a/jbs/src/test/java/org/openjdk/skara/jbs/BackportsTests.java
+++ b/jbs/src/test/java/org/openjdk/skara/jbs/BackportsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,7 +55,7 @@ public class BackportsTests {
             assertEquals(issue1, Backports.findMainIssue(issue2).orElseThrow());
             assertEquals(issue1, Backports.findMainIssue(issue3).orElseThrow());
 
-            assertEquals(List.of(issue2), Backports.findBackports(issue1, false));
+            assertEquals(List.of(issue2, issue3), Backports.findBackports(issue1, false));
             assertEquals(List.of(), Backports.findBackports(issue1, true));
         }
     }
@@ -92,12 +92,12 @@ public class BackportsTests {
             var issue2 = credentials.createIssue(issueProject, "Issue 2");
             issue2.setProperty("issuetype", JSON.of("Bug"));
             issue2.setState(Issue.State.RESOLVED);
-            issue1.addLink(Link.create(issue2, "duplicated by").build());
+            issue1.addLink(Link.create(issue2, "duplicates").build());
 
             var issue3 = credentials.createIssue(issueProject, "Issue 3");
             issue3.setProperty("issuetype", JSON.of("CSR"));
             issue3.setState(Issue.State.RESOLVED);
-            issue1.addLink(Link.create(issue3, "CSRed by").build());
+            issue1.addLink(Link.create(issue3, "csr for").build());
 
             var issue4 = credentials.createIssue(issueProject, "Issue 4");
             issue4.setProperty("issuetype", JSON.of("Backport"));

--- a/test/src/main/java/org/openjdk/skara/test/TestIssue.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestIssue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -240,7 +240,12 @@ public class TestIssue implements Issue {
             existing.ifPresent(data.links::remove);
             data.links.add(link);
             if (existing.isEmpty()) {
-                var reverse = Link.create(this, link.relationship().get()).build();
+                var map = Map.of("backported by", "backport of", "backport of", "backported by",
+                        "csr for", "csr of", "csr of", "csr for",
+                        "blocks", "is blocked by", "is blocked by", "blocks",
+                        "clones", "is cloned by", "is cloned by", "clones");
+                var reverseRelationship = map.getOrDefault(link.relationship().get(), link.relationship().get());
+                var reverse = Link.create(this, reverseRelationship).build();
                 link.issue().get().addLink(reverse);
             }
         } else {


### PR DESCRIPTION
Hi all,

This patch fixes the reversed link type. For example, when adding a `csr for` link at `ISSUE-1` which links to `ISSUE-2`, the `ISSUE-2` should have a reversed link `csr of` instead of the same link type `csr for`.

The reversed relations are shown below:
- `backported by` and `backport of`
- `csr for` and `csr of`
- `blocks` and `is blocked by`
- `clones` and `is cloned by`

And the `duplicates` link type doesn't have the reversed linke type like `duplicated by` now. So we should use the link type `duplicates` instead of `duplicated by` in the test cases so that the tests can be closer to the actual situation.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1434](https://bugs.openjdk.java.net/browse/SKARA-1434): Testissue#addLink doesn't generate the right relationship for the reversed link


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1325/head:pull/1325` \
`$ git checkout pull/1325`

Update a local copy of the PR: \
`$ git checkout pull/1325` \
`$ git pull https://git.openjdk.java.net/skara pull/1325/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1325`

View PR using the GUI difftool: \
`$ git pr show -t 1325`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1325.diff">https://git.openjdk.java.net/skara/pull/1325.diff</a>

</details>
