### PR TITLE
SKARA-1119: A bot should remind a PR author not to force push

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifier.java
@@ -34,9 +34,9 @@ import java.util.logging.Logger;
 public class PullRequestBranchNotifier implements Notifier, PullRequestListener {
     protected static final String FORCE_PUSH_MARKER = "<!-- force-push suggestion -->";
     protected static final String FORCE_PUSH_SUGGESTION= """
-            Please don't rebase and force-push to your branch of this PR because it invalidates previous review comments. \
-            To keep track of your changes incrementally, you only need to merge the target branch (optionally), \
-            commit your new change and push normally. The bot can squash them as a single commit when integrating.
+            Please do not rebase or force-push to an active PR as it invalidates existing review comments. \
+            All changes will be squashed into a single commit automatically when integrating. \
+            See [OpenJDK Developers’ Guide](https://openjdk.java.net/guide/#working-with-pull-requests) for more information.
             """;
     private final Path seedFolder;
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots.notify");

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifier.java
@@ -32,6 +32,12 @@ import java.nio.file.Path;
 import java.util.logging.Logger;
 
 public class PullRequestBranchNotifier implements Notifier, PullRequestListener {
+    protected static final String FORCE_PUSH_MARKER = "<!-- force-push suggestion -->";
+    protected static final String FORCE_PUSH_SUGGESTION= """
+            Please don't rebase and force-push to your branch of this PR because it invalidates previous review comments. \
+            To keep track of your changes incrementally, you only need to merge the target branch (optionally), \
+            commit your new change and push normally. The bot can squash them as a single commit when integrating.
+            """;
     private final Path seedFolder;
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots.notify");
 
@@ -111,5 +117,19 @@ public class PullRequestBranchNotifier implements Notifier, PullRequestListener 
         if (pr.state() == Issue.State.OPEN) {
             pushBranch(pr);
         }
+        var lastForcePushTime = pr.lastForcePushTime();
+        if (lastForcePushTime.isPresent()) {
+            var lastForcePushSuggestion = pr.comments().stream()
+                    .filter(comment -> comment.body().contains(FORCE_PUSH_MARKER))
+                    .reduce((a, b) -> b);
+            if (lastForcePushSuggestion.isEmpty() || lastForcePushSuggestion.get().createdAt().isBefore(lastForcePushTime.get())) {
+                log.info("Found force-push for " + describe(pr) + ", adding force-push suggestion");
+                pr.addComment("@" + pr.author().username() + " " + FORCE_PUSH_SUGGESTION + FORCE_PUSH_MARKER);
+            }
+        }
+    }
+
+    private String describe(PullRequest pr) {
+        return pr.repository().name() + "#" + pr.id();
     }
 }

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -326,5 +326,10 @@ class InMemoryPullRequest implements PullRequest {
     @Override
     public URI filesUrl(Hash hash) {
         return null;
+    }
+
+    @Override
+    public Optional<ZonedDateTime> lastForcePushTime() {
+        return Optional.empty();
     }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -170,4 +170,10 @@ public interface PullRequest extends Issue {
     default boolean isSame(PullRequest other) {
         return id().equals(other.id()) && repository().isSame(other.repository());
     }
+
+    /**
+     * Get the last force-push time. If there is no force-push in pull request
+     * or the restful api doesn't support force-push, return empty.
+     */
+    Optional<ZonedDateTime> lastForcePushTime();
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -765,4 +765,16 @@ public class GitHubPullRequest implements PullRequest {
         var endpoint = "/" + repository.name() + "/pull/" + id() + "/files/" + hash.hex();
         return host.getWebURI(endpoint);
     }
+
+    @Override
+    public Optional<ZonedDateTime> lastForcePushTime() {
+        return request.get("issues/" + json.get("number").toString() + "/timeline")
+                      .execute()
+                      .stream()
+                      .map(JSONValue::asObject)
+                      .filter(obj -> obj.contains("event"))
+                      .filter(obj -> obj.get("event").asString().equals("head_ref_force_pushed"))
+                      .reduce((a, b) -> b)
+                      .map(obj -> ZonedDateTime.parse(obj.get("created_at").asString()));
+    }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -853,4 +853,9 @@ public class GitLabMergeRequest implements PullRequest {
         }
         return host.getWebUri(uri);
     }
+
+    @Override
+    public Optional<ZonedDateTime> lastForcePushTime() {
+        return Optional.empty();
+    }
 }

--- a/forge/src/test/java/org/openjdk/skara/forge/github/GitHubRestApiTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/github/GitHubRestApiTests.java
@@ -95,4 +95,14 @@ public class GitHubRestApiTests {
         assertEquals(expectedPatchesSize, commit.get().parentDiffs().get(0).patches().size());
         return commit.get().parentDiffs().get(0);
     }
+
+    @Test
+    void testLastForcePushTime() {
+        var githubRepoOpt = githubHost.repository("openjdk/playground");
+        assumeTrue(githubRepoOpt.isPresent());
+        var githubRepo = githubRepoOpt.get();
+        var pr = githubRepo.pullRequest("96");
+        var lastForcePushTime = pr.lastForcePushTime();
+        assertEquals("2022-05-29T10:32:43Z", lastForcePushTime.get().toString());
+    }
 }

--- a/test/src/main/java/org/openjdk/skara/test/PullRequestData.java
+++ b/test/src/main/java/org/openjdk/skara/test/PullRequestData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,7 @@
  */
 package org.openjdk.skara.test;
 
+import java.time.ZonedDateTime;
 import org.openjdk.skara.forge.*;
 import org.openjdk.skara.vcs.Hash;
 
@@ -34,4 +35,5 @@ class PullRequestData extends IssueData {
     final Set<Check> checks = new HashSet<>();
     final List<Review> reviews = new ArrayList<>();
     boolean draft;
+    ZonedDateTime lastForcePushTime;
 }

--- a/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -261,5 +261,14 @@ public class TestPullRequest extends TestIssue implements PullRequest {
     @Override
     public URI filesUrl(Hash hash) {
         return URI.create(webUrl().toString() + "/files/" + hash.hex());
+    }
+
+    @Override
+    public Optional<ZonedDateTime> lastForcePushTime() {
+        return Optional.ofNullable(data.lastForcePushTime);
+    }
+
+    public void setLastForcePushTime(ZonedDateTime lastForcePushTime) {
+        data.lastForcePushTime = lastForcePushTime;
     }
 }


### PR DESCRIPTION
Hi all,

This patch adds a suggestion comment to the PR when the developers force-push the branch each time. Because I can't find the related rest api of the GitLab so I only implement it for GitHub.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issues
 * [SKARA-1119](https://bugs.openjdk.java.net/browse/SKARA-1119): A bot should remind a PR author not to force push
 * [SKARA-225](https://bugs.openjdk.java.net/browse/SKARA-225): Notify when commits are force pushed to a branch


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1328/head:pull/1328` \
`$ git checkout pull/1328`

Update a local copy of the PR: \
`$ git checkout pull/1328` \
`$ git pull https://git.openjdk.java.net/skara pull/1328/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1328`

View PR using the GUI difftool: \
`$ git pr show -t 1328`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1328.diff">https://git.openjdk.java.net/skara/pull/1328.diff</a>

</details>
