### PR TITLE
Improve logging in PR bot

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -35,7 +35,6 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.*;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 class PullRequestBot implements Bot {
     private final HostedRepository remoteRepo;
@@ -161,7 +160,7 @@ class PullRequestBot implements Bot {
     }
 
     private List<WorkItem> getWorkItems(List<PullRequest> pullRequests) {
-        var ret = new LinkedList<WorkItem>();
+        var ret = new ArrayList<WorkItem>();
         ret.add(new CommitCommentsWorkItem(this, remoteRepo, excludeCommitCommentsFrom));
 
         for (var pr : pullRequests) {
@@ -186,10 +185,10 @@ class PullRequestBot implements Bot {
         List<PullRequest> prs;
         if (lastFullUpdate == null || lastFullUpdate.isBefore(Instant.now().minus(Duration.ofMinutes(10)))) {
             lastFullUpdate = Instant.now();
-            log.info("Fetching all open pull requests");
+            log.info("Fetching all open pull requests for " + remoteRepo.name());
             prs = remoteRepo.pullRequests();
         } else {
-            log.info("Fetching recently updated pull requests (open and closed)");
+            log.info("Fetching recently updated pull requests (open and closed) for " + remoteRepo.name());
             prs = remoteRepo.pullRequests(ZonedDateTime.now().minus(Duration.ofDays(1)));
         }
 


### PR DESCRIPTION
This very minor patch adds the repo names to log messages in `getPeriodicItems()`. I'm going to look into performance issues with the bots, and just seeing a bunch of

```
Fetching all open pull requests
Fetching all open pull requests
```

in the log without any further context isn't helping.

I also stumbled over an unused import as well as a bad use of LinkedList while in the area.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1347/head:pull/1347` \
`$ git checkout pull/1347`

Update a local copy of the PR: \
`$ git checkout pull/1347` \
`$ git pull https://git.openjdk.org/skara pull/1347/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1347`

View PR using the GUI difftool: \
`$ git pr show -t 1347`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1347.diff">https://git.openjdk.org/skara/pull/1347.diff</a>

</details>
