### PR TITLE
1663: Mark integrated Pull Requests as properly merged in their repositories

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifier.java
@@ -77,7 +77,7 @@ public class PullRequestBranchNotifier implements Notifier, PullRequestListener 
 
     @Override
     public void onStateChange(PullRequest pr, Path scratchPath, Issue.State oldState) {
-        if (pr.state() == Issue.State.CLOSED) {
+        if (pr.state() != Issue.State.OPEN) {
             var retargetedDependencies = PreIntegrations.retargetDependencies(pr);
             deleteBranch(pr);
             if (pr.labelNames().contains("integrated")) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
@@ -22,22 +22,32 @@
  */
 package org.openjdk.skara.bots.pr;
 
-import org.openjdk.skara.forge.*;
-import org.openjdk.skara.issuetracker.Comment;
-import org.openjdk.skara.vcs.Branch;
-import org.openjdk.skara.vcs.Commit;
-import org.openjdk.skara.vcs.Hash;
-import org.openjdk.skara.vcs.Repository;
-
-import java.io.*;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import java.time.Duration;
-import java.util.*;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.logging.Level;
-import java.util.stream.Collectors;
 import java.util.logging.Logger;
-import java.util.regex.Pattern;
 import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.openjdk.skara.forge.Check;
+import org.openjdk.skara.forge.CheckStatus;
+import org.openjdk.skara.forge.CommitFailure;
+import org.openjdk.skara.forge.HostedRepositoryPool;
+import org.openjdk.skara.forge.PullRequest;
+import org.openjdk.skara.forge.PullRequestUtils;
+import org.openjdk.skara.issuetracker.Comment;
+import org.openjdk.skara.vcs.Branch;
+import org.openjdk.skara.vcs.Hash;
+import org.openjdk.skara.vcs.Repository;
 
 public class IntegrateCommand implements CommandHandler {
     private final static Logger log = Logger.getLogger("org.openjdk.skara.bots.pr");
@@ -164,7 +174,18 @@ public class IntegrateCommand implements CommandHandler {
 
         Optional<Hash> prepushHash = checkForPrePushHash(bot, pr, scratchPath, allComments, "integrate");
         if (prepushHash.isPresent()) {
-            markIntegratedAndMerged(bot, scratchPath, pr, prepushHash.get(), reply);
+            if (pr.state() == PullRequest.State.OPEN) {
+                try {
+                    final Repository repository = materializeLocalRepo(bot, pr, scratchPath, "integrate");
+                    repository.fetch(pr.repository().url(), "+" + pr.targetRef() + ":" + pr.sourceRef());
+                    repository.checkout(new Branch(pr.sourceRef()));
+                    repository.reset(prepushHash.get(), true);
+                    repository.push(prepushHash.get(), pr.sourceRepository().orElseThrow().url(), pr.sourceRef(), true);
+                } catch (IOException exception) {
+                    throw new UncheckedIOException(exception);
+                }
+            }
+            markIntegrated(pr, prepushHash.get(), reply);
             return;
         }
 
@@ -192,28 +213,7 @@ public class IntegrateCommand implements CommandHandler {
             // Now that we have the integration lock, refresh the PR metadata
             pr = pr.repository().pullRequest(pr.id());
 
-            Repository localRepo = new HostedRepositoryPool(bot.seedStorage().orElse(scratchPath.resolve("seeds")))
-                     .materialize(pr.repository(), scratchPath.resolve(pr.targetRef() + "/" + pr.headHash().hex()));
-            localRepo.fetch(pr.repository().url(), "+" + pr.targetRef() + ":" + pr.targetRef() + pr.headHash().hex(), true);
-            localRepo.checkout(new Branch(pr.targetRef() + pr.headHash().hex()), false);
-
-            // See markIntegratedAndMerged for the logic for rogue mark as merged handling
-            final List<Commit> commits = localRepo.commits(2).asList();
-            commits.forEach(commit -> log.fine(commit.toString()));
-            final Commit currentMarkAsMergedCommit =
-                    isMarkAsMergeCommit(commits.get(0)) ? commits.get(0) : null;
-            final Commit lastMarkAsMergedCommit =
-                    (commits.size() == 2 ? (isMarkAsMergeCommit(commits.get(1)) ? commits.get(1) : null) : null);
-
-            if (lastMarkAsMergedCommit != null) {
-                localRepo.reset(lastMarkAsMergedCommit.parents().get(0), true);
-                localRepo.push(lastMarkAsMergedCommit.parents().get(0), pr.repository().url(), pr.targetRef(), true);
-            } else if (currentMarkAsMergedCommit != null) {
-                localRepo.reset(currentMarkAsMergedCommit.parents().get(0), true);
-                localRepo.push(currentMarkAsMergedCommit.parents().get(0), pr.repository().url(), pr.targetRef(), true);
-            }
-
-            localRepo = materializeLocalRepo(bot, pr, scratchPath, "integrate");
+            Repository localRepo = materializeLocalRepo(bot, pr, scratchPath, "integrate");
             var checkablePr = new CheckablePullRequest(pr, localRepo, bot.ignoreStaleReviews(),
                                                        bot.confOverrideRepository().orElse(null),
                                                        bot.confOverrideName(),
@@ -264,7 +264,8 @@ public class IntegrateCommand implements CommandHandler {
                 var amendedHash = checkablePr.amendManualReviewers(localHash, censusInstance.namespace(), original);
                 addPrePushComment(pr, amendedHash, rebaseMessage.toString());
                 localRepo.push(amendedHash, pr.repository().url(), pr.targetRef());
-                markIntegratedAndMerged(bot, scratchPath, pr, amendedHash, reply);
+                localRepo.push(amendedHash, pr.sourceRepository().orElseThrow().url(), pr.sourceRef(), true);
+                markIntegrated(pr, amendedHash, reply);
             } else {
                 reply.print("Warning! Your commit did not result in any changes! ");
                 reply.println("No push attempt will be made.");
@@ -348,72 +349,10 @@ public class IntegrateCommand implements CommandHandler {
         pr.addComment(commentBody.toString());
     }
 
-    static void markIntegratedAndMerged(PullRequestBot bot, Path scratchPath, PullRequest pr, Hash hash, PrintWriter reply) {
+    static void markIntegrated(PullRequest pr, Hash hash, PrintWriter reply) {
         // Note that the order of operations here is tested in IntegrateTests::retryAfterInterrupt
         // so any change here requires careful update of that test
-        Repository repository;
-        Hash markMergedHash;
-        Commit currentMarkAsMergedCommit;
-        Commit lastMarkAsMergedCommit;
-
-        try {
-            repository = new HostedRepositoryPool(bot.seedStorage().orElse(scratchPath.resolve("seeds")))
-                      .materialize(pr.repository(), scratchPath.resolve(pr.targetRef() + "/" + pr.headHash().hex()));
-            repository.reinitialize();
-            repository.fetch(pr.repository().url(), "+" + pr.targetRef() + ":" + pr.targetRef() + pr.headHash().hex(), true);
-            repository.checkout(new Branch(pr.targetRef() + pr.headHash().hex()), false);
-            List<Commit> commits = repository.commits(2).asList();
-            commits.forEach(commit -> log.fine(commit.toString()));
-            currentMarkAsMergedCommit = isMarkAsMergeCommit(commits.get(0)) ? commits.get(0) : null;
-            // Work with the possibility that only a single commit exists on the repository
-            lastMarkAsMergedCommit =
-                    (commits.size() == 2 ? (isMarkAsMergeCommit(commits.get(1)) ? commits.get(1) : null) : null);
-
-            /*
-             * Not good, have to handle this now, since commits after a mark as merged one are
-             * treated as broken)
-             */
-            if (lastMarkAsMergedCommit != null) {
-                // Mark as Merged commits always have a preceding commit, same applies below
-                repository.reset(lastMarkAsMergedCommit.parents().get(0), true);
-                repository.push(lastMarkAsMergedCommit.parents().get(0), pr.repository().url(), pr.targetRef(), true);
-                lastMarkAsMergedCommit = null;
-
-                /*
-                 * In the unlikely and very erroneous case that 2 mark as merged commits are back
-                 * to back getting rid of the first one would remove the one that comes after
-                 */
-                currentMarkAsMergedCommit = null;
-            } else if (currentMarkAsMergedCommit != null) {
-                if (pr.state() == PullRequest.State.RESOLVED ||
-                        !currentMarkAsMergedCommit.message().get(0).substring(31).equals(hash.hex())) {
-                    repository.reset(currentMarkAsMergedCommit.parents().get(0), true);
-                    repository.push(currentMarkAsMergedCommit.parents().get(0), pr.repository().url(), pr.targetRef(), true);
-                    currentMarkAsMergedCommit = null;
-                }
-            }
-
-            /*
-             * Not needed if Pull Request is already marked as merged, or we are on our
-             * own mark as merged commit
-             */
-            if (pr.state() != PullRequest.State.RESOLVED && currentMarkAsMergedCommit == null) {
-                commits = repository.commits(hash.hex(), 2).asList();
-                commits.forEach(commit -> log.fine(commit.toString()));
-                // There is always at least one prior commit before the integrated one
-                repository.revert(commits.get(1).hash());
-                repository.addremove();
-                markMergedHash = repository.commit("Mark Integration as Merged for " + hash.hex(), "duke", "duke@openjdk.org");
-                repository.push(markMergedHash, pr.repository().url(), pr.targetRef(), false);
-            } else {
-                markMergedHash = (pr.state() == PullRequest.State.RESOLVED ? null : currentMarkAsMergedCommit.hash());
-            }
-        } catch (IOException exception) {
-            throw new UncheckedIOException(exception);
-        }
-
         pr.addLabel("integrated");
-        if (pr.state() != PullRequest.State.RESOLVED) pr.setState(PullRequest.State.RESOLVED);
         pr.removeLabel("ready");
         pr.removeLabel("rfr");
         if (pr.labelNames().contains("delegated")) {
@@ -424,23 +363,7 @@ public class IntegrateCommand implements CommandHandler {
         }
         reply.println(PullRequest.commitHashMessage(hash));
         reply.println();
-        reply.println(":bulb: You may see a message that your pull request was closed with unmerged commits. This can be safely ignored.");
-
-        try {
-            if (markMergedHash != null) {
-                repository.reset(hash, true);
-                repository.push(hash, pr.repository().url(), pr.targetRef(), true);
-            }
-        } catch (IOException exception) {
-            throw new UncheckedIOException(exception);
-        }
-    }
-
-    static boolean isMarkAsMergeCommit(Commit commit) {
-        return commit.author().name().equals("duke")
-                && commit.author().email().equals("duke@openjdk.org")
-                && (commit.message().size() == 1 ?
-                    commit.message().get(0).startsWith("Mark Integration as Merged for ") : false);
+        reply.println(":bulb: You may see changes to your pull request during integration. This can be safely ignored.");
     }
 
     @Override

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
@@ -98,9 +98,9 @@ public class SponsorCommand implements CommandHandler {
             pr = pr.repository().pullRequest(pr.id());
 
             Repository localRepo = new HostedRepositoryPool(bot.seedStorage().orElse(scratchPath.resolve("seeds")))
-                    .materialize(pr.repository(), scratchPath.resolve(pr.headHash().hex()));
-            localRepo.fetch(pr.repository().url(), pr.targetRef(), true);
-            localRepo.checkout(new Branch(pr.targetRef()), false);
+                    .materialize(pr.repository(), scratchPath.resolve(pr.targetRef() + "/" + pr.headHash().hex()));
+            localRepo.fetch(pr.repository().url(), "+" + pr.targetRef() + ":" + pr.targetRef() + pr.headHash().hex(), true);
+            localRepo.checkout(new Branch(pr.targetRef() + pr.headHash().hex()), false);
 
             // See markIntegratedAndMerged for the logic for rogue mark as merged handling
             final List<Commit> commits = localRepo.commits(2).asList();

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
@@ -24,7 +24,10 @@ package org.openjdk.skara.bots.pr;
 
 import org.openjdk.skara.forge.*;
 import org.openjdk.skara.issuetracker.Comment;
+import org.openjdk.skara.vcs.Branch;
+import org.openjdk.skara.vcs.Commit;
 import org.openjdk.skara.vcs.Hash;
+import org.openjdk.skara.vcs.Repository;
 
 import java.io.*;
 import java.nio.file.Path;
@@ -49,7 +52,7 @@ public class SponsorCommand implements CommandHandler {
 
         Optional<Hash> prePushHash = IntegrateCommand.checkForPrePushHash(bot, pr, scratchPath, allComments, "sponsor");
         if (prePushHash.isPresent()) {
-            markIntegratedAndClosed(pr, prePushHash.get(), reply);
+            IntegrateCommand.markIntegratedAndMerged(bot, scratchPath, pr, prePushHash.get(), reply);
             return;
         }
 
@@ -94,7 +97,28 @@ public class SponsorCommand implements CommandHandler {
             // Now that we have the integration lock, refresh the PR metadata
             pr = pr.repository().pullRequest(pr.id());
 
-            var localRepo = IntegrateCommand.materializeLocalRepo(bot, pr, scratchPath, "sponsor");
+            Repository localRepo = new HostedRepositoryPool(bot.seedStorage().orElse(scratchPath.resolve("seeds")))
+                    .materialize(pr.repository(), scratchPath.resolve(pr.headHash().hex()));
+            localRepo.fetch(pr.repository().url(), pr.targetRef(), true);
+            localRepo.checkout(new Branch(pr.targetRef()), false);
+
+            // See markIntegratedAndMerged for the logic for rogue mark as merged handling
+            final List<Commit> commits = localRepo.commits(2).asList();
+            commits.forEach(commit -> log.fine(commit.toString()));
+            final Commit currentMarkAsMergedCommit =
+                    IntegrateCommand.isMarkAsMergeCommit(commits.get(0)) ? commits.get(0) : null;
+            final Commit lastMarkAsMergedCommit =
+                    (commits.size() == 2 ? (IntegrateCommand.isMarkAsMergeCommit(commits.get(1)) ? commits.get(1) : null) : null);
+
+            if (lastMarkAsMergedCommit != null) {
+                localRepo.reset(lastMarkAsMergedCommit.parents().get(0), true);
+                localRepo.push(lastMarkAsMergedCommit.parents().get(0), pr.repository().url(), pr.targetRef(), true);
+            } else if (currentMarkAsMergedCommit != null) {
+                localRepo.reset(currentMarkAsMergedCommit.parents().get(0), true);
+                localRepo.push(currentMarkAsMergedCommit.parents().get(0), pr.repository().url(), pr.targetRef(), true);
+            }
+
+            localRepo = IntegrateCommand.materializeLocalRepo(bot, pr, scratchPath, "sponsor");
             var checkablePr = new CheckablePullRequest(pr, localRepo, bot.ignoreStaleReviews(),
                                                        bot.confOverrideRepository().orElse(null),
                                                        bot.confOverrideName(),
@@ -131,7 +155,7 @@ public class SponsorCommand implements CommandHandler {
                 var amendedHash = checkablePr.amendManualReviewers(localHash, censusInstance.namespace(), original);
                 IntegrateCommand.addPrePushComment(pr, amendedHash, rebaseMessage.toString());
                 localRepo.push(amendedHash, pr.repository().url(), pr.targetRef());
-                markIntegratedAndClosed(pr, amendedHash, reply);
+                IntegrateCommand.markIntegratedAndMerged(bot, scratchPath, pr, amendedHash, reply);
             } else {
                 reply.print("Warning! This commit did not result in any changes! ");
                 reply.println("No push attempt will be made.");
@@ -142,10 +166,6 @@ public class SponsorCommand implements CommandHandler {
                                   "The error has been logged and will be investigated. It is possible that this error " +
                                   "is caused by a transient issue; feel free to retry the operation.");
         }
-    }
-
-    private void markIntegratedAndClosed(PullRequest pr, Hash amendedHash, PrintWriter reply) {
-        IntegrateCommand.markIntegratedAndClosed(pr, amendedHash, reply);
     }
 
     @Override

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrateTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrateTests.java
@@ -531,7 +531,7 @@ class IntegrateTests {
 
             // The bot should reply with an ok message
             var prePush = pr.comments().stream()
-                           .filter(comment -> comment.body().contains("Going to push as commit"))
+                           .filter(comment -> comment.body().contains("Recording snapshot of final changes as commit"))
                            .filter(comment -> comment.body().contains("commit was automatically rebased without conflicts"))
                            .count();
             assertEquals(1, prePush);

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/SponsorTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/SponsorTests.java
@@ -372,7 +372,7 @@ class SponsorTests {
 
             // The bot should reply with an ok message
             var prePush = pr.comments().stream()
-                    .filter(comment -> comment.body().contains("Going to push as commit"))
+                    .filter(comment -> comment.body().contains("Recording snapshot of final changes as commit"))
                     .filter(comment -> comment.body().contains("commit was automatically rebased without conflicts"))
                     .count();
             assertEquals(1, prePush);

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -407,9 +407,7 @@ public class GitHubPullRequest implements PullRequest {
         if (state == State.RESOLVED) {
 
            /*
-            *
-            * SKARA-1663: Implement State.RESOLVED as a squash merge, until GitHub
-            * allows for marking a Pull Request as merged in the future.
+            * SKARA-1663: State.RESOLVED cannot be set directly.
             *
             * If a method for actual merging is required, the following implementation
             * will suffice for the different types of merges GitHub allows for:
@@ -418,12 +416,9 @@ public class GitHubPullRequest implements PullRequest {
             *        .execute();
             *
             * Where "merge_method" can be set to one of: "rebase", "squash", or "merge"
-            *
             */
 
-            request.put("pulls/" + this.id() + "/merge")
-                   .body("merge_method", "squash")
-                   .execute();
+            throw new UnsupportedOperationException();
         } else {
             request.patch("pulls/" + this.id())
                    .body("state", state == State.OPEN ? "open" : "closed")

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -445,24 +445,21 @@ public class GitLabMergeRequest implements PullRequest {
         if (state == State.RESOLVED) {
 
             /*
-             *
-             * SKARA-1663: Implement State.RESOLVED as a squash merge, until GitLab
-             * allows for marking a Pull Request as merged in the future.
+             * SKARA-1663: State.RESOLVED cannot be set directly.
              *
              * If a method for actual merging is required, the following implementations
              * will suffice for the different types of merges GitLab allows for:
              *
              * (In order of merge methods: Rebase, Merge, and Squash)
              *
-             * request.put("rebase").execute();
              * request.put("merge").body(JSON.object().put("squash", false)).execute();
              * request.put("merge").body(JSON.object().put("squash", true)).execute();
              *
+             * Merge Request branches can be rebased via:
+             * request.put("rebase").execute();
              */
 
-            request.put("merge")
-                   .body(JSON.object().put("squash", true))
-                   .execute();
+            throw new UnsupportedOperationException();
         } else {
             request.put("")
                    .body("state_event", state == State.OPEN ? "reopen" : "close")

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -445,21 +445,24 @@ public class GitLabMergeRequest implements PullRequest {
         if (state == State.RESOLVED) {
 
             /*
-             * SKARA-1663: State.RESOLVED cannot be set directly.
+             * SKARA-1663: Implement State.RESOLVED as a fast forward merge, until GitLab
+             * allows for marking a Pull Request as merged in the future.
              *
              * If a method for actual merging is required, the following implementations
              * will suffice for the different types of merges GitLab allows for:
              *
-             * (In order of merge methods: Rebase, Merge, and Squash)
+             * (In order of merge methods: Merge, and Squash)
              *
              * request.put("merge").body(JSON.object().put("squash", false)).execute();
-             * request.put("merge").body(JSON.object().put("squash", true)).execute();
+             * request.put("merge").body(JSON.object().put("squash", true)).execute();\
              *
-             * Merge Request branches can be rebased via:
+             * Merge Requests can be rebased in GitLab via:
              * request.put("rebase").execute();
              */
 
-            throw new UnsupportedOperationException();
+            // TODO Set repository merge setting to fast forward
+            request.put("merge").body(JSON.object().put("squash", false)).execute();
+            // TODO Maybe reset repository merge setting to original
         } else {
             request.put("")
                    .body("state_event", state == State.OPEN ? "reopen" : "close")
@@ -876,7 +879,13 @@ public class GitLabMergeRequest implements PullRequest {
 
     @Override
     public Optional<Hash> findIntegratedCommitHash() {
-        return findIntegratedCommitHash(List.of(repository.forge().currentUser().id()));
+        final JSONValue result = json.get("merge_commit_sha");
+        if (result.isNull()) {
+            // Backwards Compatibility for older Pull Requests
+            return findIntegratedCommitHash(List.of(repository.forge().currentUser().id()));
+        } else {
+            return Optional.of(new Hash(result.asString()));
+        }
     }
 
     /**

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -469,7 +469,7 @@ public class GitRepository implements Repository {
 
     @Override
     public void revert(Hash h) throws IOException {
-        try (var p = capture("git", "checkout", "--recurse-submodules", h.hex(), "--", ".")) {
+        try (var p = capture("git", "restore", "--recurse-submodules", "--source", h.hex(), "--", ".")) {
             await(p);
         }
     }


### PR DESCRIPTION
Skara currently closes integrated Pull Requests, since the actual integration is done internally and then pushed to the repository separately. This makes every integrated request always look like it was closed to an outside observer, forcing the use of a special integrated flag to distinguish between integrated and closed, or rejected and closed. On top of that, it just looks awful in the interface all around (and is also not included in the accepted Pull Request count by GitHub for the committer, which is frustrating for newer contributors to a surprising extent). In the [willful absence of a reply from the GitHub team to allow marking a pull request as merged through a flag](https://github.com/orgs/community/discussions/12437), and [GitLab being unlikely to make a similar change either](https://gitlab.com/gitlab-org/gitlab/-/issues/16701), we can look at implementing this as an integration feature in Skara itself instead.

Every pull has a corresponding pre-integration branch created at the time it was made, and this special branch is marked for deletion when the pull is integrated, and initially it was thought to merge the Pull Request into these corresponding pr/ branches just before their deletion but that proved to present too many challenges to be viable. Instead a related approach of enhancing the Pull Request bots with their own special integration branches can be taken, as well as providing a flexible utility method for extracting the actual branch the Pull Request was integrated into, to address the concern of losing information on what the actual Pull Request target branch was.


https://gitlab.com/gitlab-org/gitlab/-/blob/master/app/models/merge_request.rb#L172

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1663](https://bugs.openjdk.org/browse/SKARA-1663): Mark integrated Pull Requests as properly merged in their repositories


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1409/head:pull/1409` \
`$ git checkout pull/1409`

Update a local copy of the PR: \
`$ git checkout pull/1409` \
`$ git pull https://git.openjdk.org/skara.git pull/1409/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1409`

View PR using the GUI difftool: \
`$ git pr show -t 1409`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1409.diff">https://git.openjdk.org/skara/pull/1409.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1409#issuecomment-1301652127)