### PR TITLE
1602: Fix labels handling in GitLabMergeRequest

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -44,7 +44,9 @@ public class GitLabMergeRequest implements PullRequest {
     private final GitLabRepository repository;
     private final GitLabHost host;
 
-    private List<Label> labels;
+    // Only cache the label names as those are most commonly used and converting to
+    // Label objects is expensive.
+    private List<String> labels;
 
     GitLabMergeRequest(GitLabRepository repository, GitLabHost host, JSONValue jsonValue, RestRequest request) {
         this.repository = repository;
@@ -52,9 +54,8 @@ public class GitLabMergeRequest implements PullRequest {
         this.json = jsonValue;
         this.request = request.restrict("merge_requests/" + json.get("iid").toString() + "/");
 
-        labels = json.get("labels")
-                     .stream()
-                     .map(s -> labelNameToLabel(s.asString()))
+        labels = json.get("labels").stream()
+                     .map(JSONValue::asString)
                      .sorted()
                      .collect(Collectors.toList());
     }
@@ -622,22 +623,21 @@ public class GitLabMergeRequest implements PullRequest {
 
     @Override
     public void addLabel(String label) {
-        labels = null;
         // GitLab does not allow adding/removing single labels, only setting the full list
         // We retrieve the list again here to try to minimize the race condition window
         var currentJson = request.get("").execute().asObject();
         var labels = Stream.concat(currentJson.get("labels").stream()
-                .map(JSONValue::asString),
-                List.of(label).stream())
+                                .map(JSONValue::asString),
+                        Stream.of(label))
                 .collect(Collectors.toSet());
         request.put("")
                .body("labels", String.join(",", labels))
                .execute();
+        this.labels = List.copyOf(labels);
     }
 
     @Override
     public void removeLabel(String label) {
-        labels = null;
         var currentJson = request.get("").execute().asObject();
         var labels = currentJson.get("labels").stream()
                 .map(JSONValue::asString)
@@ -646,6 +646,7 @@ public class GitLabMergeRequest implements PullRequest {
         request.put("")
                .body("labels", String.join(",", labels))
                .execute();
+        this.labels = List.copyOf(labels);
     }
 
     @Override
@@ -653,21 +654,20 @@ public class GitLabMergeRequest implements PullRequest {
         request.put("")
                .body("labels", String.join(",", labels))
                .execute();
-        this.labels = labels.stream().map(this::labelNameToLabel).collect(Collectors.toList());
+        this.labels = List.copyOf(labels);
     }
 
     @Override
     public List<Label> labels() {
-        if (labels == null) {
-            var currentJson = request.get("").execute().asObject();
-            labels = currentJson.get("labels")
-                                .stream()
-                                .map(s -> labelNameToLabel(s.asString()))
-                                // Avoid throwing NPE for unknown labels
-                                .filter(Objects::nonNull)
-                                .sorted()
-                                .collect(Collectors.toList());
-        }
+        return labels.stream()
+                .map(this::labelNameToLabel)
+                // Avoid throwing NPE for unknown labels
+                .filter(Objects::nonNull)
+                .toList();
+    }
+
+    @Override
+    public List<String> labelNames() {
         return labels;
     }
 

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -45,7 +45,7 @@ public class GitLabMergeRequest implements PullRequest {
     private final GitLabHost host;
 
     // Only cache the label names as those are most commonly used and converting to
-    // Label objects is expensive.
+    // Label objects is expensive. This list is always sorted.
     private List<String> labels;
 
     GitLabMergeRequest(GitLabRepository repository, GitLabHost host, JSONValue jsonValue, RestRequest request) {
@@ -633,7 +633,7 @@ public class GitLabMergeRequest implements PullRequest {
         request.put("")
                .body("labels", String.join(",", labels))
                .execute();
-        this.labels = List.copyOf(labels);
+        this.labels = labels.stream().sorted().toList();
     }
 
     @Override
@@ -646,7 +646,7 @@ public class GitLabMergeRequest implements PullRequest {
         request.put("")
                .body("labels", String.join(",", labels))
                .execute();
-        this.labels = List.copyOf(labels);
+        this.labels = labels.stream().sorted().toList();
     }
 
     @Override
@@ -654,7 +654,7 @@ public class GitLabMergeRequest implements PullRequest {
         request.put("")
                .body("labels", String.join(",", labels))
                .execute();
-        this.labels = List.copyOf(labels);
+        this.labels = labels.stream().sorted().toList();
     }
 
     @Override


### PR DESCRIPTION
A PullRequest exports two methods for getting all labels: `labels()` and `labelNames()`. The first returns `List<Label>` and the latter returns `List<String>`. The labelNames method has a default implementation that calls labels() and maps them to the name field. This is ok for most implementations, but not for GitLabMergeRequest. 

In GitLabMergeRequest, only the names of the labels are available from the merge_request REST object itself. In order to convert these to Label objects, it needs to make another REST call on the "project" (repository) to get the full label data. This extra call can add up to quite significant amounts of time when processing multiple PullRequest instances.

To make matters worse, the labels in GitLabMergeRequest are initialized in the constructor, so for every GitLabMergeRequest instance created, an extra REST call is made. There is also just a single use of PullRequest::labels() in the whole code base, and that is in the default implementation for labelNames(), so caller is ever interested in the full Label objects. This means that every instance of GitLabMergeRequest is making this extra REST call to initialize a cached set of data that is never used.

I'm solving this by only caching the label names instead of full Label objects. I've tried to retain the semantics of each method that deal with labels. The add/remove/set methods have been improved to update the cache instead of just clearing it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1602](https://bugs.openjdk.org/browse/SKARA-1602): Fix labels handling in GitLabMergeRequest


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1376/head:pull/1376` \
`$ git checkout pull/1376`

Update a local copy of the PR: \
`$ git checkout pull/1376` \
`$ git pull https://git.openjdk.org/skara pull/1376/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1376`

View PR using the GUI difftool: \
`$ git pr show -t 1376`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1376.diff">https://git.openjdk.org/skara/pull/1376.diff</a>

</details>
