### PR TITLE
1482: Add more metrics

### DIFF
--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
@@ -64,11 +64,17 @@ public class BotRunner {
         private static final Counter.WithThreeLabels EXCEPTIONS_COUNTER =
             Counter.name("skara_runner_exceptions").labels("bot", "work_item", "exception").register();
         private static final Gauge.WithTwoLabels CPU_TIME_GAUGE =
-            Gauge.name("skara_runner_cpu_time").labels("bot", "work_item").register();
+                Gauge.name("skara_runner_cpu_time").labels("bot", "work_item").register();
         private static final Gauge.WithTwoLabels USER_TIME_GAUGE =
-            Gauge.name("skara_runner_user_time").labels("bot", "work_item").register();
+                Gauge.name("skara_runner_user_time").labels("bot", "work_item").register();
         private static final Gauge.WithTwoLabels ALLOCATED_BYTES_GAUGE =
-            Gauge.name("skara_runner_allocated_bytes").labels("bot", "work_item").register();
+                Gauge.name("skara_runner_allocated_bytes").labels("bot", "work_item").register();
+        private static final Counter.WithTwoLabels CPU_TIME_COUNTER =
+                Counter.name("skara_runner_cpu_time_total").labels("bot", "work_item").register();
+        private static final Counter.WithTwoLabels USER_TIME_COUNTER =
+                Counter.name("skara_runner_user_time_total").labels("bot", "work_item").register();
+        private static final Counter.WithTwoLabels ALLOCATED_BYTES_COUNTER =
+                Counter.name("skara_runner_allocated_bytes_total").labels("bot", "work_item").register();
 
         private final WorkItem item;
         private final int workId = workIdCounter.incrementAndGet();
@@ -159,13 +165,16 @@ public class BotRunner {
                 if (cpuTimeNs != -1L) {
                     double cpuTimeSeconds = cpuTimeNs / 1_000_000_000.0;
                     CPU_TIME_GAUGE.labels(item.botName(), item.workItemName()).set(cpuTimeSeconds);
+                    CPU_TIME_COUNTER.labels(item.botName(), item.workItemName()).inc(cpuTimeSeconds);
                 }
                 if (userTimeNs != -1L) {
                     double userTimeSeconds = userTimeNs / 1_000_000_000.0;
                     USER_TIME_GAUGE.labels(item.botName(), item.workItemName()).set(userTimeSeconds);
+                    USER_TIME_COUNTER.labels(item.botName(), item.workItemName()).inc(userTimeSeconds);
                 }
                 if (allocatedBytes != -1L) {
                     ALLOCATED_BYTES_GAUGE.labels(item.botName(), item.workItemName()).set(allocatedBytes);
+                    ALLOCATED_BYTES_COUNTER.labels(item.botName(), item.workItemName()).inc(allocatedBytes);
                 }
             }
         }


### PR DESCRIPTION
In order to better analyze Skara bot performance, I need more metrics. Specifically the skara_runner_*_time gauges are pretty useless in their current form. They would be more useful as counters so we could look at the total execution time for workitems for a specific bot instead of randomly picked single executions of the same.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1482](https://bugs.openjdk.org/browse/SKARA-1482): Add more metrics


### Reviewers
 * [Erik Helin](https://openjdk.org/census#ehelin) (@edvbld - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1339/head:pull/1339` \
`$ git checkout pull/1339`

Update a local copy of the PR: \
`$ git checkout pull/1339` \
`$ git pull https://git.openjdk.org/skara pull/1339/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1339`

View PR using the GUI difftool: \
`$ git pr show -t 1339`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1339.diff">https://git.openjdk.org/skara/pull/1339.diff</a>

</details>
