### PR TITLE
1467: Update JBS URL in Skara src

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,8 +20,8 @@ on [GitHub](https://github.com/openjdk/skara/pulls/).
 ## Issues
 
 You can find open issues to work on in the Skara project in the
-[JDK Bug System](https://bugs.openjdk.java.net/):
-<https://bugs.openjdk.java.net/projects/SKARA>.
+[JDK Bug System](https://bugs.openjdk.org/):
+<https://bugs.openjdk.org/projects/SKARA>.
 
 ## Larger Contributions
 

--- a/README.md
+++ b/README.md
@@ -244,8 +244,8 @@ Project Skara's wiki is available at <https://wiki.openjdk.java.net/display/skar
 
 ## Issues
 
-Issues are tracked in the [JDK Bug System](https://bugs.openjdk.java.net/)
-under project Skara at <https://bugs.openjdk.java.net/projects/SKARA/>.
+Issues are tracked in the [JDK Bug System](https://bugs.openjdk.org/)
+under project Skara at <https://bugs.openjdk.org/projects/SKARA/>.
 
 ## Contributing
 

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
@@ -107,7 +107,7 @@ class WebrevStorage {
                 var id = issue.get().shortId();
                 IssueTracker issueTracker = null;
                 try {
-                    issueTracker = IssueTracker.from("jira", URI.create("https://bugs.openjdk.java.net"));
+                    issueTracker = IssueTracker.from("jira", URI.create("https://bugs.openjdk.org"));
                 } catch (RuntimeException e) {
                     log.warning("Failed to create Jira issue tracker");
                 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CSRCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CSRCommand.java
@@ -49,7 +49,7 @@ public class CSRCommand implements CommandHandler {
 
     private static void jbsReply(PullRequest pr, PrintWriter writer) {
         writer.println("@" + pr.author().username() + " this pull request must refer to an issue in " +
-                      "[JBS](https://bugs.openjdk.java.net) to be able to link it to a [CSR](https://wiki.openjdk.java.net/display/csr/Main) request. To refer this pull request to " +
+                      "[JBS](https://bugs.openjdk.org) to be able to link it to a [CSR](https://wiki.openjdk.java.net/display/csr/Main) request. To refer this pull request to " +
                       "an issue in JBS, please use the `/issue` command in a comment in this pull request.");
     }
 

--- a/cli/src/main/java/org/openjdk/skara/cli/GitInfo.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitInfo.java
@@ -40,7 +40,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class GitInfo {
-    private static final URI JBS = URI.create("https://bugs.openjdk.java.net");
+    private static final URI JBS = URI.create("https://bugs.openjdk.org");
 
     private static void exit(String fmt, Object...args) {
         System.err.println(String.format(fmt, args));

--- a/cli/src/main/java/org/openjdk/skara/cli/GitWebrev.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitWebrev.java
@@ -423,7 +423,7 @@ public class GitWebrev {
                 System.exit(1);
         }
 
-        var jbs = "https://bugs.openjdk.java.net/browse/";
+        var jbs = "https://bugs.openjdk.org/browse/";
         var issueParts = issue != null ? issue.split("-") : new String[0];
         var jbsProject = issueParts.length == 2 && KNOWN_JBS_PROJECTS.contains(issueParts[0])?
             issueParts[0] : "JDK";

--- a/cli/src/main/java/org/openjdk/skara/cli/debug/IssueRedecorate.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/debug/IssueRedecorate.java
@@ -35,7 +35,7 @@ public class IssueRedecorate {
     static final List<Flag> flags = List.of(
             Switch.shortcut("u")
                   .fullname("url")
-                  .helptext("Alternative JBS URL (defaults to https://bugs.openjdk.java.net)")
+                  .helptext("Alternative JBS URL (defaults to https://bugs.openjdk.org)")
                   .optional(),
             Switch.shortcut("")
                   .fullname("version")
@@ -59,7 +59,7 @@ public class IssueRedecorate {
         }
 
         IssueTracker issueTracker = null;
-        var issueTrackerURI = URI.create(arguments.get("url").orString("https://bugs.openjdk.java.net"));
+        var issueTrackerURI = URI.create(arguments.get("url").orString("https://bugs.openjdk.org"));
         var issueTrackerFactories = IssueTrackerFactory.getIssueTrackerFactories();
         for (var issueTrackerFactory : issueTrackerFactories) {
             var tracker = issueTrackerFactory.create(issueTrackerURI, null, null);

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/Utils.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/Utils.java
@@ -47,7 +47,7 @@ import java.util.regex.Matcher;
 class Utils {
     static final Pattern ISSUE_ID_PATTERN = Pattern.compile("([A-Za-z][A-Za-z0-9]+)?-([0-9]+)");
     static final Pattern ISSUE_MARKDOWN_PATTERN =
-        Pattern.compile("^(?: \\* )?\\[([A-Z]+-[0-9]+)\\]\\(https:\\/\\/bugs.openjdk.java.net\\/browse\\/[A-Z]+-[0-9]+\\): .*$");
+        Pattern.compile("^(?: \\* )?\\[([A-Z]+-[0-9]+)\\]\\(https:\\/\\/bugs.openjdk.(?:java.net)|(?:org)\\/browse\\/[A-Z]+-[0-9]+\\): .*$");
 
     static void exit(String fmt, Object...args) {
         System.err.println(String.format(fmt, args));
@@ -217,7 +217,7 @@ class Utils {
             if (project == null) {
                 project = m.group(1);
             }
-            var issueTracker = IssueTracker.from("jira", URI.create("https://bugs.openjdk.java.net"));
+            var issueTracker = IssueTracker.from("jira", URI.create("https://bugs.openjdk.org"));
             return issueTracker.project(project).issue(id);
         }
 

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
@@ -120,7 +120,7 @@ public interface HostedRepository {
          * <!-- COMMIT COMMENT NOTIFICATION -->
          * ### Review
          *
-         * - [openjdk/skara/123](https://git.openjdk.java.net/skara/pull/123)
+         * - [openjdk/skara/123](https://git.openjdk.org/skara/pull/123)
          */
 
         var pattern = Pattern.compile("### Review[^]]*]\\((.*)\\)");

--- a/forge/src/test/java/org/openjdk/skara/forge/ForgeTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/ForgeTests.java
@@ -113,11 +113,11 @@ class ForgeTests {
                     <!-- COMMIT COMMENT NOTIFICATION -->
                     ### Review
 
-                     - [openjdk/skara/123](https://git.openjdk.java.net/skara/pull/123)
+                     - [openjdk/skara/123](https://git.openjdk.org/skara/pull/123)
                     """);
 
             var reviewUrl = gitHostedRepo.reviewUrl(hash);
-            assertEquals(URI.create("https://git.openjdk.java.net/skara/pull/123"), reviewUrl);
+            assertEquals(URI.create("https://git.openjdk.org/skara/pull/123"), reviewUrl);
         }
     }
 }

--- a/issuetracker/src/test/java/org/openjdk/skara/issuetracker/IssueTrackerTests.java
+++ b/issuetracker/src/test/java/org/openjdk/skara/issuetracker/IssueTrackerTests.java
@@ -91,10 +91,10 @@ class IssueTrackerTests {
             var link = Link.create(URI.create("http://www.example.com/abc"), "openjdk/skara/13")
                            .relationship("reviewed in")
                            .summary("Pull request")
-                           .iconUrl(URI.create("https://bugs.openjdk.java.net/images/icons/icon-view.png"))
+                           .iconUrl(URI.create("https://bugs.openjdk.org/images/icons/icon-view.png"))
                            .iconTitle("Review")
                            .resolved(true)
-                           .statusIconUrl(URI.create("https://bugs.openjdk.java.net/images/icons/icon-status-done-green.png"))
+                           .statusIconUrl(URI.create("https://bugs.openjdk.org/images/icons/icon-status-done-green.png"))
                            .statusIconTitle("Ready for integration")
                            .build();
             issue.addLink(link);

--- a/issuetracker/src/test/java/org/openjdk/skara/issuetracker/jira/JiraProjectTests.java
+++ b/issuetracker/src/test/java/org/openjdk/skara/issuetracker/jira/JiraProjectTests.java
@@ -41,7 +41,7 @@ public class JiraProjectTests {
 
     @Test
     void testJepIssue() throws IOException {
-        var uri = URIBuilder.base("https://bugs.openjdk.java.net").build();
+        var uri = URIBuilder.base("https://bugs.openjdk.org").build();
         var jiraHost = new JiraIssueTrackerFactory().create(uri, null, null);
         var jiraProject = jiraHost.project("JDK");
 

--- a/vcs/src/test/java/org/openjdk/skara/vcs/openjdk/converter/GitToHgConverterTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/openjdk/converter/GitToHgConverterTests.java
@@ -416,7 +416,7 @@ class GitToHgConverterTests {
     private void cloneAndConvertAndVerify(String repo) throws IOException {
         try (var hgRoot = new TemporaryDirectory(false);
              var gitRoot = new TemporaryDirectory(false)) {
-            var gitRepo = Repository.clone(URI.create("https://git.openjdk.java.net/" + repo + ".git"), gitRoot.path());
+            var gitRepo = Repository.clone(URI.create("https://git.openjdk.org/" + repo + ".git"), gitRoot.path());
             var hgRepo = TestableRepository.init(hgRoot.path(), VCS.HG);
             var converter = new GitToHgConverter(new Branch("master"));
             var marks = converter.convert(gitRepo, hgRepo);


### PR DESCRIPTION
This patch changes all bugs and github.openjdk.java.net references to openjdk.org.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1467](https://bugs.openjdk.org/browse/SKARA-1467): Update JBS URL in Skara src


### Reviewers
 * [Guoxiong Li](https://openjdk.java.net/census#gli) (@lgxbslgx - Committer)
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/skara pull/1332/head:pull/1332` \
`$ git checkout pull/1332`

Update a local copy of the PR: \
`$ git checkout pull/1332` \
`$ git pull https://git.openjdk.java.net/skara pull/1332/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1332`

View PR using the GUI difftool: \
`$ git pr show -t 1332`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/skara/pull/1332.diff">https://git.openjdk.java.net/skara/pull/1332.diff</a>

</details>
