### PR TITLE
1393: PR bot fails on missing .jcheck/conf

### DIFF
--- a/bots/pr/build.gradle
+++ b/bots/pr/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     implementation project(':email')
     implementation project(':metrics')
     implementation project(':jbs')
+    implementation project(':network')
 
     testImplementation project(':test')
 }

--- a/bots/pr/src/main/java/module-info.java
+++ b/bots/pr/src/main/java/module-info.java
@@ -32,6 +32,7 @@ module org.openjdk.skara.bots.pr {
     requires org.openjdk.skara.process;
     requires org.openjdk.skara.email;
     requires org.openjdk.skara.jbs;
+    requires org.openjdk.skara.network;
     requires java.logging;
 
     provides org.openjdk.skara.bot.BotFactory with PullRequestBotFactory;

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CensusInstance.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CensusInstance.java
@@ -48,20 +48,20 @@ class CensusInstance extends LimitedCensusInstance {
         return project;
     }
 
-    static Optional<CensusInstance> createCensusInstance(HostedRepositoryPool hostedRepositoryPool,
+    static CensusInstance createCensusInstance(HostedRepositoryPool hostedRepositoryPool,
                                  HostedRepository censusRepo, String censusRef, Path folder, PullRequest pr,
                                  HostedRepository confOverrideRepo, String confOverrideName, String confOverrideRef) throws InvalidJCheckConfException, MissingJCheckConfException {
         return createCensusInstance(hostedRepositoryPool, censusRepo, censusRef, folder, pr.repository(), pr.targetRef(),
                       confOverrideRepo, confOverrideName, confOverrideRef);
     }
 
-    static Optional<CensusInstance> createCensusInstance(HostedRepositoryPool hostedRepositoryPool,
+    static CensusInstance createCensusInstance(HostedRepositoryPool hostedRepositoryPool,
                                  HostedRepository censusRepo, String censusRef, Path folder, HostedRepository repository, String ref,
                                  HostedRepository confOverrideRepo, String confOverrideName, String confOverrideRef) throws InvalidJCheckConfException, MissingJCheckConfException {
         var limitedCensusInstance = LimitedCensusInstance.createLimitedCensusInstance(hostedRepositoryPool, censusRepo,
                 censusRef, folder, repository, ref, confOverrideRepo, confOverrideName, confOverrideRef);
-        return limitedCensusInstance.map(l ->
-                new CensusInstance(l.census, l.configuration, project(l.configuration, l.census), l.namespace));
+        return new CensusInstance(limitedCensusInstance.census, limitedCensusInstance.configuration,
+                project(limitedCensusInstance.configuration, limitedCensusInstance.census), limitedCensusInstance.namespace);
     }
 
     Project project() {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CensusInstance.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CensusInstance.java
@@ -50,14 +50,14 @@ class CensusInstance extends LimitedCensusInstance {
 
     static Optional<CensusInstance> createCensusInstance(HostedRepositoryPool hostedRepositoryPool,
                                  HostedRepository censusRepo, String censusRef, Path folder, PullRequest pr,
-                                 HostedRepository confOverrideRepo, String confOverrideName, String confOverrideRef) {
+                                 HostedRepository confOverrideRepo, String confOverrideName, String confOverrideRef) throws InvalidJCheckConfException, MissingJCheckConfException {
         return createCensusInstance(hostedRepositoryPool, censusRepo, censusRef, folder, pr.repository(), pr.targetRef(),
                       confOverrideRepo, confOverrideName, confOverrideRef);
     }
 
     static Optional<CensusInstance> createCensusInstance(HostedRepositoryPool hostedRepositoryPool,
                                  HostedRepository censusRepo, String censusRef, Path folder, HostedRepository repository, String ref,
-                                 HostedRepository confOverrideRepo, String confOverrideName, String confOverrideRef) {
+                                 HostedRepository confOverrideRepo, String confOverrideName, String confOverrideRef) throws InvalidJCheckConfException, MissingJCheckConfException {
         var limitedCensusInstance = LimitedCensusInstance.createLimitedCensusInstance(hostedRepositoryPool, censusRepo,
                 censusRef, folder, repository, ref, confOverrideRepo, confOverrideName, confOverrideRef);
         return limitedCensusInstance.map(l ->

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -248,7 +248,7 @@ class CheckWorkItem extends PullRequestWorkItem {
                         + "Until that is resolved, this pull request cannot be processed. Please notify the repository owner.";
                 addErrorComment(text, comments);
             } else {
-                var text = " ⚠️ @" + pr.author().username() + " The external jcheck configuration for this repository could not be resolved. "
+                var text = " ⚠️ @" + pr.author().username() + " The external jcheck configuration for this repository is invalid. "
                         + "Until that is resolved, this pull request cannot be processed. Please notify a Skara admin.";
                 addErrorComment(text, comments);
             }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -233,10 +233,12 @@ class CheckWorkItem extends PullRequestWorkItem {
                     bot.confOverrideRepository().orElse(null), bot.confOverrideName(), bot.confOverrideRef());
         } catch (MissingJCheckConfException e) {
             if (bot.confOverrideRepository().isEmpty()) {
+                log.info("No .jcheck/conf found in repo " + bot.repo().name() + ": " + e);
                 var text = " ⚠️ @" + pr.author().username() + " No `.jcheck/conf` found in the target branch of this pull request. "
                         + "Until that is resolved, this pull request cannot be processed. Please notify the repository owner.";
                 addErrorComment(text, comments);
             } else {
+                log.info("No .jcheck/conf found in external repo " + bot.confOverrideRepository().get().name() + ": " + e);
                 var text = " ⚠️ @" + pr.author().username() + " The external jcheck configuration for this repository could not be found. "
                         + "Until that is resolved, this pull request cannot be processed. Please notify a Skara admin.";
                 addErrorComment(text, comments);
@@ -244,10 +246,12 @@ class CheckWorkItem extends PullRequestWorkItem {
             return List.of();
         } catch (InvalidJCheckConfException e) {
             if (bot.confOverrideRepository().isEmpty()) {
+                log.info("Invalid .jcheck/conf found in repo " + bot.repo().name() + ": " + e);
                 var text = " ⚠️ @" + pr.author().username() + " The `.jcheck/conf` in the target branch of this pull request is invalid. "
                         + "Until that is resolved, this pull request cannot be processed. Please notify the repository owner.";
                 addErrorComment(text, comments);
             } else {
+                log.info("Invalid .jcheck/conf found in external repo " + bot.confOverrideRepository().get().name() + ": " + e);
                 var text = " ⚠️ @" + pr.author().username() + " The external jcheck configuration for this repository is invalid. "
                         + "Until that is resolved, this pull request cannot be processed. Please notify a Skara admin.";
                 addErrorComment(text, comments);

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -230,7 +230,7 @@ class CheckWorkItem extends PullRequestWorkItem {
         var labels = new HashSet<>(pr.labelNames());
         try {
             census = CensusInstance.createCensusInstance(hostedRepositoryPool, bot.censusRepo(), bot.censusRef(), scratchPath.resolve("census"), pr,
-                    bot.confOverrideRepository().orElse(null), bot.confOverrideName(), bot.confOverrideRef()).orElseThrow();
+                    bot.confOverrideRepository().orElse(null), bot.confOverrideName(), bot.confOverrideRef());
         } catch (MissingJCheckConfException e) {
             if (bot.confOverrideRepository().isEmpty()) {
                 var text = " ⚠️ @" + pr.author().username() + " No `.jcheck/conf` found in the target branch of this pull request. "

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -233,7 +233,7 @@ class CheckWorkItem extends PullRequestWorkItem {
                     bot.confOverrideRepository().orElse(null), bot.confOverrideName(), bot.confOverrideRef()).orElseThrow();
         } catch (MissingJCheckConfException e) {
             if (bot.confOverrideRepository().isEmpty()) {
-                var text = " ⚠️ @" + pr.author().username() + " The `.jcheck/conf` in the target branch of this pull request is missing completely. "
+                var text = " ⚠️ @" + pr.author().username() + " No `.jcheck/conf` found in the target branch of this pull request. "
                         + "Until that is resolved, this pull request cannot be processed. Please notify the repository owner.";
                 addErrorComment(text, comments);
             } else {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -224,7 +224,7 @@ class CheckWorkItem extends PullRequestWorkItem {
         // First determine if the current state of the PR has already been checked
         var seedPath = bot.seedStorage().orElse(scratchPath.resolve("seeds"));
         var hostedRepositoryPool = new HostedRepositoryPool(seedPath);
-        CensusInstance census = null;
+        CensusInstance census;
         var comments = pr.comments();
         var allReviews = pr.reviews();
         var labels = new HashSet<>(pr.labelNames());
@@ -238,7 +238,8 @@ class CheckWorkItem extends PullRequestWorkItem {
                         + "Until that is resolved, this pull request cannot be processed. Please notify the repository owner.";
                 addErrorComment(text, comments);
             } else {
-                log.info("No .jcheck/conf found in external repo " + bot.confOverrideRepository().get().name() + ": " + e);
+                log.log(Level.SEVERE, "Jcheck configuration file " + bot.confOverrideName()
+                        + " not found in external repo " + bot.confOverrideRepository().get().name(), e);
                 var text = " ⚠️ @" + pr.author().username() + " The external jcheck configuration for this repository could not be found. "
                         + "Until that is resolved, this pull request cannot be processed. Please notify a Skara admin.";
                 addErrorComment(text, comments);
@@ -251,7 +252,8 @@ class CheckWorkItem extends PullRequestWorkItem {
                         + "Until that is resolved, this pull request cannot be processed. Please notify the repository owner.";
                 addErrorComment(text, comments);
             } else {
-                log.info("Invalid .jcheck/conf found in external repo " + bot.confOverrideRepository().get().name() + ": " + e);
+                log.log(Level.SEVERE, "Invalid Jcheck configuration file " + bot.confOverrideName()
+                        + " in external repo " + bot.confOverrideRepository().get().name(), e);
                 var text = " ⚠️ @" + pr.author().username() + " The external jcheck configuration for this repository is invalid. "
                         + "Until that is resolved, this pull request cannot be processed. Please notify a Skara admin.";
                 addErrorComment(text, comments);

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -233,7 +233,7 @@ class CheckWorkItem extends PullRequestWorkItem {
                     bot.confOverrideRepository().orElse(null), bot.confOverrideName(), bot.confOverrideRef());
         } catch (MissingJCheckConfException e) {
             if (bot.confOverrideRepository().isEmpty()) {
-                log.info("No .jcheck/conf found in repo " + bot.repo().name() + ": " + e);
+                log.log(Level.SEVERE, "No .jcheck/conf found in repo " + bot.repo().name(), e);
                 var text = " ⚠️ @" + pr.author().username() + " No `.jcheck/conf` found in the target branch of this pull request. "
                         + "Until that is resolved, this pull request cannot be processed. Please notify the repository owner.";
                 addErrorComment(text, comments);
@@ -247,7 +247,7 @@ class CheckWorkItem extends PullRequestWorkItem {
             return List.of();
         } catch (InvalidJCheckConfException e) {
             if (bot.confOverrideRepository().isEmpty()) {
-                log.info("Invalid .jcheck/conf found in repo " + bot.repo().name() + ": " + e);
+                log.log(Level.SEVERE, "Invalid .jcheck/conf found in repo " + bot.repo().name(), e);
                 var text = " ⚠️ @" + pr.author().username() + " The `.jcheck/conf` in the target branch of this pull request is invalid. "
                         + "Until that is resolved, this pull request cannot be processed. Please notify the repository owner.";
                 addErrorComment(text, comments);

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -237,7 +237,7 @@ class CheckWorkItem extends PullRequestWorkItem {
                         + "Until that is resolved, this pull request cannot be processed. Please notify the repository owner.";
                 addErrorComment(text, comments);
             } else {
-                var text = " ⚠️ @" + pr.author().username() + " The external jcheck configuration for this repository could not be resolved. "
+                var text = " ⚠️ @" + pr.author().username() + " The external jcheck configuration for this repository could not be found. "
                         + "Until that is resolved, this pull request cannot be processed. Please notify a Skara admin.";
                 addErrorComment(text, comments);
             }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommandWorkItem.java
@@ -139,6 +139,7 @@ public class CommitCommandWorkItem implements WorkItem {
                         bot.confOverrideName(),
                         bot.confOverrideRef());
             } catch (MissingJCheckConfException e) {
+                log.info("No .jcheck/conf found: " + e);
                 var comment = String.format(commandReplyMarker, command.id()) + "\n" +
                         "@" + command.user().username() +
                         " There is no `.jcheck/conf` present at revision " +
@@ -146,6 +147,7 @@ public class CommitCommandWorkItem implements WorkItem {
                 bot.repo().addCommitComment(commit.hash(), comment);
                 return List.of();
             } catch (InvalidJCheckConfException e) {
+                log.info("Invalid .jcheck/conf: " + e);
                 var comment = String.format(commandReplyMarker, command.id()) + "\n" +
                         "@" + command.user().username() +
                         " Invalid `.jcheck/conf` present at revision " +

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommandWorkItem.java
@@ -130,7 +130,7 @@ public class CommitCommandWorkItem implements WorkItem {
         if (nextCommand.isEmpty()) {
             log.info("No new commit comments found, stopping further processing");
         } else {
-            Optional<LimitedCensusInstance> census = Optional.empty();
+            LimitedCensusInstance census;
             var command = nextCommand.get();
             try {
                 census = LimitedCensusInstance.createLimitedCensusInstance(hostedRepositoryPool, bot.censusRepo(), bot.censusRef(),
@@ -153,7 +153,7 @@ public class CommitCommandWorkItem implements WorkItem {
                 bot.repo().addCommitComment(commit.hash(), comment);
                 return List.of();
             }
-            processCommand(scratchPath, commit, census.get(), command, allComments);
+            processCommand(scratchPath, commit, census, command, allComments);
         }
         return List.of();
     }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommandWorkItem.java
@@ -148,7 +148,7 @@ public class CommitCommandWorkItem implements WorkItem {
             } catch (InvalidJCheckConfException e) {
                 var comment = String.format(commandReplyMarker, command.id()) + "\n" +
                         "@" + command.user().username() +
-                        " invalid `.jcheck/conf` present at revision " +
+                        " Invalid `.jcheck/conf` present at revision " +
                         commit.hash().abbreviate() + " - cannot process command.";
                 bot.repo().addCommitComment(commit.hash(), comment);
                 return List.of();

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommandWorkItem.java
@@ -141,7 +141,7 @@ public class CommitCommandWorkItem implements WorkItem {
             } catch (MissingJCheckConfException e) {
                 var comment = String.format(commandReplyMarker, command.id()) + "\n" +
                         "@" + command.user().username() +
-                        " there is no `.jcheck/conf` present at revision " +
+                        " There is no `.jcheck/conf` present at revision " +
                         commit.hash().abbreviate() + " - cannot process command.";
                 bot.repo().addCommitComment(commit.hash(), comment);
                 return List.of();

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LimitedCensusInstance.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LimitedCensusInstance.java
@@ -44,7 +44,7 @@ class LimitedCensusInstance {
         this.namespace = namespace;
     }
 
-    static Optional<LimitedCensusInstance> createLimitedCensusInstance(HostedRepositoryPool hostedRepositoryPool,
+    static LimitedCensusInstance createLimitedCensusInstance(HostedRepositoryPool hostedRepositoryPool,
             HostedRepository censusRepo, String censusRef, Path folder, HostedRepository repository, String ref,
             HostedRepository confOverrideRepo, String confOverrideName, String confOverrideRef) throws MissingJCheckConfException, InvalidJCheckConfException {
         Path repoFolder = getRepoFolder(hostedRepositoryPool, censusRepo, censusRef, folder);
@@ -54,7 +54,7 @@ class LimitedCensusInstance {
                     confOverrideName, confOverrideRef).orElseThrow(MissingJCheckConfException::new);
             var census = Census.parse(repoFolder);
             var namespace = namespace(census, repository.namespace());
-            return Optional.of(new LimitedCensusInstance(census, configuration, namespace));
+            return new LimitedCensusInstance(census, configuration, namespace);
         } catch (IOException e) {
             throw new UncheckedIOException("Cannot parse census at " + repoFolder, e);
         }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LimitedCensusInstance.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LimitedCensusInstance.java
@@ -5,6 +5,8 @@ import java.io.UncheckedIOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import org.openjdk.skara.census.Census;
 import org.openjdk.skara.census.Contributor;
@@ -14,6 +16,16 @@ import org.openjdk.skara.forge.HostedRepositoryPool;
 import org.openjdk.skara.host.HostUser;
 import org.openjdk.skara.jcheck.JCheckConfiguration;
 
+class MissingJCheckConfException extends Exception {
+    public MissingJCheckConfException() {
+    }
+}
+
+class InvalidJCheckConfException extends Exception {
+    public InvalidJCheckConfException(Throwable cause) {
+        super(cause);
+    }
+}
 /**
  * The LimitedCensusInstance does not have a Project. Use this when the project
  * may be invalid or unavailable to avoid errors, otherwise use CensusInstance
@@ -32,18 +44,15 @@ class LimitedCensusInstance {
 
     static Optional<LimitedCensusInstance> createLimitedCensusInstance(HostedRepositoryPool hostedRepositoryPool,
             HostedRepository censusRepo, String censusRef, Path folder, HostedRepository repository, String ref,
-            HostedRepository confOverrideRepo, String confOverrideName, String confOverrideRef) {
+            HostedRepository confOverrideRepo, String confOverrideName, String confOverrideRef) throws MissingJCheckConfException, InvalidJCheckConfException {
         Path repoFolder = getRepoFolder(hostedRepositoryPool, censusRepo, censusRef, folder);
 
         try {
-            Optional<JCheckConfiguration> configuration = jCheckConfiguration(hostedRepositoryPool,
-                    repository, ref, confOverrideRepo, confOverrideName, confOverrideRef);
-            if (configuration.isEmpty()) {
-                return Optional.empty();
-            }
+            JCheckConfiguration configuration = jCheckConfiguration(repository, ref, confOverrideRepo,
+                    confOverrideName, confOverrideRef).orElseThrow(MissingJCheckConfException::new);
             var census = Census.parse(repoFolder);
             var namespace = namespace(census, repository.namespace());
-            return Optional.of(new LimitedCensusInstance(census, configuration.get(), namespace));
+            return Optional.of(new LimitedCensusInstance(census, configuration, namespace));
         } catch (IOException e) {
             throw new UncheckedIOException("Cannot parse census at " + repoFolder, e);
         }
@@ -55,27 +64,43 @@ class LimitedCensusInstance {
         if (namespace == null) {
             throw new RuntimeException("Namespace not found in census: " + hostNamespace);
         }
-
         return namespace;
     }
 
-    private static Optional<JCheckConfiguration> configuration(HostedRepositoryPool hostedRepositoryPool, HostedRepository remoteRepo, String name, String ref) throws IOException {
-        return hostedRepositoryPool.lines(remoteRepo, Path.of(name), ref).map(JCheckConfiguration::parse);
+    private static Optional<JCheckConfiguration> configuration(HostedRepository remoteRepo, String name, String ref) {
+        Optional<List<String>> conf;
+        try {
+            conf = Optional.of(Arrays.stream(remoteRepo.fileContents(name, ref).split("\n")).toList());
+        } catch (RuntimeException e) {
+            if (e.getMessage().contains("Request returned bad status:")) {
+                if (!e.getMessage().contains("404")) {
+                    throw e;
+                }
+            }
+            conf = Optional.empty();
+        }
+        return conf.map(JCheckConfiguration::parse);
     }
 
-    private static Optional<JCheckConfiguration> jCheckConfiguration(HostedRepositoryPool hostedRepositoryPool,
+    private static Optional<JCheckConfiguration> jCheckConfiguration(
             HostedRepository repository, String ref, HostedRepository confOverrideRepo, String confOverrideName,
-            String confOverrideRef) throws IOException {
+            String confOverrideRef) throws IOException, InvalidJCheckConfException {
         Optional<JCheckConfiguration> configuration;
-        if (confOverrideRepo == null) {
-            configuration = configuration(hostedRepositoryPool, repository, ".jcheck/conf", ref);
-        } else {
-            configuration = configuration(hostedRepositoryPool,
-                    confOverrideRepo,
-                    confOverrideName,
-                    confOverrideRef);
+        try {
+            if (confOverrideRepo == null) {
+                configuration = configuration(repository, ".jcheck/conf", ref);
+            } else {
+                configuration = configuration(confOverrideRepo,
+                        confOverrideName,
+                        confOverrideRef);
+            }
+            return configuration;
+        } catch (RuntimeException e) {
+            if (e.getMessage().contains("Request returned bad status:")) {
+                throw e;
+            }
+            throw new InvalidJCheckConfException(e);
         }
-        return configuration;
     }
 
     private static Path getRepoFolder(HostedRepositoryPool hostedRepositoryPool, HostedRepository censusRepo, String censusRef, Path folder) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LimitedCensusInstance.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LimitedCensusInstance.java
@@ -7,7 +7,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.Optional;
 import org.openjdk.skara.census.Census;
 import org.openjdk.skara.census.Contributor;
@@ -73,8 +72,6 @@ class LimitedCensusInstance {
         Optional<List<String>> conf = Optional.empty();
         try {
             conf = Optional.of(Arrays.stream(remoteRepo.fileContents(name, ref).split("\n")).toList());
-        } catch (NoSuchElementException ignored) {
-            // NoSuchElementException will only work for tests
         } catch (UncheckedRestException e) {
             if (e.getStatusCode() != 404) {
                 throw e;

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
@@ -199,7 +199,7 @@ public class PullRequestCommandWorkItem extends PullRequestWorkItem {
         CensusInstance census = null;
         try {
             census = CensusInstance.createCensusInstance(hostedRepositoryPool, bot.censusRepo(), bot.censusRef(), scratchPath.resolve("census"), pr,
-                    bot.confOverrideRepository().orElse(null), bot.confOverrideName(), bot.confOverrideRef()).orElseThrow();
+                    bot.confOverrideRepository().orElse(null), bot.confOverrideName(), bot.confOverrideRef());
         } catch (InvalidJCheckConfException | MissingJCheckConfException e) {
             throw new RuntimeException(e);
         }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
@@ -196,8 +196,13 @@ public class PullRequestCommandWorkItem extends PullRequestWorkItem {
         var seedPath = bot.seedStorage().orElse(scratchPath.resolve("seeds"));
         var hostedRepositoryPool = new HostedRepositoryPool(seedPath);
 
-        var census = CensusInstance.createCensusInstance(hostedRepositoryPool, bot.censusRepo(), bot.censusRef(), scratchPath.resolve("census"), pr,
-                                           bot.confOverrideRepository().orElse(null), bot.confOverrideName(), bot.confOverrideRef()).orElseThrow();
+        CensusInstance census = null;
+        try {
+            census = CensusInstance.createCensusInstance(hostedRepositoryPool, bot.censusRepo(), bot.censusRef(), scratchPath.resolve("census"), pr,
+                    bot.confOverrideRepository().orElse(null), bot.confOverrideName(), bot.confOverrideRef()).orElseThrow();
+        } catch (InvalidJCheckConfException | MissingJCheckConfException e) {
+            throw new RuntimeException(e);
+        }
         var command = nextCommand.get();
         log.info("Processing command: " + command.id() + " - " + command.name());
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
@@ -196,7 +196,7 @@ public class PullRequestCommandWorkItem extends PullRequestWorkItem {
         var seedPath = bot.seedStorage().orElse(scratchPath.resolve("seeds"));
         var hostedRepositoryPool = new HostedRepositoryPool(seedPath);
 
-        CensusInstance census = null;
+        CensusInstance census;
         try {
             census = CensusInstance.createCensusInstance(hostedRepositoryPool, bot.censusRepo(), bot.censusRef(), scratchPath.resolve("census"), pr,
                     bot.confOverrideRepository().orElse(null), bot.confOverrideName(), bot.confOverrideRef());

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -29,6 +29,7 @@ import org.openjdk.skara.issuetracker.Link;
 import org.openjdk.skara.json.JSON;
 import org.openjdk.skara.test.*;
 
+import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
@@ -2171,6 +2172,279 @@ class CheckTests {
             assertFalse(pr.store().body().contains(backportIssue.title()));
             assertFalse(pr.store().body().contains(backportCsr.id()));
             assertFalse(pr.store().body().contains(backportCsr.title()));
+        }
+    }
+
+    @Test
+    void missingJCheckConf(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var reviewer = credentials.getHostedRepository();
+
+            var censusBuilder = credentials.getCensusBuilder()
+                    .addAuthor(author.forge().currentUser().id())
+                    .addReviewer(reviewer.forge().currentUser().id());
+            var seedFolder = tempFolder.path().resolve("seed");
+            var checkBot = PullRequestBot.newBuilder()
+                    .repo(author)
+                    .censusRepo(censusBuilder.build())
+                    .censusLink("https://census.com/{{contributor}}-profile")
+                    .seedStorage(seedFolder)
+                    .build();
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
+
+            // Remove .jcheck/conf
+            localRepo.remove(localRepo.root().resolve(".jcheck/conf"));
+            localRepo.commit("no conf", "testauthor", "ta@none.none");
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Create a new branch
+            var editBranch = localRepo.branch(masterHash, "edit");
+            localRepo.checkout(editBranch);
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.url(), "edit", true);
+
+            var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
+
+            // Check the status
+            TestBotRunner.runPeriodicItems(checkBot);
+            var comments = pr.store().comments();
+            assertTrue(comments.get(comments.size() - 1).body().contains(" ⚠️ @" + pr.author().username() + " The `.jcheck/conf` in the target branch of this pull request is missing completely. "
+                    + "Until that is resolved, this pull request cannot be processed. Please notify the repository owner."));
+            // Make sure the warning message will be sent only once
+            TestBotRunner.runPeriodicItems(checkBot);
+            TestBotRunner.runPeriodicItems(checkBot);
+            assertEquals(1, pr.store().comments().size());
+
+            // Restore .jcheck/conf
+            localRepo.checkout(masterHash);
+            Files.createDirectories(tempFolder.path().resolve(".jcheck"));
+            var checkConf = tempFolder.path().resolve(".jcheck/conf");
+            writeToCheckConf(checkConf);
+            localRepo.add(checkConf);
+            var restoreHash = localRepo.commit("add conf to master", "testauthor", "ta@none.none");
+            localRepo.push(restoreHash, author.url(), "master", true);
+
+            pr.addComment(".jcheck/conf is uploaded");
+            TestBotRunner.runPeriodicItems(checkBot);
+            assertTrue(pr.store().labelNames().contains("rfr"));
+        }
+    }
+
+    @Test
+    void invalidJCheckConf(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var reviewer = credentials.getHostedRepository();
+
+            var censusBuilder = credentials.getCensusBuilder()
+                    .addAuthor(author.forge().currentUser().id())
+                    .addReviewer(reviewer.forge().currentUser().id());
+            var seedFolder = tempFolder.path().resolve("seed");
+            var checkBot = PullRequestBot.newBuilder()
+                    .repo(author)
+                    .censusRepo(censusBuilder.build())
+                    .censusLink("https://census.com/{{contributor}}-profile")
+                    .seedStorage(seedFolder)
+                    .build();
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
+
+            // Make .jcheck/conf invalid
+            try (var output = new FileWriter(tempFolder.path().resolve(".jcheck/conf").toFile(), true)) {
+                output.append("\n6r4tt32etdffyufv");
+            }
+            localRepo.add(tempFolder.path().resolve(".jcheck/conf"));
+            var masterHash = localRepo.commit("make .jcheck/conf invalid", "testauthor", "ta@none.none");
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Create a new branch
+            var editBranch = localRepo.branch(masterHash, "edit");
+            localRepo.checkout(editBranch);
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.url(), "edit", true);
+
+            var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
+
+            // Check the status
+            TestBotRunner.runPeriodicItems(checkBot);
+            var comments = pr.store().comments();
+            assertTrue(comments.get(comments.size() - 1).body().contains(" ⚠️ @" + pr.author().username() + " The `.jcheck/conf` in the target branch of this pull request is invalid. "
+                    + "Until that is resolved, this pull request cannot be processed. Please notify the repository owner."));
+            // Make sure the warning message will be sent only once
+            TestBotRunner.runPeriodicItems(checkBot);
+            TestBotRunner.runPeriodicItems(checkBot);
+            assertEquals(1, pr.store().comments().size());
+
+            // Restore .jcheck/conf
+            localRepo.checkout(masterHash);
+            Files.createDirectories(tempFolder.path().resolve(".jcheck"));
+            var checkConf = tempFolder.path().resolve(".jcheck/conf");
+            writeToCheckConf(checkConf);
+            localRepo.add(checkConf);
+            var restoreHash = localRepo.commit("restore conf", "testauthor", "ta@none.none");
+            localRepo.push(restoreHash, author.url(), "master", true);
+
+            pr.addComment(".jcheck/conf is uploaded");
+            TestBotRunner.runPeriodicItems(checkBot);
+            assertTrue(pr.store().labelNames().contains("rfr"));
+        }
+    }
+
+    @Test
+    void missingExternalJcheckConf(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var conf = credentials.getHostedRepository();
+
+            var censusBuilder = credentials.getCensusBuilder()
+                    .addAuthor(author.forge().currentUser().id());
+            var checkBot = PullRequestBot.newBuilder()
+                    .repo(author)
+                    .censusRepo(censusBuilder.build())
+                    .confOverrideRepo(conf)
+                    .confOverrideName("jcheck.conf")
+                    .confOverrideRef("jcheck-branch")
+                    .build();
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Remove conf
+            localRepo.remove(localRepo.root().resolve(".jcheck/conf"));
+            var newMasterHash = localRepo.commit("No more conf", "duke", "duke@openjdk.org");
+            localRepo.push(newMasterHash, author.url(), "master");
+
+            // Create a new branch
+            var editBranch = localRepo.branch(masterHash, "edit");
+            localRepo.checkout(editBranch);
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.url(), "edit", true);
+
+            var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
+
+            // Check the status (should become ready immediately as reviewercount is overridden to 0)
+            TestBotRunner.runPeriodicItems(checkBot);
+            var comments = pr.store().comments();
+            assertTrue(comments.get(comments.size() - 1).body().contains(" ⚠️ @" + pr.author().username() + " The external jcheck configuration for this repository could not be resolved. "
+                    + "Until that is resolved, this pull request cannot be processed. Please notify a Skara admin."));
+            // Make sure the warning message will be sent only once
+            TestBotRunner.runPeriodicItems(checkBot);
+            TestBotRunner.runPeriodicItems(checkBot);
+            assertEquals(1, pr.store().comments().size());
+
+            // upload .jcheck/conf to jcheck-branch
+            var jCheckBranch = localRepo.branch(masterHash, "jcheck-branch");
+            localRepo.checkout(jCheckBranch);
+            var checkConf = tempFolder.path().resolve("jcheck.conf");
+            writeToCheckConf(checkConf);
+            localRepo.add(checkConf);
+            var restoreHash = localRepo.commit("restore conf", "testauthor", "ta@none.none");
+            localRepo.push(restoreHash, conf.url(), "jcheck-branch", true);
+
+            pr.addComment("jcheck.conf is uploaded");
+            TestBotRunner.runPeriodicItems(checkBot);
+            assertTrue(pr.store().labelNames().contains("rfr"));
+        }
+    }
+
+    @Test
+    void invalidExternalJcheckConf(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var conf = credentials.getHostedRepository();
+
+            var censusBuilder = credentials.getCensusBuilder()
+                    .addAuthor(author.forge().currentUser().id());
+            var checkBot = PullRequestBot.newBuilder()
+                    .repo(author)
+                    .censusRepo(censusBuilder.build())
+                    .confOverrideRepo(conf)
+                    .confOverrideName("jcheck.conf")
+                    .confOverrideRef("jcheck-branch")
+                    .build();
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Remove conf
+            localRepo.remove(localRepo.root().resolve(".jcheck/conf"));
+            var newMasterHash = localRepo.commit("No more conf", "duke", "duke@openjdk.org");
+            localRepo.push(newMasterHash, author.url(), "master");
+
+            // upload invalid jcheck.conf to conf repo
+            var jCheckBranch = localRepo.branch(masterHash, "jcheck-branch");
+            localRepo.checkout(jCheckBranch);
+            var checkConf = tempFolder.path().resolve("jcheck.conf");
+            try (var output = new FileWriter(checkConf.toFile(), true)) {
+                output.append("\n6r4tt32etdffyufv");
+            }
+            localRepo.add(checkConf);
+            var confHash = localRepo.commit("restore conf", "testauthor", "ta@none.none");
+            localRepo.push(confHash, conf.url(), "jcheck-branch", true);
+
+            // Create a new branch
+            var editBranch = localRepo.branch(masterHash, "edit");
+            localRepo.checkout(editBranch);
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.url(), "edit", true);
+
+            var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
+
+            // Check the status (should become ready immediately as reviewercount is overridden to 0)
+            TestBotRunner.runPeriodicItems(checkBot);
+            var comments = pr.store().comments();
+            assertTrue(comments.get(comments.size() - 1).body().contains(" ⚠️ @" + pr.author().username() + " The external jcheck configuration for this repository could not be resolved. "
+                    + "Until that is resolved, this pull request cannot be processed. Please notify a Skara admin."));
+            // Make sure the warning message will be sent only once
+            TestBotRunner.runPeriodicItems(checkBot);
+            TestBotRunner.runPeriodicItems(checkBot);
+            assertEquals(1, pr.store().comments().size());
+
+            // restore jcheck.conf to jcheck-branch
+            localRepo.checkout(jCheckBranch);
+            writeToCheckConf(checkConf);
+            localRepo.add(checkConf);
+            var restoreHash = localRepo.commit("restore conf", "testauthor", "ta@none.none");
+            localRepo.push(restoreHash, conf.url(), "jcheck-branch", true);
+
+            pr.addComment("jcheck.conf is uploaded");
+            TestBotRunner.runPeriodicItems(checkBot);
+            assertTrue(pr.store().labelNames().contains("rfr"));
+        }
+    }
+
+    private void writeToCheckConf(Path checkConf) throws IOException {
+        try (var output = Files.newBufferedWriter(checkConf)) {
+            output.append("[general]\n");
+            output.append("project=test\n");
+            output.append("jbs=tstprj\n");
+            output.append("\n");
+            output.append("[checks]\n");
+            output.append("error=");
+            output.append(String.join(",", Set.of("author", "reviewers", "whitespace")));
+            output.append("\n\n");
+            output.append("[census]\n");
+            output.append("version=0\n");
+            output.append("domain=openjdk.org\n");
+            output.append("\n");
+            output.append("[checks \"whitespace\"]\n");
+            output.append("files=.*\\.txt\n");
+            output.append("\n");
+            output.append("[checks \"reviewers\"]\n");
+            output.append("reviewers=1\n");
         }
     }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -2308,7 +2308,7 @@ class CheckTests {
 
             // Make .jcheck/conf invalid
             try (var output = new FileWriter(tempFolder.path().resolve(".jcheck/conf").toFile(), true)) {
-                output.append("\n6r4tt32etdffyufv");
+                output.append("\nRandomCharacters");
             }
             localRepo.add(tempFolder.path().resolve(".jcheck/conf"));
             var masterHash = localRepo.commit("make .jcheck/conf invalid", "testauthor", "ta@none.none");
@@ -2439,7 +2439,7 @@ class CheckTests {
             localRepo.checkout(jCheckBranch);
             var checkConf = tempFolder.path().resolve("jcheck.conf");
             try (var output = new FileWriter(checkConf.toFile(), true)) {
-                output.append("\n6r4tt32etdffyufv");
+                output.append("\nRandomCharacters");
             }
             localRepo.add(checkConf);
             var confHash = localRepo.commit("restore conf", "testauthor", "ta@none.none");

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -2263,7 +2263,7 @@ class CheckTests {
             // Check the status
             TestBotRunner.runPeriodicItems(checkBot);
             var comments = pr.store().comments();
-            assertTrue(comments.get(comments.size() - 1).body().contains(" ⚠️ @" + pr.author().username() + " The `.jcheck/conf` in the target branch of this pull request is missing completely. "
+            assertTrue(comments.get(comments.size() - 1).body().contains(" ⚠️ @" + pr.author().username() + " No `.jcheck/conf` found in the target branch of this pull request. "
                     + "Until that is resolved, this pull request cannot be processed. Please notify the repository owner."));
             // Make sure the warning message will be sent only once
             TestBotRunner.runPeriodicItems(checkBot);
@@ -2385,14 +2385,14 @@ class CheckTests {
             // Check the status (should become ready immediately as reviewercount is overridden to 0)
             TestBotRunner.runPeriodicItems(checkBot);
             var comments = pr.store().comments();
-            assertTrue(comments.get(comments.size() - 1).body().contains(" ⚠️ @" + pr.author().username() + " The external jcheck configuration for this repository could not be resolved. "
+            assertTrue(comments.get(comments.size() - 1).body().contains(" ⚠️ @" + pr.author().username() + " The external jcheck configuration for this repository could not be found. "
                     + "Until that is resolved, this pull request cannot be processed. Please notify a Skara admin."));
             // Make sure the warning message will be sent only once
             TestBotRunner.runPeriodicItems(checkBot);
             TestBotRunner.runPeriodicItems(checkBot);
             assertEquals(1, pr.store().comments().size());
 
-            // upload .jcheck/conf to jcheck-branch
+            // Upload .jcheck/conf to jcheck-branch
             var jCheckBranch = localRepo.branch(masterHash, "jcheck-branch");
             localRepo.checkout(jCheckBranch);
             var checkConf = tempFolder.path().resolve("jcheck.conf");
@@ -2434,7 +2434,7 @@ class CheckTests {
             var newMasterHash = localRepo.commit("No more conf", "duke", "duke@openjdk.org");
             localRepo.push(newMasterHash, author.url(), "master");
 
-            // upload invalid jcheck.conf to conf repo
+            // Upload invalid jcheck.conf to conf repo
             var jCheckBranch = localRepo.branch(masterHash, "jcheck-branch");
             localRepo.checkout(jCheckBranch);
             var checkConf = tempFolder.path().resolve("jcheck.conf");
@@ -2456,7 +2456,7 @@ class CheckTests {
             // Check the status (should become ready immediately as reviewercount is overridden to 0)
             TestBotRunner.runPeriodicItems(checkBot);
             var comments = pr.store().comments();
-            assertTrue(comments.get(comments.size() - 1).body().contains(" ⚠️ @" + pr.author().username() + " The external jcheck configuration for this repository could not be resolved. "
+            assertTrue(comments.get(comments.size() - 1).body().contains(" ⚠️ @" + pr.author().username() + " The external jcheck configuration for this repository is invalid. "
                     + "Until that is resolved, this pull request cannot be processed. Please notify a Skara admin."));
             // Make sure the warning message will be sent only once
             TestBotRunner.runPeriodicItems(checkBot);

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CommitCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CommitCommandTests.java
@@ -260,7 +260,7 @@ public class CommitCommandTests {
 
             // Look at the reply
             var replies = author.commitComments(masterHash);
-            CommitCommandAsserts.assertLastCommentContains(replies, "there is no `.jcheck/conf` present");
+            CommitCommandAsserts.assertLastCommentContains(replies, "There is no `.jcheck/conf` present at revision");
             CommitCommandAsserts.assertLastCommentContains(replies, "cannot process command");
         }
     }

--- a/network/src/main/java/org/openjdk/skara/network/RestRequest.java
+++ b/network/src/main/java/org/openjdk/skara/network/RestRequest.java
@@ -374,7 +374,7 @@ public class RestRequest {
             log.warning("Request returned bad status: " + response.statusCode());
             log.info(queryBuilder.toString());
             log.info(response.body());
-            throw new UncheckedRestException("Request returned bad status: " + response.statusCode());
+            throw new UncheckedRestException("Request returned bad status: " + response.statusCode(), response.statusCode());
         } else {
             return Optional.empty();
         }

--- a/network/src/main/java/org/openjdk/skara/network/UncheckedRestException.java
+++ b/network/src/main/java/org/openjdk/skara/network/UncheckedRestException.java
@@ -6,8 +6,14 @@ package org.openjdk.skara.network;
  * has already been logged.
  */
 public class UncheckedRestException extends RuntimeException {
+    int statusCode;
 
-    public UncheckedRestException(String message) {
+    public UncheckedRestException(String message, int statusCode) {
         super(message);
+        this.statusCode = statusCode;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
     }
 }

--- a/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
@@ -27,6 +27,7 @@ import org.openjdk.skara.host.HostUser;
 import org.openjdk.skara.issuetracker.Issue;
 import org.openjdk.skara.issuetracker.Label;
 import org.openjdk.skara.json.JSONValue;
+import org.openjdk.skara.network.UncheckedRestException;
 import org.openjdk.skara.vcs.*;
 
 import java.io.*;
@@ -201,6 +202,9 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
             return String.join("\n", lines.orElseThrow());
         } catch (IOException e) {
             throw new UncheckedIOException(e);
+        } catch (NoSuchElementException e) {
+            // Make this method behave more like other remote repo implementations
+            throw new UncheckedRestException("Can't find file " + filename, 404);
         }
     }
 


### PR DESCRIPTION
SKARA-1393 describes a problem related with `.jcheck/conf` missing.

In this patch, when the problem happens, the author of this pull request will get instructions about how to solve this problem.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1393](https://bugs.openjdk.org/browse/SKARA-1393): PR bot fails on missing .jcheck/conf


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1407/head:pull/1407` \
`$ git checkout pull/1407`

Update a local copy of the PR: \
`$ git checkout pull/1407` \
`$ git pull https://git.openjdk.org/skara pull/1407/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1407`

View PR using the GUI difftool: \
`$ git pr show -t 1407`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1407.diff">https://git.openjdk.org/skara/pull/1407.diff</a>

</details>
