### PR TITLE
1575: Adjust the pull request APIs in HostedRepository

### DIFF
--- a/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestCloserBot.java
+++ b/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestCloserBot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -138,7 +138,7 @@ public class PullRequestCloserBot implements Bot {
     public List<WorkItem> getPeriodicItems() {
         List<WorkItem> ret = new LinkedList<>();
 
-        for (var pr : remoteRepo.pullRequests()) {
+        for (var pr : remoteRepo.openPullRequests()) {
             if (updateCache.needsUpdate(pr)) {
                 var item = new PullRequestCloserBotWorkItem(remoteRepo, pr, type, e -> updateCache.invalidate(pr));
                 ret.add(item);

--- a/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestPrunerBot.java
+++ b/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestPrunerBot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -142,7 +142,7 @@ public class PullRequestPrunerBot implements Bot {
                 return ret;
             }
             currentMaxAge = maxAges.get(nextRepository);
-            pullRequestToCheck.addAll(nextRepository.pullRequests());
+            pullRequestToCheck.addAll(nextRepository.openPullRequests());
         }
 
         var pr = pullRequestToCheck.pollFirst();

--- a/bots/bridgekeeper/src/test/java/org/openjdk/skara/bots/bridgekeeper/PullRequestCloserBotTests.java
+++ b/bots/bridgekeeper/src/test/java/org/openjdk/skara/bots/bridgekeeper/PullRequestCloserBotTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,7 +55,7 @@ class PullRequestCloserBotTests {
             TestBotRunner.runPeriodicItems(bot);
 
             // There should now be no open PRs
-            var prs = author.pullRequests();
+            var prs = author.openPullRequests();
             assertEquals(0, prs.size());
 
             var updatedPr = author.pullRequest(pr.id());
@@ -84,17 +84,17 @@ class PullRequestCloserBotTests {
             TestBotRunner.runPeriodicItems(bot);
 
             // There should now be no open PRs
-            var prs = author.pullRequests();
+            var prs = author.openPullRequests();
             assertEquals(0, prs.size());
 
             // The author is persistent
             pr.setState(Issue.State.OPEN);
-            prs = author.pullRequests();
+            prs = author.openPullRequests();
             assertEquals(1, prs.size());
 
             // But so is the bot
             TestBotRunner.runPeriodicItems(bot);
-            prs = author.pullRequests();
+            prs = author.openPullRequests();
             assertEquals(0, prs.size());
 
             // There should still only be one welcome comment
@@ -126,17 +126,17 @@ class PullRequestCloserBotTests {
             TestBotRunner.runPeriodicItems(bot);
 
             // There should now be no open PRs
-            var prs = author.pullRequests();
+            var prs = author.openPullRequests();
             assertEquals(0, prs.size());
 
             // The author is persistent
             pr.setState(Issue.State.OPEN);
-            prs = author.pullRequests();
+            prs = author.openPullRequests();
             assertEquals(1, prs.size());
 
             // But so is the bot
             TestBotRunner.runPeriodicItems(bot);
-            prs = author.pullRequests();
+            prs = author.openPullRequests();
             assertEquals(0, prs.size());
 
             // There should still only be one welcome comment

--- a/bots/bridgekeeper/src/test/java/org/openjdk/skara/bots/bridgekeeper/PullRequestPrunerBotTests.java
+++ b/bots/bridgekeeper/src/test/java/org/openjdk/skara/bots/bridgekeeper/PullRequestPrunerBotTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -77,7 +77,7 @@ class PullRequestPrunerBotTests {
             TestBotRunner.runPeriodicItems(bot);
 
             // There should now be no open PRs
-            var prs = author.pullRequests();
+            var prs = author.openPullRequests();
             assertEquals(0, prs.size());
 
             // There should be a mention on how to reopen
@@ -107,7 +107,7 @@ class PullRequestPrunerBotTests {
             TestBotRunner.runPeriodicItems(bot);
 
             // There should still be an open PR
-            var prs = author.pullRequests();
+            var prs = author.openPullRequests();
             assertEquals(1, prs.size());
         }
     }

--- a/bots/csr/src/main/java/org/openjdk/skara/bots/csr/CSRPullRequestBot.java
+++ b/bots/csr/src/main/java/org/openjdk/skara/bots/csr/CSRPullRequestBot.java
@@ -67,7 +67,7 @@ class CSRPullRequestBot implements Bot {
         Map<String, ZonedDateTime> newPrsUpdatedAt = new HashMap<>();
         // On the first run we have to re-evaluate all open PRs, after that, only
         // looking at PRs that have been updated should be enough.
-        var prs = lastUpdatedAt != null ? repo.openPullRequestsAfter(lastUpdatedAt) : repo.pullRequests();
+        var prs = lastUpdatedAt != null ? repo.openPullRequestsAfter(lastUpdatedAt) : repo.openPullRequests();
         for (PullRequest pr : prs) {
             newPrsUpdatedAt.put(pr.id(), pr.updatedAt());
             // Update lastUpdatedAt with the last found updatedAt for the next call

--- a/bots/jep/src/main/java/org/openjdk/skara/bots/jep/JEPBot.java
+++ b/bots/jep/src/main/java/org/openjdk/skara/bots/jep/JEPBot.java
@@ -60,7 +60,7 @@ public class JEPBot implements Bot, WorkItem {
 
     @Override
     public Collection<WorkItem> run(Path scratchPath) {
-        var prs = repo.pullRequests();
+        var prs = repo.openPullRequests();
         for (var pr : prs) {
             var jepComment = pr.comments().stream()
                     .filter(comment -> comment.author().equals(pr.repository().forge().currentUser()))

--- a/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
+++ b/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -294,7 +294,7 @@ class MergeBot implements Bot, WorkItem {
             var prTarget = fork.forge().repository(target.name()).orElseThrow(() ->
                     new IllegalStateException("Can't get well-known repository " + target.name())
             );
-            var prs = prTarget.pullRequests();
+            var prs = prTarget.openPullRequests();
             var currentUser = prTarget.forge().currentUser();
 
             var unmerged = new HashSet<String>();
@@ -399,7 +399,7 @@ class MergeBot implements Bot, WorkItem {
                 // Check if any prerequisite repository has a conflict pull request open
                 if (shouldMerge) {
                     for (var prereq : spec.prerequisites()) {
-                        var openMergeConflictPRs = prereq.pullRequests()
+                        var openMergeConflictPRs = prereq.openPullRequests()
                                                          .stream()
                                                          .filter(pr -> pr.title().startsWith("Merge "))
                                                          .filter(pr -> pr.body().startsWith(marker))

--- a/bots/merge/src/test/java/org/openjdk/skara/bots/merge/MergeBotTests.java
+++ b/bots/merge/src/test/java/org/openjdk/skara/bots/merge/MergeBotTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -110,7 +110,7 @@ class MergeBotTests {
             assertEquals("duke", merge.author().name());
             assertEquals("duke@openjdk.org", merge.author().email());
 
-            assertEquals(0, toHostedRepo.pullRequests().size());
+            assertEquals(0, toHostedRepo.openPullRequests().size());
         }
     }
 
@@ -358,7 +358,7 @@ class MergeBotTests {
             assertTrue(toHashes.contains(toHashA));
             assertTrue(toHashes.contains(toHashB));
 
-            var pullRequests = toHostedRepo.pullRequests();
+            var pullRequests = toHostedRepo.openPullRequests();
             assertEquals(1, pullRequests.size());
             var pr = pullRequests.get(0);
             assertEquals("Merge test:master", pr.title());
@@ -429,7 +429,7 @@ class MergeBotTests {
             assertTrue(toHashes.contains(toHashA));
             assertTrue(toHashes.contains(toHashB));
 
-            var pullRequests = toHostedRepo.pullRequests();
+            var pullRequests = toHostedRepo.openPullRequests();
             assertEquals(1, pullRequests.size());
             var pr = pullRequests.get(0);
             assertEquals("Merge test:master", pr.title());
@@ -562,7 +562,7 @@ class MergeBotTests {
             assertTrue(toHashes.contains(toHashA));
             assertTrue(toHashes.contains(toHashB));
 
-            var pullRequests = toHostedRepo.pullRequests();
+            var pullRequests = toHostedRepo.openPullRequests();
             assertEquals(1, pullRequests.size());
             var pr = pullRequests.get(0);
             assertEquals("Merge test:master", pr.title());
@@ -674,7 +674,7 @@ class MergeBotTests {
             assertEquals("duke", merge.author().name());
             assertEquals("duke@openjdk.org", merge.author().email());
 
-            assertEquals(0, toHostedRepo.pullRequests().size());
+            assertEquals(0, toHostedRepo.openPullRequests().size());
 
             var fromFileD = fromDir.resolve("d.txt");
             Files.writeString(fromFileD, "Hello D\n");
@@ -789,7 +789,7 @@ class MergeBotTests {
             assertEquals("duke", merge.author().name());
             assertEquals("duke@openjdk.org", merge.author().email());
 
-            assertEquals(0, toHostedRepo.pullRequests().size());
+            assertEquals(0, toHostedRepo.openPullRequests().size());
 
             var fromFileD = fromDir.resolve("d.txt");
             Files.writeString(fromFileD, "Hello D\n");
@@ -910,7 +910,7 @@ class MergeBotTests {
             assertEquals("duke", merge.author().name());
             assertEquals("duke@openjdk.org", merge.author().email());
 
-            assertEquals(0, toHostedRepo.pullRequests().size());
+            assertEquals(0, toHostedRepo.openPullRequests().size());
 
             var fromFileD = fromDir.resolve("d.txt");
             Files.writeString(fromFileD, "Hello D\n");
@@ -1031,7 +1031,7 @@ class MergeBotTests {
             assertEquals("duke", merge.author().name());
             assertEquals("duke@openjdk.org", merge.author().email());
 
-            assertEquals(0, toHostedRepo.pullRequests().size());
+            assertEquals(0, toHostedRepo.openPullRequests().size());
 
             var fromFileD = fromDir.resolve("d.txt");
             Files.writeString(fromFileD, "Hello D\n");
@@ -1152,7 +1152,7 @@ class MergeBotTests {
             assertEquals("duke", merge.author().name());
             assertEquals("duke@openjdk.org", merge.author().email());
 
-            assertEquals(0, toHostedRepo.pullRequests().size());
+            assertEquals(0, toHostedRepo.openPullRequests().size());
 
             var fromFileD = fromDir.resolve("d.txt");
             Files.writeString(fromFileD, "Hello D\n");

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBot.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -211,10 +211,10 @@ public class MailingListBridgeBot implements Bot {
             lastFullUpdate = ZonedDateTime.now();
             lastPartialUpdate = lastFullUpdate;
             log.info("Fetching all open pull requests for " + codeRepo.name());
-            prs = codeRepo.pullRequests();
+            prs = codeRepo.openPullRequests();
         } else {
             log.info("Fetching recently updated pull requests (open and closed) for " + codeRepo.name());
-            prs = codeRepo.pullRequests(ZonedDateTime.now().minus(Duration.ofDays(14)));
+            prs = codeRepo.pullRequestsAfter(ZonedDateTime.now().minus(Duration.ofDays(14)));
             lastPartialUpdate = ZonedDateTime.now();
         }
 

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/NotifyBot.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/NotifyBot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -122,10 +122,10 @@ public class NotifyBot implements Bot, Emitter {
             if (lastFullUpdate == null || lastFullUpdate.isBefore(ZonedDateTime.now().minus(Duration.ofMinutes(10)))) {
                 lastFullUpdate = ZonedDateTime.now();
                 log.info("Fetching all open pull requests");
-                prs = repository.pullRequests();
+                prs = repository.openPullRequests();
             } else {
                 log.info("Fetching recently updated pull requests (open and closed)");
-                prs = repository.pullRequests(ZonedDateTime.now().minus(Duration.ofDays(14)));
+                prs = repository.pullRequestsAfter(ZonedDateTime.now().minus(Duration.ofDays(14)));
             }
 
             // Pull request events

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -186,10 +186,10 @@ class PullRequestBot implements Bot {
         if (lastFullUpdate == null || lastFullUpdate.isBefore(Instant.now().minus(Duration.ofMinutes(10)))) {
             lastFullUpdate = Instant.now();
             log.info("Fetching all open pull requests for " + remoteRepo.name());
-            prs = remoteRepo.pullRequests();
+            prs = remoteRepo.openPullRequests();
         } else {
             log.info("Fetching recently updated pull requests (open and closed) for " + remoteRepo.name());
-            prs = remoteRepo.pullRequests(ZonedDateTime.now().minus(Duration.ofDays(1)));
+            prs = remoteRepo.pullRequestsAfter(ZonedDateTime.now().minus(Duration.ofDays(1)));
         }
 
         return getWorkItems(prs);

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportCommitCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportCommitCommandTests.java
@@ -118,7 +118,7 @@ public class BackportCommitCommandTests {
             assertTrue(botReply.body().contains("target repository"));
             assertTrue(botReply.body().contains("is not a valid target for backports"));
             assertTrue(botReply.body().contains("List of valid target repositories: foobar/other-repo, test"));
-            assertEquals(List.of(), author.pullRequests());
+            assertEquals(List.of(), author.openPullRequests());
         }
     }
 
@@ -159,7 +159,7 @@ public class BackportCommitCommandTests {
             var botReply = recentCommitComments.get(0);
             assertTrue(botReply.body().contains("is not a valid target for backports"));
             assertTrue(botReply.body().contains("List of valid target repositories: foobar/other-repo"));
-            assertEquals(List.of(), author.pullRequests());
+            assertEquals(List.of(), author.openPullRequests());
         }
     }
 
@@ -200,7 +200,7 @@ public class BackportCommitCommandTests {
             var botReply = recentCommitComments.get(0);
             assertTrue(botReply.body().contains("target branch"));
             assertTrue(botReply.body().contains("does not exist"));
-            assertEquals(List.of(), author.pullRequests());
+            assertEquals(List.of(), author.openPullRequests());
         }
     }
 
@@ -252,7 +252,7 @@ public class BackportCommitCommandTests {
             assertTrue(botReply.body().contains("Please fetch the appropriate branch/commit and manually resolve these conflicts"));
             assertTrue(botReply.body().contains("master:master"));
             assertTrue(botReply.body().contains("$ git checkout master"));
-            assertEquals(List.of(), author.pullRequests());
+            assertEquals(List.of(), author.openPullRequests());
         }
     }
 

--- a/bots/submit/src/main/java/org/openjdk/skara/bots/submit/SubmitBot.java
+++ b/bots/submit/src/main/java/org/openjdk/skara/bots/submit/SubmitBot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,7 @@ public class SubmitBot implements Bot {
 
     @Override
     public List<WorkItem> getPeriodicItems() {
-        return repository.pullRequests().stream()
+        return repository.openPullRequests().stream()
                          .filter(updateCache::needsUpdate)
                          .flatMap(pr -> executors.stream()
                                                  .map(executor -> new SubmitBotWorkItem(this, executor, pr)))

--- a/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestBot.java
+++ b/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestBot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -119,7 +119,7 @@ public class TestBot implements Bot {
 
         var host = repo.webUrl().getHost();
         var repoId = Long.toString(repo.id());
-        for (var pr : repo.pullRequests()) {
+        for (var pr : repo.openPullRequests()) {
             var workItem = new TestWorkItem(ci,
                                             approversGroupId,
                                             allowlist,

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
@@ -64,7 +64,12 @@ class InMemoryHostedRepository implements HostedRepository {
     }
 
     @Override
-    public List<PullRequest> pullRequests(ZonedDateTime updatedAfter) {
+    public List<PullRequest> openPullRequests() {
+        return null;
+    }
+
+    @Override
+    public List<PullRequest> pullRequestsAfter(ZonedDateTime updatedAfter) {
         return null;
     }
 

--- a/bots/testinfo/src/main/java/org/openjdk/skara/bots/testinfo/TestInfoBot.java
+++ b/bots/testinfo/src/main/java/org/openjdk/skara/bots/testinfo/TestInfoBot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,7 @@ public class TestInfoBot implements Bot {
 
     @Override
     public List<WorkItem> getPeriodicItems() {
-        var prs = repo.pullRequests(ZonedDateTime.now().minus(Duration.ofDays(1)));
+        var prs = repo.pullRequestsAfter(ZonedDateTime.now().minus(Duration.ofDays(1)));
         var ret = new ArrayList<WorkItem>();
         for (var pr : prs) {
             if (pr.sourceRepository().isEmpty()) {

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrList.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -118,7 +118,7 @@ public class GitPrList {
         var host = getForge(uri, repo, arguments);
         var remoteRepo = ForgeUtils.getHostedRepositoryFor(uri, repo, host);
 
-        var prs = remoteRepo.pullRequests();
+        var prs = remoteRepo.openPullRequests();
         var ids = new ArrayList<String>();
         var titles = new ArrayList<String>();
         var authors = new ArrayList<String>();

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
@@ -43,16 +43,21 @@ public interface HostedRepository {
     PullRequest pullRequest(String id);
 
     /**
-     * Returns a list of all open pull requests.
+     * Returns a list of all the pull requests (included open and closed).
      */
     List<PullRequest> pullRequests();
+
+    /**
+     * Returns a list of all open pull requests.
+     */
+    List<PullRequest> openPullRequests();
 
     /**
      * Returns a list of all pull requests (both open and closed) that have been updated after the
      * provided time, ordered by latest updated first. If there are many pull requests that
      * match, the list may have been truncated.
      */
-    List<PullRequest> pullRequests(ZonedDateTime updatedAfter);
+    List<PullRequest> pullRequestsAfter(ZonedDateTime updatedAfter);
 
     /**
      * Returns a list of all open pull requests that have been updated after the given time.

--- a/forge/src/main/java/org/openjdk/skara/forge/PreIntegrations.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PreIntegrations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@ public class PreIntegrations {
         var ret = new ArrayList<PullRequest>();
         var dependentRef = preIntegrateBranch(pr);
 
-        var candidates = pr.repository().pullRequests();
+        var candidates = pr.repository().openPullRequests();
         for (var candidate : candidates) {
             if (candidate.targetRef().equals(dependentRef)) {
                 candidate.setTargetRef(pr.targetRef());

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -147,6 +147,9 @@ public class GitHubRepository implements HostedRepository {
     public List<PullRequest> pullRequests() {
         return request.get("pulls")
                       .param("state", "all")
+                      .param("sort", "updated")
+                      .param("direction", "desc")
+                      .maxPages(1)
                       .execute().asArray().stream()
                       .map(jsonValue -> new GitHubPullRequest(this, jsonValue, request))
                       .collect(Collectors.toList());
@@ -154,8 +157,6 @@ public class GitHubRepository implements HostedRepository {
 
     @Override
     public List<PullRequest> openPullRequests() {
-        // The default `state` parameter is `open` in GitHub which is not same as `GitLab`.
-        // Here, the `state` parameter is also added to avoid misunderstanding.
         return request.get("pulls")
                       .param("state", "open")
                       .execute().asArray().stream()
@@ -178,8 +179,6 @@ public class GitHubRepository implements HostedRepository {
 
     @Override
     public List<PullRequest> openPullRequestsAfter(ZonedDateTime updatedAfter) {
-        // The default `state` parameter is `open` in GitHub which is not same as `GitLab`.
-        // Here, the `state` parameter is also added to avoid misunderstanding.
         return request.get("pulls")
                 .param("state", "open")
                 .execute().asArray().stream()

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -145,13 +145,26 @@ public class GitHubRepository implements HostedRepository {
 
     @Override
     public List<PullRequest> pullRequests() {
-        return request.get("pulls").execute().asArray().stream()
+        return request.get("pulls")
+                      .param("state", "all")
+                      .execute().asArray().stream()
                       .map(jsonValue -> new GitHubPullRequest(this, jsonValue, request))
                       .collect(Collectors.toList());
     }
 
     @Override
-    public List<PullRequest> pullRequests(ZonedDateTime updatedAfter) {
+    public List<PullRequest> openPullRequests() {
+        // The default `state` parameter is `open` in GitHub which is not same as `GitLab`.
+        // Here, the `state` parameter is also added to avoid misunderstanding.
+        return request.get("pulls")
+                      .param("state", "open")
+                      .execute().asArray().stream()
+                      .map(jsonValue -> new GitHubPullRequest(this, jsonValue, request))
+                      .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<PullRequest> pullRequestsAfter(ZonedDateTime updatedAfter) {
         return request.get("pulls")
                       .param("state", "all")
                       .param("sort", "updated")
@@ -165,6 +178,8 @@ public class GitHubRepository implements HostedRepository {
 
     @Override
     public List<PullRequest> openPullRequestsAfter(ZonedDateTime updatedAfter) {
+        // The default `state` parameter is `open` in GitHub which is not same as `GitLab`.
+        // Here, the `state` parameter is also added to avoid misunderstanding.
         return request.get("pulls")
                 .param("state", "open")
                 .execute().asArray().stream()

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -133,6 +133,15 @@ public class GitLabRepository implements HostedRepository {
     @Override
     public List<PullRequest> pullRequests() {
         return request.get("merge_requests")
+                      .execute().stream()
+                      .filter(this::hasHeadHash)
+                      .map(value -> new GitLabMergeRequest(this, gitLabHost, value, request))
+                      .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<PullRequest> openPullRequests() {
+        return request.get("merge_requests")
                       .param("state", "opened")
                       .execute().stream()
                       .filter(this::hasHeadHash)
@@ -141,7 +150,7 @@ public class GitLabRepository implements HostedRepository {
     }
 
     @Override
-    public List<PullRequest> pullRequests(ZonedDateTime updatedAfter) {
+    public List<PullRequest> pullRequestsAfter(ZonedDateTime updatedAfter) {
         return request.get("merge_requests")
                       .param("order_by", "updated_at")
                       .param("updated_after", updatedAfter.format(DateTimeFormatter.ISO_DATE_TIME))

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -133,6 +133,8 @@ public class GitLabRepository implements HostedRepository {
     @Override
     public List<PullRequest> pullRequests() {
         return request.get("merge_requests")
+                      .param("order_by", "updated_at")
+                      .maxPages(1)
                       .execute().stream()
                       .filter(this::hasHeadHash)
                       .map(value -> new GitLabMergeRequest(this, gitLabHost, value, request))
@@ -154,6 +156,7 @@ public class GitLabRepository implements HostedRepository {
         return request.get("merge_requests")
                       .param("order_by", "updated_at")
                       .param("updated_after", updatedAfter.format(DateTimeFormatter.ISO_DATE_TIME))
+                      .maxPages(1)
                       .execute().stream()
                       .filter(this::hasHeadHash)
                       .map(value -> new GitLabMergeRequest(this, gitLabHost, value, request))

--- a/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
@@ -77,13 +77,18 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
 
     @Override
     public List<PullRequest> pullRequests() {
+        return new ArrayList<>(host.getPullRequests(this));
+    }
+
+    @Override
+    public List<PullRequest> openPullRequests() {
         return host.getPullRequests(this).stream()
                    .filter(pr -> pr.state().equals(Issue.State.OPEN))
                    .collect(Collectors.toList());
     }
 
     @Override
-    public List<PullRequest> pullRequests(ZonedDateTime updatedAfter) {
+    public List<PullRequest> pullRequestsAfter(ZonedDateTime updatedAfter) {
         return host.getPullRequests(this).stream()
                    .filter(pr -> pr.updatedAt().isAfter(updatedAfter))
                    .sorted(Comparator.comparing(PullRequest::updatedAt).reversed())
@@ -100,7 +105,7 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
 
     @Override
     public List<PullRequest> findPullRequestsWithComment(String author, String body) {
-        return pullRequests().stream()
+        return openPullRequests().stream()
                              .filter(pr -> pr.comments().stream()
                                                 .filter(comment -> author == null || comment.author().username().equals(author))
                                                 .filter(comment -> comment == null ||comment.body().contains(body))


### PR DESCRIPTION
Hi all,

This patch mainly has the following changes in `HostedRepository` and its sub-classes. And the usages of the changed methods are also changed.

1. Change the name of the `pullRequests(ZonedDateTime updatedAfter)` to `pullRequestsAfter` so that it is consistent as the `openPullRequestsAfter`.
2. Add the new api `openPullRequests` to get all the open pull requests.
3. Change the implementation of the method `pullRequests()` to get all the pull requests (included open and closed)

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1575](https://bugs.openjdk.org/browse/SKARA-1575): Adjust the pull request APIs in HostedRepository


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1367/head:pull/1367` \
`$ git checkout pull/1367`

Update a local copy of the PR: \
`$ git checkout pull/1367` \
`$ git pull https://git.openjdk.org/skara pull/1367/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1367`

View PR using the GUI difftool: \
`$ git pr show -t 1367`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1367.diff">https://git.openjdk.org/skara/pull/1367.diff</a>

</details>
