### PR TITLE
1513: Reduce polling of mailing list archives

### DIFF
--- a/mailinglist/src/main/java/org/openjdk/skara/mailinglist/mailman/MailmanListReader.java
+++ b/mailinglist/src/main/java/org/openjdk/skara/mailinglist/mailman/MailmanListReader.java
@@ -96,6 +96,7 @@ public class MailmanListReader implements MailingListReader {
             } else if (response.statusCode() == 304) {
                 return Optional.of(response);
             } else if (response.statusCode() == 404) {
+                pageCache.put(uri, response);
                 log.fine("Page not found for " + uri);
                 return Optional.empty();
             } else {
@@ -115,10 +116,7 @@ public class MailmanListReader implements MailingListReader {
                                                   .sorted(Comparator.reverseOrder())
                                                   .collect(Collectors.toList());
 
-        var useCached = new HashMap<String, Boolean>();
-        for (var name : names) {
-            useCached.put(name, false);
-        }
+        var monthCount = 0;
         var newContent = false;
         var emails = new ArrayList<Email>();
         for (var month : potentialPages) {
@@ -126,9 +124,10 @@ public class MailmanListReader implements MailingListReader {
                 URI mboxUri = server.getMbox(name, month);
                 var sender = EmailAddress.from(name + "@" + mboxUri.getHost());
 
-                if (useCached.get(name)) {
+                // For archives older than the previous month, always use cached results
+                if (monthCount > 1 && pageCache.containsKey(mboxUri)) {
                     var cachedResponse = pageCache.get(mboxUri);
-                    if (cachedResponse != null) {
+                    if (cachedResponse != null && cachedResponse.statusCode() != 404) {
                         emails.addAll(0, Mbox.splitMbox(cachedResponse.body(), sender));
                     }
                 } else {
@@ -136,7 +135,6 @@ public class MailmanListReader implements MailingListReader {
                     if (mboxResponse.isPresent()) {
                         if (mboxResponse.get().statusCode() == 304) {
                             emails.addAll(0, Mbox.splitMbox(pageCache.get(mboxUri).body(), sender));
-                            useCached.put(name, true);
                         } else {
                             emails.addAll(0, Mbox.splitMbox(mboxResponse.get().body(), sender));
                             newContent = true;
@@ -144,6 +142,7 @@ public class MailmanListReader implements MailingListReader {
                     }
                 }
             }
+            monthCount++;
         }
 
         if (newContent) {


### PR DESCRIPTION
This patch changes the strategy used by the MailmanListReader for polling the mailman archives. The current implementation relies on the server supporting "etag" in order to trust any cached results. Recent testing has shown that etags aren't supported by mail.openjdk.org, which means no results are ever cached, we just keep spamming the mailman archives for the last 12 months over and over.

My new implementation assumes that new emails will only ever appear in the current and previous months archives. (If this proves to be wrong, I still think that would be rare enough that it doesn't matter, as the full 12 months will be re-evaluated on bot restart.) So for anything older than the previous month, all successful (200) or non-existent (404) results will be cached and never re-queried.

The reason mlbridge needs to query emails for up to a year back is that it needs to piece together conversations and trace them back to the original post in order to correctly identify the PR link associating the conversation with a certain PR. (It's possible that this could be made more efficient in a separate change.)

The change itself is rather small, but in order to test it, I needed to expand functionality in the TestMailmanServer. The existing tests did not verify any calls to archives for months other than the current, so I needed to add support for actually handling that. I also moved the data to in memory storage in HashMaps instead of writing to temp files.

My only worry here is that I messed up with the test so that it will start failing on certain days of the year.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1513](https://bugs.openjdk.org/browse/SKARA-1513): Reduce polling of mailing list archives


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1343/head:pull/1343` \
`$ git checkout pull/1343`

Update a local copy of the PR: \
`$ git checkout pull/1343` \
`$ git pull https://git.openjdk.org/skara pull/1343/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1343`

View PR using the GUI difftool: \
`$ git pr show -t 1343`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1343.diff">https://git.openjdk.org/skara/pull/1343.diff</a>

</details>
