### PR TITLE
1478: Add metrics and loggin measuring time before WorkItems start to run

### DIFF
--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
@@ -59,7 +59,12 @@ public class BotRunner {
 
     private final AtomicInteger workIdCounter = new AtomicInteger();
 
-    private class PendingWorkItem {
+    /**
+     * A wrapper for a WorkItem while it's tracked as pending. Used to track
+     * when a particular WorkItem entered the pending state so that metrics
+     * and log messages can use this information.
+     */
+    private static class PendingWorkItem {
         private final WorkItem item;
         private final Instant createTime;
 

--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
@@ -33,7 +33,6 @@ import java.time.*;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.logging.*;
-import java.util.stream.Collectors;
 import java.lang.management.ManagementFactory;
 import com.sun.management.ThreadMXBean;
 
@@ -60,6 +59,24 @@ public class BotRunner {
 
     private final AtomicInteger workIdCounter = new AtomicInteger();
 
+    private class PendingWorkItem {
+        private final WorkItem item;
+        private final Instant createTime;
+
+        public PendingWorkItem(WorkItem item) {
+            this(item, null);
+        }
+
+        public PendingWorkItem(WorkItem item, Instant originalCreateTime) {
+            this.item = item;
+            if (originalCreateTime != null) {
+                this.createTime = originalCreateTime;
+            } else {
+                this.createTime = Instant.now();
+            }
+        }
+    }
+
     private class RunnableWorkItem implements Runnable {
         private static final Counter.WithThreeLabels EXCEPTIONS_COUNTER =
             Counter.name("skara_runner_exceptions").labels("bot", "work_item", "exception").register();
@@ -69,6 +86,18 @@ public class BotRunner {
             Gauge.name("skara_runner_user_time").labels("bot", "work_item").register();
         private static final Gauge.WithTwoLabels ALLOCATED_BYTES_GAUGE =
             Gauge.name("skara_runner_allocated_bytes").labels("bot", "work_item").register();
+        /**
+         * Gauge that tracks the time WorkItems have been pending before
+         * being submitted.
+         */
+        private static final Gauge.WithTwoLabels PENDING_TIME_GAUGE =
+            Gauge.name("skara_runner_pending_time").labels("bot", "work_item").register();
+        /**
+         * Gauge that tracks the time WorkItems have been submitted before
+         * starting to run.
+         */
+        private static final Gauge.WithTwoLabels SUBMITTED_TIME_GAUGE =
+                Gauge.name("skara_runner_submitted_time").labels("bot", "work_item").register();
 
         private final WorkItem item;
         private final int workId = workIdCounter.incrementAndGet();
@@ -175,8 +204,8 @@ public class BotRunner {
 
             synchronized (executor) {
                 if (scratchPaths.isEmpty()) {
-                    log.finer("No scratch paths available - postponing " + item);
-                    addPending(item, null);
+                    log.warning("No scratch paths available - postponing " + item);
+                    addPending(new PendingWorkItem(item), null);
                     return;
                 }
                 scratchPath = scratchPaths.removeFirst();
@@ -185,7 +214,10 @@ public class BotRunner {
             Collection<WorkItem> followUpItems = null;
             try (var __ = new LogContext(Map.of("work_item", item.toString(),
                     "work_id", String.valueOf(workId)))) {
-                log.log(Level.FINE, "Executing item " + item + " on repository " + scratchPath, TaskPhases.BEGIN);
+                var submittedDuration = Duration.between(createTime, Instant.now());
+                SUBMITTED_TIME_GAUGE.labels(item.botName(), item.workItemName()).set(submittedDuration.toMillis() / 1_000_000.0);
+                log.log(Level.FINE, "Executing item " + item + " on repository " + scratchPath
+                        + " after being submitted for " + submittedDuration, TaskPhases.BEGIN);
                 try {
                     followUpItems = item.run(scratchPath);
                 } catch (UncheckedRestException e) {
@@ -218,15 +250,15 @@ public class BotRunner {
 
                 // Some of the pending items may now be eligible for execution
                 var candidateItems = pending.entrySet().stream()
-                                            .filter(e -> e.getValue().isEmpty() || !active.containsKey(e.getValue().get()))
-                                            .map(Map.Entry::getKey)
-                                            .collect(Collectors.toList());
+                        .filter(e -> e.getValue().isEmpty() || !active.containsKey(e.getValue().get()))
+                        .map(Map.Entry::getKey)
+                        .toList();
 
                 // Try the candidates against the current active set
                 for (var candidate : candidateItems) {
                     boolean maySubmit = true;
                     for (var activeItem : active.keySet()) {
-                        if (!activeItem.concurrentWith(candidate)) {
+                        if (!activeItem.concurrentWith(candidate.item)) {
                             // Still can't run this candidate, leave it pending
                             log.finer("Cannot submit candidate " + candidate + " - not concurrent with " + activeItem);
                             maySubmit = false;
@@ -236,8 +268,12 @@ public class BotRunner {
 
                     if (maySubmit) {
                         removePending(candidate);
-                        submit(candidate);
-                        log.finer("Submitting candidate: " + candidate);
+                        submit(candidate.item);
+                        var timeSinceCreation = Duration.between(candidate.createTime, Instant.now());
+                        PENDING_TIME_GAUGE.labels(candidate.item.botName(), candidate.item.workItemName())
+                                .set(timeSinceCreation.toMillis() / 1_000_000.0);
+                        log.fine("Submitting candidate: " + candidate.item
+                                + " after being pending for " + timeSinceCreation);
                     }
                 }
             }
@@ -245,7 +281,7 @@ public class BotRunner {
     }
 
     // Mapping of pending items to the active item preventing them from running
-    private final Map<WorkItem, Optional<WorkItem>> pending;
+    private final Map<PendingWorkItem, Optional<WorkItem>> pending;
     // Mapping of active WorkItem to their RunnableWorkItem
     private final Map<WorkItem, RunnableWorkItem> active;
     private final Deque<Path> scratchPaths;
@@ -271,19 +307,21 @@ public class BotRunner {
             for (var activeItem : active.keySet()) {
                 if (!activeItem.concurrentWith(item)) {
 
+                    Instant originalCreateTime = null;
                     for (var pendingItem : pending.keySet()) {
                         // If there are pending items of the same type that we cannot run concurrently with, replace them.
-                        if (item.replaces(pendingItem)) {
+                        if (item.replaces(pendingItem.item)) {
                             log.finer("Discarding obsoleted item " + pendingItem +
                                               " in favor of item " + item);
                             DISCARDED_COUNTER.labels(item.botName(), item.workItemName()).inc();
                             removePending(pendingItem);
+                            originalCreateTime = pendingItem.createTime;
                             // There can't be more than one
                             break;
                         }
                     }
 
-                    addPending(item, activeItem);
+                    addPending(new PendingWorkItem(item, originalCreateTime), activeItem);
                     return;
                 }
             }
@@ -294,20 +332,20 @@ public class BotRunner {
 
     /**
      * Called to add a WorkItem to the pending queue
-     * @param item Item to queue
+     * @param pendingItem Item to queue
      * @param activeItem Optional active item that this item is waiting for
      */
-    private void addPending(WorkItem item, WorkItem activeItem) {
-        pending.put(item, Optional.ofNullable(activeItem));
-        pendingGauge.labels(item.botName(), item.workItemName()).inc();
+    private void addPending(PendingWorkItem pendingItem, WorkItem activeItem) {
+        pending.put(pendingItem, Optional.ofNullable(activeItem));
+        pendingGauge.labels(pendingItem.item.botName(), pendingItem.item.workItemName()).inc();
     }
 
     /**
      * Called to remove an item from the pending queue.
      */
-    private void removePending(WorkItem item) {
-        pending.remove(item);
-        pendingGauge.labels(item.botName(), item.workItemName()).dec();
+    private void removePending(PendingWorkItem pendingItem) {
+        pending.remove(pendingItem);
+        pendingGauge.labels(pendingItem.item.botName(), pendingItem.item.workItemName()).dec();
     }
 
     /**

--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
@@ -220,7 +220,7 @@ public class BotRunner {
             try (var __ = new LogContext(Map.of("work_item", item.toString(),
                     "work_id", String.valueOf(workId)))) {
                 var submittedDuration = Duration.between(createTime, Instant.now());
-                SUBMITTED_TIME_GAUGE.labels(item.botName(), item.workItemName()).set(submittedDuration.toMillis() / 1_000_000.0);
+                SUBMITTED_TIME_GAUGE.labels(item.botName(), item.workItemName()).set(submittedDuration.toMillis() / 1_000.0);
                 log.log(Level.FINE, "Executing item " + item + " on repository " + scratchPath
                         + " after being submitted for " + submittedDuration, TaskPhases.BEGIN);
                 try {
@@ -276,7 +276,7 @@ public class BotRunner {
                         submit(candidate.item);
                         var timeSinceCreation = Duration.between(candidate.createTime, Instant.now());
                         PENDING_TIME_GAUGE.labels(candidate.item.botName(), candidate.item.workItemName())
-                                .set(timeSinceCreation.toMillis() / 1_000_000.0);
+                                .set(timeSinceCreation.toMillis() / 1_000.0);
                         log.fine("Submitting candidate: " + candidate.item
                                 + " after being pending for " + timeSinceCreation);
                     }


### PR DESCRIPTION
In order to investigate and assess performance issues with the Skara bots, I need more data. One key class of data I'm missing is the time it takes from when a WorkItem is created or submitted to when it actually starts to run. This patch adds both metric gauges and log messages that include this information.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1478](https://bugs.openjdk.org/browse/SKARA-1478): Add metrics and loggin measuring time before WorkItems start to run


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1337/head:pull/1337` \
`$ git checkout pull/1337`

Update a local copy of the PR: \
`$ git checkout pull/1337` \
`$ git pull https://git.openjdk.org/skara pull/1337/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1337`

View PR using the GUI difftool: \
`$ git pr show -t 1337`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1337.diff">https://git.openjdk.org/skara/pull/1337.diff</a>

</details>
