### PR TITLE
1466: Empty backport causes endless retries of command

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
@@ -157,6 +157,13 @@ public class BackportCommand implements CommandHandler {
                     localRepo.reset(head, true);
                     return;
                 }
+                // Check that applying the change actually created a diff
+                if (localRepo.diff(head).patches().isEmpty()) {
+                    reply.println("Could **not** apply backport `" + hash.abbreviate() + "` to " +
+                            "[" + repoName + "](" + targetRepo.webUrl() + ") because the change is already present in the target.");
+                    localRepo.reset(head, true);
+                    return;
+                }
 
                 backportHash = localRepo.commit("Backport " + hash.hex(), "duke", "duke@openjdk.org");
                 localRepo.push(backportHash, fork.url(), backportBranchName, false);


### PR DESCRIPTION
If a user tries to /backport a commit that results in an empty change, the BackportCommand fails to realize this and just errors out. It will then endlessly retry the command. This patch makes the BackportCommand detect an empty change and report it to the user.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1466](https://bugs.openjdk.org/browse/SKARA-1466): Empty backport causes endless retries of command


### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1329/head:pull/1329` \
`$ git checkout pull/1329`

Update a local copy of the PR: \
`$ git checkout pull/1329` \
`$ git pull https://git.openjdk.java.net/skara pull/1329/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1329`

View PR using the GUI difftool: \
`$ git pr show -t 1329`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1329.diff">https://git.openjdk.java.net/skara/pull/1329.diff</a>

</details>
