### PR TITLE
1474: Backout SKARA-1119

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifier.java
@@ -32,12 +32,6 @@ import java.nio.file.Path;
 import java.util.logging.Logger;
 
 public class PullRequestBranchNotifier implements Notifier, PullRequestListener {
-    protected static final String FORCE_PUSH_MARKER = "<!-- force-push suggestion -->";
-    protected static final String FORCE_PUSH_SUGGESTION= """
-            Please do not rebase or force-push to an active PR as it invalidates existing review comments. \
-            All changes will be squashed into a single commit automatically when integrating. \
-            See [OpenJDK Developers’ Guide](https://openjdk.java.net/guide/#working-with-pull-requests) for more information.
-            """;
     private final Path seedFolder;
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots.notify");
 
@@ -117,19 +111,5 @@ public class PullRequestBranchNotifier implements Notifier, PullRequestListener 
         if (pr.state() == Issue.State.OPEN) {
             pushBranch(pr);
         }
-        var lastForcePushTime = pr.lastForcePushTime();
-        if (lastForcePushTime.isPresent()) {
-            var lastForcePushSuggestion = pr.comments().stream()
-                    .filter(comment -> comment.body().contains(FORCE_PUSH_MARKER))
-                    .reduce((a, b) -> b);
-            if (lastForcePushSuggestion.isEmpty() || lastForcePushSuggestion.get().createdAt().isBefore(lastForcePushTime.get())) {
-                log.info("Found force-push for " + describe(pr) + ", adding force-push suggestion");
-                pr.addComment("@" + pr.author().username() + " " + FORCE_PUSH_SUGGESTION + FORCE_PUSH_MARKER);
-            }
-        }
-    }
-
-    private String describe(PullRequest pr) {
-        return pr.repository().name() + "#" + pr.id();
     }
 }

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifierTests.java
@@ -22,7 +22,6 @@
  */
 package org.openjdk.skara.bots.notify.prbranch;
 
-import java.time.ZonedDateTime;
 import org.junit.jupiter.api.*;
 import org.openjdk.skara.forge.*;
 import org.openjdk.skara.issuetracker.Issue;
@@ -34,8 +33,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.openjdk.skara.bots.notify.prbranch.PullRequestBranchNotifier.FORCE_PUSH_MARKER;
-import static org.openjdk.skara.bots.notify.prbranch.PullRequestBranchNotifier.FORCE_PUSH_SUGGESTION;
 
 public class PullRequestBranchNotifierTests {
     private TestBotFactory testBotBuilder(HostedRepository hostedRepository, Path storagePath) {
@@ -296,93 +293,6 @@ public class PullRequestBranchNotifierTests {
             assertTrue(lastComment.body().contains("The dependent pull request has now"), lastComment.body());
             assertTrue(lastComment.body().contains("git checkout followup"), lastComment.body());
             assertTrue(lastComment.body().contains("git commit -m \"Merge master\""), lastComment.body());
-        }
-    }
-
-    @Test
-    void testForcePush(TestInfo testInfo) throws IOException {
-        try (var credentials = new HostCredentials(testInfo);
-             var tempFolder = new TemporaryDirectory()) {
-            var repo = credentials.getHostedRepository();
-            var repoFolder = tempFolder.path().resolve("repo");
-            var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
-            var storageFolder = tempFolder.path().resolve("storage");
-            var notifyBot = testBotBuilder(repo, storageFolder).create("notify", JSON.object());
-
-            // Create a PR
-            var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line");
-            localRepo.push(editHash, repo.url(), "source", true);
-            var pr = credentials.createPullRequest(repo, "master", "source", "This is a PR", false);
-            pr.addLabel("rfr");
-            pr.addComment("initial");
-            TestBotRunner.runPeriodicItems(notifyBot);
-
-            // The PR shouldn't have the force-push suggestion comment
-            assertEquals(1, pr.comments().size());
-            var lastComment = pr.comments().get(pr.comments().size() - 1);
-            assertTrue(lastComment.body().contains("initial"));
-            assertFalse(lastComment.body().contains(FORCE_PUSH_MARKER));
-            assertFalse(lastComment.body().contains(FORCE_PUSH_SUGGESTION));
-
-            // Normally push.
-            var updatedHash = CheckableRepository.appendAndCommit(localRepo, "Normally push");
-            localRepo.push(updatedHash, repo.url(), "source", false);
-            pr.addComment("Normally push");
-            TestBotRunner.runPeriodicItems(notifyBot);
-
-            // The PR shouldn't have the force-push suggestion comment.
-            assertEquals(2, pr.comments().size());
-            lastComment = pr.comments().get(pr.comments().size() - 1);
-            assertTrue(lastComment.body().contains("Normally push"));
-            assertFalse(lastComment.body().contains(FORCE_PUSH_MARKER));
-            assertFalse(lastComment.body().contains(FORCE_PUSH_SUGGESTION));
-
-            // Simulate force-push.
-            updatedHash = CheckableRepository.appendAndCommit(localRepo, "test force-push");
-            localRepo.checkout(editHash);
-            localRepo.squash(updatedHash);
-            var forcePushHash = localRepo.commit("test force-push", "duke", "duke@openjdk.java.net");
-            localRepo.push(forcePushHash, repo.url(), "source", true);
-            ((TestPullRequest) pr).setLastForcePushTime(ZonedDateTime.now());
-            pr.addComment("Force-push");
-            TestBotRunner.runPeriodicItems(notifyBot);
-
-            // The last comment of the PR should be the force-push suggestion comment.
-            assertEquals(4, pr.comments().size());
-            lastComment = pr.comments().get(pr.comments().size() - 1);
-            assertFalse(lastComment.body().contains("Force-push"));
-            assertTrue(lastComment.body().contains(FORCE_PUSH_MARKER));
-            assertTrue(lastComment.body().contains(FORCE_PUSH_SUGGESTION));
-
-            // Normally push again.
-            updatedHash = CheckableRepository.appendAndCommit(localRepo, "Normally push");
-            localRepo.push(updatedHash, repo.url(), "source", false);
-            pr.addComment("Normally push again");
-            TestBotRunner.runPeriodicItems(notifyBot);
-
-            // The last comment of the PR shouldn't be the force-push suggestion comment.
-            assertEquals(5, pr.comments().size());
-            lastComment = pr.comments().get(pr.comments().size() - 1);
-            assertTrue(lastComment.body().contains("Normally push again"));
-            assertFalse(lastComment.body().contains(FORCE_PUSH_MARKER));
-            assertFalse(lastComment.body().contains(FORCE_PUSH_SUGGESTION));
-
-            // Simulate force-push again.
-            updatedHash = CheckableRepository.appendAndCommit(localRepo, "test force-push again");
-            localRepo.checkout(editHash);
-            localRepo.squash(updatedHash);
-            forcePushHash = localRepo.commit("test force-push again", "duke", "duke@openjdk.java.net");
-            localRepo.push(forcePushHash, repo.url(), "source", true);
-            ((TestPullRequest) pr).setLastForcePushTime(ZonedDateTime.now());
-            pr.addComment("Force-push again");
-            TestBotRunner.runPeriodicItems(notifyBot);
-
-            // The last comment of the PR should be the force-push suggestion comment.
-            assertEquals(7, pr.comments().size());
-            lastComment = pr.comments().get(pr.comments().size() - 1);
-            assertFalse(lastComment.body().contains("Force-push again"));
-            assertTrue(lastComment.body().contains(FORCE_PUSH_MARKER));
-            assertTrue(lastComment.body().contains(FORCE_PUSH_SUGGESTION));
         }
     }
 }

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -326,10 +326,5 @@ class InMemoryPullRequest implements PullRequest {
     @Override
     public URI filesUrl(Hash hash) {
         return null;
-    }
-
-    @Override
-    public Optional<ZonedDateTime> lastForcePushTime() {
-        return Optional.empty();
     }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -170,10 +170,4 @@ public interface PullRequest extends Issue {
     default boolean isSame(PullRequest other) {
         return id().equals(other.id()) && repository().isSame(other.repository());
     }
-
-    /**
-     * Get the last force-push time. If there is no force-push in pull request
-     * or the restful api doesn't support force-push, return empty.
-     */
-    Optional<ZonedDateTime> lastForcePushTime();
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -765,16 +765,4 @@ public class GitHubPullRequest implements PullRequest {
         var endpoint = "/" + repository.name() + "/pull/" + id() + "/files/" + hash.hex();
         return host.getWebURI(endpoint);
     }
-
-    @Override
-    public Optional<ZonedDateTime> lastForcePushTime() {
-        return request.get("issues/" + json.get("number").toString() + "/timeline")
-                      .execute()
-                      .stream()
-                      .map(JSONValue::asObject)
-                      .filter(obj -> obj.contains("event"))
-                      .filter(obj -> obj.get("event").asString().equals("head_ref_force_pushed"))
-                      .reduce((a, b) -> b)
-                      .map(obj -> ZonedDateTime.parse(obj.get("created_at").asString()));
-    }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -853,9 +853,4 @@ public class GitLabMergeRequest implements PullRequest {
         }
         return host.getWebUri(uri);
     }
-
-    @Override
-    public Optional<ZonedDateTime> lastForcePushTime() {
-        return Optional.empty();
-    }
 }

--- a/forge/src/test/java/org/openjdk/skara/forge/github/GitHubRestApiTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/github/GitHubRestApiTests.java
@@ -95,14 +95,4 @@ public class GitHubRestApiTests {
         assertEquals(expectedPatchesSize, commit.get().parentDiffs().get(0).patches().size());
         return commit.get().parentDiffs().get(0);
     }
-
-    @Test
-    void testLastForcePushTime() {
-        var githubRepoOpt = githubHost.repository("openjdk/playground");
-        assumeTrue(githubRepoOpt.isPresent());
-        var githubRepo = githubRepoOpt.get();
-        var pr = githubRepo.pullRequest("96");
-        var lastForcePushTime = pr.lastForcePushTime();
-        assertEquals("2022-05-29T10:32:43Z", lastForcePushTime.get().toString());
-    }
 }

--- a/test/src/main/java/org/openjdk/skara/test/PullRequestData.java
+++ b/test/src/main/java/org/openjdk/skara/test/PullRequestData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,6 @@
  */
 package org.openjdk.skara.test;
 
-import java.time.ZonedDateTime;
 import org.openjdk.skara.forge.*;
 import org.openjdk.skara.vcs.Hash;
 
@@ -35,5 +34,4 @@ class PullRequestData extends IssueData {
     final Set<Check> checks = new HashSet<>();
     final List<Review> reviews = new ArrayList<>();
     boolean draft;
-    ZonedDateTime lastForcePushTime;
 }

--- a/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -261,14 +261,5 @@ public class TestPullRequest extends TestIssue implements PullRequest {
     @Override
     public URI filesUrl(Hash hash) {
         return URI.create(webUrl().toString() + "/files/" + hash.hex());
-    }
-
-    @Override
-    public Optional<ZonedDateTime> lastForcePushTime() {
-        return Optional.ofNullable(data.lastForcePushTime);
-    }
-
-    public void setLastForcePushTime(ZonedDateTime lastForcePushTime) {
-        data.lastForcePushTime = lastForcePushTime;
     }
 }


### PR DESCRIPTION
This patch is a revert/backout of SKARA-1119.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1474](https://bugs.openjdk.org/browse/SKARA-1474): Backout SKARA-1119


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1334/head:pull/1334` \
`$ git checkout pull/1334`

Update a local copy of the PR: \
`$ git checkout pull/1334` \
`$ git pull https://git.openjdk.org/skara pull/1334/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1334`

View PR using the GUI difftool: \
`$ git pr show -t 1334`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1334.diff">https://git.openjdk.org/skara/pull/1334.diff</a>

</details>
