### PR TITLE
1215: Clean label not updating correctly

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -54,6 +54,7 @@ class CheckWorkItem extends PullRequestWorkItem {
     CheckWorkItem(PullRequestBot bot, String prId, Consumer<RuntimeException> errorHandler, ZonedDateTime prUpdatedAt) {
         super(bot, prId, errorHandler, prUpdatedAt);
     }
+
     private String encodeReviewer(HostUser reviewer, CensusInstance censusInstance) {
         var census = censusInstance.census();
         var project = censusInstance.project();

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportTests.java
@@ -1576,4 +1576,123 @@ class BackportTests {
             assertEquals(List.of(), message.additional());
         }
     }
+
+    @Test
+    void updateOriginalHashFromWrongToCorrect(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+
+            var author = credentials.getHostedRepository();
+            var integrator = credentials.getHostedRepository();
+            var reviewer = credentials.getHostedRepository();
+            var issues = credentials.getIssueProject();
+            var censusBuilder = credentials.getCensusBuilder()
+                    .addCommitter(author.forge().currentUser().id())
+                    .addReviewer(integrator.forge().currentUser().id())
+                    .addReviewer(reviewer.forge().currentUser().id());
+            var bot = PullRequestBot.newBuilder()
+                    .repo(integrator)
+                    .censusRepo(censusBuilder.build())
+                    .issueProject(issues)
+                    .build();
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            var releaseBranch = localRepo.branch(masterHash, "release");
+            localRepo.checkout(releaseBranch);
+            var newFile = localRepo.root().resolve("a_new_file.txt");
+            Files.writeString(newFile, "hello");
+            localRepo.add(newFile);
+            var issue1 = credentials.createIssue(issues, "An issue");
+            var issue1Number = issue1.id().split("-")[1];
+            var originalMessage = issue1Number + ": An issue\n" +
+                    "\n" +
+                    "Reviewed-by: integrationreviewer2";
+            var releaseHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
+            localRepo.push(releaseHash, author.url(), "refs/heads/release", true);
+
+            var newFileSZ = localRepo.root().resolve("a_new_file2.txt");
+            Files.writeString(newFileSZ, "hello2");
+            localRepo.add(newFileSZ);
+            var releaseHash2 =localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
+            localRepo.push(releaseHash2, author.url(), "refs/heads/release", true);
+
+
+            // "backport" the new file to the master branch
+            localRepo.checkout(localRepo.defaultBranch());
+            var editBranch = localRepo.branch(masterHash, "edit");
+            localRepo.checkout(editBranch);
+            var newFile2 = localRepo.root().resolve("a_new_file.txt");
+            Files.writeString(newFile2, "hello");
+            localRepo.add(newFile2);
+            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
+            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            // create a pr with wrong hash
+            var pr = credentials.createPullRequest(author, "master", "edit", "Backport " + releaseHash2.hex());
+
+            // The bot should reply with a backport message
+            TestBotRunner.runPeriodicItems(bot);
+            var backportComment = pr.comments().get(0).body();
+            assertTrue(backportComment.contains("This backport pull request has now been updated with issue"));
+            assertTrue(backportComment.contains("<!-- backport " + releaseHash2.hex() + " -->"));
+            assertEquals(issue1Number + ": An issue", pr.store().title());
+            assertTrue(pr.store().labelNames().contains("backport"));
+            // The pr must not contain clean label
+            assertFalse(pr.store().labelNames().contains("clean"));
+
+            // correct the Backport original commit Hash
+            pr.setTitle("Backport "+releaseHash.hex());
+            TestBotRunner.runPeriodicItems(bot);
+            var backportComment2 = pr.comments().get(1).body();
+            assertTrue(backportComment2.contains("This backport pull request has now been updated with issue"));
+            assertTrue(backportComment2.contains("<!-- backport " + releaseHash.hex() + " -->"));
+            assertEquals(issue1Number + ": An issue", pr.store().title());
+            assertTrue(pr.store().labelNames().contains("backport"));
+            // The pr must contain clean label
+            assertTrue(pr.store().labelNames().contains("clean"));
+
+            // Approve PR and re-run bot
+            var prAsReviewer = reviewer.pullRequest(pr.id());
+            prAsReviewer.addReview(Review.Verdict.APPROVED, "Looks good");
+            TestBotRunner.runPeriodicItems(bot);
+            assertLastCommentContains(pr, "This change now passes all *automated* pre-integration checks");
+
+            // Integrate
+            author.pullRequest(pr.id());
+            pr.addComment("/integrate");
+            TestBotRunner.runPeriodicItems(bot);
+
+            // Find the commit
+            assertLastCommentContains(pr, "Pushed as commit");
+
+            String hex = null;
+            var comment = pr.comments().get(pr.comments().size() - 1);
+            var lines = comment.body().split("\n");
+            var pattern = Pattern.compile(".* Pushed as commit ([0-9a-z]{40}).*");
+            for (var line : lines) {
+                var m = pattern.matcher(line);
+                if (m.matches()) {
+                    hex = m.group(1);
+                    break;
+                }
+            }
+            assertNotNull(hex);
+            assertEquals(40, hex.length());
+            localRepo.checkout(localRepo.defaultBranch());
+            localRepo.pull(author.url().toString(), "master", false);
+            var commit = localRepo.lookup(new Hash(hex)).orElseThrow();
+
+            var message = CommitMessageParsers.v1.parse(commit);
+            assertEquals(1, message.issues().size());
+            assertEquals("An issue", message.issues().get(0).description());
+            assertEquals(List.of("integrationreviewer3"), message.reviewers());
+            assertEquals(Optional.of(releaseHash), message.original());
+            assertEquals(List.of(), message.contributors());
+            assertEquals(List.of(), message.summaries());
+            assertEquals(List.of(), message.additional());
+        }
+    }
 }


### PR DESCRIPTION
Originally, If the user mistakenly creates a Backport PR with the wrong hash and then later corrects it, the clean status is never correctly re-evaluated. 

Currently, If the user correct the hash, the bot will be forced to do the check again and could correctly add clean label.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1215](https://bugs.openjdk.org/browse/SKARA-1215): Clean label not updating correctly


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1388/head:pull/1388` \
`$ git checkout pull/1388`

Update a local copy of the PR: \
`$ git checkout pull/1388` \
`$ git pull https://git.openjdk.org/skara pull/1388/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1388`

View PR using the GUI difftool: \
`$ git pr show -t 1388`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1388.diff">https://git.openjdk.org/skara/pull/1388.diff</a>

</details>
