### PR TITLE
1584: Require re-review of a PR if the target branch changes

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -501,8 +501,8 @@ class CheckRun {
                                .map(review -> {
                                    var entry = " * " + formatReviewer(review.reviewer());
                                    if (!review.targetRef().equals(pr.targetRef())) {
-                                       entry += " 🔄 Re-review required (review applies to pull request targeting [" + review.targetRef()
-                                               + "](" + pr.repository().webUrl(new Branch(review.targetRef())) + "))";
+                                       entry += " 🔄 Re-review required (review was made when pull request targeted the [" + review.targetRef()
+                                               + "](" + pr.repository().webUrl(new Branch(review.targetRef())) + ") branch)";
                                    } else {
                                        var hash = review.hash();
                                        if (hash.isPresent()) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -500,19 +500,24 @@ class CheckRun {
                                .filter(review -> review.verdict() == Review.Verdict.APPROVED)
                                .map(review -> {
                                    var entry = " * " + formatReviewer(review.reviewer());
-                                   var hash = review.hash();
-                                   if (hash.isPresent()) {
-                                       if (!hash.get().equals(pr.headHash())) {
-                                           if (ignoreStaleReviews) {
-                                               entry += " 🔄 Re-review required (review applies to [" + hash.get().abbreviate()
-                                                     + "](" + pr.filesUrl(hash.get()) + "))";
-                                           } else {
-                                               entry += " ⚠️ Review applies to [" + hash.get().abbreviate()
-                                                       + "](" + pr.filesUrl(hash.get()) + ")";
-                                           }
-                                       }
+                                   if (!review.targetRef().equals(pr.targetRef())) {
+                                       entry += " 🔄 Re-review required (review applies to pull request targeting [" + review.targetRef()
+                                               + "](" + pr.repository().webUrl(new Branch(review.targetRef())) + "))";
                                    } else {
-                                       entry += " 🔄 Re-review required (review applies to a commit that is no longer present)";
+                                       var hash = review.hash();
+                                       if (hash.isPresent()) {
+                                           if (!hash.get().equals(pr.headHash())) {
+                                               if (ignoreStaleReviews) {
+                                                   entry += " 🔄 Re-review required (review applies to [" + hash.get().abbreviate()
+                                                           + "](" + pr.filesUrl(hash.get()) + "))";
+                                               } else {
+                                                   entry += " ⚠️ Review applies to [" + hash.get().abbreviate()
+                                                           + "](" + pr.filesUrl(hash.get()) + ")";
+                                               }
+                                           }
+                                       } else {
+                                           entry += " 🔄 Re-review required (review applies to a commit that is no longer present)";
+                                       }
                                    }
                                    return entry;
                                })

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -77,7 +77,8 @@ class CheckWorkItem extends PullRequestWorkItem {
             var approverString = reviews.stream()
                                         .filter(review -> review.verdict() == Review.Verdict.APPROVED)
                                         .filter(review -> review.hash().isPresent())
-                                        .map(review -> encodeReviewer(review.reviewer(), censusInstance) + review.hash().orElseThrow().hex())
+                                        .map(review -> encodeReviewer(review.reviewer(), censusInstance) + review.targetRef()
+                                                + review.hash().orElseThrow().hex())
                                         .sorted()
                                         .collect(Collectors.joining());
             var commentString = comments.stream()
@@ -231,7 +232,7 @@ class CheckWorkItem extends PullRequestWorkItem {
         var labels = new HashSet<>(pr.labelNames());
 
         // Filter out the active reviews
-        var activeReviews = CheckablePullRequest.filterActiveReviews(allReviews);
+        var activeReviews = CheckablePullRequest.filterActiveReviews(allReviews, pr.targetRef());
         if (!currentCheckValid(census, comments, activeReviews, labels)) {
             if (labels.contains("integrated")) {
                 log.info("Skipping check of integrated PR");

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
@@ -339,7 +339,7 @@ class InMemoryPullRequest implements PullRequest {
     }
 
     @Override
-    public List<RefChange> targetRefChanges() {
+    public List<ReferenceChange> targetRefChanges() {
         return List.of();
     }
 }

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
@@ -337,4 +337,9 @@ class InMemoryPullRequest implements PullRequest {
     public Optional<Hash> findIntegratedCommitHash() {
         return Optional.empty();
     }
+
+    @Override
+    public List<RefChange> targetRefChanges() {
+        return List.of();
+    }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/RefChange.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/RefChange.java
@@ -1,6 +1,0 @@
-package org.openjdk.skara.forge;
-
-import java.time.ZonedDateTime;
-
-public record RefChange(String prevRefName, String curRefName, ZonedDateTime createdAt) {
-}

--- a/forge/src/main/java/org/openjdk/skara/forge/RefChange.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/RefChange.java
@@ -1,0 +1,6 @@
+package org.openjdk.skara.forge;
+
+import java.time.ZonedDateTime;
+
+public record RefChange(String prevRefName, String curRefName, ZonedDateTime createdAt) {
+}

--- a/forge/src/main/java/org/openjdk/skara/forge/ReferenceChange.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/ReferenceChange.java
@@ -1,0 +1,6 @@
+package org.openjdk.skara.forge;
+
+import java.time.ZonedDateTime;
+
+public record ReferenceChange(String from, String to, ZonedDateTime at) {
+}

--- a/forge/src/main/java/org/openjdk/skara/forge/Review.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/Review.java
@@ -49,14 +49,8 @@ public class Review {
         this.targetRef = targetRef;
     }
 
-    public Review(Review other, String targetRef) {
-        this.createdAt = other.createdAt;
-        this.reviewer = other.reviewer;
-        this.verdict = other.verdict;
-        this.hash = other.hash;
-        this.id = other.id;
-        this.body = other.body;
-        this.targetRef = targetRef;
+    public Review withTargetRef(String targetRef) {
+        return new Review(createdAt, reviewer, verdict, hash, id, body, targetRef);
     }
 
     public ZonedDateTime createdAt() {

--- a/forge/src/main/java/org/openjdk/skara/forge/Review.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/Review.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.skara.forge;
 
+import java.util.Objects;
 import org.openjdk.skara.host.HostUser;
 import org.openjdk.skara.vcs.Hash;
 
@@ -35,14 +36,27 @@ public class Review {
     private final Hash hash;
     private final int id;
     private final String body;
+    private final String targetRef;
 
-    public Review(ZonedDateTime createdAt, HostUser reviewer, Verdict verdict, Hash hash, int id, String body) {
+    public Review(ZonedDateTime createdAt, HostUser reviewer, Verdict verdict, Hash hash, int id, String body,
+            String targetRef) {
         this.createdAt = createdAt;
         this.reviewer = reviewer;
         this.verdict = verdict;
         this.hash = hash;
         this.id = id;
         this.body = body;
+        this.targetRef = targetRef;
+    }
+
+    public Review(Review other, String targetRef) {
+        this.createdAt = other.createdAt;
+        this.reviewer = other.reviewer;
+        this.verdict = other.verdict;
+        this.hash = other.hash;
+        this.id = other.id;
+        this.body = other.body;
+        this.targetRef = targetRef;
     }
 
     public ZonedDateTime createdAt() {
@@ -73,9 +87,37 @@ public class Review {
         return Optional.ofNullable(body);
     }
 
+    public String targetRef() {
+        return targetRef;
+    }
+
     public enum Verdict {
         NONE,
         APPROVED,
         DISAPPROVED
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Review review;
+        review = (Review) o;
+        return id == review.id &&
+                Objects.equals(createdAt, review.createdAt) &&
+                Objects.equals(reviewer, review.reviewer) &&
+                verdict == review.verdict &&
+                Objects.equals(hash, review.hash) &&
+                Objects.equals(body, review.body) &&
+                Objects.equals(targetRef, review.targetRef);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(createdAt, reviewer, verdict, hash, id, body, targetRef);
     }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -116,7 +116,7 @@ public class GitHubPullRequest implements PullRequest {
     }
 
     @Override
-    public List<RefChange> targetRefChanges() {
+    public List<ReferenceChange> targetRefChanges() {
         // If the base ref has changed after a review, we treat those as invalid - unless it was a PreIntegration ref
         var parts = repository.name().split("/");
         var owner = parts[0];
@@ -132,7 +132,7 @@ public class GitHubPullRequest implements PullRequest {
                 "          ... on BaseRefChangedEvent {\n" +
                 "            currentRefName,\n" +
                 "            previousRefName,\n" +
-                "            createdAt\n" +
+                "            at\n" +
                 "          }\n" +
                 "        }\n" +
                 "      }\n" +
@@ -146,8 +146,8 @@ public class GitHubPullRequest implements PullRequest {
                 .get("data");
         return data.get("repository").get("pullRequest").get("timelineItems").get("nodes").stream()
                 .map(JSONValue::asObject)
-                .map(obj -> new RefChange(obj.get("previousRefName").asString(), obj.get("currentRefName").asString(),
-                        ZonedDateTime.parse(obj.get("createdAt").asString())))
+                .map(obj -> new ReferenceChange(obj.get("previousRefName").asString(), obj.get("currentRefName").asString(),
+                        ZonedDateTime.parse(obj.get("at").asString())))
                 .toList();
     }
 

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -347,7 +347,7 @@ public class GitHubRepository implements HostedRepository {
             "  repository(owner: \"" + owner + "\", name: \"" + name + "\") {",
             "    commitComments(last: 100) {",
             "      nodes {",
-            "        createdAt,",
+            "        at,",
             "        updatedAt,",
             "        author {,",
             "          login,",
@@ -380,7 +380,7 @@ public class GitHubRepository implements HostedRepository {
                            .filter(o -> !excludeAuthors.contains(o.get("author").get("databaseId").asInt()))
                            .map(o -> {
                                var hash = new Hash(o.get("commit").get("oid").asString());
-                               var createdAt = ZonedDateTime.parse(o.get("createdAt").asString());
+                               var createdAt = ZonedDateTime.parse(o.get("at").asString());
                                var updatedAt = ZonedDateTime.parse(o.get("updatedAt").asString());
                                var id = String.valueOf(o.get("databaseId").asInt());
                                var body = o.get("body").asString();

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -22,7 +22,6 @@
  */
 package org.openjdk.skara.forge.gitlab;
 
-import java.util.regex.Matcher;
 import org.openjdk.skara.forge.*;
 import org.openjdk.skara.host.HostUser;
 import org.openjdk.skara.issuetracker.*;
@@ -140,14 +139,14 @@ public class GitLabMergeRequest implements PullRequest {
     }
 
     private static final Pattern REF_CHANGES_PATTERN = Pattern.compile("changed target branch from `(.*)` to `(.*)`");
-    private List<RefChange> targetRefChanges(JSONValue notes) {
+    private List<ReferenceChange> targetRefChanges(JSONValue notes) {
         return notes.stream()
                 .map(JSONValue::asObject)
                 .filter(obj -> obj.get("system").asBoolean())
                 .map(obj -> {
                     var matcher = REF_CHANGES_PATTERN.matcher(obj.get("body").asString());
                     if (matcher.matches()) {
-                        return new RefChange(matcher.group(1), matcher.group(2), ZonedDateTime.parse(obj.get("created_at").asString()));
+                        return new ReferenceChange(matcher.group(1), matcher.group(2), ZonedDateTime.parse(obj.get("created_at").asString()));
                     } else {
                         return null;
                     }
@@ -157,7 +156,7 @@ public class GitLabMergeRequest implements PullRequest {
     }
 
     @Override
-    public List<RefChange> targetRefChanges() {
+    public List<ReferenceChange> targetRefChanges() {
         return targetRefChanges(request.get("notes").execute());
     }
 

--- a/forge/src/test/java/org/openjdk/skara/forge/PullRequestTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/PullRequestTests.java
@@ -20,8 +20,8 @@ public class PullRequestTests {
     void calculateReviewTargetRefs2Changes() {
         var now = ZonedDateTime.now();
 
-        var refChange1 = new RefChange("first", "second", now.minus(Duration.ofMinutes(4)));
-        var refChange2 = new RefChange("second", "third", now.minus(Duration.ofMinutes(2)));
+        var refChange1 = new ReferenceChange("first", "second", now.minus(Duration.ofMinutes(4)));
+        var refChange2 = new ReferenceChange("second", "third", now.minus(Duration.ofMinutes(2)));
 
         var review1 = newReview(now.minus(Duration.ofMinutes(5)), 1, "third");
         var review2 = newReview(now.minus(Duration.ofMinutes(3)), 2, "third");
@@ -39,8 +39,8 @@ public class PullRequestTests {
     void calculateReviewTargetRefsPreIntegrationBranch() {
         var now = ZonedDateTime.now();
 
-        var refChange1 = new RefChange("first", "pr/4711", now.minus(Duration.ofMinutes(4)));
-        var refChange2 = new RefChange("pr/4711", "third", now.minus(Duration.ofMinutes(2)));
+        var refChange1 = new ReferenceChange("first", "pr/4711", now.minus(Duration.ofMinutes(4)));
+        var refChange2 = new ReferenceChange("pr/4711", "third", now.minus(Duration.ofMinutes(2)));
 
         var review1 = newReview(now.minus(Duration.ofMinutes(5)), 1, "");
         var review2 = newReview(now.minus(Duration.ofMinutes(3)), 2, "");
@@ -58,8 +58,8 @@ public class PullRequestTests {
     void calculateReviewTargetRefsPreIntegrationBranchLast() {
         var now = ZonedDateTime.now();
 
-        var refChange1 = new RefChange("first", "pr/4711", now.minus(Duration.ofMinutes(4)));
-        var refChange2 = new RefChange("pr/4711", "pr/4712", now.minus(Duration.ofMinutes(2)));
+        var refChange1 = new ReferenceChange("first", "pr/4711", now.minus(Duration.ofMinutes(4)));
+        var refChange2 = new ReferenceChange("pr/4711", "pr/4712", now.minus(Duration.ofMinutes(2)));
 
         var review1 = newReview(now.minus(Duration.ofMinutes(5)), 1, "");
         var review2 = newReview(now.minus(Duration.ofMinutes(3)), 2, "foo");

--- a/forge/src/test/java/org/openjdk/skara/forge/PullRequestTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/PullRequestTests.java
@@ -1,0 +1,82 @@
+package org.openjdk.skara.forge;
+
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class PullRequestTests {
+
+    @Test
+    void calculateReviewTargetRefsSimple() {
+        assertEquals(List.of(), PullRequest.calculateReviewTargetRefs(List.of(), List.of()));
+        var review1 = newReview(ZonedDateTime.now(), 1, "master");
+        assertEquals(List.of(review1), PullRequest.calculateReviewTargetRefs(List.of(review1), List.of()));
+    }
+
+    @Test
+    void calculateReviewTargetRefs2Changes() {
+        var now = ZonedDateTime.now();
+
+        var refChange1 = new RefChange("first", "second", now.minus(Duration.ofMinutes(4)));
+        var refChange2 = new RefChange("second", "third", now.minus(Duration.ofMinutes(2)));
+
+        var review1 = newReview(now.minus(Duration.ofMinutes(5)), 1, "third");
+        var review2 = newReview(now.minus(Duration.ofMinutes(3)), 2, "third");
+        var review3 = newReview(now.minus(Duration.ofMinutes(1)), 3, "third");
+
+        var reviews = PullRequest.calculateReviewTargetRefs(List.of(review1, review2, review3), List.of(refChange2, refChange1));
+
+        assertEquals(3, reviews.size());
+        assertEquals("first", reviews.get(0).targetRef());
+        assertEquals("second", reviews.get(1).targetRef());
+        assertEquals("third", reviews.get(2).targetRef());
+    }
+
+    @Test
+    void calculateReviewTargetRefsPreIntegrationBranch() {
+        var now = ZonedDateTime.now();
+
+        var refChange1 = new RefChange("first", "pr/4711", now.minus(Duration.ofMinutes(4)));
+        var refChange2 = new RefChange("pr/4711", "third", now.minus(Duration.ofMinutes(2)));
+
+        var review1 = newReview(now.minus(Duration.ofMinutes(5)), 1, "");
+        var review2 = newReview(now.minus(Duration.ofMinutes(3)), 2, "");
+        var review3 = newReview(now.minus(Duration.ofMinutes(1)), 3, "third");
+
+        var reviews = PullRequest.calculateReviewTargetRefs(List.of(review1, review2, review3), List.of(refChange1, refChange2));
+
+        assertEquals(3, reviews.size());
+        assertEquals("first", reviews.get(0).targetRef());
+        assertEquals("third", reviews.get(1).targetRef());
+        assertEquals("third", reviews.get(2).targetRef());
+    }
+
+    @Test
+    void calculateReviewTargetRefsPreIntegrationBranchLast() {
+        var now = ZonedDateTime.now();
+
+        var refChange1 = new RefChange("first", "pr/4711", now.minus(Duration.ofMinutes(4)));
+        var refChange2 = new RefChange("pr/4711", "pr/4712", now.minus(Duration.ofMinutes(2)));
+
+        var review1 = newReview(now.minus(Duration.ofMinutes(5)), 1, "");
+        var review2 = newReview(now.minus(Duration.ofMinutes(3)), 2, "foo");
+        var review3 = newReview(now.minus(Duration.ofMinutes(1)), 3, "pr/4712");
+
+        var reviews = PullRequest.calculateReviewTargetRefs(List.of(review1, review2, review3), List.of(refChange1, refChange2));
+
+        assertEquals(3, reviews.size());
+        assertEquals("first", reviews.get(0).targetRef());
+        assertEquals("pr/4712", reviews.get(1).targetRef());
+        assertEquals("pr/4712", reviews.get(2).targetRef());
+    }
+
+    /**
+     * Creates a new review with just the relevant fields.
+     */
+    private Review newReview(ZonedDateTime createdAt, int id, String targetRef) {
+        return new Review(createdAt, null, Review.Verdict.APPROVED, null, id, null, targetRef);
+    }
+}

--- a/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
@@ -161,7 +161,7 @@ public class TestPullRequest extends TestIssue implements PullRequest {
     }
 
     @Override
-    public List<RefChange> targetRefChanges() {
+    public List<ReferenceChange> targetRefChanges() {
         return store().targetRefChanges();
     }
 

--- a/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
@@ -83,7 +83,7 @@ public class TestPullRequest extends TestIssue implements PullRequest {
 
     @Override
     public List<Review> reviews() {
-        return new ArrayList<>(store().reviews());
+        return PullRequest.calculateReviewTargetRefs(store().reviews(), targetRefChanges());
     }
 
     @Override
@@ -92,7 +92,7 @@ public class TestPullRequest extends TestIssue implements PullRequest {
             var review = new Review(ZonedDateTime.now(), user,
                                     verdict, targetRepository.localRepository().resolve(store().sourceRef()).orElseThrow(),
                                     store().reviews().size(),
-                                    body);
+                                    body, targetRef);
 
             store().reviews().add(review);
             store().setLastUpdate(ZonedDateTime.now());
@@ -158,6 +158,11 @@ public class TestPullRequest extends TestIssue implements PullRequest {
     @Override
     public String targetRef() {
         return targetRef;
+    }
+
+    @Override
+    public List<RefChange> targetRefChanges() {
+        return store().targetRefChanges();
     }
 
     @Override

--- a/test/src/main/java/org/openjdk/skara/test/TestPullRequestStore.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestPullRequestStore.java
@@ -45,7 +45,7 @@ public class TestPullRequestStore extends TestIssueStore {
     private boolean draft;
     private ZonedDateTime lastForcePushTime;
     private Hash headHash;
-    private final List<RefChange> targetRefChanges = new ArrayList<>();
+    private final List<ReferenceChange> targetReferenceChanges = new ArrayList<>();
 
     public TestPullRequestStore(String id, HostUser author, String title, List<String> body,
             TestHostedRepository sourceRepository, String targetRef, String sourceRef, boolean draft) {
@@ -110,12 +110,12 @@ public class TestPullRequestStore extends TestIssueStore {
     }
 
     public void setTargetRef(String targetRef) {
-        targetRefChanges.add(new RefChange(this.targetRef, targetRef, ZonedDateTime.now()));
+        targetReferenceChanges.add(new ReferenceChange(this.targetRef, targetRef, ZonedDateTime.now()));
         this.targetRef = targetRef;
     }
 
-    public List<RefChange> targetRefChanges() {
-        return targetRefChanges;
+    public List<ReferenceChange> targetRefChanges() {
+        return targetReferenceChanges;
     }
 
     public void setSourceRef(String sourceRef) {

--- a/test/src/main/java/org/openjdk/skara/test/TestPullRequestStore.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestPullRequestStore.java
@@ -27,7 +27,6 @@ import java.io.UncheckedIOException;
 import java.time.ZonedDateTime;
 import org.openjdk.skara.forge.*;
 import org.openjdk.skara.host.HostUser;
-import org.openjdk.skara.issuetracker.IssueProject;
 import org.openjdk.skara.vcs.Hash;
 
 import java.util.*;
@@ -46,6 +45,7 @@ public class TestPullRequestStore extends TestIssueStore {
     private boolean draft;
     private ZonedDateTime lastForcePushTime;
     private Hash headHash;
+    private final List<RefChange> targetRefChanges = new ArrayList<>();
 
     public TestPullRequestStore(String id, HostUser author, String title, List<String> body,
             TestHostedRepository sourceRepository, String targetRef, String sourceRef, boolean draft) {
@@ -110,7 +110,12 @@ public class TestPullRequestStore extends TestIssueStore {
     }
 
     public void setTargetRef(String targetRef) {
+        targetRefChanges.add(new RefChange(this.targetRef, targetRef, ZonedDateTime.now()));
         this.targetRef = targetRef;
+    }
+
+    public List<RefChange> targetRefChanges() {
+        return targetRefChanges;
     }
 
     public void setSourceRef(String sourceRef) {

--- a/vcs/src/test/java/org/openjdk/skara/vcs/UnifiedDiffParserTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/UnifiedDiffParserTests.java
@@ -365,9 +365,9 @@ public class UnifiedDiffParserTests {
             "+                          var id = o.get(\"note\").get(\"id\").asstring();\n" +
             "+                          supplier<hash> hash = () -> commitwithcomment(o.get(\"target_title\").asstring(),\n" +
             "+                                                                        body,\n" +
-            "+                                                                        createdAt,\n" +
+            "+                                                                        at,\n" +
             "+                                                                        user);\n" +
-            "+                          return new CommitComment(hash, null, -1, id, body, user, createdAt, createdAt);\n" +
+            "+                          return new CommitComment(hash, null, -1, id, body, user, at, at);\n" +
             "                       })\n" +
             "                       .collect(Collectors.toList());\n" +
             "     }\n";


### PR DESCRIPTION
This change improves reviewer handling when the target branch of a PR is changed. Currently this only invalidates a review on GitHub, but not on GitLab. With this change the behavior is made uniform. In addition to this, the following new behavior is added.

1. When the target branch of a PR is changed, any existing reviews in the Reviewers list will be flagged as "Re-review required (review applies to pull request targeting <branch>)" to make what happened clearer.
2. If the target branch of a PR is changed back to a previously targeted branch, any reviews made against that branch may now become valid again (if all other requirements are met).

Note that changes to and from pr/X branches are ignored, just like before.

PullRequest::reviews is no longer specifying the order of reviews returned. This order was actually not consistent between implementations and I would rather we use explicit sorts when needed instead of assuming an order.

I'm not really happy with the placement of the new static method `calculateReviewTargetRefs`, but I couldn't really find a better location, and I really wanted to share this between different `PullRequest` implementations. I think the correct solution would be to introduce an `AbstractPullRequest` common super class, but I didn't want to do this for a single method.

I have verified this with the new and modified tests, as well as by running against the playground repo(s).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1584](https://bugs.openjdk.org/browse/SKARA-1584): Require re-review of a PR if the target branch changes


### Reviewers
 * [Erik Helin](https://openjdk.org/census#ehelin) (@edvbld - **Reviewer**) ⚠️ Review applies to [afc188de](https://git.openjdk.org/skara/pull/1383/files/afc188de39ee9afe494b73b1a0e28feef8e21884)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1383/head:pull/1383` \
`$ git checkout pull/1383`

Update a local copy of the PR: \
`$ git checkout pull/1383` \
`$ git pull https://git.openjdk.org/skara pull/1383/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1383`

View PR using the GUI difftool: \
`$ git pr show -t 1383`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1383.diff">https://git.openjdk.org/skara/pull/1383.diff</a>

</details>
