### PR TITLE
1235: git sync --branches doesn't work as expected

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitSync.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitSync.java
@@ -362,7 +362,7 @@ public class GitSync {
                 logVerbose("Skipping branch " + name);
                 continue;
             }
-            if (ignore.matcher(name).matches()) {
+            if (!branches.contains(name) && ignore.matcher(name).matches()) {
                 logVerbose("Skipping branch " + name);
                 continue;
             }


### PR DESCRIPTION
Make git sync --branches works as expected.

The argument after git sync --branches will not be ignored right now.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1235](https://bugs.openjdk.org/browse/SKARA-1235): git sync --branches doesn't work as expected


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**) ⚠️ Review applies to [eccff671](https://git.openjdk.org/skara/pull/1381/files/eccff6714947383d308071d596c7bafe7974bbf6)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1381/head:pull/1381` \
`$ git checkout pull/1381`

Update a local copy of the PR: \
`$ git checkout pull/1381` \
`$ git pull https://git.openjdk.org/skara pull/1381/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1381`

View PR using the GUI difftool: \
`$ git pr show -t 1381`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1381.diff">https://git.openjdk.org/skara/pull/1381.diff</a>

</details>
