### PR TITLE
1606: PullRequestPoller always processes the last updated MR for GitLab

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -102,7 +102,7 @@ class PullRequestBot implements Bot {
         this.enableJep = enableJep;
 
         autoLabelled = new HashSet<>();
-        poller = new PullRequestPoller(repo, true, true, true);
+        poller = new PullRequestPoller(repo, true);
 
         // Only check recently updated when starting up to avoid congestion
         lastFullUpdate = Instant.now();

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
@@ -339,7 +339,7 @@ class InMemoryPullRequest implements PullRequest {
     }
 
     @Override
-    public Object comparisonSnapshot() {
+    public Object snapshot() {
         return this;
     }
 }

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
@@ -337,4 +337,9 @@ class InMemoryPullRequest implements PullRequest {
     public Optional<Hash> findIntegratedCommitHash() {
         return Optional.empty();
     }
+
+    @Override
+    public Object comparisonSnapshot() {
+        return this;
+    }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
@@ -53,14 +53,16 @@ public interface HostedRepository {
     List<PullRequest> openPullRequests();
 
     /**
-     * Returns a list of all pull requests (both open and closed) that have been updated after the
-     * provided time, ordered by latest updated first. If there are many pull requests that
-     * match, the list may have been truncated.
+     * Returns a list of all pull requests (both open and closed) that have
+     * been updated after or on the given time, with a resolution given by
+     * Host::timeStampQueryPrecision, ordered by latest updated first. If there
+     * are many pull requests that match, the list may have been truncated.
      */
     List<PullRequest> pullRequestsAfter(ZonedDateTime updatedAfter);
 
     /**
-     * Returns a list of all open pull requests that have been updated after the given time.
+     * Returns a list of all open pull requests that have been updated after or on
+     * the given time, with a resolution given by Host::timeStampQueryPrecision.
      */
     List<PullRequest> openPullRequestsAfter(ZonedDateTime updatedAfter);
     List<PullRequest> findPullRequestsWithComment(String author, String body);

--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
@@ -211,5 +211,5 @@ public interface PullRequest extends Issue {
      * Returns an object that represents a complete snapshot of this pull request.
      * Used for detecting if anything has changed between two snapshots.
      */
-    Object comparisonSnapshot();
+    Object snapshot();
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
@@ -206,4 +206,10 @@ public interface PullRequest extends Issue {
     static String commitHashMessage(Hash hash) {
         return hash != null ? "Pushed as commit " + hash.hex() + "." : "";
     }
+
+    /**
+     * Returns an object that represents a complete snapshot of this pull request.
+     * Used for detecting if anything has changed between two snapshots.
+     */
+    Object comparisonSnapshot();
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequestPoller.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequestPoller.java
@@ -210,7 +210,7 @@ public class PullRequestPoller {
     private Map<String, Object> fetchComparisonSnapshots(List<PullRequest> prs, ZonedDateTime maxUpdatedAt) {
         return prs.stream()
                 .filter(pr -> !pr.updatedAt().isBefore(maxUpdatedAt.minus(negativeQueryPadding)))
-                .collect(Collectors.toMap(Issue::id, PullRequest::comparisonSnapshot));
+                .collect(Collectors.toMap(Issue::id, PullRequest::snapshot));
     }
 
     /**
@@ -226,7 +226,7 @@ public class PullRequestPoller {
         if (prPrev == null || pr.updatedAt().isAfter(prPrev.updatedAt())) {
             return true;
         }
-        if (!pr.comparisonSnapshot().equals(prev.comparisonSnapshots.get(pr.id()))) {
+        if (!pr.snapshot().equals(prev.comparisonSnapshots.get(pr.id()))) {
             return true;
         }
         return false;

--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequestPoller.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequestPoller.java
@@ -10,9 +10,7 @@ import java.util.Map;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.openjdk.skara.issuetracker.Comment;
 import org.openjdk.skara.issuetracker.Issue;
-import org.openjdk.skara.vcs.Hash;
 
 /**
  * A PullRequestPoller handles querying for new and updated pull requests. It
@@ -42,11 +40,14 @@ public class PullRequestPoller {
     private static final Duration CLOSED_PR_AGE_LIMIT = Duration.ofDays(7);
 
     private final HostedRepository repository;
-    private final Duration queryPadding;
+    // Negative query padding is used to compensate for the forge only updating
+    // timestamps on pull requests once for set minimum duration.
+    private final Duration negativeQueryPadding;
+    // Positive query padding is used to work around timestamp queries being
+    // inclusive down to a certain time resolution.
+    private final Duration positiveQueryPadding;
     private final boolean includeClosed;
     private final boolean trustUpdatedAt;
-    private final boolean checkComments;
-    private final boolean checkReviews;
 
     private record PullRequestRetry(PullRequest pr, Instant when) {}
     private final Map<String, PullRequestRetry> retryMap = new HashMap<>();
@@ -56,53 +57,38 @@ public class PullRequestPoller {
      * This record represents all the query results data needed to correctly figure
      * out if future results have been updated or not.
      */
-    private record QueryResult(Map<String, PullRequest> pullRequests, Map<String, List<Comment>> comments,
-                               Map<String, List<Review>> reviews, ZonedDateTime maxUpdatedAt,
-                               Instant afterQuery, List<PullRequest> result) {}
+    record QueryResult(Map<String, PullRequest> pullRequests, Map<String, Object> comparisonSnapshots,
+                       ZonedDateTime maxUpdatedAt, Instant afterQuery, List<PullRequest> result) {}
     private QueryResult current;
     private QueryResult prev;
 
     /**
-     * When enough time has past since the last time we actually received results
-     * padding the updatedAt query parameter is no longer needed. This is indicated
-     * using this boolean.
+     * When enough time has passed since the last time we returned results, applying
+     * negative padding to the updatedAt query parameter is no longer needed. This
+     * is indicated using this boolean.
      */
-    private boolean paddingNeeded = true;
+    private boolean negativePaddingNeeded = true;
 
-    public PullRequestPoller(HostedRepository repository, boolean includeClosed, boolean commentsRelevant,
-            boolean reviewsRelevant) {
+    public PullRequestPoller(HostedRepository repository, boolean includeClosed) {
         this.repository = repository;
         this.includeClosed = includeClosed;
-        queryPadding = repository.forge().minTimeStampUpdateInterval();
-        if (!queryPadding.isZero()) {
+        negativeQueryPadding = repository.forge().minTimeStampUpdateInterval();
+        positiveQueryPadding = repository.forge().timeStampQueryPrecision();
+        if (!negativeQueryPadding.isZero()) {
             trustUpdatedAt = false;
-            checkComments = commentsRelevant;
-            checkReviews = reviewsRelevant;
         } else {
             trustUpdatedAt = true;
-            checkComments = false;
-            checkReviews = false;
         }
     }
 
     /**
-     * The main API method. Call this go get updated PRs. When done processing the results
+     * The main API method. Call this to get updated PRs. When done processing the results
      * call lastBatchHandled() to acknowledge that all the returned PRs have been handled
      * and should not be included in the next call of this method.
      */
     public List<PullRequest> updatedPullRequests() {
         var beforeQuery = Instant.now();
         List<PullRequest> prs = queryPullRequests();
-
-        // If nothing was found. Update the paddingNeeded state if enough time
-        // has passed since last we found something.
-        if (prs.isEmpty()) {
-            if (prev != null && prev.afterQuery.isBefore(beforeQuery.minus(queryPadding))) {
-                paddingNeeded = false;
-            }
-        } else {
-            paddingNeeded = true;
-        }
         var afterQuery = Instant.now();
 
         // Convert the query result into a map
@@ -116,13 +102,8 @@ public class PullRequestPoller {
                 .max(Comparator.naturalOrder())
                 .orElseGet(() -> prev != null ? prev.maxUpdatedAt : null);
 
-        // If checking comments, save the current state of comments for future
-        // comparisons.
-        var commentsMap = fetchComments(prs, maxUpdatedAt);
-
-        // If checking reviews, save the current state of reviews for future
-        // comparisons.
-        var reviewsMap = fetchReviews(prs, maxUpdatedAt);
+        // Save the current comparisonSnapshots
+        var comparisonSnapshots = fetchComparisonSnapshots(prs, maxUpdatedAt);
 
         // Filter the results
         var filtered = prs.stream()
@@ -133,8 +114,19 @@ public class PullRequestPoller {
 
         var result = processQuarantined(withRetries);
 
+        // If nothing is to be returned. Update the paddingNeeded state if enough time
+        // has passed since last we found something.
+        if (result.isEmpty()) {
+            if (prev != null && prev.afterQuery.isBefore(beforeQuery.minus(negativeQueryPadding)
+                    .minus(positiveQueryPadding))) {
+                negativePaddingNeeded = false;
+            }
+        } else {
+            negativePaddingNeeded = true;
+        }
+
         // Save the state of the current query results
-        current = new QueryResult(pullRequestMap, commentsMap, reviewsMap, maxUpdatedAt, afterQuery, result);
+        current = new QueryResult(pullRequestMap, comparisonSnapshots, maxUpdatedAt, afterQuery, result);
 
         log.info("Found " + result.size() + " updated pull requests for " + repository.name());
         return result;
@@ -206,7 +198,8 @@ public class PullRequestPoller {
                 return repository.openPullRequests();
             }
         } else {
-            var queryUpdatedAt = paddingNeeded ? prev.maxUpdatedAt.minus(queryPadding) : prev.maxUpdatedAt;
+            var queryUpdatedAt = negativePaddingNeeded
+                    ? prev.maxUpdatedAt.minus(negativeQueryPadding) : prev.maxUpdatedAt.plus(positiveQueryPadding);
             if (includeClosed) {
                 log.fine("Fetching open and closed pull requests updated after " + queryUpdatedAt + " for " + repository.name());
                 return repository.pullRequestsAfter(queryUpdatedAt);
@@ -217,31 +210,16 @@ public class PullRequestPoller {
         }
     }
 
-    private Map<String, List<Comment>> fetchComments(List<PullRequest> prs, ZonedDateTime maxUpdatedAt) {
-        if (checkComments) {
-            return prs.stream()
-                    .filter(pr -> pr.updatedAt().isAfter(maxUpdatedAt.minus(queryPadding)))
-                    .collect(Collectors.toMap(Issue::id, Issue::comments));
-        } else {
-            return Map.of();
-        }
-    }
-
-    private Map<String, List<Review>> fetchReviews(List<PullRequest> prs, ZonedDateTime maxUpdatedAt) {
-        if (checkReviews) {
-            return prs.stream()
-                    .filter(pr -> pr.updatedAt().isAfter(maxUpdatedAt.minus(queryPadding)))
-                    .collect(Collectors.toMap(Issue::id, PullRequest::reviews));
-        } else {
-            return Map.of();
-        }
+    private Map<String, Object> fetchComparisonSnapshots(List<PullRequest> prs, ZonedDateTime maxUpdatedAt) {
+        return prs.stream()
+                .filter(pr -> !pr.updatedAt().isBefore(maxUpdatedAt.minus(negativeQueryPadding)))
+                .collect(Collectors.toMap(Issue::id, PullRequest::comparisonSnapshot));
     }
 
     /**
-     * Evaluates if a PR has been updated since the previous query result. If we
-     * can trust updatedAt from the forge, it's a simple comparison, otherwise
-     * we need to compare the complete contents of the PR object, as well as
-     * comments and/or reviews as configured.
+     * Evaluates if a PR has been updated since the previous query result.
+     * First checks updatedAt and then the comparisonSnapshot of the PR if
+     * present in the prev data.
      */
     private boolean isUpdated(PullRequest pr) {
         if (prev == null) {
@@ -251,16 +229,8 @@ public class PullRequestPoller {
         if (prPrev == null || pr.updatedAt().isAfter(prPrev.updatedAt())) {
             return true;
         }
-        if (!trustUpdatedAt) {
-            if (!pr.equals(prPrev)) {
-                return true;
-            }
-            if (checkComments && !pr.comments().equals(prev.comments.get(pr.id()))) {
-                return true;
-            }
-            if (checkReviews && !pr.reviews().equals(prev.reviews.get(pr.id()))) {
-                return true;
-            }
+        if (!pr.comparisonSnapshot().equals(prev.comparisonSnapshots.get(pr.id()))) {
+            return true;
         }
         return false;
     }
@@ -320,5 +290,10 @@ public class PullRequestPoller {
                             pastQuarantine.stream())
                     .toList();
         }
+    }
+
+    // Expose the query results to tests
+    QueryResult getCurrentQueryResult() {
+        return current;
     }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequestPoller.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequestPoller.java
@@ -47,7 +47,6 @@ public class PullRequestPoller {
     // inclusive down to a certain time resolution.
     private final Duration positiveQueryPadding;
     private final boolean includeClosed;
-    private final boolean trustUpdatedAt;
 
     private record PullRequestRetry(PullRequest pr, Instant when) {}
     private final Map<String, PullRequestRetry> retryMap = new HashMap<>();
@@ -73,11 +72,6 @@ public class PullRequestPoller {
         this.includeClosed = includeClosed;
         negativeQueryPadding = repository.forge().minTimeStampUpdateInterval();
         positiveQueryPadding = repository.forge().timeStampQueryPrecision();
-        if (!negativeQueryPadding.isZero()) {
-            trustUpdatedAt = false;
-        } else {
-            trustUpdatedAt = true;
-        }
     }
 
     /**

--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequestPoller.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequestPoller.java
@@ -103,7 +103,7 @@ public class PullRequestPoller {
                 .filter(this::isUpdated)
                 .toList();
 
-        // If nothing was left after filtering. Update the paddingNeeded state if enough time
+        // If nothing was left after filtering, update the paddingNeeded state if enough time
         // has passed since last we found something.
         boolean negativePaddingNeeded = true;
         if (filtered.isEmpty()) {

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -787,7 +787,7 @@ public class GitHubPullRequest implements PullRequest {
      * For GitHubPullRequest, the json represents the complete snapshot
      */
     @Override
-    public Object comparisonSnapshot() {
+    public Object snapshot() {
         return json;
     }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -782,4 +782,12 @@ public class GitHubPullRequest implements PullRequest {
     public Optional<Hash> findIntegratedCommitHash() {
         return findIntegratedCommitHash(List.of(repository.forge().currentUser().id()));
     }
+
+    /**
+     * For GitHubPullRequest, the json represents the complete snapshot
+     */
+    @Override
+    public Object comparisonSnapshot() {
+        return json;
+    }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -173,7 +173,7 @@ public class GitHubRepository implements HostedRepository {
                       .maxPages(1)
                       .execute().asArray().stream()
                       .map(jsonValue -> new GitHubPullRequest(this, jsonValue, request))
-                      .filter(pr -> pr.updatedAt().isAfter(updatedAfter))
+                      .filter(pr -> !pr.updatedAt().isBefore(updatedAfter))
                       .collect(Collectors.toList());
     }
 
@@ -183,7 +183,7 @@ public class GitHubRepository implements HostedRepository {
                 .param("state", "open")
                 .execute().asArray().stream()
                 .map(jsonValue -> new GitHubPullRequest(this, jsonValue, request))
-                .filter(pr -> pr.updatedAt().isAfter(updatedAfter))
+                .filter(pr -> !pr.updatedAt().isBefore(updatedAfter))
                 .collect(Collectors.toList());
     }
 

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabHost.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabHost.java
@@ -258,4 +258,9 @@ public class GitLabHost implements Forge {
     public Duration minTimeStampUpdateInterval() {
         return Duration.ofMinutes(1);
     }
+
+    @Override
+    public Duration timeStampQueryPrecision() {
+        return Duration.ofSeconds(1);
+    }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -48,6 +48,9 @@ public class GitLabMergeRequest implements PullRequest {
     // Label objects is expensive. This list is always sorted.
     private List<String> labels;
 
+    // Lazy cache for comparisonSnapshot
+    private Object comparisonSnapshot;
+
     GitLabMergeRequest(GitLabRepository repository, GitLabHost host, JSONValue jsonValue, RestRequest request) {
         this.repository = repository;
         this.host = host;
@@ -826,6 +829,18 @@ public class GitLabMergeRequest implements PullRequest {
     @Override
     public Optional<Hash> findIntegratedCommitHash() {
         return findIntegratedCommitHash(List.of(repository.forge().currentUser().id()));
+    }
+
+    /**
+     * For GitLabMergeRequest, a snapshot comparison needs to include the comments
+     * and reviews, which are both part of the general "notes".
+     */
+    @Override
+    public Object comparisonSnapshot() {
+        if (comparisonSnapshot == null) {
+            comparisonSnapshot = List.of(json, request.get("notes").execute());
+        }
+        return comparisonSnapshot;
     }
 
     /**

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -836,7 +836,7 @@ public class GitLabMergeRequest implements PullRequest {
      * and reviews, which are both part of the general "notes".
      */
     @Override
-    public Object comparisonSnapshot() {
+    public Object snapshot() {
         if (comparisonSnapshot == null) {
             comparisonSnapshot = List.of(json, request.get("notes").execute());
         }

--- a/forge/src/test/java/org/openjdk/skara/forge/PullRequestPollerTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/PullRequestPollerTests.java
@@ -3,14 +3,14 @@ package org.openjdk.skara.forge;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.ZonedDateTime;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.openjdk.skara.issuetracker.Issue;
 import org.openjdk.skara.test.HostCredentials;
 import org.openjdk.skara.test.TestHost;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class PullRequestPollerTests {
 
@@ -18,7 +18,7 @@ public class PullRequestPollerTests {
     void onlyOpen(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo)) {
             var repo = credentials.getHostedRepository();
-            var prPoller = new PullRequestPoller(repo, false, true, true);
+            var prPoller = new PullRequestPoller(repo, false);
 
             // Create closed PR that should never be returned
             var prClosed = credentials.createPullRequest(repo, null, null, "Foo");
@@ -54,7 +54,7 @@ public class PullRequestPollerTests {
     void includeClosed(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo)) {
             var repo = credentials.getHostedRepository();
-            var prPoller = new PullRequestPoller(repo, true, true, true);
+            var prPoller = new PullRequestPoller(repo, true);
 
             // Create a and an open closed PR, that should both be returned
             var prClosed = credentials.createPullRequest(repo, null, null, "Foo");
@@ -99,7 +99,7 @@ public class PullRequestPollerTests {
             var repo = credentials.getHostedRepository();
             var forge = repo.forge();
             ((TestHost) forge).setMinTimeStampUpdateInterval(Duration.ofDays(1));
-            var prPoller = new PullRequestPoller(repo, true, false, false);
+            var prPoller = new PullRequestPoller(repo, true);
 
             // Create a closed PR and poll for it
             var pr = credentials.createPullRequest(repo, "master", "master", "Foo");
@@ -111,6 +111,7 @@ public class PullRequestPollerTests {
             // Poll for it again
             prs = prPoller.updatedPullRequests();
             assertEquals(0, prs.size());
+            assertFalse(prPoller.getCurrentQueryResult().pullRequests().isEmpty());
             prPoller.lastBatchHandled();
 
             // Add a new label but make sure the updatedAt time was not updated. This should trigger an update.
@@ -119,22 +120,6 @@ public class PullRequestPollerTests {
             pr.store().setLastUpdate(prevUpdatedAt);
             prs = prPoller.updatedPullRequests();
             assertEquals(1, prs.size());
-            prPoller.lastBatchHandled();
-
-            // Add comment while keeping the updatedAt time unchanged. This should not trigger an update
-            prevUpdatedAt = pr.updatedAt();
-            pr.addComment("foo");
-            pr.store().setLastUpdate(prevUpdatedAt);
-            prs = prPoller.updatedPullRequests();
-            assertEquals(0, prs.size());
-            prPoller.lastBatchHandled();
-
-            // Add review while keeping the updatedAt time unchanged. This should not trigger an update
-            prevUpdatedAt = pr.updatedAt();
-            pr.addReview(Review.Verdict.APPROVED, "foo");
-            pr.store().setLastUpdate(prevUpdatedAt);
-            prs = prPoller.updatedPullRequests();
-            assertEquals(0, prs.size());
             prPoller.lastBatchHandled();
         }
     }
@@ -148,7 +133,7 @@ public class PullRequestPollerTests {
             var repo = credentials.getHostedRepository();
             var forge = repo.forge();
             ((TestHost) forge).setMinTimeStampUpdateInterval(Duration.ofDays(1));
-            var prPoller = new PullRequestPoller(repo, true, true, false);
+            var prPoller = new PullRequestPoller(repo, true);
 
             // Create a PR and poll for it
             var pr = credentials.createPullRequest(repo, "master", "master", "Foo");
@@ -159,6 +144,7 @@ public class PullRequestPollerTests {
             // Poll for it again
             prs = prPoller.updatedPullRequests();
             assertEquals(0, prs.size());
+            assertFalse(prPoller.getCurrentQueryResult().pullRequests().isEmpty());
             prPoller.lastBatchHandled();
 
             // Add a new comment but make sure the updatedAt time was not updated. This should trigger an update.
@@ -185,55 +171,7 @@ public class PullRequestPollerTests {
             assertEquals(1, prs.size());
             prPoller.lastBatchHandled();
 
-            // Add review while keeping updatedAt unchanged. This should not trigger an update.
-            prevUpdatedAt = pr.updatedAt();
-            pr.addReview(Review.Verdict.APPROVED, "foo");
-            pr.store().setLastUpdate(prevUpdatedAt);
-            prs = prPoller.updatedPullRequests();
-            assertEquals(0, prs.size());
-            prPoller.lastBatchHandled();
-        }
-    }
-
-    /**
-     * Tests polling with padding needed and creating/modifying reviews
-     */
-    @Test
-    void queryPaddingReview(TestInfo testInfo) throws IOException {
-        try (var credentials = new HostCredentials(testInfo)) {
-            var repo = credentials.getHostedRepository();
-            var forge = repo.forge();
-            ((TestHost) forge).setMinTimeStampUpdateInterval(Duration.ofDays(1));
-            var prPoller = new PullRequestPoller(repo, true, false, true);
-
-            // Create a PR and poll for it
-            var pr = credentials.createPullRequest(repo, "master", "master", "Foo");
-            var prs = prPoller.updatedPullRequests();
-            assertEquals(1, prs.size());
-            prPoller.lastBatchHandled();
-
-            // Poll for it again
-            prs = prPoller.updatedPullRequests();
-            assertEquals(0, prs.size());
-            prPoller.lastBatchHandled();
-
-            // Add a label but make sure the updatedAt time was not updated. This should trigger an update.
-            var prevUpdatedAt = pr.updatedAt();
-            pr.addLabel("foo");
-            pr.store().setLastUpdate(prevUpdatedAt);
-            prs = prPoller.updatedPullRequests();
-            assertEquals(1, prs.size());
-            prPoller.lastBatchHandled();
-
-            // Add comment while keeping updatedAt unchanged. This should not trigger an update
-            prevUpdatedAt = pr.updatedAt();
-            pr.addComment("foo");
-            pr.store().setLastUpdate(prevUpdatedAt);
-            prs = prPoller.updatedPullRequests();
-            assertEquals(0, prs.size());
-            prPoller.lastBatchHandled();
-
-            // Add review while keeping updatedAt unchanged. This should trigger an update
+            // Add review while keeping updatedAt unchanged. This should trigger an update.
             prevUpdatedAt = pr.updatedAt();
             pr.addReview(Review.Verdict.APPROVED, "foo");
             pr.store().setLastUpdate(prevUpdatedAt);
@@ -247,7 +185,7 @@ public class PullRequestPollerTests {
     void retries(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo)) {
             var repo = credentials.getHostedRepository();
-            var prPoller = new PullRequestPoller(repo, false, true, true);
+            var prPoller = new PullRequestPoller(repo, false);
 
             // Create PR
             var pr1 = credentials.createPullRequest(repo, null, null, "Foo");
@@ -296,7 +234,7 @@ public class PullRequestPollerTests {
     void quarantine(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo)) {
             var repo = credentials.getHostedRepository();
-            var prPoller = new PullRequestPoller(repo, false, false, false);
+            var prPoller = new PullRequestPoller(repo, false);
 
             // Create PR
             var pr1 = credentials.createPullRequest(repo, null, null, "Foo");
@@ -341,6 +279,54 @@ public class PullRequestPollerTests {
             prPoller.quarantinePullRequest(pr1, Instant.now().plus(Duration.ofDays(1)));
             prs = prPoller.updatedPullRequests();
             assertEquals(0, prs.size());
+            prPoller.lastBatchHandled();
+        }
+    }
+
+    @Test
+    void positivePadding(TestInfo testInfo) throws IOException, InterruptedException {
+        try (var credentials = new HostCredentials(testInfo)) {
+            var repo = credentials.getHostedRepository();
+            var forge = repo.forge();
+            ((TestHost) forge).setMinTimeStampUpdateInterval(Duration.ofNanos(1));
+            ((TestHost) forge).setTimeStampQueryPrecision(Duration.ofNanos(1));
+            ZonedDateTime base = ZonedDateTime.now();
+            var prPoller = new PullRequestPoller(repo, false);
+
+            // Create a PR with updatedAt set to 'base', and poll it so lastUpdatedAt is now 'base'
+            var pr1 = credentials.createPullRequest(repo, null, null, "Foo");
+            pr1.store().setLastUpdate(base);
+            var prs = prPoller.updatedPullRequests();
+            assertEquals(1, prs.size());
+            prPoller.lastBatchHandled();
+
+            // Create two more PRs, with updatedAt just before and just after 'base'
+            var pr2 = credentials.createPullRequest(repo, null, null, "Foo");
+            pr2.store().setLastUpdate(base.minus(Duration.ofNanos(2)));
+            var pr3 = credentials.createPullRequest(repo, null, null, "Foo");
+            pr3.store().setLastUpdate(base.plus(Duration.ofNanos(2)));
+            // The negative padding is not big enough to include pr2 and pr1 has already been returned
+            prs = prPoller.updatedPullRequests();
+            assertEquals(1, prs.size());
+            assertEquals(pr3.id(), prs.get(0).id());
+            assertTrue(prPoller.getCurrentQueryResult().pullRequests().containsKey(pr1.id()));
+            prPoller.lastBatchHandled();
+
+            // Sleep a minimal amount and query again to trigger positive padding
+            Thread.sleep(1);
+            prs = prPoller.updatedPullRequests();
+            assertEquals(0, prs.size());
+            // The query should still return pr3
+            assertTrue(prPoller.getCurrentQueryResult().pullRequests().containsKey(pr3.id()));
+            prPoller.lastBatchHandled();
+
+            // Now even the query should not include p3, but we should get the new pr4
+            var pr4 = credentials.createPullRequest(repo, null, null, "Foo");
+            pr4.store().setLastUpdate(base.plus(Duration.ofNanos(4)));
+            prs = prPoller.updatedPullRequests();
+            assertEquals(1, prs.size());
+            assertEquals(pr4.id(), prs.get(0).id());
+            assertFalse(prPoller.getCurrentQueryResult().pullRequests().containsKey(pr3.id()));
             prPoller.lastBatchHandled();
         }
     }

--- a/forge/src/test/java/org/openjdk/skara/forge/PullRequestPollerTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/PullRequestPollerTests.java
@@ -209,10 +209,12 @@ public class PullRequestPollerTests {
             prPoller.retryPullRequest(pr2);
             prs = prPoller.updatedPullRequests();
             assertEquals(1, prs.size());
+            assertEquals(pr2.id(), prs.get(0).id());
 
             // Call again without calling .lastBatchHandled, the retry should be included again
             prs = prPoller.updatedPullRequests();
             assertEquals(1, prs.size());
+            assertEquals(pr2.id(), prs.get(0).id());
             prPoller.lastBatchHandled();
 
             // Mark a PR for retry far in the future, it should not be included
@@ -318,6 +320,12 @@ public class PullRequestPollerTests {
             assertEquals(0, prs.size());
             // The query should still return pr3
             assertTrue(prPoller.getCurrentQueryResult().pullRequests().containsKey(pr3.id()));
+
+            // The same should happen again until we call lastBatchHandled()
+            prs = prPoller.updatedPullRequests();
+            assertEquals(0, prs.size());
+            // The query should still return pr3
+            assertTrue(prPoller.getCurrentQueryResult().pullRequests().containsKey(pr3.id()));
             prPoller.lastBatchHandled();
 
             // Now even the query should not include p3, but we should get the new pr4
@@ -327,6 +335,25 @@ public class PullRequestPollerTests {
             assertEquals(1, prs.size());
             assertEquals(pr4.id(), prs.get(0).id());
             assertFalse(prPoller.getCurrentQueryResult().pullRequests().containsKey(pr3.id()));
+
+            // The same should happen again until we call lastBatchHandled()
+            prs = prPoller.updatedPullRequests();
+            assertEquals(1, prs.size());
+            assertEquals(pr4.id(), prs.get(0).id());
+            assertFalse(prPoller.getCurrentQueryResult().pullRequests().containsKey(pr3.id()));
+            prPoller.lastBatchHandled();
+
+            // Since we got a result, positive padding should be disabled again.
+            prs = prPoller.updatedPullRequests();
+            assertEquals(0, prs.size());
+            assertEquals(1, prPoller.getCurrentQueryResult().pullRequests().size());
+            assertTrue(prPoller.getCurrentQueryResult().pullRequests().containsKey(pr4.id()));
+
+            // The same should happen again until we call lastBatchHandled()
+            prs = prPoller.updatedPullRequests();
+            assertEquals(0, prs.size());
+            assertEquals(1, prPoller.getCurrentQueryResult().pullRequests().size());
+            assertTrue(prPoller.getCurrentQueryResult().pullRequests().containsKey(pr4.id()));
             prPoller.lastBatchHandled();
         }
     }

--- a/host/src/main/java/org/openjdk/skara/host/Host.java
+++ b/host/src/main/java/org/openjdk/skara/host/Host.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.skara.host;
 
+import java.time.Duration;
 import java.util.Optional;
 
 public interface Host {
@@ -30,4 +31,13 @@ public interface Host {
     HostUser currentUser();
     boolean isMemberOf(String groupId, HostUser user);
     String hostname();
+    /**
+     * The precision at which timeStamp based queries are supported for this
+     * Host. The default is 1 nanosecond, knowing this can be used to avoid
+     * re-querying for the same Issues over and over (as timestamp based
+     * queries are often inclusive).
+     */
+    default Duration timeStampQueryPrecision() {
+        return Duration.ofNanos(1);
+    }
 }

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/IssuePoller.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/IssuePoller.java
@@ -20,8 +20,8 @@ public class IssuePoller {
     private final ZonedDateTime initialUpdatedAt;
     private final Map<String, Issue> retryMap = new HashMap<>();
 
-    private record QueryResult(Map<String, Issue> issues, ZonedDateTime maxUpdatedAt,
-                               Instant afterQuery, List<Issue> result) {}
+    record QueryResult(Map<String, Issue> issues, ZonedDateTime maxUpdatedAt,
+                       Instant afterQuery, List<Issue> result) {}
     private QueryResult current;
     private QueryResult prev;
 
@@ -160,5 +160,10 @@ public class IssuePoller {
                 return Stream.concat(issues.stream(), retries.stream()).toList();
             }
         }
+    }
+
+    // Expose the query results to tests
+    QueryResult getCurrentQueryResult() {
+        return current;
     }
 }

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/IssueProject.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/IssueProject.java
@@ -34,6 +34,11 @@ public interface IssueProject {
     Issue createIssue(String title, List<String> body, Map<String, JSONValue> properties);
     Optional<Issue> issue(String id);
     List<Issue> issues();
+
+    /**
+     * Find all issues that have been updated after or on the given time, with
+     * a resolution given by Host::timeStampQueryPrecision.
+     */
     List<Issue> issues(ZonedDateTime updatedAfter);
     String name();
 
@@ -45,8 +50,8 @@ public interface IssueProject {
     Optional<Issue> jepIssue(String jepId);
 
     /**
-     * Find all issues of CSR type updated after the given timestamp.
-     * Note that time queries in Jira are only on minute resolution.
+     * Find all issues of CSR type updated after or on the given time, with
+     * a resolution given by Host::timeStampQueryPrecision.
      * @param updatedAfter Timestamp
      * @return List of issues found
      */

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/IssueTracker.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/IssueTracker.java
@@ -33,15 +33,6 @@ public interface IssueTracker extends Host {
 
     URI uri();
 
-    /**
-     * The precision at which timeStamp based queries are supported for this
-     * IssueTracker. If this is >0, knowing this can be used to avoid
-     * re-querying for the same Issues over and over.
-     */
-    default Duration timeStampQueryPrecision() {
-        return Duration.ZERO;
-    }
-
     static IssueTracker from(String name, URI uri, Credential credential, JSONObject configuration) {
         var factory = IssueTrackerFactory.getIssueTrackerFactories().stream()
                                   .filter(f -> f.name().equals(name))

--- a/issuetracker/src/test/java/org/openjdk/skara/issuetracker/IssuePollerTests.java
+++ b/issuetracker/src/test/java/org/openjdk/skara/issuetracker/IssuePollerTests.java
@@ -111,6 +111,13 @@ public class IssuePollerTests {
             Thread.sleep(1);
             issues = issuePoller.updatedIssues();
             assertEquals(0, issues.size());
+            // The query should still return the issue
+            assertEquals(1, issuePoller.getCurrentQueryResult().issues().size());
+
+            // The same should happen again until we call lastBatchHandled()
+            issues = issuePoller.updatedIssues();
+            assertEquals(0, issues.size());
+            assertEquals(1, issuePoller.getCurrentQueryResult().issues().size());
             issuePoller.lastBatchHandled();
 
             // With padding triggered, no issues should be returned even at the query
@@ -121,11 +128,22 @@ public class IssuePollerTests {
             assertTrue(issuePoller.getCurrentQueryResult().issues().isEmpty(),
                     "Nothing should have been returned by the query but contained: "
                             + issuePoller.getCurrentQueryResult().issues());
+
+            // The same should happen again until we call lastBatchHandled()
+            issues = issuePoller.updatedIssues();
+            assertEquals(0, issues.size());
+            assertTrue(issuePoller.getCurrentQueryResult().issues().isEmpty(),
+                    "Nothing should have been returned by the query but contained: "
+                            + issuePoller.getCurrentQueryResult().issues());
             issuePoller.lastBatchHandled();
 
             // Update to something just after the lastUpdate + precision and poll
             // again. Now it should be returned.
             issue1.store().setLastUpdate(lastFoundUpdatedAt.plus(Duration.ofNanos(3)));
+            issues = issuePoller.updatedIssues();
+            assertEquals(1, issues.size());
+
+            // The same should happen again until we call lastBatchHandled()
             issues = issuePoller.updatedIssues();
             assertEquals(1, issues.size());
             issuePoller.lastBatchHandled();

--- a/test/src/main/java/org/openjdk/skara/test/TestHost.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHost.java
@@ -59,7 +59,7 @@ public class TestHost implements Forge, IssueTracker {
     // Setting this field doesn't change the behavior of the TestHost, but it changes
     // what the associated method returns, which triggers different code paths in
     // dependent test code.
-    private Duration timeStampQueryPrecision = Duration.ZERO;
+    private Duration timeStampQueryPrecision = Duration.ofNanos(1);
 
     private static class HostData {
         final List<HostUser> users = new ArrayList<>();
@@ -254,8 +254,6 @@ public class TestHost implements Forge, IssueTracker {
         return data.issues.entrySet().stream()
                           .sorted(Map.Entry.comparingByKey())
                           .map(issue -> getIssue(issueProject, issue.getKey()))
-                          // Accept updatedAfter == updatedAt to make tests more
-                          // resilient on hardware with lower resolution system clocks.
                           .filter(i -> !i.updatedAt().isBefore(updatedAfter))
                           .collect(Collectors.toList());
     }
@@ -268,7 +266,7 @@ public class TestHost implements Forge, IssueTracker {
                     var type = i.properties().get("issuetype");
                     return type != null && "CSR".equals(type.asString());
                 })
-                .filter(i -> i.updatedAt().isAfter(updatedAfter))
+                .filter(i -> !i.updatedAt().isBefore(updatedAfter))
                 .collect(Collectors.toList());
     }
 

--- a/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
@@ -90,7 +90,7 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
     @Override
     public List<PullRequest> pullRequestsAfter(ZonedDateTime updatedAfter) {
         return host.getPullRequests(this).stream()
-                   .filter(pr -> pr.updatedAt().isAfter(updatedAfter))
+                   .filter(pr -> !pr.updatedAt().isBefore(updatedAfter))
                    .sorted(Comparator.comparing(PullRequest::updatedAt).reversed())
                    .collect(Collectors.toList());
     }
@@ -99,7 +99,7 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
     public List<PullRequest> openPullRequestsAfter(ZonedDateTime updatedAfter) {
         return host.getPullRequests(this).stream()
                 .filter(pr -> pr.state().equals(Issue.State.OPEN))
-                .filter(pr -> pr.updatedAt().isAfter(updatedAfter))
+                .filter(pr -> !pr.updatedAt().isBefore(updatedAfter))
                 .collect(Collectors.toList());
     }
 

--- a/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
@@ -280,7 +280,7 @@ public class TestPullRequest extends TestIssue implements PullRequest {
     }
 
     @Override
-    public Object comparisonSnapshot() {
+    public Object snapshot() {
         return List.of(this, comments(), reviews());
     }
 

--- a/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
@@ -279,6 +279,11 @@ public class TestPullRequest extends TestIssue implements PullRequest {
         return findIntegratedCommitHash(List.of(repository().forge().currentUser().id()));
     }
 
+    @Override
+    public Object comparisonSnapshot() {
+        return List.of(this, comments(), reviews());
+    }
+
     /**
      * Mimic GitHub/GitLab where the labels are fetched lazily and cached.
      * In GitLabMergeRequest, the labels are actually part of the main json, but


### PR DESCRIPTION
The new PullRequestPoller from [SKARA-1565](https://bugs.openjdk.org/browse/SKARA-1565) is inefficient in combination with GitLab. In the most common case, when no MRs have been updated, you would expect it to only do one GET query and be done. Instead, that initial query will always return the last updated MR, and then continue to fetch all the metadata for it, which adds up to a lot of time. 

This is made even worse by having to fetch comments and reviews for every MR to be able to compare them for potential updates. In GitLab, both comments and reviews are stored in the same set of "notes" for a merge request. Since we are only fetching them for comparing between different snapshots, we can make this faster by just fetching all notes once (which will also increase accuracy as there are other kinds of notes too, which we probably should check for updates too).

The repeated refetching of the last updated MR is basically the same problem as the IssuePoller is already solving. The resolution for timestamp based queries is limited (1s on GitLab) and the query is inclusive. In contrast, the current implementation for GitLabRepository treats the timestamp as exclusive.

This patch does the following:

1. Change all timestamp based pull request and issue queries (including for test implementations) to be inclusive, for consistency.
2. Implement the same kind of "positive" padding to the updatedAfter parameter in PullRequestPoller as is already present in IssuePoller. I'm also modifying tests to actually verify this behavior by exposing some of the internal data of the poller to the test.
3. Add `PullRequest::comparisonSnapshot` which returns an `Object` that represents all data that needs to be considered when evaluating if a snapshot is equal to another. In GitLabMergeRequest, this is cached lazily to avoid repeated remote calls.

While working on this, I've realized that IssuePoller and PullRequestPoller are basically doing the exact same thing now, with pretty small variations. Ideally we should combine these into a common super class, but I'm leaving that for a separate change to make the current changes easier to follow.

I'm going to run this change in "staging" for a bit to see how it behaves.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1606](https://bugs.openjdk.org/browse/SKARA-1606): PullRequestPoller always processes the last updated MR for GitLab


### Reviewers
 * [Erik Helin](https://openjdk.org/census#ehelin) (@edvbld - **Reviewer**) ⚠️ Review applies to [b9092aee](https://git.openjdk.org/skara/pull/1380/files/b9092aee8618ff2b5b08010396d3fb34da250337)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1380/head:pull/1380` \
`$ git checkout pull/1380`

Update a local copy of the PR: \
`$ git checkout pull/1380` \
`$ git pull https://git.openjdk.org/skara pull/1380/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1380`

View PR using the GUI difftool: \
`$ git pr show -t 1380`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1380.diff">https://git.openjdk.org/skara/pull/1380.diff</a>

</details>
