### PR TITLE
1618: CSR bot failed to update PR when CSR was approved

### DIFF
--- a/bots/csr/src/main/java/org/openjdk/skara/bots/csr/IssueWorkItem.java
+++ b/bots/csr/src/main/java/org/openjdk/skara/bots/csr/IssueWorkItem.java
@@ -56,13 +56,28 @@ class IssueWorkItem implements WorkItem {
         return botName() + "/IssueWorkItem@" + csrIssue.id();
     }
 
+    /**
+     * Concurrency between IssueWorkItems is ok as long as they aren't processing the
+     * same issue and are spawned from the same bot instance.
+     */
     @Override
     public boolean concurrentWith(WorkItem other) {
         if (!(other instanceof IssueWorkItem otherItem)) {
             return true;
         }
 
-        return !csrIssue.project().name().equals(otherItem.csrIssue.project().name());
+        if (!csrIssue.project().name().equals(otherItem.csrIssue.project().name())) {
+            return true;
+        }
+
+        if (!csrIssue.id().equals(otherItem.csrIssue.id())) {
+            return true;
+        }
+
+        if (!bot.equals(otherItem.bot)) {
+            return true;
+        }
+        return false;
     }
 
     @Override


### PR DESCRIPTION
This patch fixes a mistake in the CSRBotFactory. The intention was to create one CSRIssueBot for each unique IssueProject, but we currently get one per repository instead. This is because JiraProject doesn't implement hashcode, so we can't trust a HashSet to sort out uniqueness. I'm changing this to a HashMap and using the configuration string as key instead.

For details on how this was causing the reported problem, see comments in the bug.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1618](https://bugs.openjdk.org/browse/SKARA-1618): CSR bot failed to update PR when CSR was approved


### Reviewers
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer)
 * [Erik Helin](https://openjdk.org/census#ehelin) (@edvbld - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1391/head:pull/1391` \
`$ git checkout pull/1391`

Update a local copy of the PR: \
`$ git checkout pull/1391` \
`$ git pull https://git.openjdk.org/skara pull/1391/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1391`

View PR using the GUI difftool: \
`$ git pr show -t 1391`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1391.diff">https://git.openjdk.org/skara/pull/1391.diff</a>

</details>
