### PR TITLE
1568: Dependency PR Resolution Detection Does Not Check Means of Resolution

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifier.java
@@ -114,11 +114,11 @@ public class PullRequestBranchNotifier implements Notifier, PullRequestListener 
                 for (var retargeted : retargetedDependencies) {
                     log.info("Posting retargeted comment on PR " + pr.id());
                     retargeted.addComment("""
-                            The parent pull request that this pull request depends on has been closed without being integrated. \
-                            This has caused the pull request branch pr/XX to be deleted and the target branch of this pull \
-                            request to be updated, which means that changes from the parent pull request will start to show up \
-                            in this pull request. If closing the parent pull request was done in error, it will need to be \
-                            re-opened and this pull request will need to be retargeted again manually.
+                            The parent pull request that this pull request depends on has been closed without being \
+                            integrated and the target branch of this pull request has been updated as the previous \
+                            branch was deleted. This means that changes from the parent pull request will start to \
+                            show up in this pull request. If closing the parent pull request was done in error, it will \
+                            need to be re-opened and this pull request will need to manually be retargeted again.
                             """);
                 }
             }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifier.java
@@ -86,16 +86,17 @@ public class PullRequestBranchNotifier implements Notifier, PullRequestListener 
     @Override
     public void onStateChange(PullRequest pr, Path scratchPath, Issue.State oldState) {
         if (pr.state() == Issue.State.CLOSED) {
+            var retargetedDependencies = PreIntegrations.retargetDependencies(pr);
             deleteBranch(pr);
             if (pr.labelNames().contains("integrated")) {
-                var retargetedDependencies = PreIntegrations.retargetDependencies(pr);
                 for (var retargeted : retargetedDependencies) {
                     log.info("Posting retargeted comment on PR " + pr.id());
                     retargeted.addComment("""
-                            The dependent pull request has now been integrated, and the target branch of this pull request \
-                            has been updated. This means that changes from the dependent pull request can start to show up \
-                            as belonging to this pull request, which may be confusing for reviewers. To remedy this situation, \
-                            simply merge the latest changes from the new target branch into this pull request by running commands \
+                            The parent pull request that this pull request depends on has now been integrated and \
+                            the target branch of this pull request has been updated. This means that changes from \
+                            the dependent pull request can start to show up as belonging to this pull request, \
+                            which may be confusing for reviewers. To remedy this situation, simply merge the latest \
+                            changes from the new target branch into this pull request by running commands \
                             similar to these in the local repository for your personal fork:
 
                             ```bash
@@ -108,6 +109,17 @@ public class PullRequestBranchNotifier implements Notifier, PullRequestListener 
                             ```
                             """.formatted(retargeted.sourceRef(), pr.repository().webUrl(), pr.targetRef(),
                             pr.targetRef()));
+                }
+            } else {
+                for (var retargeted : retargetedDependencies) {
+                    log.info("Posting retargeted comment on PR " + pr.id());
+                    retargeted.addComment("""
+                            The parent pull request that this pull request depends on has been closed without being integrated. \
+                            This has caused the pull request branch pr/XX to be deleted and the target branch of this pull \
+                            request to be updated, which means that changes from the parent pull request will start to show up \
+                            in this pull request. If closing the parent pull request was done in error, it will need to be \
+                            re-opened and this pull request will need to be retargeted again manually.
+                            """);
                 }
             }
         } else {

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifierTests.java
@@ -295,7 +295,7 @@ public class PullRequestBranchNotifierTests {
             // Instructions on how to adapt to the newly integrated changes should have been posted
             var lastComment = followUpPr.comments().get(followUpPr.comments().size() - 1);
             assertTrue(lastComment.body().contains("The parent pull request that this pull request "
-                    + "depends on has been closed without being integrated."), lastComment.body());
+                    + "depends on has been closed without being integrated"), lastComment.body());
 
             // Create another follow-up work
             var anotherFollowUp = CheckableRepository.appendAndCommit(localRepo, "another follow-up work", "another follow-up change");


### PR DESCRIPTION
Hi all,

Currently, the closed but not integrated PR causes the dependent PRs to be retargeted. It is not right. This patch fixes it and changes the test case.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1568](https://bugs.openjdk.org/browse/SKARA-1568): Dependency PR Resolution Detection Does Not Check Means of Resolution


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1365/head:pull/1365` \
`$ git checkout pull/1365`

Update a local copy of the PR: \
`$ git checkout pull/1365` \
`$ git pull https://git.openjdk.org/skara pull/1365/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1365`

View PR using the GUI difftool: \
`$ git pr show -t 1365`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1365.diff">https://git.openjdk.org/skara/pull/1365.diff</a>

</details>
