### PR TITLE
1479: Backports are resolved with Dukebot as assignee

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
@@ -314,7 +314,11 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
                 if (issue.state() == Issue.State.OPEN) {
                     log.info("Resolving issue " + issue.id());
                     issue.setState(Issue.State.RESOLVED);
-                    if (issue.assignees().isEmpty()) {
+                    var assignees = issue.assignees();
+                    // Due to a bug in the backport plugin, certain users can't be assigned directly.
+                    // Work around this by overwriting the assignee afterwards if the current assignee
+                    // is the bot user.
+                    if (assignees.isEmpty() || (assignees.size() == 1 && assignees.get(0).equals(issueProject.issueTracker().currentUser()))) {
                         if (username.isPresent()) {
                             var assignee = issueProject.issueTracker().user(username.get());
                             if (assignee.isPresent()) {


### PR DESCRIPTION
For certain users in JBS, the backport API seems to have a problem handling them as initial assignees. This is causing a lot of backports to get dukebot as assignee instead of the user actually integrating the fix. It would certainly be best to fix this in the plugin (which would also fix the issue when using the "Create Backport" menu item in the JBS WebUI). In the meantime, I think we can add a rather simple workaround in Skara to alleviate the problem.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1479](https://bugs.openjdk.org/browse/SKARA-1479): Backports are resolved with Dukebot as assignee


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1378/head:pull/1378` \
`$ git checkout pull/1378`

Update a local copy of the PR: \
`$ git checkout pull/1378` \
`$ git pull https://git.openjdk.org/skara pull/1378/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1378`

View PR using the GUI difftool: \
`$ git pr show -t 1378`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1378.diff">https://git.openjdk.org/skara/pull/1378.diff</a>

</details>
