### PR TITLE
1587: Adding review comments should not mean approval status change

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
@@ -140,9 +140,9 @@ public class CheckablePullRequest {
                 var reviewCorrectTarget = review.targetRef().equals(targetRef);
                 var reviewNewer = prevReview.createdAt().isBefore(review.createdAt());
 
-                if ((prevReviewCorrectTarget && reviewCorrectTarget && reviewNewer)
+                if ((!review.verdict().equals(Review.Verdict.NONE)) && ((prevReviewCorrectTarget && reviewCorrectTarget && reviewNewer)
                         || (!prevReviewCorrectTarget && !reviewCorrectTarget && reviewNewer)
-                        || (!prevReviewCorrectTarget && reviewCorrectTarget)) {
+                        || (!prevReviewCorrectTarget && reviewCorrectTarget))) {
                     reviewPerUser.put(review.reviewer(), review);
                 }
             } else {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
@@ -140,7 +140,8 @@ public class CheckablePullRequest {
                 var reviewCorrectTarget = review.targetRef().equals(targetRef);
                 var reviewNewer = prevReview.createdAt().isBefore(review.createdAt());
 
-                if ((!review.verdict().equals(Review.Verdict.NONE)) && ((prevReviewCorrectTarget && reviewCorrectTarget && reviewNewer)
+                if ((!review.verdict().equals(Review.Verdict.NONE))
+                        && ((prevReviewCorrectTarget && reviewCorrectTarget && reviewNewer)
                         || (!prevReviewCorrectTarget && !reviewCorrectTarget && reviewNewer)
                         || (!prevReviewCorrectTarget && reviewCorrectTarget))) {
                     reviewPerUser.put(review.reviewer(), review);

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ReviewersTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ReviewersTests.java
@@ -646,40 +646,35 @@ public class ReviewersTests {
             TestBotRunner.runPeriodicItems(prBot);
             TestBotRunner.runPeriodicItems(prBot);
             // The pr should contain 'Ready' label
-            var updatedPr = author.pullRequest(pr.id());
-            assertTrue(updatedPr.labelNames().contains("ready"));
+            assertTrue(pr.store().labelNames().contains("ready"));
 
             // Add a review comment
             reviewerPr.addReview(Review.Verdict.NONE, "Just a comment1");
             TestBotRunner.runPeriodicItems(prBot);
             TestBotRunner.runPeriodicItems(prBot);
             // The pr should still contain 'Ready' label
-            updatedPr = author.pullRequest(pr.id());
-            assertTrue(updatedPr.labelNames().contains("ready"));
+            assertTrue(pr.store().labelNames().contains("ready"));
 
             // Add a review comment
             reviewerPr.addReview(Review.Verdict.NONE, "Just a comment2");
             TestBotRunner.runPeriodicItems(prBot);
             TestBotRunner.runPeriodicItems(prBot);
             // The pr should still contain 'Ready' label
-            updatedPr = author.pullRequest(pr.id());
-            assertTrue(updatedPr.labelNames().contains("ready"));
+            assertTrue(pr.store().labelNames().contains("ready"));
 
             // Disapprove this pr
             reviewerPr.addReview(Review.Verdict.DISAPPROVED, "Disapproved");
             TestBotRunner.runPeriodicItems(prBot);
             TestBotRunner.runPeriodicItems(prBot);
             // The pr should not contain 'Ready' label
-            updatedPr = author.pullRequest(pr.id());
-            assertFalse(updatedPr.labelNames().contains("ready"));
+            assertFalse(pr.store().labelNames().contains("ready"));
 
             // Add a review comment
             reviewerPr.addReview(Review.Verdict.NONE, "Just a comment3");
             TestBotRunner.runPeriodicItems(prBot);
             TestBotRunner.runPeriodicItems(prBot);
             // The pr should still not contain 'Ready' label
-            updatedPr = author.pullRequest(pr.id());
-            assertFalse(updatedPr.labelNames().contains("ready"));
+            assertFalse(pr.store().labelNames().contains("ready"));
         }
     }
 }


### PR DESCRIPTION
The issue here is ' if a user leaves additional comments using the "Review changes" dialog, and selects the "Comments", then their approval is considered revoked.'

I believe this happens because if we use "Review changes" to add a comment, it will add a review with `Review.Verdict.NONE` to our pr.  According to our current logic, this new review will cover old reviews, so the approval will be revoked.

I made changes to `CheckablePullRequest#filterActiveReviews`. Now If latest review is just a comment, the verdict will inherit from the previous review.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1587](https://bugs.openjdk.org/browse/SKARA-1587): Adding review comments should not mean approval status change


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1399/head:pull/1399` \
`$ git checkout pull/1399`

Update a local copy of the PR: \
`$ git checkout pull/1399` \
`$ git pull https://git.openjdk.org/skara pull/1399/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1399`

View PR using the GUI difftool: \
`$ git pr show -t 1399`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1399.diff">https://git.openjdk.org/skara/pull/1399.diff</a>

</details>
