### PR TITLE
1625: Validate input from /summary command

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
@@ -236,7 +236,8 @@ class PullRequestCheckIssueVisitor implements IssueVisitor {
     @Override
     public void visit(MessageIssue issue) {
         var message = String.join("\n", issue.commit().message());
-        addFailureMessage(issue.check(), "Incorrectly formatted commit message: " + message);
+        log.info("Incorrectly formatted commit message: " + message);
+        addFailureMessage(issue.check(), "Incorrectly formatted commit message");
     }
 
     @Override

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
@@ -236,7 +236,7 @@ class PullRequestCheckIssueVisitor implements IssueVisitor {
     @Override
     public void visit(MessageIssue issue) {
         var message = String.join("\n", issue.commit().message());
-        log.info("Incorrectly formatted commit message: " + message);
+        log.warning("Incorrectly formatted commit message: " + message);
         addFailureMessage(issue.check(), "Incorrectly formatted commit message");
     }
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
@@ -149,7 +149,7 @@ class PullRequestCheckIssueVisitor implements IssueVisitor {
     @Override
     public void visit(InvalidReviewersIssue e) {
         var invalid = String.join(", ", e.invalid());
-        throw new IllegalStateException("Invalid reviewers " + invalid);
+        addFailureMessage(e.check(), "Invalid reviewers " + invalid);
     }
 
     @Override
@@ -236,7 +236,7 @@ class PullRequestCheckIssueVisitor implements IssueVisitor {
     @Override
     public void visit(MessageIssue issue) {
         var message = String.join("\n", issue.commit().message());
-        throw new IllegalStateException("Incorrectly formatted commit message: " + message);
+        addFailureMessage(issue.check(), "Incorrectly formatted commit message: " + message);
     }
 
     @Override

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/SummaryTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/SummaryTests.java
@@ -388,7 +388,7 @@ class SummaryTests {
     }
 
     @Test
-    void invalidSummaryTest(TestInfo testInfo) throws IOException{
+    void invalidSummaryTest(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
              var tempFolder = new TemporaryDirectory()) {
             var author = credentials.getHostedRepository();
@@ -429,7 +429,7 @@ class SummaryTests {
 
             pr.addComment("/summary normal comment");
             TestBotRunner.runPeriodicItems(prBot);
-            assertLastCommentContains(pr,"Setting summary to `normal comment`");
+            assertLastCommentContains(pr, "Setting summary to `normal comment`");
 
             System.out.println(pr.store().comments());
         }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/SummaryTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/SummaryTests.java
@@ -386,4 +386,52 @@ class SummaryTests {
                                               "```");
         }
     }
+
+    @Test
+    void invalidSummaryTest(TestInfo testInfo) throws IOException{
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var integrator = credentials.getHostedRepository();
+
+            var censusBuilder = credentials.getCensusBuilder()
+                    .addReviewer(integrator.forge().currentUser().id())
+                    .addCommitter(author.forge().currentUser().id());
+            var prBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
+
+            // Populate the projects repository
+            var localRepoFolder = tempFolder.path().resolve("localrepo");
+            var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
+
+            pr.addComment("/summary Co-authored-by: user1");
+            TestBotRunner.runPeriodicItems(prBot);
+            assertLastCommentContains(pr, "Invalid summary");
+
+            pr.addComment("/summary first line\n Reviewed-by: user1");
+            TestBotRunner.runPeriodicItems(prBot);
+            assertLastCommentContains(pr, "Invalid summary");
+
+            pr.addComment("/summary Backport-of: 12434");
+            TestBotRunner.runPeriodicItems(prBot);
+            assertLastCommentContains(pr, "Invalid summary");
+
+            pr.addComment("/summary 1642: TITLE");
+            TestBotRunner.runPeriodicItems(prBot);
+            assertLastCommentContains(pr, "Invalid summary");
+
+            pr.addComment("/summary normal comment");
+            TestBotRunner.runPeriodicItems(prBot);
+            assertLastCommentContains(pr,"Setting summary to `normal comment`");
+
+            System.out.println(pr.store().comments());
+        }
+    }
 }


### PR DESCRIPTION
1.  Added validation to SummaryCommand.
2. If exceptions are thrown when the bot is evaluating the current status of the pr, the exceptions will be treated as integration blocker.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1625](https://bugs.openjdk.org/browse/SKARA-1625): Validate input from /summary command


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1401/head:pull/1401` \
`$ git checkout pull/1401`

Update a local copy of the PR: \
`$ git checkout pull/1401` \
`$ git pull https://git.openjdk.org/skara pull/1401/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1401`

View PR using the GUI difftool: \
`$ git pr show -t 1401`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1401.diff">https://git.openjdk.org/skara/pull/1401.diff</a>

</details>
