### PR TITLE
1530: Race with CheckWorkItem in PR bot

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
@@ -36,13 +36,13 @@ import java.util.stream.Collectors;
 public class LabelerWorkItem extends PullRequestWorkItem {
     private static final String initialLabelMessage = "<!-- PullRequestBot initial label help comment -->";
 
-    LabelerWorkItem(PullRequestBot bot, PullRequest pr, Consumer<RuntimeException> errorHandler) {
-        super(bot, pr, errorHandler);
+    LabelerWorkItem(PullRequestBot bot, String prId, Consumer<RuntimeException> errorHandler) {
+        super(bot, prId, errorHandler);
     }
 
     @Override
     public String toString() {
-        return "LabelerWorkItem@" + pr.repository().name() + "#" + pr.id();
+        return "LabelerWorkItem@" + pr.repository().name() + "#" + prId;
     }
 
     private Set<String> getLabels(Repository localRepo) throws IOException {
@@ -114,7 +114,7 @@ public class LabelerWorkItem extends PullRequestWorkItem {
     }
 
     @Override
-    public Collection<WorkItem> run(Path scratchPath) {
+    public Collection<WorkItem> prRun(Path scratchPath) {
         if (bot.isAutoLabelled(pr)) {
             return List.of();
         }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -169,10 +169,10 @@ class PullRequestBot implements Bot {
                     continue;
                 }
                 if (pr.state() == Issue.State.OPEN) {
-                    ret.add(new CheckWorkItem(this, pr, e -> updateCache.invalidate(pr)));
+                    ret.add(new CheckWorkItem(this, pr.id(), e -> updateCache.invalidate(pr)));
                 } else {
                     // Closed PR's do not need to be checked
-                    ret.add(new PullRequestCommandWorkItem(this, pr, e -> updateCache.invalidate(pr)));
+                    ret.add(new PullRequestCommandWorkItem(this, pr.id(), e -> updateCache.invalidate(pr)));
                 }
             }
         }


### PR DESCRIPTION
This patch fixes a race in the PR bot. 

Currently, all WorkItems that process PRs get an instance of the PullRequest that was  fetched before the WorkItem instance was created. The data in that PullRequest instance (the parts that aren't dynamically fetched on method calls) may then be stale before the WorkItem even starts running.

With this patch, I'm changing PullRequestWorkItem (the super class of all WorkItems that handle PRs), to only be instantiated with the ID of the PR, and then fetches the actual PullRequest object at the start of the `run()` method. When the `run()` method is called, we are guaranteed to be the only WorkItem currently processing the particular PR, so fetching data there should guarantee a coherent and current view.

In many cases where PullRequestWorkItems were created, the creator first refreshed the PullRequest object to provide an updated view, reflecting any changes made by the creator. These refreshes are no longer necessary, so I've removed them all.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1530](https://bugs.openjdk.org/browse/SKARA-1530): Race with CheckWorkItem in PR bot


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1349/head:pull/1349` \
`$ git checkout pull/1349`

Update a local copy of the PR: \
`$ git checkout pull/1349` \
`$ git pull https://git.openjdk.org/skara pull/1349/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1349`

View PR using the GUI difftool: \
`$ git pr show -t 1349`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1349.diff">https://git.openjdk.org/skara/pull/1349.diff</a>

</details>
