### PR TITLE
SKARA-1475

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierBuilder.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierBuilder.java
@@ -47,6 +47,7 @@ class IssueNotifierBuilder {
     private boolean useHeadVersion = false;
     private HostedRepository originalRepository;
     private boolean resolve = true;
+    private Set<String> tagIgnoreOpt = Set.of();
 
     IssueNotifierBuilder issueProject(IssueProject issueProject) {
         this.issueProject = issueProject;
@@ -139,6 +140,11 @@ class IssueNotifierBuilder {
         return this;
     }
 
+    public IssueNotifierBuilder tagIgnoreOpt(Set<String> tagIgnoreOpt) {
+        this.tagIgnoreOpt = tagIgnoreOpt;
+        return this;
+    }
+
     public boolean prOnly() {
         return prOnly;
     }
@@ -152,6 +158,6 @@ class IssueNotifierBuilder {
         return new IssueNotifier(issueProject, reviewLink, reviewIcon, commitLink, commitIcon,
                 setFixVersion, fixVersions, altFixVersions, jbsBackport, prOnly,
                 repoOnly, buildName, censusRepository, censusRef, namespace, useHeadVersion, originalRepository,
-                resolve);
+                resolve, tagIgnoreOpt);
     }
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierFactory.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierFactory.java
@@ -123,6 +123,15 @@ public class IssueNotifierFactory implements NotifierFactory {
             builder.originalRepository(botConfiguration.repository(notifierConfiguration.get("originalrepository").asString()));
         }
 
+        if (notifierConfiguration.contains("tag")) {
+            var tag = notifierConfiguration.get("tag");
+            if (tag.contains("ignoreopt")) {
+                builder.tagIgnoreOpt(tag.get("ignoreopt").stream()
+                        .map(JSONValue::asString)
+                        .collect(Collectors.toSet()));
+            }
+        }
+
         return builder.build();
     }
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/JbsBackport.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/JbsBackport.java
@@ -63,7 +63,7 @@ public class JbsBackport {
 
     public Issue createBackport(Issue primary, String fixVersion, String assignee) {
         if (backportRequest == null) {
-            if (primary.project().webUrl().toString().contains("openjdk.java.net")) {
+            if (primary.project().webUrl().toString().contains("openjdk.org")) {
                 throw new RuntimeException("Backports on JBS require vault authentication");
             } else {
                 return createBackportIssue(primary);

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
@@ -878,9 +878,10 @@ public class IssueNotifierTests {
             var issueProject = credentials.getIssueProject();
             var storageFolder = tempFolder.path().resolve("storage");
             var jbsNotifierConfig = JSON.object().put("fixversions", JSON.object()
-                                                                         .put("master", "16-foo")
-                                                                         .put("other", "16.0.2"))
-                                        .put("buildname", "team");
+                            .put("master", "16-foo")
+                            .put("other", "16.0.2"))
+                    .put("buildname", "team")
+                    .put("tag", JSON.object().put("ignoreopt", JSON.array().add("foo")));
             var notifyBot = testBotBuilder(repo, issueProject, storageFolder, jbsNotifierConfig).create("notify", JSON.object());
 
             // Initialize history
@@ -1050,6 +1051,92 @@ public class IssueNotifierTests {
             assertEquals("b01", backportIssue.properties().get(RESOLVED_IN_BUILD).asString());
             // But not in the update backport
             assertEquals("team", updatedIssue.properties().get(RESOLVED_IN_BUILD).asString());
+        }
+    }
+
+    @Test
+    void testIssueBuildAfterTagJdk8uSuffix(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+
+            var repo = credentials.getHostedRepository();
+            var repoFolder = tempFolder.path().resolve("repo");
+            var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
+            credentials.commitLock(localRepo);
+            localRepo.pushAll(repo.url());
+
+            var issueProject = credentials.getIssueProject();
+            var storageFolder = tempFolder.path().resolve("storage");
+            var jbsNotifierConfig = JSON.object().put("fixversions", JSON.object()
+                            .put("master", "8u341")
+                            .put("other", "8u341-foo"))
+                    .put("buildname", "team");
+            var notifyBot = testBotBuilder(repo, issueProject, storageFolder, jbsNotifierConfig).create("notify", JSON.object());
+
+            // Initialize history
+            var current = localRepo.resolve("master").orElseThrow();
+            localRepo.push(current, repo.url(), "other");
+            localRepo.tag(current, "jdk8u341-b00", "First tag", "duke", "duke@openjdk.org");
+            localRepo.tag(current, "jdk8u341-foo-b00", "First foo tag", "duke", "duke@openjdk.org");
+            localRepo.push(new Branch(repo.url().toString()), "--tags", false);
+            TestBotRunner.runPeriodicItems(notifyBot);
+
+            // Create an issue and commit a fix
+            var authorEmailAddress = issueProject.issueTracker().currentUser().username() + "@openjdk.org";
+            var issue = issueProject.createIssue("This is an issue", List.of("Indeed"), Map.of("issuetype", JSON.of("Enhancement")));
+            issue.setProperty("fixVersions", JSON.of("8u341"));
+            var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", issue.id() + ": Fix that issue", "Duke", authorEmailAddress);
+            localRepo.push(editHash, repo.url(), "master");
+            localRepo.push(editHash, repo.url(), "other");
+            TestBotRunner.runPeriodicItems(notifyBot);
+
+            // The changeset should be reflected in a comment in the issue and in a new backport
+            var updatedIssue = issueProject.issue(issue.id()).orElseThrow();
+            var backportIssue = updatedIssue.links().get(0).issue().orElseThrow();
+
+            var comments = updatedIssue.comments();
+            assertEquals(1, comments.size());
+            var comment = comments.get(0);
+            assertTrue(comment.body().contains(editHash.toString()));
+
+            var backportComments = backportIssue.comments();
+            assertEquals(1, backportComments.size());
+            var backportComment = backportComments.get(0);
+            assertTrue(backportComment.body().contains(editHash.toString()));
+
+            // As well as a fixVersion and a resolved in build
+            assertEquals(Set.of("8u341"), fixVersions(updatedIssue));
+            assertEquals("team", updatedIssue.properties().get(RESOLVED_IN_BUILD).asString());
+            assertEquals(Set.of("8u341-foo"), fixVersions(backportIssue));
+            assertEquals("team", backportIssue.properties().get(RESOLVED_IN_BUILD).asString());
+
+            // The issue should be assigned and resolved
+            assertEquals(RESOLVED, updatedIssue.state());
+            assertEquals(List.of(issueProject.issueTracker().currentUser()), updatedIssue.assignees());
+            assertEquals(RESOLVED, backportIssue.state());
+            assertEquals(List.of(issueProject.issueTracker().currentUser()), backportIssue.assignees());
+
+            // Tag it
+            localRepo.tag(editHash, "jdk8u341-b01", "Second tag", "duke", "duke@openjdk.org");
+            localRepo.push(new Branch(repo.url().toString()), "--tags", false);
+            TestBotRunner.runPeriodicItems(notifyBot);
+
+            // The build should now be updated
+            updatedIssue = issueProject.issue(issue.id()).orElseThrow();
+            backportIssue = issueProject.issue(backportIssue.id()).orElseThrow();
+            assertEquals("b01", updatedIssue.properties().get(RESOLVED_IN_BUILD).asString());
+            // But not in the update backport
+            assertEquals("team", backportIssue.properties().get(RESOLVED_IN_BUILD).asString());
+
+            // Tag it with an unrelated tag
+            localRepo.tag(editHash, "jdk8u341-foo-b01", "Second foo tag", "duke", "duke@openjdk.org");
+            localRepo.push(new Branch(repo.url().toString()), "--tags", false);
+            TestBotRunner.runPeriodicItems(notifyBot);
+
+            // The build should now be updated
+            updatedIssue = issueProject.issue(issue.id()).orElseThrow();
+            backportIssue = issueProject.issue(backportIssue.id()).orElseThrow();
+            assertEquals("b01", backportIssue.properties().get(RESOLVED_IN_BUILD).asString());
         }
     }
 

--- a/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/OpenJDKTag.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/OpenJDKTag.java
@@ -45,18 +45,19 @@ public class OpenJDKTag {
     /**
      * The patterns have the following groups:
      *
-     *                prefix   version  update  buildPrefix  buildNum
-     *                -------  -------  ------  -----------  ------
-     * jdk-9.1+27  -> jdk-9.1  9.1              +            27
-     * jdk8-b90    -> jdk8     8                -b           90
-     * jdk7u40-b20 -> jdk7u40  7u40     u20     -b           29
-     * hs24-b30    -> hs24     24               -b           30
-     * hs23.6-b19  -> hs23.6   23.6     .6      -b           19
-     * 11.1+22     -> 11.1     11.1     .1      +            22
-     * 8u321-b03   -> 8u321    8u321    u321    -b           3
+     *                     prefix       version   buildPrefix  buildNum
+     *                     -------      -------   -----------  ------
+     * jdk-9.1+27       -> jdk-9.1      9.1       +            27
+     * jdk8-b90         -> jdk8         8         -b           90
+     * jdk7u40-b20      -> jdk7u40      7u40      -b           29
+     * hs24-b30         -> hs24         24        -b           30
+     * hs23.6-b19       -> hs23.6       23.6      -b           19
+     * 11.1+22          -> 11.1         11.1      +            22
+     * 8u321-b03        -> 8u321        8u321     -b           3
+     * jdk8u341-foo-b17 -> jdk8u341-foo 8u341-foo -b           17
      */
 
-    private final static String legacyOpenJDKVersionPattern = "(jdk([0-9]{1,2}(u[0-9]{1,3})?))";
+    private final static String legacyOpenJDKVersionPattern = "(jdk([0-9]{1,2}(u[0-9]{1,3}(?:-[a-z0-9]+)?)?))";
     private final static String legacyHSVersionPattern = "((hs[0-9]{1,2}(\\.[0-9]{1,3})?))";
     private final static String legacyBuildPattern = "(-b)([0-9]{2,3})";
     // Version pattern matching project Verona (JEP 223) based versions

--- a/vcs/src/test/java/org/openjdk/skara/vcs/openjdk/OpenJDKTagTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/openjdk/OpenJDKTagTests.java
@@ -143,4 +143,12 @@ class OpenJDKTagTests {
         assertEquals("11.0.15.0.3.4.5", jdkTag.version());
         assertEquals(1, jdkTag.buildNum().orElseThrow());
     }
+
+    @Test
+    void parse8uSuffixVersion() {
+        var tag = new Tag("jdk8u341-foo-b17");
+        var jdkTag = OpenJDKTag.create(tag).orElseThrow();
+        assertEquals("8u341-foo", jdkTag.version());
+        assertEquals(17, jdkTag.buildNum().orElseThrow());
+    }
 }


### PR DESCRIPTION
This patch adds a configuration option for the IssueNotifier. This new option controls how tags are matched with fixVersion when updating the Resolved In Build field. Currently, any "opt" string in the fixVersion (e.g. 17.0.4-oracle) is ignored as tags are do not include the 'oracle' opt string. We now have the need to require tags to include such a string for some releases/versions. I believe this should be the default behavior and ignoring "oracle" should be the exception.

The new option goes into the issue part of the notifier block. By default, the opt string will be considered part of the version string and required in the tag for a match (this is the opposite of the current behavior). By using the new option, a set of opt strings that should not be required in a tag for a match may be configured. In the example below a tag `jdk8u341-b01` would match a fix version of `8u341-foo`.

```
"issue": {
  "tag": {
    "ignoreopt": [ "foo", "bar" ],
  }
}
```