### PR TITLE
1626: 8-pool records not consumed by openjdk8uX fixversions

### DIFF
--- a/jbs/src/test/java/org/openjdk/skara/jbs/BackportsTests.java
+++ b/jbs/src/test/java/org/openjdk/skara/jbs/BackportsTests.java
@@ -176,6 +176,9 @@ public class BackportsTests {
             backportFoo.setProperty("fixVersions", JSON.array().add("8-pool-foo"));
             assertEquals(backportFoo.id(), Backports.findIssue(issue, JdkVersion.parse("8u333-foo").orElseThrow()).orElseThrow().id());
 
+            backport.setProperty("fixVersions", JSON.array().add("8-pool"));
+            assertEquals(backport.id(), Backports.findIssue(issue, JdkVersion.parse("openjdk8u333").orElseThrow()).orElseThrow().id());
+
             issue.setProperty("fixVersions", JSON.array().add("tbd"));
             assertEquals(issue.id(), Backports.findIssue(issue, JdkVersion.parse("11.1").orElseThrow()).orElseThrow().id());
 


### PR DESCRIPTION
The logic for matching *-pool records in backports is not matching openjdk8uX to an issue with fixVersion 8-pool. The version parsing logic for OpenJDK releases is a bit of a minefield, where sometimes the prefix is relevant and sometimes not. This fix isolates ignoring of the prefix to just matching of *-pool records in Backports.java. I'm reusing the same regex that already existed for doing something similar in that class. The previous usage was in the logic for the hgupdate-sync label.

I don't think this will introduce any unwanted behavior, but I would appreciate if someone else could help think it through.

I chose to prioritize exact *-pool matches and fallback to matching just the numeric part of the feature version. This means that if we decided to add openjdk8-pool as a pool version in the future, that would continue to work.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1626](https://bugs.openjdk.org/browse/SKARA-1626): 8-pool records not consumed by openjdk8uX fixversions


### Reviewers
 * [Erik Helin](https://openjdk.org/census#ehelin) (@edvbld - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1389/head:pull/1389` \
`$ git checkout pull/1389`

Update a local copy of the PR: \
`$ git checkout pull/1389` \
`$ git pull https://git.openjdk.org/skara pull/1389/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1389`

View PR using the GUI difftool: \
`$ git pr show -t 1389`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1389.diff">https://git.openjdk.org/skara/pull/1389.diff</a>

</details>
