### PR TITLE
1537: SponsorCommand can fail indefinitely with '/integrate auto'

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -359,7 +359,8 @@ class CheckWorkItem extends PullRequestWorkItem {
             }
         }
 
-        if (pr.labelNames().contains("auto") && pr.labelNames().contains("ready") && !pr.labelNames().contains("sponsor")) {
+        if (pr.labelNames().contains("auto") && pr.labelNames().contains("ready")
+                && !pr.labelNames().contains("sponsor") && !unhandledIntegrateCommand(comments)) {
             pr.addComment("/integrate\n" + PullRequestCommandWorkItem.VALID_BOT_COMMAND_MARKER);
         }
 
@@ -387,6 +388,18 @@ class CheckWorkItem extends PullRequestWorkItem {
             localRepo = PullRequestUtils.materialize(hostedRepositoryPool, pr, localRepoPath);
         }
         return localRepo;
+    }
+
+    /**
+     * Looks through comments for any /integrate command that has not yet been handled.
+     * Used to avoid double posting /integrate
+     */
+    private boolean unhandledIntegrateCommand(List<Comment> comments) {
+        var allCommands = PullRequestCommandWorkItem.findAllCommands(pr, comments);
+        var handled = PullRequestCommandWorkItem.findHandledCommands(pr, comments);
+        return allCommands.stream()
+                .filter(ci -> ci.name().equals("integrate"))
+                .anyMatch(ci -> !handled.contains(ci.id()));
     }
 
     @Override

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
@@ -54,15 +54,23 @@ public class SponsorCommand implements CommandHandler {
         }
 
         var readyHash = ReadyForSponsorTracker.latestReadyForSponsor(pr.repository().forge().currentUser(), allComments);
-        if (!pr.labelNames().contains("auto") && readyHash.isEmpty()) {
-            reply.println("The change author (@" + pr.author().username() + ") must issue an `integrate` command before the integration can be sponsored.");
+        if (readyHash.isEmpty()) {
+            if (!pr.labelNames().contains("auto")) {
+                reply.println("The change author (@" + pr.author().username() + ") must issue an `integrate` command before the integration can be sponsored.");
+            } else {
+                reply.println("The PR is not yet marked as ready to be sponsored. Please try again when it is.");
+            }
             return;
         }
 
-        var acceptedHash = readyHash.orElseThrow();
-        if (!pr.labelNames().contains("auto") && !pr.headHash().equals(acceptedHash)) {
-            reply.print("The PR has been updated since the change author (@" + pr.author().username() + ") ");
-            reply.println("issued the `integrate` command - the author must perform this command again.");
+        var acceptedHash = readyHash.get();
+        if (!pr.headHash().equals(acceptedHash)) {
+            if (!pr.labelNames().contains("auto")) {
+                reply.print("The PR has been updated since the change author (@" + pr.author().username() + ") ");
+                reply.println("issued the `integrate` command - the author must perform this command again.");
+            } else {
+                reply.print("The PR is not yet marked as ready to be sponsored. Please try again when it is.");
+            }
             return;
         }
 


### PR DESCRIPTION
This patch fixes two issues. The main one is an Optional "No value present" issue in SponsorCommand which can happen in combination with '/integrate auto' if a sponsor is too quick. With this patch, appropriate error replies are added by the bot when this happens, asking the sponsor to try again when the PR is in a suitable state. The commands on PRs and commits are designed to be evaluated in order, so there is really no way around this if they aren't issued in the right order.

Related to this, I'm also fixing SKARA-1534, where CheckWorkItem would continuously post new '/integrate' comments when '/integrate auto' is activated. This would typically happen in conjunction with the above sponsor problem, and did actually cause my new test to fail (as it found 2 replies to /integrate instead of 1), so I decided to fix that in the same patch. To do that, I exposed some static utility methods from PullRequestCommandWorkItem to be able to identify if any unhandled '/integrate' commands were already present in the PR.

/issue add SKARA-1534

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issues
 * [SKARA-1537](https://bugs.openjdk.org/browse/SKARA-1537): SponsorCommand can fail indefinitely with '/integrate auto'
 * [SKARA-1534](https://bugs.openjdk.org/browse/SKARA-1534): Bot posts multiple /integrate commands


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1354/head:pull/1354` \
`$ git checkout pull/1354`

Update a local copy of the PR: \
`$ git checkout pull/1354` \
`$ git pull https://git.openjdk.org/skara pull/1354/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1354`

View PR using the GUI difftool: \
`$ git pr show -t 1354`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1354.diff">https://git.openjdk.org/skara/pull/1354.diff</a>

</details>
