### PR TITLE
1642: RepositoryTests > testSubmodulesOnRepoWithSubmodule(VCS) fails in GitHub Actions

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -1499,7 +1499,7 @@ public class GitRepository implements Repository {
 
     @Override
     public void addSubmodule(String pullPath, Path path) throws IOException {
-        try (var p = capture("git", "submodule", "add", pullPath, path.toString())) {
+        try (var p = capture("git", "-c", "protocol.file.allow=always", "submodule", "add", pullPath, path.toString())) {
             await(p);
         }
     }


### PR DESCRIPTION
I tested all the git commands related with 'submodule' and found only the 'git submodule add' is affected.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1642](https://bugs.openjdk.org/browse/SKARA-1642): RepositoryTests > testSubmodulesOnRepoWithSubmodule(VCS) fails in GitHub Actions


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1400/head:pull/1400` \
`$ git checkout pull/1400`

Update a local copy of the PR: \
`$ git checkout pull/1400` \
`$ git pull https://git.openjdk.org/skara pull/1400/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1400`

View PR using the GUI difftool: \
`$ git pr show -t 1400`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1400.diff">https://git.openjdk.org/skara/pull/1400.diff</a>

</details>
