### PR TITLE
1495: /backport should be allowed in PRs which have been integrated

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/PullRequestWorkItem.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/PullRequestWorkItem.java
@@ -184,7 +184,7 @@ public class PullRequestWorkItem implements WorkItem {
                 .materialize(historyPath);
 
         var issues = parseIssues();
-        var commit = pr.findIntegratedCommitHash(List.of(integratorId)).orElse(null);
+        var commit = integratorId != null ? pr.findIntegratedCommitHash(List.of(integratorId)).orElse(null) : null;
         var state = new PullRequestState(pr, issues, commit, pr.headHash(), pr.state());
         var stored = storage.current();
         if (stored.contains(state)) {
@@ -199,7 +199,7 @@ public class PullRequestWorkItem implements WorkItem {
         // The stored entry could be old and be missing commit information - if so, upgrade it
         if (storedState.isPresent()) {
             if (storedState.get().commitId().equals(Optional.of(Hash.zero()))) {
-                var hash = pr.findIntegratedCommitHash(List.of(integratorId)).orElse(null);
+                var hash = integratorId != null ? pr.findIntegratedCommitHash(List.of(integratorId)).orElse(null) : null;
                 storedState = Optional.of(new PullRequestState(pr, storedState.get().issueIds(), hash, pr.headHash(), pr.state()));
                 storage.put(storedState.get());
             }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 package org.openjdk.skara.bots.pr;
 
 import org.openjdk.skara.forge.HostedCommit;
+import org.openjdk.skara.forge.PullRequest;
 import org.openjdk.skara.issuetracker.Comment;
 import org.openjdk.skara.vcs.*;
 import org.openjdk.skara.vcs.openjdk.CommitMessageParsers;
@@ -52,8 +53,9 @@ public class BackportCommand implements CommandHandler {
     }
 
     @Override
-    public boolean allowedInPullRequest() {
-        return false;
+    public void handle(PullRequestBot bot, PullRequest pr, CensusInstance censusInstance, Path scratchPath,
+                CommandInvocation command, List<Comment> allComments, PrintWriter reply) {
+        reply.println("The command `backport` can not be used in a pull request that has not yet been integrated.");
     }
 
     @Override

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
@@ -55,7 +55,7 @@ public class BackportCommand implements CommandHandler {
     @Override
     public void handle(PullRequestBot bot, PullRequest pr, CensusInstance censusInstance, Path scratchPath,
                 CommandInvocation command, List<Comment> allComments, PrintWriter reply) {
-        reply.println("The command `backport` can not be used in a pull request that has not yet been integrated.");
+        reply.println("The command `backport` can only be used in a pull request that has been integrated.");
     }
 
     @Override

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandExtractor.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandExtractor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,7 @@ public class CommandExtractor {
         }
     }
 
-    static List<CommandInvocation> extractCommands(Map<String, CommandHandler> commandHandlers, String text, String baseId, HostUser user) {
+    static List<CommandInvocation> extractCommands(boolean commitCommandFirst, String text, String baseId, HostUser user) {
         var ret = new ArrayList<CommandInvocation>();
         CommandHandler multiLineHandler = null;
         List<String> multiLineBuffer = null;
@@ -52,7 +52,10 @@ public class CommandExtractor {
                     multiLineHandler = null;
                 }
                 var command = commandMatcher.group(1).toLowerCase();
-                var handler = commandHandlers.get(command);
+                var handler = commitCommandFirst ? CommitCommandWorkItem.commandHandlers.get(command) : PullRequestCommandWorkItem.commandHandlers.get(command);
+                if (handler == null) {
+                    handler = commitCommandFirst ? PullRequestCommandWorkItem.commandHandlers.get(command) : CommitCommandWorkItem.commandHandlers.get(command);
+                }
                 if (handler != null && handler.multiLine()) {
                     multiLineHandler = handler;
                     multiLineBuffer = new ArrayList<>();

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommandWorkItem.java
@@ -44,35 +44,6 @@ public class CommitCommandWorkItem implements WorkItem {
 
     private static final Logger log = Logger.getLogger("org.openjdk.skara.bots.pr");
 
-    static final Map<String, CommandHandler> commandHandlers = Map.ofEntries(
-            Map.entry("help", new HelpCommand()),
-            Map.entry("backport", new BackportCommand()),
-            Map.entry("tag", new TagCommand())
-    );
-
-    static class HelpCommand implements CommandHandler {
-        @Override
-        public void handle(PullRequestBot bot, HostedCommit commit, CensusInstance censusInstance, Path scratchPath, CommandInvocation command, List<Comment> allComments, PrintWriter reply) {
-            reply.println("Available commands:");
-            Stream.concat(
-                    commandHandlers.entrySet().stream()
-                                   .map(entry -> entry.getKey() + " - " + entry.getValue().description()),
-                    bot.externalCommitCommands().entrySet().stream()
-                       .map(entry -> entry.getKey() + " - " + entry.getValue())
-            ).sorted().forEachOrdered(c -> reply.println(" * " + c));
-        }
-
-        @Override
-        public String description() {
-            return "shows this text";
-        }
-
-        @Override
-        public boolean allowedInCommit() {
-            return true;
-        }
-    }
-
     CommitCommandWorkItem(PullRequestBot bot, CommitComment commitComment, Consumer<RuntimeException> onError) {
         this.bot = bot;
         this.commitComment = commitComment;
@@ -95,7 +66,7 @@ public class CommitCommandWorkItem implements WorkItem {
 
     private Optional<CommandInvocation> nextCommand(List<CommitComment> allComments) {
         var self = bot.repo().forge().currentUser();
-        var command = CommandExtractor.extractCommands(true, commitComment.body(),
+        var command = CommandExtractor.extractCommands(commitComment.body(),
                                                        commitComment.id(), commitComment.author());
         if (command.isEmpty()) {
             return Optional.empty();

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommandWorkItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@ public class CommitCommandWorkItem implements WorkItem {
 
     private static final Logger log = Logger.getLogger("org.openjdk.skara.bots.pr");
 
-    private static final Map<String, CommandHandler> commandHandlers = Map.ofEntries(
+    static final Map<String, CommandHandler> commandHandlers = Map.ofEntries(
             Map.entry("help", new HelpCommand()),
             Map.entry("backport", new BackportCommand()),
             Map.entry("tag", new TagCommand())
@@ -95,7 +95,7 @@ public class CommitCommandWorkItem implements WorkItem {
 
     private Optional<CommandInvocation> nextCommand(List<CommitComment> allComments) {
         var self = bot.repo().forge().currentUser();
-        var command = CommandExtractor.extractCommands(commandHandlers, commitComment.body(),
+        var command = CommandExtractor.extractCommands(true, commitComment.body(),
                                                        commitComment.id(), commitComment.author());
         if (command.isEmpty()) {
             return Optional.empty();
@@ -144,6 +144,7 @@ public class CommitCommandWorkItem implements WorkItem {
 
         bot.repo().addCommitComment(commitComment.commit(), writer.toString());
     }
+
     @Override
     public Collection<WorkItem> run(Path scratchPath) {
         log.info("Looking for commit comment commands");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
@@ -330,7 +330,7 @@ public class IntegrateCommand implements CommandHandler {
         if (pr.labelNames().contains("sponsor")) {
             pr.removeLabel("sponsor");
         }
-        reply.println("Pushed as commit " + hash.hex() + ".");
+        reply.println(PullRequest.commitHashMessage(hash));
         reply.println();
         reply.println(":bulb: You may see a message that your pull request was closed with unmerged commits. This can be safely ignored.");
     }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
@@ -202,7 +202,7 @@ public class PullRequestCommandWorkItem extends PullRequestWorkItem {
                 } else {
                     printer.print("The command `");
                     printer.print(command.name());
-                    printer.println("` can not be used in pull requests.");
+                    printer.println("` can not be used in pull requests. Please try to use this command on the commit.");
                 }
             }
         } else {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
@@ -202,7 +202,7 @@ public class PullRequestCommandWorkItem extends PullRequestWorkItem {
                 } else {
                     printer.print("The command `");
                     printer.print(command.name());
-                    printer.println("` can not be used in pull requests. Please try to use this command on the commit.");
+                    printer.println("` can not be used in pull requests.");
                 }
             }
         } else {

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CommitCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CommitCommandTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,12 +69,19 @@ public class CommitCommandTests {
             var replies = author.commitComments(editHash);
             CommitCommandAsserts.assertLastCommentContains(replies, "Available commands");
 
+            // Add a command which is only valid in pull request
+            author.addCommitComment(editHash, "/issue 12");
+            TestBotRunner.runPeriodicItems(bot);
+
+            replies = author.commitComments(editHash);
+            CommitCommandAsserts.assertLastCommentContains(replies, "The command `issue` can only be used in pull requests.");
+
             // Try an invalid one
             author.addCommitComment(editHash, "/hello");
             TestBotRunner.runPeriodicItems(bot);
 
             replies = author.commitComments(editHash);
-            CommitCommandAsserts.assertLastCommentContains(replies, "Unknown");
+            CommitCommandAsserts.assertLastCommentContains(replies, "Unknown command `hello` - for a list of valid commands use `/help`.");
         }
     }
 
@@ -95,6 +102,7 @@ public class CommitCommandTests {
                                     .censusRepo(censusBuilder.build())
                                     .censusLink("https://census.com/{{contributor}}-profile")
                                     .seedStorage(seedFolder)
+                                    .forks(Map.of("jdk17u-dev", credentials.getHostedRepository()))
                                     .build();
 
             // Populate the projects repository
@@ -107,6 +115,12 @@ public class CommitCommandTests {
             localRepo.push(editHash, author.url(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
+            // Add a `backport` command
+            pr.addComment("/backport jdk17u-dev");
+            TestBotRunner.runPeriodicItems(bot);
+            // The `backport` command is invalid because the pull request is not integrated.
+            PullRequestAsserts.assertLastCommentContains(pr, "The command `backport` can not be used in a pull request that has not yet been integrated.");
+
             // Simulate an integration
             var botPr = botRepo.pullRequest(pr.id());
             localRepo.push(editHash, author.url(), "master");
@@ -118,6 +132,13 @@ public class CommitCommandTests {
             pr.addComment("/help");
             TestBotRunner.runPeriodicItems(bot);
             PullRequestAsserts.assertLastCommentContains(pr, "Available commands");
+
+            // Add a `backport` command
+            pr.addComment("/backport jdk17u-dev");
+            TestBotRunner.runPeriodicItems(bot);
+            // The `backport` command is valid.
+            PullRequestAsserts.assertLastCommentContains(pr, "Could **not** automatically backport");
+            PullRequestAsserts.assertLastCommentContains(pr, "To manually resolve these conflicts");
 
             // Try an unavailable one
             pr.addComment("/integrate");

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CommitCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CommitCommandTests.java
@@ -119,7 +119,7 @@ public class CommitCommandTests {
             pr.addComment("/backport jdk17u-dev");
             TestBotRunner.runPeriodicItems(bot);
             // The `backport` command is invalid because the pull request is not integrated.
-            PullRequestAsserts.assertLastCommentContains(pr, "The command `backport` can not be used in a pull request that has not yet been integrated.");
+            PullRequestAsserts.assertLastCommentContains(pr, "The command `backport` can only be used in a pull request that has been integrated.");
 
             // Simulate an integration
             var botPr = botRepo.pullRequest(pr.id());

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestCommandTests.java
@@ -59,7 +59,7 @@ class PullRequestCommandTests {
             // Issue a commit command
             pr.addComment("/tag");
             TestBotRunner.runPeriodicItems(mergeBot);
-            PullRequestAsserts.assertLastCommentContains(pr, "The command `tag` can not be used in pull requests. Please try to use this command on the commit.");
+            PullRequestAsserts.assertLastCommentContains(pr, "The command `tag` can not be used in pull requests.");
 
             // Issue an invalid command
             pr.addComment("/howdy");

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestCommandTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,6 +55,11 @@ class PullRequestCommandTests {
             var editHash = CheckableRepository.appendAndCommit(localRepo);
             localRepo.push(editHash, author.url(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
+
+            // Issue a commit command
+            pr.addComment("/tag");
+            TestBotRunner.runPeriodicItems(mergeBot);
+            PullRequestAsserts.assertLastCommentContains(pr, "The command `tag` can not be used in pull requests.");
 
             // Issue an invalid command
             pr.addComment("/howdy");

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestCommandTests.java
@@ -59,7 +59,7 @@ class PullRequestCommandTests {
             // Issue a commit command
             pr.addComment("/tag");
             TestBotRunner.runPeriodicItems(mergeBot);
-            PullRequestAsserts.assertLastCommentContains(pr, "The command `tag` can not be used in pull requests.");
+            PullRequestAsserts.assertLastCommentContains(pr, "The command `tag` can not be used in pull requests. Please try to use this command on the commit.");
 
             // Issue an invalid command
             pr.addComment("/howdy");

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
@@ -332,4 +332,9 @@ class InMemoryPullRequest implements PullRequest {
     public Optional<ZonedDateTime> lastForcePushTime() {
         return Optional.empty();
     }
+
+    @Override
+    public Optional<Hash> findIntegratedCommitHash() {
+        return Optional.empty();
+    }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
@@ -199,4 +199,8 @@ public interface PullRequest extends Issue {
         }
         return Optional.empty();
     }
+
+    static String commitHashMessage(Hash hash) {
+        return hash != null ? "Pushed as commit " + hash.hex() + "." : "";
+    }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
@@ -200,6 +200,9 @@ public interface PullRequest extends Issue {
         return Optional.empty();
     }
 
+    /**
+     * Return the comment message about the commit hash.
+     */
     static String commitHashMessage(Hash hash) {
         return hash != null ? "Pushed as commit " + hash.hex() + "." : "";
     }

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -777,4 +777,9 @@ public class GitHubPullRequest implements PullRequest {
                       .reduce((a, b) -> b)
                       .map(obj -> ZonedDateTime.parse(obj.get("created_at").asString()));
     }
+
+    @Override
+    public Optional<Hash> findIntegratedCommitHash() {
+        return findIntegratedCommitHash(List.of(repository.forge().currentUser().id()));
+    }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -858,4 +858,9 @@ public class GitLabMergeRequest implements PullRequest {
     public Optional<ZonedDateTime> lastForcePushTime() {
         return Optional.empty();
     }
+
+    @Override
+    public Optional<Hash> findIntegratedCommitHash() {
+        return findIntegratedCommitHash(List.of(repository.forge().currentUser().id()));
+    }
 }

--- a/forge/src/test/java/org/openjdk/skara/forge/github/GitHubRestApiTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/github/GitHubRestApiTests.java
@@ -34,6 +34,7 @@ import org.openjdk.skara.vcs.DiffComparator;
 import org.openjdk.skara.vcs.Hash;
 
 import java.io.IOException;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -104,5 +105,28 @@ public class GitHubRestApiTests {
         var pr = githubRepo.pullRequest("96");
         var lastForcePushTime = pr.lastForcePushTime();
         assertEquals("2022-05-29T10:32:43Z", lastForcePushTime.get().toString());
+    }
+
+    @Test
+    void testFindIntegratedCommitHash() {
+        var playgroundRepoOpt = githubHost.repository("openjdk/playground");
+        assumeTrue(playgroundRepoOpt.isPresent());
+        var playgroundRepo = playgroundRepoOpt.get();
+        var playgroundPr = playgroundRepo.pullRequest("96");
+        var playgroundHashOpt = playgroundPr.findIntegratedCommitHash();
+        assertTrue(playgroundHashOpt.isEmpty());
+        // `43336822` is the id of the `openjdk` bot(a GitHub App).
+        playgroundHashOpt = playgroundPr.findIntegratedCommitHash(List.of("43336822"));
+        assertTrue(playgroundHashOpt.isEmpty());
+
+        var jdkRepoOpt = githubHost.repository("openjdk/jdk");
+        assumeTrue(jdkRepoOpt.isPresent());
+        var jdkRepo = jdkRepoOpt.get();
+        var jdkPr = jdkRepo.pullRequest("8648");
+        var jdkHashOpt = jdkPr.findIntegratedCommitHash();
+        assertTrue(jdkHashOpt.isEmpty());
+        // `43336822` is the id of the `openjdk` bot(a GitHub App).
+        jdkHashOpt = jdkPr.findIntegratedCommitHash(List.of("43336822"));
+        assertTrue(jdkHashOpt.isPresent());
     }
 }

--- a/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
@@ -271,4 +271,9 @@ public class TestPullRequest extends TestIssue implements PullRequest {
     public void setLastForcePushTime(ZonedDateTime lastForcePushTime) {
         data.lastForcePushTime = lastForcePushTime;
     }
+
+    @Override
+    public Optional<Hash> findIntegratedCommitHash() {
+        return findIntegratedCommitHash(List.of(repository().forge().currentUser().id()));
+    }
 }


### PR DESCRIPTION
Hi all,

This patch mainly solves the issue described at SKARA-1495 which makes the `backport` command be valid in a pull request which has been integrated.

But in detail, this patch has the following feature or solves the following issues:

- Currently, the commands of the pull request and the commands of the commit are not related and can't be known from each other. So when we use the commit commands, such as `tag`, in the pull request, the bot replies `Unknown command tag`. Actually, the bot should replies the message like `The command tag can not be used in pull requests.  Please try to use this command on the commit`. The change is mainly at method `CommandExtractor::extractCommands`.
- Many places of the code use a duplicated method, named `resultingCommitHash`, this method could be put into class `PullRequest` to avoid the duplication. I refactor it in this patch.
- Now the `backport` command can not be used in pull requests. I revise the logic to let it available in a pull request which has been integrated, mainly removing the overrided method `allowedInPullRequest` of the class `BackportCommand`.
- The reason that these issues are not found before is that we hadn't tested all the branches of the code, especially the branches in methods `PullRequestCommandWorkItem::processCommand` and `CommitCommandWorkItem::processCommand`. So I add more test cases to test almost all the branches. And if the branch can't be tested, I add a comment to explain it.

Although it seems that many features are not related to SKARA-1495, I put them together as an enhancement of the PullRequestBot.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1495](https://bugs.openjdk.org/browse/SKARA-1495): /backport should be allowed in PRs which have been integrated


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1341/head:pull/1341` \
`$ git checkout pull/1341`

Update a local copy of the PR: \
`$ git checkout pull/1341` \
`$ git pull https://git.openjdk.org/skara pull/1341/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1341`

View PR using the GUI difftool: \
`$ git pr show -t 1341`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1341.diff">https://git.openjdk.org/skara/pull/1341.diff</a>

</details>
