### PR TITLE
1452: Can never notify on first commit

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryWorkItem.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryWorkItem.java
@@ -368,9 +368,7 @@ public class RepositoryWorkItem implements WorkItem {
             for (var ref : knownRefs) {
                 if (!hasBranchHistory) {
                     log.warning("No previous history found for any branch - resetting mark for '" + ref.name());
-                    int existingCommits = localRepo.commitCount();
-                    if (existingCommits <= NEW_REPOSITORY_COMMIT_THRESHOLD) {
-                        // In this case, the repo will be considered as a new repo, notify bot will notify start from the first commit
+                    if (localRepo.commitCount() <= NEW_REPOSITORY_COMMIT_THRESHOLD) {
                         log.info("This is a new repo, starting notifications from the very first commit");
                         for (var listener : listeners) {
                             log.info("Resetting mark for branch '" + ref.name() + "' for listener '" + listener.name() + "'");
@@ -378,7 +376,6 @@ public class RepositoryWorkItem implements WorkItem {
                             history.setBranchHash(new Branch(ref.name()), listener.name(), EMPTY_TREE);
                         }
                     } else {
-                        // In this case, the repo will be considered as an existing repo with history, notify bot will only notify on new commits
                         log.info("This is an existing repo with history, starting notifications from commits after " + ref.hash());
                         for (var listener : listeners) {
                             log.info("Resetting mark for branch '" + ref.name() + "' for listener '" + listener.name() + "'");

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryWorkItem.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryWorkItem.java
@@ -37,8 +37,6 @@ import java.util.logging.*;
 import java.util.regex.Pattern;
 import java.util.stream.*;
 
-import static org.openjdk.skara.vcs.git.GitRepository.EMPTY_TREE;
-
 /**
  * A RepositoryWorkItem acts on changes to a particular repository. Multiple kinds
  * of listeners can be notified about various types of changes. Some listeners can
@@ -373,7 +371,7 @@ public class RepositoryWorkItem implements WorkItem {
                         for (var listener : listeners) {
                             log.info("Resetting mark for branch '" + ref.name() + "' for listener '" + listener.name() + "'");
                             // Initialize the mark for the branches with special Git empty tree hash to trigger notifications on all existing commits.
-                            history.setBranchHash(new Branch(ref.name()), listener.name(), EMPTY_TREE);
+                            history.setBranchHash(new Branch(ref.name()), listener.name(), localRepo.initialHash());
                         }
                     } else {
                         log.info("This is an existing repo with history, starting notifications from commits after " + ref.hash());

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdaterTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdaterTests.java
@@ -135,8 +135,8 @@ public class UpdaterTests {
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // Both updaters should have run
-            assertEquals(1, idempotent.updateCount);
-            assertEquals(1, nonIdempotent.updateCount);
+            assertEquals(2, idempotent.updateCount);
+            assertEquals(2, nonIdempotent.updateCount);
 
             var nextEditHash = CheckableRepository.appendAndCommit(localRepo, "Yet another line", "Fix more stuff");
             localRepo.push(nextEditHash, repo.url(), "master");
@@ -146,14 +146,14 @@ public class UpdaterTests {
             assertThrows(RuntimeException.class, () -> TestBotRunner.runPeriodicItems(notifyBot));
 
             // Both updaters should have run again
-            assertEquals(2, idempotent.updateCount);
-            assertEquals(2, nonIdempotent.updateCount);
+            assertEquals(3, idempotent.updateCount);
+            assertEquals(3, nonIdempotent.updateCount);
 
             assertThrows(RuntimeException.class, () -> TestBotRunner.runPeriodicItems(notifyBot));
 
             // But now only the idempotent one should have been retried
-            assertEquals(3, idempotent.updateCount);
-            assertEquals(2, nonIdempotent.updateCount);
+            assertEquals(4, idempotent.updateCount);
+            assertEquals(3, nonIdempotent.updateCount);
         }
     }
 }

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/mailinglist/MailingListNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/mailinglist/MailingListNotifierTests.java
@@ -91,16 +91,9 @@ public class MailingListNotifierTests {
             listServer.processIncoming();
 
             var conversations = mailmanList.conversations(Duration.ofDays(1));
-            conversations.sort((c1, c2) -> {
-                if (c2.first().date().isAfter(c1.first().date())) {
-                    return 1;
-                } else if (c2.first().date().isBefore(c1.first().date())) {
-                    return -1;
-                }
-                return 0;
-            });
+            conversations.sort(Comparator.comparing(conversation -> conversation.first().subject()));
             // get the latest email
-            var email = conversations.get(0).first();
+            var email = conversations.get(1).first();
             assertEquals(listAddress, email.sender());
             assertEquals(sender, email.author());
             assertEquals(email.recipients(), List.of(listAddress));
@@ -175,16 +168,12 @@ public class MailingListNotifierTests {
             listServer.processIncoming();
 
             var conversations = mailmanList.conversations(Duration.ofDays(1));
-            conversations.sort((c1, c2) -> {
-                if (c2.first().date().isAfter(c1.first().date())) {
-                    return 1;
-                } else if (c2.first().date().isBefore(c1.first().date())) {
-                    return -1;
-                }
-                return 0;
-            });
+            conversations.sort(Comparator.comparing(conversation -> conversation.first().subject()));
             // get the latest email
             var email = conversations.get(0).first();
+            if (email.body().contains("Initial commit")) {
+                email = conversations.get(1).first();
+            }
             assertEquals(listAddress, email.sender());
             assertEquals(EmailAddress.from("another_author", "another@author.example.com"), email.author());
             assertEquals(email.recipients(), List.of(listAddress));
@@ -262,16 +251,9 @@ public class MailingListNotifierTests {
             listServer.processIncoming();
 
             var conversations = mailmanList.conversations(Duration.ofDays(1));
-            conversations.sort((c1, c2) -> {
-                if (c2.first().date().isAfter(c1.first().date())) {
-                    return 1;
-                } else if (c2.first().date().isBefore(c1.first().date())) {
-                    return -1;
-                }
-                return 0;
-            });
+            conversations.sort(Comparator.comparing(conversation -> conversation.first().subject()));
             // get the latest email
-            var email = conversations.get(0).first();
+            var email = conversations.get(1).first();
             assertEquals(listAddress, email.sender());
             assertEquals(EmailAddress.from("merge_author", "merge@author.example.com"), email.author());
             assertEquals(email.recipients(), List.of(listAddress));
@@ -340,16 +322,9 @@ public class MailingListNotifierTests {
             listServer.processIncoming();
 
             var conversations = mailmanList.conversations(Duration.ofDays(1));
-            conversations.sort((c1, c2) -> {
-                if (c2.first().date().isAfter(c1.first().date())) {
-                    return 1;
-                } else if (c2.first().date().isBefore(c1.first().date())) {
-                    return -1;
-                }
-                return 0;
-            });
+            conversations.sort(Comparator.comparing(conversation -> conversation.first().subject()));
             // get the latest email
-            var email = conversations.get(0).first();
+            var email = conversations.get(1).first();
             assertEquals(listAddress, email.sender());
             assertEquals(EmailAddress.from("committer", "committer@test.test"), email.author());
             assertEquals(email.recipients(), List.of(listAddress));
@@ -418,16 +393,12 @@ public class MailingListNotifierTests {
             listServer.processIncoming();
 
             var conversations = mailmanList.conversations(Duration.ofDays(1));
-            conversations.sort((c1, c2) -> {
-                if (c2.first().date().isAfter(c1.first().date())) {
-                    return 1;
-                } else if (c2.first().date().isBefore(c1.first().date())) {
-                    return -1;
-                }
-                return 0;
-            });
+            conversations.sort(Comparator.comparing(conversation -> conversation.first().subject()));
             // get the latest email
-            var email = conversations.get(0).first();
+            var email = conversations.get(1).first();
+            if (email.body().contains("Initial commit")) {
+                email = conversations.get(2).first();
+            }
             assertEquals(listAddress, email.sender());
             assertEquals(author, email.author());
             assertEquals(email.recipients(), List.of(listAddress));
@@ -453,14 +424,6 @@ public class MailingListNotifierTests {
 
             conversations = mailmanList.conversations(Duration.ofDays(1));
             conversations.sort(Comparator.comparing(conversation -> conversation.first().subject()));
-            conversations.sort((c1, c2) -> {
-                if (c2.first().date().isAfter(c1.first().date())) {
-                    return 1;
-                } else if (c2.first().date().isBefore(c1.first().date())) {
-                    return -1;
-                }
-                return 0;
-            });
             email = conversations.get(0).first();
             assertEquals(author, email.author());
             assertEquals(listAddress, email.sender());
@@ -557,15 +520,8 @@ public class MailingListNotifierTests {
             // This one should generate a plain integration mail
             var conversations = mailmanList.conversations(Duration.ofDays(1));
             assertEquals(4, conversations.size());
-            conversations.sort((c1, c2) -> {
-                if (c2.first().date().isAfter(c1.first().date())) {
-                    return 1;
-                } else if (c2.first().date().isBefore(c1.first().date())) {
-                    return -1;
-                }
-                return 0;
-            });
-            var secondEmail = conversations.get(0).first();
+            conversations.sort(Comparator.comparing(conversation -> conversation.first().subject()));
+            var secondEmail = conversations.get(2).first();
             assertEquals("git: test: other: 23456789: More fixes", secondEmail.subject());
         }
     }
@@ -646,18 +602,11 @@ public class MailingListNotifierTests {
             listServer.processIncoming();
 
             var conversations = mailmanList.conversations(Duration.ofDays(1));
-            conversations.sort((c1, c2) -> {
-                if (c2.first().date().isAfter(c1.first().date())) {
-                    return 1;
-                } else if (c2.first().date().isBefore(c1.first().date())) {
-                    return -1;
-                }
-                return 0;
-            });
+            conversations.sort(Comparator.comparing(conversation -> conversation.first().subject()));
             assertEquals(3, conversations.size());
 
-            var prConversation = conversations.get(1);
-            var pushConversation = conversations.get(0);
+            var prConversation = conversations.get(0);
+            var pushConversation = conversations.get(2);
             assertEquals(1, prConversation.allMessages().size());
 
             var pushEmail = pushConversation.first();
@@ -749,21 +698,16 @@ public class MailingListNotifierTests {
             listServer.processIncoming();
 
             var conversations = mailmanList.conversations(Duration.ofDays(1));
-            conversations.sort((c1, c2) -> {
-                if (c2.first().date().isAfter(c1.first().date())) {
-                    return 1;
-                } else if (c2.first().date().isBefore(c1.first().date())) {
-                    return -1;
-                }
-                return 0;
-            });
+            conversations.sort(Comparator.comparing(conversation -> conversation.first().subject()));
             assertEquals(3, conversations.size());
 
-            var prConversation = conversations.get(1);
-            var pushConversation = conversations.get(0);
+            var prConversation = conversations.get(0);
             assertEquals(1, prConversation.allMessages().size());
 
-            var pushEmail = pushConversation.first();
+            var pushEmail = conversations.get(1).first();
+            if (pushEmail.body().contains("Initial commit")) {
+                pushEmail = conversations.get(2).first();
+            }
             assertEquals(listAddress, pushEmail.sender());
             assertEquals(EmailAddress.from("unrelated_author", "unrelated@author.example.com"), pushEmail.author());
             assertEquals(pushEmail.recipients(), List.of(listAddress));
@@ -843,14 +787,7 @@ public class MailingListNotifierTests {
             assertThrows(RuntimeException.class, () -> listServer.processIncoming(Duration.ofMillis(1)));
 
             var conversations = mailmanList.conversations(Duration.ofDays(1));
-            conversations.sort((c1, c2) -> {
-                if (c2.first().date().isAfter(c1.first().date())) {
-                    return 1;
-                } else if (c2.first().date().isBefore(c1.first().date())) {
-                    return -1;
-                }
-                return 0;
-            });
+            conversations.sort(Comparator.comparing(conversation -> conversation.first().subject()));
             assertEquals(3, conversations.size());
 
             var prConversation = conversations.get(0);
@@ -863,17 +800,10 @@ public class MailingListNotifierTests {
 
             // The change should now end up as a separate notification thread
             conversations = mailmanList.conversations(Duration.ofDays(1));
-            conversations.sort((c1, c2) -> {
-                if (c2.first().date().isAfter(c1.first().date())) {
-                    return 1;
-                } else if (c2.first().date().isBefore(c1.first().date())) {
-                    return -1;
-                }
-                return 0;
-            });
+            conversations.sort(Comparator.comparing(conversation -> conversation.first().subject()));
             assertEquals(4, conversations.size());
 
-            var pushConversation = conversations.get(0);
+            var pushConversation = conversations.get(2);
             var pushEmail = pushConversation.first();
             assertEquals(listAddress, pushEmail.sender());
             assertEquals(EmailAddress.from("testauthor", "ta@none.none"), pushEmail.author());
@@ -1153,15 +1083,8 @@ public class MailingListNotifierTests {
             listServer.processIncoming();
 
             var conversations = mailmanList.conversations(Duration.ofDays(1));
-            conversations.sort((c1, c2) -> {
-                if (c2.first().date().isAfter(c1.first().date())) {
-                    return 1;
-                } else if (c2.first().date().isBefore(c1.first().date())) {
-                    return -1;
-                }
-                return 0;
-            });
-            var email = conversations.get(0).first();
+            conversations.sort(Comparator.comparing(conversation -> conversation.first().subject()));
+            var email = conversations.get(1).first();
             assertEquals(listAddress, email.sender());
             assertEquals(EmailAddress.from("testauthor", "ta@none.none"), email.author());
             assertEquals(email.recipients(), List.of(listAddress));
@@ -1179,16 +1102,9 @@ public class MailingListNotifierTests {
             TestBotRunner.runPeriodicItems(notifyBot);
             listServer.processIncoming();
 
-            var newConversations = mailmanList.conversations(Duration.ofDays(1));
-            newConversations.sort((c1, c2) -> {
-                if (c2.first().date().isAfter(c1.first().date())) {
-                    return 1;
-                } else if (c2.first().date().isBefore(c1.first().date())) {
-                    return -1;
-                }
-                return 0;
-            });
-            email = newConversations.get(0).first();
+            conversations = mailmanList.conversations(Duration.ofDays(1));
+            conversations.sort(Comparator.comparing(conversation -> conversation.first().subject()));
+            email = conversations.get(2).first();
             assertEquals(listAddress, email.sender());
             assertEquals(sender, email.author());
             assertEquals(email.recipients(), List.of(listAddress));

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/mailinglist/MailingListNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/mailinglist/MailingListNotifierTests.java
@@ -1226,7 +1226,7 @@ public class MailingListNotifierTests {
             var updateHash = CheckableRepository.appendAndCommit(localRepo,"commit3", "commit3");
             localRepo.push(updateHash,repo.url(),"master");
 
-            // No mail should be sent on first commit because it has a long history(commit times > 5)
+            // No mail should be sent on first commit because it has a long history(commit count > 5)
             TestBotRunner.runPeriodicItems(notifyBot);
             assertThrows(RuntimeException.class, () -> listServer.processIncoming());
 

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/TestRepository.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/TestRepository.java
@@ -337,4 +337,9 @@ class TestRepository implements ReadOnlyRepository {
     public boolean contains(Hash h) {
         return false;
     }
+
+    @Override
+    public int commitCount() throws IOException {
+        return 0;
+    }
 }

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/TestRepository.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/TestRepository.java
@@ -342,4 +342,9 @@ class TestRepository implements ReadOnlyRepository {
     public int commitCount() throws IOException {
         return 0;
     }
+
+    @Override
+    public Hash initialHash() {
+        return null;
+    }
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
@@ -170,5 +170,8 @@ public interface ReadOnlyRepository {
 
     int commitCount() throws IOException;
 
+    /**
+     * Returns the special hash that references the virtual commit before the first real commit in a repository.
+     */
     Hash initialHash();
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
@@ -167,4 +167,6 @@ public interface ReadOnlyRepository {
     }
 
     Optional<Tag.Annotated> annotate(Tag tag) throws IOException;
+
+    int commitCount() throws IOException;
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
@@ -169,4 +169,6 @@ public interface ReadOnlyRepository {
     Optional<Tag.Annotated> annotate(Tag tag) throws IOException;
 
     int commitCount() throws IOException;
+
+    Hash initialHash();
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
@@ -297,4 +297,6 @@ public interface Repository extends ReadOnlyRepository {
             GitRepository.mirror(from, to) :
             HgRepository.clone(from, to, true, null); // hg does not have concept of "mirror"
     }
+
+    int getExistingCommits() throws IOException;
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
@@ -297,6 +297,4 @@ public interface Repository extends ReadOnlyRepository {
             GitRepository.mirror(from, to) :
             HgRepository.clone(from, to, true, null); // hg does not have concept of "mirror"
     }
-
-    int getExistingCommits() throws IOException;
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -48,7 +48,7 @@ public class GitRepository implements Repository {
     private final Path dir;
     private final Logger log = Logger.getLogger("org.openjdk.skara.vcs.git");
     private Path cachedRoot = null;
-    private static final Hash EMPTY_TREE = new Hash("4b825dc642cb6eb9a060e54bf8d69288fbee4904");
+    public static final Hash EMPTY_TREE = new Hash("4b825dc642cb6eb9a060e54bf8d69288fbee4904");
 
     public static void ignoreConfiguration() {
         currentEnv = NO_CONFIG_ENV;
@@ -1649,9 +1649,9 @@ public class GitRepository implements Repository {
     }
 
     @Override
-    public int getExistingCommits() throws IOException {
+    public int commitCount() throws IOException {
         try (var p = capture("git", "rev-list", "--all", "--count")) {
-            return Integer.valueOf(await(p).stdout().get(0));
+            return Integer.parseInt(await(p).stdout().get(0));
         }
     }
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -48,7 +48,7 @@ public class GitRepository implements Repository {
     private final Path dir;
     private final Logger log = Logger.getLogger("org.openjdk.skara.vcs.git");
     private Path cachedRoot = null;
-    public static final Hash EMPTY_TREE = new Hash("4b825dc642cb6eb9a060e54bf8d69288fbee4904");
+    private static final Hash EMPTY_TREE = new Hash("4b825dc642cb6eb9a060e54bf8d69288fbee4904");
 
     public static void ignoreConfiguration() {
         currentEnv = NO_CONFIG_ENV;
@@ -1653,5 +1653,10 @@ public class GitRepository implements Repository {
         try (var p = capture("git", "rev-list", "--all", "--count")) {
             return Integer.parseInt(await(p).stdout().get(0));
         }
+    }
+
+    @Override
+    public Hash initialHash() {
+        return EMPTY_TREE;
     }
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -1647,4 +1647,11 @@ public class GitRepository implements Repository {
             return p.await().status() == 0;
         }
     }
+
+    @Override
+    public int getExistingCommits() throws IOException {
+        try (var p = capture("git", "rev-list", "--all", "--count")) {
+            return Integer.valueOf(await(p).stdout().get(0));
+        }
+    }
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -1494,4 +1494,10 @@ public class HgRepository implements Repository {
             return p.await().status() == 0;
         }
     }
+
+    @Override
+    public int getExistingCommits() throws IOException {
+        //TODO:: implement it later, return 10 here so that it will maintain the previous behavior
+        return 10;
+    }
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -1496,8 +1496,9 @@ public class HgRepository implements Repository {
     }
 
     @Override
-    public int getExistingCommits() throws IOException {
-        //TODO:: implement it later, return 10 here so that it will maintain the previous behavior
-        return 10;
+    public int commitCount() throws IOException {
+        try (var p = capture("hg", "id", "--num", "--rev","tip")) {
+            return Integer.parseInt(await(p).stdout().get(0)) + 1;
+        }
     }
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -50,7 +50,7 @@ public class HgRepository implements Repository {
     private final Path dir;
     private final Logger log = Logger.getLogger("org.openjdk.skara.vcs.hg");
 
-    private static final Hash NULL_REVISION = new Hash("0000000000000000000000000000000000000000");
+    private static final Hash NULL_REVISION = new Hash("0".repeat(40));
 
     public static void ignoreConfiguration() {
         currentEnv = NO_CONFIG_ENV;

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -1497,7 +1497,7 @@ public class HgRepository implements Repository {
 
     @Override
     public int commitCount() throws IOException {
-        try (var p = capture("hg", "id", "--num", "--rev","tip")) {
+        try (var p = capture("hg", "id", "--num", "--rev", "tip")) {
             return Integer.parseInt(await(p).stdout().get(0)) + 1;
         }
     }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -50,6 +50,8 @@ public class HgRepository implements Repository {
     private final Path dir;
     private final Logger log = Logger.getLogger("org.openjdk.skara.vcs.hg");
 
+    private static final Hash NULL_REVISION = new Hash("0000000000000000000000000000000000000000");
+
     public static void ignoreConfiguration() {
         currentEnv = NO_CONFIG_ENV;
     }
@@ -1500,5 +1502,10 @@ public class HgRepository implements Repository {
         try (var p = capture("hg", "id", "--num", "--rev", "tip")) {
             return Integer.parseInt(await(p).stdout().get(0)) + 1;
         }
+    }
+
+    @Override
+    public Hash initialHash() {
+        return NULL_REVISION;
     }
 }


### PR DESCRIPTION
I changed the logic when there is no notify history.

Originally, on the first commit of a new repo, the bot would find no notify history, so it will make the first commit as an initial state and it will not make any notification.

Now, on the first commit of a new repo, the bot would find no notify history too, but it will make the initial git hash as the initial state of the repo, so it will treat the first commit as an 'update' operation and will make notifications.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1452](https://bugs.openjdk.org/browse/SKARA-1452): Can never notify on first commit


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer) ⚠️ Review applies to [fe3bbdb4](https://git.openjdk.org/skara/pull/1385/files/fe3bbdb46d5511c187463e8c0dc1b3222a1c34f7)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1385/head:pull/1385` \
`$ git checkout pull/1385`

Update a local copy of the PR: \
`$ git checkout pull/1385` \
`$ git pull https://git.openjdk.org/skara pull/1385/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1385`

View PR using the GUI difftool: \
`$ git pr show -t 1385`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1385.diff">https://git.openjdk.org/skara/pull/1385.diff</a>

</details>
