### PR TITLE
1581: Commit command error message misleading

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
@@ -62,7 +62,10 @@ public class BackportCommand implements CommandHandler {
     public void handle(PullRequestBot bot, HostedCommit commit, LimitedCensusInstance censusInstance,
             Path scratchPath, CommandInvocation command, List<Comment> allComments, PrintWriter reply) {
         if (censusInstance.contributor(command.user()).isEmpty()) {
-            reply.println("Only OpenJDK [contributors](https://openjdk.org/bylaws#contributor) can use the `/backport` command");
+            reply.println("To use the `/backport` command, you need to be in the OpenJDK [census](https://openjdk.org/census)"
+                    + " and your GitHub account needs to be linked with your OpenJDK username"
+                    + " ([how to associate your GitHub account with your OpenJDK username]"
+                    + "(https://wiki.openjdk.org/display/skara#Skara-AssociatingyourGitHubaccountandyourOpenJDKusername)).");
             return;
         }
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/TagCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/TagCommand.java
@@ -62,12 +62,15 @@ public class TagCommand implements CommandHandler {
     public void handle(PullRequestBot bot, HostedCommit commit, LimitedCensusInstance censusInstance,
             Path scratchPath, CommandInvocation command, List<Comment> allComments, PrintWriter reply) {
         try {
-            if (censusInstance.contributor(command.user()).isEmpty()) {
-                reply.println("Only OpenJDK [contributors](https://openjdk.org/bylaws#contributor) can use the `/tag` command.");
-                return;
-            }
             if (!bot.integrators().contains(command.user().username())) {
                 reply.println("Only integrators for this repository are allowed to use the `/tag` command.");
+                return;
+            }
+            if (censusInstance.contributor(command.user()).isEmpty()) {
+                reply.println("To use the `/tag` command, you need to be in the OpenJDK [census](https://openjdk.org/census)"
+                        + " and your GitHub account needs to be linked with your OpenJDK username"
+                        + " ([how to associate your GitHub account with your OpenJDK username]"
+                        + "(https://wiki.openjdk.org/display/skara#Skara-AssociatingyourGitHubaccountandyourOpenJDKusername)).");
                 return;
             }
 


### PR DESCRIPTION
This patch updated the warning message when a user is not authorized to use the command `/backport`, `/tag`, `/clean`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1581](https://bugs.openjdk.org/browse/SKARA-1581): Commit command error message misleading


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1405/head:pull/1405` \
`$ git checkout pull/1405`

Update a local copy of the PR: \
`$ git checkout pull/1405` \
`$ git pull https://git.openjdk.org/skara pull/1405/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1405`

View PR using the GUI difftool: \
`$ git pr show -t 1405`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1405.diff">https://git.openjdk.org/skara/pull/1405.diff</a>

</details>
