### PR TITLE
1551: Improve logging and metrics for BotRunner

### DIFF
--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
@@ -442,11 +442,14 @@ public class BotRunner {
             log.log(Level.FINE, "Starting of checking for periodic items", TaskPhases.BEGIN);
             try {
                 for (var bot : bots) {
-                    Instant botStart = Instant.now();
-                    var items = bot.getPeriodicItems();
-                    PERIODIC_CHECK_TIME.labels(bot.name()).inc(Duration.between(botStart, Instant.now()).toMillis() / 1_000.0);
-                    for (var item : items) {
-                        submitOrSchedule(item);
+                    try (var ___ = new LogContext("bot", bot.toString())) {
+                        Instant botStart = Instant.now();
+                        log.fine("Starting of checking for periodic items for " + bot.toString());
+                        var items = bot.getPeriodicItems();
+                        PERIODIC_CHECK_TIME.labels(bot.name()).inc(Duration.between(botStart, Instant.now()).toMillis() / 1_000.0);
+                        for (var item : items) {
+                            submitOrSchedule(item);
+                        }
                     }
                 }
             } catch (UncheckedRestException e) {

--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
@@ -100,7 +100,7 @@ public class BotRunner {
         private static final Counter.WithTwoLabels TIME_COUNTER =
                 Counter.name("skara_runner_run_time_total").labels("bot", "work_item").register();
         private static final Counter.WithTwoLabels ITEM_FINISHED_COUNTER =
-                Counter.name("skara_runner_finished").labels("bot", "work_item").register();
+                Counter.name("skara_runner_finished_counter").labels("bot", "work_item").register();
         private static final Counter.WithTwoLabels CPU_TIME_COUNTER =
                 Counter.name("skara_runner_cpu_time_total").labels("bot", "work_item").register();
         private static final Counter.WithTwoLabels ALLOCATED_BYTES_COUNTER =

--- a/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestCloserBot.java
+++ b/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestCloserBot.java
@@ -152,4 +152,9 @@ public class PullRequestCloserBot implements Bot {
     public String name() {
         return BridgekeeperBotFactory.NAME;
     }
+
+    @Override
+    public String toString() {
+        return "PullRequestCloserBot@" + remoteRepo.name();
+    }
 }

--- a/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestPrunerBot.java
+++ b/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestPrunerBot.java
@@ -176,4 +176,9 @@ public class PullRequestPrunerBot implements Bot {
     public String name() {
         return BridgekeeperBotFactory.NAME;
     }
+
+    @Override
+    public String toString() {
+        return "PullRequestPrunerBot";
+    }
 }

--- a/bots/cli/src/test/java/org/openjdk/skara/bots/cli/BotLogstashHandlerTests.java
+++ b/bots/cli/src/test/java/org/openjdk/skara/bots/cli/BotLogstashHandlerTests.java
@@ -90,7 +90,7 @@ class BotLogstashHandlerTests {
             assertEquals("Bye", requests.get(2).get("message").asString());
             assertEquals(Level.WARNING.toString(), requests.get(0).get("level").asString());
             assertNotNull(requests.get(0).get("work_id"), "work_id not set");
-            assertTrue(requests.get(0).get("work_item").asString().contains("LoggingBot@"),
+            assertTrue(requests.get(0).get("work_item").asString().contains("LoggingBot"),
                     "work_item has bad value " + requests.get(0).get("work_item").asString());
         }
     }

--- a/bots/cli/src/test/java/org/openjdk/skara/bots/cli/LoggingBot.java
+++ b/bots/cli/src/test/java/org/openjdk/skara/bots/cli/LoggingBot.java
@@ -95,4 +95,9 @@ public class LoggingBot implements Bot, WorkItem {
     public String workItemName() {
         return botName();
     }
+
+    @Override
+    public String toString() {
+        return "LoggingBot";
+    }
 }

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBot.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBot.java
@@ -148,4 +148,9 @@ public class MailingListArchiveReaderBot implements Bot {
     public String name() {
         return MailingListBridgeBotFactory.NAME;
     }
+
+    @Override
+    public String toString() {
+        return "MailingListArchiveReaderBot@" + repository.name();
+    }
 }

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBot.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBot.java
@@ -238,4 +238,9 @@ public class MailingListBridgeBot implements Bot {
     public String name() {
         return MailingListBridgeBotFactory.NAME;
     }
+
+    @Override
+    public String toString() {
+        return "MailingListBridgeBot@" + codeRepo.name();
+    }
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/NotifyBot.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/NotifyBot.java
@@ -109,7 +109,7 @@ public class NotifyBot implements Bot, Emitter {
 
     @Override
     public String toString() {
-        return "JNotifyBot@" + repository.name();
+        return "NotifyBot@" + repository.name();
     }
 
     @Override

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -316,4 +316,9 @@ class PullRequestBot implements Bot {
     public String name() {
         return PullRequestBotFactory.NAME;
     }
+
+    @Override
+    public String toString() {
+        return "PullRequestBot@" + remoteRepo.name();
+    }
 }

--- a/bots/submit/src/main/java/org/openjdk/skara/bots/submit/SubmitBot.java
+++ b/bots/submit/src/main/java/org/openjdk/skara/bots/submit/SubmitBot.java
@@ -56,4 +56,9 @@ public class SubmitBot implements Bot {
     public String name() {
         return SubmitBotFactory.NAME;
     }
+
+    @Override
+    public String toString() {
+        return "SubmitBot@" + repository.name();
+    }
 }

--- a/bots/synclabel/src/main/java/org/openjdk/skara/bots/synclabel/SyncLabelBot.java
+++ b/bots/synclabel/src/main/java/org/openjdk/skara/bots/synclabel/SyncLabelBot.java
@@ -87,4 +87,9 @@ public class SyncLabelBot implements Bot {
     public String name() {
         return SyncLabelBotFactory.NAME;
     }
+
+    @Override
+    public String toString() {
+        return "SyncLabelBot@" + issueProject.name();
+    }
 }

--- a/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestBot.java
+++ b/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestBot.java
@@ -143,4 +143,9 @@ public class TestBot implements Bot {
     public String name() {
         return "test";
     }
+
+    @Override
+    public String toString() {
+        return "TestBot@" + repo.name();
+    }
 }

--- a/bots/testinfo/src/main/java/org/openjdk/skara/bots/testinfo/TestInfoBot.java
+++ b/bots/testinfo/src/main/java/org/openjdk/skara/bots/testinfo/TestInfoBot.java
@@ -71,4 +71,9 @@ public class TestInfoBot implements Bot {
     public String name() {
         return TestInfoBotFactory.NAME;
     }
+
+    @Override
+    public String toString() {
+        return "TestInfoBot@" + repo.name();
+    }
 }


### PR DESCRIPTION
I'm trying to better understand bot performance. I'm sure there are lots of things we could improve performance wise, but first we need to figure out how. We already have some logging and metrics gathering, but it's still not providing me with the information I need.

With this change, I'm aiming to gather better metrics and logging around the getPeriodicItems() call, as well as refining the metrics for running WorkItems.

The thread user time measurements from MX beans is useless to me, so I'm removing it. The cpu time is probably also useless, but I'm keeping it for now. What I really want is wall clock time for WorkItems, so I'm adding that. The gauges for measuring any kind of running time aren't useful at all. At least with counters, we can get some kind of idea how much time is spent on each kind of WorkItem over some time frame (using a rate function in the presentation layer).

To complement the timing counters, I'm adding simple WorkItem counters as well, to keep track how many are scheduled, added as pending, submitted and finished.

For the BotRunner.checkPeriodicItems() method, I'm adding two metrics. Since the whole method is running only one at a time, a gauge for tracking how long each round takes does make sense. Then for each sub call to Bot.getPeriodicItems there is a counter that basically gives the breakdown on how much of the time is spent in each kind of bot.

For logging, I'm adding some more log messages to better track which Bot.getPeriodic item is called when, and a LogContext, so that all log messages are tagged with the bot toString, just like WorkItems are already. To support this I had to add toString() methods to all Bot implementations that were missing it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1551](https://bugs.openjdk.org/browse/SKARA-1551): Improve logging and metrics for BotRunner


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1359/head:pull/1359` \
`$ git checkout pull/1359`

Update a local copy of the PR: \
`$ git checkout pull/1359` \
`$ git pull https://git.openjdk.org/skara pull/1359/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1359`

View PR using the GUI difftool: \
`$ git pr show -t 1359`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1359.diff">https://git.openjdk.org/skara/pull/1359.diff</a>

</details>
