### PR TITLE
1604: Unify behavior in gradlew and gradlew.bat

### DIFF
--- a/gradlew.bat
+++ b/gradlew.bat
@@ -27,6 +27,7 @@ for /f %%i in ("%GRADLE_URL%") do set GRADLE_DIR=%%~ni
 if exist %~dp0\.jdk\%JDK_WINDOWS_DIR%.zip goto extractJdk
 
 echo Downloading JDK...
+mkdir %~dp0\.jdk
 curl -L %JDK_WINDOWS_X64_URL% -o %JDK_WINDOWS_DIR%.zip
 move %JDK_WINDOWS_DIR%.zip %~dp0\.jdk\
 for /f "tokens=*" %%i in ('@certutil -hashfile %~dp0/.jdk/%JDK_WINDOWS_DIR%.zip sha256 ^| %WINDIR%\System32\find /v "hash of file" ^| %WINDIR%\System32\find /v "CertUtil"') do set SHA256JDK=%%i
@@ -36,6 +37,7 @@ goto done
 
 :extractJdk
 if exist %~dp0\.jdk\%JDK_WINDOWS_DIR% goto gradle
+
 echo Extracting JDK...
 md %~dp0\.jdk\%JDK_WINDOWS_DIR%
 %WINDIR%\System32\tar -xf %~dp0/.jdk/%JDK_WINDOWS_DIR%.zip -C %~dp0/.jdk/%JDK_WINDOWS_DIR%\
@@ -44,6 +46,7 @@ md %~dp0\.jdk\%JDK_WINDOWS_DIR%
 if exist %~dp0\.gradle\%GRADLE_DIR%.zip goto extractGradle
 
 echo Downloading Gradle...
+mkdir %~dp0\.gradle
 curl -L %GRADLE_URL% -o %GRADLE_DIR%.zip
 move %GRADLE_DIR%.zip %~dp0\.gradle\
 for /f "tokens=*" %%i in ('@certutil -hashfile %~dp0/.gradle/%GRADLE_DIR%.zip sha256 ^| %WINDIR%\System32\find /v "hash of file" ^| %WINDIR%\System32\find /v "CertUtil"') do set SHA256GRADLE=%%i
@@ -53,6 +56,7 @@ goto done
 
 :extractGradle
 if exist %~dp0\.gradle\%GRADLE_DIR% goto run
+
 echo Extracting Gradle...
 md %~dp0\.gradle\%GRADLE_DIR%
 %WINDIR%\System32\tar -xf %~dp0/.gradle/%GRADLE_DIR%.zip -C %~dp0/.gradle/%GRADLE_DIR%


### PR DESCRIPTION
This patch changes the gradlew.bat script to download and extract Gradle and the JDK in the same locations as the gradlew bash script, so that running either script interchangeably works fine in the same workspace.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1604](https://bugs.openjdk.org/browse/SKARA-1604): Unify behavior in gradlew and gradlew.bat


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1377/head:pull/1377` \
`$ git checkout pull/1377`

Update a local copy of the PR: \
`$ git checkout pull/1377` \
`$ git pull https://git.openjdk.org/skara pull/1377/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1377`

View PR using the GUI difftool: \
`$ git pr show -t 1377`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1377.diff">https://git.openjdk.org/skara/pull/1377.diff</a>

</details>
