### PR TITLE
1431: The method TestPullRequest#diff sometimes returns wrong information

### DIFF
--- a/bots/csr/src/test/java/org/openjdk/skara/bots/csr/CSRBotTests.java
+++ b/bots/csr/src/test/java/org/openjdk/skara/bots/csr/CSRBotTests.java
@@ -329,6 +329,9 @@ class CSRBotTests {
             // The bot shouldn't add the `csr` label.
             assertFalse(pr.labelNames().contains("csr"));
 
+            // Test the method `TestPullRequest#diff`.
+            assertEquals(1, pr.diff().patches().size());
+
             // Add `version=bla` to `.jcheck/conf`, set the version as a wrong value
             localRepo.checkout(localRepo.defaultBranch());
             defaultConf = Files.readString(localRepo.root().resolve(".jcheck/conf"), StandardCharsets.UTF_8);
@@ -341,6 +344,9 @@ class CSRBotTests {
             TestBotRunner.runPeriodicItems(csrPullRequestBot);
             // The bot shouldn't add the `csr` label.
             assertFalse(pr.labelNames().contains("csr"));
+
+            // Test the method `TestPullRequest#diff`.
+            assertEquals(1, pr.diff().patches().size());
 
             // Set the `version` in `.jcheck/conf` as 17 which is an available version.
             localRepo.checkout(localRepo.defaultBranch());

--- a/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
@@ -252,14 +252,7 @@ public class TestPullRequest extends TestIssue implements PullRequest {
                 sourceHash = targetLocalRepository.fetch(sourceUri, sourceRef);
             }
             // Find the base hash of the source and target branches.
-            var baseHash = sourceHash;
-            var targetBranch = new Branch(targetRef());
-            while (!"0".repeat(40).equals(baseHash.hex())) {
-                if (targetLocalRepository.contains(targetBranch, baseHash)) {
-                    break;
-                }
-                baseHash = targetRepository.commit(baseHash).get().parents().get(0);
-            }
+            var baseHash = targetLocalRepository.mergeBase(sourceHash, targetRepository.branchHash(targetRef()));
             return targetLocalRepository.diff(baseHash, sourceHash);
         } catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
@@ -26,6 +26,7 @@ import org.openjdk.skara.forge.*;
 import org.openjdk.skara.host.*;
 import org.openjdk.skara.issuetracker.IssueProject;
 import org.openjdk.skara.network.URIBuilder;
+import org.openjdk.skara.vcs.Branch;
 import org.openjdk.skara.vcs.Diff;
 import org.openjdk.skara.vcs.Hash;
 
@@ -242,17 +243,24 @@ public class TestPullRequest extends TestIssue implements PullRequest {
     @Override
     public Diff diff() {
         try {
-            var targetHash = targetRepository.branchHash(targetRef());
             var targetLocalRepository = targetRepository.localRepository();
             var sourceLocalRepository = sourceRepository.localRepository();
-            if (targetLocalRepository.root().equals(sourceLocalRepository.root())) {
-                // same target and source repo, must contain both commits
-                return targetLocalRepository.diff(targetHash, headHash());
-            } else {
-                var uri = URI.create("file://" + sourceLocalRepository.root().toString());
-                var fetchHead = targetLocalRepository.fetch(uri, sourceRef);
-                return targetLocalRepository.diff(targetHash, fetchHead);
+            var sourceHash = headHash();
+            if (!targetLocalRepository.root().equals(sourceLocalRepository.root())) {
+                // The target and source repo are not same, fetch the source branch
+                var sourceUri = URI.create("file://" + sourceLocalRepository.root().toString());
+                sourceHash = targetLocalRepository.fetch(sourceUri, sourceRef);
             }
+            // Find the base hash of the source and target branches.
+            var baseHash = sourceHash;
+            var targetBranch = new Branch(targetRef());
+            while (!"0".repeat(40).equals(baseHash.hex())) {
+                if (targetLocalRepository.contains(targetBranch, baseHash)) {
+                    break;
+                }
+                baseHash = targetRepository.commit(baseHash).get().parents().get(0);
+            }
+            return targetLocalRepository.diff(baseHash, sourceHash);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }


### PR DESCRIPTION
Hi all,

The method `TestPullRequest#diff` always passes the head hash of the target branch to the method `Repository#diff` as the base hash. But it may be wrong when the target branch was submitted some new commits after creating the pull request. `TestPullRequest#diff` should find the last common hash of the source and target branch as the base hash.

This patch fixes the bug and adds the test case. I don't know whether it is good to place the test case at the class `CSRBotTests`, but the method `CSRBotTests#testBackportCsr` indeed contains the situation of this bug.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1431](https://bugs.openjdk.org/browse/SKARA-1431): The method TestPullRequest#diff sometimes returns wrong information


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1360/head:pull/1360` \
`$ git checkout pull/1360`

Update a local copy of the PR: \
`$ git checkout pull/1360` \
`$ git pull https://git.openjdk.org/skara pull/1360/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1360`

View PR using the GUI difftool: \
`$ git pr show -t 1360`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1360.diff">https://git.openjdk.org/skara/pull/1360.diff</a>

</details>
