### PR TITLE
1469: Skara does not build on macOS arm64

### DIFF
--- a/deps.env
+++ b/deps.env
@@ -1,8 +1,14 @@
 JDK_LINUX_X64_URL="https://download.java.net/java/GA/jdk17/0d483333a00540d886896bac774ff48b/35/GPL/openjdk-17_linux-x64_bin.tar.gz"
 JDK_LINUX_X64_SHA256="aef49cc7aa606de2044302e757fa94c8e144818e93487081c4fd319ca858134b"
 
+JDK_LINUX_AARCH64_URL="https://download.java.net/java/GA/jdk17/0d483333a00540d886896bac774ff48b/35/GPL/openjdk-17_linux-aarch64_bin.tar.gz"
+JDK_LINUX_AARCH64_SHA256="b5bf6377aabdc935bd72b36c494e178b12186b0e1f4be50f35134daa33bda052"
+
 JDK_MACOS_X64_URL="https://download.java.net/java/GA/jdk17/0d483333a00540d886896bac774ff48b/35/GPL/openjdk-17_macos-x64_bin.tar.gz"
 JDK_MACOS_X64_SHA256="18e11cf9bbc6f584031e801b11ae05a233c32086f8e1b84eb8a1e9bb8e1f5d90"
+
+JDK_MACOS_AARCH64_URL="https://download.java.net/java/GA/jdk17/0d483333a00540d886896bac774ff48b/35/GPL/openjdk-17_macos-aarch64_bin.tar.gz"
+JDK_MACOS_AARCH64_SHA256="b5bf6377aabdc935bd72b36c494e178b12186b0e1f4be50f35134daa33bda052"
 
 JDK_WINDOWS_X64_URL="https://download.java.net/java/GA/jdk17/0d483333a00540d886896bac774ff48b/35/GPL/openjdk-17_windows-x64_bin.zip"
 JDK_WINDOWS_X64_SHA256="e88b0df00021c9d266bb435c9a95fdc67d1948cce4518daf85c234907bd393c5"

--- a/gradlew
+++ b/gradlew
@@ -100,6 +100,17 @@ if [ "${ARCH}" = "x86_64" ]; then
             JDK_SHA256="${JDK_WINDOWS_X64_SHA256}"
             ;;
     esac
+elif [ "${ARCH}" = "arm64" ]; then
+    case "${OS}" in
+        Linux )
+            JDK_URL="${JDK_LINUX_AARCH64_URL}"
+            JDK_SHA256="${JDK_LINUX_AARCH64_SHA256}"
+            ;;
+        Darwin )
+            JDK_URL="${JDK_MACOS_AARCH64_URL}"
+            JDK_SHA256="${JDK_MACOS_AARCH64_SHA256}"
+            ;;
+    esac
 fi
 
 if [ -z "${HTTPS_PROXY}" -a -z "${https_proxy}" -a -z "${HTTP_PROXY}" -a -z "${http_proxy}" ]; then

--- a/gradlew
+++ b/gradlew
@@ -100,15 +100,15 @@ if [ "${ARCH}" = "x86_64" ]; then
             JDK_SHA256="${JDK_WINDOWS_X64_SHA256}"
             ;;
     esac
-elif [ "${ARCH}" = "arm64" ]; then
+elif [ "${ARCH}" = "arm64" -o "${ARCH}" = "aarch64" ]; then
     case "${OS}" in
-        Linux )
-            JDK_URL="${JDK_LINUX_AARCH64_URL}"
-            JDK_SHA256="${JDK_LINUX_AARCH64_SHA256}"
-            ;;
         Darwin )
             JDK_URL="${JDK_MACOS_AARCH64_URL}"
             JDK_SHA256="${JDK_MACOS_AARCH64_SHA256}"
+            ;;
+        Linux )
+            JDK_URL="${JDK_LINUX_AARCH64_URL}"
+            JDK_SHA256="${JDK_LINUX_AARCH64_SHA256}"
             ;;
     esac
 fi


### PR DESCRIPTION
Hi all,

please review this patch that adds support for both Linux and macOS AArch64 to `gradlew`. I tested this for macOS/AArch64 but did not have a Linux/AArch64 system available (but it really should work unless I made a typo 😄).

Testing:
- [x] Tested locally on macOS/AArch64 using `sh gradlew`
- [x] `sh gradlew test` passes

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1469](https://bugs.openjdk.org/browse/SKARA-1469): Skara does not build on macOS arm64


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1333/head:pull/1333` \
`$ git checkout pull/1333`

Update a local copy of the PR: \
`$ git checkout pull/1333` \
`$ git pull https://git.openjdk.org/skara pull/1333/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1333`

View PR using the GUI difftool: \
`$ git pr show -t 1333`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1333.diff">https://git.openjdk.org/skara/pull/1333.diff</a>

</details>
