### PR TITLE
1608: Handle shenandoah tags in IssueNotifier

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
@@ -73,6 +73,11 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
     // do not need to be part of a tag to be considered a match.
     private final Set<String> tagIgnoreOpt;
 
+    // Should the prefix of a tag match the prefix of a fix version to be considered
+    // a match (except for the special tag prefix 'jdk' which will always be ignored
+    // when parsing a version from a tag).
+    private final boolean tagMatchPrefix;
+
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots.notify");
 
     // Lazy loaded
@@ -82,7 +87,8 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
                   boolean setFixVersion, Map<String, String> fixVersions, Map<String, List<String>> altFixVersions,
                   JbsBackport jbsBackport, boolean prOnly, boolean repoOnly, String buildName,
                   HostedRepository censusRepository, String censusRef, String namespace, boolean useHeadVersion,
-                  HostedRepository originalRepository, boolean resolve, Set<String> tagIgnoreOpt) {
+                  HostedRepository originalRepository, boolean resolve, Set<String> tagIgnoreOpt,
+                  boolean tagMatchPrefix) {
         this.issueProject = issueProject;
         this.reviewLink = reviewLink;
         this.reviewIcon = reviewIcon;
@@ -102,6 +108,7 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
         this.originalRepository = originalRepository;
         this.resolve = resolve;
         this.tagIgnoreOpt = tagIgnoreOpt;
+        this.tagMatchPrefix = tagMatchPrefix;
     }
 
     static IssueNotifierBuilder newBuilder() {
@@ -463,17 +470,19 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
             }
         }
 
-        // The fixVersion may have a prefix in the first component that is not present
-        // in the tagVersion. e.g. 'openjdk8u342' vs '8u342'
-        var fixComponents = fixVersion.components();
-        var tagComponents = tagVersion.components();
-        // Check that the rest of the components are equal
-        if (fixComponents.size() > 0 && fixComponents.size() == tagComponents.size()
-                && fixComponents.subList(1, fixComponents.size()).equals(tagComponents.subList(1, tagComponents.size()))) {
-            var fixFirst = fixComponents.get(0);
-            var tagFirst = tagComponents.get(0);
-            // Check if the first fixVersion component has a prefix consisting of only lower case letters
-            return fixFirst.matches("[a-z]+" + tagFirst);
+        if (!tagMatchPrefix) {
+            // The fixVersion may have a prefix in the first component that is not present
+            // in the tagVersion. e.g. 'openjdk8u342' vs '8u342'
+            var fixComponents = fixVersion.components();
+            var tagComponents = tagVersion.components();
+            // Check that the rest of the components are equal
+            if (fixComponents.size() > 0 && fixComponents.size() == tagComponents.size()
+                    && fixComponents.subList(1, fixComponents.size()).equals(tagComponents.subList(1, tagComponents.size()))) {
+                var fixFirst = fixComponents.get(0);
+                var tagFirst = tagComponents.get(0);
+                // Check if the first fixVersion component has a prefix consisting of only lower case letters
+                return fixFirst.matches("[a-z]+" + tagFirst);
+            }
         }
         return false;
     }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierBuilder.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierBuilder.java
@@ -48,6 +48,7 @@ class IssueNotifierBuilder {
     private HostedRepository originalRepository;
     private boolean resolve = true;
     private Set<String> tagIgnoreOpt = Set.of();
+    private boolean tagMatchPrefix = false;
 
     IssueNotifierBuilder issueProject(IssueProject issueProject) {
         this.issueProject = issueProject;
@@ -145,6 +146,11 @@ class IssueNotifierBuilder {
         return this;
     }
 
+    public IssueNotifierBuilder tagMatchPrefix(boolean tagMatchPrefix) {
+        this.tagMatchPrefix = tagMatchPrefix;
+        return this;
+    }
+
     public boolean prOnly() {
         return prOnly;
     }
@@ -158,6 +164,6 @@ class IssueNotifierBuilder {
         return new IssueNotifier(issueProject, reviewLink, reviewIcon, commitLink, commitIcon,
                 setFixVersion, fixVersions, altFixVersions, jbsBackport, prOnly,
                 repoOnly, buildName, censusRepository, censusRef, namespace, useHeadVersion, originalRepository,
-                resolve, tagIgnoreOpt);
+                resolve, tagIgnoreOpt, tagMatchPrefix);
     }
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierFactory.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierFactory.java
@@ -130,6 +130,9 @@ public class IssueNotifierFactory implements NotifierFactory {
                         .map(JSONValue::asString)
                         .collect(Collectors.toSet()));
             }
+            if (tag.contains("matchprefix")) {
+                builder.tagMatchPrefix(tag.get("matchprefix").asBoolean());
+            }
         }
 
         return builder.build();

--- a/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/OpenJDKTag.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/OpenJDKTag.java
@@ -55,6 +55,7 @@ public class OpenJDKTag {
      * 11.1+22          -> 11.1         11.1      +            22
      * 8u321-b03        -> 8u321        8u321     -b           3
      * jdk8u341-foo-b17 -> jdk8u341-foo 8u341-foo -b           17
+     * foo8u341-b17     -> foo8u341     foo8u341  -b           17
      */
 
     private final static String legacyOpenJDKVersionPattern = "(jdk([0-9]{1,2}(u[0-9]{1,3}(?:-[a-z0-9]+)?)?))";
@@ -63,11 +64,13 @@ public class OpenJDKTag {
     // Version pattern matching project Verona (JEP 223) based versions
     private final static String veronaVersionPattern = "((?:jdk-){0,1}([1-9](?:(?:[0-9]*)(\\.(?:0|[1-9][0-9]*)){0,6})))(?:(\\+)([0-9]+)|(-ga))";
     private final static String legacyOpenJFXVersionPattern = "(([0-9](u[0-9]{1,3})?))";
+    private final static String legacyOpenJDKProjectVersionPattern = "(([a-z]+[0-9]{1,2}(u[0-9]{1,3}(?:-[a-z0-9]+)?)?))";
 
     private final static List<Pattern> tagPatterns = List.of(Pattern.compile(legacyOpenJDKVersionPattern + legacyBuildPattern),
                                                              Pattern.compile(legacyHSVersionPattern + legacyBuildPattern),
                                                              Pattern.compile(veronaVersionPattern),
-                                                             Pattern.compile(legacyOpenJFXVersionPattern + legacyBuildPattern));
+                                                             Pattern.compile(legacyOpenJFXVersionPattern + legacyBuildPattern),
+                                                             Pattern.compile(legacyOpenJDKProjectVersionPattern + legacyBuildPattern));
 
     /**
      * Attempts to create an OpenJDKTag instance from a general Tag.
@@ -104,6 +107,16 @@ public class OpenJDKTag {
      */
     public String version() {
         return version;
+    }
+
+    /**
+     * The complete prefix, which is everything except the build number and any
+     * delimiter before it (e.g. jdk8u20, shenandoah8u332, jdk8u333-foo)
+     *
+     * @return
+     */
+    public String prefix() {
+        return prefix;
     }
 
     /**

--- a/vcs/src/test/java/org/openjdk/skara/vcs/openjdk/OpenJDKTagTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/openjdk/OpenJDKTagTests.java
@@ -151,4 +151,12 @@ class OpenJDKTagTests {
         assertEquals("8u341-foo", jdkTag.version());
         assertEquals(17, jdkTag.buildNum().orElseThrow());
     }
+
+    @Test
+    void parse8uPrefixVersion() {
+        var tag = new Tag("shenandoah8u332-b01");
+        var jdkTag = OpenJDKTag.create(tag).orElseThrow();
+        assertEquals("shenandoah8u332", jdkTag.version());
+        assertEquals(1, jdkTag.buildNum().orElseThrow());
+    }
 }


### PR DESCRIPTION
This patch aims to add support for notifying JBS when tags are added in the shenandoah-jdk8u repository. This repository is special because it's a jdk8u 'project' repo that is never going to be merged upstream. Instead it's a downstream repo that produces its own releases. Because of this it has its own fixVersion configured in .jcheck/conf and its own tag format, to keep them apart from the main JDK jdk8u tags.

The logic for matching fixVersions and tags is already a bit convoluted due to conventions that have been added over time. This repo will now add another matching rule. A typical fixVersion would be `shenandoah8u332` and a corresponding tag `shenandoah8u332-b01`. This is actually a pretty neat pattern to match for as the tag prefix is exactly the fixVersion, which is why I agreed to implement support for this. The complicating factors are that for mainline OpenJDK jdk8u we have fixVersion `openjdk8u332` and tag `jdk8u332-b01` (and for Oracle jdk8u the fixVersion is `8u332` but with the same tag format). This special handling of a 'jdk' prefix for a tag, and ignoring any prefix in the fixVersion is what complicates things.

So currently we ignore any prefix before the main version number in both a tag and fixVersion when matching them. For shenandoah-jdk8u we want to exactly match this prefix. To handle this, I've added a new configuration option for the notifier:
```
"issue": {  // existing config element
  "tag": {  // existing config element
    "matchprefix": true  // new
  }
}
```
The default value for this option is `false` to reflect the current behavior. When set true, a fixVersion and tag version must match exactly. Note though that the special handling of the tag prefix 'jdk' will still be at play due to the way OpenJDKTag currently parses a JdkVersion from a tag, and I don't dare changing it. This means that if this option is set, then a fixVersion `8u332` will match tags `jdk8u332-b01` and `8u332-b01`, but a fixVersion `jdk8u332` would not match the tag `jdk8u332-b01`. We don't currently use the 'jdk' prefix in any fixVersions in JBS, so this should be fine. I just want to make it clear.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1608](https://bugs.openjdk.org/browse/SKARA-1608): Handle shenandoah tags in IssueNotifier


### Reviewers
 * [Erik Helin](https://openjdk.org/census#ehelin) (@edvbld - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1406/head:pull/1406` \
`$ git checkout pull/1406`

Update a local copy of the PR: \
`$ git checkout pull/1406` \
`$ git pull https://git.openjdk.org/skara pull/1406/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1406`

View PR using the GUI difftool: \
`$ git pr show -t 1406`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1406.diff">https://git.openjdk.org/skara/pull/1406.diff</a>

</details>
