### PR TITLE
1432: The command `/csr unneeded` doesn't correctly handle an approved CSR

### DIFF
--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CSRTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CSRTests.java
@@ -830,7 +830,14 @@ class CSRTests {
             assertFalse(pr.labelNames().contains("csr"));
             assertLastCommentContains(pr, "the issue for this pull request");
             assertLastCommentContains(pr, "already has an approved CSR request");
-            // FIXME here, `/csr unneeded` is not used because these is a bug at CSRCommand. See the FIXME at CSRCommand.
+            // Use `/csr unneeded`.
+            pr.addComment("/csr unneeded");
+            TestBotRunner.runPeriodicItems(bot);
+            assertTrue(pr.body().contains("- [x] Change requires a CSR request to be approved"));
+            assertFalse(pr.labelNames().contains("csr"));
+            assertLastCommentContains(pr, "The CSR requirement cannot be removed as there is already a CSR associated " +
+                    "with the main issue of this pull request. Please withdraw the CSR");
+            assertLastCommentContains(pr, "and then use the command `/csr unneeded` again");
 
             // Revert the fix versions of the primary CSR to 18.
             csr.setProperty("fixVersions", JSON.array().add("18"));


### PR DESCRIPTION
Hi all,

Currently, when using the command `/csr unneeded` and the PR doesn't have `csr` label, the `CSRCommand` can't distinguish the situations of having no csr request and having an approved csr request. This patch removes the conditional statement `labels.contains(CSR_LABEL)` of the method `CSRCommand::handle` so that its following code can distinguish the different situations and reply different messages.

And the code about removing `csr` label is moved to the method `csrUnneededReply` to reduce some duplication.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1432](https://bugs.openjdk.org/browse/SKARA-1432): The command `/csr unneeded` doesn't correctly handle an approved CSR


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1331/head:pull/1331` \
`$ git checkout pull/1331`

Update a local copy of the PR: \
`$ git checkout pull/1331` \
`$ git pull https://git.openjdk.java.net/skara pull/1331/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1331`

View PR using the GUI difftool: \
`$ git pr show -t 1331`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1331.diff">https://git.openjdk.java.net/skara/pull/1331.diff</a>

</details>
