### PR TITLE
1659: Fix polling and retries in testinfo bot

### DIFF
--- a/bots/testinfo/src/main/java/org/openjdk/skara/bots/testinfo/TestInfoBot.java
+++ b/bots/testinfo/src/main/java/org/openjdk/skara/bots/testinfo/TestInfoBot.java
@@ -55,11 +55,12 @@ public class TestInfoBot implements Bot {
 
     @Override
     public List<WorkItem> getPeriodicItems() {
+        var now = Instant.now();
         var prs = poller.updatedPullRequests();
         return prs.stream()
                 .filter(pr -> pr.sourceRepository().isPresent())
                 .map(pr -> (WorkItem) new TestInfoBotWorkItem(pr,
-                        recheckIn -> poller.retryPullRequest(pr, Instant.now().plus(recheckIn))))
+                        delay -> poller.retryPullRequest(pr, now.plus(delay))))
                 .toList();
     }
 

--- a/bots/testinfo/src/main/java/org/openjdk/skara/bots/testinfo/TestInfoBot.java
+++ b/bots/testinfo/src/main/java/org/openjdk/skara/bots/testinfo/TestInfoBot.java
@@ -31,6 +31,19 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Logger;
 
+/**
+ * The TestInfoBot copies 'checks' from the source repository of a PR to the
+ * PR itself. In GitHub, these checks are usually workflow/action runs which
+ * users may have activated on their personal forks. By copying them to a PR,
+ * reviewers can easily see the status of the last workflow runs directly in
+ * the PR.
+ * <p>
+ * The bot polls for work using the standard PullRequestPoller, so will
+ * process any updated PR. Depending on the outcome of this processing, the
+ * TestInfoBotWorkItem calls back to the bot with a re-check request which
+ * causes the bot to submit that PR again after the specified amount of time,
+ * or earlier if another change the PR has been detected.
+ */
 public class TestInfoBot implements Bot {
     private final HostedRepository repo;
     private final PullRequestPoller poller;
@@ -38,10 +51,6 @@ public class TestInfoBot implements Bot {
     TestInfoBot(HostedRepository repo) {
         this.repo = repo;
         this.poller = new PullRequestPoller(repo, true);
-    }
-
-    private String pullRequestToKey(PullRequest pr) {
-        return pr.id() + "#" + pr.headHash().hex();
     }
 
     @Override

--- a/bots/testinfo/src/main/java/org/openjdk/skara/bots/testinfo/TestInfoBotWorkItem.java
+++ b/bots/testinfo/src/main/java/org/openjdk/skara/bots/testinfo/TestInfoBotWorkItem.java
@@ -33,12 +33,15 @@ import java.util.logging.Logger;
 
 public class TestInfoBotWorkItem implements WorkItem {
     private final PullRequest pr;
-    private final Consumer<Duration> expiresIn;
+    // This is a callback to the bot telling it that this PR needs a recheck after the
+    // specified duration. If this isn't called, then the PR will only be rechecked if
+    // it is updated by someone else.
+    private final Consumer<Duration> recheckIn;
     private static final Logger log = Logger.getLogger("org.openjdk.skara.bots");
 
-    TestInfoBotWorkItem(PullRequest pr, Consumer<Duration> expiresIn) {
+    TestInfoBotWorkItem(PullRequest pr, Consumer<Duration> recheckIn) {
         this.pr = pr;
-        this.expiresIn = expiresIn;
+        this.recheckIn = recheckIn;
     }
 
     @Override
@@ -81,7 +84,11 @@ public class TestInfoBotWorkItem implements WorkItem {
 
     @Override
     public Collection<WorkItem> run(Path scratch) {
-        var sourceRepo = pr.sourceRepository().get();
+        Optional<HostedRepository> optionalSourceRepository = pr.sourceRepository();
+        if (optionalSourceRepository.isEmpty()) {
+            return List.of();
+        }
+        var sourceRepo = optionalSourceRepository.get();
         var sourceChecks = sourceRepo.allChecks(pr.headHash());
 
         var targetChecks = pr.checks(pr.headHash());
@@ -90,18 +97,40 @@ public class TestInfoBotWorkItem implements WorkItem {
         if (sourceRepo.workflowStatus() == WorkflowStatus.NOT_CONFIGURED) {
             if (noticeCheck == null) {
                 pr.createCheck(testingNotConfiguredNotice(pr));
-                expiresIn.accept(Duration.ofMinutes(2));
+            }
+            // It's pretty unlikely that a user suddenly enables workflows. I think we
+            // can be pretty lax with automatically discovering this. Touching the PR
+            // will always trigger an immediate recheck anyway.
+            if (pr.isOpen()) {
+                recheckIn.accept(Duration.ofMinutes(30));
             }
         } else if (sourceRepo.workflowStatus() == WorkflowStatus.DISABLED) {
             // Explicitly disabled - could possibly post a notice
         } else {
             var summarizedChecks = TestResults.summarize(sourceChecks);
             if (summarizedChecks.isEmpty()) {
-                // No test related checks found, they may not have started yet, so we'll keep looking
+                // No test related checks found, they may not have started yet, so we'll keep
+                // looking as long as the PR is open.
                 log.fine("No checks found to summarize - waiting");
-                expiresIn.accept(Duration.ofMinutes(2));
+                if (pr.isOpen()) {
+                    recheckIn.accept(Duration.ofMinutes(2));
+                }
             } else {
-                expiresIn.accept(TestResults.expiresIn(sourceChecks).orElse(Duration.ofMinutes(30)));
+                Optional<Duration> expiresIn = TestResults.expiresIn(sourceChecks);
+                if (expiresIn.isPresent()) {
+                    // Workflow is currently running, recheck often to update, but revert
+                    // to longer recheck intervals if the PR hasn't been updated in the
+                    // last 24h and is still open.
+                    if (pr.updatedAt().isAfter(ZonedDateTime.now().minus(Duration.ofDays(1)))) {
+                        recheckIn.accept(expiresIn.get());
+                    } else if (pr.isOpen()) {
+                        recheckIn.accept(Duration.ofMinutes(30));
+                    }
+                } else if (pr.isOpen()) {
+                    // All current checks are finished, as long as PR is open, keep rechecking
+                    // at regular, but much longer intervals.
+                    recheckIn.accept(Duration.ofMinutes(30));
+                }
             }
 
             if (noticeCheck != null && noticeCheck.status() == CheckStatus.SKIPPED) {

--- a/bots/testinfo/src/main/java/org/openjdk/skara/bots/testinfo/TestInfoBotWorkItem.java
+++ b/bots/testinfo/src/main/java/org/openjdk/skara/bots/testinfo/TestInfoBotWorkItem.java
@@ -146,7 +146,7 @@ public class TestInfoBotWorkItem implements WorkItem {
                 var current = targetChecks.get(check.name());
                 if ((current.status() != check.status()) ||
                         (!current.summary().equals(check.summary())) ||
-                        (!current.title().equals(check.summary()))) {
+                        (!current.title().equals(check.title()))) {
                     pr.updateCheck(check);
                 } else {
                     log.fine("Not updating unchanged check: " + check.name());

--- a/bots/testinfo/src/test/java/org/openjdk/skara/bots/testinfo/TestInfoBotFactoryTest.java
+++ b/bots/testinfo/src/test/java/org/openjdk/skara/bots/testinfo/TestInfoBotFactoryTest.java
@@ -1,8 +1,10 @@
 package org.openjdk.skara.bots.testinfo;
 
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.openjdk.skara.json.JWCC;
 import org.openjdk.skara.test.TestBotFactory;
+import org.openjdk.skara.test.TestHost;
 import org.openjdk.skara.test.TestHostedRepository;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -20,9 +22,10 @@ class TestInfoBotFactoryTest {
                 """;
         var jsonConfig = JWCC.parse(jsonString).asObject();
 
+        var testHost = TestHost.createNew(List.of());
         var testBotFactory = TestBotFactory.newBuilder()
-                .addHostedRepository("repo1", new TestHostedRepository("repo1"))
-                .addHostedRepository("repo2", new TestHostedRepository("repo2"))
+                .addHostedRepository("repo1", new TestHostedRepository(testHost, "repo1"))
+                .addHostedRepository("repo2", new TestHostedRepository(testHost, "repo2"))
                 .build();
 
         var bots = testBotFactory.createBots(TestInfoBotFactory.NAME, jsonConfig);

--- a/bots/testinfo/src/test/java/org/openjdk/skara/bots/testinfo/TestInfoTests.java
+++ b/bots/testinfo/src/test/java/org/openjdk/skara/bots/testinfo/TestInfoTests.java
@@ -38,7 +38,7 @@ public class TestInfoTests {
     void simple(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
              var tempFolder = new TemporaryDirectory()) {
-            var author = credentials.getHostedRepository();
+            var author = (TestHostedRepository) credentials.getHostedRepository();
             var checkBot = new TestInfoBot(author);
 
             // Populate the projects repository
@@ -47,24 +47,19 @@ public class TestInfoTests {
             var masterHash = localRepo.resolve("master").orElseThrow();
             localRepo.push(masterHash, author.url(), "master", true);
 
-            // Make a draft PR where we can add some checks
+            // Add some checks to the repository
             var editHash = CheckableRepository.appendAndCommit(localRepo);
             localRepo.push(editHash, author.url(), "preedit", true);
-            var draftPr = credentials.createPullRequest(author, "master", "preedit", "This is a pull request", true);
             var check1 = CheckBuilder.create("ps1", editHash).title("PS1");
-            draftPr.createCheck(check1.build());
-            draftPr.updateCheck(check1.complete(true).build());
+            author.createCheck(check1.complete(true).build());
             var check2 = CheckBuilder.create("ps2", editHash).title("PS2");
-            draftPr.createCheck(check2.build());
-            draftPr.updateCheck(check2.complete(false).build());
+            author.createCheck(check2.complete(false).build());
             var check3 = CheckBuilder.create("ps3", editHash).title("PS3");
-            draftPr.createCheck(check3.build());
-            draftPr.updateCheck(check3.details(URI.create("https://www.example.com")).complete(false).build());
+            author.createCheck(check3.details(URI.create("https://www.example.com")).complete(false).build());
             var check4 = CheckBuilder.create("ps4", editHash).title("PS4");
-            draftPr.createCheck(check4.build());
-            draftPr.updateCheck(check4.details(URI.create("https://www.example.com")).build());
+            author.createCheck(check4.details(URI.create("https://www.example.com")).build());
 
-            // Now make an actual PR
+            // Now make a PR
             localRepo.push(editHash, author.url(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
@@ -92,7 +87,7 @@ public class TestInfoTests {
     void update(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
              var tempFolder = new TemporaryDirectory()) {
-            var author = credentials.getHostedRepository();
+            var author = (TestHostedRepository) credentials.getHostedRepository();
             var checkBot = new TestInfoBot(author);
 
             // Populate the projects repository
@@ -101,13 +96,11 @@ public class TestInfoTests {
             var masterHash = localRepo.resolve("master").orElseThrow();
             localRepo.push(masterHash, author.url(), "master", true);
 
-            // Make a draft PR where we can add some checks
+            // Add a check to the repository
             var editHash = CheckableRepository.appendAndCommit(localRepo);
             localRepo.push(editHash, author.url(), "preedit", true);
-            var draftPr1 = credentials.createPullRequest(author, "master", "preedit", "This is a pull request", true);
             var check1 = CheckBuilder.create("ps1", editHash).title("PS1");
-            draftPr1.createCheck(check1.build());
-            draftPr1.updateCheck(check1.complete(true).build());
+            author.createCheck(check1.complete(true).build());
 
             // Now make an actual PR
             localRepo.push(editHash, author.url(), "edit", true);
@@ -123,10 +116,8 @@ public class TestInfoTests {
             // And a second one
             var editHash2 = CheckableRepository.appendAndCommit(localRepo);
             localRepo.push(editHash2, author.url(), "preedit");
-            var draftPr2 = credentials.createPullRequest(author, "master", "preedit", "This is a pull request", true);
             var check2 = CheckBuilder.create("ps2", editHash2).title("PS2");
-            draftPr2.createCheck(check2.build());
-            draftPr2.updateCheck(check2.complete(false).build());
+            author.createCheck(check2.complete(false).build());
 
             // Push an update to the PR
             localRepo.push(editHash2, author.url(), "edit", true);

--- a/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
@@ -323,7 +323,6 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
         checks.add(check);
     }
 
-
     @Override
     public WorkflowStatus workflowStatus() {
         return WorkflowStatus.ENABLED;

--- a/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
@@ -45,6 +45,7 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
     private final Map<Hash, List<CommitComment>> commitComments;
     private Map<String, Boolean> collaborators = new HashMap<>();
     private List<Label> labels = new ArrayList<>();
+    private final Set<Check> checks = new HashSet<>();
 
     public TestHostedRepository(TestHost host, String projectName, Repository localRepository) {
         super(host, projectName);
@@ -309,10 +310,19 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
 
     @Override
     public List<Check> allChecks(Hash hash) {
-        return host.getPullRequests(this).stream()
-                   .flatMap(testPr -> testPr.checks(hash).values().stream())
-                   .collect(Collectors.toList());
+        return checks.stream()
+                .filter(check -> check.hash().equals(hash))
+                .toList();
     }
+
+    public void createCheck(Check check) {
+        var existing = checks.stream()
+                .filter(c -> c.name().equals(check.name()))
+                .findAny();
+        existing.ifPresent(checks::remove);
+        checks.add(check);
+    }
+
 
     @Override
     public WorkflowStatus workflowStatus() {


### PR DESCRIPTION
The testinfo bot monitors "checks" in the source repository of PRs and copies over the results to the PR itself. This makes it easier for PR reviewers to see results of e.g. GitHub actions.

Since this bot needs to react to things that aren't part of the PR, it needs some kind of periodic polling of PRs where new check updates are likely. This is currently handled by the TestInfoBotWorkItem calling back with an "expiration time" for a retry, depending on the conclusion of the current run. The idea seems to be that a new WorkItem should not be scheduled until after this expiration time. This isn't exactly how it ends up working however. The big issue here is that if no callback is made, the bot will happily schedule another WorkItem without delay in the next call to getPeriodicItems. There is also a race between the execution of getPeriodicItems and the execution of a WorkItem. If the WorkItem isn't calling back with an expiration in time for the next getPeriodicItems, then a new WorkItem will also be scheduled without delay.

This patch attempts to solve this by using the `PullRequestPoller` for getting updated PRs. For any PR that hasn't been updated, the only way to get scheduled is if a WorkItem is calling back with a "recheckAt" time. The poller has this functionality built in already with the retry with a date feature. This will change the bot to recheck some PRs more often (every time they are touched by a user or another bot), but it will also stop rechecking certain PRs constantly.

I'm also changing the how and when the `TestInfoBotWorkItem` calls back with a recheckAt. I'm making sure each category has a built in termination condition, to avoid ending up with an endless loop of rechecking every time interval. This is either if a PR is closed, or if checks are still running, for max of 24h since the PR was touched.

The test fix was a perplexing problem to solve. The old test setup created "checks" on a draft PR instead of a repository, which confused me. The TestInfoBot copies checks from a repository to a PR so that is what we are supposed to test. The reason for this was that `TestHostedRepository` didn't have support for having checks itself, instead the `checks` method just returned all checks from all PRs associated with the TestHost. As far as I can tell, this was just an unnecessary simplification of the test classes that made implementing a test for the `TestInfoBot` more complicated than necessary. To make things even weirder, by having `TestHostedRepository::checks` return all checks from all PRs, depending on which order the "draft" PR and the real PR were processed by TestInfoBot, they would get each others checks copied repeatedly. The old test happened to "work" because the right PR was processed first, but with my new implementation, the processing order happened to be reversed. My fix was to add a checks field on `TestHostedRepository` and put the checks there in the test setups instead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1659](https://bugs.openjdk.org/browse/SKARA-1659): Fix polling and retries in testinfo bot


### Reviewers
 * [Erik Helin](https://openjdk.org/census#ehelin) (@edvbld - **Reviewer**) ⚠️ Review applies to [4cc4ab09](https://git.openjdk.org/skara/pull/1411/files/4cc4ab093486c013740aaf1d3ef0808dab8b4dbe)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**) ⚠️ Review applies to [8485b360](https://git.openjdk.org/skara/pull/1411/files/8485b360b41e53c4cdaedf038ce7122a922d94ba)
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1411/head:pull/1411` \
`$ git checkout pull/1411`

Update a local copy of the PR: \
`$ git checkout pull/1411` \
`$ git pull https://git.openjdk.org/skara pull/1411/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1411`

View PR using the GUI difftool: \
`$ git pr show -t 1411`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1411.diff">https://git.openjdk.org/skara/pull/1411.diff</a>

</details>
