### PR TITLE
1516: Command 'git pr integrate' gets error message 'time out'

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrSponsor.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrSponsor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ import static org.openjdk.skara.cli.pr.Utils.*;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.regex.Pattern;
 
 public class GitPrSponsor {
     static final List<Flag> flags = List.of(
@@ -75,6 +76,7 @@ public class GitPrSponsor {
 
         var seenSponsorComment = false;
         var expected = "<!-- Jmerge command reply message (" + sponsorComment.id() + ") -->";
+        var pushedPattern = Pattern.compile("Pushed as commit ([a-f0-9]{40})\\.");
         for (var i = 0; i < 90; i++) {
             var comments = pr.comments();
             for (var comment : comments) {
@@ -87,7 +89,7 @@ public class GitPrSponsor {
                 var lines = comment.body().split("\n");
                 if (lines.length > 0 && lines[0].equals(expected)) {
                     for (var line : lines) {
-                        if (line.startsWith("Pushed as commit")) {
+                        if (pushedPattern.matcher(line).find()) {
                             var output = removeTrailing(line, ".");
                             System.out.println(output);
                             System.exit(0);


### PR DESCRIPTION
Hi all,

I tried the command `git pr integrate 1341` to integrate SKARA-1495. The command replies `error: timed out waiting for response to /integrate command`. It is because the bot added a comment `@lgxbslgx Pushed as commit XXX.` so that this line is not started with `Pushed as commit`.

This patch fixes the bug by using a pattern matcher instead of judging the beginning of the line. And I verified this patch by using the command `git pr integrate 1344` to integrate SKARA-1463 just now. It works well and replies `@lgxbslgx Pushed as commit 35b23b882393c33565e49ec0399adba7e8eb2f5b`. But I have not verified the sponsor flow because I don't have a chance to do that now.

Thanks for taking the time to review.

Best Regards,
-- Guoxion

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1516](https://bugs.openjdk.org/browse/SKARA-1516): Command 'git pr integrate' gets error message 'time out'


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1352/head:pull/1352` \
`$ git checkout pull/1352`

Update a local copy of the PR: \
`$ git checkout pull/1352` \
`$ git pull https://git.openjdk.org/skara pull/1352/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1352`

View PR using the GUI difftool: \
`$ git pr show -t 1352`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1352.diff">https://git.openjdk.org/skara/pull/1352.diff</a>

</details>
