### PR TITLE
1578: Skara can't parse shenandoah jdk8u versions like 'shenandoah8u332'

### DIFF
--- a/jbs/src/main/java/org/openjdk/skara/jbs/JdkVersion.java
+++ b/jbs/src/main/java/org/openjdk/skara/jbs/JdkVersion.java
@@ -35,8 +35,8 @@ public class JdkVersion implements Comparable<JdkVersion> {
     private final static Pattern jdkVersionPattern = Pattern.compile("(5\\.0|[1-9][0-9]?)(u([0-9]{1,3}))?(?:-(.*))?$");
     private final static Pattern hsxVersionPattern = Pattern.compile("(hs[1-9][0-9]{1,2})(\\.([0-9]{1,3}))?$");
     private final static Pattern embVersionPattern = Pattern.compile("(emb-[8-9])(u([0-9]{1,3}))?$");
-    private final static Pattern ojVersionPattern = Pattern.compile("(openjdk[1-9][0-9]?)(u([0-9]{1,3}))?$");
-    private final static Pattern fxVersionPattern = Pattern.compile("(openjfx[1-9][0-9]?)(u([0-9]{1,3}))?$");
+    // Accept any lower case alphanumeric prefix, such as 'openjdk', 'openjfx' or 'shenandoah'.
+    private final static Pattern prefixVersionPattern = Pattern.compile("([a-z]+[1-9][0-9]?)(u([0-9]{1,3}))?$");
 
     // Match a version string symbolizing some future, but yet undefined, update of a major version
     private final static Pattern futureUpdatePattern = Pattern.compile("((openjdk)?[1-9][0-9]*u)(-([a-z0-9]+))?$");
@@ -49,7 +49,7 @@ public class JdkVersion implements Comparable<JdkVersion> {
         var finalComponents = new ArrayList<String>();
 
         // First check for the legacy patterns
-        for (var legacyPattern : List.of(jdkVersionPattern, hsxVersionPattern, embVersionPattern, ojVersionPattern, fxVersionPattern)) {
+        for (var legacyPattern : List.of(jdkVersionPattern, hsxVersionPattern, embVersionPattern, prefixVersionPattern)) {
             var legacyMatcher = legacyPattern.matcher(raw);
             if (legacyMatcher.matches()) {
                 finalComponents.add(legacyMatcher.group(1));

--- a/jbs/src/main/java/org/openjdk/skara/jbs/JdkVersion.java
+++ b/jbs/src/main/java/org/openjdk/skara/jbs/JdkVersion.java
@@ -35,7 +35,7 @@ public class JdkVersion implements Comparable<JdkVersion> {
     private final static Pattern jdkVersionPattern = Pattern.compile("(5\\.0|[1-9][0-9]?)(u([0-9]{1,3}))?(?:-(.*))?$");
     private final static Pattern hsxVersionPattern = Pattern.compile("(hs[1-9][0-9]{1,2})(\\.([0-9]{1,3}))?$");
     private final static Pattern embVersionPattern = Pattern.compile("(emb-[8-9])(u([0-9]{1,3}))?$");
-    // Accept any lower case alphanumeric prefix, such as 'openjdk', 'openjfx' or 'shenandoah'.
+    // Accept any lower case prefix, such as 'openjdk', 'openjfx' or 'shenandoah'.
     private final static Pattern prefixVersionPattern = Pattern.compile("([a-z]+[1-9][0-9]?)(u([0-9]{1,3}))?$");
 
     // Match a version string symbolizing some future, but yet undefined, update of a major version

--- a/jbs/src/main/java/org/openjdk/skara/jbs/JdkVersion.java
+++ b/jbs/src/main/java/org/openjdk/skara/jbs/JdkVersion.java
@@ -35,7 +35,7 @@ public class JdkVersion implements Comparable<JdkVersion> {
     private final static Pattern jdkVersionPattern = Pattern.compile("(5\\.0|[1-9][0-9]?)(u([0-9]{1,3}))?(?:-(.*))?$");
     private final static Pattern hsxVersionPattern = Pattern.compile("(hs[1-9][0-9]{1,2})(\\.([0-9]{1,3}))?$");
     private final static Pattern embVersionPattern = Pattern.compile("(emb-[8-9])(u([0-9]{1,3}))?$");
-    // Accept any lower case prefix, such as 'openjdk', 'openjfx' or 'shenandoah'.
+    // Accept any lower case letter prefix, such as 'openjdk', 'openjfx' or 'shenandoah'.
     private final static Pattern prefixVersionPattern = Pattern.compile("([a-z]+[1-9][0-9]?)(u([0-9]{1,3}))?$");
 
     // Match a version string symbolizing some future, but yet undefined, update of a major version

--- a/jbs/src/test/java/org/openjdk/skara/jbs/JdkVersionTests.java
+++ b/jbs/src/test/java/org/openjdk/skara/jbs/JdkVersionTests.java
@@ -67,6 +67,8 @@ public class JdkVersionTests {
         assertEquals(List.of("openjdk7"), from("openjdk7").components());
         assertEquals(List.of("openjdk8"), from("openjdk8").components());
         assertEquals(List.of("openjdk8", "211"), from("openjdk8u211").components());
+        assertEquals(List.of("shenandoah8", "211"), from("shenandoah8u211").components());
+        assertEquals(List.of("foobar8", "211"), from("foobar8u211").components());
     }
 
     @Test


### PR DESCRIPTION
When configuring the notify bot for SKARA-1574, I discovered that Skara fails to parse the fixversion of the shenandoah-jdk8u repo. This patch fixes that. 

It seems to me that there is little point in keeping a complete list of valid prefixes in the Skara source code, so instead of adding another explicit string like 'openjdk' or 'openjfx', I made the regexp accept any string of lower case letters as prefix for XuY type version strings.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1578](https://bugs.openjdk.org/browse/SKARA-1578): Skara can't parse shenandoah jdk8u versions like 'shenandoah8u332'


### Reviewers
 * [Tim Bell](https://openjdk.org/census#tbell) (@tbell29552 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1368/head:pull/1368` \
`$ git checkout pull/1368`

Update a local copy of the PR: \
`$ git checkout pull/1368` \
`$ git pull https://git.openjdk.org/skara pull/1368/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1368`

View PR using the GUI difftool: \
`$ git pr show -t 1368`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1368.diff">https://git.openjdk.org/skara/pull/1368.diff</a>

</details>
