### PR TITLE
1636: Revert GitLab workaround when modifying labels

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -661,14 +661,6 @@ public class GitLabMergeRequest implements PullRequest {
         labels = null;
         request.put("")
                 .body("add_labels", label)
-                // Temporary workaround for GitLab returning 500 when changing labels.
-                // The labels are still modified.
-                .onError(response -> {
-                    if (response.statusCode() == 500) {
-                        return Optional.of(JSON.of());
-                    }
-                    return Optional.empty();
-                })
                 .execute();
     }
 
@@ -677,14 +669,6 @@ public class GitLabMergeRequest implements PullRequest {
         labels = null;
         request.put("")
                 .body("remove_labels", label)
-                // Temporary workaround for GitLab returning 500 when changing labels.
-                // The labels are still modified.
-                .onError(response -> {
-                    if (response.statusCode() == 500) {
-                        return Optional.of(JSON.of());
-                    }
-                    return Optional.empty();
-                })
                 .execute();
     }
 


### PR DESCRIPTION
The workaround for GitLab returning 500 when modifying labels is not longer needed ([SKARA-1612](https://bugs.openjdk.org/browse/SKARA-1612)).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1636](https://bugs.openjdk.org/browse/SKARA-1636): Revert GitLab workaround when modifying labels


### Reviewers
 * [Erik Helin](https://openjdk.org/census#ehelin) (@edvbld - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1398/head:pull/1398` \
`$ git checkout pull/1398`

Update a local copy of the PR: \
`$ git checkout pull/1398` \
`$ git pull https://git.openjdk.org/skara pull/1398/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1398`

View PR using the GUI difftool: \
`$ git pr show -t 1398`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1398.diff">https://git.openjdk.org/skara/pull/1398.diff</a>

</details>
