### PR TITLE
1433: The change of the CSR status doesn't force the CheckWorkItem to re-run the check

### DIFF
--- a/bots/csr/src/main/java/org/openjdk/skara/bots/csr/CSRBot.java
+++ b/bots/csr/src/main/java/org/openjdk/skara/bots/csr/CSRBot.java
@@ -37,7 +37,8 @@ import java.util.logging.Logger;
 
 class CSRBot implements Bot, WorkItem {
     private final static String CSR_LABEL = "csr";
-    private final static String CSR_UPDATE_MARKER = "\n<!-- csr: 'update' -->\n";
+    private final static String CSR_UPDATE_MARKER = "<!-- csr: 'update' -->";
+    private static final String PROGRESS_MARKER = "<!-- Anything below this marker will be automatically updated, please do not edit manually! -->";
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots");;
     private final HostedRepository repo;
     private final IssueProject project;
@@ -74,19 +75,39 @@ class CSRBot implements Bot, WorkItem {
     }
 
     private boolean hasCsrIssueAndProgress(PullRequest pr, Issue csr) {
-        return hasCsrIssue(pr, csr) &&
-                (pr.body().contains("- [ ] Change requires a CSR request to be approved") ||
-                 pr.body().contains("- [x] Change requires a CSR request to be approved"));
+        var statusMessage = getStatusMessage(pr);
+        return hasCsrIssue(statusMessage, csr) &&
+               (statusMessage.contains("- [ ] Change requires a CSR request to be approved") ||
+                statusMessage.contains("- [x] Change requires a CSR request to be approved"));
     }
 
     private boolean hasCsrIssueAndProgressChecked(PullRequest pr, Issue csr) {
-        return hasCsrIssue(pr, csr) && pr.body().contains("- [x] Change requires a CSR request to be approved");
+        var statusMessage = getStatusMessage(pr);
+        return hasCsrIssue(statusMessage, csr) && statusMessage.contains("- [x] Change requires a CSR request to be approved");
     }
 
-    private boolean hasCsrIssue(PullRequest pr, Issue csr) {
-        return pr.body().contains(csr.id()) &&
-                pr.body().contains(csr.webUrl().toString()) &&
-                pr.body().contains(csr.title() + " (**CSR**)");
+    private boolean hasCsrIssue(String statusMessage, Issue csr) {
+        return statusMessage.contains(csr.id()) &&
+               statusMessage.contains(csr.webUrl().toString()) &&
+               statusMessage.contains(csr.title() + " (**CSR**)");
+    }
+
+    private String getStatusMessage(PullRequest pr) {
+        var lastIndex = pr.body().lastIndexOf(PROGRESS_MARKER);
+        if (lastIndex == -1) {
+            return "";
+        } else {
+            return pr.body().substring(lastIndex);
+        }
+    }
+
+    private void addUpdateMarker(PullRequest pr) {
+        var statusMessage = getStatusMessage(pr);
+        if (!statusMessage.contains(CSR_UPDATE_MARKER)) {
+            pr.setBody(pr.body() + "\n" + CSR_UPDATE_MARKER + "\n");
+        } else {
+            log.info("The pull request " + describe(pr) + " has already had a csr update marker. Do not need to add it again.");
+        }
     }
 
     @Override
@@ -118,12 +139,12 @@ class CSRBot implements Bot, WorkItem {
             }
             var csr = csrOptional.get();
 
-            log.info("Found CSR for " + describe(pr) + ". It has id " + csr.id());
+            log.info("Found CSR " + csr.id() + " for " + describe(pr));
             if (!hasCsrIssueAndProgress(pr, csr)) {
                 // If the PR body doesn't have the CSR issue or doesn't have the CSR progress,
                 // this bot need to add the csr update marker so that the PR bot can update the message of the PR body.
                 log.info("The PR body doesn't have the CSR issue or progress, adding the csr update marker for " + describe(pr));
-                pr.setBody(pr.body() + CSR_UPDATE_MARKER);
+                addUpdateMarker(pr);
             }
 
             var resolution = csr.properties().get("resolution");
@@ -181,7 +202,7 @@ class CSRBot implements Bot, WorkItem {
                 // If the PR body doesn't have the CSR issue or doesn't have the CSR progress or the CSR progress checkbox is not selected,
                 // this bot need to add the csr update marker so that the PR bot can update the message of the PR body.
                 log.info("CSR closed and approved for " + describe(pr) + ", adding the csr update marker");
-                pr.setBody(pr.body() + CSR_UPDATE_MARKER);
+                addUpdateMarker(pr);
             }
         }
         return List.of();

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CSRCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CSRCommand.java
@@ -33,6 +33,8 @@ import java.util.List;
 
 public class CSRCommand implements CommandHandler {
     private static final String CSR_LABEL = "csr";
+    private static final String CSR_NEEDED_MARKER = "<!-- csr: 'needed' -->";
+    private static final String CSR_UNNEEDED_MARKER = "<!-- csr: 'unneeded' -->";
 
     private static void showHelp(PrintWriter writer) {
         writer.println("usage: `/csr [needed|unneeded]`, requires that the issue the pull request refers to links to an approved [CSR](https://wiki.openjdk.java.net/display/csr/Main) request.");
@@ -42,6 +44,7 @@ public class CSRCommand implements CommandHandler {
         writer.println("has indicated that a " +
                       "[compatibility and specification](https://wiki.openjdk.java.net/display/csr/Main) (CSR) request " +
                       "is needed for this pull request.");
+        writer.println(CSR_NEEDED_MARKER);
     }
 
     private static void jbsReply(PullRequest pr, PrintWriter writer) {
@@ -59,6 +62,7 @@ public class CSRCommand implements CommandHandler {
     private static void csrUnneededReply(PrintWriter writer) {
         writer.println("determined that a [CSR](https://wiki.openjdk.java.net/display/csr/Main) request " +
                 "is not needed for this pull request.");
+        writer.println(CSR_UNNEEDED_MARKER);
     }
 
     @Override
@@ -131,6 +135,7 @@ public class CSRCommand implements CommandHandler {
                 reply.println("The CSR requirement cannot be removed as there is already a CSR associated with the main issue" +
                               " of this pull request. Please withdraw the CSR [" + csrIssue.id() + "](" + csrIssue.webUrl() +
                               ") and then use the command `/csr unneeded` again.");
+                reply.println(CSR_NEEDED_MARKER);
                 return;
             }
 
@@ -143,6 +148,7 @@ public class CSRCommand implements CommandHandler {
         if (labels.contains(CSR_LABEL)) {
             reply.println("an approved [CSR](https://wiki.openjdk.java.net/display/csr/Main) request " +
                           "is already required for this pull request.");
+            reply.println(CSR_NEEDED_MARKER);
             return;
         }
 
@@ -192,10 +198,12 @@ public class CSRCommand implements CommandHandler {
         if (csr.state() == Issue.State.CLOSED && resolutionName.equals("Approved")) {
             reply.println("the issue for this pull request, [" + jbsIssue.id() + "](" + jbsIssue.webUrl() + "), already has " +
                           "an approved CSR request: [" + csr.id() + "](" + csr.webUrl() + ")");
+            reply.println(CSR_NEEDED_MARKER);
         } else {
             reply.println("this pull request will not be integrated until the [CSR](https://wiki.openjdk.java.net/display/csr/Main) " +
                           "request " + "[" + csr.id() + "](" + csr.webUrl() + ")" + " for issue " +
                           "[" + jbsIssue.id() + "](" + jbsIssue.webUrl() + ") has been approved.");
+            reply.println(CSR_NEEDED_MARKER);
             pr.addLabel(CSR_LABEL);
         }
     }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -42,7 +42,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 class CheckWorkItem extends PullRequestWorkItem {
-    private final Pattern metadataComments = Pattern.compile("<!-- (?:(add|remove) (?:contributor|reviewer))|(?:summary: ')|(?:solves: ')|(?:additional required reviewers)|(?:jep: ')");
+    private final Pattern metadataComments = Pattern.compile("<!-- (?:(add|remove) (?:contributor|reviewer))|(?:summary: ')|(?:solves: ')|(?:additional required reviewers)|(?:jep: ')|(?:csr: ')");
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots.pr");
     static final Pattern ISSUE_ID_PATTERN = Pattern.compile("^(?:(?<prefix>[A-Za-z][A-Za-z0-9]+)-)?(?<id>[0-9]+)"
             + "(?::(?<space>[\\s\u00A0\u2007\u202F]+)(?<title>.+))?$");

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CSRTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CSRTests.java
@@ -676,6 +676,7 @@ class CSRTests {
             TestBotRunner.runPeriodicItems(disableCsrBot);
             assertLastCommentContains(pr, "This repository has not been configured to use the `csr` command.");
             assertFalse(pr.labelNames().contains("csr"));
+            assertFalse(pr.body().contains("Change requires a CSR request to be approved"));
 
             // Test the pull request bot with csr enable
             var enableCsrBot = PullRequestBot.newBuilder().repo(bot).issueProject(issues)
@@ -686,6 +687,7 @@ class CSRTests {
                     "[compatibility and specification](https://wiki.openjdk.java.net/display/csr/Main) (CSR) request " +
                     "is needed for this pull request.");
             assertTrue(pr.labelNames().contains("csr"));
+            assertTrue(pr.body().contains("Change requires a CSR request to be approved"));
         }
     }
 
@@ -822,7 +824,6 @@ class CSRTests {
             // Set the fix versions of the primary CSR to 17 and 18.
             csr.setProperty("fixVersions", JSON.array().add("17").add("18"));
             // Run bot. Request a CSR.
-            pr.addComment("/summary\n" + commitMessage);
             pr.addComment("/csr");
             TestBotRunner.runPeriodicItems(bot);
             assertTrue(pr.body().contains("- [x] Change requires a CSR request to be approved"));
@@ -840,7 +841,6 @@ class CSRTests {
             backportIssue.setState(Issue.State.OPEN);
             issue.addLink(Link.create(backportIssue, "backported by").build());
             // Run bot. Request a CSR.
-            pr.addComment("/summary\n" + commitMessage);
             pr.addComment("/csr");
             TestBotRunner.runPeriodicItems(bot);
             assertTrue(pr.body().contains("- [ ] Change requires a CSR request to be approved"));
@@ -852,7 +852,6 @@ class CSRTests {
             assertLastCommentContains(pr, "with the correct fix version");
             assertLastCommentContains(pr, "This pull request cannot be integrated until the CSR request is approved.");
             // Use `/csr unneeded` to revert the change.
-            pr.addComment("/summary\n" + commitMessage);
             pr.addComment("/csr unneeded");
             TestBotRunner.runPeriodicItems(bot);
             assertFalse(pr.body().contains("Change requires a CSR request to be approved"));
@@ -867,7 +866,6 @@ class CSRTests {
             backportCsr.setState(Issue.State.OPEN);
             backportIssue.addLink(Link.create(backportCsr, "csr for").build());
             // Run bot. Request a CSR.
-            pr.addComment("/summary\n" + commitMessage);
             pr.addComment("/csr");
             TestBotRunner.runPeriodicItems(bot);
             assertTrue(pr.body().contains("- [ ] Change requires a CSR request to be approved"));
@@ -876,7 +874,6 @@ class CSRTests {
             assertLastCommentContains(pr, "for issue ");
             assertLastCommentContains(pr, "has been approved.");
             // Use `/csr unneeded` to revert the change.
-            pr.addComment("/summary\n" + commitMessage);
             pr.addComment("/csr unneeded");
             TestBotRunner.runPeriodicItems(bot);
             assertTrue(pr.body().contains("- [ ] Change requires a CSR request to be approved"));
@@ -899,7 +896,6 @@ class CSRTests {
             createBackport(localRepo, author, confHash, "edit4");
             pr = credentials.createPullRequest(author, "master", "edit4", "Backport " + commitHash);
             // Run bot.
-            pr.addComment("/summary\n" + commitMessage);
             pr.addComment("/csr");
             TestBotRunner.runPeriodicItems(bot);
             assertTrue(pr.body().contains("- [ ] Change requires a CSR request to be approved"));
@@ -910,7 +906,6 @@ class CSRTests {
             // Set the backport CSR to have multiple fix versions, excluded 11.
             backportCsr.setProperty("fixVersions", JSON.array().add("17").add("8"));
             // Use `/csr unneeded` to revert the change.
-            pr.addComment("/summary\n" + commitMessage);
             pr.addComment("/csr unneeded");
             TestBotRunner.runPeriodicItems(bot);
             assertFalse(pr.body().contains("Change requires a CSR request to be approved"));
@@ -919,7 +914,6 @@ class CSRTests {
                     "is not needed for this pull request.");
 
             // re-run bot.
-            pr.addComment("/summary\n" + commitMessage);
             pr.addComment("/csr");
             TestBotRunner.runPeriodicItems(bot);
             assertTrue(pr.body().contains("- [ ] Change requires a CSR request to be approved"));


### PR DESCRIPTION
Hi all,

Currently, the CheckWorkItem of the PR bot doesn't re-run the check in the following two situations so that the message of the PR body is not updated and then confuses the developers.

Situation 1 steps:
- The issue has no csr at first
- Use command `/csr needed` (now the PR has `csr` label)
- Create a csr for this issue
- Then the CheckWorkItem doesn't re-run the check (Because the `csr` label is kept in the PR and no new metadata found by CheckWorkItem)
- (optionally) use command `/csr needed` again
- (optionally) then the CheckWorkItem also doesn't re-run the check

Situation 2 steps:
- The issue has no csr at first (now the PR doesn't have `csr` label)
- Add the new fix version to the existing approved csr. (Now the issue has the csr issue. And because this csr issue had been approved, PR also doesn't have `csr` label.)
- then the CheckWorkItem doesn't re-run the check (No new metadata found by CheckWorkItem)
- (optionally) use command `/csr needed`
- (optionally) then the CheckWorkItem doesn't re-run the check

It is because these two situations don't add or remove the `csr` label so that the `CheckWorkItem#getMetadata` doesn't return new metadata and then `CheckWorkItem#currentCheckValid` returns true and then the check doesn't re-run.

This patch adds a new tag/marker named `<!-- csr:` so that `CheckWorkItem#getMetadata` can generate new metadata from it. When the developers use the `/csr` command or the csr issue status has been modified, the CSRBot or CSRCommand will add the `<!-- csr:` tag to the PR body or the comment. Then the CheckWorkItem will re-run the check because `CheckWorkItem#getMetadata` meets the newly added `<!-- csr:` tag.

Some test cases are added or adjusted.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1433](https://bugs.openjdk.java.net/browse/SKARA-1433): The change of the CSR status doesn't force the CheckWorkItem to re-run the check


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1327/head:pull/1327` \
`$ git checkout pull/1327`

Update a local copy of the PR: \
`$ git checkout pull/1327` \
`$ git pull https://git.openjdk.java.net/skara pull/1327/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1327`

View PR using the GUI difftool: \
`$ git pr show -t 1327`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1327.diff">https://git.openjdk.java.net/skara/pull/1327.diff</a>

</details>
