### PR TITLE
1563: The method 'CheckRun#updateMergeReadyComment' shouldn't update the comment if the comment has not changed

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -931,14 +931,18 @@ class CheckRun {
                 log.info("Adding merge ready comment");
                 pr.addComment(message);
             } else {
-                log.info("Updating merge ready comment");
-                pr.updateComment(existing.get().id(), message);
+                if (!existing.get().body().equals(message)) {
+                    log.info("Updating merge ready comment");
+                    pr.updateComment(existing.get().id(), message);
+                } else {
+                    log.info("Merge ready comment already exists, no need to update the comment");
+                }
             }
         } else if (existing.isPresent()) {
-            String noLongerReadyComment = getMergeNoLongerReadyComment();
-            if (!existing.get().body().equals(noLongerReadyComment)) {
-                log.info("Updating merge ready comment as no longer ready");
-                pr.updateComment(existing.get().id(), noLongerReadyComment);
+            var message = getMergeNoLongerReadyComment();
+            if (!existing.get().body().equals(message)) {
+                log.info("Updating no longer ready comment");
+                pr.updateComment(existing.get().id(), message);
             } else {
                 log.info("No longer ready comment already exists, no need to update the comment");
             }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -935,7 +935,7 @@ class CheckRun {
                     log.info("Updating merge ready comment");
                     pr.updateComment(existing.get().id(), message);
                 } else {
-                    log.info("Merge ready comment already exists, no need to update the comment");
+                    log.info("Merge ready comment already exists, no need to update");
                 }
             }
         } else if (existing.isPresent()) {
@@ -944,7 +944,7 @@ class CheckRun {
                 log.info("Updating no longer ready comment");
                 pr.updateComment(existing.get().id(), message);
             } else {
-                log.info("No longer ready comment already exists, no need to update the comment");
+                log.info("No longer ready comment already exists, no need to update");
             }
         }
     }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -935,8 +935,13 @@ class CheckRun {
                 pr.updateComment(existing.get().id(), message);
             }
         } else if (existing.isPresent()) {
-            log.info("Updating merge ready comment as no longer ready");
-            pr.updateComment(existing.get().id(), getMergeNoLongerReadyComment());
+            String noLongerReadyComment = getMergeNoLongerReadyComment();
+            if (!existing.get().body().equals(noLongerReadyComment)) {
+                log.info("Updating merge ready comment as no longer ready");
+                pr.updateComment(existing.get().id(), noLongerReadyComment);
+            } else {
+                log.info("No longer ready comment already exists, no need to update the comment");
+            }
         }
     }
 


### PR DESCRIPTION
Do not update comment if the comment already exists.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1563](https://bugs.openjdk.org/browse/SKARA-1563): The method 'CheckRun#updateMergeReadyComment' shouldn't update the comment if the comment has not changed


### Reviewers
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1386/head:pull/1386` \
`$ git checkout pull/1386`

Update a local copy of the PR: \
`$ git checkout pull/1386` \
`$ git pull https://git.openjdk.org/skara pull/1386/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1386`

View PR using the GUI difftool: \
`$ git pr show -t 1386`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1386.diff">https://git.openjdk.org/skara/pull/1386.diff</a>

</details>
