### PR TITLE
1463: Include starting branch in back port instructions

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
@@ -145,6 +145,8 @@ public class BackportCommand implements CommandHandler {
                     lines.add("To manually resolve these conflicts run the following commands in your personal fork of [" + repoName + "](" + targetRepo.webUrl() + "):");
                     lines.add("");
                     lines.add("```");
+                    lines.add("$ git fetch --no-tags " + targetRepo.webUrl() + " " + targetBranch.name() + ":" + targetBranch.name());
+                    lines.add("$ git checkout " + targetBranch.name());
                     lines.add("$ git checkout -b " + backportBranchName);
                     lines.add("$ git fetch --no-tags " + bot.repo().webUrl() + " " + hash.hex());
                     lines.add("$ git cherry-pick --no-commit " + hash.hex());

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
@@ -142,7 +142,8 @@ public class BackportCommand implements CommandHandler {
                         lines.add("- " + path.toString());
                     }
                     lines.add("");
-                    lines.add("To manually resolve these conflicts run the following commands in your personal fork of [" + repoName + "](" + targetRepo.webUrl() + "):");
+                    lines.add("To manually resolve these conflicts, please fetch the appropriate branch/commit and resolve conflicts "
+                            + "by using the following commands in your personal fork of [" + repoName + "](" + targetRepo.webUrl() + "):");
                     lines.add("");
                     lines.add("```");
                     lines.add("$ git fetch --no-tags " + targetRepo.webUrl() + " " + targetBranch.name() + ":" + targetBranch.name());

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
@@ -143,15 +143,25 @@ public class BackportCommand implements CommandHandler {
                     }
                     lines.add("");
                     lines.add("Please fetch the appropriate branch/commit and manually resolve these conflicts "
-                            + "by using the following commands in your personal fork of [" + repoName + "](" + targetRepo.webUrl() + "):");
+                            + "by using the following commands in your personal fork of [" + repoName + "](" + targetRepo.webUrl()
+                            + "). Note: these commands are just some suggestions and you can use other equivalent commands you know.");
                     lines.add("");
                     lines.add("```");
+                    lines.add("# Fetch the up-to-date version of the target branch");
                     lines.add("$ git fetch --no-tags " + targetRepo.webUrl() + " " + targetBranch.name() + ":" + targetBranch.name());
+                    lines.add("");
+                    lines.add("# Check out the target branch and create your own branch to backport");
                     lines.add("$ git checkout " + targetBranch.name());
                     lines.add("$ git checkout -b " + backportBranchName);
+                    lines.add("");
+                    lines.add("# Fetch the commit you want to backport");
                     lines.add("$ git fetch --no-tags " + bot.repo().webUrl() + " " + hash.hex());
+                    lines.add("");
+                    lines.add("# Backport the commit");
                     lines.add("$ git cherry-pick --no-commit " + hash.hex());
-                    lines.add("$ # Resolve conflicts");
+                    lines.add("# Resolve conflicts now");
+                    lines.add("");
+                    lines.add("# Commit the files you have modified");
                     lines.add("$ git add files/with/resolved/conflicts");
                     lines.add("$ git commit -m 'Backport " + hash.hex() + "'");
                     lines.add("```");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
@@ -142,7 +142,7 @@ public class BackportCommand implements CommandHandler {
                         lines.add("- " + path.toString());
                     }
                     lines.add("");
-                    lines.add("To manually resolve these conflicts, please fetch the appropriate branch/commit and resolve conflicts "
+                    lines.add("Please fetch the appropriate branch/commit and manually resolve these conflicts "
                             + "by using the following commands in your personal fork of [" + repoName + "](" + targetRepo.webUrl() + "):");
                     lines.add("");
                     lines.add("```");

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportCommitCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportCommitCommandTests.java
@@ -249,7 +249,7 @@ public class BackportCommitCommandTests {
             assertEquals(2, recentCommitComments.size());
             var botReply = recentCommitComments.get(0);
             assertTrue(botReply.body().contains("Could **not** automatically backport"));
-            assertTrue(botReply.body().contains("To manually resolve these conflicts run the following commands"));
+            assertTrue(botReply.body().contains("Please fetch the appropriate branch/commit and manually resolve these conflicts"));
             assertTrue(botReply.body().contains("master:master"));
             assertTrue(botReply.body().contains("$ git checkout master"));
             assertEquals(List.of(), author.pullRequests());

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportCommitCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportCommitCommandTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -249,6 +249,9 @@ public class BackportCommitCommandTests {
             assertEquals(2, recentCommitComments.size());
             var botReply = recentCommitComments.get(0);
             assertTrue(botReply.body().contains("Could **not** automatically backport"));
+            assertTrue(botReply.body().contains("To manually resolve these conflicts run the following commands"));
+            assertTrue(botReply.body().contains("master:master"));
+            assertTrue(botReply.body().contains("$ git checkout master"));
             assertEquals(List.of(), author.pullRequests());
         }
     }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CommitCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CommitCommandTests.java
@@ -138,7 +138,7 @@ public class CommitCommandTests {
             TestBotRunner.runPeriodicItems(bot);
             // The `backport` command is valid.
             PullRequestAsserts.assertLastCommentContains(pr, "Could **not** automatically backport");
-            PullRequestAsserts.assertLastCommentContains(pr, "To manually resolve these conflicts");
+            PullRequestAsserts.assertLastCommentContains(pr, "Please fetch the appropriate branch/commit and manually resolve these conflicts");
 
             // Try an unavailable one
             pr.addComment("/integrate");


### PR DESCRIPTION
Hi all,

This patch adds the suggested git command about fetching the newest code 
from the target branch before solving the conflicts.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1463](https://bugs.openjdk.org/browse/SKARA-1463): Include starting branch in back port instructions


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1344/head:pull/1344` \
`$ git checkout pull/1344`

Update a local copy of the PR: \
`$ git checkout pull/1344` \
`$ git pull https://git.openjdk.org/skara pull/1344/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1344`

View PR using the GUI difftool: \
`$ git pr show -t 1344`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1344.diff">https://git.openjdk.org/skara/pull/1344.diff</a>

</details>
