### PR TITLE
1529: Optimize Census namespace instantiation

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -78,6 +78,9 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
 
     private static final String pullRequestTip = "A pull request was submitted for review.";
 
+    // Lazy loaded
+    private CensusInstance census = null;
+
     IssueNotifier(IssueProject issueProject, boolean reviewLink, URI reviewIcon, boolean commitLink, URI commitIcon,
                   boolean setFixVersion, Map<String, String> fixVersions, Map<String, List<String>> altFixVersions,
                   JbsBackport jbsBackport, boolean prOnly, boolean repoOnly, String buildName,
@@ -108,12 +111,18 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
         return new IssueNotifierBuilder();
     }
 
+    private CensusInstance getCensus() {
+        if (census == null) {
+            census = CensusInstance.create(censusRepository, censusRef, namespace);
+        }
+        return census;
+    }
+
     private Optional<String> findCensusUser(String user, Path scratchPath) {
         if (censusRepository == null) {
             return Optional.empty();
         }
-        var censusInstance = CensusInstance.create(censusRepository, censusRef, scratchPath, namespace);
-        var ns = censusInstance.namespace();
+        var ns = getCensus().namespace();
         for (var entry : ns.entries()) {
             if (entry.getValue().username().equals(user)) {
                 return Optional.of(entry.getKey());

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -519,7 +519,7 @@ class CheckRun {
         // Check for manually added reviewers
         if (!ignoreStaleReviews) {
             var namespace = censusInstance.namespace();
-            var allReviewers = PullRequestUtils.reviewerNames(reviews, namespace);
+            var allReviewers = CheckablePullRequest.reviewerNames(reviews, namespace);
             var additionalEntries = new ArrayList<String>();
             for (var additional : Reviewers.reviewers(pr.repository().forge().currentUser(), comments)) {
                 if (!allReviewers.contains(additional)) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
@@ -66,12 +66,12 @@ public class CheckablePullRequest {
                                            .filter(review -> !ignoreStaleReviews || review.hash().orElseThrow().equals(pr.headHash()))
                                            .filter(review -> review.verdict() == Review.Verdict.APPROVED)
                                            .collect(Collectors.toList());
-        var reviewers = PullRequestUtils.reviewerNames(eligibleReviews, namespace);
+        var reviewers = reviewerNames(eligibleReviews, namespace);
         var comments = pr.comments();
         var currentUser = pr.repository().forge().currentUser();
 
         if (manualReviewers) {
-            var allReviewers = PullRequestUtils.reviewerNames(activeReviews, namespace);
+            var allReviewers = reviewerNames(activeReviews, namespace);
             var additionalReviewers = Reviewers.reviewers(currentUser, comments);
             for (var additionalReviewer : additionalReviewers) {
                 if (!allReviewers.contains(additionalReviewer)) {
@@ -294,5 +294,13 @@ public class CheckablePullRequest {
             targetHash = PullRequestUtils.targetHash(localRepo);
         }
         return targetHash;
+    }
+
+    public static Set<String> reviewerNames(List<Review> reviews, Namespace namespace) {
+        return reviews.stream()
+                .map(review -> namespace.get(review.reviewer().id()))
+                .filter(Objects::nonNull)
+                .map(Contributor::username)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewerCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewerCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -92,7 +92,7 @@ public class ReviewerCommand implements CommandHandler {
         }
 
         var namespace = censusInstance.namespace();
-        var authenticatedReviewers = PullRequestUtils.reviewerNames(pr.reviews(), namespace);
+        var authenticatedReviewers = CheckablePullRequest.reviewerNames(pr.reviews(), namespace);
         var action = matcher.group(1);
         if (action.equals("credit")) {
             for (var reviewer : reviewers) {

--- a/census/build.gradle
+++ b/census/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,12 +25,20 @@ module {
     name = 'org.openjdk.skara.census'
     test {
         requires 'org.junit.jupiter.api'
+        requires 'org.openjdk.skara.test'
+        requires 'org.openjdk.skara.vcs'
         opens 'org.openjdk.skara.census' to 'org.junit.platform.commons'
     }
 }
 
 dependencies {
     implementation project(':xml')
+    implementation project(':forge')
+    implementation project(':issuetracker')
+    implementation project(':host')
+
+    testImplementation project(':test')
+    testImplementation project(':vcs')
 }
 
 publishing {

--- a/census/src/main/java/module-info.java
+++ b/census/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,7 @@
  */
 module org.openjdk.skara.census {
     requires org.openjdk.skara.xml;
+    requires static org.openjdk.skara.forge;
     requires java.xml;
     requires java.net.http;
     requires java.logging;

--- a/census/src/main/java/org/openjdk/skara/census/Census.java
+++ b/census/src/main/java/org/openjdk/skara/census/Census.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@ import java.net.URI;
 import java.net.http.*;
 import java.time.*;
 
+import org.openjdk.skara.forge.HostedRepository;
 import org.openjdk.skara.xml.XML;
 import org.w3c.dom.Document;
 import static java.util.function.Function.identity;
@@ -211,5 +212,24 @@ public class Census {
         } catch (InterruptedException e) {
             throw new IOException(e);
         }
+    }
+
+    /**
+     * Initializes a single Namespace directly from a hosted repository. This works
+     * because the files needed to populate a single namespace are statically known.
+     * A full Census needs to discover files by listing them, which makes
+     * initialization from a remote repository inconvenient.
+     *
+     * @param repository HostedRepository to initialize from
+     * @param ref The reference in the repository to get data from
+     * @param name Name of namespace to initialize
+     * @return Just the named Namespace from the Census hosted in the repository
+     */
+    public static Namespace parseNamespace(HostedRepository repository, String ref, String name) throws IOException {
+        log.finer("Parsing namespace from repository " + repository.name());
+        var contributorsData = repository.fileContents("contributors.xml", ref);
+        var contributors = Contributors.parse(contributorsData);
+        var namespaceData = repository.fileContents("namespaces/" + name + ".xml", ref);
+        return Namespace.parse(namespaceData, contributors);
     }
 }

--- a/census/src/main/java/org/openjdk/skara/census/Contributors.java
+++ b/census/src/main/java/org/openjdk/skara/census/Contributors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,14 +27,22 @@ import org.openjdk.skara.xml.XML;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.*;
+import org.w3c.dom.Document;
+
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
 
 class Contributors {
     static Map<String, Contributor> parse(Path p) throws IOException {
-        var result = new ArrayList<Contributor>();
+        return parse(XML.parse(p));
+    }
 
-        var document = XML.parse(p);
+    static Map<String, Contributor> parse(String s) throws IOException {
+        return parse(XML.parse(s));
+    }
+
+    private static Map<String, Contributor> parse(Document document) {
+        var result = new ArrayList<Contributor>();
         var contributors = XML.child(document, "contributors");
         for (var contributor : XML.children(contributors, "contributor")) {
             var username = XML.attribute(contributor, "username");

--- a/census/src/main/java/org/openjdk/skara/census/Namespace.java
+++ b/census/src/main/java/org/openjdk/skara/census/Namespace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ import org.openjdk.skara.xml.XML;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.*;
+import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 public class Namespace {
@@ -58,6 +59,15 @@ public class Namespace {
 
     static Namespace parse(Path p, Map<String, Contributor> contributors) throws IOException {
         var document = XML.parse(p);
+        return parse(document, contributors);
+    }
+
+    static Namespace parse(String s, Map<String, Contributor> contributors) throws IOException {
+        var document = XML.parse(s);
+        return parse(document, contributors);
+    }
+
+    private static Namespace parse(Document document, Map<String, Contributor> contributors) throws IOException {
         var namespace = XML.child(document, "namespace");
         return parse(namespace, contributors);
     }

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,6 @@ module {
 
 dependencies {
     implementation project(':vcs')
-    implementation project(':census')
     implementation project(':json')
     implementation project(':ini')
     implementation project(':process')

--- a/forge/src/main/java/module-info.java
+++ b/forge/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,6 @@
  */
 module org.openjdk.skara.forge {
     requires org.openjdk.skara.vcs;
-    requires org.openjdk.skara.census;
     requires org.openjdk.skara.json;
     requires org.openjdk.skara.ini;
     requires org.openjdk.skara.process;

--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequestUtils.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,6 @@
  */
 package org.openjdk.skara.forge;
 
-import org.openjdk.skara.census.*;
 import org.openjdk.skara.vcs.*;
 
 import java.io.IOException;
@@ -198,14 +197,6 @@ public class PullRequestUtils {
             }
         }
         return ret;
-    }
-
-    public static Set<String> reviewerNames(List<Review> reviews, Namespace namespace) {
-        return reviews.stream()
-                      .map(review -> namespace.get(review.reviewer().id()))
-                      .filter(Objects::nonNull)
-                      .map(Contributor::username)
-                      .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     public static boolean containsForeignMerge(PullRequest pr, Repository localRepo) throws IOException {

--- a/host/build.gradle
+++ b/host/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,20 +26,11 @@ module {
     test {
         requires 'org.openjdk.skara.test'
         requires 'org.junit.jupiter.api'
-        requires 'jdk.httpserver'
         opens 'org.openjdk.skara.host' to 'org.junit.platform.commons'
     }
 }
 
 dependencies {
-    implementation project(':vcs')
-    implementation project(':census')
-    implementation project(':json')
-    implementation project(':ini')
-    implementation project(':process')
-    implementation project(':email')
-    implementation project(':network')
-
     testImplementation project(':test')
 }
 

--- a/host/src/main/java/module-info.java
+++ b/host/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,15 +21,5 @@
  * questions.
  */
 module org.openjdk.skara.host {
-    requires org.openjdk.skara.vcs;
-    requires org.openjdk.skara.census;
-    requires org.openjdk.skara.json;
-    requires org.openjdk.skara.ini;
-    requires org.openjdk.skara.process;
-    requires org.openjdk.skara.email;
-    requires org.openjdk.skara.network;
-    requires java.net.http;
-    requires java.logging;
-
     exports org.openjdk.skara.host;
 }

--- a/issuetracker/build.gradle
+++ b/issuetracker/build.gradle
@@ -34,7 +34,6 @@ module {
 
 dependencies {
     implementation project(':vcs')
-    implementation project(':census')
     implementation project(':json')
     implementation project(':ini')
     implementation project(':process')

--- a/issuetracker/src/main/java/module-info.java
+++ b/issuetracker/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,6 @@
  */
 module org.openjdk.skara.issuetracker {
     requires org.openjdk.skara.vcs;
-    requires org.openjdk.skara.census;
     requires org.openjdk.skara.json;
     requires org.openjdk.skara.ini;
     requires org.openjdk.skara.process;


### PR DESCRIPTION
This patch adds a new factory method `Census::parseNamespace`, which enables initialization of a single Namespace directly from a HostedRepository (without having to clone the census repo to local disk first). 

The motivation behind this is bot performance. The Census is loaded in many WorkItems. Cloning/fetching the complete census repo to local disk is relatively expensive compared to a couple of REST calls to just read files directly from the remote repo. Especially as our REST client already leverages caching through ETag. This particular optimization can however only be applied to the IssueNotifier in the NotifyBot, where I doubt it will make that much of a difference. The main performance gain is realized in a different bot which currently isn't public (but these gains will impact all Skara users).

I chose to at least for now, only apply this for initializing a single Namespace as that can be done by reading only 2 files from the remote, so the performance gain is very clear. Other bots either need to read considerably more files, or have the need to update the census. This optimization idea may be expanded in the future if I see a need and noticeable gains from it. 

In order to make HostedRepository available to the Census class, I had to get rid of several existing module dependencies to avoid circular dependencies. Fortunately this wasn't too hard. It made no sense to me that `org.openjdk.skara.forge` would require `org.openjdk.skara.census`. There was just one static method `PullRequestUtils` in the forge module that used a reference to the census module, and this static method was only used from one module `org.openjdk.skara.bots.pr`, so I simply moved it to `CheckablePullRequest` which is kind of a utility class in that module. The rest of the offending dependencies were just unused, so I cleaned out a fair few of those.

In the `IssueNotifier`, in addition to using the new initialization method, I also added lazy initialization and reusing of the `CensusInstance` class, to avoid re-initializing the same data for every round in loops.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1529](https://bugs.openjdk.org/browse/SKARA-1529): Optimize Census namespace instantiation


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1348/head:pull/1348` \
`$ git checkout pull/1348`

Update a local copy of the PR: \
`$ git checkout pull/1348` \
`$ git pull https://git.openjdk.org/skara pull/1348/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1348`

View PR using the GUI difftool: \
`$ git pr show -t 1348`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1348.diff">https://git.openjdk.org/skara/pull/1348.diff</a>

</details>
