### PR TITLE
1497: build: update JUnit to 5.8.2 completely

### DIFF
--- a/test/build.gradle
+++ b/test/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,9 +40,9 @@ dependencies {
     implementation project(':proxy')
     implementation project(':metrics')
 
-    implementation 'org.junit.jupiter:junit-jupiter-api:5.6.2'
-    implementation 'org.junit.jupiter:junit-jupiter-params:5.6.2'
-    runtimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.6.2'
+    implementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
+    implementation 'org.junit.jupiter:junit-jupiter-params:5.8.2'
+    runtimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
 }
 
 publishing {


### PR DESCRIPTION
Hi all,

This patch updates JUnit to 5.8.2 completely. The previous patch [1] didn't update the file `test/build.gradle`.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

[1] https://github.com/openjdk/skara/commit/abe48a5d

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1497](https://bugs.openjdk.org/browse/SKARA-1497): build: update JUnit to 5.8.2 completely


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1340/head:pull/1340` \
`$ git checkout pull/1340`

Update a local copy of the PR: \
`$ git checkout pull/1340` \
`$ git pull https://git.openjdk.org/skara pull/1340/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1340`

View PR using the GUI difftool: \
`$ git pr show -t 1340`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1340.diff">https://git.openjdk.org/skara/pull/1340.diff</a>

</details>
