### PR TITLE
1595: Introduce an IssuePoller similar to the PullRequestPoller

### DIFF
--- a/issuetracker/build.gradle
+++ b/issuetracker/build.gradle
@@ -26,6 +26,7 @@ module {
     test {
         requires 'org.openjdk.skara.test'
         requires 'org.junit.jupiter.api'
+        requires 'org.openjdk.skara.forge'
         requires 'jdk.httpserver'
         opens 'org.openjdk.skara.issuetracker' to 'org.junit.platform.commons'
         opens 'org.openjdk.skara.issuetracker.jira' to 'org.junit.platform.commons'
@@ -42,6 +43,7 @@ dependencies {
     implementation project(':host')
 
     testImplementation project(':test')
+    testImplementation project(':forge')
 }
 
 publishing {

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/IssuePoller.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/IssuePoller.java
@@ -1,0 +1,161 @@
+package org.openjdk.skara.issuetracker;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class IssuePoller {
+
+    private static final Logger log = Logger.getLogger(IssuePoller.class.getName());
+
+    private final IssueProject issueProject;
+    private final Duration timeStampQueryPrecision;
+    private final ZonedDateTime initialUpdatedAt;
+    private final Map<String, Issue> retryMap = new HashMap<>();
+
+    private record QueryResult(Map<String, Issue> issues, ZonedDateTime maxUpdatedAt,
+                               Instant afterQuery, List<Issue> result) {}
+    private QueryResult current;
+    private QueryResult prev;
+
+    /**
+     * When enough time has passed since the last time we actually returned
+     * results, it's possible to pad the updatedAt query parameter to avoid
+     * receiving the same issues over and over, only to then filter them out.
+     */
+    private boolean paddingPossible = false;
+
+    /**
+     * @param issueProject The IssueProject to poll from
+     * @param startUpPadding The amount of historic time to include in the
+     *                       very first query
+     */
+    public IssuePoller(IssueProject issueProject, Duration startUpPadding) {
+        this.issueProject = issueProject;
+        this.timeStampQueryPrecision = issueProject.issueTracker().timeStampQueryPrecision();
+        this.initialUpdatedAt = ZonedDateTime.now().minus(startUpPadding);
+    }
+
+    public List<Issue> updatedIssues() {
+        var beforeQuery = Instant.now();
+        List<Issue> issues = queryIssues();
+        var afterQuery = Instant.now();
+
+        // Convert the query result into a map
+        var issuesMap = issues.stream().collect(Collectors.toMap(Issue::id, i -> i));
+
+        // Find the max updatedAt value in the result set. Fall back on the previous
+        // value (happens if no results were returned), or the initialUpdatedAt (if
+        // no results have been found at all so far).
+        var maxUpdatedAt = issues.stream()
+                .map(Issue::updatedAt)
+                .max(Comparator.naturalOrder())
+                .orElseGet(() -> prev != null ? prev.maxUpdatedAt : initialUpdatedAt);
+
+        // Filter the results
+        var filtered = issues.stream()
+                .filter(this::isUpdated)
+                .toList();
+
+        var withRetries = addRetries(filtered);
+
+        // If nothing will be returned, update the paddingPossible state if enough time
+        // has passed since last we found something.
+        if (withRetries.isEmpty()) {
+            if (prev != null && prev.afterQuery.isBefore(beforeQuery.minus(timeStampQueryPrecision))) {
+                paddingPossible = true;
+            }
+        } else {
+            paddingPossible = false;
+        }
+
+        // Save the state of the current query results
+        current = new QueryResult(issuesMap, maxUpdatedAt, afterQuery, withRetries);
+
+        log.info("Found " + withRetries.size() + " updated issues for " + issueProject.name());
+        return withRetries;
+    }
+
+    /**
+     * After calling getUpdatedIssues(), this method must be called to acknowledge
+     * that all the issues returned have been handled. If not, the previous results will be
+     * included in the next call to getUpdatedIssues() again.
+     */
+    public synchronized void lastBatchHandled() {
+        if (current != null) {
+            prev = current;
+            current = null;
+            // Remove any returned PRs from the retry/quarantine sets
+            prev.result.forEach(pr -> retryMap.remove(pr.id()));
+        }
+    }
+
+    public synchronized void retryIssue(Issue issue) {
+        retryMap.put(issue.id(), issue);
+    }
+
+    private List<Issue> queryIssues() {
+        ZonedDateTime queryAfter;
+        if (prev == null || prev.maxUpdatedAt == null) {
+            queryAfter = initialUpdatedAt;
+        } else if (paddingPossible) {
+            // If we haven't found any actual results for long enough,
+            // we can pad on the query precision to avoid fetching the
+            // last returned issue over and over.
+            queryAfter = prev.maxUpdatedAt.plus(timeStampQueryPrecision);
+        } else {
+            queryAfter = prev.maxUpdatedAt;
+        }
+        log.fine("Fetching issues updated after " + queryAfter);
+        return queryIssues(issueProject, queryAfter);
+    }
+
+    /**
+     * Subclasses can override this method to query for specific kinds of issues.
+     * @param issueProject IssueProject to run query on
+     * @param updatedAfter Timestamp for updatedAt query
+     */
+    protected List<Issue> queryIssues(IssueProject issueProject, ZonedDateTime updatedAfter) {
+        return issueProject.issues(updatedAfter);
+    }
+
+    /**
+     * Evaluates if an issue has been updated since the previous query result.
+     */
+    private boolean isUpdated(Issue issue) {
+        if (prev == null) {
+            return true;
+        }
+        var issuePrev = prev.issues.get(issue.id());
+        if (issuePrev == null || issue.updatedAt().isAfter(issuePrev.updatedAt())) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Returns a list of all prs with retries added.
+     */
+    private synchronized List<Issue> addRetries(List<Issue> issues) {
+        if (retryMap.isEmpty()) {
+            return issues;
+        } else {
+            // Find the retries not already present in the issues list
+            var retries = retryMap.values().stream()
+                    .filter(retryIssue -> issues.stream().noneMatch(issue -> issue.id().equals(retryIssue.id())))
+                    .toList();
+            if (retries.isEmpty()) {
+                return issues;
+            } else {
+                return Stream.concat(issues.stream(), retries.stream()).toList();
+            }
+        }
+    }
+}

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/IssuePoller.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/IssuePoller.java
@@ -137,6 +137,9 @@ public class IssuePoller {
         if (issuePrev == null || issue.updatedAt().isAfter(issuePrev.updatedAt())) {
             return true;
         }
+        if (!issuePrev.equals(issue)) {
+            return true;
+        }
         return false;
     }
 

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/IssueTracker.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/IssueTracker.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.skara.issuetracker;
 
+import java.time.Duration;
 import org.openjdk.skara.host.*;
 import org.openjdk.skara.json.JSONObject;
 
@@ -31,6 +32,15 @@ public interface IssueTracker extends Host {
     IssueProject project(String name);
 
     URI uri();
+
+    /**
+     * The precision at which timeStamp based queries are supported for this
+     * IssueTracker. If this is >0, knowing this can be used to avoid
+     * re-querying for the same Issues over and over.
+     */
+    default Duration timeStampQueryPrecision() {
+        return Duration.ZERO;
+    }
 
     static IssueTracker from(String name, URI uri, Credential credential, JSONObject configuration) {
         var factory = IssueTrackerFactory.getIssueTrackerFactories().stream()

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraHost.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraHost.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.skara.issuetracker.jira;
 
+import java.time.Duration;
 import java.time.ZoneId;
 import org.openjdk.skara.host.HostUser;
 import org.openjdk.skara.issuetracker.*;
@@ -166,5 +167,13 @@ public class JiraHost implements IssueTracker {
     @Override
     public String hostname() {
         return uri.getHost();
+    }
+
+    /**
+     * Jira can only query on timestamps with minute precision.
+     */
+    @Override
+    public Duration timeStampQueryPrecision() {
+        return Duration.ofMinutes(1);
     }
 }

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraIssue.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraIssue.java
@@ -590,4 +590,25 @@ public class JiraIssue implements Issue {
     public Optional<HostUser> closedBy() {
         throw new RuntimeException("Not implemented yet");
     }
+
+    /**
+     * Equality for a JiraIssue is based on the data snapshot retrieved when
+     * the instance was created.
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        JiraIssue jiraIssue = (JiraIssue) o;
+        return Objects.equals(json, jiraIssue.json);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(json);
+    }
 }

--- a/issuetracker/src/test/java/org/openjdk/skara/issuetracker/IssuePollerTests.java
+++ b/issuetracker/src/test/java/org/openjdk/skara/issuetracker/IssuePollerTests.java
@@ -16,7 +16,7 @@ public class IssuePollerTests {
     void simple(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo)) {
             var issueProject = credentials.getIssueProject();
-            var issuePoller = new IssuePoller(issueProject, Duration.ofSeconds(1));
+            var issuePoller = new IssuePoller(issueProject, Duration.ZERO);
 
             // Poll with no Issues in the project
             var issues = issuePoller.updatedIssues();
@@ -85,7 +85,7 @@ public class IssuePollerTests {
             var issueProject = credentials.getIssueProject();
             var testHost = (TestHost) issueProject.issueTracker();
             testHost.setTimeStampQueryPrecision(Duration.ofNanos(2));
-            var issuePoller = new IssuePoller(issueProject, Duration.ofSeconds(1));
+            var issuePoller = new IssuePoller(issueProject, Duration.ZERO);
 
             // Create issue and poll for it
             var issue1 = credentials.createIssue(issueProject, "Issue 1");
@@ -138,7 +138,7 @@ public class IssuePollerTests {
     void retries(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo)) {
             var issueProject = credentials.getIssueProject();
-            var issuePoller = new IssuePoller(issueProject, Duration.ofSeconds(1));
+            var issuePoller = new IssuePoller(issueProject, Duration.ZERO);
 
             // Create issue
             var issue1 = credentials.createIssue(issueProject, "Issue 1");

--- a/issuetracker/src/test/java/org/openjdk/skara/issuetracker/IssuePollerTests.java
+++ b/issuetracker/src/test/java/org/openjdk/skara/issuetracker/IssuePollerTests.java
@@ -1,0 +1,174 @@
+package org.openjdk.skara.issuetracker;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.openjdk.skara.test.HostCredentials;
+import org.openjdk.skara.test.TestHost;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class IssuePollerTests {
+
+    @Test
+    void simple(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo)) {
+            var issueProject = credentials.getIssueProject();
+            var issuePoller = new IssuePoller(issueProject, Duration.ZERO);
+
+            // Poll with no Issues in the project
+            var issues = issuePoller.updatedIssues();
+            assertEquals(0, issues.size());
+
+            // Poll again without marking as handled
+            issues = issuePoller.updatedIssues();
+            assertEquals(0, issues.size());
+            issuePoller.lastBatchHandled();
+
+            // Create issue and poll for it
+            var issue1 = credentials.createIssue(issueProject, "Issue 1");
+            issues = issuePoller.updatedIssues();
+            assertEquals(1, issues.size());
+
+            // Poll again without marking as handled
+            issues = issuePoller.updatedIssues();
+            assertEquals(1, issues.size());
+            issuePoller.lastBatchHandled();
+
+            // Poll again
+            issues = issuePoller.updatedIssues();
+            assertEquals(0, issues.size());
+            issuePoller.lastBatchHandled();
+
+            // Touch issue and poll again
+            issue1.setBody("foo");
+            issues = issuePoller.updatedIssues();
+            assertEquals(1, issues.size());
+
+            // Poll again without marking as handled
+            issues = issuePoller.updatedIssues();
+            assertEquals(1, issues.size());
+            issuePoller.lastBatchHandled();
+
+            // Poll again
+            issues = issuePoller.updatedIssues();
+            assertEquals(0, issues.size());
+            issuePoller.lastBatchHandled();
+        }
+    }
+
+    @Test
+    void startUpPadding(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo)) {
+            var issueProject = credentials.getIssueProject();
+            var issuePoller = new IssuePoller(issueProject, Duration.ofDays(2));
+
+            // Create two issues, one with updatedAt before and one after the startup
+            // padding limit.
+            var issue1 = credentials.createIssue(issueProject, "Issue 1");
+            issue1.store().setLastUpdate(ZonedDateTime.now().minus(Duration.ofDays(1)));
+            var issue2 = credentials.createIssue(issueProject, "Issue 2");
+            issue2.store().setLastUpdate(ZonedDateTime.now().minus(Duration.ofDays(3)));
+
+            // First poll should find issue1 but not issue2.
+            var issues = issuePoller.updatedIssues();
+            assertEquals(1, issues.size());
+            assertEquals(issue1.id(), issues.get(0).id());
+        }
+    }
+
+    @Test
+    void timeStampPadding(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo)) {
+            var issueProject = credentials.getIssueProject();
+            var testHost = (TestHost) issueProject.issueTracker();
+            testHost.setTimeStampQueryPrecision(Duration.ofNanos(2));
+            var issuePoller = new IssuePoller(issueProject, Duration.ZERO);
+
+            // Create issue and poll for it
+            var issue1 = credentials.createIssue(issueProject, "Issue 1");
+            var issues = issuePoller.updatedIssues();
+            assertEquals(1, issues.size());
+            issuePoller.lastBatchHandled();
+
+            // Poll again
+            issues = issuePoller.updatedIssues();
+            assertEquals(0, issues.size());
+            issuePoller.lastBatchHandled();
+
+            // Touch issue and poll again
+            issue1.setBody("foo");
+            issues = issuePoller.updatedIssues();
+            assertEquals(1, issues.size());
+            issuePoller.lastBatchHandled();
+
+            // Poll again
+            issues = issuePoller.updatedIssues();
+            assertEquals(0, issues.size());
+            issuePoller.lastBatchHandled();
+
+            // With the extremely short precision, the poller should now be padding
+            // the fetch query with the precision duration to avoid fetching issue1
+            // again. We can prove that by updating the updatedAt to something after
+            // the last updatedAt but before last updatedAt + precision. If the fetch
+            // call would return it, then isUpdated should also return true.
+            var lastFoundUpdatedAt = issue1.store().lastUpdate();
+            issue1.store().setLastUpdate(lastFoundUpdatedAt.plus(Duration.ofNanos(1)));
+            issues = issuePoller.updatedIssues();
+            assertEquals(0, issues.size());
+            issuePoller.lastBatchHandled();
+
+            // Update to something just after the lastUpdate + precision and poll
+            // again. Now it should be returned.
+            issue1.store().setLastUpdate(lastFoundUpdatedAt.plus(Duration.ofNanos(3)));
+            issues = issuePoller.updatedIssues();
+            assertEquals(1, issues.size());
+            issuePoller.lastBatchHandled();
+        }
+    }
+
+    @Test
+    void retries(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo)) {
+            var issueProject = credentials.getIssueProject();
+            var issuePoller = new IssuePoller(issueProject, Duration.ZERO);
+
+            // Create issue
+            var issue1 = credentials.createIssue(issueProject, "Issue 1");
+            var issues = issuePoller.updatedIssues();
+            assertEquals(1, issues.size());
+            issuePoller.lastBatchHandled();
+
+            // Create another PR and mark the first PR for retry
+            var issue2 = credentials.createIssue(issueProject, "Issue 2");
+            issuePoller.retryIssue(issue1);
+            issues = issuePoller.updatedIssues();
+            assertEquals(2, issues.size());
+            issuePoller.lastBatchHandled();
+
+            // Poll again, nothing should not be returned
+            issues = issuePoller.updatedIssues();
+            assertEquals(0, issues.size());
+            issuePoller.lastBatchHandled();
+
+            // Just mark a PR for retry
+            issuePoller.retryIssue(issue2);
+            issues = issuePoller.updatedIssues();
+            assertEquals(1, issues.size());
+
+            // Call again without calling .lastBatchHandled, the retry should be included again
+            issues = issuePoller.updatedIssues();
+            assertEquals(1, issues.size());
+            issuePoller.lastBatchHandled();
+
+            // Update PR and add it as retry, only one copy should be returned
+            issue1.addLabel("foo");
+            issuePoller.retryIssue(issue1);
+            issues = issuePoller.updatedIssues();
+            assertEquals(1, issues.size());
+            issuePoller.lastBatchHandled();
+        }
+    }
+}

--- a/test/src/main/java/org/openjdk/skara/test/TestHost.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHost.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.skara.test;
 
+import java.time.Duration;
 import org.openjdk.skara.forge.*;
 import org.openjdk.skara.host.HostUser;
 import org.openjdk.skara.issuetracker.*;
@@ -51,6 +52,10 @@ public class TestHost implements Forge, IssueTracker {
     private final int currentUser;
     private HostData data;
     private final Logger log = Logger.getLogger("org.openjdk.skara.test");
+    // Setting this field doesn't change the behavior of the TestHost, but it changes
+    // what the associated method returns, which triggers different code paths in
+    // dependent test code.
+    private Duration timeStampQueryPrecision = Duration.ZERO;
 
     private static class HostData {
         final List<HostUser> users = new ArrayList<>();
@@ -265,5 +270,14 @@ public class TestHost implements Forge, IssueTracker {
         return data.issues.keySet().stream()
                 .map(testIssue -> getIssue(issueProject, testIssue))
                 .max(Comparator.comparing(TestIssue::updatedAt));
+    }
+
+    public void setTimeStampQueryPrecision(Duration timeStampQueryPrecision) {
+        this.timeStampQueryPrecision = timeStampQueryPrecision;
+    }
+
+    @Override
+    public Duration timeStampQueryPrecision() {
+        return timeStampQueryPrecision;
     }
 }

--- a/test/src/main/java/org/openjdk/skara/test/TestHost.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHost.java
@@ -250,7 +250,9 @@ public class TestHost implements Forge, IssueTracker {
         return data.issues.entrySet().stream()
                           .sorted(Map.Entry.comparingByKey())
                           .map(issue -> getIssue(issueProject, issue.getKey()))
-                          .filter(i -> i.updatedAt().isAfter(updatedAfter))
+                          // Accept updatedAfter == updatedAt to make tests more
+                          // resilient on hardware with lower resolution system clocks.
+                          .filter(i -> !i.updatedAt().isBefore(updatedAfter))
                           .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
Inspired by the `PullRequestPoller`, I have now also created an `IssuePoller`. The requirements are a bit different on this poller, which makes it a bit easier to implement. 

Like the `PullRequestPoller`, it needs to handle retries, something I had overlooked in the original `CSRIssueBot`. Compared to that implementation, I'm also moving away from using `IssueProject::lastUpdatedIssue` for the initial query. The problem with relying on such a query for the very first round is if it, or something else in that round, fails. At least for the `CSRIssueBot`, once we are in the second round, after a failed first round, it's no longer safe to only query for the very last updated Issue, there could be multiple updates that we would miss. Instead there is a configurable `Duration` that defines how far back we go from the time the bot was created for the first query. Depending on what the bot needs, this Duration can be expected to cover any downtime for the bot (typically in the order of days), which would be the case for the `SyncLabelBot` bot, or it could just be needed to cover any time sync differences between the bot and the server (typically in the order of minutes to an hour), which would apply to the `CSRIssueBot`.

Like with my revised PR for SKARA-1565, I'm not changing any bot to use this poller yet. I'm going to followup with that change for the CSRBot in SKARA-1594, and for other bots later.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1595](https://bugs.openjdk.org/browse/SKARA-1595): Introduce an IssuePoller similar to the PullRequestPoller


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1372/head:pull/1372` \
`$ git checkout pull/1372`

Update a local copy of the PR: \
`$ git checkout pull/1372` \
`$ git pull https://git.openjdk.org/skara pull/1372/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1372`

View PR using the GUI difftool: \
`$ git pr show -t 1372`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1372.diff">https://git.openjdk.org/skara/pull/1372.diff</a>

</details>
