### PR TITLE
1611: Improve adding and removing of labels in GitLab

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -698,13 +698,7 @@ public class GitLabMergeRequest implements PullRequest {
 
     @Override
     public List<Label> labels() {
-        if (labels == null) {
-            labels = request.get("").execute().get("labels").stream()
-                    .map(JSONValue::asString)
-                    .sorted()
-                    .collect(Collectors.toList());
-        }
-        return labels.stream()
+        return labelNames().stream()
                 .map(this::labelNameToLabel)
                 // Avoid throwing NPE for unknown labels
                 .filter(Objects::nonNull)
@@ -713,6 +707,12 @@ public class GitLabMergeRequest implements PullRequest {
 
     @Override
     public List<String> labelNames() {
+        if (labels == null) {
+            labels = request.get("").execute().get("labels").stream()
+                    .map(JSONValue::asString)
+                    .sorted()
+                    .collect(Collectors.toList());
+        }
         return labels;
     }
 

--- a/forge/src/test/java/org/openjdk/skara/forge/gitlab/GitLabRestApiTest.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/gitlab/GitLabRestApiTest.java
@@ -75,4 +75,34 @@ public class GitLabRestApiTest {
         var nonVersionUrl = gitLabMergeRequest.filesUrl(new Hash(settings.getProperty("gitlab.nonversion.hash")));
         assertEquals(settings.getProperty("gitlab.nonversion.url"), nonVersionUrl.toString());
     }
+
+    @Test
+    void testLabels() throws IOException {
+        var settings = ManualTestSettings.loadManualTestSettings();
+        var username = settings.getProperty("gitlab.user");
+        var token = settings.getProperty("gitlab.pat");
+        var credential = new Credential(username, token);
+        var uri = URIBuilder.base(settings.getProperty("gitlab.uri")).build();
+        var gitLabHost = new GitLabHost("gitlab", uri, false, credential, Set.of());
+        var gitLabRepo = gitLabHost.repository(settings.getProperty("gitlab.repository")).orElseThrow();
+        var gitLabMergeRequest = gitLabRepo.pullRequest(settings.getProperty("gitlab.merge.request.id"));
+
+        // Get the labels
+        var labels = gitLabMergeRequest.labelNames();
+        assertEquals(1, labels.size());
+        assertEquals("test", labels.get(0));
+
+        // Add a label
+        gitLabMergeRequest.addLabel("test1");
+        labels = gitLabMergeRequest.labelNames();
+        assertEquals(2, labels.size());
+        assertEquals("test", labels.get(0));
+        assertEquals("test1", labels.get(1));
+
+        // Remove a label
+        gitLabMergeRequest.removeLabel("test1");
+        labels = gitLabMergeRequest.labelNames();
+        assertEquals(1, labels.size());
+        assertEquals("test", labels.get(0));
+    }
 }


### PR DESCRIPTION
Improved adding and removing of labels in GitLabMergeRequest.

And make the label handling consistent with GitHubPullRequest.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1611](https://bugs.openjdk.org/browse/SKARA-1611): Improve adding and removing of labels in GitLab


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1396/head:pull/1396` \
`$ git checkout pull/1396`

Update a local copy of the PR: \
`$ git checkout pull/1396` \
`$ git pull https://git.openjdk.org/skara pull/1396/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1396`

View PR using the GUI difftool: \
`$ git pr show -t 1396`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1396.diff">https://git.openjdk.org/skara/pull/1396.diff</a>

</details>
