### PR TITLE
1217: ProblemList errors should not prevent a PR from being rfr

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
@@ -283,6 +283,5 @@ class PullRequestCheckIssueVisitor implements IssueVisitor {
     @Override
     public void visit(ProblemListsIssue issue) {
         addFailureMessage(issue.check(), issue.issue() + " is used in problem lists: " + issue.files());
-        readyForReview = false;
     }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -2182,14 +2182,14 @@ class CheckTests {
             var reviewer = credentials.getHostedRepository();
             var issueProject = credentials.getIssueProject();
 
-
             var censusBuilder = credentials.getCensusBuilder()
                     .addAuthor(author.forge().currentUser().id())
                     .addReviewer(reviewer.forge().currentUser().id());
             var checkBot = PullRequestBot.newBuilder().repo(author).censusRepo(censusBuilder.build()).issueProject(issueProject).build();
 
             // Populate the projects repository
-            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(), Path.of("appendable.txt"), Set.of("author", "reviewers", "whitespace", "problemlists"), "0.1");
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(),
+                    Path.of("appendable.txt"), Set.of("author", "reviewers", "whitespace", "problemlists"), "0.1");
 
             // Add problemlists configuration to conf
             try (var output = new FileWriter(tempFolder.path().resolve(".jcheck/conf").toFile(), true)) {

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -2175,7 +2175,7 @@ class CheckTests {
     }
 
     @Test
-    void problemListsIssue(TestInfo testInfo) throws IOException {
+    void testProblemListsIssue(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
              var tempFolder = new TemporaryDirectory()) {
             var author = credentials.getHostedRepository();

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -29,7 +29,7 @@ import org.openjdk.skara.issuetracker.Link;
 import org.openjdk.skara.json.JSON;
 import org.openjdk.skara.test.*;
 
-import java.io.IOException;
+import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.nio.file.attribute.PosixFilePermission;
@@ -2171,6 +2171,57 @@ class CheckTests {
             assertFalse(pr.store().body().contains(backportIssue.title()));
             assertFalse(pr.store().body().contains(backportCsr.id()));
             assertFalse(pr.store().body().contains(backportCsr.title()));
+        }
+    }
+
+    @Test
+    void problemListsIssue(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var reviewer = credentials.getHostedRepository();
+            var issueProject = credentials.getIssueProject();
+
+
+            var censusBuilder = credentials.getCensusBuilder()
+                    .addAuthor(author.forge().currentUser().id())
+                    .addReviewer(reviewer.forge().currentUser().id());
+            var checkBot = PullRequestBot.newBuilder().repo(author).censusRepo(censusBuilder.build()).issueProject(issueProject).build();
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(), Path.of("appendable.txt"), Set.of("author", "reviewers", "whitespace", "problemlists"), "0.1");
+
+            // Add problemlists configuration to conf
+            try (var output = new FileWriter(tempFolder.path().resolve(".jcheck/conf").toFile(), true)) {
+                output.append("\n[checks \"problemlists\"]\n");
+                output.append("dirs=test/jdk\n");
+            }
+
+            // Create ProblemList.txt
+            Files.createDirectories(tempFolder.path().resolve("test/jdk"));
+            var problemList = tempFolder.path().resolve("test/jdk/ProblemList.txt");
+            try (var output = Files.newBufferedWriter(problemList)) {
+                output.append("test 1 windows-all");
+            }
+            localRepo.add(tempFolder.path().resolve(".jcheck/conf"));
+            localRepo.add(problemList);
+            localRepo.commit("add problemList.txt", "testauthor", "ta@none.none");
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo, "A line");
+            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+
+            var issue = issueProject.createIssue("The main issue", List.of("main"), Map.of("issuetype", JSON.of("Bug")));
+
+            var pr = credentials.createPullRequest(author, "master", "edit", issue.id());
+
+            // Check the status
+            TestBotRunner.runPeriodicItems(checkBot);
+            assertTrue(pr.store().labelNames().contains("rfr"));
+            assertFalse(pr.store().labelNames().contains("ready"));
+            assertTrue(pr.store().body().contains("1 is used in problem lists"));
         }
     }
 }


### PR DESCRIPTION
In this patch, `ProblemListsIssue` will not prevent a PR from being ready for review(rfr) any more.

Also added `testProblemListsIssue` to test this behavior.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1217](https://bugs.openjdk.org/browse/SKARA-1217): ProblemList errors should not prevent a PR from being rfr


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1410/head:pull/1410` \
`$ git checkout pull/1410`

Update a local copy of the PR: \
`$ git checkout pull/1410` \
`$ git pull https://git.openjdk.org/skara pull/1410/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1410`

View PR using the GUI difftool: \
`$ git pr show -t 1410`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1410.diff">https://git.openjdk.org/skara/pull/1410.diff</a>

</details>
