### PR TITLE
1536: The method "JiraIssue#setState" is invalid when using the argument "State.CLOSED"

### DIFF
--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraHost.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraHost.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,6 +47,20 @@ public class JiraHost implements IssueTracker {
                                 .appendPath("/rest/api/2/")
                                 .build();
         request = new RestRequest(baseApi);
+    }
+
+    /**
+     * This constructor is only used by the manual test code.
+     */
+    JiraHost(URI uri, String cookie) {
+        this.uri = uri;
+        this.visibilityRole = null;
+        this.securityLevel = null;
+
+        var baseApi = URIBuilder.base(uri)
+                                .appendPath("/rest/api/2/")
+                                .build();
+        request = new RestRequest(baseApi, "test", (r) -> Arrays.asList("Cookie", cookie));
     }
 
     JiraHost(URI uri, JiraVault jiraVault) {

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraIssue.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraIssue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -242,8 +242,8 @@ public class JiraIssue implements Issue {
                 } else {
                     throw new RuntimeException("Cannot transition to Closed");
                 }
-                performTransition(availableTransitions.get("Closed"));
             }
+            performTransition(availableTransitions.get("Closed"));
         } else if (state == State.OPEN) {
             if (!availableTransitions.containsKey("Open")) {
                 throw new RuntimeException("Cannot transition to Open");

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraIssueTrackerFactory.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraIssueTrackerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,5 +52,13 @@ public class JiraIssueTrackerFactory implements IssueTrackerFactory {
                 throw new RuntimeException("basic authentication not implemented yet");
             }
         }
+    }
+
+    /**
+     * Get the issue tracker according to the cookie which is copied from the browser.
+     * This method is only used by the manual test code.
+     */
+    public IssueTracker create(URI uri, String cookie) {
+        return new JiraHost(uri, cookie);
     }
 }

--- a/issuetracker/src/test/java/org/openjdk/skara/issuetracker/jira/JiraProjectTests.java
+++ b/issuetracker/src/test/java/org/openjdk/skara/issuetracker/jira/JiraProjectTests.java
@@ -26,9 +26,9 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openjdk.skara.issuetracker.Issue;
 import org.openjdk.skara.network.URIBuilder;
+import org.openjdk.skara.test.ManualTestSettings;
 
 import java.io.IOException;
-import org.openjdk.skara.test.ManualTestSettings;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;

--- a/issuetracker/src/test/java/org/openjdk/skara/issuetracker/jira/JiraProjectTests.java
+++ b/issuetracker/src/test/java/org/openjdk/skara/issuetracker/jira/JiraProjectTests.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import org.openjdk.skara.test.ManualTestSettings;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.openjdk.skara.issuetracker.jira.JiraProject.JEP_NUMBER;
 
@@ -77,7 +78,7 @@ public class JiraProjectTests {
         var jiraProject = jiraHost.project(projectId);
         var jiraIssueOpt = jiraProject.issue(issueId);
         var jiraIssue = jiraIssueOpt.get();
-        assertEquals(Issue.State.RESOLVED, jiraIssue.state());
+        assertNotEquals(Issue.State.CLOSED, jiraIssue.state());
         jiraIssue.setState(Issue.State.CLOSED);
         var jiraIssueOpt2 = jiraProject.issue(issueId);
         assertEquals(Issue.State.CLOSED, jiraIssueOpt2.get().state());

--- a/issuetracker/src/test/java/org/openjdk/skara/issuetracker/jira/JiraProjectTests.java
+++ b/issuetracker/src/test/java/org/openjdk/skara/issuetracker/jira/JiraProjectTests.java
@@ -24,9 +24,11 @@ package org.openjdk.skara.issuetracker.jira;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.openjdk.skara.issuetracker.Issue;
 import org.openjdk.skara.network.URIBuilder;
 
 import java.io.IOException;
+import org.openjdk.skara.test.ManualTestSettings;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -61,5 +63,23 @@ public class JiraProjectTests {
         // Test the wrong JEP (number with alphabet).
         var wrongNumberJepOpt = jiraProject.jepIssue("JDK-123");
         assertTrue(wrongNumberJepOpt.isEmpty());
+    }
+
+    @Test
+    void test() throws IOException {
+        var settings = ManualTestSettings.loadManualTestSettings();
+        var jiraUri = settings.getProperty("jira-uri");
+        var cookie = settings.getProperty("jira-cookie");
+        var projectId = settings.getProperty("jira-project-id");
+        var issueId = settings.getProperty("jira-issue-id");
+        var uri = URIBuilder.base(jiraUri).build();
+        var jiraHost = new JiraIssueTrackerFactory().create(uri, cookie);
+        var jiraProject = jiraHost.project(projectId);
+        var jiraIssueOpt = jiraProject.issue(issueId);
+        var jiraIssue = jiraIssueOpt.get();
+        assertEquals(Issue.State.RESOLVED, jiraIssue.state());
+        jiraIssue.setState(Issue.State.CLOSED);
+        var jiraIssueOpt2 = jiraProject.issue(issueId);
+        assertEquals(Issue.State.CLOSED, jiraIssueOpt2.get().state());
     }
 }


### PR DESCRIPTION
Hi all,

Currently, when the method "JiraIssue#setState" is invoked with the argument "State.CLOSED", it can't work as expected. This patch fixes it and add a manual test case for it. And I run the newly added test munually to close SKARA-1463 [1] and SKARA-1516 [2] so that this patch can be verified.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

[1] https://bugs.openjdk.org/browse/SKARA-1463
[2] https://bugs.openjdk.org/browse/SKARA-1516

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1536](https://bugs.openjdk.org/browse/SKARA-1536): The method "JiraIssue#setState" is invalid when using the argument "State.CLOSED"


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**) ⚠️ Review applies to [558561f0](https://git.openjdk.org/skara/pull/1353/files/558561f0e7010f0bbd8e407f56d24bd757722ee2)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1353/head:pull/1353` \
`$ git checkout pull/1353`

Update a local copy of the PR: \
`$ git checkout pull/1353` \
`$ git pull https://git.openjdk.org/skara pull/1353/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1353`

View PR using the GUI difftool: \
`$ git pr show -t 1353`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1353.diff">https://git.openjdk.org/skara/pull/1353.diff</a>

</details>
