### PR TITLE
1635: Add configurable regex message filter to BotLogstashHandler

### DIFF
--- a/bots/cli/src/main/java/org/openjdk/skara/bots/cli/BotLauncher.java
+++ b/bots/cli/src/main/java/org/openjdk/skara/bots/cli/BotLauncher.java
@@ -98,6 +98,11 @@ public class BotLauncher {
                     }
                 }
             }
+            if (logstashConf.contains("replacements")) {
+                for (var field : logstashConf.get("replacements").asArray()) {
+                    handler.addReplacement(field.get("pattern").asString(), field.get("replacement").asString());
+                }
+            }
             handler.setLevel(level);
             var dateTimeFormatter = DateTimeFormatter.ISO_INSTANT
                     .withLocale(Locale.getDefault())

--- a/bots/cli/src/main/java/org/openjdk/skara/bots/cli/BotLogstashHandler.java
+++ b/bots/cli/src/main/java/org/openjdk/skara/bots/cli/BotLogstashHandler.java
@@ -47,9 +47,9 @@ public class BotLogstashHandler extends StreamHandler {
     // Optionally store all futures for testing purposes
     private Collection<Future<HttpResponse<Void>>> futures;
 
-    record RegexReplacement(Pattern pattern, String replacement) {}
+    private record RegexReplacement(Pattern pattern, String replacement) {}
 
-    private List<RegexReplacement> regexReplacements = new ArrayList<>();
+    private final List<RegexReplacement> regexReplacements = new ArrayList<>();
 
     private static class ExtraField {
         String name;


### PR DESCRIPTION
For increased flexibility with how certain log messages are handled, I need to be able to apply custom regex replacements on log messages going to logstash. This patch adds such a configurable option.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1635](https://bugs.openjdk.org/browse/SKARA-1635): Add configurable regex message filter to BotLogstashHandler


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1397/head:pull/1397` \
`$ git checkout pull/1397`

Update a local copy of the PR: \
`$ git checkout pull/1397` \
`$ git pull https://git.openjdk.org/skara pull/1397/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1397`

View PR using the GUI difftool: \
`$ git pr show -t 1397`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1397.diff">https://git.openjdk.org/skara/pull/1397.diff</a>

</details>
