### PR TITLE
1384: Cannot configure integrators for repositories in PullRequestBot

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
@@ -167,7 +167,7 @@ public class PullRequestBotFactory implements BotFactory {
             if (repo.value().contains("integrators")) {
                 var integrators = repo.value().get("integrators")
                         .stream()
-                        .map(integrator -> integrator.asString())
+                        .map(JSONValue::asString)
                         .collect(Collectors.toSet());
                 botBuilder.integrators(integrators);
             }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
@@ -164,6 +164,13 @@ public class PullRequestBotFactory implements BotFactory {
             if (repo.value().contains("jep")) {
                 botBuilder.enableJep(repo.value().get("jep").asBoolean());
             }
+            if (repo.value().contains("integrators")) {
+                var integrators = repo.value().get("integrators")
+                        .stream()
+                        .map(integrator -> integrator.asString())
+                        .collect(Collectors.toSet());
+                botBuilder.integrators(integrators);
+            }
 
             ret.add(botBuilder.build());
         }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestBotFactoryTest.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestBotFactoryTest.java
@@ -51,6 +51,10 @@ class PullRequestBotFactoryTest {
                           ],
                           "24h": [
                             "24h_test"
+                          ],
+                          "integrators": [
+                            "integrator1",
+                            "integrator2"
                           ]
                         }
                       },
@@ -82,14 +86,18 @@ class PullRequestBotFactoryTest {
             assertEquals("PullRequestBot@repo2", pullRequestBot1.toString());
             assertEquals("used to run tests", pullRequestBot1.externalPullRequestCommands().get("test"));
             assertEquals("TEST", pullRequestBot1.issueProject().name());
-            assertEquals("census",pullRequestBot1.censusRepo().name());
-            assertEquals("master",pullRequestBot1.censusRef());
-            assertEquals("{test=used to run tests}",pullRequestBot1.externalPullRequestCommands().toString());
-            assertEquals("{test=Signature needs verify}",pullRequestBot1.blockingCheckLabels().toString());
-            assertEquals("[rfr]",pullRequestBot1.twoReviewersLabels().toString());
-            assertEquals("[24h_test]",pullRequestBot1.twentyFourHoursLabels().toString());
+            assertEquals("census", pullRequestBot1.censusRepo().name());
+            assertEquals("master", pullRequestBot1.censusRef());
+            assertEquals("{test=used to run tests}", pullRequestBot1.externalPullRequestCommands().toString());
+            assertEquals("{test=Signature needs verify}", pullRequestBot1.blockingCheckLabels().toString());
+            assertEquals("[rfr]", pullRequestBot1.twoReviewersLabels().toString());
+            assertEquals("[24h_test]", pullRequestBot1.twentyFourHoursLabels().toString());
             assertFalse(pullRequestBot1.ignoreStaleReviews());
-            assertEquals(".*",pullRequestBot1.allowedTargetBranches().toString());
+            assertEquals(".*", pullRequestBot1.allowedTargetBranches().toString());
+            var integrators = pullRequestBot1.integrators();
+            assertEquals(2, integrators.size());
+            assertTrue(integrators.contains("integrator1"));
+            assertTrue(integrators.contains("integrator2"));
         }
     }
 }


### PR DESCRIPTION
Now, `PullRequestBotFactory` could parse the config `integrators`.

Also fixed some whitespace issues in `PullRequestBotFactoryTest`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1384](https://bugs.openjdk.org/browse/SKARA-1384): Cannot configure integrators for repositories in PullRequestBot


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to [e4c60499](https://git.openjdk.org/skara/pull/1402/files/e4c604993c147ecb9083171258c480d533124397)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1402/head:pull/1402` \
`$ git checkout pull/1402`

Update a local copy of the PR: \
`$ git checkout pull/1402` \
`$ git pull https://git.openjdk.org/skara pull/1402/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1402`

View PR using the GUI difftool: \
`$ git pr show -t 1402`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1402.diff">https://git.openjdk.org/skara/pull/1402.diff</a>

</details>
