### PR TITLE
1603: Make labels handling consistent in all Issue implementations

### DIFF
--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraIssue.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraIssue.java
@@ -38,7 +38,7 @@ import java.util.stream.*;
 public class JiraIssue implements Issue {
     private final JiraProject jiraProject;
     private final RestRequest request;
-    private JSONValue json;
+    private final JSONValue json;
     private final boolean needSecurity;
 
     private final Logger log = Logger.getLogger("org.openjdk.skara.issuetracker.jira");
@@ -284,7 +284,6 @@ public class JiraIssue implements Issue {
 
     @Override
     public void setLabels(List<String> labels) {
-        this.labels = null;
         var labelsArray = JSON.array();
         for (var label : labels) {
             labelsArray.add(label);
@@ -294,13 +293,13 @@ public class JiraIssue implements Issue {
                                            .put("labels", JSON.array().add(JSON.object()
                                                                                .put("set", labelsArray))));
         request.put("").body(query).execute();
+        this.labels = labels.stream().map(Label::new).collect(Collectors.toList());
     }
 
     @Override
     public List<Label> labels() {
-        if(labels == null){
-            json = request.get("").execute();
-            labels = json.get("fields").get("labels").stream()
+        if (labels == null) {
+            labels = request.get("").execute().get("fields").get("labels").stream()
                     .map(s -> new Label(s.asString()))
                     .collect(Collectors.toList());
         }

--- a/test/src/main/java/org/openjdk/skara/test/TestIssue.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestIssue.java
@@ -47,7 +47,7 @@ public class TestIssue implements Issue {
     protected final String body;
     protected final String title;
     protected final State state;
-    // Mimic JiraIssue where labels are part of the main JSON object
+    // Labels are cached but still kept up to date
     private List<Label> labels;
     protected ZonedDateTime lastUpdate;
 
@@ -197,13 +197,13 @@ public class TestIssue implements Issue {
 
     @Override
     public void setLabels(List<String> labels) {
-        this.labels = null;
         store.labels().clear();
         var now = ZonedDateTime.now();
         for (var label : labels) {
             store.labels().put(label, now);
         }
         store.setLastUpdate(ZonedDateTime.now());
+        this.labels = labels.stream().map(Label::new).collect(Collectors.toList());
     }
 
     @Override

--- a/test/src/main/java/org/openjdk/skara/test/TestIssue.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestIssue.java
@@ -48,7 +48,7 @@ public class TestIssue implements Issue {
     protected final String title;
     protected final State state;
     // Mimic JiraIssue where labels are part of the main JSON object
-    private final List<Label> labels;
+    private List<Label> labels;
     protected ZonedDateTime lastUpdate;
 
     protected TestIssue(TestIssueStore store, HostUser user) {
@@ -182,6 +182,7 @@ public class TestIssue implements Issue {
 
     @Override
     public void addLabel(String label) {
+        labels = null;
         var now = ZonedDateTime.now();
         store.labels().put(label, now);
         store.setLastUpdate(now);
@@ -189,12 +190,14 @@ public class TestIssue implements Issue {
 
     @Override
     public void removeLabel(String label) {
+        labels = null;
         store.labels().remove(label);
         store.setLastUpdate(ZonedDateTime.now());
     }
 
     @Override
     public void setLabels(List<String> labels) {
+        this.labels = null;
         store.labels().clear();
         var now = ZonedDateTime.now();
         for (var label : labels) {
@@ -205,6 +208,9 @@ public class TestIssue implements Issue {
 
     @Override
     public List<Label> labels() {
+        if (labels == null) {
+            labels = store.labels().keySet().stream().map(Label::new).collect(Collectors.toList());
+        }
         return labels;
     }
 


### PR DESCRIPTION
Make TestIssue and JiraIssue update the cache when updating labels.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1603](https://bugs.openjdk.org/browse/SKARA-1603): Make labels handling consistent in all Issue implementations


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1387/head:pull/1387` \
`$ git checkout pull/1387`

Update a local copy of the PR: \
`$ git checkout pull/1387` \
`$ git pull https://git.openjdk.org/skara pull/1387/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1387`

View PR using the GUI difftool: \
`$ git pr show -t 1387`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1387.diff">https://git.openjdk.org/skara/pull/1387.diff</a>

</details>
