### PR TITLE
1542: Census Namespace missing hashCode and equals

### DIFF
--- a/census/src/main/java/org/openjdk/skara/census/Namespace.java
+++ b/census/src/main/java/org/openjdk/skara/census/Namespace.java
@@ -101,7 +101,9 @@ public class Namespace {
             return false;
         }
         Namespace namespace = (Namespace) o;
-        return name.equals(namespace.name) && mapping.equals(namespace.mapping) && reverse.equals(namespace.reverse);
+        return Objects.equals(name, namespace.name)
+                && Objects.equals(mapping, namespace.mapping)
+                && Objects.equals(reverse, namespace.reverse);
     }
 
     @Override

--- a/census/src/main/java/org/openjdk/skara/census/Namespace.java
+++ b/census/src/main/java/org/openjdk/skara/census/Namespace.java
@@ -91,4 +91,21 @@ public class Namespace {
 
         return new Namespace(name, mapping, reverse);
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Namespace namespace = (Namespace) o;
+        return name.equals(namespace.name) && mapping.equals(namespace.mapping) && reverse.equals(namespace.reverse);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, mapping, reverse);
+    }
 }


### PR DESCRIPTION
The Namespace class is missing hashCode and equals. This patch adds implementations for those two methods. The other data classes in the Census module already have them. 

This is preventing the change in [SKARA-1529](https://bugs.openjdk.org/browse/SKARA-1529) from actually taking effect, as we can't compare two instances of Namespace to see if they have the same contents.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1542](https://bugs.openjdk.org/browse/SKARA-1542): Census Namespace missing hashCode and equals


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**) ⚠️ Review applies to [e0f5d6ea](https://git.openjdk.org/skara/pull/1356/files/e0f5d6ea32d8fb8b830660887799d201af19cd9f)
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**) ⚠️ Review applies to [e0f5d6ea](https://git.openjdk.org/skara/pull/1356/files/e0f5d6ea32d8fb8b830660887799d201af19cd9f)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1356/head:pull/1356` \
`$ git checkout pull/1356`

Update a local copy of the PR: \
`$ git checkout pull/1356` \
`$ git pull https://git.openjdk.org/skara pull/1356/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1356`

View PR using the GUI difftool: \
`$ git pr show -t 1356`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1356.diff">https://git.openjdk.org/skara/pull/1356.diff</a>

</details>
