### PR TITLE
1512: MirrorBot may get stuck failing to clone repository

### DIFF
--- a/bots/mirror/src/main/java/org/openjdk/skara/bots/mirror/MirrorBot.java
+++ b/bots/mirror/src/main/java/org/openjdk/skara/bots/mirror/MirrorBot.java
@@ -89,7 +89,7 @@ class MirrorBot implements Bot, WorkItem {
             } else {
                 log.info("Found existing scratch directory for " + to.name());
                 repo = Repository.get(dir).orElseGet(() -> {
-                    log.info("The existing scratch directory has problem. Now recloning " + from.name());
+                    log.info("The existing scratch directory is not a valid repository. Recloning " + from.name());
                     try {
                         Files.walk(dir)
                                 .map(Path::toFile)

--- a/bots/mirror/src/test/java/org/openjdk/skara/bots/mirror/MirrorBotTests.java
+++ b/bots/mirror/src/test/java/org/openjdk/skara/bots/mirror/MirrorBotTests.java
@@ -481,8 +481,8 @@ class MirrorBotTests {
             var storage = temp.path().resolve("storage");
             var sanitizedUrl =
                     URLEncoder.encode(toHostedRepo.webUrl().toString(), StandardCharsets.UTF_8);
-            var dir_temporary = storage.resolve(sanitizedUrl);
-            Files.createDirectories(dir_temporary);
+            var temporaryDir = storage.resolve(sanitizedUrl);
+            Files.createDirectories(temporaryDir);
             var bot = new MirrorBot(storage, fromHostedRepo, toHostedRepo);
             TestBotRunner.runPeriodicItems(bot);
 

--- a/bots/mirror/src/test/java/org/openjdk/skara/bots/mirror/MirrorBotTests.java
+++ b/bots/mirror/src/test/java/org/openjdk/skara/bots/mirror/MirrorBotTests.java
@@ -481,7 +481,7 @@ class MirrorBotTests {
             var storage = temp.path().resolve("storage");
             var sanitizedUrl =
                     URLEncoder.encode(toHostedRepo.webUrl().toString(), StandardCharsets.UTF_8);
-            var dir_temporary = storage.resolve(sanitizedUrl + "temporary");
+            var dir_temporary = storage.resolve(sanitizedUrl);
             Files.createDirectories(dir_temporary);
             var bot = new MirrorBot(storage, fromHostedRepo, toHostedRepo);
             TestBotRunner.runPeriodicItems(bot);


### PR DESCRIPTION
Optimized the logic in MirrorBot.

When MirrorBot tries to create a directory, the directory will have a 'temporary' suffix, then it will attempts cloning. It the cloning succeed, the suffix will be removed. If the clone fails or the bot happens to die, the directory will retain the suffix. On the next time, if we try to rerun the bot, the bot will detect the temporary directory and will delete the temporary directory first, therefore, the bot will not get stuck.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1512](https://bugs.openjdk.org/browse/SKARA-1512): MirrorBot may get stuck failing to clone repository


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1374/head:pull/1374` \
`$ git checkout pull/1374`

Update a local copy of the PR: \
`$ git checkout pull/1374` \
`$ git pull https://git.openjdk.org/skara pull/1374/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1374`

View PR using the GUI difftool: \
`$ git pr show -t 1374`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1374.diff">https://git.openjdk.org/skara/pull/1374.diff</a>

</details>
