### PR TITLE
1552: Log relevant timer numbers

### DIFF
--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
@@ -233,7 +233,7 @@ public class BotRunner {
                     item.handleRuntimeException(e);
                 } finally {
                     var duration = Duration.between(start, Instant.now());
-                    log.log(Level.FINE, "Item " + item + " is now done " + duration,
+                    log.log(Level.FINE, "Item " + item + " is now done after " + duration,
                             new Object[]{TaskPhases.END, duration});
                 }
                 if (followUpItems != null) {

--- a/bot/src/main/java/org/openjdk/skara/bot/BotTaskAggregationHandler.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotTaskAggregationHandler.java
@@ -56,10 +56,7 @@ public abstract class BotTaskAggregationHandler extends StreamHandler {
         if (record.getParameters() == null) {
             return false;
         }
-        if (record.getParameters().length != 1) {
-            return false;
-        }
-        return marker.equals(record.getParameters()[0]);
+        return Arrays.asList(record.getParameters()).contains(marker);
     }
 
     @Override

--- a/bots/cli/src/main/java/org/openjdk/skara/bots/cli/BotLogstashHandler.java
+++ b/bots/cli/src/main/java/org/openjdk/skara/bots/cli/BotLogstashHandler.java
@@ -113,6 +113,15 @@ public class BotLogstashHandler extends StreamHandler {
             query.put("logger_name", record.getLoggerName());
         }
 
+        var parameters = record.getParameters();
+        if (parameters != null) {
+            for (var parameter : parameters) {
+                if (parameter instanceof Duration duration) {
+                    query.put("duration", duration.toMillis());
+                }
+            }
+        }
+
         if (record.getThrown() != null) {
             var writer = new StringWriter();
             var printer = new PrintWriter(writer);

--- a/bots/csr/src/main/java/org/openjdk/skara/bots/csr/CSRIssueBot.java
+++ b/bots/csr/src/main/java/org/openjdk/skara/bots/csr/CSRIssueBot.java
@@ -102,7 +102,6 @@ public class CSRIssueBot implements Bot {
                 }
             }
             var issueWorkItem = new IssueWorkItem(this, issue);
-            log.fine("Scheduling: " + issueWorkItem);
             ret.add(issueWorkItem);
         }
         issueUpdatedAt = newIssuesUpdatedAt;

--- a/bots/csr/src/main/java/org/openjdk/skara/bots/csr/CSRPullRequestBot.java
+++ b/bots/csr/src/main/java/org/openjdk/skara/bots/csr/CSRPullRequestBot.java
@@ -80,8 +80,7 @@ class CSRPullRequestBot implements Bot {
                     continue;
                 }
             }
-            var pullRequestWorkItem = new PullRequestWorkItem(repo, pr.id(), project);
-            log.fine("Scheduling: " + pullRequestWorkItem);
+            var pullRequestWorkItem = new PullRequestWorkItem(repo, pr.id(), project, pr.updatedAt());
             items.add(pullRequestWorkItem);
         }
         prsUpdatedAt = newPrsUpdatedAt;

--- a/bots/csr/src/main/java/org/openjdk/skara/bots/csr/IssueWorkItem.java
+++ b/bots/csr/src/main/java/org/openjdk/skara/bots/csr/IssueWorkItem.java
@@ -83,9 +83,10 @@ class IssueWorkItem implements WorkItem {
                         .flatMap(Optional::stream)
                         .findAny())
                 .flatMap(Optional::stream)
-                .map(pr -> new PullRequestWorkItem(pr.repository(), pr.id(), csrIssue.project()))
+                // This will mix time stamps from the IssueTracker and the Forge hosting PRs, but it's the
+                // best we can do.
+                .map(pr -> new PullRequestWorkItem(pr.repository(), pr.id(), csrIssue.project(), csrIssue.updatedAt()))
                 .forEach(ret::add);
-        ret.forEach(item -> log.fine("Scheduling: " + item.toString() + " due to update in " + csrIssue.id()));
         return ret;
     }
 

--- a/bots/csr/src/main/java/org/openjdk/skara/bots/csr/PullRequestWorkItem.java
+++ b/bots/csr/src/main/java/org/openjdk/skara/bots/csr/PullRequestWorkItem.java
@@ -23,9 +23,12 @@
 package org.openjdk.skara.bots.csr;
 
 import java.nio.file.Path;
+import java.time.Duration;
+import java.time.ZonedDateTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.openjdk.skara.bot.WorkItem;
 import org.openjdk.skara.forge.HostedRepository;
@@ -50,11 +53,19 @@ class PullRequestWorkItem implements WorkItem {
     private final HostedRepository repository;
     private final String prId;
     private final IssueProject project;
+    /**
+     * The updatedAt timestamp of the external entity that triggered this WorkItem,
+     * which would be either a PR or a CSR Issue. Used for tracking reaction legacy
+     * of the bot through logging.
+     */
+    private final ZonedDateTime updatedAtTrigger;
 
-    public PullRequestWorkItem(HostedRepository repository, String prId, IssueProject project) {
+    public PullRequestWorkItem(HostedRepository repository, String prId, IssueProject project,
+            ZonedDateTime updatedAtTrigger) {
         this.repository = repository;
         this.prId = prId;
         this.project = project;
+        this.updatedAtTrigger = updatedAtTrigger;
     }
 
     @Override
@@ -168,6 +179,7 @@ class PullRequestWorkItem implements WorkItem {
             } else {
                 log.info("CSR issue resolution is null for " + describe(pr) + ", not removing the CSR label");
             }
+            logLatency();
             return List.of();
         }
         var name = resolution.get("name");
@@ -178,6 +190,7 @@ class PullRequestWorkItem implements WorkItem {
             } else {
                 log.info("CSR issue resolution name is null for " + describe(pr) + ", not removing the CSR label");
             }
+            logLatency();
             return List.of();
         }
 
@@ -188,6 +201,7 @@ class PullRequestWorkItem implements WorkItem {
             } else {
                 log.info("CSR issue state is not closed for " + describe(pr) + ", not removing the CSR label");
             }
+            logLatency();
             return List.of();
         }
 
@@ -204,6 +218,7 @@ class PullRequestWorkItem implements WorkItem {
             } else {
                 log.info("CSR issue resolution is not 'Approved' for " + describe(pr) + ", not removing the CSR label");
             }
+            logLatency();
             return List.of();
         }
 
@@ -217,7 +232,16 @@ class PullRequestWorkItem implements WorkItem {
             log.info("CSR closed and approved for " + describe(pr) + ", adding the csr update marker");
             addUpdateMarker(pr);
         }
+        logLatency();
         return List.of();
+    }
+
+    private void logLatency() {
+        if (log.isLoggable(Level.INFO)) {
+            var updatedPr = repository.pullRequest(prId);
+            var latency = Duration.between(updatedAtTrigger, updatedPr.updatedAt());
+            log.log(Level.INFO, "Time from trigger to CSR state updated in PR " + latency, latency);
+        }
     }
 
     @Override

--- a/bots/csr/src/main/java/org/openjdk/skara/bots/csr/PullRequestWorkItem.java
+++ b/bots/csr/src/main/java/org/openjdk/skara/bots/csr/PullRequestWorkItem.java
@@ -58,14 +58,14 @@ class PullRequestWorkItem implements WorkItem {
      * which would be either a PR or a CSR Issue. Used for tracking reaction legacy
      * of the bot through logging.
      */
-    private final ZonedDateTime updatedAtTrigger;
+    private final ZonedDateTime triggerUpdatedAt;
 
     public PullRequestWorkItem(HostedRepository repository, String prId, IssueProject project,
-            ZonedDateTime updatedAtTrigger) {
+            ZonedDateTime triggerUpdatedAt) {
         this.repository = repository;
         this.prId = prId;
         this.project = project;
-        this.updatedAtTrigger = updatedAtTrigger;
+        this.triggerUpdatedAt = triggerUpdatedAt;
     }
 
     @Override
@@ -239,7 +239,7 @@ class PullRequestWorkItem implements WorkItem {
     private void logLatency() {
         if (log.isLoggable(Level.INFO)) {
             var updatedPr = repository.pullRequest(prId);
-            var latency = Duration.between(updatedAtTrigger, updatedPr.updatedAt());
+            var latency = Duration.between(triggerUpdatedAt, updatedPr.updatedAt());
             log.log(Level.INFO, "Time from trigger to CSR state updated in PR " + latency, latency);
         }
     }

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.skara.bots.mlbridge;
 
+import java.util.logging.Level;
 import org.openjdk.skara.bot.WorkItem;
 import org.openjdk.skara.email.*;
 import org.openjdk.skara.forge.*;
@@ -403,6 +404,10 @@ class ArchiveWorkItem implements WorkItem {
                                          .build();
                 listServer.post(filteredEmail);
             }
+            // Mixing forge time and local time for the latency is not ideal, but the best
+            // we can do here.
+            var latency = Duration.between(pr.updatedAt(), ZonedDateTime.now());
+            log.log(Level.INFO, "Time from PR updated to emails sent " + latency, latency);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/CommentPosterWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/CommentPosterWorkItem.java
@@ -22,6 +22,9 @@
  */
 package org.openjdk.skara.bots.mlbridge;
 
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.util.logging.Level;
 import org.openjdk.skara.bot.WorkItem;
 import org.openjdk.skara.email.*;
 import org.openjdk.skara.forge.PullRequest;
@@ -87,6 +90,9 @@ public class CommentPosterWorkItem implements WorkItem {
 
             log.info("Bridging new message " + message.id() + " from " + message.author() + " to " + pr);
             BridgedComment.post(pr, message);
+            // Timestamp from email and a local date is the best we can do for latency here
+            var latency = Duration.between(message.date(), ZonedDateTime.now());
+            log.log(Level.INFO, "Time from message date to posting comment " + latency, latency);
         }
         return List.of();
     }

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBot.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBot.java
@@ -124,6 +124,7 @@ public class MailingListArchiveReaderBot implements Bot {
             return;
         }
 
+        log.info("Found " + bridgeCandidates.size() + " candidates for comments");
         var workItem = new CommentPosterWorkItem(pr, bridgeCandidates, e -> invalidate(bridgeCandidates));
         commentQueue.add(workItem);
     }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/NotifyBot.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/NotifyBot.java
@@ -33,7 +33,7 @@ import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
 public class NotifyBot implements Bot, Emitter {
-    private final Logger log = Logger.getLogger("org.openjdk.skara.bots");;
+    private final Logger log = Logger.getLogger("org.openjdk.skara.bots");
     private final HostedRepository repository;
     private final Path storagePath;
     private final Pattern branches;

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/PullRequestWorkItem.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/PullRequestWorkItem.java
@@ -22,6 +22,10 @@
  */
 package org.openjdk.skara.bots.notify;
 
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.openjdk.skara.bot.WorkItem;
 import org.openjdk.skara.forge.PullRequest;
 import org.openjdk.skara.json.*;
@@ -36,6 +40,7 @@ import java.util.regex.*;
 import java.util.stream.*;
 
 public class PullRequestWorkItem implements WorkItem {
+    private final Logger log = Logger.getLogger("org.openjdk.skara.bots.notify");
     private final PullRequest pr;
     private final StorageBuilder<PullRequestState> prStateStorageBuilder;
     private final List<PullRequestListener> listeners;
@@ -245,6 +250,10 @@ public class PullRequestWorkItem implements WorkItem {
         }
 
         storage.put(state);
+        // This is mixing timestamps from the forge and the local host, which may not produce
+        // very accurate latencies, but it's the best we can do for this bot.
+        var latency = Duration.between(pr.updatedAt(), ZonedDateTime.now());
+        log.log(Level.INFO, "Time from PR updated to notifications done " + latency, latency);
         return List.of();
     }
 

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryWorkItem.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryWorkItem.java
@@ -22,6 +22,8 @@
  */
 package org.openjdk.skara.bots.notify;
 
+import java.time.Duration;
+import java.time.ZonedDateTime;
 import org.openjdk.skara.bot.WorkItem;
 import org.openjdk.skara.forge.*;
 import org.openjdk.skara.storage.StorageBuilder;
@@ -151,6 +153,14 @@ public class RepositoryWorkItem implements WorkItem {
                 }
                 try {
                     handleUpdatedRef(localRepo, ref, commits, listener, scratchPath.resolve(listener.name()));
+                    if (log.isLoggable(Level.INFO)) {
+                        var now = ZonedDateTime.now();
+                        for (Commit commit : commits) {
+                            var latency = Duration.between(commit.metadata().committed(), now);
+                            log.log(Level.INFO, "Time from committed to notified for " + commit.hash()
+                                    + " on branch " + ref + " " + latency, latency);
+                        }
+                    }
                 } catch (NonRetriableException e) {
                     log.log(Level.INFO, "Non retriable exception occurred", e);
                     errors.add(e.cause());

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/comment/CommitCommentNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/comment/CommitCommentNotifier.java
@@ -85,6 +85,7 @@ class CommitCommentNotifier implements Notifier, PullRequestListener {
         if (existingComments.stream().anyMatch(c -> c.body().equals(commentBody))) {
             log.warning("Commit comment for " + hash + " already posted");
         } else {
+            log.info("Posting commit comment on " + hash);
             repository.addCommitComment(hash, commentBody);
         }
     }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/mailinglist/MailingListNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/mailinglist/MailingListNotifier.java
@@ -209,6 +209,9 @@ class MailingListNotifier implements Notifier, RepositoryListener {
                          .build();
 
         try {
+            log.info("Sending email for commits " + String.join(" ",
+                    commits.stream().map(Commit::hash).map(Hash::toString).toList())
+                    + " on branch " + branch + " to " + recipient);
             server.post(email);
         } catch (RuntimeException e) {
             throw new NonRetriableException(e);
@@ -278,6 +281,9 @@ class MailingListNotifier implements Notifier, RepositoryListener {
             email.author(commitToAuthor(taggedCommit));
         }
 
+        log.info("Sending email for commits " + String.join(" ",
+                commits.stream().map(Commit::hash).map(Hash::toString).toList())
+                + " for tag " + tag + " to " + recipient);
         try {
             server.post(email.build());
         } catch (RuntimeException e) {
@@ -311,6 +317,8 @@ class MailingListNotifier implements Notifier, RepositoryListener {
             email.author(commitToAuthor(commit));
         }
 
+        log.info("Sending email for commit " + commit
+                + " for tag " + tag + " to " + recipient);
         try {
             server.post(email.build());
         } catch (RuntimeException e) {
@@ -369,6 +377,7 @@ class MailingListNotifier implements Notifier, RepositoryListener {
                          .headers(headers)
                          .headers(commitHeaders(repository, commits))
                          .build();
+        log.info("Sending email for new branch " + branch + " to " + recipient);
         try {
             server.post(email);
         } catch (RuntimeException e) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -356,6 +356,11 @@ class CheckWorkItem extends PullRequestWorkItem {
 
                 var expiresAt = CheckRun.execute(this, pr, localRepo, comments, allReviews, activeReviews, labels, census, bot.ignoreStaleReviews(), bot.integrators());
                 if (log.isLoggable(Level.INFO)) {
+                    // Log latency from the original updatedAt of the PR when this WorkItem
+                    // was triggered to when it was just updated by the CheckRun.execute above.
+                    // Both timestamps are taken from the PR data so they originate from the
+                    // same clock (on the forge). Guard this with isLoggable since we need to
+                    // re-fetch the PR data from the forge.
                     var updatedPr = bot.repo().pullRequest(prId);
                     logLatency("Time from PR updated to CheckRun done ", updatedPr.updatedAt(), log);
                 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandExtractor.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandExtractor.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.skara.bots.pr;
 
+import java.time.ZonedDateTime;
 import org.openjdk.skara.forge.HostedCommit;
 import org.openjdk.skara.forge.PullRequest;
 import org.openjdk.skara.issuetracker.Comment;
@@ -100,7 +101,7 @@ public class CommandExtractor {
         }
     }
 
-    static List<CommandInvocation> extractCommands(String text, String baseId, HostUser user) {
+    static List<CommandInvocation> extractCommands(String text, String baseId, HostUser user, ZonedDateTime createdAt) {
         var ret = new ArrayList<CommandInvocation>();
         CommandHandler multiLineHandler = null;
         List<String> multiLineBuffer = null;
@@ -110,7 +111,8 @@ public class CommandExtractor {
             var commandMatcher = commandPattern.matcher(line);
             if (commandMatcher.matches()) {
                 if (multiLineHandler != null) {
-                    ret.add(new CommandInvocation(formatId(baseId, subId++), user, multiLineHandler, multiLineCommand, String.join("\n", multiLineBuffer)));
+                    ret.add(new CommandInvocation(formatId(baseId, subId++), user, multiLineHandler, multiLineCommand,
+                            String.join("\n", multiLineBuffer), createdAt));
                     multiLineHandler = null;
                 }
                 var command = commandMatcher.group(1).toLowerCase();
@@ -123,7 +125,8 @@ public class CommandExtractor {
                     }
                     multiLineCommand = command;
                 } else {
-                    ret.add(new CommandInvocation(formatId(baseId, subId++), user, handler, command, commandMatcher.group(2)));
+                    ret.add(new CommandInvocation(formatId(baseId, subId++), user, handler, command,
+                            commandMatcher.group(2), createdAt));
                 }
             } else {
                 if (multiLineHandler != null) {
@@ -132,7 +135,8 @@ public class CommandExtractor {
             }
         }
         if (multiLineHandler != null) {
-            ret.add(new CommandInvocation(formatId(baseId, subId), user, multiLineHandler, multiLineCommand, String.join("\n", multiLineBuffer)));
+            ret.add(new CommandInvocation(formatId(baseId, subId), user, multiLineHandler,
+                    multiLineCommand, String.join("\n", multiLineBuffer), createdAt));
         }
         return ret;
     }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandInvocation.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandInvocation.java
@@ -22,8 +22,8 @@
  */
 package org.openjdk.skara.bots.pr;
 
+import java.time.ZonedDateTime;
 import org.openjdk.skara.host.HostUser;
-import org.openjdk.skara.issuetracker.Comment;
 
 import java.util.Optional;
 
@@ -33,13 +33,15 @@ class CommandInvocation {
     private final CommandHandler handler;
     private final String name;
     private final String args;
+    private final ZonedDateTime createdAt;
 
-    CommandInvocation(String id, HostUser user, CommandHandler handler, String name, String args) {
+    CommandInvocation(String id, HostUser user, CommandHandler handler, String name, String args, ZonedDateTime createdAt) {
         this.id = id;
         this.user = user;
         this.handler = handler;
         this.name = name;
         this.args = args != null ? args.strip() : "";
+        this.createdAt = createdAt;
     }
 
     String id() {
@@ -60,5 +62,9 @@ class CommandInvocation {
 
     String args() {
         return args;
+    }
+
+    ZonedDateTime createdAt() {
+        return createdAt;
     }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommandWorkItem.java
@@ -67,7 +67,7 @@ public class CommitCommandWorkItem implements WorkItem {
     private Optional<CommandInvocation> nextCommand(List<CommitComment> allComments) {
         var self = bot.repo().forge().currentUser();
         var command = CommandExtractor.extractCommands(commitComment.body(),
-                                                       commitComment.id(), commitComment.author());
+                commitComment.id(), commitComment.author(), commitComment.createdAt());
         if (command.isEmpty()) {
             return Optional.empty();
         }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.skara.bots.pr;
 
+import java.time.ZonedDateTime;
 import org.openjdk.skara.bot.WorkItem;
 import org.openjdk.skara.forge.*;
 import org.openjdk.skara.issuetracker.Comment;
@@ -36,8 +37,9 @@ import java.util.stream.Collectors;
 public class LabelerWorkItem extends PullRequestWorkItem {
     private static final String initialLabelMessage = "<!-- PullRequestBot initial label help comment -->";
 
-    LabelerWorkItem(PullRequestBot bot, String prId, Consumer<RuntimeException> errorHandler) {
-        super(bot, prId, errorHandler);
+    LabelerWorkItem(PullRequestBot bot, String prId, Consumer<RuntimeException> errorHandler,
+            ZonedDateTime prUpdatedAt) {
+        super(bot, prId, errorHandler, prUpdatedAt);
     }
 
     @Override

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -169,10 +169,10 @@ class PullRequestBot implements Bot {
                     continue;
                 }
                 if (pr.state() == Issue.State.OPEN) {
-                    ret.add(new CheckWorkItem(this, pr.id(), e -> updateCache.invalidate(pr)));
+                    ret.add(new CheckWorkItem(this, pr.id(), e -> updateCache.invalidate(pr), pr.updatedAt()));
                 } else {
                     // Closed PR's do not need to be checked
-                    ret.add(new PullRequestCommandWorkItem(this, pr.id(), e -> updateCache.invalidate(pr)));
+                    ret.add(new PullRequestCommandWorkItem(this, pr.id(), e -> updateCache.invalidate(pr), pr.updatedAt()));
                 }
             }
         }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
@@ -155,7 +155,7 @@ public class PullRequestCommandWorkItem extends PullRequestWorkItem {
                     handler.get().handle(bot, pr, censusInstance, scratchPath, command, allComments, printer, labelsToAdd, labelsToRemove);
                     var newComment = pr.addComment(writer.toString());
                     var latency = Duration.between(command.createdAt(), newComment.createdAt());
-                    log.log(Level.INFO, "Time from command to reply " + latency, latency);
+                    log.log(Level.INFO, "Time from command '" + command.name() + "' to reply " + latency, latency);
                     changeLabelsAfterComment(labelsToAdd, labelsToRemove);
                     return;
                 } else {
@@ -172,7 +172,7 @@ public class PullRequestCommandWorkItem extends PullRequestWorkItem {
 
         var newComment = pr.addComment(writer.toString());
         var latency = Duration.between(command.createdAt(), newComment.createdAt());
-        log.log(Level.INFO, "Time from command to reply " + latency, latency);
+        log.log(Level.INFO, "Time from command '" + command.name() + "' to reply " + latency, latency);
     }
 
     @Override

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
@@ -153,7 +153,9 @@ public class PullRequestCommandWorkItem extends PullRequestWorkItem {
                     var labelsToAdd = new ArrayList<String>();
                     var labelsToRemove = new ArrayList<String>();
                     handler.get().handle(bot, pr, censusInstance, scratchPath, command, allComments, printer, labelsToAdd, labelsToRemove);
-                    pr.addComment(writer.toString());
+                    var newComment = pr.addComment(writer.toString());
+                    var latency = Duration.between(command.createdAt(), newComment.createdAt());
+                    log.log(Level.INFO, "Time from command to reply " + latency, latency);
                     changeLabelsAfterComment(labelsToAdd, labelsToRemove);
                     return;
                 } else {


### PR DESCRIPTION
This is a pretty big patch, but it shouldn't be too scary as it's only supposed to change logging, mainly by adding more logging (and also removing some now redundant log calls).

The main focus here is to add structured timing data to some log messages. To do this, I'm using the optional `parameters` `Object[]` that you can supply to the logger from `java.util.logging`. If the LogstashHandler finds a `Duration` instance in that array, it will add it as a "duration" field in the logstash log document. In the BotRunner, we were already using parameters for a different purpose, so it got a little bit messy, but I think it's ok.

There are two kinds of timings I'm adding logging for. The obvious one is timing external HTTP calls and running processes, as well as total running/pending/scheduled times for WorkItems and getPeriodicItems in the BotRunner. The other kind are more complex as I'm trying to measure the user perceived latency from when a PR or bug is updated to when the bot actually reacts with a response to that update. This is of course tricky to get right and needs to be carefully implemented for each instance, but I believe I have at least added some reasonably relevant approximations that will make sense to measure and track. To generate these, I had to introduce a new field in various WorkItems that stores the timestamp from the external change that triggered it (e.g. `prUpdatedAt`).

In addition to this, there are a ton more regular log messages, mostly on info level, that detail actions performed by various WorkItems. This is something I have been missing a lot when browsing logs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1552](https://bugs.openjdk.org/browse/SKARA-1552): Log relevant timer numbers


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**) ⚠️ Review applies to [2cb0aee7](https://git.openjdk.org/skara/pull/1361/files/2cb0aee7088042572d1c4c764d93b544ad1a6d8d)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1361/head:pull/1361` \
`$ git checkout pull/1361`

Update a local copy of the PR: \
`$ git checkout pull/1361` \
`$ git pull https://git.openjdk.org/skara pull/1361/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1361`

View PR using the GUI difftool: \
`$ git pr show -t 1361`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1361.diff">https://git.openjdk.org/skara/pull/1361.diff</a>

</details>
