### PR TITLE
1480: Update all openjdk.java.net->openjdk.org

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,15 +1,15 @@
 # Contributing
 
 Thank you for considering contributing to project
-[Skara](https://openjdk.java.net/projects/skara)! For information about
-contributing to [OpenJDK](https://openjdk.java.net/) projects, which include
-Skara, please see <https://openjdk.java.net/contribute/>.
+[Skara](https://openjdk.org/projects/skara)! For information about
+contributing to [OpenJDK](https://openjdk.org/) projects, which include
+Skara, please see <https://openjdk.org/contribute/>.
 
 ## Mailing List
 
 Project Skara happily accept contributions in the forms of patches sent to
-our mailing list, `skara-dev@openjdk.java.net`. See
-<https://mail.openjdk.java.net/mailman/listinfo/skara-dev> for instructions
+our mailing list, `skara-dev@openjdk.org`. See
+<https://mail.openjdk.org/mailman/listinfo/skara-dev> for instructions
 on how to subscribe of if you want to read the archives
 
 ## Pull Requests
@@ -26,11 +26,11 @@ You can find open issues to work on in the Skara project in the
 ## Larger Contributions
 
 If you have a larger contribution in mind then we highly encourage you to first
-discuss your changes on the Skara mailing list, `skara-dev@openjdk.java.net`,
+discuss your changes on the Skara mailing list, `skara-dev@openjdk.org`,
 _before_ you start to write the code.
 
 ## Questions
 
 If you have a question or need help, please send an email to our mailing list
-`skara-dev@openjdk.java.net` or stop by the IRC channel `#openjdk` on
-[OFTC](https://www.oftc.net/) (see <http://openjdk.java.net/irc/> for details).
+`skara-dev@openjdk.org` or stop by the IRC channel `#openjdk` on
+[OFTC](https://www.oftc.net/) (see <http://openjdk.org/irc/> for details).

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ This repository contains tooling for working with OpenJDK projects and
 their repositories. The following CLI tools are available as part of this
 repository:
 
-- git-jcheck - a backwards compatible Git port of [jcheck](https://openjdk.java.net/projects/code-tools/jcheck/)
-- git-webrev - a backwards compatible Git port of [webrev](https://openjdk.java.net/projects/code-tools/webrev/)
-- git-defpath - a backwards compatible Git port of [defpath](https://openjdk.java.net/projects/code-tools/defpath/)
+- git-jcheck - a backwards compatible Git port of [jcheck](https://openjdk.org/projects/code-tools/jcheck/)
+- git-webrev - a backwards compatible Git port of [webrev](https://openjdk.org/projects/code-tools/webrev/)
+- git-defpath - a backwards compatible Git port of [defpath](https://openjdk.org/projects/code-tools/defpath/)
 - git-fork - fork a project on an external Git source code hosting provider to your personal space and optionally clone it
 - git-sync - sync the personal fork of the project with the current state of the upstream repository
 - git-pr - interact with pull requests for a project on an external Git source code hosting provider
@@ -240,7 +240,7 @@ to you to run `:make` and `:make tests` in Vim.
 
 ## Wiki
 
-Project Skara's wiki is available at <https://wiki.openjdk.java.net/display/skara>.
+Project Skara's wiki is available at <https://wiki.openjdk.org/display/skara>.
 
 ## Issues
 
@@ -251,26 +251,26 @@ under project Skara at <https://bugs.openjdk.org/projects/SKARA/>.
 
 We are more than happy to accept contributions to the Skara tooling, both via
 patches sent to the Skara
-[mailing list](https://mail.openjdk.java.net/mailman/listinfo/skara-dev) and in the
+[mailing list](https://mail.openjdk.org/mailman/listinfo/skara-dev) and in the
 form of pull requests on [GitHub](https://github.com/openjdk/skara/pulls/).
 
 ## Members
 
-See <http://openjdk.java.net/census#skara> for the current Skara
-[Reviewers](https://openjdk.java.net/bylaws#reviewer),
-[Committers](https://openjdk.java.net/bylaws#committer) and
-[Authors](https://openjdk.java.net/bylaws#author). See
-<https://openjdk.java.net/projects/> for how to become an author, committer
+See <http://openjdk.org/census#skara> for the current Skara
+[Reviewers](https://openjdk.org/bylaws#reviewer),
+[Committers](https://openjdk.org/bylaws#committer) and
+[Authors](https://openjdk.org/bylaws#author). See
+<https://openjdk.org/projects/> for how to become an author, committer
 or reviewer in an OpenJDK project.
 
 ## Discuss
 
 Development discussions take place on the project Skara mailing list
-`skara-dev@openjdk.java.net`, see
-<https://mail.openjdk.java.net/mailman/listinfo/skara-dev> for instructions
+`skara-dev@openjdk.org`, see
+<https://mail.openjdk.org/mailman/listinfo/skara-dev> for instructions
 on how to subscribe of if you want to read the archives. You can also reach
 many project Skara developers in the `#openjdk` IRC channel on
-[OFTC](https://www.oftc.net/), see <https://openjdk.java.net/irc/> for details.
+[OFTC](https://www.oftc.net/), see <https://openjdk.org/irc/> for details.
 
 ## License
 

--- a/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestCloserBot.java
+++ b/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestCloserBot.java
@@ -58,9 +58,9 @@ class PullRequestCloserBotWorkItem implements WorkItem {
             if (type == PullRequestCloserBot.Type.MIRROR) {
                 message = "Welcome to the OpenJDK organization on GitHub!\n\n" +
                 "This repository is currently a read-only git mirror of the official Mercurial " +
-                "repository (located at https://hg.openjdk.java.net/). As such, we are not " +
+                "repository (located at https://hg.openjdk.org/). As such, we are not " +
                 "currently accepting pull requests here. If you would like to contribute to " +
-                "the OpenJDK project, please see https://openjdk.java.net/contribute/ on how " +
+                "the OpenJDK project, please see https://openjdk.org/contribute/ on how " +
                 "to proceed.\n\n" +
                 "This pull request will be automatically closed.";
             } else if (type == PullRequestCloserBot.Type.DATA) {

--- a/bots/checkout/src/test/java/org/openjdk/skara/bots/checkout/CheckoutBotTests.java
+++ b/bots/checkout/src/test/java/org/openjdk/skara/bots/checkout/CheckoutBotTests.java
@@ -41,15 +41,15 @@ class CheckoutBotTests {
         Files.write(readme, List.of("Hello, readme!"));
 
         r.add(readme);
-        r.commit("Add README", "duke", "duke@openjdk.java.net");
+        r.commit("Add README", "duke", "duke@openjdk.org");
 
         Files.write(readme, List.of("Another line"), WRITE, APPEND);
         r.add(readme);
-        r.commit("Modify README", "duke", "duke@openjdk.java.net");
+        r.commit("Modify README", "duke", "duke@openjdk.org");
 
         Files.write(readme, List.of("A final line"), WRITE, APPEND);
         r.add(readme);
-        r.commit("Final README", "duke", "duke@openjdk.java.net");
+        r.commit("Final README", "duke", "duke@openjdk.org");
     }
 
     @Test
@@ -118,7 +118,7 @@ class CheckoutBotTests {
             var readme = gitLocalRepo.root().resolve("README");
             Files.write(readme, List.of("An updated line"), WRITE, APPEND);
             gitLocalRepo.add(readme);
-            gitLocalRepo.commit("Updated Final README", "duke", "duke@openjdk.java.net");
+            gitLocalRepo.commit("Updated Final README", "duke", "duke@openjdk.org");
 
             runner.runPeriodicItems(bot);
             assertEquals(4, hgRepo.commitMetadata().size());

--- a/bots/csr/src/test/java/org/openjdk/skara/bots/csr/CSRBotTests.java
+++ b/bots/csr/src/test/java/org/openjdk/skara/bots/csr/CSRBotTests.java
@@ -292,7 +292,7 @@ class CSRBotTests {
             localRepo.add(newFile);
             var issueNumber = issue.id().split("-")[1];
             var commitMessage = issueNumber + ": This is the primary issue\n\nReviewed-by: integrationreviewer2";
-            var commitHash = localRepo.commit(commitMessage, "integrationcommitter1", "integrationcommitter1@openjdk.java.net");
+            var commitHash = localRepo.commit(commitMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
             localRepo.push(commitHash, repo.url(), "jdk18", true);
 
             // "backport" the commit to the master branch
@@ -302,7 +302,7 @@ class CSRBotTests {
             var newFile2 = localRepo.root().resolve("a_new_file.txt");
             Files.writeString(newFile2, "a_new_file");
             localRepo.add(newFile2);
-            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.java.net");
+            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
             localRepo.push(editHash, repo.url(), "edit", true);
             var pr = credentials.createPullRequest(repo, "master", "edit", issueNumber + ": This is the primary issue");
             pr.addLabel("backport");

--- a/bots/hgbridge/src/test/java/org/openjdk/skara/bots/hgbridge/BridgeBotTests.java
+++ b/bots/hgbridge/src/test/java/org/openjdk/skara/bots/hgbridge/BridgeBotTests.java
@@ -97,8 +97,8 @@ class BridgeBotTests {
             var lowercase = new HashSet<Hash>();
             var punctuated = new HashSet<Hash>();
 
-            var authors = Map.of("jjg", "JJG <jjg@openjdk.java.net>",
-                                 "duke", "Duke <duke@openjdk.java.net>");
+            var authors = Map.of("jjg", "JJG <jjg@openjdk.org>",
+                                 "duke", "Duke <duke@openjdk.org>");
             var contributors = new HashMap<String, String>();
             var sponsors = new HashMap<String, List<String>>();
 
@@ -132,7 +132,7 @@ class BridgeBotTests {
         // Export the beginning of the jtreg repository
         sourceFolder = new TemporaryDirectory();
         try {
-            var localRepo = Repository.materialize(sourceFolder.path(), URIBuilder.base("http://hg.openjdk.java.net/code-tools/jtreg").build(), "default");
+            var localRepo = Repository.materialize(sourceFolder.path(), URIBuilder.base("http://hg.openjdk.org/code-tools/jtreg").build(), "default");
             runHgCommand(localRepo, "strip", "-r", "b2511c725d81");
 
             // Create a lockfile in the mercurial repo, as it will overwrite the existing lock in the remote git repo
@@ -141,9 +141,9 @@ class BridgeBotTests {
             var lockFile = localRepo.root().resolve("lock.txt");
             Files.writeString(lockFile, ZonedDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME), StandardCharsets.UTF_8);
             localRepo.add(lockFile);
-            localRepo.commit("Lock", "duke", "Duke <duke@openjdk.java.net>");
+            localRepo.commit("Lock", "duke", "Duke <duke@openjdk.org>");
         } catch (IOException e) {
-            Assumptions.assumeTrue(false, "Failed to connect to hg.openjdk.java.net - skipping tests");
+            Assumptions.assumeTrue(false, "Failed to connect to hg.openjdk.org - skipping tests");
         }
         this.source = sourceFolder.path().toUri();
     }

--- a/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
+++ b/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
@@ -531,7 +531,7 @@ class MergeBot implements Bot, WorkItem {
 
                     var project = JCheckConfiguration.from(repo, head).map(conf -> conf.general().project());
                     if (project.isPresent()) {
-                        message.add("All Committers in this [project](https://openjdk.java.net/census#" + project.get() + ") " +
+                        message.add("All Committers in this [project](https://openjdk.org/census#" + project.get() + ") " +
                                     "have access to my [personal fork](" + fork.nonTransformedWebUrl() + ") and can " +
                                     "therefore help resolve these merge conflicts (you may want to coordinate " +
                                     "who should do this).");
@@ -543,7 +543,7 @@ class MergeBot implements Bot, WorkItem {
                     message.add("The following paragraphs will give an example on how to solve these " +
                                 "merge conflicts and push the resulting merge commit to this pull request.");
                     message.add("The below commands should be run in a local clone of your " +
-                                "[personal fork](https://wiki.openjdk.java.net/display/skara#Skara-Personalforks) " +
+                                "[personal fork](https://wiki.openjdk.org/display/skara#Skara-Personalforks) " +
                                 "of the [" + target.name() + "](" + target.nonTransformedWebUrl() + ") repository.");
                     message.add("");
                     var localBranchName = "openjdk-bot-" + branchDesc;

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -1033,7 +1033,7 @@ class MailingListBridgeBotTests {
             assertEquals(archive.forge().currentUser().fullName(), thread1reply1.author().fullName().orElseThrow());
             var thread1reply2 = conversations.get(0).replies(thread1reply1).get(0);
             assertTrue(thread1reply2.body().contains("Great"));
-            assertEquals("integrationreviewer1@openjdk.java.net", thread1reply2.author().address());
+            assertEquals("integrationreviewer1@openjdk.org", thread1reply2.author().address());
             assertEquals("Generated Reviewer 1", thread1reply2.author().fullName().orElseThrow());
 
             var thread2 = conversations.get(0).replies(mail).get(1);
@@ -2019,13 +2019,13 @@ class MailingListBridgeBotTests {
 
             // Perform the merge - resolve conflicts in our favor
             localRepo.merge(editHash, "ours");
-            localRepo.commit("Merged edit", "duke", "duke@openjdk.java.net");
+            localRepo.commit("Merged edit", "duke", "duke@openjdk.org");
             var mergeOnlyFile = Path.of("mergeonly.txt");
             Files.writeString(localRepo.root().resolve(mergeOnlyFile), "Only added in the merge");
             localRepo.add(mergeOnlyFile);
             Files.writeString(localRepo.root().resolve(reviewFile), "Overwriting the conflict resolution");
             localRepo.add(reviewFile);
-            var appendedCommit = localRepo.amend("Updated merge commit", "duke", "duke@openjdk.java.net");
+            var appendedCommit = localRepo.amend("Updated merge commit", "duke", "duke@openjdk.org");
             localRepo.push(appendedCommit, author.url(), "merge_of_edit", true);
 
             // Make a merge PR
@@ -2169,10 +2169,10 @@ class MailingListBridgeBotTests {
             var masterOnlyFile = Path.of("masteronly.txt");
             Files.writeString(localRepo.root().resolve(masterOnlyFile), "Only added in master");
             localRepo.add(masterOnlyFile);
-            var updatedMasterHash = localRepo.commit("Only added in master", "duke", "duke@openjdk.java.net");
+            var updatedMasterHash = localRepo.commit("Only added in master", "duke", "duke@openjdk.org");
             localRepo.push(updatedMasterHash, author.url(), "master");
             localRepo.merge(editHash);
-            var mergeCommit = localRepo.commit("Merged edit", "duke", "duke@openjdk.java.net");
+            var mergeCommit = localRepo.commit("Merged edit", "duke", "duke@openjdk.org");
             localRepo.push(mergeCommit, author.url(), "edit", true);
 
             // Make a merge PR

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/JbsBackport.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/JbsBackport.java
@@ -63,7 +63,7 @@ public class JbsBackport {
 
     public Issue createBackport(Issue primary, String fixVersion, String assignee) {
         if (backportRequest == null) {
-            if (primary.project().webUrl().toString().contains("openjdk.java.net")) {
+            if (primary.project().webUrl().toString().contains("openjdk.org")) {
                 throw new RuntimeException("Backports on JBS require vault authentication");
             } else {
                 return createBackportIssue(primary);

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifier.java
@@ -36,7 +36,7 @@ public class PullRequestBranchNotifier implements Notifier, PullRequestListener 
     protected static final String FORCE_PUSH_SUGGESTION= """
             Please do not rebase or force-push to an active PR as it invalidates existing review comments. \
             All changes will be squashed into a single commit automatically when integrating. \
-            See [OpenJDK Developers’ Guide](https://openjdk.java.net/guide/#working-with-pull-requests) for more information.
+            See [OpenJDK Developers’ Guide](https://openjdk.org/guide/#working-with-pull-requests) for more information.
             """;
     private final Path seedFolder;
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots.notify");

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/TestUtils.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/TestUtils.java
@@ -28,17 +28,17 @@ import org.openjdk.skara.storage.StorageBuilder;
 public class TestUtils {
     public static StorageBuilder<UpdatedTag> createTagStorage(HostedRepository repository) {
         return new StorageBuilder<UpdatedTag>("tags.txt")
-                .remoteRepository(repository, "history", "Duke", "duke@openjdk.java.net", "Updated tags");
+                .remoteRepository(repository, "history", "Duke", "duke@openjdk.org", "Updated tags");
     }
 
     public static StorageBuilder<UpdatedBranch> createBranchStorage(HostedRepository repository) {
         return new StorageBuilder<UpdatedBranch>("branches.txt")
-                .remoteRepository(repository, "history", "Duke", "duke@openjdk.java.net", "Updated branches");
+                .remoteRepository(repository, "history", "Duke", "duke@openjdk.org", "Updated branches");
     }
 
     public static StorageBuilder<PullRequestState> createPullRequestStateStorage(HostedRepository repository) {
         return new StorageBuilder<PullRequestState>("prissues.txt")
-                .remoteRepository(repository, "history", "Duke", "duke@openjdk.java.net", "Updated prissues");
+                .remoteRepository(repository, "history", "Duke", "duke@openjdk.org", "Updated prissues");
     }
 
     // Test implementation of a RepositoryListener that does nothing

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdateHistoryTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdateHistoryTests.java
@@ -44,7 +44,7 @@ class UpdateHistoryTests {
         var firstFile = folder.resolve("first.txt");
         Files.writeString(firstFile, "First file to commit");
         localRepository.add(firstFile);
-        var firstCommit = localRepository.commit("First commit", "Duke", "duke@openjdk.java.net");
+        var firstCommit = localRepository.commit("First commit", "Duke", "duke@openjdk.org");
         localRepository.push(firstCommit, repository.url(), localRepository.defaultBranch().toString(), true);
         return localRepository.defaultBranch().toString();
     }
@@ -52,9 +52,9 @@ class UpdateHistoryTests {
     private UpdateHistory createHistory(HostedRepository repository, String ref) throws IOException {
         var folder = Files.createTempDirectory("updatehistory");
         var tagStorage = new StorageBuilder<UpdatedTag>("tags.txt")
-                                       .remoteRepository(repository, ref, "Duke", "duke@openjdk.java.net", "Updated tags");
+                                       .remoteRepository(repository, ref, "Duke", "duke@openjdk.org", "Updated tags");
         var branchStorage = new StorageBuilder<UpdatedBranch>("branches.txt")
-                .remoteRepository(repository, ref, "Duke", "duke@openjdk.java.net", "Updated branches");
+                .remoteRepository(repository, ref, "Duke", "duke@openjdk.org", "Updated branches");
         return UpdateHistory.create(tagStorage,folder.resolve("tags"), branchStorage, folder.resolve("branches"));
     }
 

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/json/JsonNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/json/JsonNotifierTests.java
@@ -101,7 +101,7 @@ public class JsonNotifierTests {
             var localRepo = CheckableRepository.init(localRepoFolder, repo.repositoryType());
             credentials.commitLock(localRepo);
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.tag(masterHash, "jdk-12+1", "Added tag 1", "Duke", "duke@openjdk.java.net");
+            localRepo.tag(masterHash, "jdk-12+1", "Added tag 1", "Duke", "duke@openjdk.org");
             localRepo.pushAll(repo.url());
 
             var tagStorage = createTagStorage(repo);
@@ -128,9 +128,9 @@ public class JsonNotifierTests {
 
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", "23456789: More fixes");
             localRepo.fetch(repo.url(), "history:history");
-            localRepo.tag(editHash, "jdk-12+2", "Added tag 2", "Duke", "duke@openjdk.java.net");
+            localRepo.tag(editHash, "jdk-12+2", "Added tag 2", "Duke", "duke@openjdk.org");
             var editHash2 = CheckableRepository.appendAndCommit(localRepo, "Another line", "34567890: Even more fixes");
-            localRepo.tag(editHash2, "jdk-12+4", "Added tag 3", "Duke", "duke@openjdk.java.net");
+            localRepo.tag(editHash2, "jdk-12+4", "Added tag 3", "Duke", "duke@openjdk.org");
             localRepo.pushAll(repo.url());
 
             TestBotRunner.runPeriodicItems(notifyBot);

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/mailinglist/MailingListNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/mailinglist/MailingListNotifierTests.java
@@ -801,7 +801,7 @@ public class MailingListNotifierTests {
             var localRepo = CheckableRepository.init(localRepoFolder, repo.repositoryType());
             credentials.commitLock(localRepo);
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.tag(masterHash, "jdk-12+1", "Added tag 1", "Duke Tagger", "tagger@openjdk.java.net");
+            localRepo.tag(masterHash, "jdk-12+1", "Added tag 1", "Duke Tagger", "tagger@openjdk.org");
             localRepo.pushAll(repo.url());
 
             var listAddress = EmailAddress.parse(listServer.createList("test"));
@@ -846,14 +846,14 @@ public class MailingListNotifierTests {
 
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", "23456789: More fixes");
             localRepo.fetch(repo.url(), "history:history");
-            localRepo.tag(editHash, "jdk-12+2", "Added tag 2", "Duke Tagger", "tagger@openjdk.java.net");
+            localRepo.tag(editHash, "jdk-12+2", "Added tag 2", "Duke Tagger", "tagger@openjdk.org");
             CheckableRepository.appendAndCommit(localRepo, "Another line 1", "34567890: Even more fixes");
             CheckableRepository.appendAndCommit(localRepo, "Another line 2", "45678901: Yet even more fixes");
             var editHash2 = CheckableRepository.appendAndCommit(localRepo, "Another line 3", "56789012: Still even more fixes");
-            localRepo.tag(editHash2, "jdk-12+4", "Added tag 3", "Duke Tagger", "tagger@openjdk.java.net");
+            localRepo.tag(editHash2, "jdk-12+4", "Added tag 3", "Duke Tagger", "tagger@openjdk.org");
             CheckableRepository.appendAndCommit(localRepo, "Another line 4", "67890123: Brand new fixes");
             var editHash3 = CheckableRepository.appendAndCommit(localRepo, "Another line 5", "78901234: More brand new fixes");
-            localRepo.tag(editHash3, "jdk-13+0", "Added tag 4", "Duke Tagger", "tagger@openjdk.java.net");
+            localRepo.tag(editHash3, "jdk-13+0", "Added tag 4", "Duke Tagger", "tagger@openjdk.org");
             localRepo.pushAll(repo.url());
 
             TestBotRunner.runPeriodicItems(notifyBot, scratchFolder.path());
@@ -874,7 +874,7 @@ public class MailingListNotifierTests {
                     assertFalse(email.body().contains("56789012: Still even more fixes"));
                     assertFalse(email.body().contains("67890123: Brand new fixes"));
                     assertFalse(email.body().contains("78901234: More brand new fixes"));
-                    assertEquals(EmailAddress.from("Duke Tagger", "tagger@openjdk.java.net"), email.author());
+                    assertEquals(EmailAddress.from("Duke Tagger", "tagger@openjdk.org"), email.author());
                 } else if (email.subject().equals("git: test: Added tag jdk-12+4 for changeset " + editHash2.abbreviate())) {
                     assertFalse(email.body().contains("23456789: More fixes"));
                     assertTrue(email.body().contains("34567890: Even more fixes"));
@@ -882,7 +882,7 @@ public class MailingListNotifierTests {
                     assertTrue(email.body().contains("56789012: Still even more fixes"));
                     assertFalse(email.body().contains("67890123: Brand new fixes"));
                     assertFalse(email.body().contains("78901234: More brand new fixes"));
-                    assertEquals(EmailAddress.from("Duke Tagger", "tagger@openjdk.java.net"), email.author());
+                    assertEquals(EmailAddress.from("Duke Tagger", "tagger@openjdk.org"), email.author());
                 } else if (email.subject().equals("git: test: Added tag jdk-13+0 for changeset " + editHash3.abbreviate())) {
                     assertFalse(email.body().contains("23456789: More fixes"));
                     assertFalse(email.body().contains("34567890: Even more fixes"));
@@ -890,7 +890,7 @@ public class MailingListNotifierTests {
                     assertFalse(email.body().contains("56789012: Still even more fixes"));
                     assertFalse(email.body().contains("67890123: Brand new fixes"));
                     assertTrue(email.body().contains("78901234: More brand new fixes"));
-                    assertEquals(EmailAddress.from("Duke Tagger", "tagger@openjdk.java.net"), email.author());
+                    assertEquals(EmailAddress.from("Duke Tagger", "tagger@openjdk.org"), email.author());
                 } else if (email.subject().equals("git: test: 6 new changesets")) {
                     assertTrue(email.body().contains("23456789: More fixes"));
                     assertTrue(email.body().contains("34567890: Even more fixes"));
@@ -920,7 +920,7 @@ public class MailingListNotifierTests {
             var localRepo = CheckableRepository.init(localRepoFolder, repo.repositoryType());
             credentials.commitLock(localRepo);
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.tag(masterHash, "jdk-12+1", "Added tag 1", "Duke Tagger", "tagger@openjdk.java.net");
+            localRepo.tag(masterHash, "jdk-12+1", "Added tag 1", "Duke Tagger", "tagger@openjdk.org");
             localRepo.pushAll(repo.url());
 
             var listAddress = EmailAddress.parse(listServer.createList("test"));
@@ -965,14 +965,14 @@ public class MailingListNotifierTests {
 
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", "23456789: More fixes");
             localRepo.fetch(repo.url(), "history:history");
-            localRepo.tag(editHash, "jdk-12+2", "Added tag 2", "Duke Tagger", "tagger@openjdk.java.net");
+            localRepo.tag(editHash, "jdk-12+2", "Added tag 2", "Duke Tagger", "tagger@openjdk.org");
             CheckableRepository.appendAndCommit(localRepo, "Another line 1", "34567890: Even more fixes");
             CheckableRepository.appendAndCommit(localRepo, "Another line 2", "45678901: Yet even more fixes");
             var editHash2 = CheckableRepository.appendAndCommit(localRepo, "Another line 3", "56789012: Still even more fixes");
-            localRepo.tag(editHash2, "jdk-12+4", "Added tag 3", "Duke Tagger", "tagger@openjdk.java.net");
+            localRepo.tag(editHash2, "jdk-12+4", "Added tag 3", "Duke Tagger", "tagger@openjdk.org");
             CheckableRepository.appendAndCommit(localRepo, "Another line 4", "67890123: Brand new fixes");
             var editHash3 = CheckableRepository.appendAndCommit(localRepo, "Another line 5", "78901234: More brand new fixes");
-            localRepo.tag(editHash3, "jdk-13+0", "Added tag 4", "Duke Tagger", "tagger@openjdk.java.net");
+            localRepo.tag(editHash3, "jdk-13+0", "Added tag 4", "Duke Tagger", "tagger@openjdk.org");
             localRepo.pushAll(repo.url());
 
             TestBotRunner.runPeriodicItems(notifyBot);
@@ -987,11 +987,11 @@ public class MailingListNotifierTests {
             for (var conversation : conversations) {
                 var email = conversation.first();
                 if (email.subject().equals("git: test: Added tag jdk-12+2 for changeset " + editHash.abbreviate())) {
-                    assertEquals(EmailAddress.from("Duke Tagger", "tagger@openjdk.java.net"), email.author());
+                    assertEquals(EmailAddress.from("Duke Tagger", "tagger@openjdk.org"), email.author());
                 } else if (email.subject().equals("git: test: Added tag jdk-12+4 for changeset " + editHash2.abbreviate())) {
-                    assertEquals(EmailAddress.from("Duke Tagger", "tagger@openjdk.java.net"), email.author());
+                    assertEquals(EmailAddress.from("Duke Tagger", "tagger@openjdk.org"), email.author());
                 } else if (email.subject().equals("git: test: Added tag jdk-13+0 for changeset " + editHash3.abbreviate())) {
-                    assertEquals(EmailAddress.from("Duke Tagger", "tagger@openjdk.java.net"), email.author());
+                    assertEquals(EmailAddress.from("Duke Tagger", "tagger@openjdk.org"), email.author());
                 } else if (email.subject().equals("git: test: 6 new changesets")) {
                     assertEquals(EmailAddress.from("testauthor", "ta@none.none"), email.author());
                 } else {

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifierTests.java
@@ -341,7 +341,7 @@ public class PullRequestBranchNotifierTests {
             updatedHash = CheckableRepository.appendAndCommit(localRepo, "test force-push");
             localRepo.checkout(editHash);
             localRepo.squash(updatedHash);
-            var forcePushHash = localRepo.commit("test force-push", "duke", "duke@openjdk.java.net");
+            var forcePushHash = localRepo.commit("test force-push", "duke", "duke@openjdk.org");
             localRepo.push(forcePushHash, repo.url(), "source", true);
             ((TestPullRequest) pr).setLastForcePushTime(ZonedDateTime.now());
             pr.addComment("Force-push");
@@ -371,7 +371,7 @@ public class PullRequestBranchNotifierTests {
             updatedHash = CheckableRepository.appendAndCommit(localRepo, "test force-push again");
             localRepo.checkout(editHash);
             localRepo.squash(updatedHash);
-            forcePushHash = localRepo.commit("test force-push again", "duke", "duke@openjdk.java.net");
+            forcePushHash = localRepo.commit("test force-push again", "duke", "duke@openjdk.org");
             localRepo.push(forcePushHash, repo.url(), "source", true);
             ((TestPullRequest) pr).setLastForcePushTime(ZonedDateTime.now());
             pr.addComment("Force-push again");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
@@ -59,7 +59,7 @@ public class BackportCommand implements CommandHandler {
     @Override
     public void handle(PullRequestBot bot, HostedCommit commit, CensusInstance censusInstance, Path scratchPath, CommandInvocation command, List<Comment> allComments, PrintWriter reply) {
         if (censusInstance.contributor(command.user()).isEmpty()) {
-            reply.println("Only OpenJDK [contributors](https://openjdk.java.net/bylaws#contributor) can use the `/backport` command");
+            reply.println("Only OpenJDK [contributors](https://openjdk.org/bylaws#contributor) can use the `/backport` command");
             return;
         }
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CSRCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CSRCommand.java
@@ -37,30 +37,30 @@ public class CSRCommand implements CommandHandler {
     private static final String CSR_UNNEEDED_MARKER = "<!-- csr: 'unneeded' -->";
 
     private static void showHelp(PrintWriter writer) {
-        writer.println("usage: `/csr [needed|unneeded]`, requires that the issue the pull request refers to links to an approved [CSR](https://wiki.openjdk.java.net/display/csr/Main) request.");
+        writer.println("usage: `/csr [needed|unneeded]`, requires that the issue the pull request refers to links to an approved [CSR](https://wiki.openjdk.org/display/csr/Main) request.");
     }
 
     private static void csrReply(PrintWriter writer) {
         writer.println("has indicated that a " +
-                      "[compatibility and specification](https://wiki.openjdk.java.net/display/csr/Main) (CSR) request " +
+                      "[compatibility and specification](https://wiki.openjdk.org/display/csr/Main) (CSR) request " +
                       "is needed for this pull request.");
         writer.println(CSR_NEEDED_MARKER);
     }
 
     private static void jbsReply(PullRequest pr, PrintWriter writer) {
         writer.println("@" + pr.author().username() + " this pull request must refer to an issue in " +
-                      "[JBS](https://bugs.openjdk.org) to be able to link it to a [CSR](https://wiki.openjdk.java.net/display/csr/Main) request. To refer this pull request to " +
+                      "[JBS](https://bugs.openjdk.org) to be able to link it to a [CSR](https://wiki.openjdk.org/display/csr/Main) request. To refer this pull request to " +
                       "an issue in JBS, please use the `/issue` command in a comment in this pull request.");
     }
 
     private static void linkReply(PullRequest pr, Issue issue, PrintWriter writer) {
-        writer.println("@" + pr.author().username() + " please create a [CSR](https://wiki.openjdk.java.net/display/csr/Main) request for issue " +
+        writer.println("@" + pr.author().username() + " please create a [CSR](https://wiki.openjdk.org/display/csr/Main) request for issue " +
                 "[" + issue.id() + "](" + issue.webUrl() + ") with the correct fix version. " +
                 "This pull request cannot be integrated until the CSR request is approved.");
     }
 
     private static void csrUnneededReply(PullRequest pr, PrintWriter writer) {
-        writer.println("determined that a [CSR](https://wiki.openjdk.java.net/display/csr/Main) request " +
+        writer.println("determined that a [CSR](https://wiki.openjdk.org/display/csr/Main) request " +
                 "is not needed for this pull request.");
         writer.println(CSR_UNNEEDED_MARKER);
         if (pr.labelNames().contains(CSR_LABEL)) {
@@ -76,7 +76,7 @@ public class CSRCommand implements CommandHandler {
         }
 
         if (!pr.author().equals(command.user()) && !censusInstance.isReviewer(command.user())) {
-            reply.println("only the pull request author and [Reviewers](https://openjdk.java.net/bylaws#reviewer) are allowed to use the `csr` command.");
+            reply.println("only the pull request author and [Reviewers](https://openjdk.org/bylaws#reviewer) are allowed to use the `csr` command.");
             return;
         }
 
@@ -90,7 +90,7 @@ public class CSRCommand implements CommandHandler {
 
         if (cmd.equals("unneeded") || cmd.equals("uneeded")) {
             if (pr.author().equals(command.user()) && !censusInstance.isReviewer(command.user())) {
-                reply.println("only [Reviewers](https://openjdk.java.net/bylaws#reviewer) can determine that a CSR is not needed.");
+                reply.println("only [Reviewers](https://openjdk.org/bylaws#reviewer) can determine that a CSR is not needed.");
                 return;
             }
 
@@ -138,7 +138,7 @@ public class CSRCommand implements CommandHandler {
         }
 
         if (labels.contains(CSR_LABEL)) {
-            reply.println("an approved [CSR](https://wiki.openjdk.java.net/display/csr/Main) request " +
+            reply.println("an approved [CSR](https://wiki.openjdk.org/display/csr/Main) request " +
                           "is already required for this pull request.");
             reply.println(CSR_NEEDED_MARKER);
             return;
@@ -192,7 +192,7 @@ public class CSRCommand implements CommandHandler {
                           "an approved CSR request: [" + csr.id() + "](" + csr.webUrl() + ")");
             reply.println(CSR_NEEDED_MARKER);
         } else {
-            reply.println("this pull request will not be integrated until the [CSR](https://wiki.openjdk.java.net/display/csr/Main) " +
+            reply.println("this pull request will not be integrated until the [CSR](https://wiki.openjdk.org/display/csr/Main) " +
                           "request " + "[" + csr.id() + "](" + csr.webUrl() + ")" + " for issue " +
                           "[" + jbsIssue.id() + "](" + jbsIssue.webUrl() + ") has been approved.");
             reply.println(CSR_NEEDED_MARKER);

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -811,10 +811,10 @@ class CheckRun {
         message.append(commitMessage);
         message.append("\n```\n");
 
-        message.append("You can use [pull request commands](https://wiki.openjdk.java.net/display/SKARA/Pull+Request+Commands) ");
-        message.append("such as [/summary](https://wiki.openjdk.java.net/display/SKARA/Pull+Request+Commands#PullRequestCommands-/summary), ");
-        message.append("[/contributor](https://wiki.openjdk.java.net/display/SKARA/Pull+Request+Commands#PullRequestCommands-/contributor) and ");
-        message.append("[/issue](https://wiki.openjdk.java.net/display/SKARA/Pull+Request+Commands#PullRequestCommands-/issue) to adjust it as needed.");
+        message.append("You can use [pull request commands](https://wiki.openjdk.org/display/SKARA/Pull+Request+Commands) ");
+        message.append("such as [/summary](https://wiki.openjdk.org/display/SKARA/Pull+Request+Commands#PullRequestCommands-/summary), ");
+        message.append("[/contributor](https://wiki.openjdk.org/display/SKARA/Pull+Request+Commands#PullRequestCommands-/contributor) and ");
+        message.append("[/issue](https://wiki.openjdk.org/display/SKARA/Pull+Request+Commands#PullRequestCommands-/issue) to adjust it as needed.");
         message.append("\n\n");
 
         var divergingCommits = checkablePullRequest.divergingCommits();
@@ -857,16 +857,16 @@ class CheckRun {
             message.append("any potential automatic rebasing");
         }
         message.append(", please check the documentation for the ");
-        message.append("[/integrate](https://wiki.openjdk.java.net/display/SKARA/Pull+Request+Commands#PullRequestCommands-/integrate) ");
+        message.append("[/integrate](https://wiki.openjdk.org/display/SKARA/Pull+Request+Commands#PullRequestCommands-/integrate) ");
         message.append("command for further details.\n");
 
         if (!censusInstance.isCommitter(pr.author())) {
             message.append("\n");
-            message.append("As you do not have [Committer](https://openjdk.java.net/bylaws#committer) status in ");
-            message.append("[this project](https://openjdk.java.net/census#");
+            message.append("As you do not have [Committer](https://openjdk.org/bylaws#committer) status in ");
+            message.append("[this project](https://openjdk.org/census#");
             message.append(censusInstance.project().name());
             message.append(") an existing Committer must agree to ");
-            message.append("[sponsor](https://openjdk.java.net/sponsor/) your change. ");
+            message.append("[sponsor](https://openjdk.org/sponsor/) your change. ");
             var candidates = reviews.stream()
                                     .filter(review -> censusInstance.isCommitter(review.reviewer()))
                                     .map(review -> "@" + review.reviewer().username())
@@ -883,7 +883,7 @@ class CheckRun {
         } else {
             message.append("\n");
             message.append("➡️ To integrate this PR with the above commit message to the `").append(pr.targetRef()).append("` branch, type ");
-            message.append("[/integrate](https://wiki.openjdk.java.net/display/SKARA/Pull+Request+Commands#PullRequestCommands-/integrate) ");
+            message.append("[/integrate](https://wiki.openjdk.org/display/SKARA/Pull+Request+Commands#PullRequestCommands-/integrate) ");
             message.append("in a new comment.\n");
         }
         message.append(mergeReadyMarker);

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CleanCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CleanCommand.java
@@ -48,13 +48,13 @@ public class CleanCommand implements CommandHandler {
     public void handle(PullRequestBot bot, PullRequest pr, CensusInstance censusInstance, Path scratchPath, CommandInvocation command, List<Comment> allComments, PrintWriter reply)
     {
         if (!censusInstance.isCommitter(command.user())) {
-            reply.println("Only OpenJDK [Committers](https://openjdk.java.net/bylaws#committer) can use the `/clean` command");
+            reply.println("Only OpenJDK [Committers](https://openjdk.org/bylaws#committer) can use the `/clean` command");
             return;
         }
 
         if (!pr.labelNames().contains("backport") || CheckablePullRequest.findOriginalBackportHash(pr) == null) {
             reply.println("Can only mark [backport pull requests]" +
-                    "(https://wiki.openjdk.java.net/display/SKARA/Backports#Backports-BackportPullRequests)," +
+                    "(https://wiki.openjdk.org/display/SKARA/Backports#Backports-BackportPullRequests)," +
                     " with an original hash, as clean");
             return;
         }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
@@ -135,17 +135,17 @@ public class IntegrateCommand implements CommandHandler {
                 pr.removeLabel("auto");
             }
             reply.println("This pull request will have to be integrated manually using the " +
-                    "[/integrate](https://wiki.openjdk.java.net/display/SKARA/Pull+Request+Commands#PullRequestCommands-/integrate) pull request command.");
+                    "[/integrate](https://wiki.openjdk.org/display/SKARA/Pull+Request+Commands#PullRequestCommands-/integrate) pull request command.");
             return;
         } else if (commandArg == Command.defer) {
             pr.addLabel("deferred");
             reply.println("Integration of this pull request has been deferred and may be completed by any project committer using the " +
-                    "[/integrate](https://wiki.openjdk.java.net/display/SKARA/Pull+Request+Commands#PullRequestCommands-/integrate) pull request command.");
+                    "[/integrate](https://wiki.openjdk.org/display/SKARA/Pull+Request+Commands#PullRequestCommands-/integrate) pull request command.");
             return;
         } else if (commandArg == Command.undefer) {
             if (pr.labelNames().contains("deferred")) {
                 reply.println("Integration of this pull request is no longer deferred and may only be integrated by the author (@" + pr.author().username() + ")using the " +
-                        "[/integrate](https://wiki.openjdk.java.net/display/SKARA/Pull+Request+Commands#PullRequestCommands-/integrate) pull request command.");
+                        "[/integrate](https://wiki.openjdk.org/display/SKARA/Pull+Request+Commands#PullRequestCommands-/integrate) pull request command.");
                 pr.removeLabel("deferred");
             }
             reply.println("This pull request may now only be integrated by the author");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IssueCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IssueCommand.java
@@ -212,7 +212,7 @@ public class IssueCommand implements CommandHandler {
 
     private void createIssue(PullRequestBot bot, PullRequest pr, String args, CensusInstance censusInstance, HostUser author, PrintWriter reply) {
         if (!censusInstance.isAuthor(author)) {
-            reply.println("Only [Authors](https://openjdk.java.net/bylaws#author) are allowed to create issues.");
+            reply.println("Only [Authors](https://openjdk.org/bylaws#author) are allowed to create issues.");
             return;
         }
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/JEPCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/JEPCommand.java
@@ -94,7 +94,7 @@ public class JEPCommand implements CommandHandler {
         }
 
         if (!pr.author().equals(command.user()) && !censusInstance.isReviewer(command.user())) {
-            reply.println("Only the pull request author and [Reviewers](https://openjdk.java.net/bylaws#reviewer) are allowed to use the `jep` command.");
+            reply.println("Only the pull request author and [Reviewers](https://openjdk.org/bylaws#reviewer) are allowed to use the `jep` command.");
             return;
         }
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelCommand.java
@@ -36,7 +36,7 @@ public class LabelCommand implements CommandHandler {
 
     private static final Pattern argumentPattern = Pattern.compile("(?:(add|remove)\\s+)((?:[A-Za-z0-9_@.-]+[\\s,]*)+)");
     private static final Pattern shortArgumentPattern = Pattern.compile("((?:[-+]?[A-Za-z0-9_@.-]+[\\s,]*)+)");
-    private static final Pattern ignoredSuffixes = Pattern.compile("^(.*)(?:-dev(?:@openjdk.java.net)?)$");
+    private static final Pattern ignoredSuffixes = Pattern.compile("^(.*)(?:-dev(?:@openjdk.org)?)$");
 
     LabelCommand() {
         this("label");
@@ -57,7 +57,7 @@ public class LabelCommand implements CommandHandler {
     @Override
     public void handle(PullRequestBot bot, PullRequest pr, CensusInstance censusInstance, Path scratchPath, CommandInvocation command, List<Comment> allComments, PrintWriter reply) {
         if (!command.user().equals(pr.author()) && (!censusInstance.isCommitter(command.user()))) {
-            reply.println("Only the PR author and project [Committers](https://openjdk.java.net/bylaws#committer) are allowed to modify labels on a PR.");
+            reply.println("Only the PR author and project [Committers](https://openjdk.org/bylaws#committer) are allowed to modify labels on a PR.");
             return;
         }
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
@@ -76,7 +76,7 @@ public class LabelerWorkItem extends PullRequestWorkItem {
             message.append("However, no automatic labelling rule matches the changes in this pull request. ");
             message.append("In order to have an \"RFR\" email sent to the correct mailing list, you will ");
             message.append("need to add one or more applicable labels manually using the ");
-            message.append("[/label](https://wiki.openjdk.java.net/display/SKARA/Pull+Request+Commands#PullRequestCommands-/label)");
+            message.append("[/label](https://wiki.openjdk.org/display/SKARA/Pull+Request+Commands#PullRequestCommands-/label)");
             message.append(" pull request command.\n\n");
             message.append("<details>\n");
             message.append("<summary>Applicable Labels</summary>\n");
@@ -104,7 +104,7 @@ public class LabelerWorkItem extends PullRequestWorkItem {
                 message.append("s");
             }
             message.append(". If you would like to change these labels, use the ");
-            message.append("[/label](https://wiki.openjdk.java.net/display/SKARA/Pull+Request+Commands#PullRequestCommands-/label)");
+            message.append("[/label](https://wiki.openjdk.org/display/SKARA/Pull+Request+Commands#PullRequestCommands-/label)");
             message.append(" pull request command.");
         }
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewersCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewersCommand.java
@@ -77,7 +77,7 @@ public class ReviewersCommand implements CommandHandler {
     @Override
     public void handle(PullRequestBot bot, PullRequest pr, CensusInstance censusInstance, Path scratchPath, CommandInvocation command, List<Comment> allComments, PrintWriter reply) {
         if (!pr.author().equals(command.user()) && !censusInstance.isReviewer(command.user())) {
-            reply.println("Only the author of the pull request or [Reviewers](https://openjdk.java.net/bylaws#reviewer) are allowed to change the number of required reviewers.");
+            reply.println("Only the author of the pull request or [Reviewers](https://openjdk.org/bylaws#reviewer) are allowed to change the number of required reviewers.");
             return;
         }
 
@@ -120,11 +120,11 @@ public class ReviewersCommand implements CommandHandler {
             var previous = ReviewersTracker.additionalRequiredReviewers(user, allComments);
             if (previous.isPresent()) {
                 if (roleIsLower(role, previous.get().role())) {
-                    reply.println("Only [Reviewers](https://openjdk.java.net/bylaws#reviewer) are allowed to lower the role for additional reviewers.");
+                    reply.println("Only [Reviewers](https://openjdk.org/bylaws#reviewer) are allowed to lower the role for additional reviewers.");
                     return;
                 }
                 if (numReviewers < previous.get().number()) {
-                    reply.println("Only [Reviewers](https://openjdk.java.net/bylaws#reviewer) are allowed to decrease the number of required reviewers.");
+                    reply.println("Only [Reviewers](https://openjdk.org/bylaws#reviewer) are allowed to decrease the number of required reviewers.");
                     return;
                 }
             }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
@@ -43,7 +43,7 @@ public class SponsorCommand implements CommandHandler {
             return;
         }
         if (!censusInstance.isCommitter(command.user())) {
-            reply.println("Only [Committers](https://openjdk.java.net/bylaws#committer) are allowed to sponsor changes.");
+            reply.println("Only [Committers](https://openjdk.org/bylaws#committer) are allowed to sponsor changes.");
             return;
         }
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/TagCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/TagCommand.java
@@ -62,7 +62,7 @@ public class TagCommand implements CommandHandler {
     public void handle(PullRequestBot bot, HostedCommit commit, CensusInstance censusInstance, Path scratchPath, CommandInvocation command, List<Comment> allComments, PrintWriter reply) {
         try {
             if (censusInstance.contributor(command.user()).isEmpty()) {
-                reply.println("Only OpenJDK [contributors](https://openjdk.java.net/bylaws#contributor) can use the `/tag` command.");
+                reply.println("Only OpenJDK [contributors](https://openjdk.org/bylaws#contributor) can use the `/tag` command.");
                 return;
             }
             if (!bot.integrators().contains(command.user().username())) {

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportTests.java
@@ -72,7 +72,7 @@ class BackportTests {
             var originalMessage = issue1Number + ": An issue\n" +
                                   "\n" +
                                   "Reviewed-by: integrationreviewer2";
-            var releaseHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.java.net");
+            var releaseHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
             localRepo.push(releaseHash, author.url(), "refs/heads/release", true);
 
             // "backport" the new file to the master branch
@@ -82,7 +82,7 @@ class BackportTests {
             var newFile2 = localRepo.root().resolve("a_new_file.txt");
             Files.writeString(newFile2, "hello");
             localRepo.add(newFile2);
-            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.java.net");
+            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
             localRepo.push(editHash, author.url(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Backport " + releaseHash.hex());
 
@@ -172,7 +172,7 @@ class BackportTests {
                                   "This is a summary\n" +
                                   "\n" +
                                   "Reviewed-by: integrationreviewer2";
-            var releaseHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.java.net");
+            var releaseHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
             localRepo.push(releaseHash, author.url(), "refs/heads/release", true);
 
             // "backport" the new file to the master branch
@@ -182,7 +182,7 @@ class BackportTests {
             var newFile2 = localRepo.root().resolve("a_new_file.txt");
             Files.writeString(newFile2, "hello");
             localRepo.add(newFile2);
-            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.java.net");
+            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
             localRepo.push(editHash, author.url(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Backport " + releaseHash.hex());
 
@@ -276,7 +276,7 @@ class BackportTests {
                                   "This is a summary\n" +
                                   "\n" +
                                   "Reviewed-by: integrationreviewer2";
-            var releaseHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.java.net");
+            var releaseHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
             localRepo.push(releaseHash, author.url(), "refs/heads/release", true);
 
             // "backport" the new file to the master branch
@@ -286,7 +286,7 @@ class BackportTests {
             var newFile2 = localRepo.root().resolve("a_new_file.txt");
             Files.writeString(newFile2, "hello");
             localRepo.add(newFile2);
-            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.java.net");
+            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
             localRepo.push(editHash, author.url(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Backport " + releaseHash.hex());
 
@@ -421,7 +421,7 @@ class BackportTests {
             var originalMessage = issue1Number + ": An issue\n" +
                     "\n" +
                     "Reviewed-by: integrationreviewer2";
-            var releaseHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.java.net");
+            var releaseHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
             localRepo.push(releaseHash, author.url(), "refs/heads/release", true);
 
             // "backport" the new file to the master branch
@@ -431,7 +431,7 @@ class BackportTests {
             var newFile2 = localRepo.root().resolve("a_new_file.txt");
             Files.writeString(newFile2, "hello");
             localRepo.add(newFile2);
-            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.java.net");
+            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
             localRepo.push(editHash, author.url(), "refs/heads/edit", true);
             // Create the backport with the hash from the PR branch
             var pr = credentials.createPullRequest(author, "master", "edit", "Backport " + editHash.hex());
@@ -489,7 +489,7 @@ class BackportTests {
             var originalMessage = issue1Number + ": An issue\n" +
                     "\n" +
                     "Reviewed-by: integrationreviewer2";
-            var releaseHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.java.net");
+            var releaseHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
             localRepo.push(releaseHash, author.url(), "refs/heads/release", true);
 
             // "backport" the new file to the master branch
@@ -499,7 +499,7 @@ class BackportTests {
             var newFile2 = localRepo.root().resolve("a_new_file.txt");
             Files.writeString(newFile2, "hello");
             localRepo.add(newFile2);
-            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.java.net");
+            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
             localRepo.push(editHash, author.url(), "refs/heads/edit", true);
             // Add another change on top of the backport
             var editHash2 = CheckableRepository.appendAndCommit(localRepo);
@@ -556,7 +556,7 @@ class BackportTests {
             var originalMessage = issue1Number + ": An issue\n" +
                                   "\n" +
                                   "Reviewed-by: integrationreviewer2";
-            var releaseHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.java.net");
+            var releaseHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
             localRepo.push(releaseHash, author.url(), "refs/heads/release", true);
 
             // "backport" the new file to the master branch
@@ -566,7 +566,7 @@ class BackportTests {
             var newFile2 = localRepo.root().resolve("a_new_file.txt");
             Files.writeString(newFile2, "hello");
             localRepo.add(newFile2);
-            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.java.net");
+            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
             localRepo.push(editHash, author.url(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Backport " + releaseHash.hex(), List.of());
 
@@ -616,7 +616,7 @@ class BackportTests {
             var originalMessage = issue1Number + ": An issue\n" +
                                   "\n" +
                                   "Reviewed-by: integrationreviewer2";
-            var masterHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.java.net");
+            var masterHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
 
             localRepo.push(masterHash, author.url(), "master", true);
 
@@ -629,7 +629,7 @@ class BackportTests {
             var upstreamMessage = issue2Number + ": Another issue\n" +
                                   "\n" +
                                   "Reviewed-by: integrationreviewer2";
-            var upstreamHash = localRepo.commit(upstreamMessage, "integrationcommitter1", "integrationcommitter1@openjdk.java.net");
+            var upstreamHash = localRepo.commit(upstreamMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
             localRepo.push(upstreamHash, author.url(), "refs/heads/release", true);
 
             // "backport" the new file to the master branch
@@ -638,7 +638,7 @@ class BackportTests {
             localRepo.checkout(editBranch);
             Files.writeString(newFile, "a\nb\nc\ne\nd\n");
             localRepo.add(newFile);
-            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.java.net");
+            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
             localRepo.push(editHash, author.url(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Backport " + upstreamHash.hex());
 
@@ -686,7 +686,7 @@ class BackportTests {
             var originalMessage = issue1Number + ": An issue\n" +
                                   "\n" +
                                   "Reviewed-by: integrationreviewer2";
-            var masterHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.java.net");
+            var masterHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
 
             localRepo.push(masterHash, author.url(), "master", true);
 
@@ -699,7 +699,7 @@ class BackportTests {
             var upstreamMessage = issue2Number + ": Another issue\n" +
                                   "\n" +
                                   "Reviewed-by: integrationreviewer2";
-            var upstreamHash = localRepo.commit(upstreamMessage, "integrationcommitter1", "integrationcommitter1@openjdk.java.net");
+            var upstreamHash = localRepo.commit(upstreamMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
             localRepo.push(upstreamHash, author.url(), "refs/heads/release", true);
 
             // "backport" the new file to the master branch
@@ -708,7 +708,7 @@ class BackportTests {
             localRepo.checkout(editBranch);
             Files.writeString(newFile, "a\nb\nc\nd\nd");
             localRepo.add(newFile);
-            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.java.net");
+            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
             localRepo.push(editHash, author.url(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Backport " + upstreamHash.hex());
 
@@ -757,7 +757,7 @@ class BackportTests {
             var originalMessage = issue1Number + ": An issue\n" +
                                   "\n" +
                                   "Reviewed-by: integrationreviewer2";
-            var masterHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.java.net");
+            var masterHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
 
             localRepo.push(masterHash, author.url(), "master", true);
 
@@ -770,7 +770,7 @@ class BackportTests {
             var upstreamMessage = issue2Number + ": Another issue\n" +
                                   "\n" +
                                   "Reviewed-by: integrationreviewer2";
-            var upstreamHash = localRepo.commit(upstreamMessage, "integrationcommitter1", "integrationcommitter1@openjdk.java.net");
+            var upstreamHash = localRepo.commit(upstreamMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
             localRepo.push(upstreamHash, author.url(), "refs/heads/release", true);
 
             // "backport" the new file to the master branch
@@ -782,7 +782,7 @@ class BackportTests {
             var anotherFile = localRepo.root().resolve("another_file.txt");
             Files.writeString(anotherFile, "f\ng\nh\ni");
             localRepo.add(anotherFile);
-            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.java.net");
+            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
             localRepo.push(editHash, author.url(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Backport " + upstreamHash.hex());
 
@@ -834,7 +834,7 @@ class BackportTests {
             var originalMessage = issue1Number + ": An issue\n" +
                                   "\n" +
                                   "Reviewed-by: integrationreviewer2";
-            var releaseHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.java.net");
+            var releaseHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
             localRepo.push(releaseHash, author.url(), "refs/heads/release", true);
 
             // "backport" the new file to the master branch
@@ -844,7 +844,7 @@ class BackportTests {
             var newFile2 = localRepo.root().resolve("a_new_file.txt");
             Files.writeString(newFile2, "hello");
             localRepo.add(newFile2);
-            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.java.net");
+            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
             localRepo.push(editHash, author.url(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Backport " + releaseHash.hex());
 
@@ -930,7 +930,7 @@ class BackportTests {
             var originalMessage = issue1Number + ": An issue\n" +
                                   "\n" +
                                   "Reviewed-by: integrationreviewer2";
-            var releaseHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.java.net");
+            var releaseHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
             localRepo.push(releaseHash, author.url(), "refs/heads/release", true);
 
             // "backport" the new file to the master branch
@@ -940,7 +940,7 @@ class BackportTests {
             var newFile2 = localRepo.root().resolve("a_new_file.txt");
             Files.writeString(newFile2, "hello");
             localRepo.add(newFile2);
-            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.java.net");
+            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
             localRepo.push(editHash, author.url(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Backport " + releaseHash.hex());
 
@@ -1039,7 +1039,7 @@ class BackportTests {
             var originalMessage = issue1Number + ": An issue\n" +
                                   "\n" +
                                   "Reviewed-by: integrationreviewer2";
-            var releaseHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.java.net");
+            var releaseHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
             localRepo.push(releaseHash, author.url(), "refs/heads/release", true);
 
             // "backport" the new file to the master branch
@@ -1049,7 +1049,7 @@ class BackportTests {
             var newFile2 = localRepo.root().resolve("a_new_file.txt");
             Files.writeString(newFile2, "hello");
             localRepo.add(newFile2);
-            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.java.net");
+            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
             localRepo.push(editHash, author.url(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Backport  " + releaseHash.hex());
 
@@ -1097,7 +1097,7 @@ class BackportTests {
             var originalMessage = issue1Number + ": An issue\n" +
                                   "\n" +
                                   "Reviewed-by: integrationreviewer2";
-            var releaseHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.java.net");
+            var releaseHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
             localRepo.push(releaseHash, author.url(), "refs/heads/release", true);
 
             // "backport" the new file to the master branch
@@ -1107,7 +1107,7 @@ class BackportTests {
             var newFile2 = localRepo.root().resolve("a_new_file.txt");
             Files.writeString(newFile2, "hello");
             localRepo.add(newFile2);
-            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.java.net");
+            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
             localRepo.push(editHash, author.url(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Backport " + releaseHash.hex() + " ");
 
@@ -1155,7 +1155,7 @@ class BackportTests {
             var originalMessage = issue1Number + ": An issue\n" +
                                   "\n" +
                                   "Reviewed-by: integrationreviewer2";
-            var releaseHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.java.net");
+            var releaseHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
             localRepo.push(releaseHash, author.url(), "refs/heads/release", true);
 
             // "backport" the new file to the master branch
@@ -1165,7 +1165,7 @@ class BackportTests {
             var newFile2 = localRepo.root().resolve("a_new_file.txt");
             Files.writeString(newFile2, "hello");
             localRepo.add(newFile2);
-            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.java.net");
+            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
             localRepo.push(editHash, author.url(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Backport" + releaseHash.hex());
 
@@ -1213,7 +1213,7 @@ class BackportTests {
             var originalMessage = issue1Number + ": A issue\n" +
                                   "\n" +
                                   "Reviewed-by: integrationreviewer2";
-            var releaseHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.java.net");
+            var releaseHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
             localRepo.push(releaseHash, author.url(), "refs/heads/release", true);
 
             // "backport" the new file to the master branch
@@ -1223,7 +1223,7 @@ class BackportTests {
             var newFile2 = localRepo.root().resolve("a_new_file.txt");
             Files.writeString(newFile2, "hello");
             localRepo.add(newFile2);
-            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.java.net");
+            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
             localRepo.push(editHash, author.url(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Backport " + releaseHash.hex());
 
@@ -1311,7 +1311,7 @@ class BackportTests {
             var originalMessage = issue1Number + " An issue\n" +
                                   "\n" +
                                   "Reviewed-by: integrationreviewer2";
-            var releaseHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.java.net");
+            var releaseHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
             localRepo.push(releaseHash, author.url(), "refs/heads/release", true);
 
             // "backport" the new file to the master branch
@@ -1321,7 +1321,7 @@ class BackportTests {
             var newFile2 = localRepo.root().resolve("a_new_file.txt");
             Files.writeString(newFile2, "hello");
             localRepo.add(newFile2);
-            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.java.net");
+            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
             localRepo.push(editHash, author.url(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Backport " + releaseHash.hex());
 
@@ -1368,7 +1368,7 @@ class BackportTests {
             var newFile2 = localRepo.root().resolve("a_new_file.txt");
             Files.writeString(newFile2, "hello");
             localRepo.add(newFile2);
-            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.java.net");
+            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
             localRepo.push(editHash, author.url(), "refs/heads/edit", true);
 
             // Create various kinds of bad pull request titles
@@ -1484,7 +1484,7 @@ class BackportTests {
             var originalMessage = issue1Number + ": An issue\n" +
                     "\n" +
                     "Reviewed-by: integrationreviewer2";
-            var releaseHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.java.net");
+            var releaseHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
             localRepo.push(releaseHash, author.url(), "refs/heads/release", true);
 
             // Create the same fix in another release branch
@@ -1493,7 +1493,7 @@ class BackportTests {
             var newFile2 = localRepo.root().resolve("a_new_file.txt");
             Files.writeString(newFile2, "hello2");
             localRepo.add(newFile);
-            var releaseHash2 = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.java.net");
+            var releaseHash2 = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
             localRepo.push(releaseHash2, author.url(), "refs/heads/release2", true);
 
             // "backport" the new file to the master branch
@@ -1503,7 +1503,7 @@ class BackportTests {
             var newFile3 = localRepo.root().resolve("a_new_file.txt");
             Files.writeString(newFile3, "hello");
             localRepo.add(newFile3);
-            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.java.net");
+            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
             localRepo.push(editHash, author.url(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Backport " + releaseHash.hex());
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CSRTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CSRTests.java
@@ -74,7 +74,7 @@ class CSRTests {
 
             // The bot should reply with a message that a CSR is needed
             assertLastCommentContains(pr, "has indicated that a " +
-                                          "[compatibility and specification](https://wiki.openjdk.java.net/display/csr/Main) (CSR) request " +
+                                          "[compatibility and specification](https://wiki.openjdk.org/display/csr/Main) (CSR) request " +
                                           "is needed for this pull request.");
             assertTrue(pr.labelNames().contains("csr"));
             // The PR body should contain the progress about CSR request
@@ -85,7 +85,7 @@ class CSRTests {
             TestBotRunner.runPeriodicItems(prBot);
 
             // The bot should reply with a message that a CSR is no longer needed
-            assertLastCommentContains(pr, "determined that a [CSR](https://wiki.openjdk.java.net/display/csr/Main) request " +
+            assertLastCommentContains(pr, "determined that a [CSR](https://wiki.openjdk.org/display/csr/Main) request " +
                                           "is not needed for this pull request.");
             assertFalse(pr.labelNames().contains("csr"));
             // The PR body shouldn't contain the progress about CSR request
@@ -97,7 +97,7 @@ class CSRTests {
 
             // The bot should reply with a message that a CSR is needed
             assertLastCommentContains(pr, "has indicated that a " +
-                                          "[compatibility and specification](https://wiki.openjdk.java.net/display/csr/Main) (CSR) request " +
+                                          "[compatibility and specification](https://wiki.openjdk.org/display/csr/Main) (CSR) request " +
                                           "is needed for this pull request.");
             assertTrue(pr.labelNames().contains("csr"));
             // The PR body should contain the progress about CSR request
@@ -183,7 +183,7 @@ class CSRTests {
 
             // The bot should reply with a message that the CSR is already aproved
             assertLastCommentContains(pr, "has indicated that a " +
-                                          "[compatibility and specification](https://wiki.openjdk.java.net/display/csr/Main) " +
+                                          "[compatibility and specification](https://wiki.openjdk.org/display/csr/Main) " +
                                           "(CSR) request is needed for this pull request.");
             assertLastCommentContains(pr, "this pull request must refer to an issue in [JBS]");
             assertLastCommentContains(pr, "To refer this pull request to an issue in JBS");
@@ -245,7 +245,7 @@ class CSRTests {
 
             // The bot should reply with a message that a CSR is needed
             assertLastCommentContains(pr, "has indicated that a " +
-                                          "[compatibility and specification](https://wiki.openjdk.java.net/display/csr/Main) (CSR) request " +
+                                          "[compatibility and specification](https://wiki.openjdk.org/display/csr/Main) (CSR) request " +
                                           "is needed for this pull request.");
             assertTrue(pr.labelNames().contains("csr"));
             // The PR body should contain the progress about CSR request
@@ -303,7 +303,7 @@ class CSRTests {
 
             // Show help
             assertLastCommentContains(pr, "usage: `/csr [needed|unneeded]`, requires that the issue the pull request refers to links " +
-                                          "to an approved [CSR](https://wiki.openjdk.java.net/display/csr/Main) request.");
+                                          "to an approved [CSR](https://wiki.openjdk.org/display/csr/Main) request.");
             assertFalse(pr.labelNames().contains("csr"));
             // The PR body shouldn't contain the progress about CSR request
             assertFalse(pr.body().contains("Change requires a CSR request to be approved"));
@@ -343,10 +343,10 @@ class CSRTests {
 
             // The bot should reply with a message that the PR must refer to an issue in JBS
             assertLastCommentContains(pr, "has indicated that a " +
-                                          "[compatibility and specification](https://wiki.openjdk.java.net/display/csr/Main) " +
+                                          "[compatibility and specification](https://wiki.openjdk.org/display/csr/Main) " +
                                           "(CSR) request is needed for this pull request.");
             assertLastCommentContains(pr, "this pull request must refer to an issue in [JBS]");
-            assertLastCommentContains(pr, "to be able to link it to a [CSR](https://wiki.openjdk.java.net/display/csr/Main) request. To refer this pull request to an issue in JBS");
+            assertLastCommentContains(pr, "to be able to link it to a [CSR](https://wiki.openjdk.org/display/csr/Main) request. To refer this pull request to an issue in JBS");
             assertTrue(pr.labelNames().contains("csr"));
             // The PR body should contain the progress about CSR request
             assertTrue(pr.body().contains("- [ ] Change requires a CSR request to be approved"));
@@ -387,7 +387,7 @@ class CSRTests {
 
             // The bot should reply with a message that a CSR is needed
             assertLastCommentContains(pr, "has indicated that a " +
-                                          "[compatibility and specification](https://wiki.openjdk.java.net/display/csr/Main) (CSR) request " +
+                                          "[compatibility and specification](https://wiki.openjdk.org/display/csr/Main) (CSR) request " +
                                           "is needed for this pull request.");
             assertTrue(pr.labelNames().contains("csr"));
             // The PR body should contain the progress about CSR request
@@ -471,7 +471,7 @@ class CSRTests {
             TestBotRunner.runPeriodicItems(prBot);
 
             // The bot should reply with a message that a CSR is no longer needed
-            assertLastCommentContains(pr, "determined that a [CSR](https://wiki.openjdk.java.net/display/csr/Main) request " +
+            assertLastCommentContains(pr, "determined that a [CSR](https://wiki.openjdk.org/display/csr/Main) request " +
                     "is not needed for this pull request.");
             assertFalse(pr.labelNames().contains("csr"));
             // The PR body shouldn't contain the progress about CSR request
@@ -543,7 +543,7 @@ class CSRTests {
             TestBotRunner.runPeriodicItems(prBot);
 
             // The bot should reply with a message that a CSR is no longer needed
-            assertLastCommentContains(pr, "determined that a [CSR](https://wiki.openjdk.java.net/display/csr/Main) request " +
+            assertLastCommentContains(pr, "determined that a [CSR](https://wiki.openjdk.org/display/csr/Main) request " +
                     "is not needed for this pull request.");
             assertFalse(pr.labelNames().contains("csr"));
             // The PR body shouldn't contain the progress about CSR request
@@ -579,7 +579,7 @@ class CSRTests {
 
             // The bot should reply with a message that a CSR is needed
             assertLastCommentContains(pr, "has indicated that a " +
-                                          "[compatibility and specification](https://wiki.openjdk.java.net/display/csr/Main) (CSR) request " +
+                                          "[compatibility and specification](https://wiki.openjdk.org/display/csr/Main) (CSR) request " +
                                           "is needed for this pull request.");
             assertTrue(pr.labelNames().contains("csr"));
             // The PR body should contain the progress about CSR request
@@ -634,7 +634,7 @@ class CSRTests {
 
             // The bot should reply with a message that a CSR is needed
             assertLastCommentContains(pr, "has indicated that a " +
-                                          "[compatibility and specification](https://wiki.openjdk.java.net/display/csr/Main) (CSR) request " +
+                                          "[compatibility and specification](https://wiki.openjdk.org/display/csr/Main) (CSR) request " +
                                           "is needed for this pull request.");
             assertTrue(pr.labelNames().contains("csr"));
 
@@ -684,7 +684,7 @@ class CSRTests {
             pr.addComment("/csr");
             TestBotRunner.runPeriodicItems(enableCsrBot);
             assertLastCommentContains(pr, "has indicated that a " +
-                    "[compatibility and specification](https://wiki.openjdk.java.net/display/csr/Main) (CSR) request " +
+                    "[compatibility and specification](https://wiki.openjdk.org/display/csr/Main) (CSR) request " +
                     "is needed for this pull request.");
             assertTrue(pr.labelNames().contains("csr"));
             assertTrue(pr.body().contains("Change requires a CSR request to be approved"));
@@ -731,7 +731,7 @@ class CSRTests {
             localRepo.add(newFile);
             var issueNumber = issue.id().split("-")[1];
             var commitMessage = issueNumber + ": This is the primary issue\n\nReviewed-by: integrationreviewer2";
-            var commitHash = localRepo.commit(commitMessage, "integrationcommitter1", "integrationcommitter1@openjdk.java.net");
+            var commitHash = localRepo.commit(commitMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
             localRepo.push(commitHash, author.url(), "jdk18", true);
 
             // Remove `version=0.1` from `.jcheck/conf`, set the version as null
@@ -750,9 +750,9 @@ class CSRTests {
             assertTrue(pr.body().contains("- [ ] Change requires a CSR request to be approved"));
             assertTrue(pr.labelNames().contains("csr"));
             assertLastCommentContains(pr, "has indicated that a " +
-                    "[compatibility and specification](https://wiki.openjdk.java.net/display/csr/Main) (CSR) request " +
+                    "[compatibility and specification](https://wiki.openjdk.org/display/csr/Main) (CSR) request " +
                     "is needed for this pull request.");
-            assertLastCommentContains(pr, "please create a [CSR](https://wiki.openjdk.java.net/display/csr/Main) request for issue");
+            assertLastCommentContains(pr, "please create a [CSR](https://wiki.openjdk.org/display/csr/Main) request for issue");
             assertLastCommentContains(pr, "with the correct fix version");
             assertLastCommentContains(pr, "This pull request cannot be integrated until the CSR request is approved.");
             // Use `/csr unneeded` to revert the change.
@@ -760,7 +760,7 @@ class CSRTests {
             TestBotRunner.runPeriodicItems(bot);
             assertFalse(pr.body().contains("Change requires a CSR request to be approved"));
             assertFalse(pr.labelNames().contains("csr"));
-            assertLastCommentContains(pr, "determined that a [CSR](https://wiki.openjdk.java.net/display/csr/Main) request " +
+            assertLastCommentContains(pr, "determined that a [CSR](https://wiki.openjdk.org/display/csr/Main) request " +
                     "is not needed for this pull request.");
 
             // Add `version=bla` to `.jcheck/conf`, set the version as a wrong value
@@ -779,9 +779,9 @@ class CSRTests {
             assertTrue(pr.body().contains("- [ ] Change requires a CSR request to be approved"));
             assertTrue(pr.labelNames().contains("csr"));
             assertLastCommentContains(pr, "has indicated that a " +
-                    "[compatibility and specification](https://wiki.openjdk.java.net/display/csr/Main) (CSR) request " +
+                    "[compatibility and specification](https://wiki.openjdk.org/display/csr/Main) (CSR) request " +
                     "is needed for this pull request.");
-            assertLastCommentContains(pr, "please create a [CSR](https://wiki.openjdk.java.net/display/csr/Main) request for issue");
+            assertLastCommentContains(pr, "please create a [CSR](https://wiki.openjdk.org/display/csr/Main) request for issue");
             assertLastCommentContains(pr, "with the correct fix version");
             assertLastCommentContains(pr, "This pull request cannot be integrated until the CSR request is approved.");
             // Use `/csr unneeded` to revert the change.
@@ -789,7 +789,7 @@ class CSRTests {
             TestBotRunner.runPeriodicItems(bot);
             assertFalse(pr.body().contains("Change requires a CSR request to be approved"));
             assertFalse(pr.labelNames().contains("csr"));
-            assertLastCommentContains(pr, "determined that a [CSR](https://wiki.openjdk.java.net/display/csr/Main) request " +
+            assertLastCommentContains(pr, "determined that a [CSR](https://wiki.openjdk.org/display/csr/Main) request " +
                     "is not needed for this pull request.");
 
             // Set the `version` in `.jcheck/conf` as 17 which is an available version.
@@ -808,9 +808,9 @@ class CSRTests {
             assertTrue(pr.body().contains("- [ ] Change requires a CSR request to be approved"));
             assertTrue(pr.labelNames().contains("csr"));
             assertLastCommentContains(pr, "has indicated that a " +
-                    "[compatibility and specification](https://wiki.openjdk.java.net/display/csr/Main) (CSR) request " +
+                    "[compatibility and specification](https://wiki.openjdk.org/display/csr/Main) (CSR) request " +
                     "is needed for this pull request.");
-            assertLastCommentContains(pr, "please create a [CSR](https://wiki.openjdk.java.net/display/csr/Main) request for issue");
+            assertLastCommentContains(pr, "please create a [CSR](https://wiki.openjdk.org/display/csr/Main) request for issue");
             assertLastCommentContains(pr, "with the correct fix version");
             assertLastCommentContains(pr, "This pull request cannot be integrated until the CSR request is approved.");
             // Use `/csr unneeded` to revert the change.
@@ -818,7 +818,7 @@ class CSRTests {
             TestBotRunner.runPeriodicItems(bot);
             assertFalse(pr.body().contains("Change requires a CSR request to be approved"));
             assertFalse(pr.labelNames().contains("csr"));
-            assertLastCommentContains(pr, "determined that a [CSR](https://wiki.openjdk.java.net/display/csr/Main) request " +
+            assertLastCommentContains(pr, "determined that a [CSR](https://wiki.openjdk.org/display/csr/Main) request " +
                     "is not needed for this pull request.");
 
             // Set the fix versions of the primary CSR to 17 and 18.
@@ -853,9 +853,9 @@ class CSRTests {
             assertTrue(pr.body().contains("- [ ] Change requires a CSR request to be approved"));
             assertTrue(pr.labelNames().contains("csr"));
             assertLastCommentContains(pr, "has indicated that a " +
-                    "[compatibility and specification](https://wiki.openjdk.java.net/display/csr/Main) (CSR) request " +
+                    "[compatibility and specification](https://wiki.openjdk.org/display/csr/Main) (CSR) request " +
                     "is needed for this pull request.");
-            assertLastCommentContains(pr, "please create a [CSR](https://wiki.openjdk.java.net/display/csr/Main) request for issue");
+            assertLastCommentContains(pr, "please create a [CSR](https://wiki.openjdk.org/display/csr/Main) request for issue");
             assertLastCommentContains(pr, "with the correct fix version");
             assertLastCommentContains(pr, "This pull request cannot be integrated until the CSR request is approved.");
             // Use `/csr unneeded` to revert the change.
@@ -863,7 +863,7 @@ class CSRTests {
             TestBotRunner.runPeriodicItems(bot);
             assertFalse(pr.body().contains("Change requires a CSR request to be approved"));
             assertFalse(pr.labelNames().contains("csr"));
-            assertLastCommentContains(pr, "determined that a [CSR](https://wiki.openjdk.java.net/display/csr/Main) request " +
+            assertLastCommentContains(pr, "determined that a [CSR](https://wiki.openjdk.org/display/csr/Main) request " +
                     "is not needed for this pull request.");
 
             // Create a backport CSR whose fix version is 17.
@@ -917,7 +917,7 @@ class CSRTests {
             TestBotRunner.runPeriodicItems(bot);
             assertFalse(pr.body().contains("Change requires a CSR request to be approved"));
             assertFalse(pr.labelNames().contains("csr"));
-            assertLastCommentContains(pr, "determined that a [CSR](https://wiki.openjdk.java.net/display/csr/Main) request " +
+            assertLastCommentContains(pr, "determined that a [CSR](https://wiki.openjdk.org/display/csr/Main) request " +
                     "is not needed for this pull request.");
 
             // re-run bot.
@@ -926,9 +926,9 @@ class CSRTests {
             assertTrue(pr.body().contains("- [ ] Change requires a CSR request to be approved"));
             assertTrue(pr.labelNames().contains("csr"));
             assertLastCommentContains(pr, "has indicated that a " +
-                    "[compatibility and specification](https://wiki.openjdk.java.net/display/csr/Main) (CSR) request " +
+                    "[compatibility and specification](https://wiki.openjdk.org/display/csr/Main) (CSR) request " +
                     "is needed for this pull request.");
-            assertLastCommentContains(pr, "please create a [CSR](https://wiki.openjdk.java.net/display/csr/Main) request for issue");
+            assertLastCommentContains(pr, "please create a [CSR](https://wiki.openjdk.org/display/csr/Main) request for issue");
             assertLastCommentContains(pr, "with the correct fix version");
             assertLastCommentContains(pr, "This pull request cannot be integrated until the CSR request is approved.");
         }
@@ -941,7 +941,7 @@ class CSRTests {
         var newFile2 = localRepo.root().resolve("a_new_file.txt");
         Files.writeString(newFile2, "a_new_file");
         localRepo.add(newFile2);
-        var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.java.net");
+        var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
         localRepo.push(editHash, author.url(), branchName, true);
     }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -2090,7 +2090,7 @@ class CheckTests {
             localRepo.add(newFile);
             var issueNumber = issue.id().split("-")[1];
             var commitMessage = issueNumber + ": This is the primary issue\n\nReviewed-by: integrationreviewer2";
-            var commitHash = localRepo.commit(commitMessage, "integrationcommitter1", "integrationcommitter1@openjdk.java.net");
+            var commitHash = localRepo.commit(commitMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
             localRepo.push(commitHash, author.url(), "jdk18", true);
 
             // "backport" the commit to the master branch
@@ -2100,7 +2100,7 @@ class CheckTests {
             var newFile2 = localRepo.root().resolve("a_new_file.txt");
             Files.writeString(newFile2, "a_new_file");
             localRepo.add(newFile2);
-            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.java.net");
+            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
             localRepo.push(editHash, author.url(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Backport " + commitHash);
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CleanCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CleanCommandTests.java
@@ -110,7 +110,7 @@ public class CleanCommandTests {
             var originalMessage = issue1Number + ": An issue\n" +
                                   "\n" +
                                   "Reviewed-by: integrationreviewer2";
-            var releaseHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.java.net");
+            var releaseHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
             localRepo.push(releaseHash, author.url(), "refs/heads/release", true);
 
             // "backport" the new file to the master branch
@@ -120,7 +120,7 @@ public class CleanCommandTests {
             var newFile2 = localRepo.root().resolve("a_new_file.txt");
             Files.writeString(newFile2, "hello");
             localRepo.add(newFile2);
-            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.java.net");
+            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
             localRepo.push(editHash, author.url(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Backport " + releaseHash.hex());
 
@@ -173,7 +173,7 @@ public class CleanCommandTests {
             var originalMessage = issue1Number + ": An issue\n" +
                                   "\n" +
                                   "Reviewed-by: integrationreviewer2";
-            var masterHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.java.net");
+            var masterHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
 
             localRepo.push(masterHash, author.url(), "master", true);
 
@@ -186,7 +186,7 @@ public class CleanCommandTests {
             var upstreamMessage = issue2Number + ": Another issue\n" +
                                   "\n" +
                                   "Reviewed-by: integrationreviewer2";
-            var upstreamHash = localRepo.commit(upstreamMessage, "integrationcommitter1", "integrationcommitter1@openjdk.java.net");
+            var upstreamHash = localRepo.commit(upstreamMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
             localRepo.push(upstreamHash, author.url(), "refs/heads/release", true);
 
             // "backport" the new file to the master branch
@@ -195,7 +195,7 @@ public class CleanCommandTests {
             localRepo.checkout(editBranch);
             Files.writeString(newFile, "a\nb\nc\nd\nd");
             localRepo.add(newFile);
-            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.java.net");
+            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
             localRepo.push(editHash, author.url(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Backport " + upstreamHash.hex());
 
@@ -252,7 +252,7 @@ public class CleanCommandTests {
             var originalMessage = issue1Number + ": An issue\n" +
                                   "\n" +
                                   "Reviewed-by: integrationreviewer2";
-            var masterHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.java.net");
+            var masterHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
 
             localRepo.push(masterHash, author.url(), "master", true);
 
@@ -265,7 +265,7 @@ public class CleanCommandTests {
             var upstreamMessage = issue2Number + ": Another issue\n" +
                                   "\n" +
                                   "Reviewed-by: integrationreviewer2";
-            var upstreamHash = localRepo.commit(upstreamMessage, "integrationcommitter1", "integrationcommitter1@openjdk.java.net");
+            var upstreamHash = localRepo.commit(upstreamMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
             localRepo.push(upstreamHash, author.url(), "refs/heads/release", true);
 
             // "backport" the new file to the master branch
@@ -274,7 +274,7 @@ public class CleanCommandTests {
             localRepo.checkout(editBranch);
             Files.writeString(newFile, "a\nb\nc\nd\nd");
             localRepo.add(newFile);
-            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.java.net");
+            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
             localRepo.push(editHash, author.url(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Backport " + upstreamHash.hex());
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrateTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrateTests.java
@@ -96,9 +96,9 @@ class IntegrateTests {
 
             // Author and committer should be the same
             assertEquals("Generated Committer 1", headCommit.author().name());
-            assertEquals("integrationcommitter1@openjdk.java.net", headCommit.author().email());
+            assertEquals("integrationcommitter1@openjdk.org", headCommit.author().email());
             assertEquals("Generated Committer 1", headCommit.committer().name());
-            assertEquals("integrationcommitter1@openjdk.java.net", headCommit.committer().email());
+            assertEquals("integrationcommitter1@openjdk.org", headCommit.committer().email());
             assertTrue(pr.labelNames().contains("integrated"));
 
             // Ready label should have been removed
@@ -936,9 +936,9 @@ class IntegrateTests {
 
             // Author and committer should be the same
             assertEquals("Generated Committer 1", headCommit.author().name());
-            assertEquals("integrationcommitter1@openjdk.java.net", headCommit.author().email());
+            assertEquals("integrationcommitter1@openjdk.org", headCommit.author().email());
             assertEquals("Generated Committer 1", headCommit.committer().name());
-            assertEquals("integrationcommitter1@openjdk.java.net", headCommit.committer().email());
+            assertEquals("integrationcommitter1@openjdk.org", headCommit.committer().email());
             assertTrue(pr.labelNames().contains("integrated"));
 
             // Ready label should have been removed
@@ -1002,9 +1002,9 @@ class IntegrateTests {
 
             // Author and committer should be the same
             assertEquals("Generated Committer 1", headCommit.author().name());
-            assertEquals("integrationcommitter1@openjdk.java.net", headCommit.author().email());
+            assertEquals("integrationcommitter1@openjdk.org", headCommit.author().email());
             assertEquals("Generated Committer 1", headCommit.committer().name());
-            assertEquals("integrationcommitter1@openjdk.java.net", headCommit.committer().email());
+            assertEquals("integrationcommitter1@openjdk.org", headCommit.committer().email());
             assertTrue(pr.labelNames().contains("integrated"));
 
             // Ready label should have been removed
@@ -1093,9 +1093,9 @@ class IntegrateTests {
 
             // Author and committer should be the same
             assertEquals("Generated Committer 1", headCommit.author().name());
-            assertEquals("integrationcommitter1@openjdk.java.net", headCommit.author().email());
+            assertEquals("integrationcommitter1@openjdk.org", headCommit.author().email());
             assertEquals("Generated Committer 1", headCommit.committer().name());
-            assertEquals("integrationcommitter1@openjdk.java.net", headCommit.committer().email());
+            assertEquals("integrationcommitter1@openjdk.org", headCommit.committer().email());
             assertTrue(pr.labelNames().contains("integrated"));
 
             // Ready label should have been removed
@@ -1402,9 +1402,9 @@ class IntegrateTests {
             // Verify that the author and committer of the change are the correct users
             // The number is implied from the order the add* methods of CensusBuilder were called above.
             assertEquals("Generated Committer 1", headCommit.author().name());
-            assertEquals("integrationcommitter1@openjdk.java.net", headCommit.author().email());
+            assertEquals("integrationcommitter1@openjdk.org", headCommit.author().email());
             assertEquals("Generated Committer 4", headCommit.committer().name());
-            assertEquals("integrationcommitter4@openjdk.java.net", headCommit.committer().email());
+            assertEquals("integrationcommitter4@openjdk.org", headCommit.committer().email());
             assertTrue(authorPr.labelNames().contains("integrated"));
 
             // Ready and deferred labels should have been removed
@@ -1499,9 +1499,9 @@ class IntegrateTests {
 
             // Verify that the author and committer of the change are the correct users
             assertEquals("Generated Committer 1", headCommit.author().name());
-            assertEquals("integrationcommitter1@openjdk.java.net", headCommit.author().email());
+            assertEquals("integrationcommitter1@openjdk.org", headCommit.author().email());
             assertEquals("Generated Committer 1", headCommit.committer().name());
-            assertEquals("integrationcommitter1@openjdk.java.net", headCommit.committer().email());
+            assertEquals("integrationcommitter1@openjdk.org", headCommit.committer().email());
         }
     }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/JEPCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/JEPCommandTests.java
@@ -247,7 +247,7 @@ public class JEPCommandTests {
             TestBotRunner.runPeriodicItems(prBot);
             assertFalse(pr.labelNames().contains(JEPCommand.JEP_LABEL));
             assertLastCommentContains(pr, "Only the pull request author and [Reviewers]" +
-                    "(https://openjdk.java.net/bylaws#reviewer) are allowed to use the `jep` command.");
+                    "(https://openjdk.org/bylaws#reviewer) are allowed to use the `jep` command.");
 
             // Require jep by the PR author
             pr.addComment("/jep TEST-2");
@@ -276,7 +276,7 @@ public class JEPCommandTests {
             TestBotRunner.runPeriodicItems(prBot);
             assertTrue(pr.labelNames().contains(JEPCommand.JEP_LABEL));
             assertLastCommentContains(pr, "Only the pull request author and [Reviewers]" +
-                    "(https://openjdk.java.net/bylaws#reviewer) are allowed to use the `jep` command.");
+                    "(https://openjdk.org/bylaws#reviewer) are allowed to use the `jep` command.");
             assertTrue(pr.body().contains("- [ ] Change requires a JEP request to be targeted"));
 
             // Not require jep by a reviewer

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelTests.java
@@ -349,7 +349,7 @@ public class LabelTests {
             assertLastCommentContains(pr,"The `1` label was successfully added.");
 
             // One more
-            pr.addComment("/cc group-dev@openjdk.java.net");
+            pr.addComment("/cc group-dev@openjdk.org");
             TestBotRunner.runPeriodicItems(prBot);
 
             // The bot should reply with a success message

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
@@ -121,9 +121,9 @@ class MergeTests {
             var headCommit = pushedRepo.commits(headHash.hex() + "^.." + headHash.hex()).asList().get(0);
             assertEquals("Merge " + author.name() + ":other", headCommit.message().get(0));
             assertEquals("Generated Committer 1", headCommit.author().name());
-            assertEquals("integrationcommitter1@openjdk.java.net", headCommit.author().email());
+            assertEquals("integrationcommitter1@openjdk.org", headCommit.author().email());
             assertEquals("Generated Committer 1", headCommit.committer().name());
-            assertEquals("integrationcommitter1@openjdk.java.net", headCommit.committer().email());
+            assertEquals("integrationcommitter1@openjdk.org", headCommit.committer().email());
         }
     }
 
@@ -328,9 +328,9 @@ class MergeTests {
             var headCommit = pushedRepo.commits(headHash.hex() + "^.." + headHash.hex()).asList().get(0);
             assertEquals("Merge " + otherHash2.hex(), headCommit.message().get(0));
             assertEquals("Generated Committer 1", headCommit.author().name());
-            assertEquals("integrationcommitter1@openjdk.java.net", headCommit.author().email());
+            assertEquals("integrationcommitter1@openjdk.org", headCommit.author().email());
             assertEquals("Generated Committer 1", headCommit.committer().name());
-            assertEquals("integrationcommitter1@openjdk.java.net", headCommit.committer().email());
+            assertEquals("integrationcommitter1@openjdk.org", headCommit.committer().email());
         }
     }
 
@@ -473,9 +473,9 @@ class MergeTests {
             var headCommit = pushedRepo.commits(headHash.hex() + "^.." + headHash.hex()).asList().get(0);
             assertEquals("Merge", headCommit.message().get(0));
             assertEquals("Generated Committer 1", headCommit.author().name());
-            assertEquals("integrationcommitter1@openjdk.java.net", headCommit.author().email());
+            assertEquals("integrationcommitter1@openjdk.org", headCommit.author().email());
             assertEquals("Generated Committer 1", headCommit.committer().name());
-            assertEquals("integrationcommitter1@openjdk.java.net", headCommit.committer().email());
+            assertEquals("integrationcommitter1@openjdk.org", headCommit.committer().email());
         }
     }
 
@@ -557,9 +557,9 @@ class MergeTests {
             // Author and committer should updated in the merge commit
             var headCommit = pushedRepo.commits(headHash.hex() + "^.." + headHash.hex()).asList().get(0);
             assertEquals("Generated Committer 1", headCommit.author().name());
-            assertEquals("integrationcommitter1@openjdk.java.net", headCommit.author().email());
+            assertEquals("integrationcommitter1@openjdk.org", headCommit.author().email());
             assertEquals("Generated Committer 1", headCommit.committer().name());
-            assertEquals("integrationcommitter1@openjdk.java.net", headCommit.committer().email());
+            assertEquals("integrationcommitter1@openjdk.org", headCommit.committer().email());
         }
     }
 
@@ -643,9 +643,9 @@ class MergeTests {
             // Author and committer should updated in the merge commit
             var headCommit = pushedRepo.commits(headHash.hex() + "^.." + headHash.hex()).asList().get(0);
             assertEquals("Generated Committer 1", headCommit.author().name());
-            assertEquals("integrationcommitter1@openjdk.java.net", headCommit.author().email());
+            assertEquals("integrationcommitter1@openjdk.org", headCommit.author().email());
             assertEquals("Generated Committer 1", headCommit.committer().name());
-            assertEquals("integrationcommitter1@openjdk.java.net", headCommit.committer().email());
+            assertEquals("integrationcommitter1@openjdk.org", headCommit.committer().email());
         }
     }
 
@@ -737,9 +737,9 @@ class MergeTests {
             // Author and committer should updated in the merge commit
             var headCommit = pushedRepo.commits(headHash.hex() + "^.." + headHash.hex()).asList().get(0);
             assertEquals("Generated Committer 1", headCommit.author().name());
-            assertEquals("integrationcommitter1@openjdk.java.net", headCommit.author().email());
+            assertEquals("integrationcommitter1@openjdk.org", headCommit.author().email());
             assertEquals("Generated Committer 1", headCommit.committer().name());
-            assertEquals("integrationcommitter1@openjdk.java.net", headCommit.committer().email());
+            assertEquals("integrationcommitter1@openjdk.org", headCommit.committer().email());
         }
     }
 
@@ -847,9 +847,9 @@ class MergeTests {
             // Author and committer should updated in the merge commit
             var headCommit = pushedRepo.commits(headHash.hex() + "^.." + headHash.hex()).asList().get(0);
             assertEquals("Generated Committer 1", headCommit.author().name());
-            assertEquals("integrationcommitter1@openjdk.java.net", headCommit.author().email());
+            assertEquals("integrationcommitter1@openjdk.org", headCommit.author().email());
             assertEquals("Generated Committer 1", headCommit.committer().name());
-            assertEquals("integrationcommitter1@openjdk.java.net", headCommit.committer().email());
+            assertEquals("integrationcommitter1@openjdk.org", headCommit.committer().email());
 
             // The latest content from the source and the updated master should be present
             assertEquals("New on master", Files.readString(pushedRepoFolder.resolve("newmaster.txt")));

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ReviewersTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ReviewersTests.java
@@ -374,7 +374,7 @@ public class ReviewersTests {
             // The author should not be allowed to decrease even its own /reviewers command
             authorPR.addComment("/reviewers 1");
             TestBotRunner.runPeriodicItems(prBot);
-            assertLastCommentContains(authorPR, "Only [Reviewers](https://openjdk.java.net/bylaws#reviewer) "
+            assertLastCommentContains(authorPR, "Only [Reviewers](https://openjdk.org/bylaws#reviewer) "
                     + "are allowed to decrease the number of required reviewers.");
             assertTrue(authorPR.body().contains(getReviewersExpectedProgress(0, 1, 0, 1, 0)));
 
@@ -388,7 +388,7 @@ public class ReviewersTests {
             // The author should not be allowed to lower the role of the reviewers
             authorPR.addComment("/reviewers 1 contributors");
             TestBotRunner.runPeriodicItems(prBot);
-            assertLastCommentContains(authorPR, "Only [Reviewers](https://openjdk.java.net/bylaws#reviewer) "
+            assertLastCommentContains(authorPR, "Only [Reviewers](https://openjdk.org/bylaws#reviewer) "
                     + "are allowed to lower the role for additional reviewers.");
             assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 1, 0, 0, 0)));
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/SponsorTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/SponsorTests.java
@@ -107,14 +107,14 @@ class SponsorTests {
 
             if (isAuthor) {
                 assertEquals("Generated Author 2", headCommit.author().name());
-                assertEquals("integrationauthor2@openjdk.java.net", headCommit.author().email());
+                assertEquals("integrationauthor2@openjdk.org", headCommit.author().email());
             } else {
                 assertEquals(authorFullName, headCommit.author().name());
                 assertEquals(authorEmail, headCommit.author().email());
             }
 
             assertEquals("Generated Reviewer 1", headCommit.committer().name());
-            assertEquals("integrationreviewer1@openjdk.java.net", headCommit.committer().email());
+            assertEquals("integrationreviewer1@openjdk.org", headCommit.committer().email());
             assertTrue(pr.labelNames().contains("integrated"));
             assertFalse(pr.labelNames().contains("ready"));
             assertFalse(pr.labelNames().contains("sponsor"));
@@ -643,7 +643,7 @@ class SponsorTests {
             var anotherFile = localRepo.root().resolve("ANOTHER_FILE.txt");
             Files.writeString(anotherFile, "A string\n");
             localRepo.add(anotherFile);
-            var masterHash = localRepo.commit("Another commit\n\nReviewed-by: " + reviewerId, "duke", "duke@openjdk.java.net");
+            var masterHash = localRepo.commit("Another commit\n\nReviewed-by: " + reviewerId, "duke", "duke@openjdk.org");
             localRepo.push(masterHash, author.url(), "master", true);
 
             // Create a new branch, new commit and publish it
@@ -657,7 +657,7 @@ class SponsorTests {
             var editToMasterBranch = localRepo.branch(masterHash, "edit->master");
             localRepo.checkout(editToMasterBranch);
             localRepo.merge(editHash);
-            var mergeHash = localRepo.commit("Merge edit", "duke", "duke@openjdk.java.net");
+            var mergeHash = localRepo.commit("Merge edit", "duke", "duke@openjdk.org");
             localRepo.push(mergeHash, author.url(), "edit->master", true);
 
 

--- a/bots/testinfo/src/main/java/org/openjdk/skara/bots/testinfo/TestInfoBotWorkItem.java
+++ b/bots/testinfo/src/main/java/org/openjdk/skara/bots/testinfo/TestInfoBotWorkItem.java
@@ -67,7 +67,7 @@ public class TestInfoBotWorkItem implements WorkItem {
                            .summary("In order to run pre-submit tests, the [source repository](" +
                                             sourceRepoUrl + ")" +
                                             " must be properly configured to allow test execution. " +
-                                            "See https://wiki.openjdk.java.net/display/SKARA/Testing for more information on how to configure this.")
+                                            "See https://wiki.openjdk.org/display/SKARA/Testing for more information on how to configure this.")
                            .build();
     }
 

--- a/cli/src/main/java/org/openjdk/skara/cli/GitJCheck.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitJCheck.java
@@ -91,7 +91,7 @@ public class GitJCheck {
             Option.shortcut("")
                   .fullname("census")
                   .describe("FILE")
-                  .helptext("Use the specified census (default: https://openjdk.java.net/census.xml)")
+                  .helptext("Use the specified census (default: https://openjdk.org/census.xml)")
                   .optional(),
             Option.shortcut("")
                   .fullname("ignore")

--- a/cli/src/main/java/org/openjdk/skara/cli/GitSkara.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitSkara.java
@@ -85,9 +85,9 @@ public class GitSkara {
         System.out.println("For more information, please see the Skara wiki:");
         System.out.println("");
         if (isMercurial) {
-            System.out.println("    https://wiki.openjdk.java.net/display/SKARA/Mercurial");
+            System.out.println("    https://wiki.openjdk.org/display/SKARA/Mercurial");
         } else {
-            System.out.println("    https://wiki.openjdk.java.net/display/skara");
+            System.out.println("    https://wiki.openjdk.org/display/skara");
         }
         System.out.println("");
         System.exit(0);

--- a/cli/src/main/java/org/openjdk/skara/cli/GitWebrev.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitWebrev.java
@@ -228,7 +228,7 @@ public class GitWebrev {
         if (upstream == null) {
             if (upstreamPullPath != null) {
                 var host = upstreamPullPath.getHost();
-                if (host != null && host.endsWith("openjdk.java.net")) {
+                if (host != null && host.endsWith("openjdk.org")) {
                     upstream = upstreamPullPath.toString();
                 } else if (host != null && host.equals("github.com")) {
                     var path = upstreamPullPath.getPath();
@@ -238,7 +238,7 @@ public class GitWebrev {
                 }
             } else if (originPullPath != null) {
                 var host = originPullPath.getHost();
-                if (host != null && host.endsWith("openjdk.java.net")) {
+                if (host != null && host.endsWith("openjdk.org")) {
                     upstream = originPullPath.toString();
                 } else if (host != null && host.equals("github.com")) {
                     var path = originPullPath.getPath();

--- a/cli/src/main/java/org/openjdk/skara/cli/debug/GitMlRules.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/debug/GitMlRules.java
@@ -134,7 +134,7 @@ public class GitMlRules {
             throw new UncheckedIOException(e);
         }
         return archivePageNames().parallelStream()
-                                 .map(name -> HttpRequest.newBuilder(URI.create("https://mail.openjdk.java.net/pipermail/" + list + "/" + name + ".txt"))
+                                 .map(name -> HttpRequest.newBuilder(URI.create("https://mail.openjdk.org/pipermail/" + list + "/" + name + ".txt"))
                                                          .GET().build())
                                  .map(req -> {
                                      try {

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrCreate.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrCreate.java
@@ -316,7 +316,7 @@ public class GitPrCreate {
                 var lists = cc.split(",");
                 for (var input : lists) {
                     var label = input;
-                    if (label.endsWith("@openjdk.java.net")) {
+                    if (label.endsWith("@openjdk.org")) {
                         label = input.split("@")[0];
                     }
                     if (label.endsWith("-dev")) {
@@ -324,19 +324,19 @@ public class GitPrCreate {
                     }
                     if (!config.isAllowed(label) && !config.isAllowed(label + "-dev")) {
                         System.out.println("error: the mailing list \"" + label +
-                                           "-dev@openjdk.java.net\" is not applicable, aborting.");
+                                           "-dev@openjdk.org\" is not applicable, aborting.");
                         System.exit(1);
                     }
                 }
                 System.out.println("You have chosen the following mailing lists to be CC:d for the \"RFR\" e-mail:");
                 for (var input : lists) {
                     String list = null;
-                    if (input.endsWith("@openjdk.java.net")) {
+                    if (input.endsWith("@openjdk.org")) {
                         list = input;
                     } else if (input.endsWith("-dev")) {
-                        list = input + "@openjdk.java.net";
+                        list = input + "@openjdk.org";
                     } else  {
-                        list = input + "-dev@openjdk.java.net";
+                        list = input + "-dev@openjdk.org";
                     }
                     System.out.println("- " + list);
                     mailingLists.add(list);

--- a/forge/src/test/java/org/openjdk/skara/forge/ForgeTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/ForgeTests.java
@@ -92,7 +92,7 @@ class ForgeTests {
         Files.write(readme, List.of("Hello, readme!"));
 
         r.add(readme);
-        return r.commit("Add README", "duke", "duke@openjdk.java.net");
+        return r.commit("Add README", "duke", "duke@openjdk.org");
     }
 
     @Test

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/CensusConfiguration.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/CensusConfiguration.java
@@ -27,7 +27,7 @@ import java.net.URI;
 
 public class CensusConfiguration {
     private static final CensusConfiguration DEFAULT =
-        new CensusConfiguration(0, "localhost", URI.create("https://openjdk.java.net/census.xml"));
+        new CensusConfiguration(0, "localhost", URI.create("https://openjdk.org/census.xml"));
 
     private final int version;
     private final String domain;

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/ReviewersConfiguration.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/ReviewersConfiguration.java
@@ -30,7 +30,7 @@ import java.util.List;
 
 public class ReviewersConfiguration {
     static final ReviewersConfiguration DEFAULT = new ReviewersConfiguration(0, 1, 0, 0, 0, List.of("duke"), false);
-    public static final String BYLAWS_URL = "https://openjdk.java.net/bylaws";
+    public static final String BYLAWS_URL = "https://openjdk.org/bylaws";
 
     private final int lead;
     private final int reviewers;

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/DuplicateIssuesCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/DuplicateIssuesCheckTests.java
@@ -66,15 +66,15 @@ class DuplicateIssuesCheckTests {
             var readme = dir.path().resolve("README");
             Files.write(readme, List.of("Hello, world!"));
             r.add(readme);
-            var first = r.commit("1: Added README and .jcheck/conf", "duke", "duke@openjdk.java.net");
+            var first = r.commit("1: Added README and .jcheck/conf", "duke", "duke@openjdk.org");
 
             Files.write(readme, List.of("One more line"), WRITE, APPEND);
             r.add(readme);
-            var second = r.commit("2: Modified README", "duke", "duke@openjdk.java.net");
+            var second = r.commit("2: Modified README", "duke", "duke@openjdk.org");
 
             Files.write(readme, List.of("One more line again"), WRITE, APPEND);
             r.add(readme);
-            var third = r.commit("3: Modified README again", "duke", "duke@openjdk.java.net");
+            var third = r.commit("3: Modified README again", "duke", "duke@openjdk.org");
             var check = new DuplicateIssuesCheck(r);
 
             var commit = r.lookup(third).orElseThrow();
@@ -91,15 +91,15 @@ class DuplicateIssuesCheckTests {
             var readme = dir.path().resolve("README");
             Files.write(readme, List.of("Hello, world!"));
             r.add(readme);
-            var first = r.commit("1: Added README and .jcheck/conf", "duke", "duke@openjdk.java.net");
+            var first = r.commit("1: Added README and .jcheck/conf", "duke", "duke@openjdk.org");
 
             Files.write(readme, List.of("One more line"), WRITE, APPEND);
             r.add(readme);
-            var second = r.commit("2: Modified README", "duke", "duke@openjdk.java.net");
+            var second = r.commit("2: Modified README", "duke", "duke@openjdk.org");
 
             Files.write(readme, List.of("One more line again"), WRITE, APPEND);
             r.add(readme);
-            var third = r.commit("3: Modified README again\n3: Modified README again", "duke", "duke@openjdk.java.net");
+            var third = r.commit("3: Modified README again\n3: Modified README again", "duke", "duke@openjdk.org");
 
             var check = new DuplicateIssuesCheck(r);
 
@@ -121,15 +121,15 @@ class DuplicateIssuesCheckTests {
             var readme = dir.path().resolve("README");
             Files.write(readme, List.of("Hello, world!"));
             r.add(readme);
-            var first = r.commit("1: Added README and .jcheck/conf", "duke", "duke@openjdk.java.net");
+            var first = r.commit("1: Added README and .jcheck/conf", "duke", "duke@openjdk.org");
 
             Files.write(readme, List.of("One more line"), WRITE, APPEND);
             r.add(readme);
-            var second = r.commit("2: Modified README", "duke", "duke@openjdk.java.net");
+            var second = r.commit("2: Modified README", "duke", "duke@openjdk.org");
 
             Files.write(readme, List.of("One more line again"), WRITE, APPEND);
             r.add(readme);
-            var third = r.commit("2: Modified README again", "duke", "duke@openjdk.java.net");
+            var third = r.commit("2: Modified README again", "duke", "duke@openjdk.org");
 
             var check = new DuplicateIssuesCheck(r);
             var commit = r.lookup(third).orElseThrow();
@@ -152,18 +152,18 @@ class DuplicateIssuesCheckTests {
             var readme = dir.path().resolve("README");
             Files.write(readme, List.of("Hello, world!"));
             r.add(readme);
-            var first = r.commit("1: Added README and .jcheck/conf", "duke", "duke@openjdk.java.net");
+            var first = r.commit("1: Added README and .jcheck/conf", "duke", "duke@openjdk.org");
 
             Files.write(readme, List.of("One more line"), WRITE, APPEND);
             r.add(readme);
-            var second = r.commit("2: Modified README", "duke", "duke@openjdk.java.net");
+            var second = r.commit("2: Modified README", "duke", "duke@openjdk.org");
 
             var myBranch = r.branch(first, "myBranch");
             r.checkout(myBranch);
 
             Files.write(readme, List.of("Another line"), WRITE, APPEND);
             r.add(readme);
-            var third = r.commit("2: Modified README", "duke", "duke@openjdk.java.net");
+            var third = r.commit("2: Modified README", "duke", "duke@openjdk.org");
             var check = new DuplicateIssuesCheck(r);
 
             var commit = r.lookup(third).orElseThrow();

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/JCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/JCheckTests.java
@@ -54,7 +54,7 @@ class JCheckTests {
                 output.append("\n");
                 output.append("[census]\n");
                 output.append("version=0\n");
-                output.append("domain=openjdk.java.net\n");
+                output.append("domain=openjdk.org\n");
                 output.append("\n");
                 output.append("[checks \"whitespace\"]\n");
                 output.append("suffixes=.txt\n");
@@ -64,7 +64,7 @@ class JCheckTests {
             }
             repo.add(checkConf);
 
-            repo.commit("Initial commit\n\nReviewed-by: user2", "user3", "user3@openjdk.java.net");
+            repo.commit("Initial commit\n\nReviewed-by: user2", "user3", "user3@openjdk.org");
 
             return repo;
         }
@@ -259,7 +259,7 @@ class JCheckTests {
             var readme = repoPath.resolve("README");
             Files.write(readme, List.of("Hello, readme!"));
             repo.add(readme);
-            var first = repo.commit("Add README", "duke", "duke@openjdk.java.net");
+            var first = repo.commit("Add README", "duke", "duke@openjdk.org");
 
             var checks = JCheck.checksFor(repo, first);
             var checkNames = checks.stream()
@@ -279,11 +279,11 @@ class JCheckTests {
             var file = repoPath.resolve("file.txt");
             Files.write(file, List.of("Hello, file!"));
             repo.add(file);
-            var first = repo.commit("Add file", "duke", "duke@openjdk.java.net");
+            var first = repo.commit("Add file", "duke", "duke@openjdk.org");
 
             Files.delete(file);
             repo.remove(file);
-            var second = repo.commit("Remove file", "duke", "duke@openjdk.java.net");
+            var second = repo.commit("Remove file", "duke", "duke@openjdk.org");
 
             var censusPath = dir.path().resolve("census");
             Files.createDirectories(censusPath);
@@ -314,7 +314,7 @@ class JCheckTests {
             Files.writeString(jcheckConf, "[checks \"reviewers\"]\nminimum = 0\n",
                               StandardOpenOption.WRITE, StandardOpenOption.APPEND);
             repo.add(jcheckConf);
-            var secondCommit = repo.commit("Do not require reviews", "user3", "user3@openjdk.java.net");
+            var secondCommit = repo.commit("Do not require reviews", "user3", "user3@openjdk.org");
 
             var censusPath = dir.path().resolve("census");
             Files.createDirectories(censusPath);

--- a/skara.py
+++ b/skara.py
@@ -120,7 +120,7 @@ def webrev(ui, repo, **opts):
 
 jcheck_opts = [
     (b'r', b'rev', b'', b'Check the specified revision or range (default: tip)'),
-    (b'',  b'census', b'', b'Use the specified census (default: https://openjdk.java.net/census.xml)'),
+    (b'',  b'census', b'', b'Use the specified census (default: https://openjdk.org/census.xml)'),
     (b'',  b'local', False, b'Run jcheck in "local" mode'),
     (b'',  b'lax', False, b'Check comments, tags and whitespace laxly'),
     (b's', b'strict', False, b'Check everything')

--- a/storage/src/test/java/org/openjdk/skara/storage/RepositoryStorageTests.java
+++ b/storage/src/test/java/org/openjdk/skara/storage/RepositoryStorageTests.java
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class RepositoryStorageTests {
     private RepositoryStorage<String> stringStorage(Repository repository) {
-        return new RepositoryStorage<>(repository, "db.txt", "Duke", "duke@openjdk.java.net", "Test update",
+        return new RepositoryStorage<>(repository, "db.txt", "Duke", "duke@openjdk.org", "Test update",
                                        (added, cur) -> Stream.concat(cur.stream(), added.stream())
                                                              .sorted()
                                                              .collect(Collectors.joining(";")),

--- a/test/src/main/java/org/openjdk/skara/test/CheckableRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/CheckableRepository.java
@@ -72,7 +72,7 @@ public class CheckableRepository {
             output.append("\n\n");
             output.append("[census]\n");
             output.append("version=0\n");
-            output.append("domain=openjdk.java.net\n");
+            output.append("domain=openjdk.org\n");
             output.append("\n");
             output.append("[checks \"whitespace\"]\n");
             output.append("files=.*\\.txt\n");

--- a/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
@@ -135,7 +135,7 @@ public class RepositoryTests {
             Files.write(readme, List.of("Hello, readme!"));
 
             r.add(readme);
-            var head = r.commit("Add README", "duke", "duke@openjdk.java.net");
+            var head = r.commit("Add README", "duke", "duke@openjdk.org");
             assertEquals(head, r.head());
         }
     }
@@ -179,13 +179,13 @@ public class RepositoryTests {
             Files.write(readme, List.of("Hello, readme!"));
             r.add(readme);
 
-            var head1 = r.commit("Add README", "duke", "duke@openjdk.java.net");
+            var head1 = r.commit("Add README", "duke", "duke@openjdk.org");
             assertEquals(head1, r.head());
 
             Files.write(readme, List.of("Another line"), WRITE, APPEND);
             r.add(readme);
 
-            var head2 = r.commit("Add one more line", "duke", "duke@openjdk.java.net");
+            var head2 = r.commit("Add one more line", "duke", "duke@openjdk.org");
             assertEquals(head2, r.head());
 
             r.checkout(head1, false);
@@ -206,14 +206,14 @@ public class RepositoryTests {
             Files.write(readme, List.of("Hello, readme!"));
             r.add(readme);
 
-            var head1 = r.commit("Add README", "duke", "duke@openjdk.java.net");
+            var head1 = r.commit("Add README", "duke", "duke@openjdk.org");
             assertEquals(List.of("Hello, readme!"),
                          r.lines(readme, head1).orElseThrow());
 
             Files.write(readme, List.of("Another line"), WRITE, APPEND);
             r.add(readme);
 
-            var head2 = r.commit("Add one more line", "duke", "duke@openjdk.java.net");
+            var head2 = r.commit("Add one more line", "duke", "duke@openjdk.org");
             assertEquals(List.of("Hello, readme!", "Another line"),
                          r.lines(readme, head2).orElseThrow());
         }
@@ -233,7 +233,7 @@ public class RepositoryTests {
             Files.write(readme, List.of("Hello, readme!"));
             r.add(readme);
 
-            var head = r.commit("Add README", "duke", "duke@openjdk.java.net");
+            var head = r.commit("Add README", "duke", "duke@openjdk.org");
             assertEquals(List.of("Hello, readme!"),
                          r.lines(readme, head).orElseThrow());
 
@@ -241,7 +241,7 @@ public class RepositoryTests {
             Files.write(example, List.of("An example"));
             r.add(example);
 
-            var head2 = r.commit("Add EXAMPLE", "duke", "duke@openjdk.java.net");
+            var head2 = r.commit("Add EXAMPLE", "duke", "duke@openjdk.org");
             assertEquals(List.of("An example"),
                          r.lines(example, head2).orElseThrow());
         }
@@ -268,15 +268,15 @@ public class RepositoryTests {
             r.add(readme);
 
             var committerName = vcs == VCS.GIT ? "bot" : "duke";
-            var committerEmail = vcs == VCS.GIT ? "bot@openjdk.java.net" : "duke@openjdk.java.net";
-            var hash = r.commit("Add README", "duke", "duke@openjdk.java.net", committerName, committerEmail);
+            var committerEmail = vcs == VCS.GIT ? "bot@openjdk.org" : "duke@openjdk.org";
+            var hash = r.commit("Add README", "duke", "duke@openjdk.org", committerName, committerEmail);
 
             var commits = r.commits().asList();
             assertEquals(1, commits.size());
 
             var commit = commits.get(0);
             assertEquals("duke", commit.author().name());
-            assertEquals("duke@openjdk.java.net", commit.author().email());
+            assertEquals("duke@openjdk.org", commit.author().email());
             assertEquals(committerName, commit.committer().name());
             assertEquals(committerEmail, commit.committer().email());
 
@@ -346,18 +346,18 @@ public class RepositoryTests {
             Files.write(readme, List.of("Hello, readme!"));
 
             r.add(readme);
-            var hash1 = r.commit("Add README", "duke", "duke@openjdk.java.net");
+            var hash1 = r.commit("Add README", "duke", "duke@openjdk.org");
 
             Files.write(readme, List.of("Another line"), WRITE, APPEND);
             r.add(readme);
-            var hash2 = r.commit("Modify README", "duke", "duke@openjdk.java.net");
+            var hash2 = r.commit("Modify README", "duke", "duke@openjdk.org");
 
             var commits = r.commits().asList();
             assertEquals(2, commits.size());
 
             var commit = commits.get(0);
             assertEquals("duke", commit.author().name());
-            assertEquals("duke@openjdk.java.net", commit.author().email());
+            assertEquals("duke@openjdk.org", commit.author().email());
 
             assertEquals(List.of("Modify README"), commit.message());
 
@@ -419,22 +419,22 @@ public class RepositoryTests {
             Files.write(file3, List.of("Hello, file 3!"));
 
             r.add(file1, file2, file3);
-            var hash1 = r.commit("Add files", "duke", "duke@openjdk.java.net");
+            var hash1 = r.commit("Add files", "duke", "duke@openjdk.org");
 
             Files.delete(file2);
             r.remove(file2);
-            var hash2 = r.commit("Remove file 2", "duke", "duke@openjdk.java.net");
+            var hash2 = r.commit("Remove file 2", "duke", "duke@openjdk.org");
 
             Files.delete(file3);
             r.remove(file3);
-            var hash3 = r.commit("Remove file 3", "duke", "duke@openjdk.java.net");
+            var hash3 = r.commit("Remove file 3", "duke", "duke@openjdk.org");
 
             var refspec = vcs == VCS.GIT ? r.head().hex() : r.head().hex() + ":0";
             assertEquals(3, r.commits(refspec).asList().size());
 
             r.checkout(hash1, false);
             r.squash(hash3);
-            r.commit("Squashed remove of file 2 and 3", "duke", "duke@openjdk.java.net");
+            r.commit("Squashed remove of file 2 and 3", "duke", "duke@openjdk.org");
 
             refspec = vcs == VCS.GIT ? r.head().hex() : r.head().hex() + ":0";
             var commits = r.commits(refspec).asList();
@@ -474,22 +474,22 @@ public class RepositoryTests {
             Files.write(readme, List.of("Hello, readme!"));
 
             r.add(readme);
-            var hash1 = r.commit("Add README", "duke", "duke@openjdk.java.net");
+            var hash1 = r.commit("Add README", "duke", "duke@openjdk.org");
 
             Files.write(readme, List.of("Another line"), WRITE, APPEND);
             r.add(readme);
-            var hash2 = r.commit("Modify README", "duke", "duke@openjdk.java.net");
+            var hash2 = r.commit("Modify README", "duke", "duke@openjdk.org");
 
             Files.write(readme, List.of("A final line"), WRITE, APPEND);
             r.add(readme);
-            var hash3 = r.commit("Modify README again", "duke", "duke@openjdk.java.net");
+            var hash3 = r.commit("Modify README again", "duke", "duke@openjdk.org");
 
             var refspec = vcs == VCS.GIT ? r.head().hex() : r.head().hex() + ":0";
             assertEquals(3, r.commits(refspec).asList().size());
 
             r.checkout(hash1, false);
             r.squash(hash3);
-            r.commit("Squashed commits 2 and 3", "duke", "duke@openjdk.java.net");
+            r.commit("Squashed commits 2 and 3", "duke", "duke@openjdk.org");
 
             refspec = vcs == VCS.GIT ? r.head().hex() : r.head().hex() + ":0";
             var commits = r.commits(refspec).asList();
@@ -549,16 +549,16 @@ public class RepositoryTests {
             Files.write(readme, List.of("Hello, readme!"));
 
             r.add(readme);
-            var hash1 = r.commit("Add README", "duke", "duke@openjdk.java.net");
+            var hash1 = r.commit("Add README", "duke", "duke@openjdk.org");
 
             Files.write(readme, List.of("Another line"), WRITE, APPEND);
             r.add(readme);
-            var hash2 = r.commit("Modify README", "duke", "duke@openjdk.java.net");
+            var hash2 = r.commit("Modify README", "duke", "duke@openjdk.org");
 
             r.checkout(hash1, false);
             Files.write(readme, List.of("A conflicting line"), WRITE, APPEND);
             r.add(readme);
-            var hash3 = r.commit("Branching README modification", "duke", "duke@openjdk.java.net");
+            var hash3 = r.commit("Branching README modification", "duke", "duke@openjdk.org");
 
             assertEquals(hash1, r.mergeBase(hash2, hash3));
         }
@@ -574,18 +574,18 @@ public class RepositoryTests {
             Files.write(readme, List.of("Hello, readme!"));
 
             r.add(readme);
-            var hash1 = r.commit("Add README", "duke", "duke@openjdk.java.net");
+            var hash1 = r.commit("Add README", "duke", "duke@openjdk.org");
 
             Files.write(readme, List.of("Another line"), WRITE, APPEND);
             r.add(readme);
-            var hash2 = r.commit("Modify README", "duke", "duke@openjdk.java.net");
+            var hash2 = r.commit("Modify README", "duke", "duke@openjdk.org");
 
             assertTrue(r.isAncestor(hash1, hash2));
 
             r.checkout(hash1, false);
             Files.write(readme, List.of("A conflicting line"), WRITE, APPEND);
             r.add(readme);
-            var hash3 = r.commit("Branching README modification", "duke", "duke@openjdk.java.net");
+            var hash3 = r.commit("Branching README modification", "duke", "duke@openjdk.org");
 
             assertTrue(r.isAncestor(hash1, hash3));
             assertFalse(r.isAncestor(hash2, hash3));
@@ -602,21 +602,21 @@ public class RepositoryTests {
             Files.write(readme, List.of("Hello, readme!"));
 
             r.add(readme);
-            var hash1 = r.commit("Add README", "duke", "duke@openjdk.java.net");
+            var hash1 = r.commit("Add README", "duke", "duke@openjdk.org");
 
             Files.write(readme, List.of("Another line"), WRITE, APPEND);
             r.add(readme);
-            var hash2 = r.commit("Modify README", "duke", "duke@openjdk.java.net");
+            var hash2 = r.commit("Modify README", "duke", "duke@openjdk.org");
 
             r.checkout(hash1, false);
 
             var contributing = dir.path().resolve("CONTRIBUTING");
             Files.write(contributing, List.of("Keep the patches coming"));
             r.add(contributing);
-            var hash3 = r.commit("Add independent change", "duke", "duke@openjdk.java.net");
+            var hash3 = r.commit("Add independent change", "duke", "duke@openjdk.org");
 
             var committerName = vcs == VCS.GIT ? "bot" : "duke";
-            var committerEmail = vcs == VCS.GIT ? "bot@openjdk.java.net" : "duke@openjdk.java.net";
+            var committerEmail = vcs == VCS.GIT ? "bot@openjdk.org" : "duke@openjdk.org";
             r.rebase(hash2, committerName, committerEmail);
 
             var refspec = vcs == VCS.GIT ? r.head().hex() : r.head().hex() + ":0";
@@ -626,19 +626,19 @@ public class RepositoryTests {
             assertEquals(hash1, commits.get(2).hash());
 
             assertEquals("duke", commits.get(0).author().name());
-            assertEquals("duke@openjdk.java.net", commits.get(0).author().email());
+            assertEquals("duke@openjdk.org", commits.get(0).author().email());
             assertEquals(committerName, commits.get(0).committer().name());
             assertEquals(committerEmail, commits.get(0).committer().email());
 
             assertEquals("duke", commits.get(1).author().name());
-            assertEquals("duke@openjdk.java.net", commits.get(1).author().email());
+            assertEquals("duke@openjdk.org", commits.get(1).author().email());
             assertEquals("duke", commits.get(1).committer().name());
-            assertEquals("duke@openjdk.java.net", commits.get(1).committer().email());
+            assertEquals("duke@openjdk.org", commits.get(1).committer().email());
 
             assertEquals("duke", commits.get(2).author().name());
-            assertEquals("duke@openjdk.java.net", commits.get(2).author().email());
+            assertEquals("duke@openjdk.org", commits.get(2).author().email());
             assertEquals("duke", commits.get(2).committer().name());
-            assertEquals("duke@openjdk.java.net", commits.get(2).committer().email());
+            assertEquals("duke@openjdk.org", commits.get(2).committer().email());
 
             var head = commits.get(0);
             assertEquals(hash2, head.parents().get(0));
@@ -684,7 +684,7 @@ public class RepositoryTests {
             Files.write(readme, List.of("Hello, readme!"));
 
             r.add(readme);
-            r.commit("Add README", "duke", "duke@openjdk.java.net");
+            r.commit("Add README", "duke", "duke@openjdk.org");
 
             assertFalse(r.isEmpty());
         }
@@ -709,7 +709,7 @@ public class RepositoryTests {
             Files.write(readme, List.of("Hello, readme!"));
 
             r.add(readme);
-            r.commit("Add README", "duke", "duke@openjdk.java.net");
+            r.commit("Add README", "duke", "duke@openjdk.org");
 
             assertTrue(r.isHealthy());
         }
@@ -726,8 +726,8 @@ public class RepositoryTests {
             Files.write(readme, List.of("Hello, readme!"));
 
             r1.add(readme);
-            var hash = r1.commit("Add README", "duke", "duke@openjdk.java.net");
-            r1.tag(hash, "tag", "tagging", "duke", "duke@openjdk.java.net");
+            var hash = r1.commit("Add README", "duke", "duke@openjdk.org");
+            r1.tag(hash, "tag", "tagging", "duke", "duke@openjdk.org");
 
             var r2 = TestableRepository.init(dir2.path(), vcs);
             r2.fetch(r1.root().toUri(), r1.defaultBranch().name());
@@ -756,7 +756,7 @@ public class RepositoryTests {
             Files.write(readme, List.of("Hello, readme!"));
 
             r.add(readme);
-            r.commit("Add README", "duke", "duke@openjdk.java.net");
+            r.commit("Add README", "duke", "duke@openjdk.org");
 
             assertEquals(List.of(r.defaultBranch()), r.branches());
         }
@@ -782,7 +782,7 @@ public class RepositoryTests {
             Files.write(readme, List.of("Hello, readme!"));
 
             r.add(readme);
-            r.commit("Add README", "duke", "duke@openjdk.java.net");
+            r.commit("Add README", "duke", "duke@openjdk.org");
 
             var expected = vcs == VCS.GIT ? List.of() : List.of(new Tag("tip"));
             assertEquals(expected, r.tags());
@@ -805,7 +805,7 @@ public class RepositoryTests {
             Files.write(readme, List.of("Hello, readme!"));
 
             upstream.add(readme);
-            upstream.commit("Add README", "duke", "duke@openjdk.java.net");
+            upstream.commit("Add README", "duke", "duke@openjdk.org");
 
             try (var dir2 = new TemporaryDirectory()) {
                 var downstream = TestableRepository.init(dir2.path(), vcs);
@@ -820,7 +820,7 @@ public class RepositoryTests {
                 Files.write(downstreamReadme, List.of("Downstream change"), WRITE, APPEND);
 
                 downstream.add(downstreamReadme);
-                var head = downstream.commit("Modify README", "duke", "duke@openjdk.java.net");
+                var head = downstream.commit("Modify README", "duke", "duke@openjdk.org");
 
                 downstream.push(head, upstreamURI, downstream.defaultBranch().name());
             }
@@ -848,9 +848,9 @@ public class RepositoryTests {
             Files.write(readme, List.of("Hello, readme!"));
 
             upstream.add(readme);
-            var firstHash = upstream.commit("Add README", "duke", "duke@openjdk.java.net");
+            var firstHash = upstream.commit("Add README", "duke", "duke@openjdk.org");
 
-            var firstTag = upstream.tag(firstHash, "my-tag", "First tag message", "duke", "duke@openjdk.java.net");
+            var firstTag = upstream.tag(firstHash, "my-tag", "First tag message", "duke", "duke@openjdk.org");
 
             try (var dir2 = new TemporaryDirectory()) {
                 var downstream = TestableRepository.init(dir2.path(), vcs);
@@ -864,9 +864,9 @@ public class RepositoryTests {
 
                 Files.write(readme, List.of("Readme change"), WRITE, APPEND);
                 upstream.add(readme);
-                var secondHash = upstream.commit("Modify README", "duke", "duke@openjdk.java.net");
+                var secondHash = upstream.commit("Modify README", "duke", "duke@openjdk.org");
                 var secondTag = upstream.tag(secondHash, "my-tag", "Second tag message","duke",
-                        "duke@openjdk.java.net", null, true);
+                        "duke@openjdk.org", null, true);
 
                 downstream.fetch(upstreamURI, downstream.defaultBranch().name(), true, true);
                 tagHash = downstream.resolve(secondTag).orElseThrow();
@@ -887,7 +887,7 @@ public class RepositoryTests {
             Files.write(readme, List.of("Hello, readme!"));
 
             r.add(readme);
-            var hash1 = r.commit("Add README", "duke", "duke@openjdk.java.net");
+            var hash1 = r.commit("Add README", "duke", "duke@openjdk.org");
 
             r.clean();
 
@@ -932,7 +932,7 @@ public class RepositoryTests {
             Files.write(dir.path().resolve(".hgignore"), List.of(".*txt"));
 
             r.add(readme);
-            var hash1 = r.commit("Add README", "duke", "duke@openjdk.java.net");
+            var hash1 = r.commit("Add README", "duke", "duke@openjdk.org");
 
             var ignored = dir.path().resolve("ignored.txt");
             Files.write(ignored, List.of("Random text"));
@@ -953,11 +953,11 @@ public class RepositoryTests {
             Files.write(readme, List.of("Hello, readme!"));
 
             r.add(readme);
-            var first = r.commit("Add README", "duke", "duke@openjdk.java.net");
+            var first = r.commit("Add README", "duke", "duke@openjdk.org");
 
             Files.write(readme, List.of("One more line"), WRITE, APPEND);
             r.add(readme);
-            var second = r.commit("Add one more line", "duke", "duke@openjdk.java.net");
+            var second = r.commit("Add one more line", "duke", "duke@openjdk.org");
 
             var diff = r.diff(first, second);
             assertEquals(first, diff.from());
@@ -1006,13 +1006,13 @@ public class RepositoryTests {
 
             r.add(readme);
             r.add(building);
-            var first = r.commit("Add README and BUILDING", "duke", "duke@openjdk.java.net");
+            var first = r.commit("Add README and BUILDING", "duke", "duke@openjdk.org");
 
             Files.write(readme, List.of("Hello, Skara!"), WRITE, TRUNCATE_EXISTING);
             Files.write(building, List.of("make images"), WRITE, TRUNCATE_EXISTING);
             r.add(readme);
             r.add(building);
-            var second = r.commit("Modify README and BUILDING", "duke", "duke@openjdk.java.net");
+            var second = r.commit("Modify README and BUILDING", "duke", "duke@openjdk.org");
 
             var diff = r.diff(first, second);
             assertEquals(first, diff.from());
@@ -1071,11 +1071,11 @@ public class RepositoryTests {
             Files.write(abc, List.of("A", "B", "C"));
 
             r.add(abc);
-            var first = r.commit("Added ABC", "duke", "duke@openjdk.java.net");
+            var first = r.commit("Added ABC", "duke", "duke@openjdk.org");
 
             Files.write(abc, List.of("1", "2", "B", "3"), WRITE, TRUNCATE_EXISTING);
             r.add(abc);
-            var second = r.commit("Modify A and C", "duke", "duke@openjdk.java.net");
+            var second = r.commit("Modify A and C", "duke", "duke@openjdk.org");
 
             var diff = r.diff(first, second);
             assertEquals(first, diff.from());
@@ -1134,11 +1134,11 @@ public class RepositoryTests {
             Files.write(readme, List.of("Hello, world!"));
 
             r.add(readme);
-            var first = r.commit("Added README", "duke", "duke@openjdk.java.net");
+            var first = r.commit("Added README", "duke", "duke@openjdk.org");
 
             Files.delete(readme);
             r.remove(readme);
-            var second = r.commit("Removed README", "duke", "duke@openjdk.java.net");
+            var second = r.commit("Removed README", "duke", "duke@openjdk.org");
 
             var diff = r.diff(first, second);
             assertEquals(first, diff.from());
@@ -1183,12 +1183,12 @@ public class RepositoryTests {
             Files.write(readme, List.of("Hello, world!"));
 
             r.add(readme);
-            var first = r.commit("Added README", "duke", "duke@openjdk.java.net");
+            var first = r.commit("Added README", "duke", "duke@openjdk.org");
 
             var building = dir.path().resolve("BUILDING");
             Files.write(building, List.of("make"));
             r.add(building);
-            var second = r.commit("Added BUILDING", "duke", "duke@openjdk.java.net");
+            var second = r.commit("Added BUILDING", "duke", "duke@openjdk.org");
 
             var diff = r.diff(first, second);
             assertEquals(first, diff.from());
@@ -1233,7 +1233,7 @@ public class RepositoryTests {
             Files.write(readme, List.of("Hello, world!"));
 
             r.add(readme);
-            var first = r.commit("Added README", "duke", "duke@openjdk.java.net");
+            var first = r.commit("Added README", "duke", "duke@openjdk.org");
 
             Files.write(readme, List.of("One more line"), WRITE, APPEND);
             var diff = r.diff(first);
@@ -1279,11 +1279,11 @@ public class RepositoryTests {
             var readme = dir.path().resolve("README");
             Files.write(readme, List.of("Hello, world!"));
             r.add(readme);
-            var first = r.commit("Added README", "duke", "duke@openjdk.java.net");
+            var first = r.commit("Added README", "duke", "duke@openjdk.org");
 
             Files.write(readme, List.of("One more line"), WRITE, APPEND);
             r.add(readme);
-            var second = r.commit("Modified README", "duke", "duke@openjdk.java.net");
+            var second = r.commit("Modified README", "duke", "duke@openjdk.org");
 
             var metadata = r.commitMetadata();
             assertEquals(2, metadata.size());
@@ -1305,16 +1305,16 @@ public class RepositoryTests {
             var readme1 = dir.path().resolve("README_1");
             Files.write(readme1, List.of("1"));
             r.add(readme1);
-            var first = r.commit("Added README_1", "duke", "duke@openjdk.java.net");
+            var first = r.commit("Added README_1", "duke", "duke@openjdk.org");
 
             var readme2 = dir.path().resolve("README_2");
             Files.write(readme2, List.of("2"));
             r.add(readme2);
-            var second = r.commit("Added README_2", "duke", "duke@openjdk.java.net");
+            var second = r.commit("Added README_2", "duke", "duke@openjdk.org");
 
             Files.write(readme2, List.of("3"), WRITE, APPEND);
             r.add(readme2);
-            var third = r.commit("Modified README_2", "duke", "duke@openjdk.java.net");
+            var third = r.commit("Modified README_2", "duke", "duke@openjdk.org");
 
             var metadata = r.commitMetadata(List.of(Path.of("README_1")));
             assertEquals(1, metadata.size());
@@ -1342,11 +1342,11 @@ public class RepositoryTests {
             var readme = dir.path().resolve("README");
             Files.write(readme, List.of("Hello, world!"));
             r.add(readme);
-            var first = r.commit("Added README", "duke", "duke@openjdk.java.net");
+            var first = r.commit("Added README", "duke", "duke@openjdk.org");
 
             Files.write(readme, List.of("One more line"), WRITE, APPEND);
             r.add(readme);
-            var second = r.commit("Modified README", "duke", "duke@openjdk.java.net");
+            var second = r.commit("Modified README", "duke", "duke@openjdk.org");
 
             var metadata = r.commitMetadata();
             assertEquals(2, metadata.size());
@@ -1369,21 +1369,21 @@ public class RepositoryTests {
             var readme = dir.path().resolve("README");
             Files.write(readme, List.of("Hello, world!"));
             r.add(readme);
-            var first = r.commit("Added README", "duke", "duke@openjdk.java.net");
+            var first = r.commit("Added README", "duke", "duke@openjdk.org");
 
             Files.write(readme, List.of("One more line"), WRITE, APPEND);
             r.add(readme);
-            var second = r.commit("Modified README", "duke", "duke@openjdk.java.net");
+            var second = r.commit("Modified README", "duke", "duke@openjdk.org");
 
             r.checkout(first, false);
 
             var contributing = dir.path().resolve("CONTRIBUTING");
             Files.write(contributing, List.of("Send those patches!"));
             r.add(contributing);
-            var third = r.commit("Added contributing", "duke", "duke@openjdk.java.net");
+            var third = r.commit("Added contributing", "duke", "duke@openjdk.org");
 
             r.merge(second);
-            r.commit("Merge", "duke", "duke@openjdk.java.net");
+            r.commit("Merge", "duke", "duke@openjdk.org");
 
             var refspec = vcs == VCS.GIT ? r.head().hex() : r.head().hex() + ":0";
             var commits = r.commits(refspec).asList();
@@ -1422,24 +1422,24 @@ public class RepositoryTests {
             var readme = dir.path().resolve("README");
             Files.write(readme, List.of("Hello, world!"));
             r.add(readme);
-            var first = r.commit("Added README", "duke", "duke@openjdk.java.net");
+            var first = r.commit("Added README", "duke", "duke@openjdk.org");
 
             Files.write(readme, List.of("One more line"), WRITE, APPEND);
             r.add(readme);
-            var second = r.commit("Modified README", "duke", "duke@openjdk.java.net");
+            var second = r.commit("Modified README", "duke", "duke@openjdk.org");
 
             r.checkout(first, false);
 
             var contributing = dir.path().resolve("CONTRIBUTING");
             Files.write(contributing, List.of("Send those patches!"));
             r.add(contributing);
-            var third = r.commit("Added contributing", "duke", "duke@openjdk.java.net");
+            var third = r.commit("Added contributing", "duke", "duke@openjdk.org");
 
             r.merge(second);
 
             Files.write(readme, List.of("One last line"), WRITE, APPEND);
             r.add(readme);
-            r.commit("Merge", "duke", "duke@openjdk.java.net");
+            r.commit("Merge", "duke", "duke@openjdk.org");
 
             var refspec = vcs == VCS.GIT ? r.head().hex() : r.head().hex() + ":0";
             var commits = r.commits(refspec).asList();
@@ -1529,7 +1529,7 @@ public class RepositoryTests {
             var readme = dir.path().resolve("README");
             Files.write(readme, List.of("Hello, world!"));
             r.add(readme);
-            r.commit("Added README", "duke", "duke@openjdk.java.net");
+            r.commit("Added README", "duke", "duke@openjdk.org");
 
             assertTrue(r.isValidRevisionRange(r.defaultBranch().toString()));
         }
@@ -1554,9 +1554,9 @@ public class RepositoryTests {
             var readme = dir.path().resolve("README");
             Files.write(readme, List.of("Hello, world!"));
             r.add(readme);
-            var first = r.commit("Added README", "duke", "duke@openjdk.java.net");
+            var first = r.commit("Added README", "duke", "duke@openjdk.org");
 
-            r.tag(first, "test", "Tagging test", "duke", "duke@openjdk.java.net");
+            r.tag(first, "test", "Tagging test", "duke", "duke@openjdk.org");
             var defaultTag = r.defaultTag().orElse(null);
             var nonDefaultTags = r.tags().stream()
                                   .filter(tag -> !tag.equals(defaultTag))
@@ -1580,7 +1580,7 @@ public class RepositoryTests {
             r.add(readme);
             assertFalse(r.isClean());
 
-            r.commit("Added README", "duke", "duke@openjdk.java.net");
+            r.commit("Added README", "duke", "duke@openjdk.org");
             assertTrue(r.isClean());
 
             Files.delete(readme);
@@ -1605,7 +1605,7 @@ public class RepositoryTests {
                 Files.setPosixFilePermissions(readOnlyExecutableFile, permissions);
             }
             r.add(readOnlyExecutableFile);
-            var hash = r.commit("Added read only executable file", "duke", "duke@openjdk.java.net");
+            var hash = r.commit("Added read only executable file", "duke", "duke@openjdk.org");
             assertEquals(Optional.of(List.of("echo 'hello'")), r.lines(readOnlyExecutableFile, hash));
 
             var readWriteExecutableFile = dir.path().resolve("goodbye.sh");
@@ -1615,7 +1615,7 @@ public class RepositoryTests {
                 Files.setPosixFilePermissions(readWriteExecutableFile, permissions);
             }
             r.add(readWriteExecutableFile);
-            var hash2 = r.commit("Added read-write executable file", "duke", "duke@openjdk.java.net");
+            var hash2 = r.commit("Added read-write executable file", "duke", "duke@openjdk.org");
             assertEquals(Optional.of(List.of("echo 'goodbye'")), r.lines(readWriteExecutableFile, hash2));
         }
     }
@@ -1637,10 +1637,10 @@ public class RepositoryTests {
             var fileWithSpaceInName = dir.path().resolve("hello world.txt");
             Files.writeString(fileWithSpaceInName, "Hello world\n");
             r.add(fileWithSpaceInName);
-            var hash1 = r.commit("Added file with space in name", "duke", "duke@openjdk.java.net");
+            var hash1 = r.commit("Added file with space in name", "duke", "duke@openjdk.org");
             Files.writeString(fileWithSpaceInName, "Goodbye world\n");
             r.add(fileWithSpaceInName);
-            var hash2 = r.commit("Modified file with space in name", "duke", "duke@openjdk.java.net");
+            var hash2 = r.commit("Modified file with space in name", "duke", "duke@openjdk.org");
             var diff = r.diff(hash1, hash2);
             var patches = diff.patches();
             assertEquals(1, patches.size());
@@ -1661,7 +1661,7 @@ public class RepositoryTests {
             var readme = dir.path().resolve("README.md");
             Files.writeString(readme, "Hello world\n");
             r.add(readme);
-            var hash = r.commit("Added readme", "duke", "duke@openjdk.java.net");
+            var hash = r.commit("Added readme", "duke", "duke@openjdk.org");
             var commit = r.lookup(hash).orElseThrow();
             var parent = commit.parents().get(0);
 
@@ -1681,7 +1681,7 @@ public class RepositoryTests {
             var readme = dir.path().resolve("README.md");
             Files.writeString(readme, "Hello world\n");
             r.add(readme);
-            var hash = r.commit("Added readme", "duke", "duke@openjdk.java.net");
+            var hash = r.commit("Added readme", "duke", "duke@openjdk.org");
             var commit = r.lookup(hash).orElseThrow();
             var parent = commit.parents().get(0);
 
@@ -1770,7 +1770,7 @@ public class RepositoryTests {
 
             Files.writeString(f, "Hello, world\n");
             r.add(f);
-            r.amend("Initial commit corrected", "duke", "duke@openjdk.java.net");
+            r.amend("Initial commit corrected", "duke", "duke@openjdk.org");
             var commits = r.commits().asList();
             assertEquals(1, commits.size());
             var commit = commits.get(0);
@@ -1940,7 +1940,7 @@ public class RepositoryTests {
             Files.writeString(readme, "Line with Windows line ending\r\n", APPEND);
 
             r.add(readme);
-            r.commit("Add README", "duke", "duke@openjdk.java.net");
+            r.commit("Add README", "duke", "duke@openjdk.org");
 
             var commits = r.commits().asList();
             assertEquals(1, commits.size());
@@ -2279,7 +2279,7 @@ public class RepositoryTests {
             Files.write(readme, List.of("Hello, readme!"));
 
             upstream.add(readme);
-            upstream.commit("Add README", "duke", "duke@openjdk.java.net");
+            upstream.commit("Add README", "duke", "duke@openjdk.org");
 
             try (var dir2 = new TemporaryDirectory()) {
                 var downstream = TestableRepository.init(dir2.path(), vcs);
@@ -2309,7 +2309,7 @@ public class RepositoryTests {
             Files.write(readme, List.of("Hello, readme!"));
 
             upstream.add(readme);
-            var head = upstream.commit("Add README", "duke", "duke@openjdk.java.net");
+            var head = upstream.commit("Add README", "duke", "duke@openjdk.org");
             var branch = upstream.branch(head, "foo");
             var upstreamBranches = upstream.branches();
             assertEquals(2, upstreamBranches.size());
@@ -2351,17 +2351,17 @@ public class RepositoryTests {
             var readme = dir.path().resolve("README");
             Files.write(readme, List.of("Hello, world!"));
             r.add(readme);
-            var first = r.commit("Added README", "duke", "duke@openjdk.java.net");
+            var first = r.commit("Added README", "duke", "duke@openjdk.org");
 
             Files.write(readme, List.of("One more line"), WRITE, APPEND);
             r.add(readme);
-            var second = r.commit("Modified README", "duke", "duke@openjdk.java.net");
+            var second = r.commit("Modified README", "duke", "duke@openjdk.org");
 
             r.checkout(first, false);
 
             Files.write(readme, List.of("Another line"), WRITE, APPEND);
             r.add(readme);
-            var third = r.commit("Modified README again", "duke", "duke@openjdk.java.net");
+            var third = r.commit("Modified README again", "duke", "duke@openjdk.org");
 
             assertThrows(IOException.class, () -> { r.merge(second); });
 
@@ -2433,14 +2433,14 @@ public class RepositoryTests {
             var gitFile = gitRepo.root().resolve("git-file.txt");
             Files.write(gitFile, List.of("Hello, Git!"));
             gitRepo.add(gitFile);
-            var gitHash = gitRepo.commit("Added git-file.txt", "duke", "duke@openjdk.java.net");
+            var gitHash = gitRepo.commit("Added git-file.txt", "duke", "duke@openjdk.org");
 
             var hgDir = gitRepo.root().resolve("hg");
             var hgRepo = TestableRepository.init(hgDir, VCS.HG);
             var hgFile = hgRepo.root().resolve("hg-file.txt");
             Files.write(hgFile, List.of("Hello, Mercurial!"));
             hgRepo.add(hgFile);
-            var hgHash = hgRepo.commit("Added hg-file.txt", "duke", "duke@openjdk.java.net");
+            var hgHash = hgRepo.commit("Added hg-file.txt", "duke", "duke@openjdk.org");
 
             var resolvedHgRepo = Repository.get(hgDir).orElseThrow();
             var resolvedHgCommits = resolvedHgRepo.commits().asList();
@@ -2461,14 +2461,14 @@ public class RepositoryTests {
             var hgFile = hgRepo.root().resolve("hg-file.txt");
             Files.write(hgFile, List.of("Hello, Mercurial!"));
             hgRepo.add(hgFile);
-            var hgHash = hgRepo.commit("Added hg-file.txt", "duke", "duke@openjdk.java.net");
+            var hgHash = hgRepo.commit("Added hg-file.txt", "duke", "duke@openjdk.org");
 
             var gitDir = hgRepo.root().resolve("git");
             var gitRepo = TestableRepository.init(gitDir, VCS.GIT);
             var gitFile = gitRepo.root().resolve("git-file.txt");
             Files.write(gitFile, List.of("Hello, Git!"));
             gitRepo.add(gitFile);
-            var gitHash = gitRepo.commit("Added git-file.txt", "duke", "duke@openjdk.java.net");
+            var gitHash = gitRepo.commit("Added git-file.txt", "duke", "duke@openjdk.org");
 
             var resolvedHgRepo = Repository.get(hgDir.path()).orElseThrow();
             var resolvedHgCommits = resolvedHgRepo.commits().asList();
@@ -2489,13 +2489,13 @@ public class RepositoryTests {
             var hgFile = hgRepo.root().resolve("hg-file.txt");
             Files.write(hgFile, List.of("Hello, Mercurial!"));
             hgRepo.add(hgFile);
-            var hgHash = hgRepo.commit("Added hg-file.txt", "duke", "duke@openjdk.java.net");
+            var hgHash = hgRepo.commit("Added hg-file.txt", "duke", "duke@openjdk.org");
 
             var gitRepo = TestableRepository.init(dir.path(), VCS.GIT);
             var gitFile = gitRepo.root().resolve("git-file.txt");
             Files.write(gitFile, List.of("Hello, Git!"));
             gitRepo.add(gitFile);
-            var gitHash = gitRepo.commit("Added git-file.txt", "duke", "duke@openjdk.java.net");
+            var gitHash = gitRepo.commit("Added git-file.txt", "duke", "duke@openjdk.org");
 
             assertThrows(IOException.class, () -> Repository.get(dir.path()));
         }
@@ -2512,15 +2512,15 @@ public class RepositoryTests {
             var authored = ZonedDateTime.parse("2020-06-15T14:27:13+02:00");
             var committed = authored.plusMinutes(10);
             var head = repo.commit("Add README",
-                                   "author", "author@openjdk.java.net", authored,
-                                   "committer", "committer@openjdk.java.net", committed);
+                                   "author", "author@openjdk.org", authored,
+                                   "committer", "committer@openjdk.org", committed);
             var commit = repo.lookup(head).orElseThrow();
             assertEquals("author", commit.author().name());
-            assertEquals("author@openjdk.java.net", commit.author().email());
+            assertEquals("author@openjdk.org", commit.author().email());
             assertEquals(authored, commit.authored());
 
             assertEquals("committer", commit.committer().name());
-            assertEquals("committer@openjdk.java.net", commit.committer().email());
+            assertEquals("committer@openjdk.org", commit.committer().email());
             assertEquals(committed, commit.committed());
         }
     }
@@ -2533,7 +2533,7 @@ public class RepositoryTests {
             Files.write(readme, List.of("Hello, readme!"));
 
             repo.add(readme);
-            var head = repo.commit("Add README", "author", "author@openjdk.java.net");
+            var head = repo.commit("Add README", "author", "author@openjdk.org");
 
             // We don't want to expose making lightweight tags via the Repository class,
             // so use a ProcessBuilder and invoke git directly here
@@ -2562,18 +2562,18 @@ public class RepositoryTests {
             var readme = dir.path().resolve("README.old");
             Files.write(readme, List.of("Hello, world!"));
             r.add(readme);
-            var first = r.commit("Added README.old", "duke", "duke@openjdk.java.net");
+            var first = r.commit("Added README.old", "duke", "duke@openjdk.org");
 
             Files.write(readme, List.of("One more line"), WRITE, APPEND);
             r.add(readme);
-            var second = r.commit("Modified README.old", "duke", "duke@openjdk.java.net");
+            var second = r.commit("Modified README.old", "duke", "duke@openjdk.org");
 
             r.checkout(first, false);
             r.move(Path.of("README.old"), Path.of("README.new"));
-            var third = r.commit("Renamed README.old to README.new", "duke", "duke@openjdk.java.net");
+            var third = r.commit("Renamed README.old to README.new", "duke", "duke@openjdk.org");
 
             r.merge(second);
-            var hash = r.commit("Merge", "duke", "duke@openjdk.java.net");
+            var hash = r.commit("Merge", "duke", "duke@openjdk.org");
             var merge = r.lookup(hash).orElseThrow();
 
             var diffs = merge.parentDiffs();
@@ -2606,7 +2606,7 @@ public class RepositoryTests {
             var readme = dir.path().resolve("README");
             Files.write(readme, List.of("Hello, readme!"));
             repo.add(readme);
-            var head = repo.commit("Add README", "author", "author@openjdk.java.net");
+            var head = repo.commit("Add README", "author", "author@openjdk.org");
             var tag = repo.tag(head, "1.0", "Add tag 1.0", "duke", null);
             var annotated = repo.annotate(tag).orElseThrow();
             assertEquals("duke", annotated.author().name());
@@ -2624,15 +2624,15 @@ public class RepositoryTests {
             Files.write(readme, List.of("Hello, readme!"));
 
             r.add(readme);
-            var hash1 = r.commit("Add README", "duke", "duke@openjdk.java.net");
+            var hash1 = r.commit("Add README", "duke", "duke@openjdk.org");
 
             Files.write(readme, List.of("Another line"), WRITE, APPEND);
             r.add(readme);
-            var hash2 = r.commit("Modify README", "duke", "duke@openjdk.java.net");
+            var hash2 = r.commit("Modify README", "duke", "duke@openjdk.org");
 
             r.checkout(hash1, false);
             r.merge(hash2, Repository.FastForward.DISABLE);
-            var hash3 = r.commit("Non fast-forward merge", "duke", "duke@openjdk.java.net");
+            var hash3 = r.commit("Non fast-forward merge", "duke", "duke@openjdk.org");
             var mergeCommit = r.lookup(hash3).orElseThrow();
             assertEquals(2, mergeCommit.parents().size());
         }
@@ -2648,13 +2648,13 @@ public class RepositoryTests {
             Files.write(readme, List.of("Hello, readme!"));
 
             r.add(readme);
-            var hash1 = r.commit("Add README", "duke", "duke@openjdk.java.net");
+            var hash1 = r.commit("Add README", "duke", "duke@openjdk.org");
             var other = r.branch(hash1, "other");
             r.checkout(other);
 
             Files.write(readme, List.of("Another line"), WRITE, APPEND);
             r.add(readme);
-            var hash2 = r.commit("Modify README", "duke", "duke@openjdk.java.net");
+            var hash2 = r.commit("Modify README", "duke", "duke@openjdk.org");
 
             r.checkout(r.defaultBranch());
             r.merge(hash2, Repository.FastForward.AUTO);
@@ -2674,7 +2674,7 @@ public class RepositoryTests {
             Files.write(readme, List.of("Hello, readme!"));
 
             r.add(readme);
-            var hash1 = r.commit("Add README", "duke", "duke@openjdk.java.net");
+            var hash1 = r.commit("Add README", "duke", "duke@openjdk.org");
             var untracked = dir.path().resolve("UNTRACKED");
             Files.write(untracked, List.of("Hello, untracked!"));
 
@@ -2699,7 +2699,7 @@ public class RepositoryTests {
             Files.write(readme, List.of("Hello, readme!"));
 
             r.add(readme);
-            var hash = r.commit("Add README", "duke", "duke@openjdk.java.net");
+            var hash = r.commit("Add README", "duke", "duke@openjdk.org");
             var date = ZonedDateTime.parse("2007-12-03T10:15:30+01:00");
             var tag = r.tag(hash, "1.0", "Added tag 1.0", "duke", "duke@openjdk.org", date);
             var annotated = r.annotate(tag);
@@ -2718,15 +2718,15 @@ public class RepositoryTests {
             Files.write(readme, List.of("Hello, readme!"));
 
             r.add(readme);
-            var first = r.commit("Add README", "duke", "duke@openjdk.java.net");
+            var first = r.commit("Add README", "duke", "duke@openjdk.org");
 
             var readme2 = dir.path().resolve("README2");
             r.move(readme, readme2);
-            var second = r.commit("Move README to README2", "duke", "duke@openjdk.java.net");
+            var second = r.commit("Move README to README2", "duke", "duke@openjdk.org");
 
             Files.write(readme2, List.of("Hello, readme2!"));
             r.add(readme2);
-            var third = r.commit("Update README2", "duke", "duke@openjdk.java.net");
+            var third = r.commit("Update README2", "duke", "duke@openjdk.org");
 
             var commits = r.follow(readme2);
             var hashes = commits.stream().map(CommitMetadata::hash).collect(Collectors.toList());
@@ -2744,16 +2744,16 @@ public class RepositoryTests {
             Files.write(readme, List.of("Hello, readme!"));
 
             r.add(readme);
-            var first = r.commit("Add README", "duke", "duke@openjdk.java.net");
+            var first = r.commit("Add README", "duke", "duke@openjdk.org");
 
             Files.write(readme, List.of("Hello, again!!"));
             r.add(readme);
-            var second = r.commit("Update README", "duke", "duke@openjdk.java.net");
+            var second = r.commit("Update README", "duke", "duke@openjdk.org");
 
             r.checkout(first);
             Files.write(readme, List.of("Greetings, world"));
             r.add(readme);
-            var third = r.commit("Update README concurrently", "duke", "duke@openjdk.java.net");
+            var third = r.commit("Update README concurrently", "duke", "duke@openjdk.org");
 
             if (vcs == VCS.GIT) {
                 r.checkout(r.defaultBranch());
@@ -2766,11 +2766,11 @@ public class RepositoryTests {
             }
             Files.write(readme, List.of("Resolve merge"));
             r.add(readme);
-            var merge = r.commit("Merge", "duke", "duke@openjdk.java.net");
+            var merge = r.commit("Merge", "duke", "duke@openjdk.org");
 
             Files.write(readme, List.of("Final update"));
             r.add(readme);
-            var fourth = r.commit("Final README update", "duke", "duke@openjdk.java.net");
+            var fourth = r.commit("Final README update", "duke", "duke@openjdk.org");
 
             var commits = r.follow(readme);
             var hashes = commits.stream().map(CommitMetadata::hash).collect(Collectors.toList());
@@ -2792,8 +2792,8 @@ public class RepositoryTests {
             Files.write(readme, List.of("Hello, readme!"));
 
             upstream.add(readme);
-            var head = upstream.commit("Add README", "duke", "duke@openjdk.java.net");
-            upstream.tag(head, "1.0", "Added tag 1.0", "duke", "duke@openjdk.java.net");
+            var head = upstream.commit("Add README", "duke", "duke@openjdk.org");
+            upstream.tag(head, "1.0", "Added tag 1.0", "duke", "duke@openjdk.org");
 
             try (var dir2 = new TemporaryDirectory()) {
                 var downstream = TestableRepository.init(dir2.path(), vcs);
@@ -2829,7 +2829,7 @@ public class RepositoryTests {
             var readme = dir.path().resolve("README.md");
             Files.writeString(readme, "Hello world\n");
             r.add(readme);
-            var hash = r.commit("Added readme", "duke", "duke@openjdk.java.net");
+            var hash = r.commit("Added readme", "duke", "duke@openjdk.org");
 
             var nonExisting = r.lookup(new Hash("0123456789012345678901234567890123456789"));
             assertEquals(Optional.empty(), nonExisting);
@@ -2846,18 +2846,18 @@ public class RepositoryTests {
             var readme = dir.path().resolve("README.md");
             Files.writeString(readme, "Hello world\n");
             r.add(readme);
-            var initial = r.commit("Added readme", "duke", "duke@openjdk.java.net");
+            var initial = r.commit("Added readme", "duke", "duke@openjdk.org");
 
             Files.writeString(readme, "Hello world\nAgain");
             r.add(readme);
-            var second = r.commit("Updated readme", "duke", "duke@openjdk.java.net");
+            var second = r.commit("Updated readme", "duke", "duke@openjdk.org");
 
             var otherBranch = r.branch(initial, "other");
             r.checkout(otherBranch);
             var contributing = dir.path().resolve("CONTRIBUTING.md");
             Files.writeString(contributing, "Patches welcome!\n");
             r.add(contributing);
-            var otherCommit = r.commit("Added contributing", "duke", "duke@openjdk.java.net");
+            var otherCommit = r.commit("Added contributing", "duke", "duke@openjdk.org");
 
             if (vcs == VCS.HG) {
                 r.checkout(second);
@@ -2885,18 +2885,18 @@ public class RepositoryTests {
             var readme = dir.path().resolve("README.md");
             Files.writeString(readme, "Hello world\n");
             r.add(readme);
-            var initial = r.commit("Added readme", "duke", "duke@openjdk.java.net");
+            var initial = r.commit("Added readme", "duke", "duke@openjdk.org");
 
             Files.writeString(readme, "Hello world\nAgain");
             r.add(readme);
-            var second = r.commit("Updated readme", "duke", "duke@openjdk.java.net");
+            var second = r.commit("Updated readme", "duke", "duke@openjdk.org");
 
             r.checkout(initial);
             var otherBranch = r.branch(initial, "other");
             r.checkout(otherBranch);
             Files.writeString(readme, "Hello world\nOne more time!");
             r.add(readme);
-            var otherCommit = r.commit("Modified readme", "duke", "duke@openjdk.java.net");
+            var otherCommit = r.commit("Modified readme", "duke", "duke@openjdk.org");
 
             if (vcs == VCS.HG) {
                 r.checkout(second);
@@ -2927,7 +2927,7 @@ public class RepositoryTests {
             var readme = dir.path().resolve("README.md");
             Files.writeString(readme, "Hello world\n");
             r.add(readme);
-            var hash = r.commit("Added readme", "duke", "duke@openjdk.java.net");
+            var hash = r.commit("Added readme", "duke", "duke@openjdk.org");
 
             assertTrue(r.contains(hash));
             assertFalse(r.contains(new Hash("0123456789012345678901234567890123456789")));
@@ -2947,7 +2947,7 @@ public class RepositoryTests {
             Files.write(readme, List.of("Hello, readme!"));
 
             upstream.add(readme);
-            var initialCommit = upstream.commit("Add README", "duke", "duke@openjdk.java.net");
+            var initialCommit = upstream.commit("Add README", "duke", "duke@openjdk.org");
 
             try (var dir2 = new TemporaryDirectory()) {
                 var downstream = Repository.init(dir2.path(), VCS.GIT);
@@ -2962,7 +2962,7 @@ public class RepositoryTests {
                 Files.write(downstreamReadme, List.of("Downstream change"), WRITE, APPEND);
 
                 downstream.add(downstreamReadme);
-                var head = downstream.commit("Modify README", "duke", "duke@openjdk.java.net");
+                var head = downstream.commit("Modify README", "duke", "duke@openjdk.org");
 
                 var tag = downstream.tag(initialCommit, "v1.0", "Added tag v1.0", "duke", "duke@openjdk.org");
 
@@ -2987,20 +2987,20 @@ public class RepositoryTests {
             var readme = dir.path().resolve("README");
             Files.write(readme, List.of("Hello, world!"));
             r.add(readme);
-            var first = r.commit("Added README", "duke", "duke@openjdk.java.net");
+            var first = r.commit("Added README", "duke", "duke@openjdk.org");
 
             var b1 = r.branch(first, "b1");
             r.checkout(b1);
             Files.write(readme, List.of("One more line"), WRITE, APPEND);
             r.add(readme);
-            var second = r.commit("Modified README", "duke", "duke@openjdk.java.net");
+            var second = r.commit("Modified README", "duke", "duke@openjdk.org");
 
             r.checkout(r.defaultBranch());
             var b2 = r.branch(first, "b2");
             r.checkout(b2);
             Files.write(readme, List.of("An additional line"), WRITE, APPEND);
             r.add(readme);
-            var third = r.commit("Additional line added to README", "duke", "duke@openjdk.java.net");
+            var third = r.commit("Additional line added to README", "duke", "duke@openjdk.org");
 
             var metadata = r.commitMetadataFor(List.of(r.defaultBranch()));
             assertEquals(1, metadata.size());

--- a/vcs/src/test/java/org/openjdk/skara/vcs/openjdk/converter/GitToHgConverterTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/openjdk/converter/GitToHgConverterTests.java
@@ -117,7 +117,7 @@ class GitToHgConverterTests {
 
             Files.writeString(readme, "Hello, world");
             gitRepo.add(readme);
-            gitRepo.commit("1234567: Added README", "Foo Bar", "foo@openjdk.java.net");
+            gitRepo.commit("1234567: Added README", "Foo Bar", "foo@openjdk.org");
 
             var hgRepo = TestableRepository.init(hgRoot.path(), VCS.HG);
             var converter = new GitToHgConverter();
@@ -149,7 +149,7 @@ class GitToHgConverterTests {
             Files.writeString(readme, "Hello, world");
             gitRepo.add(readme);
             gitRepo.commit("1234567: Added README", "Foo Bar", "foo@host.com",
-                                                    "Baz Bar", "baz@openjdk.java.net");
+                                                    "Baz Bar", "baz@openjdk.org");
 
             var hgRepo = TestableRepository.init(hgRoot.path(), VCS.HG);
             var converter = new GitToHgConverter();
@@ -175,11 +175,11 @@ class GitToHgConverterTests {
 
             Files.writeString(readme, "Hello, world");
             gitRepo.add(readme);
-            gitRepo.commit("Added README", "Foo Bar", "foo@openjdk.java.net");
+            gitRepo.commit("Added README", "Foo Bar", "foo@openjdk.org");
 
             var readme2 = gitRoot.path().resolve("README2.md");
             gitRepo.copy(readme, readme2);
-            gitRepo.commit("Copied README", "Foo Bar", "foo@openjdk.java.net");
+            gitRepo.commit("Copied README", "Foo Bar", "foo@openjdk.org");
 
             var hgRepo = TestableRepository.init(hgRoot.path(), VCS.HG);
             var converter = new GitToHgConverter();
@@ -210,11 +210,11 @@ class GitToHgConverterTests {
 
             Files.writeString(readme, "Hello, world");
             gitRepo.add(readme);
-            gitRepo.commit("Added README", "Foo Bar", "foo@openjdk.java.net");
+            gitRepo.commit("Added README", "Foo Bar", "foo@openjdk.org");
 
             var readme2 = gitRoot.path().resolve("README2.md");
             gitRepo.move(readme, readme2);
-            gitRepo.commit("Moved README", "Foo Bar", "foo@openjdk.java.net");
+            gitRepo.commit("Moved README", "Foo Bar", "foo@openjdk.org");
 
             var hgRepo = TestableRepository.init(hgRoot.path(), VCS.HG);
             var converter = new GitToHgConverter();
@@ -245,9 +245,9 @@ class GitToHgConverterTests {
 
             Files.writeString(readme, "Hello, world");
             gitRepo.add(readme);
-            var message = List.of("1234567: Added README", "", "Co-authored-by: Baz Bar <baz@openjdk.java.net>");
+            var message = List.of("1234567: Added README", "", "Co-authored-by: Baz Bar <baz@openjdk.org>");
             gitRepo.commit(String.join("\n", message), "Foo Bar", "foo@host.com",
-                                                       "Baz Bar", "baz@openjdk.java.net");
+                                                       "Baz Bar", "baz@openjdk.org");
 
             var hgRepo = TestableRepository.init(hgRoot.path(), VCS.HG);
             var converter = new GitToHgConverter();
@@ -258,7 +258,7 @@ class GitToHgConverterTests {
             var hgCommit = hgCommits.get(0);
 
             assertEquals(new Author("baz", null), hgCommit.author());
-            assertEquals(List.of("1234567: Added README", "Contributed-by: Foo Bar <foo@host.com>, Baz Bar <baz@openjdk.java.net>"),
+            assertEquals(List.of("1234567: Added README", "Contributed-by: Foo Bar <foo@host.com>, Baz Bar <baz@openjdk.org>"),
                          hgCommit.message());
             assertReposEquals(marks, gitRepo, hgRepo);
         }
@@ -277,9 +277,9 @@ class GitToHgConverterTests {
                                   "",
                                   "Additional text",
                                   "",
-                                  "Co-authored-by: Baz Bar <baz@openjdk.java.net>");
+                                  "Co-authored-by: Baz Bar <baz@openjdk.org>");
             gitRepo.commit(String.join("\n", message), "Foo Bar", "foo@host.com",
-                                                       "Baz Bar", "baz@openjdk.java.net");
+                                                       "Baz Bar", "baz@openjdk.org");
 
             var hgRepo = TestableRepository.init(hgRoot.path(), VCS.HG);
             var converter = new GitToHgConverter();
@@ -292,7 +292,7 @@ class GitToHgConverterTests {
             assertEquals(new Author("baz", null), hgCommit.author());
             assertEquals(List.of("1234567: Added README",
                                  "Summary: Additional text",
-                                 "Contributed-by: Foo Bar <foo@host.com>, Baz Bar <baz@openjdk.java.net>"),
+                                 "Contributed-by: Foo Bar <foo@host.com>, Baz Bar <baz@openjdk.org>"),
                          hgCommit.message());
             assertReposEquals(marks, gitRepo, hgRepo);
         }
@@ -307,26 +307,26 @@ class GitToHgConverterTests {
 
             Files.writeString(readme, "First line");
             gitRepo.add(readme);
-            gitRepo.commit("First line", "Foo Bar", "foo@openjdk.java.net");
+            gitRepo.commit("First line", "Foo Bar", "foo@openjdk.org");
 
             Files.writeString(readme, "Second line", StandardOpenOption.APPEND);
             gitRepo.add(readme);
-            var second = gitRepo.commit("Second line", "Foo Bar", "foo@openjdk.java.net");
+            var second = gitRepo.commit("Second line", "Foo Bar", "foo@openjdk.org");
 
             Files.writeString(readme, "Third line", StandardOpenOption.APPEND);
             gitRepo.add(readme);
-            var third = gitRepo.commit("Third line", "Foo Bar", "foo@openjdk.java.net");
+            var third = gitRepo.commit("Third line", "Foo Bar", "foo@openjdk.org");
 
             gitRepo.checkout(second, false);
 
             var contributing = gitRoot.path().resolve("CONTRIBUTING.md");
             Files.writeString(contributing, "Contribute");
             gitRepo.add(contributing);
-            var toMerge = gitRepo.commit("Contributing", "Foo Bar", "foo@openjdk.java.net");
+            var toMerge = gitRepo.commit("Contributing", "Foo Bar", "foo@openjdk.org");
 
             gitRepo.checkout(gitRepo.defaultBranch(), false);
             gitRepo.merge(toMerge);
-            gitRepo.commit("Merge", "Foo Bar", "foo@openjdk.java.net");
+            gitRepo.commit("Merge", "Foo Bar", "foo@openjdk.org");
 
             var hgRepo = TestableRepository.init(hgRoot.path(), VCS.HG);
             var converter = new GitToHgConverter();
@@ -344,28 +344,28 @@ class GitToHgConverterTests {
 
             Files.writeString(readme, "First line\n");
             gitRepo.add(readme);
-            gitRepo.commit("First line", "Foo Bar", "foo@openjdk.java.net");
+            gitRepo.commit("First line", "Foo Bar", "foo@openjdk.org");
 
             Files.writeString(readme, "Second line", StandardOpenOption.APPEND);
             gitRepo.add(readme);
-            var second = gitRepo.commit("Second line\n", "Foo Bar", "foo@openjdk.java.net");
+            var second = gitRepo.commit("Second line\n", "Foo Bar", "foo@openjdk.org");
 
             Files.writeString(readme, "Third line\n", StandardOpenOption.APPEND);
             gitRepo.add(readme);
-            var third = gitRepo.commit("Third line", "Foo Bar", "foo@openjdk.java.net");
+            var third = gitRepo.commit("Third line", "Foo Bar", "foo@openjdk.org");
 
             gitRepo.checkout(second, false);
 
             var contributing = gitRoot.path().resolve("CONTRIBUTING.md");
             Files.writeString(contributing, "Contribute\n");
             gitRepo.add(contributing);
-            var toMerge = gitRepo.commit("Contributing", "Foo Bar", "foo@openjdk.java.net");
+            var toMerge = gitRepo.commit("Contributing", "Foo Bar", "foo@openjdk.org");
 
             gitRepo.checkout(gitRepo.defaultBranch(), false);
             gitRepo.merge(toMerge);
             Files.writeString(readme, "Fourth line\n", StandardOpenOption.APPEND);
             gitRepo.add(readme);
-            gitRepo.commit("Merge", "Foo Bar", "foo@openjdk.java.net");
+            gitRepo.commit("Merge", "Foo Bar", "foo@openjdk.org");
 
             var hgRepo = TestableRepository.init(hgRoot.path(), VCS.HG);
             var converter = new GitToHgConverter();
@@ -383,28 +383,28 @@ class GitToHgConverterTests {
 
             Files.writeString(readme, "First line\n");
             gitRepo.add(readme);
-            gitRepo.commit("First line", "Foo Bar", "foo@openjdk.java.net");
+            gitRepo.commit("First line", "Foo Bar", "foo@openjdk.org");
 
             Files.writeString(readme, "Second line\n", StandardOpenOption.APPEND);
             gitRepo.add(readme);
-            var second = gitRepo.commit("Second line", "Foo Bar", "foo@openjdk.java.net");
+            var second = gitRepo.commit("Second line", "Foo Bar", "foo@openjdk.org");
 
             Files.writeString(readme, "Third line\n", StandardOpenOption.APPEND);
             gitRepo.add(readme);
-            var third = gitRepo.commit("Third line", "Foo Bar", "foo@openjdk.java.net");
+            var third = gitRepo.commit("Third line", "Foo Bar", "foo@openjdk.org");
 
             gitRepo.checkout(second, false);
 
             var contributing = gitRoot.path().resolve("CONTRIBUTING.md");
             Files.writeString(contributing, "Contribute\n");
             gitRepo.add(contributing);
-            var toMerge = gitRepo.commit("Contributing", "Foo Bar", "foo@openjdk.java.net");
+            var toMerge = gitRepo.commit("Contributing", "Foo Bar", "foo@openjdk.org");
 
             gitRepo.checkout(gitRepo.defaultBranch(), false);
             gitRepo.merge(toMerge);
             Files.writeString(contributing, "More contributions\n", StandardOpenOption.APPEND);
             gitRepo.add(contributing);
-            gitRepo.commit("Merge", "Foo Bar", "foo@openjdk.java.net");
+            gitRepo.commit("Merge", "Foo Bar", "foo@openjdk.org");
 
             var hgRepo = TestableRepository.init(hgRoot.path(), VCS.HG);
             var converter = new GitToHgConverter();
@@ -433,13 +433,13 @@ class GitToHgConverterTests {
 
             Files.writeString(readme, "First line\n");
             gitRepo.add(readme);
-            gitRepo.commit("First line", "Foo Bar", "foo@openjdk.java.net");
+            gitRepo.commit("First line", "Foo Bar", "foo@openjdk.org");
 
             Files.writeString(readme, "Second line\n", StandardOpenOption.APPEND);
             gitRepo.add(readme);
-            var second = gitRepo.commit("Second line", "Foo Bar", "foo@openjdk.java.net");
+            var second = gitRepo.commit("Second line", "Foo Bar", "foo@openjdk.org");
             var tagDate = ZonedDateTime.parse("2020-08-24T11:30:32+02:00");
-            var tag = gitRepo.tag(second, "1.0", "Added tag 1.0", "Foo Bar", "foo@openjdk.java.net", tagDate);
+            var tag = gitRepo.tag(second, "1.0", "Added tag 1.0", "Foo Bar", "foo@openjdk.org", tagDate);
 
             var hgRepo = TestableRepository.init(hgRoot.path(), VCS.HG);
             var converter = new GitToHgConverter();
@@ -450,7 +450,7 @@ class GitToHgConverterTests {
 
             Files.writeString(readme, "Third line\n");
             gitRepo.add(readme);
-            gitRepo.commit("Third line", "Foo Bar", "foo@openjdk.java.net");
+            gitRepo.commit("Third line", "Foo Bar", "foo@openjdk.org");
 
             converter = new GitToHgConverter();
             var newMarks = converter.convert(gitRepo, hgRepo, marks);

--- a/vcs/src/test/java/org/openjdk/skara/vcs/openjdk/converter/HgToGitConverterTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/openjdk/converter/HgToGitConverterTests.java
@@ -50,7 +50,7 @@ class HgToGitConverterTests {
             var gitRepo = TestableRepository.init(gitRoot.path(), VCS.GIT);
 
             var converter = new HgToGitConverter(Map.of(), Map.of(), Set.of(), Set.of(),
-                                                 Map.of("foo", "Foo Bar <foo@openjdk.java.net>"), Map.of(), Map.of());
+                                                 Map.of("foo", "Foo Bar <foo@openjdk.org>"), Map.of(), Map.of());
             var marks = converter.convert(hgRepo, gitRepo);
             assertEquals(1, marks.size());
 
@@ -62,8 +62,8 @@ class HgToGitConverterTests {
             assertEquals(1, hgCommits.size());
             var hgCommit = hgCommits.get(0);
 
-            assertEquals(gitCommit.author(), new Author("Foo Bar", "foo@openjdk.java.net"));
-            assertEquals(gitCommit.committer(), new Author("Foo Bar", "foo@openjdk.java.net"));
+            assertEquals(gitCommit.author(), new Author("Foo Bar", "foo@openjdk.org"));
+            assertEquals(gitCommit.committer(), new Author("Foo Bar", "foo@openjdk.org"));
             assertEquals(hgCommit.message(), gitCommit.message());
             assertEquals(hgCommit.authored(), gitCommit.authored());
             assertEquals(hgCommit.isInitialCommit(), gitCommit.isInitialCommit());
@@ -132,7 +132,7 @@ class HgToGitConverterTests {
             var gitRepo = TestableRepository.init(gitRoot.path(), VCS.GIT);
 
             var converter = new HgToGitConverter(Map.of(), Map.of(), Set.of(), Set.of(),
-                                                 Map.of("foo", "Foo Bar <foo@openjdk.java.net>"),
+                                                 Map.of("foo", "Foo Bar <foo@openjdk.org>"),
                                                  Map.of("baz@domain.org", "Baz Bar <baz@domain.org>"),
                                                  Map.of("foo", List.of("foo@host.com")));
             var marks = converter.convert(hgRepo, gitRepo);
@@ -147,7 +147,7 @@ class HgToGitConverterTests {
             var hgCommit = hgCommits.get(0);
 
             assertEquals(new Author("Baz Bar", "baz@domain.org"), gitCommit.author());
-            assertEquals(new Author("Foo Bar", "foo@openjdk.java.net"), gitCommit.committer());
+            assertEquals(new Author("Foo Bar", "foo@openjdk.org"), gitCommit.committer());
             assertEquals(List.of("1234567: Added README"), gitCommit.message());
         }
     }
@@ -167,7 +167,7 @@ class HgToGitConverterTests {
             var gitRepo = TestableRepository.init(gitRoot.path(), VCS.GIT);
 
             var converter = new HgToGitConverter(Map.of(), Map.of(), Set.of(), Set.of(),
-                                                 Map.of("foo", "Foo Bar <foo@openjdk.java.net>"),
+                                                 Map.of("foo", "Foo Bar <foo@openjdk.org>"),
                                                  Map.of("baz@domain.org", "Baz Bar <baz@domain.org>",
                                                         "foo@host.com", "Foo Bar <foo@host.com>"),
                                                  Map.of("foo", List.of("foo@host.com")));
@@ -182,8 +182,8 @@ class HgToGitConverterTests {
             assertEquals(1, hgCommits.size());
             var hgCommit = hgCommits.get(0);
 
-            assertEquals(new Author("Foo Bar", "foo@openjdk.java.net"), gitCommit.author());
-            assertEquals(new Author("Foo Bar", "foo@openjdk.java.net"), gitCommit.committer());
+            assertEquals(new Author("Foo Bar", "foo@openjdk.org"), gitCommit.author());
+            assertEquals(new Author("Foo Bar", "foo@openjdk.org"), gitCommit.committer());
             assertEquals(List.of("1234567: Added README", "", "Co-authored-by: Baz Bar <baz@domain.org>"),
                          gitCommit.message());
         }
@@ -204,7 +204,7 @@ class HgToGitConverterTests {
             var gitRepo = TestableRepository.init(gitRoot.path(), VCS.GIT);
 
             var converter = new HgToGitConverter(Map.of(), Map.of(), Set.of(), Set.of(),
-                                                 Map.of("foo", "Foo Bar <foo@openjdk.java.net>"),
+                                                 Map.of("foo", "Foo Bar <foo@openjdk.org>"),
                                                  Map.of("baz@domain.org", "Baz Bar <baz@domain.org>",
                                                         "foo@host.com", "Foo Bar <foo@host.com>"),
                                                  Map.of("foo", List.of("foo@host.com")));
@@ -219,8 +219,8 @@ class HgToGitConverterTests {
             assertEquals(1, hgCommits.size());
             var hgCommit = hgCommits.get(0);
 
-            assertEquals(new Author("Foo Bar", "foo@openjdk.java.net"), gitCommit.author());
-            assertEquals(new Author("Foo Bar", "foo@openjdk.java.net"), gitCommit.committer());
+            assertEquals(new Author("Foo Bar", "foo@openjdk.org"), gitCommit.author());
+            assertEquals(new Author("Foo Bar", "foo@openjdk.org"), gitCommit.committer());
             assertEquals(List.of("1234567: Added README", "", "Additional text", "", "Co-authored-by: Baz Bar <baz@domain.org>"),
                          gitCommit.message());
         }


### PR DESCRIPTION
The Skara source tree contains a lot of references to openjdk.java.net. All of them need to be updated to the new URL openjdk.org. Some of these are essential for core functionality such as jcheck so this is quite urgent.

This patch is a simple search-replace.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1480](https://bugs.openjdk.org/browse/SKARA-1480): Update all openjdk.java.net->openjdk.org


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1338/head:pull/1338` \
`$ git checkout pull/1338`

Update a local copy of the PR: \
`$ git checkout pull/1338` \
`$ git pull https://git.openjdk.org/skara pull/1338/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1338`

View PR using the GUI difftool: \
`$ git pr show -t 1338`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1338.diff">https://git.openjdk.org/skara/pull/1338.diff</a>

</details>
