### PR TITLE
SKARA-1465

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
@@ -285,7 +285,9 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
                         if (altFixedVersionIssue.isPresent()) {
                             log.info("Found an already fixed backport " + altFixedVersionIssue.get().id() + " for " + issue.id()
                                     + " with fixVersion " + Backports.mainFixVersion(altFixedVersionIssue.get()).orElseThrow());
-                            return;
+                            issue = altFixedVersionIssue.get();
+                            // Do not update fixVersion
+                            requestedVersion = null;
                         } else {
                             var fixVersion = JdkVersion.parse(requestedVersion).orElseThrow();
                             var existing = Backports.findIssue(issue, fixVersion);

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
@@ -1692,7 +1692,12 @@ public class IssueNotifierTests {
             assertEquals(Set.of("18"), fixVersions(updatedIssue));
             assertEquals(RESOLVED, updatedIssue.state());
             assertEquals(List.of(), updatedIssue.assignees());
-            assertEquals(0, updatedIssue.comments().size());
+            // A commit comment should have been added
+            List<Comment> comments = updatedIssue.comments();
+            assertEquals(1, comments.size());
+            var comment = comments.get(0);
+            assertTrue(comment.body().contains(editHash.toString()));
+            assertTrue(comment.body().contains(repo.url().toString()));
 
             // There should be no link
             var links = updatedIssue.links();


### PR DESCRIPTION
The altfixversions feature introduced in [SKARA-1213](https://bugs.openjdk.java.net/browse/SKARA-1213) had the unfortunate side effect of also blocking additional commit comments from being added to existing backports. I think this needs to be fixed as those additional commit comments help integrators track where and when changes move between different repos.

This patch fixes this and adjusts the relevant test.