### PR TITLE
1514: Add metrics for mailing list archive polling

### DIFF
--- a/mailinglist/build.gradle
+++ b/mailinglist/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation project(':network')
     implementation project(':vcs')
     implementation project(':email')
+    implementation project(':metrics')
 
     testImplementation project(':test')
 }

--- a/mailinglist/src/main/java/module-info.java
+++ b/mailinglist/src/main/java/module-info.java
@@ -21,6 +21,7 @@
  * questions.
  */
 module org.openjdk.skara.mailinglist {
+    requires transitive org.openjdk.skara.metrics;
     requires java.net.http;
     requires java.logging;
     requires org.openjdk.skara.network;


### PR DESCRIPTION
This patch adds a new metrics counter tracking the polling rate for the MailmanListReader. I would like to get this live before trying to reduce the polling rate in SKARA-1513, so that any improvements can be accurately measured.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1514](https://bugs.openjdk.org/browse/SKARA-1514): Add metrics for mailing list archive polling


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1342/head:pull/1342` \
`$ git checkout pull/1342`

Update a local copy of the PR: \
`$ git checkout pull/1342` \
`$ git pull https://git.openjdk.org/skara pull/1342/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1342`

View PR using the GUI difftool: \
`$ git pr show -t 1342`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1342.diff">https://git.openjdk.org/skara/pull/1342.diff</a>

</details>
