### PR TITLE
1594: Convert rest of bots polling PRs and Issues to use new pollers

### DIFF
--- a/bots/csr/src/main/java/org/openjdk/skara/bots/csr/CSRPullRequestBot.java
+++ b/bots/csr/src/main/java/org/openjdk/skara/bots/csr/CSRPullRequestBot.java
@@ -26,6 +26,7 @@ import java.time.ZonedDateTime;
 import org.openjdk.skara.bot.*;
 import org.openjdk.skara.forge.HostedRepository;
 import org.openjdk.skara.forge.PullRequest;
+import org.openjdk.skara.forge.PullRequestPoller;
 import org.openjdk.skara.issuetracker.IssueProject;
 
 import java.util.*;
@@ -37,22 +38,14 @@ import java.util.logging.Logger;
  * the PR.
  */
 class CSRPullRequestBot implements Bot {
-    private final Logger log = Logger.getLogger("org.openjdk.skara.bots.csr");
     private final HostedRepository repo;
     private final IssueProject project;
-    // Keeps track of updatedAt timestamps from the previous call to getPeriodicItems,
-    // so we can avoid re-evaluating PRs that are returned again without any actual
-    // update. This is needed because timestamp based searches aren't exact enough
-    // to avoid sometimes receiving the same items multiple times.
-    private Map<String, ZonedDateTime> prsUpdatedAt = new HashMap<>();
-    // The last found updateAt in any returned PR. Used for limiting results on the
-    // next call to the hosted repo. Should only contain timestamps originating
-    // from the remote repo to avoid problems with mismatched clocks.
-    private ZonedDateTime lastUpdatedAt;
+    private final PullRequestPoller poller;
 
     CSRPullRequestBot(HostedRepository repo, IssueProject project) {
         this.repo = repo;
         this.project = project;
+        this.poller = new PullRequestPoller(repo, false);
     }
 
     @Override
@@ -63,27 +56,14 @@ class CSRPullRequestBot implements Bot {
     @Override
     public List<WorkItem> getPeriodicItems() {
         var items = new ArrayList<WorkItem>();
-        log.info("Fetching all open pull requests for " + repo.name());
-        Map<String, ZonedDateTime> newPrsUpdatedAt = new HashMap<>();
-        // On the first run we have to re-evaluate all open PRs, after that, only
-        // looking at PRs that have been updated should be enough.
-        var prs = lastUpdatedAt != null ? repo.openPullRequestsAfter(lastUpdatedAt) : repo.openPullRequests();
+
+        var prs = poller.updatedPullRequests();
         for (PullRequest pr : prs) {
-            newPrsUpdatedAt.put(pr.id(), pr.updatedAt());
-            // Update lastUpdatedAt with the last found updatedAt for the next call
-            if (lastUpdatedAt == null || pr.updatedAt().isAfter(lastUpdatedAt)) {
-                lastUpdatedAt = pr.updatedAt();
-            }
-            var lastUpdate = prsUpdatedAt.get(pr.id());
-            if (lastUpdate != null) {
-                if (!pr.updatedAt().isAfter(lastUpdate)) {
-                    continue;
-                }
-            }
-            var pullRequestWorkItem = new PullRequestWorkItem(repo, pr.id(), project, pr.updatedAt());
+            var pullRequestWorkItem = new PullRequestWorkItem(repo, pr.id(), project, pr.updatedAt(),
+                    e -> poller.retryPullRequest(pr));
             items.add(pullRequestWorkItem);
         }
-        prsUpdatedAt = newPrsUpdatedAt;
+        poller.lastBatchHandled();
         return items;
     }
 

--- a/bots/csr/src/main/java/org/openjdk/skara/bots/csr/IssueWorkItem.java
+++ b/bots/csr/src/main/java/org/openjdk/skara/bots/csr/IssueWorkItem.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
 import org.openjdk.skara.bot.WorkItem;
@@ -45,10 +46,12 @@ class IssueWorkItem implements WorkItem {
 
     private final CSRIssueBot bot;
     private final Issue csrIssue;
+    private final Consumer<RuntimeException> errorHandler;
 
-    public IssueWorkItem(CSRIssueBot bot, Issue csrIssue) {
+    public IssueWorkItem(CSRIssueBot bot, Issue csrIssue, Consumer<RuntimeException> errorHandler) {
         this.bot = bot;
         this.csrIssue = csrIssue;
+        this.errorHandler = errorHandler;
     }
 
     @Override
@@ -98,7 +101,7 @@ class IssueWorkItem implements WorkItem {
                 .filter(Issue::isOpen)
                 // This will mix time stamps from the IssueTracker and the Forge hosting PRs, but it's the
                 // best we can do.
-                .map(pr -> new PullRequestWorkItem(pr.repository(), pr.id(), csrIssue.project(), csrIssue.updatedAt()))
+                .map(pr -> new PullRequestWorkItem(pr.repository(), pr.id(), csrIssue.project(), csrIssue.updatedAt(), errorHandler))
                 .forEach(ret::add);
         return ret;
     }
@@ -111,5 +114,10 @@ class IssueWorkItem implements WorkItem {
     @Override
     public String workItemName() {
         return "issue";
+    }
+
+    @Override
+    public void handleRuntimeException(RuntimeException e) {
+        errorHandler.accept(e);
     }
 }

--- a/bots/csr/src/main/java/org/openjdk/skara/bots/csr/PullRequestWorkItem.java
+++ b/bots/csr/src/main/java/org/openjdk/skara/bots/csr/PullRequestWorkItem.java
@@ -28,6 +28,7 @@ import java.time.ZonedDateTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.openjdk.skara.bot.WorkItem;
@@ -53,6 +54,7 @@ class PullRequestWorkItem implements WorkItem {
     private final HostedRepository repository;
     private final String prId;
     private final IssueProject project;
+    private final Consumer<RuntimeException> errorHandler;
     /**
      * The updatedAt timestamp of the external entity that triggered this WorkItem,
      * which would be either a PR or a CSR Issue. Used for tracking reaction legacy
@@ -61,11 +63,12 @@ class PullRequestWorkItem implements WorkItem {
     private final ZonedDateTime triggerUpdatedAt;
 
     public PullRequestWorkItem(HostedRepository repository, String prId, IssueProject project,
-            ZonedDateTime triggerUpdatedAt) {
+            ZonedDateTime triggerUpdatedAt, Consumer<RuntimeException> errorHandler) {
         this.repository = repository;
         this.prId = prId;
         this.project = project;
         this.triggerUpdatedAt = triggerUpdatedAt;
+        this.errorHandler = errorHandler;
     }
 
     @Override
@@ -252,5 +255,9 @@ class PullRequestWorkItem implements WorkItem {
     @Override
     public String workItemName() {
         return "pr";
+    }
+
+    public final void handleRuntimeException(RuntimeException e) {
+        errorHandler.accept(e);
     }
 }

--- a/bots/csr/src/test/java/org/openjdk/skara/bots/csr/CSRBotFactoryTest.java
+++ b/bots/csr/src/test/java/org/openjdk/skara/bots/csr/CSRBotFactoryTest.java
@@ -1,5 +1,6 @@
 package org.openjdk.skara.bots.csr;
 
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.openjdk.skara.json.*;
 import org.openjdk.skara.test.*;
@@ -29,12 +30,13 @@ public class CSRBotFactoryTest {
                 """;
         var jsonConfig = JWCC.parse(jsonString).asObject();
 
+        var testHost = TestHost.createNew(List.of());
         var testBotFactory = TestBotFactory.newBuilder()
-                .addHostedRepository("repo1", new TestHostedRepository("repo1"))
-                .addHostedRepository("repo2", new TestHostedRepository("repo2"))
-                .addHostedRepository("repo3", new TestHostedRepository("repo3"))
-                .addIssueProject("test_bugs/TEST", new TestIssueProject(null, "TEST"))
-                .addIssueProject("test_bugs/TEST2", new TestIssueProject(null, "TEST2"))
+                .addHostedRepository("repo1", new TestHostedRepository(testHost, "repo1"))
+                .addHostedRepository("repo2", new TestHostedRepository(testHost, "repo2"))
+                .addHostedRepository("repo3", new TestHostedRepository(testHost, "repo3"))
+                .addIssueProject("test_bugs/TEST", new TestIssueProject(testHost, "TEST"))
+                .addIssueProject("test_bugs/TEST2", new TestIssueProject(testHost, "TEST2"))
                 .build();
 
         var bots = testBotFactory.createBots(CSRBotFactory.NAME, jsonConfig);

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotFactoryTest.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotFactoryTest.java
@@ -5,6 +5,7 @@ import org.openjdk.skara.bot.Bot;
 import org.openjdk.skara.json.JWCC;
 import org.openjdk.skara.test.TemporaryDirectory;
 import org.openjdk.skara.test.TestBotFactory;
+import org.openjdk.skara.test.TestHost;
 import org.openjdk.skara.test.TestHostedRepository;
 
 import java.time.Duration;
@@ -118,12 +119,13 @@ class MailingListBridgeBotFactoryTest {
                     """;
             var jsonConfig = JWCC.parse(jsonString).asObject();
 
+            var testHost = TestHost.createNew(List.of());
             var testBotFactory = TestBotFactory.newBuilder()
-                    .addHostedRepository("repo1", new TestHostedRepository("repo1"))
-                    .addHostedRepository("repo2", new TestHostedRepository("repo2"))
-                    .addHostedRepository("repo3", new TestHostedRepository("repo3"))
-                    .addHostedRepository("repo4", new TestHostedRepository("repo4"))
-                    .addHostedRepository("repo5", new TestHostedRepository("repo5"))
+                    .addHostedRepository("repo1", new TestHostedRepository(testHost, "repo1"))
+                    .addHostedRepository("repo2", new TestHostedRepository(testHost, "repo2"))
+                    .addHostedRepository("repo3", new TestHostedRepository(testHost, "repo3"))
+                    .addHostedRepository("repo4", new TestHostedRepository(testHost, "repo4"))
+                    .addHostedRepository("repo5", new TestHostedRepository(testHost, "repo5"))
                     .addHostedRepository("archive", new TestHostedRepository("archive"))
                     .addHostedRepository("census", new TestHostedRepository("census"))
                     .storagePath(tempFolder.path().resolve("storage"))

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/NotifyBotFactoryTest.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/NotifyBotFactoryTest.java
@@ -104,11 +104,12 @@ class NotifyBotFactoryTest {
                     """;
             var jsonConfig = JWCC.parse(jsonString).asObject();
 
+            var testHost = TestHost.createNew(List.of());
             var testBotFactory = TestBotFactory.newBuilder()
                     .addHostedRepository("notify", new TestHostedRepository("notify"))
-                    .addHostedRepository("repo1", new TestHostedRepository("repo1"))
-                    .addHostedRepository("repo2", new TestHostedRepository("repo2"))
-                    .addIssueProject("test_bugs/TEST", new TestIssueProject(TestHost.createNew(List.of()), "TEST"))
+                    .addHostedRepository("repo1", new TestHostedRepository(testHost, "repo1"))
+                    .addHostedRepository("repo2", new TestHostedRepository(testHost, "repo2"))
+                    .addIssueProject("test_bugs/TEST", new TestIssueProject(testHost, "TEST"))
                     .storagePath(tempFolder.path().resolve("storage"))
                     .build();
 

--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequestPoller.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequestPoller.java
@@ -21,9 +21,11 @@ import org.openjdk.skara.issuetracker.Issue;
  * limit), are returned. After that only updated PRs should be included.
  * <p>
  * After each call for updated pull requests, the result needs to be
- * acknowledged once it has been processed by the caller. Failing to
- * acknowledge makes the next call include everything from the last call
- * again. This helps to avoid missing any updates due to errors.
+ * acknowledged once it has been processed by the caller using the
+ * lastBatchHandled method. Failing to acknowledge makes the next call include
+ * everything from the last call again. This helps to avoid missing any updates
+ * due to errors. Calling the retry/quarantine methods before lastBatchHandled
+ * for any particular PR will cause that PR to be lost.
  * <p>
  * In addition to this, it's also possible to schedule PRs for retries with
  * or without quarantine. A regular retry will not block the same PR if it
@@ -137,6 +139,13 @@ public class PullRequestPoller {
      * After calling getUpdatedPullRequests(), this method must be called to acknowledge
      * that all the PRs returned have been handled. If not, the previous results will be
      * included in the next call to getUpdatedPullRequests() again.
+     * <p>
+     * This method must be called before any retry/quarantine method is called for a pr
+     * returned by the last updatedPullRequest call, otherwise retries may be lost.
+     * <p>
+     * The typical pattern is to call this last in the getPeriodicItems/run method of a
+     * bot or WorkItem, before any generated WorkItems are published (by being returned
+     * to the bot runner).
      */
     public synchronized void lastBatchHandled() {
         if (current != null) {
@@ -158,8 +167,8 @@ public class PullRequestPoller {
     }
 
     /**
-     * Schedules a pull request to be re-evaluated after a certain time, unless it is
-     * updated before that.
+     * Schedules a pull request to be included in the next update that happens after a
+     * certain time, unless it is updated before that. Can be used to throttle retries.
      * @param pr PullRequest to retry
      * @param at Time at which to process it
      */
@@ -168,9 +177,10 @@ public class PullRequestPoller {
     }
 
     /**
-     * Schedules a pull request to be retried after a quarantine period has passed.
-     * If a quarantined pull request is returned by a query, it will be removed from
-     * the result set until the quarantine time has passed.
+     * Schedules a pull request to be included in the next update that happens after a
+     * quarantine period has passed. If a quarantined pull request is returned by a
+     * query, it will be removed from the result set until the quarantine time has
+     * passed.
      * @param pr PullRequest to quarantine
      * @param until Time at which the quarantine is lifted
      */


### PR DESCRIPTION
The new PullRequestPoller has now been in use in the PullRequestBot for a while, and hopefully most of the kinks have been ironed out. I think it's time to convert the rest of the bots that poll PRs (and the CSRIssueBot that polls Issues) to use the new pollers. 

The conversion is pretty straight forward. In the case of the CSRBots, they were missing the retry callback, so I added that functionality in line with other bots.

The new factory tests needed to be modified slightly, as the PullRequestPoller calls to the Forge/Host object of a repository during initialization, so we need a TestHost instance there instead of `null`.

I deliberately left out two bots here, the JEPBot and the TestInfoBot. The TestInfoBot is handled separately already in #1411. For the JEPBot, I think it needs a general overhaul. In the end it should function more or less the same as the CSRBot, but I'm still not sure that the CSRBot is where I want it to be.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1594](https://bugs.openjdk.org/browse/SKARA-1594): Convert rest of bots polling PRs and Issues to use new pollers


### Reviewers
 * [Erik Helin](https://openjdk.org/census#ehelin) (@edvbld - **Reviewer**) ⚠️ Review applies to [ead5f3ce](https://git.openjdk.org/skara/pull/1412/files/ead5f3ce6e5b943cb9e899f6319a0b915f8035b0)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**) ⚠️ Review applies to [ead5f3ce](https://git.openjdk.org/skara/pull/1412/files/ead5f3ce6e5b943cb9e899f6319a0b915f8035b0)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1412/head:pull/1412` \
`$ git checkout pull/1412`

Update a local copy of the PR: \
`$ git checkout pull/1412` \
`$ git pull https://git.openjdk.org/skara pull/1412/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1412`

View PR using the GUI difftool: \
`$ git pr show -t 1412`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1412.diff">https://git.openjdk.org/skara/pull/1412.diff</a>

</details>
