### PR TITLE
1560: Backport command fails to load census

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
@@ -59,7 +59,8 @@ public class BackportCommand implements CommandHandler {
     }
 
     @Override
-    public void handle(PullRequestBot bot, HostedCommit commit, CensusInstance censusInstance, Path scratchPath, CommandInvocation command, List<Comment> allComments, PrintWriter reply) {
+    public void handle(PullRequestBot bot, HostedCommit commit, LimitedCensusInstance censusInstance,
+            Path scratchPath, CommandInvocation command, List<Comment> allComments, PrintWriter reply) {
         if (censusInstance.contributor(command.user()).isEmpty()) {
             reply.println("Only OpenJDK [contributors](https://openjdk.org/bylaws#contributor) can use the `/backport` command");
             return;

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CensusInstance.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CensusInstance.java
@@ -81,6 +81,10 @@ class CensusInstance extends LimitedCensusInstance {
                 new CensusInstance(l.census, l.configuration, project(l.configuration, l.census), l.namespace));
     }
 
+    /**
+     * The LimitedCensusInstance does not have a Project. Use this when the project
+     * may be invalid or unavailable to avoid errors.
+     */
     static Optional<LimitedCensusInstance> createLimited(HostedRepositoryPool hostedRepositoryPool,
             HostedRepository censusRepo, String censusRef, Path folder, HostedRepository repository, String ref,
             HostedRepository confOverrideRepo, String confOverrideName, String confOverrideRef) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CensusInstance.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CensusInstance.java
@@ -27,9 +27,6 @@ import org.openjdk.skara.forge.*;
 import org.openjdk.skara.host.HostUser;
 import org.openjdk.skara.jcheck.JCheckConfiguration;
 
-import java.io.*;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Optional;
 
@@ -51,83 +48,20 @@ class CensusInstance extends LimitedCensusInstance {
         return project;
     }
 
-    private static Namespace namespace(Census census, String hostNamespace) {
-        //var namespace = census.namespace(pr.repository().getNamespace());
-        var namespace = census.namespace(hostNamespace);
-        if (namespace == null) {
-            throw new RuntimeException("Namespace not found in census: " + hostNamespace);
-        }
-
-        return namespace;
-    }
-
-    private static Optional<JCheckConfiguration> configuration(HostedRepositoryPool hostedRepositoryPool, HostedRepository remoteRepo, String name, String ref) throws IOException {
-        return hostedRepositoryPool.lines(remoteRepo, Path.of(name), ref).map(JCheckConfiguration::parse);
-    }
-
-    static Optional<CensusInstance> create(HostedRepositoryPool hostedRepositoryPool,
+    static Optional<CensusInstance> createCensusInstance(HostedRepositoryPool hostedRepositoryPool,
                                  HostedRepository censusRepo, String censusRef, Path folder, PullRequest pr,
                                  HostedRepository confOverrideRepo, String confOverrideName, String confOverrideRef) {
-        return create(hostedRepositoryPool, censusRepo, censusRef, folder, pr.repository(), pr.targetRef(),
+        return createCensusInstance(hostedRepositoryPool, censusRepo, censusRef, folder, pr.repository(), pr.targetRef(),
                       confOverrideRepo, confOverrideName, confOverrideRef);
     }
 
-    static Optional<CensusInstance> create(HostedRepositoryPool hostedRepositoryPool,
+    static Optional<CensusInstance> createCensusInstance(HostedRepositoryPool hostedRepositoryPool,
                                  HostedRepository censusRepo, String censusRef, Path folder, HostedRepository repository, String ref,
                                  HostedRepository confOverrideRepo, String confOverrideName, String confOverrideRef) {
-        var limitedCensusInstance = createLimited(hostedRepositoryPool, censusRepo,
+        var limitedCensusInstance = LimitedCensusInstance.createLimitedCensusInstance(hostedRepositoryPool, censusRepo,
                 censusRef, folder, repository, ref, confOverrideRepo, confOverrideName, confOverrideRef);
         return limitedCensusInstance.map(l ->
                 new CensusInstance(l.census, l.configuration, project(l.configuration, l.census), l.namespace));
-    }
-
-    /**
-     * The LimitedCensusInstance does not have a Project. Use this when the project
-     * may be invalid or unavailable to avoid errors.
-     */
-    static Optional<LimitedCensusInstance> createLimited(HostedRepositoryPool hostedRepositoryPool,
-            HostedRepository censusRepo, String censusRef, Path folder, HostedRepository repository, String ref,
-            HostedRepository confOverrideRepo, String confOverrideName, String confOverrideRef) {
-        Path repoFolder = getRepoFolder(hostedRepositoryPool, censusRepo, censusRef, folder);
-
-        try {
-            Optional<JCheckConfiguration> configuration = jCheckConfiguration(hostedRepositoryPool,
-                    repository, ref, confOverrideRepo, confOverrideName, confOverrideRef);
-            if (configuration.isEmpty()) {
-                return Optional.empty();
-            }
-            var census = Census.parse(repoFolder);
-            var namespace = namespace(census, repository.namespace());
-            return Optional.of(new LimitedCensusInstance(census, configuration.get(), namespace));
-        } catch (IOException e) {
-            throw new UncheckedIOException("Cannot parse census at " + repoFolder, e);
-        }
-    }
-
-    private static Optional<JCheckConfiguration> jCheckConfiguration(HostedRepositoryPool hostedRepositoryPool,
-            HostedRepository repository, String ref, HostedRepository confOverrideRepo, String confOverrideName,
-            String confOverrideRef) throws IOException {
-        Optional<JCheckConfiguration> configuration;
-        if (confOverrideRepo == null) {
-            configuration = configuration(hostedRepositoryPool, repository, ".jcheck/conf", ref);
-        } else {
-            configuration = configuration(hostedRepositoryPool,
-                    confOverrideRepo,
-                    confOverrideName,
-                    confOverrideRef);
-        }
-        return configuration;
-    }
-
-    private static Path getRepoFolder(HostedRepositoryPool hostedRepositoryPool, HostedRepository censusRepo, String censusRef, Path folder) {
-        var repoName = censusRepo.url().getHost() + "/" + censusRepo.name();
-        var repoFolder = folder.resolve(URLEncoder.encode(repoName, StandardCharsets.UTF_8));
-        try {
-            hostedRepositoryPool.checkoutAllowStale(censusRepo, censusRef, repoFolder);
-        } catch (IOException e) {
-            throw new UncheckedIOException("Cannot materialize census to " + repoFolder, e);
-        }
-        return repoFolder;
     }
 
     Project project() {
@@ -162,32 +96,3 @@ class CensusInstance extends LimitedCensusInstance {
     }
 }
 
-class LimitedCensusInstance {
-
-    protected final Census census;
-    protected final JCheckConfiguration configuration;
-    protected final Namespace namespace;
-
-    LimitedCensusInstance(Census census, JCheckConfiguration configuration, Namespace namespace) {
-        this.census = census;
-        this.configuration = configuration;
-        this.namespace = namespace;
-    }
-
-    Optional<Contributor> contributor(HostUser hostUser) {
-        var contributor = namespace.get(hostUser.id());
-        return Optional.ofNullable(contributor);
-    }
-
-    Census census() {
-        return census;
-    }
-
-    JCheckConfiguration configuration() {
-        return configuration;
-    }
-
-    Namespace namespace() {
-        return namespace;
-    }
-}

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -223,7 +223,7 @@ class CheckWorkItem extends PullRequestWorkItem {
         var seedPath = bot.seedStorage().orElse(scratchPath.resolve("seeds"));
         var hostedRepositoryPool = new HostedRepositoryPool(seedPath);
 
-        var census = CensusInstance.create(hostedRepositoryPool, bot.censusRepo(), bot.censusRef(), scratchPath.resolve("census"), pr,
+        var census = CensusInstance.createCensusInstance(hostedRepositoryPool, bot.censusRepo(), bot.censusRef(), scratchPath.resolve("census"), pr,
                                            bot.confOverrideRepository().orElse(null), bot.confOverrideName(), bot.confOverrideRef()).orElseThrow();
         var comments = pr.comments();
         var allReviews = pr.reviews();

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandExtractor.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandExtractor.java
@@ -78,7 +78,7 @@ public class CommandExtractor {
         }
 
         @Override
-        public void handle(PullRequestBot bot, HostedCommit hash, CensusInstance censusInstance, Path scratchPath, CommandInvocation command, List<Comment> allComments, PrintWriter reply) {
+        public void handle(PullRequestBot bot, HostedCommit hash, LimitedCensusInstance censusInstance, Path scratchPath, CommandInvocation command, List<Comment> allComments, PrintWriter reply) {
             reply.println("Available commands:");
             Stream.concat(
                     commandHandlers.entrySet().stream()

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandHandler.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandHandler.java
@@ -42,7 +42,8 @@ interface CommandHandler {
         handle(bot, pr, censusInstance, scratchPath, command, allComments, reply);
     }
 
-    default void handle(PullRequestBot bot, HostedCommit commit, CensusInstance censusInstance, Path scratchPath, CommandInvocation command, List<Comment> allComments, PrintWriter reply) {
+    default void handle(PullRequestBot bot, HostedCommit commit, LimitedCensusInstance censusInstance, Path scratchPath,
+            CommandInvocation command, List<Comment> allComments, PrintWriter reply) {
     }
 
     default boolean multiLine() {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommandWorkItem.java
@@ -130,7 +130,7 @@ public class CommitCommandWorkItem implements WorkItem {
         if (nextCommand.isEmpty()) {
             log.info("No new commit comments found, stopping further processing");
         } else {
-            var census = CensusInstance.createLimited(hostedRepositoryPool, bot.censusRepo(), bot.censusRef(),
+            var census = LimitedCensusInstance.createLimitedCensusInstance(hostedRepositoryPool, bot.censusRepo(), bot.censusRef(),
                                                scratchPath.resolve("census"), bot.repo(), commit.hash().hex(),
                                                bot.confOverrideRepository().orElse(null),
                                                bot.confOverrideName(),

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommandWorkItem.java
@@ -86,7 +86,8 @@ public class CommitCommandWorkItem implements WorkItem {
         }
     }
 
-    private void processCommand(Path scratchPath, HostedCommit commit, CensusInstance censusInstance, CommandInvocation command, List<CommitComment> allComments) {
+    private void processCommand(Path scratchPath, HostedCommit commit, LimitedCensusInstance censusInstance,
+            CommandInvocation command, List<CommitComment> allComments) {
         var writer = new StringWriter();
         var printer = new PrintWriter(writer);
 
@@ -129,7 +130,7 @@ public class CommitCommandWorkItem implements WorkItem {
         if (nextCommand.isEmpty()) {
             log.info("No new commit comments found, stopping further processing");
         } else {
-            var census = CensusInstance.create(hostedRepositoryPool, bot.censusRepo(), bot.censusRef(),
+            var census = CensusInstance.createLimited(hostedRepositoryPool, bot.censusRepo(), bot.censusRef(),
                                                scratchPath.resolve("census"), bot.repo(), commit.hash().hex(),
                                                bot.confOverrideRepository().orElse(null),
                                                bot.confOverrideName(),

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LimitedCensusInstance.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LimitedCensusInstance.java
@@ -1,0 +1,108 @@
+package org.openjdk.skara.bots.pr;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.Optional;
+import org.openjdk.skara.census.Census;
+import org.openjdk.skara.census.Contributor;
+import org.openjdk.skara.census.Namespace;
+import org.openjdk.skara.forge.HostedRepository;
+import org.openjdk.skara.forge.HostedRepositoryPool;
+import org.openjdk.skara.host.HostUser;
+import org.openjdk.skara.jcheck.JCheckConfiguration;
+
+/**
+ * The LimitedCensusInstance does not have a Project. Use this when the project
+ * may be invalid or unavailable to avoid errors, otherwise use CensusInstance
+ */
+class LimitedCensusInstance {
+
+    protected final Census census;
+    protected final JCheckConfiguration configuration;
+    protected final Namespace namespace;
+
+    LimitedCensusInstance(Census census, JCheckConfiguration configuration, Namespace namespace) {
+        this.census = census;
+        this.configuration = configuration;
+        this.namespace = namespace;
+    }
+
+    static Optional<LimitedCensusInstance> createLimitedCensusInstance(HostedRepositoryPool hostedRepositoryPool,
+            HostedRepository censusRepo, String censusRef, Path folder, HostedRepository repository, String ref,
+            HostedRepository confOverrideRepo, String confOverrideName, String confOverrideRef) {
+        Path repoFolder = getRepoFolder(hostedRepositoryPool, censusRepo, censusRef, folder);
+
+        try {
+            Optional<JCheckConfiguration> configuration = jCheckConfiguration(hostedRepositoryPool,
+                    repository, ref, confOverrideRepo, confOverrideName, confOverrideRef);
+            if (configuration.isEmpty()) {
+                return Optional.empty();
+            }
+            var census = Census.parse(repoFolder);
+            var namespace = namespace(census, repository.namespace());
+            return Optional.of(new LimitedCensusInstance(census, configuration.get(), namespace));
+        } catch (IOException e) {
+            throw new UncheckedIOException("Cannot parse census at " + repoFolder, e);
+        }
+    }
+
+    private static Namespace namespace(Census census, String hostNamespace) {
+        //var namespace = census.namespace(pr.repository().getNamespace());
+        var namespace = census.namespace(hostNamespace);
+        if (namespace == null) {
+            throw new RuntimeException("Namespace not found in census: " + hostNamespace);
+        }
+
+        return namespace;
+    }
+
+    private static Optional<JCheckConfiguration> configuration(HostedRepositoryPool hostedRepositoryPool, HostedRepository remoteRepo, String name, String ref) throws IOException {
+        return hostedRepositoryPool.lines(remoteRepo, Path.of(name), ref).map(JCheckConfiguration::parse);
+    }
+
+    private static Optional<JCheckConfiguration> jCheckConfiguration(HostedRepositoryPool hostedRepositoryPool,
+            HostedRepository repository, String ref, HostedRepository confOverrideRepo, String confOverrideName,
+            String confOverrideRef) throws IOException {
+        Optional<JCheckConfiguration> configuration;
+        if (confOverrideRepo == null) {
+            configuration = configuration(hostedRepositoryPool, repository, ".jcheck/conf", ref);
+        } else {
+            configuration = configuration(hostedRepositoryPool,
+                    confOverrideRepo,
+                    confOverrideName,
+                    confOverrideRef);
+        }
+        return configuration;
+    }
+
+    private static Path getRepoFolder(HostedRepositoryPool hostedRepositoryPool, HostedRepository censusRepo, String censusRef, Path folder) {
+        var repoName = censusRepo.url().getHost() + "/" + censusRepo.name();
+        var repoFolder = folder.resolve(URLEncoder.encode(repoName, StandardCharsets.UTF_8));
+        try {
+            hostedRepositoryPool.checkoutAllowStale(censusRepo, censusRef, repoFolder);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Cannot materialize census to " + repoFolder, e);
+        }
+        return repoFolder;
+    }
+
+    Optional<Contributor> contributor(HostUser hostUser) {
+        var contributor = namespace.get(hostUser.id());
+        return Optional.ofNullable(contributor);
+    }
+
+    Census census() {
+        return census;
+    }
+
+    JCheckConfiguration configuration() {
+        return configuration;
+    }
+
+    Namespace namespace() {
+        return namespace;
+    }
+}

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
@@ -24,7 +24,6 @@ package org.openjdk.skara.bots.pr;
 
 import org.openjdk.skara.bot.WorkItem;
 import org.openjdk.skara.forge.*;
-import org.openjdk.skara.host.HostUser;
 import org.openjdk.skara.issuetracker.*;
 
 import java.io.*;
@@ -189,7 +188,7 @@ public class PullRequestCommandWorkItem extends PullRequestWorkItem {
         var seedPath = bot.seedStorage().orElse(scratchPath.resolve("seeds"));
         var hostedRepositoryPool = new HostedRepositoryPool(seedPath);
 
-        var census = CensusInstance.create(hostedRepositoryPool, bot.censusRepo(), bot.censusRef(), scratchPath.resolve("census"), pr,
+        var census = CensusInstance.createCensusInstance(hostedRepositoryPool, bot.censusRepo(), bot.censusRef(), scratchPath.resolve("census"), pr,
                                            bot.confOverrideRepository().orElse(null), bot.confOverrideName(), bot.confOverrideRef()).orElseThrow();
         var command = nextCommand.get();
         log.info("Processing command: " + command.id() + " - " + command.name());

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/TagCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/TagCommand.java
@@ -59,7 +59,8 @@ public class TagCommand implements CommandHandler {
     }
 
     @Override
-    public void handle(PullRequestBot bot, HostedCommit commit, CensusInstance censusInstance, Path scratchPath, CommandInvocation command, List<Comment> allComments, PrintWriter reply) {
+    public void handle(PullRequestBot bot, HostedCommit commit, LimitedCensusInstance censusInstance,
+            Path scratchPath, CommandInvocation command, List<Comment> allComments, PrintWriter reply) {
         try {
             if (censusInstance.contributor(command.user()).isEmpty()) {
                 reply.println("Only OpenJDK [contributors](https://openjdk.org/bylaws#contributor) can use the `/tag` command.");


### PR DESCRIPTION
This patch attempts to fix the problem where a commit command (in our case a /backport command) fails to instantiate a CensusInstance, due to the configured jcheck "project", at the particular commit, not existing in the census in question. What happens then is that CensusInstance.create fails, which triggers an endless series of retries in the bot.

Since none of the current commit commands have a need for the "project" part of the census, I decided to create a separate CensusInstance type `LimitedCensusInstance` without the "project", and explicitly use this in the commit commands.

Tests are passing, and I could manually verify that this solves the problem we currently have with a bad /backport command in a private GitLab instance.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1560](https://bugs.openjdk.org/browse/SKARA-1560): Backport command fails to load census


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1362/head:pull/1362` \
`$ git checkout pull/1362`

Update a local copy of the PR: \
`$ git checkout pull/1362` \
`$ git pull https://git.openjdk.org/skara pull/1362/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1362`

View PR using the GUI difftool: \
`$ git pr show -t 1362`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1362.diff">https://git.openjdk.org/skara/pull/1362.diff</a>

</details>
