### PR TITLE
Fix NPE in toString

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -214,7 +214,7 @@ class CheckWorkItem extends PullRequestWorkItem {
 
     @Override
     public String toString() {
-        return "CheckWorkItem@" + pr.repository().name() + "#" + prId;
+        return "CheckWorkItem@" + bot.repo().name() + "#" + prId;
     }
 
     @Override

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
@@ -42,7 +42,7 @@ public class LabelerWorkItem extends PullRequestWorkItem {
 
     @Override
     public String toString() {
-        return "LabelerWorkItem@" + pr.repository().name() + "#" + prId;
+        return "LabelerWorkItem@" + bot.repo().name() + "#" + prId;
     }
 
     private Set<String> getLabels(Repository localRepo) throws IOException {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
@@ -201,7 +201,7 @@ public class PullRequestCommandWorkItem extends PullRequestWorkItem {
 
     @Override
     public String toString() {
-        return "PullRequestCommandWorkItem@" + pr.repository().name() + "#" + prId;
+        return "PullRequestCommandWorkItem@" + bot.repo().name() + "#" + prId;
     }
 
     @Override


### PR DESCRIPTION
My patch in SKARA-1530 did unfortunately trigger NPE in the toString() methods of all subclasses of PullRequestWorkItem. This is because the pr field isn't initialized in the constructor anymore. The repository is available through the bot field however.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1351/head:pull/1351` \
`$ git checkout pull/1351`

Update a local copy of the PR: \
`$ git checkout pull/1351` \
`$ git pull https://git.openjdk.org/skara pull/1351/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1351`

View PR using the GUI difftool: \
`$ git pr show -t 1351`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1351.diff">https://git.openjdk.org/skara/pull/1351.diff</a>

</details>
