### PR TITLE
1450: Jcheck status message can be too big for Gitlab

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -46,6 +46,8 @@ public class GitHubPullRequest implements PullRequest {
 
     private List<Label> labels = null;
 
+    private static final int GITHUB_PR_COMMENT_BODY_MAX_SIZE = 20000;
+
     GitHubPullRequest(GitHubRepository repository, JSONValue jsonValue, RestRequest request) {
         this.host = (GitHubHost)repository.forge();
         this.repository = repository;
@@ -351,6 +353,7 @@ public class GitHubPullRequest implements PullRequest {
 
     @Override
     public Comment addComment(String body) {
+        body = limitBodySize(body);
         var comment = request.post("issues/" + json.get("number").toString() + "/comments")
                 .body("body", body)
                 .execute();
@@ -364,6 +367,7 @@ public class GitHubPullRequest implements PullRequest {
 
     @Override
     public Comment updateComment(String id, String body) {
+        body = limitBodySize(body);
         var comment = request.patch("issues/comments/" + id)
                              .body("body", body)
                              .onError(r -> {
@@ -782,5 +786,16 @@ public class GitHubPullRequest implements PullRequest {
     @Override
     public Object snapshot() {
         return json;
+    }
+
+    public String limitBodySize(String body) {
+        if (body.length() > GITHUB_PR_COMMENT_BODY_MAX_SIZE) {
+            return "⚠️This comment is too long, only the first "
+                    + GITHUB_PR_COMMENT_BODY_MAX_SIZE
+                    + " characters will be displayed!\n\n"
+                    + body.substring(0, GITHUB_PR_COMMENT_BODY_MAX_SIZE)
+                    + "...";
+        }
+        return body;
     }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -46,7 +46,7 @@ public class GitHubPullRequest implements PullRequest {
 
     private List<Label> labels = null;
 
-    private static final int GITHUB_PR_COMMENT_BODY_MAX_SIZE = 20000;
+    private static final int GITHUB_PR_COMMENT_BODY_MAX_SIZE = 64_000;
 
     GitHubPullRequest(GitHubRepository repository, JSONValue jsonValue, RestRequest request) {
         this.host = (GitHubHost)repository.forge();
@@ -790,10 +790,7 @@ public class GitHubPullRequest implements PullRequest {
 
     public String limitBodySize(String body) {
         if (body.length() > GITHUB_PR_COMMENT_BODY_MAX_SIZE) {
-            return "⚠️This comment is too long, only the first "
-                    + GITHUB_PR_COMMENT_BODY_MAX_SIZE
-                    + " characters will be displayed!\n\n"
-                    + body.substring(0, GITHUB_PR_COMMENT_BODY_MAX_SIZE)
+            return body.substring(0, GITHUB_PR_COMMENT_BODY_MAX_SIZE)
                     + "...";
         }
         return body;

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -51,7 +51,7 @@ public class GitLabMergeRequest implements PullRequest {
     // Lazy cache for comparisonSnapshot
     private Object comparisonSnapshot;
 
-    private static final int GITLAB_MR_COMMENT_BODY_MAX_SIZE = 20000;
+    private static final int GITLAB_MR_COMMENT_BODY_MAX_SIZE = 64_000;
 
     GitLabMergeRequest(GitLabRepository repository, GitLabHost host, JSONValue jsonValue, RestRequest request) {
         this.repository = repository;
@@ -896,10 +896,7 @@ public class GitLabMergeRequest implements PullRequest {
 
     private String limitBodySize(String body) {
         if (body.length() > GITLAB_MR_COMMENT_BODY_MAX_SIZE) {
-            return "⚠️This comment is too long, only the first "
-                    + GITLAB_MR_COMMENT_BODY_MAX_SIZE
-                    + " characters will be displayed!\n\n"
-                    + body.substring(0, GITLAB_MR_COMMENT_BODY_MAX_SIZE)
+            return body.substring(0, GITLAB_MR_COMMENT_BODY_MAX_SIZE)
                     + "...";
         }
         return body;

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -51,6 +51,8 @@ public class GitLabMergeRequest implements PullRequest {
     // Lazy cache for comparisonSnapshot
     private Object comparisonSnapshot;
 
+    private static final int GITLAB_MR_COMMENT_BODY_MAX_SIZE = 20000;
+
     GitLabMergeRequest(GitLabRepository repository, GitLabHost host, JSONValue jsonValue, RestRequest request) {
         this.repository = repository;
         this.host = host;
@@ -396,6 +398,7 @@ public class GitLabMergeRequest implements PullRequest {
     @Override
     public Comment addComment(String body) {
         log.fine("Posting a new comment");
+        body = limitBodySize(body);
         var comment = request.post("notes")
                              .body("body", body)
                              .execute();
@@ -412,6 +415,7 @@ public class GitLabMergeRequest implements PullRequest {
     @Override
     public Comment updateComment(String id, String body) {
         log.fine("Updating existing comment " + id);
+        body =  limitBodySize(body);
         var comment = request.put("notes/" + id)
                              .body("body", body)
                              .execute();
@@ -888,5 +892,16 @@ public class GitLabMergeRequest implements PullRequest {
     @Override
     public int hashCode() {
         return Objects.hash(json);
+    }
+
+    private String limitBodySize(String body) {
+        if (body.length() > GITLAB_MR_COMMENT_BODY_MAX_SIZE) {
+            return "⚠️This comment is too long, only the first "
+                    + GITLAB_MR_COMMENT_BODY_MAX_SIZE
+                    + " characters will be displayed!\n\n"
+                    + body.substring(0, GITLAB_MR_COMMENT_BODY_MAX_SIZE)
+                    + "...";
+        }
+        return body;
     }
 }

--- a/forge/src/test/java/org/openjdk/skara/forge/github/GitHubRestApiTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/github/GitHubRestApiTests.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.*;
 import org.openjdk.skara.forge.Forge;
 import org.openjdk.skara.forge.HostedRepository;
 import org.openjdk.skara.host.Credential;
+import org.openjdk.skara.issuetracker.Comment;
 import org.openjdk.skara.network.URIBuilder;
 import org.openjdk.skara.proxy.HttpProxy;
 import org.openjdk.skara.test.ManualTestSettings;
@@ -128,5 +129,23 @@ public class GitHubRestApiTests {
         // `43336822` is the id of the `openjdk` bot(a GitHub App).
         jdkHashOpt = jdkPr.findIntegratedCommitHash(List.of("43336822"));
         assertTrue(jdkHashOpt.isPresent());
+    }
+
+    @Test
+    void testOversizeComment() {
+        var testRepoOpt = githubHost.repository("openjdk/playground");
+        assumeTrue(testRepoOpt.isPresent());
+        var testRepo = testRepoOpt.get();
+        var testPr = testRepo.pullRequest("99");
+
+        // Test add comment
+        Comment comment = testPr.addComment("1".repeat(1000000));
+        assertTrue(comment.body().contains("This comment is too long"));
+        assertTrue(comment.body().contains("1"));
+
+        // Test update comment
+        Comment updateComment = testPr.updateComment(comment.id(), "2".repeat(2000000));
+        assertTrue(updateComment.body().contains("This comment is too long"));
+        assertTrue(updateComment.body().contains("2"));
     }
 }

--- a/forge/src/test/java/org/openjdk/skara/forge/github/GitHubRestApiTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/github/GitHubRestApiTests.java
@@ -139,13 +139,13 @@ public class GitHubRestApiTests {
         var testPr = testRepo.pullRequest("99");
 
         // Test add comment
-        Comment comment = testPr.addComment("1".repeat(1000000));
-        assertTrue(comment.body().contains("This comment is too long"));
+        Comment comment = testPr.addComment("1".repeat(1_000_000));
+        assertTrue(comment.body().contains("..."));
         assertTrue(comment.body().contains("1"));
 
         // Test update comment
-        Comment updateComment = testPr.updateComment(comment.id(), "2".repeat(2000000));
-        assertTrue(updateComment.body().contains("This comment is too long"));
+        Comment updateComment = testPr.updateComment(comment.id(), "2".repeat(2_000_000));
+        assertTrue(updateComment.body().contains("..."));
         assertTrue(updateComment.body().contains("2"));
     }
 }

--- a/forge/src/test/java/org/openjdk/skara/forge/gitlab/GitLabRestApiTest.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/gitlab/GitLabRestApiTest.java
@@ -120,13 +120,13 @@ public class GitLabRestApiTest {
         var gitLabMergeRequest = gitLabRepo.pullRequest(settings.getProperty("gitlab.merge.request.id"));
 
         // Test add comment
-        Comment comment = gitLabMergeRequest.addComment("1".repeat(1000000));
-        assertTrue(comment.body().contains("This comment is too long"));
+        Comment comment = gitLabMergeRequest.addComment("1".repeat(1_000_000));
+        assertTrue(comment.body().contains("..."));
         assertTrue(comment.body().contains("1"));
 
         // Test update comment
-        Comment updateComment = gitLabMergeRequest.updateComment(comment.id(), "2".repeat(2000000));
-        assertTrue(updateComment.body().contains("This comment is too long"));
+        Comment updateComment = gitLabMergeRequest.updateComment(comment.id(), "2".repeat(2_000_000));
+        assertTrue(updateComment.body().contains("..."));
         assertTrue(updateComment.body().contains("2"));
     }
 }


### PR DESCRIPTION
SKARA-1450 describes the problem that the comment adding to a GitLab merge request can be too big to add and leads to fail. 

To fix it, I add the function `limitBodySize()` to `addComment()` and `updateComment()` in `GitLabMergeRequest`, the function will check the size of the comment and  the comment will be cropped if it is too big.

I also found that GitHub pull request might have the same problem, so I did the same change to `GitHubPullRequest`.

Currently, I set the comment max size to 20000, and I don't know whether it is fine. I think it could not be too small because the user wants to see more information and it should not be big because if it is too big, the page loading process will be slow when the user tries to open the pr.

[Maximum length for the comment body in GitHub PR](https://github.com/orgs/community/discussions/27190)
[My test in Playground](https://github.com/openjdk/playground/pull/99)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1450](https://bugs.openjdk.org/browse/SKARA-1450): Jcheck status message can be too big for Gitlab


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1403/head:pull/1403` \
`$ git checkout pull/1403`

Update a local copy of the PR: \
`$ git checkout pull/1403` \
`$ git pull https://git.openjdk.org/skara pull/1403/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1403`

View PR using the GUI difftool: \
`$ git pr show -t 1403`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1403.diff">https://git.openjdk.org/skara/pull/1403.diff</a>

</details>
