### PR TITLE
1519: MailmanListReader misses new month on the 1st

### DIFF
--- a/mailinglist/src/main/java/org/openjdk/skara/mailinglist/mailman/MailmanListReader.java
+++ b/mailinglist/src/main/java/org/openjdk/skara/mailinglist/mailman/MailmanListReader.java
@@ -69,7 +69,8 @@ public class MailmanListReader implements MailingListReader {
         var start = now.minus(maxAge);
         List<ZonedDateTime> ret = new ArrayList<>();
 
-        while (start.isBefore(now)) {
+        // Iterate all the way until start is equal to now
+        while (!start.isAfter(now)) {
             ret.add(start);
             var next = start.plus(Duration.ofDays(1));
             while (start.getMonthValue() == next.getMonthValue()) {


### PR DESCRIPTION
After expanding the tests for MailmanListReader in [SKARA-1513](https://bugs.openjdk.org/browse/SKARA-1513), I've discovered that some tests started failing on the 1st of the month. These failures actually uncovered a real problem, where the current logic would not start querying a new month archive until the 2nd of the new month. This is basically an off by one error in the loop condition where we generate the list of months to iterate over.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1519](https://bugs.openjdk.org/browse/SKARA-1519): MailmanListReader misses new month on the 1st


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1345/head:pull/1345` \
`$ git checkout pull/1345`

Update a local copy of the PR: \
`$ git checkout pull/1345` \
`$ git pull https://git.openjdk.org/skara pull/1345/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1345`

View PR using the GUI difftool: \
`$ git pr show -t 1345`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1345.diff">https://git.openjdk.org/skara/pull/1345.diff</a>

</details>
