### PR TITLE
1515: Mailing list parsing of PR links broken since openjdk.org transition

### DIFF
--- a/forge/src/test/java/org/openjdk/skara/forge/ManualForgeTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/ManualForgeTests.java
@@ -43,7 +43,7 @@ public class ManualForgeTests {
 
         var keyContents = Files.readString(keyFile, StandardCharsets.UTF_8);
         var app = new GitHubApplication(keyContents, id, installation);
-        var gitHubHost = new GitHubHost(uri, app, null, null, Set.of());
+        var gitHubHost = new GitHubHost(uri, app, null, null, null, Set.of());
 
         var repo = gitHubHost.repository(settings.getProperty("github.repository")).orElseThrow();
 

--- a/forge/src/test/java/org/openjdk/skara/forge/github/GitHubHostTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/github/GitHubHostTests.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.skara.forge.github;
 
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.openjdk.skara.network.URIBuilder;
 import org.openjdk.skara.test.TemporaryDirectory;
@@ -35,23 +36,32 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class GitHubHostTests {
     @Test
-    void webUriPatternReplacement() throws IOException, URISyntaxException {
-        try (var tempFolder = new TemporaryDirectory()) {
-            var host = new GitHubHost(URIBuilder.base("http://www.example.com").build(),
-                                      Pattern.compile("^(http://www.example.com)/test/(.*)$"), "$1/another/$2",
-                                      Set.of(), false);
-            assertEquals(new URI("http://www.example.com/another/hello"), host.getWebURI("/test/hello"));
-        }
+    void webUriPatternReplacement() throws URISyntaxException {
+        var host = new GitHubHost(URIBuilder.base("http://www.example.com").build(),
+                Pattern.compile("^(http://www.example.com)/test/(.*)$"), "$1/another/$2",
+                List.of(), Set.of(), false);
+        assertEquals(new URI("http://www.example.com/another/hello"), host.getWebURI("/test/hello"));
     }
 
     @Test
-    void nonTransformedWebUrl() throws IOException, URISyntaxException {
-        try (var tempFolder = new TemporaryDirectory()) {
-            var host = new GitHubHost(URIBuilder.base("http://www.example.com").build(),
-                                      Pattern.compile("^(http://www.example.com)/test/(.*)$"), "$1/another/$2",
-                                      Set.of(), false);
-            assertEquals(new URI("http://www.example.com/another/hello"), host.getWebURI("/test/hello"));
-            assertEquals(new URI("http://www.example.com/test/hello"), host.getWebURI("/test/hello", false));
-        }
+    void nonTransformedWebUrl() throws URISyntaxException {
+        var host = new GitHubHost(URIBuilder.base("http://www.example.com").build(),
+                Pattern.compile("^(http://www.example.com)/test/(.*)$"), "$1/another/$2",
+                List.of(), Set.of(), false);
+        assertEquals(new URI("http://www.example.com/another/hello"), host.getWebURI("/test/hello"));
+        assertEquals(new URI("http://www.example.com/test/hello"), host.getWebURI("/test/hello", false));
+    }
+
+    @Test
+    void webAltUriPatternReplacement() throws URISyntaxException {
+        var host = new GitHubHost(URIBuilder.base("http://www.example.com").build(),
+                Pattern.compile("^(http://www.example.com)/test/(.*)$"), "$1/another/$2",
+                List.of("http://localhost/$2"), Set.of(), false);
+        assertEquals(new URI("http://www.example.com/another/hello"), host.getWebURI("/test/hello"));
+        assertEquals(List.of(
+                        new URI("http://www.example.com/another/hello"),
+                        new URI("http://localhost/hello")
+                ),
+                host.getAllWebURIs("/test/hello"));
     }
 }


### PR DESCRIPTION
The mlbridge bot uses PR links in emails to identify which PR an email thread belongs to. This is then used to correctly post emails from the archive as comments on PRs. The PR links in the emails are transformed to an openjdk style URL:

github.com/openjdk -> git.openjdk.org

The URL matching logic knows about this transformation and tries to reverse it before matching PR links. The problem is that before June 9, the rewritten URLs were git.openjdk.java.net. The current logic can't handle multiple different transformation patterns, so any emails found with the old URL can't be matched correctly to PRs.

In the github host config for the mlbridge bot, we currently have this config:

```
        "weburl": {
          "pattern": "^https://github.com/openjdk/(.*)$",
          "replacement": "https://git.openjdk.org/$1",
        }
```
This patch adds the ability to add alternate replacement patterns. By using this, we can search for both the old openjdk.java.net URLs as well as the new openjdk.org one. It will look like this:

```
        "weburl": {
          "pattern": "^https://github.com/openjdk/(.*)$",
          "replacement": "https://git.openjdk.org/$1",
          "altreplacements": [
            "https://git.openjdk.java.net/$1",
          ],
        }
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1515](https://bugs.openjdk.org/browse/SKARA-1515): Mailing list parsing of PR links broken since openjdk.org transition


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1346/head:pull/1346` \
`$ git checkout pull/1346`

Update a local copy of the PR: \
`$ git checkout pull/1346` \
`$ git pull https://git.openjdk.org/skara pull/1346/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1346`

View PR using the GUI difftool: \
`$ git pr show -t 1346`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1346.diff">https://git.openjdk.org/skara/pull/1346.diff</a>

</details>
