### PR TITLE
1616: Improve error message when an author isn't found in GitLab

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -77,7 +77,13 @@ public class GitLabMergeRequest implements PullRequest {
 
     @Override
     public HostUser author() {
-        return repository.forge().user(json.get("author").get("username").asString()).get();
+        var username = json.get("author").get("username").asString();
+        var author = repository.forge().user(username);
+        if (author.isPresent()) {
+            return author.get();
+        } else {
+            throw new IllegalArgumentException("Unknown username: " + username);
+        }
     }
 
     @Override

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -82,7 +82,7 @@ public class GitLabMergeRequest implements PullRequest {
         if (author.isPresent()) {
             return author.get();
         } else {
-            throw new IllegalArgumentException("Unknown username: " + username);
+            throw new RuntimeException("Author of GitLab merge request unknown: " + username + "(maybe the user is inactive)");
         }
     }
 


### PR DESCRIPTION
Improved the error message in GitLabMergeRequest:author

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1616](https://bugs.openjdk.org/browse/SKARA-1616): Improve error message when an author isn't found in GitLab


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1390/head:pull/1390` \
`$ git checkout pull/1390`

Update a local copy of the PR: \
`$ git checkout pull/1390` \
`$ git pull https://git.openjdk.org/skara pull/1390/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1390`

View PR using the GUI difftool: \
`$ git pr show -t 1390`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1390.diff">https://git.openjdk.org/skara/pull/1390.diff</a>

</details>
