### PR TITLE
1539: Allow dots in merge PR branch name

### DIFF
--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
@@ -62,12 +62,12 @@ class MergeTests {
             localRepo.push(masterHash, author.url(), "master", true);
 
             // Make more changes in another branch
-            var otherHash1 = CheckableRepository.appendAndCommit(localRepo, "First change in other",
-                                                                "First other\n\nReviewed-by: integrationreviewer2");
-            localRepo.push(otherHash1, author.url(), "other", true);
-            var otherHash2 = CheckableRepository.appendAndCommit(localRepo, "Second change in other",
-                                                                "Second other\n\nReviewed-by: integrationreviewer2");
-            localRepo.push(otherHash2, author.url(), "other");
+            var otherHash1 = CheckableRepository.appendAndCommit(localRepo, "First change in other1.1",
+                                                                "First other1.1\n\nReviewed-by: integrationreviewer2");
+            localRepo.push(otherHash1, author.url(), "other1.1", true);
+            var otherHash2 = CheckableRepository.appendAndCommit(localRepo, "Second change in other1.1",
+                                                                "Second other1.1\n\nReviewed-by: integrationreviewer2");
+            localRepo.push(otherHash2, author.url(), "other1.1");
 
             // Go back to the original master
             localRepo.checkout(masterHash, true);
@@ -81,7 +81,7 @@ class MergeTests {
 
             var mergeHash = localRepo.commit("Merge commit", "some", "some@one");
             localRepo.push(mergeHash, author.url(), "edit", true);
-            var pr = credentials.createPullRequest(author, "master", "edit", "Merge " + author.name() + ":other");
+            var pr = credentials.createPullRequest(author, "master", "edit", "Merge " + author.name() + ":other1.1");
 
             // Approve it as another user
             var approvalPr = integrator.pullRequest(pr.id());
@@ -119,7 +119,7 @@ class MergeTests {
 
             // Author and committer should updated in the merge commit
             var headCommit = pushedRepo.commits(headHash.hex() + "^.." + headHash.hex()).asList().get(0);
-            assertEquals("Merge " + author.name() + ":other", headCommit.message().get(0));
+            assertEquals("Merge " + author.name() + ":other1.1", headCommit.message().get(0));
             assertEquals("Generated Committer 1", headCommit.author().name());
             assertEquals("integrationcommitter1@openjdk.org", headCommit.author().email());
             assertEquals("Generated Committer 1", headCommit.committer().name());

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
@@ -62,12 +62,12 @@ class MergeTests {
             localRepo.push(masterHash, author.url(), "master", true);
 
             // Make more changes in another branch
-            var otherHash1 = CheckableRepository.appendAndCommit(localRepo, "First change in other1.1",
-                                                                "First other1.1\n\nReviewed-by: integrationreviewer2");
-            localRepo.push(otherHash1, author.url(), "other1.1", true);
-            var otherHash2 = CheckableRepository.appendAndCommit(localRepo, "Second change in other1.1",
-                                                                "Second other1.1\n\nReviewed-by: integrationreviewer2");
-            localRepo.push(otherHash2, author.url(), "other1.1");
+            var otherHash1 = CheckableRepository.appendAndCommit(localRepo, "First change in other_/-1.2",
+                                                                "First other_/-1.2\n\nReviewed-by: integrationreviewer2");
+            localRepo.push(otherHash1, author.url(), "other_/-1.2", true);
+            var otherHash2 = CheckableRepository.appendAndCommit(localRepo, "Second change in other_/-1.2",
+                                                                "Second other_/-1.2\n\nReviewed-by: integrationreviewer2");
+            localRepo.push(otherHash2, author.url(), "other_/-1.2");
 
             // Go back to the original master
             localRepo.checkout(masterHash, true);
@@ -81,7 +81,7 @@ class MergeTests {
 
             var mergeHash = localRepo.commit("Merge commit", "some", "some@one");
             localRepo.push(mergeHash, author.url(), "edit", true);
-            var pr = credentials.createPullRequest(author, "master", "edit", "Merge " + author.name() + ":other1.1");
+            var pr = credentials.createPullRequest(author, "master", "edit", "Merge " + author.name() + ":other_/-1.2");
 
             // Approve it as another user
             var approvalPr = integrator.pullRequest(pr.id());
@@ -119,7 +119,7 @@ class MergeTests {
 
             // Author and committer should updated in the merge commit
             var headCommit = pushedRepo.commits(headHash.hex() + "^.." + headHash.hex()).asList().get(0);
-            assertEquals("Merge " + author.name() + ":other1.1", headCommit.message().get(0));
+            assertEquals("Merge " + author.name() + ":other_/-1.2", headCommit.message().get(0));
             assertEquals("Generated Committer 1", headCommit.author().name());
             assertEquals("integrationcommitter1@openjdk.org", headCommit.author().email());
             assertEquals("Generated Committer 1", headCommit.committer().name());
@@ -1352,7 +1352,7 @@ class MergeTests {
             assertEquals(1, error, () -> pr.comments().stream().map(Comment::body).collect(Collectors.joining("\n\n")));
 
             var check = pr.checks(mergeHash).get("jcheck");
-            assertEquals("- Could not determine the source for this merge. A Merge PR title must be specified in the format: `^Merge ([-/\\w:+]+)$` to allow verification of the merge contents.", check.summary().orElseThrow());
+            assertEquals("- Could not determine the source for this merge. A Merge PR title must be specified in the format: `^Merge ([-/.\\w:+]+)$` to allow verification of the merge contents.", check.summary().orElseThrow());
         }
     }
 

--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequestUtils.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequestUtils.java
@@ -39,7 +39,7 @@ public class PullRequestUtils {
                                 committer.name(), committer.email(), ZonedDateTime.now(), List.of(targetHash(localRepo)), localRepo.tree(finalHead));
     }
 
-    private final static Pattern mergeSourcePattern = Pattern.compile("^Merge ([-/\\w:+]+)$");
+    private final static Pattern mergeSourcePattern = Pattern.compile("^Merge ([-/.\\w:+]+)$");
     private final static Pattern hashSourcePattern = Pattern.compile("[0-9a-fA-F]{6,40}");
 
     private static Optional<Hash> fetchRef(Repository localRepo, URI uri, String ref) {


### PR DESCRIPTION
This patch makes it possible to create merge style PRs based on branches with periods `.` in the branch name. We quite commonly put periods in branch names as we like to base branches on version strings.

Modified an existing test to cover this case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1539](https://bugs.openjdk.org/browse/SKARA-1539): Allow dots in merge PR branch name


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**) ⚠️ Review applies to [bb6825b9](https://git.openjdk.org/skara/pull/1355/files/bb6825b9bd580f7d10c39300795dfa13ace9707d)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1355/head:pull/1355` \
`$ git checkout pull/1355`

Update a local copy of the PR: \
`$ git checkout pull/1355` \
`$ git pull https://git.openjdk.org/skara pull/1355/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1355`

View PR using the GUI difftool: \
`$ git pr show -t 1355`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1355.diff">https://git.openjdk.org/skara/pull/1355.diff</a>

</details>
