### PR TITLE
327: git webrev: Print the location of the generated webrev upon successful completion

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitWebrev.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitWebrev.java
@@ -173,6 +173,10 @@ public class GitWebrev {
             Switch.shortcut("v")
                   .fullname("version")
                   .helptext("Print the version of this tool")
+                  .optional(),
+            Switch.shortcut("")
+                  .fullname("quiet")
+                  .helptext("Do not print webrev link after executing successfully")
                   .optional());
 
         var inputs = List.of(
@@ -260,7 +264,7 @@ public class GitWebrev {
         }
 
         var comments = !arguments.contains("no-comments");
-
+        var quiet = arguments.contains("quiet");
         if (arguments.contains("base") && arguments.contains("rev")) {
             System.err.println("error: cannot combine --base and --rev options");
             System.exit(1);
@@ -453,6 +457,10 @@ public class GitWebrev {
                   .similarity(similarity)
                   .comments(comments)
                   .generate(base, head);
+        }
+        if (!quiet) {
+            System.out.println("Webrev executed successfully, details are in the link below:");
+            System.out.println("file://" + new File(output.resolve("index.html").toUri()).getAbsoluteFile());
         }
     }
 

--- a/cli/src/main/java/org/openjdk/skara/cli/GitWebrev.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitWebrev.java
@@ -460,7 +460,7 @@ public class GitWebrev {
         }
         if (!quiet) {
             System.out.println("Webrev executed successfully, details are in the link below:");
-            System.out.println("file://" + new File(output.resolve("index.html").toUri()).getAbsoluteFile());
+            System.out.println(output.resolve("index.html").toUri());
         }
     }
 


### PR DESCRIPTION
Originally, git webrev command would return nothing when executed successfully. It is not a good experience for user. 

Right now, when executed successfully, the location of index.html will be printed.

Also, added a --quiet flag if the current silent behavior is required.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-327](https://bugs.openjdk.org/browse/SKARA-327): git webrev: Print the location of the generated webrev upon successful completion


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**) ⚠️ Review applies to [d487b78b](https://git.openjdk.org/skara/pull/1379/files/d487b78b7917bd1df641e2ff127c193c79ea2af8)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1379/head:pull/1379` \
`$ git checkout pull/1379`

Update a local copy of the PR: \
`$ git checkout pull/1379` \
`$ git pull https://git.openjdk.org/skara pull/1379/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1379`

View PR using the GUI difftool: \
`$ git pr show -t 1379`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1379.diff">https://git.openjdk.org/skara/pull/1379.diff</a>

</details>
