### PR TITLE
1410: The reply message of the 'reviewers' command should be more accurate

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewersCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewersCommand.java
@@ -120,11 +120,11 @@ public class ReviewersCommand implements CommandHandler {
             var previous = ReviewersTracker.additionalRequiredReviewers(user, allComments);
             if (previous.isPresent()) {
                 if (roleIsLower(role, previous.get().role())) {
-                    reply.println("Cannot lower the role for additional reviewers");
+                    reply.println("Only the [Reviewers](https://openjdk.java.net/bylaws#reviewer) are allowed to lower the role for additional reviewers.");
                     return;
                 }
                 if (numReviewers < previous.get().number()) {
-                    reply.println("Cannot decrease the number of required reviewers");
+                    reply.println("Only the [Reviewers](https://openjdk.java.net/bylaws#reviewer) are allowed to decrease the number of required reviewers.");
                     return;
                 }
             }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewersCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewersCommand.java
@@ -120,11 +120,11 @@ public class ReviewersCommand implements CommandHandler {
             var previous = ReviewersTracker.additionalRequiredReviewers(user, allComments);
             if (previous.isPresent()) {
                 if (roleIsLower(role, previous.get().role())) {
-                    reply.println("Only the [Reviewers](https://openjdk.java.net/bylaws#reviewer) are allowed to lower the role for additional reviewers.");
+                    reply.println("Only [Reviewers](https://openjdk.java.net/bylaws#reviewer) are allowed to lower the role for additional reviewers.");
                     return;
                 }
                 if (numReviewers < previous.get().number()) {
-                    reply.println("Only the [Reviewers](https://openjdk.java.net/bylaws#reviewer) are allowed to decrease the number of required reviewers.");
+                    reply.println("Only [Reviewers](https://openjdk.java.net/bylaws#reviewer) are allowed to decrease the number of required reviewers.");
                     return;
                 }
             }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ReviewersTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ReviewersTests.java
@@ -374,7 +374,7 @@ public class ReviewersTests {
             // The author should not be allowed to decrease even its own /reviewers command
             authorPR.addComment("/reviewers 1");
             TestBotRunner.runPeriodicItems(prBot);
-            assertLastCommentContains(authorPR, "Only the [Reviewers](https://openjdk.java.net/bylaws#reviewer) "
+            assertLastCommentContains(authorPR, "Only [Reviewers](https://openjdk.java.net/bylaws#reviewer) "
                     + "are allowed to decrease the number of required reviewers.");
             assertTrue(authorPR.body().contains(getReviewersExpectedProgress(0, 1, 0, 1, 0)));
 
@@ -388,7 +388,7 @@ public class ReviewersTests {
             // The author should not be allowed to lower the role of the reviewers
             authorPR.addComment("/reviewers 1 contributors");
             TestBotRunner.runPeriodicItems(prBot);
-            assertLastCommentContains(authorPR, "Only the [Reviewers](https://openjdk.java.net/bylaws#reviewer) "
+            assertLastCommentContains(authorPR, "Only [Reviewers](https://openjdk.java.net/bylaws#reviewer) "
                     + "are allowed to lower the role for additional reviewers.");
             assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 1, 0, 0, 0)));
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ReviewersTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ReviewersTests.java
@@ -374,12 +374,26 @@ public class ReviewersTests {
             // The author should not be allowed to decrease even its own /reviewers command
             authorPR.addComment("/reviewers 1");
             TestBotRunner.runPeriodicItems(prBot);
-            assertLastCommentContains(authorPR, "Cannot decrease the number of required reviewers");
+            assertLastCommentContains(authorPR, "Only the [Reviewers](https://openjdk.java.net/bylaws#reviewer) "
+                    + "are allowed to decrease the number of required reviewers.");
             assertTrue(authorPR.body().contains(getReviewersExpectedProgress(0, 1, 0, 1, 0)));
 
             // Reviewer should be allowed to decrease
             var reviewerPr = integrator.pullRequest(pr.id());
             reviewerPr.addComment("/reviewers 1");
+            TestBotRunner.runPeriodicItems(prBot);
+            assertLastCommentContains(reviewerPr, getReviewersExpectedComment(0, 1, 0, 0, 0));
+            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 1, 0, 0, 0)));
+
+            // The author should not be allowed to lower the role of the reviewers
+            authorPR.addComment("/reviewers 1 contributors");
+            TestBotRunner.runPeriodicItems(prBot);
+            assertLastCommentContains(authorPR, "Only the [Reviewers](https://openjdk.java.net/bylaws#reviewer) "
+                    + "are allowed to lower the role for additional reviewers.");
+            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 1, 0, 0, 0)));
+
+            // Reviewer should be allowed to lower the role of the reviewers
+            reviewerPr.addComment("/reviewers 1 contributors");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr, getReviewersExpectedComment(0, 1, 0, 0, 0));
             assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 1, 0, 0, 0)));


### PR DESCRIPTION
Hi all,

This trivial patch fixes the reply message of the `reviewers` command.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1410](https://bugs.openjdk.java.net/browse/SKARA-1410): The reply message of the 'reviewers' command should be more accurate


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1326/head:pull/1326` \
`$ git checkout pull/1326`

Update a local copy of the PR: \
`$ git checkout pull/1326` \
`$ git pull https://git.openjdk.java.net/skara pull/1326/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1326`

View PR using the GUI difftool: \
`$ git pr show -t 1326`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1326.diff">https://git.openjdk.java.net/skara/pull/1326.diff</a>

</details>
