### PR TITLE
1355: Mirror bot needs branch selection based on patterns

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -594,6 +594,9 @@ public class GitRepository implements Repository {
 
         if (includeTags) {
             cmd.add("--tags");
+            if (force) {
+                cmd.add("--force");
+            }
         }
 
         cmd.add(uri.toString());


### PR DESCRIPTION
This patch makes it possible to configure mirrored branches with regex patterns. For what I think is improved readability, I made it possible to supply the patterns as an array of strings, so we can have multiple separate patterns. It's still possible to define "branches" as a comma separated list, for backwards compatibility.

When deploying this change, I will need to delete the existing local repos used for mirroring on the bot runner machine, because the method by which repos are cloned is changing (for repos that do not just mirror "everything"). Going forward, I think it's good to always clone all repos the same way, regardless of configuration.

There is another behavioral change, where I'm adding `--force` when pushing branches with `includeTags`. It happens a bit too often that a repo maintainer changes tags, which currently causes error for any mirroring job because we aren't force pushing tags. I don't think we ever want to not force update when mirroring repos.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1355](https://bugs.openjdk.org/browse/SKARA-1355): Mirror bot needs branch selection based on patterns


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1358/head:pull/1358` \
`$ git checkout pull/1358`

Update a local copy of the PR: \
`$ git checkout pull/1358` \
`$ git pull https://git.openjdk.org/skara pull/1358/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1358`

View PR using the GUI difftool: \
`$ git pr show -t 1358`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1358.diff">https://git.openjdk.org/skara/pull/1358.diff</a>

</details>
