### PR TITLE
1612: Temp workaround GitLab returning 500 when modifying labels

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -631,8 +631,16 @@ public class GitLabMergeRequest implements PullRequest {
                         Stream.of(label))
                 .collect(Collectors.toSet());
         request.put("")
-               .body("labels", String.join(",", labels))
-               .execute();
+                .body("labels", String.join(",", labels))
+                // Temporary workaround for GitLab returning 500 when changing labels.
+                // The labels are still modified.
+                .onError(response -> {
+                    if (response.statusCode() == 500) {
+                        return Optional.of(JSON.of());
+                    }
+                    return Optional.empty();
+                })
+                .execute();
         this.labels = labels.stream().sorted().toList();
     }
 
@@ -644,8 +652,16 @@ public class GitLabMergeRequest implements PullRequest {
                 .filter(l -> !l.equals(label))
                 .collect(Collectors.toSet());
         request.put("")
-               .body("labels", String.join(",", labels))
-               .execute();
+                .body("labels", String.join(",", labels))
+                // Temporary workaround for GitLab returning 500 when changing labels.
+                // The labels are still modified.
+                .onError(response -> {
+                    if (response.statusCode() == 500) {
+                        return Optional.of(JSON.of());
+                    }
+                    return Optional.empty();
+                })
+                .execute();
         this.labels = labels.stream().sorted().toList();
     }
 


### PR DESCRIPTION
We are currently experiencing an issue where GitLab returns 500 when we add or remove labels to a merge request. The label change still happens though, so to keep things running, I'm going to implement a temporary workaround to ignore the 500 result on these particular REST calls.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1612](https://bugs.openjdk.org/browse/SKARA-1612): Temp workaround GitLab returning 500 when modifying labels


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1384/head:pull/1384` \
`$ git checkout pull/1384`

Update a local copy of the PR: \
`$ git checkout pull/1384` \
`$ git pull https://git.openjdk.org/skara pull/1384/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1384`

View PR using the GUI difftool: \
`$ git pr show -t 1384`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1384.diff">https://git.openjdk.org/skara/pull/1384.diff</a>

</details>
