### PR TITLE
1582: /integrate defer should be named /integrate delegate

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
@@ -52,7 +52,7 @@ public class IntegrateCommand implements CommandHandler {
     }
 
     private void showHelp(PrintWriter reply) {
-        reply.println("usage: `/integrate [auto|manual|delegate|undelegate<hash>]`");
+        reply.println("usage: `/integrate [auto|manual|delegate|undelegate|<hash>]`");
     }
 
     private Optional<String> checkProblem(Map<String, Check> performedChecks, String checkName, PullRequest pr) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
@@ -52,7 +52,7 @@ public class IntegrateCommand implements CommandHandler {
     }
 
     private void showHelp(PrintWriter reply) {
-        reply.println("usage: `/integrate [auto|manual|defer|undefer|delegate|undelegate<hash>]`");
+        reply.println("usage: `/integrate [auto|manual|delegate|undelegate<hash>]`");
     }
 
     private Optional<String> checkProblem(Map<String, Check> performedChecks, String checkName, PullRequest pr) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
@@ -142,14 +142,14 @@ public class IntegrateCommand implements CommandHandler {
         } else if (commandArg == Command.defer || commandArg == Command.delegate) {
             pr.addLabel("delegated");
             if (commandArg == Command.defer) {
-                reply.println("FutureWarning: /integrate defer is deprecated and will be moved in a future version. Use /integrate delegate instead.");
+                reply.println("Warning: `/integrate defer` is deprecated and will be removed in a future version. Use `/integrate delegate` instead.");
             }
             reply.println("Integration of this pull request has been delegated and may be completed by any project committer using the " +
                     "[/integrate](https://wiki.openjdk.org/display/SKARA/Pull+Request+Commands#PullRequestCommands-/integrate) pull request command.");
             return;
         } else if (commandArg == Command.undefer || commandArg == Command.undelegate) {
             if (commandArg == Command.undefer) {
-                reply.println("FutureWarning: /integrate undefer is deprecated and will be moved in a future version. Use /integrate undelegate instead.");
+                reply.println("Warning: `/integrate undefer` is deprecated and will be removed in a future version. Use `/integrate undelegate` instead.");
             }
             if (pr.labelNames().contains("delegated")) {
                 reply.println("Integration of this pull request is no longer delegated and may only be integrated by the author (@" + pr.author().username() + ")using the " +

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrateTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrateTests.java
@@ -1346,7 +1346,7 @@ class IntegrateTests {
                     .filter(comment -> comment.body().contains("Integration of this pull request has been delegated"))
                     .count();
             var deprecated = authorPr.comments().stream()
-                    .filter(comment -> comment.body().contains("/integrate defer is deprecated"))
+                    .filter(comment -> comment.body().contains("`/integrate defer` is deprecated"))
                     .count();
             assertEquals(1, deferred, "Missing delegated message");
             assertEquals(1, deprecated, "Missing deprecated message");
@@ -1359,7 +1359,7 @@ class IntegrateTests {
                     .filter(comment -> comment.body().contains("Integration of this pull request is no longer delegated and may only be integrated by the author"))
                     .count();
             deprecated = authorPr.comments().stream()
-                    .filter(comment -> comment.body().contains("/integrate undefer is deprecated"))
+                    .filter(comment -> comment.body().contains("`/integrate undefer` is deprecated"))
                     .count();
             assertEquals(1, undeferred, "Missing undelegated message");
             assertEquals(1, deprecated, "Missing deprecated message");


### PR DESCRIPTION
In this patch, to make the user has better experience, the command `/integrate defer` has been updated to `/integrate delegate` and the command `/integrate undefer` has been updated to `/integrate undelegate`.

`/integrate defer` and `/integrate undefer` are still valid. But warning message will be printed when these two commands are used.

After this patch is merged, the wiki page [/integrate](https://wiki.openjdk.org/display/SKARA/Pull+Request+Commands#PullRequestCommands-/integrate) should be updated.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1582](https://bugs.openjdk.org/browse/SKARA-1582): /integrate defer should be named /integrate delegate


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1404/head:pull/1404` \
`$ git checkout pull/1404`

Update a local copy of the PR: \
`$ git checkout pull/1404` \
`$ git pull https://git.openjdk.org/skara pull/1404/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1404`

View PR using the GUI difftool: \
`$ git pr show -t 1404`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1404.diff">https://git.openjdk.org/skara/pull/1404.diff</a>

</details>
