### PR TITLE
SKARA-1633

### DIFF
--- a/test/src/main/java/org/openjdk/skara/test/TestIssue.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestIssue.java
@@ -102,7 +102,7 @@ public class TestIssue implements Issue {
 
     @Override
     public List<Comment> comments() {
-        return new ArrayList<>(store.comments());
+        return List.copyOf(store.comments());
     }
 
     @Override

--- a/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
@@ -83,7 +83,7 @@ public class TestPullRequest extends TestIssue implements PullRequest {
 
     @Override
     public List<Review> reviews() {
-        return PullRequest.calculateReviewTargetRefs(store().reviews(), targetRefChanges());
+        return List.copyOf(PullRequest.calculateReviewTargetRefs(store().reviews(), targetRefChanges()));
     }
 
     @Override


### PR DESCRIPTION
A combination of changes in SKARA-1584 and SKARA-1606 is causing a test failure. The problem is in `TestPullRequest::review`, where we will sometimes (most often) return the internal ArrayList<Review> from the underlying store object. This is causing TestPullRequest::snapshot to not return a pure snapshot, but instead something that gets updated when the store is updated, defeating the whole idea of the snapshot.

The fix is to wrap the return value with a `List::copyOf`. I'm also applying this to `Issue::comments` as that's also part of the snapshot and using unmodifiable collections is usually preferable.