### PR TITLE
1569: The method 'IssueWorkItem#run' may get the wrong pull request

### DIFF
--- a/bots/csr/src/main/java/org/openjdk/skara/bots/csr/IssueWorkItem.java
+++ b/bots/csr/src/main/java/org/openjdk/skara/bots/csr/IssueWorkItem.java
@@ -78,11 +78,9 @@ class IssueWorkItem implements WorkItem {
         var ret = new ArrayList<WorkItem>();
         Stream.concat(mainIssue.stream(), backports.stream())
                 .flatMap(i -> PullRequestUtils.pullRequestCommentLink(i).stream())
-                .map(uri -> bot.repositories().stream()
-                        .map(r -> r.parsePullRequestUrl(uri.toString()))
-                        .flatMap(Optional::stream)
-                        .findAny())
-                .flatMap(Optional::stream)
+                .flatMap(uri -> bot.repositories().stream()
+                        .flatMap(r -> r.parsePullRequestUrl(uri.toString()).stream()))
+                .filter(Issue::isOpen)
                 // This will mix time stamps from the IssueTracker and the Forge hosting PRs, but it's the
                 // best we can do.
                 .map(pr -> new PullRequestWorkItem(pr.repository(), pr.id(), csrIssue.project(), csrIssue.updatedAt()))


### PR DESCRIPTION
Hi all,

This patch gets all the pull requests form the issue and filters the open pull requests to avoid getting the wrong pull request. But I can't provide a test case to steadily reproduce the bug.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1569](https://bugs.openjdk.org/browse/SKARA-1569): The method 'IssueWorkItem#run' may get the wrong pull request


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1366/head:pull/1366` \
`$ git checkout pull/1366`

Update a local copy of the PR: \
`$ git checkout pull/1366` \
`$ git pull https://git.openjdk.org/skara pull/1366/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1366`

View PR using the GUI difftool: \
`$ git pr show -t 1366`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1366.diff">https://git.openjdk.org/skara/pull/1366.diff</a>

</details>
