### PR TITLE
1660: Add confname field to slack log config

### DIFF
--- a/bots/cli/src/main/java/org/openjdk/skara/bots/cli/BotLauncher.java
+++ b/bots/cli/src/main/java/org/openjdk/skara/bots/cli/BotLauncher.java
@@ -76,7 +76,7 @@ public class BotLauncher {
             }
             var handler = new BotSlackHandler(URIBuilder.base(config.get("log").get("slack").get("webhook").asString()).build(),
                     config.get("log").get("slack").get("username").asString(),
-                    config.get("log").get("slack").get("configname").asString(),
+                    config.get("log").get("slack").get("prefix").asString(),
                     maxRate,
                     details);
             handler.setLevel(level);

--- a/bots/cli/src/main/java/org/openjdk/skara/bots/cli/BotLauncher.java
+++ b/bots/cli/src/main/java/org/openjdk/skara/bots/cli/BotLauncher.java
@@ -75,9 +75,10 @@ public class BotLauncher {
                                                           o -> o.get("link").asString()));
             }
             var handler = new BotSlackHandler(URIBuilder.base(config.get("log").get("slack").get("webhook").asString()).build(),
-                                              config.get("log").get("slack").get("username").asString(),
-                                              maxRate,
-                                              details);
+                    config.get("log").get("slack").get("username").asString(),
+                    config.get("log").get("slack").get("configname").asString(),
+                    maxRate,
+                    details);
             handler.setLevel(level);
             log.addHandler(handler);
         }

--- a/bots/cli/src/main/java/org/openjdk/skara/bots/cli/BotSlackHandler.java
+++ b/bots/cli/src/main/java/org/openjdk/skara/bots/cli/BotSlackHandler.java
@@ -38,17 +38,17 @@ class BotSlackHandler extends BotTaskAggregationHandler {
 
     private final RestRequest webhook;
     private final String username;
-    private final String configName;
+    private final String prefix;
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots.cli");;
     private final Duration minimumSeparation;
     private final Map<Pattern, String> linkPatterns;
     private Instant lastUpdate;
     private int dropCount;
 
-    BotSlackHandler(URI webhookUrl, String username, String configName, Duration minimumSeparation, Map<String, String> links) {
+    BotSlackHandler(URI webhookUrl, String username, String prefix, Duration minimumSeparation, Map<String, String> links) {
         webhook = new RestRequest(webhookUrl);
         this.username = username;
-        this.configName = configName;
+        this.prefix = prefix;
         this.minimumSeparation = minimumSeparation;
         linkPatterns = links.entrySet().stream()
                             .collect(Collectors.toMap(entry -> Pattern.compile(entry.getKey(),
@@ -135,8 +135,8 @@ class BotSlackHandler extends BotTaskAggregationHandler {
 
     private String formatMessage(LogRecord record) {
         var message = new StringBuilder();
-        if (configName != null) {
-            message.append("`").append(configName).append("` ");
+        if (prefix != null) {
+            message.append(prefix);
         }
         message.append("`").append(record.getLevel().getName()).append("` ").append(record.getMessage());
         return message.toString();

--- a/bots/cli/src/test/java/org/openjdk/skara/bots/cli/BotSlackHandlerTests.java
+++ b/bots/cli/src/test/java/org/openjdk/skara/bots/cli/BotSlackHandlerTests.java
@@ -45,7 +45,7 @@ class BotSlackHandlerTests {
     void simple() throws IOException {
 
         try (var receiver = new RestReceiver()) {
-            var handler = new BotSlackHandler(receiver.getEndpoint(), "test", "testc", Duration.ofSeconds(1), new HashMap<>());
+            var handler = new BotSlackHandler(receiver.getEndpoint(), "test", "`testc` ", Duration.ofSeconds(1), new HashMap<>());
             var record = new LogRecord(Level.INFO, "Hello");
             handler.publish(record);
 


### PR DESCRIPTION
The Slack log handler currently takes a "username" value as input which if set is sent to Slack as the user name of the message. With modern webhooks, it unfortunately seems that we have lost the feature of overriding the user name of a message. Our current configs put a descriptive string identifying the bot configuration in this field, which we can no longer see.

I want to add a specific new configuration field to the Slack log handler for the "configname". If set, this will appear first in every Slack message.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1660](https://bugs.openjdk.org/browse/SKARA-1660): Add confname field to slack log config


### Reviewers
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - Author) ⚠️ Review applies to [978e28aa](https://git.openjdk.org/skara/pull/1413/files/978e28aac44dcb5d7d27ac42dd6e7513e933311d)
 * [Erik Helin](https://openjdk.org/census#ehelin) (@edvbld - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1413/head:pull/1413` \
`$ git checkout pull/1413`

Update a local copy of the PR: \
`$ git checkout pull/1413` \
`$ git pull https://git.openjdk.org/skara pull/1413/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1413`

View PR using the GUI difftool: \
`$ git pr show -t 1413`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1413.diff">https://git.openjdk.org/skara/pull/1413.diff</a>

</details>
