### PR TITLE
1222: Git patch parser fails on Status T

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/Status.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Status.java
@@ -95,6 +95,10 @@ public class Status {
             return new Status(Operation.COPIED, -1);
         }
 
+        if (c == 'T') {
+            throw new IllegalArgumentException("It is illegal to change the file type(Reminder: It is also illegal to submit symlink or executable file)");
+        }
+
         throw new IllegalArgumentException("Invalid status character: " + c);
     }
 
@@ -115,6 +119,9 @@ public class Status {
         }
         if (c == 'U') {
             return new Status(Operation.UNMERGED, -1);
+        }
+        if (c == 'T') {
+            throw new IllegalArgumentException("It is illegal to change the file type(Reminder: It is also illegal to submit symlink or executable file)");
         }
 
         var score = 0;

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Status.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Status.java
@@ -31,7 +31,8 @@ public class Status {
         RENAMED,
         COPIED,
         MODIFIED,
-        UNMERGED
+        UNMERGED,
+        FILE_TYPE_CHANGED
     }
 
     private Operation op;
@@ -66,6 +67,10 @@ public class Status {
         return op == Operation.UNMERGED;
     }
 
+    public boolean isFileTypeChanged() {
+        return op == Operation.FILE_TYPE_CHANGED;
+    }
+
     public int score() {
         return score;
     }
@@ -96,7 +101,7 @@ public class Status {
         }
 
         if (c == 'T') {
-            throw new IllegalArgumentException("It is illegal to change the file type(Reminder: It is also illegal to submit symlink or executable file)");
+            return new Status(Operation.FILE_TYPE_CHANGED, -1);
         }
 
         throw new IllegalArgumentException("Invalid status character: " + c);
@@ -121,7 +126,7 @@ public class Status {
             return new Status(Operation.UNMERGED, -1);
         }
         if (c == 'T') {
-            throw new IllegalArgumentException("It is illegal to change the file type(Reminder: It is also illegal to submit symlink or executable file)");
+            return new Status(Operation.FILE_TYPE_CHANGED, -1);
         }
 
         var score = 0;
@@ -156,6 +161,8 @@ public class Status {
                 return "M";
             case UNMERGED:
                 return "U";
+            case FILE_TYPE_CHANGED:
+                return "T";
             case RENAMED:
                 return "R" + score;
             case COPIED:

--- a/vcs/src/main/java/org/openjdk/skara/vcs/tools/PatchHeader.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/tools/PatchHeader.java
@@ -103,6 +103,9 @@ public class PatchHeader {
             sourcePath = Path.of(parts[1]);
         } else if (status.isUnmerged()) {
             sourcePath = Path.of(parts[1]);
+        } else if (status.isFileTypeChanged()) {
+            sourcePath = Path.of(parts[1]);
+            targetPath = sourcePath;
         } else {
             // either copied or renamed
             sourcePath = Path.of(parts[1]);


### PR DESCRIPTION
Make parser know Status T

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1222](https://bugs.openjdk.org/browse/SKARA-1222): Git patch parser fails on Status T


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**) ⚠️ Review applies to [e9500b37](https://git.openjdk.org/skara/pull/1373/files/e9500b37252017bf14a19def1f81adf74e3b9b5b)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1373/head:pull/1373` \
`$ git checkout pull/1373`

Update a local copy of the PR: \
`$ git checkout pull/1373` \
`$ git pull https://git.openjdk.org/skara pull/1373/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1373`

View PR using the GUI difftool: \
`$ git pr show -t 1373`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1373.diff">https://git.openjdk.org/skara/pull/1373.diff</a>

</details>
