### PR TITLE
1562: The method 'CheckRun#findComment' don't need the comment list as parameter

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -1070,8 +1070,7 @@ class CheckRun {
             var integrationBlockers = botSpecificIntegrationBlockers();
 
             // Calculate and update the status message if needed
-            var statusMessage = getStatusMessage(visitor, additionalErrors,
-                                                additionalProgresses, integrationBlockers, isCleanBackport);
+            var statusMessage = getStatusMessage(visitor, additionalErrors, additionalProgresses, integrationBlockers, isCleanBackport);
             var updatedBody = updateStatusMessage(statusMessage);
             var title = pr.title();
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -747,7 +747,7 @@ class CheckRun {
         };
     }
 
-    private Optional<Comment> findComment(List<Comment> comments, String marker) {
+    private Optional<Comment> findComment(String marker) {
         var self = pr.repository().forge().currentUser();
         return comments.stream()
                        .filter(comment -> comment.author().equals(self))
@@ -889,7 +889,7 @@ class CheckRun {
     }
 
     private void addFullNameWarningComment() {
-        var existing = findComment(comments, fullNameWarningMarker);
+        var existing = findComment(fullNameWarningMarker);
         if (existing.isPresent()) {
             // Only warn once
             return;
@@ -922,8 +922,8 @@ class CheckRun {
         }
     }
 
-    private void updateMergeReadyComment(boolean isReady, String commitMessage, List<Comment> comments, List<Review> reviews, boolean rebasePossible) {
-        var existing = findComment(comments, mergeReadyMarker);
+    private void updateMergeReadyComment(boolean isReady, String commitMessage, List<Review> reviews, boolean rebasePossible) {
+        var existing = findComment(mergeReadyMarker);
         if (isReady && rebasePossible) {
             addFullNameWarningComment();
             var message = getMergeReadyComment(commitMessage, reviews);
@@ -940,8 +940,8 @@ class CheckRun {
         }
     }
 
-    private void addSourceBranchWarningComment(List<Comment> comments) {
-        var existing = findComment(comments, sourceBranchWarningMarker);
+    private void addSourceBranchWarningComment() {
+        var existing = findComment(sourceBranchWarningMarker);
         if (existing.isPresent()) {
             // Only add the comment once per PR
             return;
@@ -972,8 +972,8 @@ class CheckRun {
         pr.addComment(message);
     }
 
-    private void addOutdatedComment(List<Comment> comments) {
-        var existing = findComment(comments, outdatedHelpMarker);
+    private void addOutdatedComment() {
+        var existing = findComment(outdatedHelpMarker);
         if (existing.isPresent()) {
             // Only add the comment once per PR
             return;
@@ -994,8 +994,8 @@ class CheckRun {
         pr.addComment(message);
     }
 
-    private void addMergeCommitWarningComment(List<Comment> comments) {
-        var existing = findComment(comments, mergeCommitWarningMarker);
+    private void addMergeCommitWarningComment() {
+        var existing = findComment(mergeCommitWarningMarker);
         if (existing.isPresent()) {
             // Only add the comment once per PR
             return;
@@ -1090,7 +1090,7 @@ class CheckRun {
                                       integrationBlockers.isEmpty();
             }
 
-            updateMergeReadyComment(readyForIntegration, commitMessage, comments, activeReviews, rebasePossible);
+            updateMergeReadyComment(readyForIntegration, commitMessage, activeReviews, rebasePossible);
             if (readyForIntegration && rebasePossible) {
                 newLabels.add("ready");
             } else {
@@ -1098,7 +1098,7 @@ class CheckRun {
             }
             if (!rebasePossible) {
                 if (!labels.contains("failed-auto-merge")) {
-                    addOutdatedComment(comments);
+                    addOutdatedComment();
                 }
                 newLabels.add("merge-conflict");
             } else {
@@ -1108,12 +1108,12 @@ class CheckRun {
             if (pr.sourceRepository().isPresent()) {
                 var branchNames = pr.repository().branches().stream().map(HostedBranch::name).collect(Collectors.toSet());
                 if (!pr.repository().url().equals(pr.sourceRepository().get().url()) && branchNames.contains(pr.sourceRef())) {
-                    addSourceBranchWarningComment(comments);
+                    addSourceBranchWarningComment();
                 }
             }
 
             if (!PullRequestUtils.isMerge(pr) && PullRequestUtils.containsForeignMerge(pr, localRepo)) {
-                addMergeCommitWarningComment(comments);
+                addMergeCommitWarningComment();
             }
 
             // Ensure that the ready for sponsor label is up to date


### PR DESCRIPTION
remove parameter 'comments' in CheckRun#findComment.

remove parameter 'activeReviews' in many method interface.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1562](https://bugs.openjdk.org/browse/SKARA-1562): The method 'CheckRun#findComment' don't need the comment list as parameter


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1375/head:pull/1375` \
`$ git checkout pull/1375`

Update a local copy of the PR: \
`$ git checkout pull/1375` \
`$ git pull https://git.openjdk.org/skara pull/1375/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1375`

View PR using the GUI difftool: \
`$ git pr show -t 1375`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1375.diff">https://git.openjdk.org/skara/pull/1375.diff</a>

</details>
