### PR TITLE
1538: Allow regex patterns in fixversions and altfixversions in the notifier

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierBuilder.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierBuilder.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.skara.bots.notify.issue;
 
+import java.util.regex.Pattern;
 import org.openjdk.skara.forge.HostedRepository;
 import org.openjdk.skara.issuetracker.IssueProject;
 
@@ -35,8 +36,8 @@ class IssueNotifierBuilder {
     private boolean commitLink = true;
     private URI commitIcon = null;
     private boolean setFixVersion = false;
-    private Map<String, String> fixVersions = null;
-    private Map<String, List<String>> altFixVersions = null;
+    private LinkedHashMap<Pattern, String> fixVersions = null;
+    private LinkedHashMap<Pattern, List<Pattern>> altFixVersions = null;
     private JbsVault vault = null;
     private boolean prOnly = true;
     private boolean repoOnly = false;
@@ -80,12 +81,12 @@ class IssueNotifierBuilder {
         return this;
     }
 
-    public IssueNotifierBuilder fixVersions(Map<String, String> fixVersions) {
+    public IssueNotifierBuilder fixVersions(LinkedHashMap<Pattern, String> fixVersions) {
         this.fixVersions = fixVersions;
         return this;
     }
 
-    public IssueNotifierBuilder altFixVersions(Map<String, List<String>> altFixVersions) {
+    public IssueNotifierBuilder altFixVersions(LinkedHashMap<Pattern, List<Pattern>> altFixVersions) {
         this.altFixVersions = altFixVersions;
         return this;
     }

--- a/jbs/src/main/java/org/openjdk/skara/jbs/Backports.java
+++ b/jbs/src/main/java/org/openjdk/skara/jbs/Backports.java
@@ -245,6 +245,18 @@ public class Backports {
     }
 
     /**
+     * Returns issue or one of its backports that has a fixVersion matching the
+     * version pattern and is fixed.
+     */
+    public static Optional<Issue> findFixedIssue(Issue primary, Pattern versionPattern) {
+        log.fine("Searching for fixed issue with fix version matching /" + versionPattern + "/ "
+                + " for primary issue " + primary.id());
+        return Stream.concat(Stream.of(primary).filter(Issue::isFixed), findBackports(primary, true).stream())
+                .filter(i -> mainFixVersion(i).map(v -> versionPattern.matcher(v.raw()).matches()).orElse(false))
+                .findFirst();
+    }
+
+    /**
      * Find the closest issue from the provided issue list according to the provided fix version.
      * This method is similar to `findIssue`, but this method can handle all the fix versions of the issue
      * instead of only the main fix version and can receive an issue list instead of only the primary issue.


### PR DESCRIPTION
This patch adds support for regex patterns when specifying fixVersions and altFixVersions in the IssueNotifier. For fixVersions, the branch name can now be a regex pattern and for the altFixVersions, both the branch name as well as the version strings in the array can all be regex patterns. Having this flexibility will enable us to construct much more static configurations for certain repositories, that don't need manual updating each time we fork or branch a new release.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1538](https://bugs.openjdk.org/browse/SKARA-1538): Allow regex patterns in fixversions and altfixversions in the notifier


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1414/head:pull/1414` \
`$ git checkout pull/1414`

Update a local copy of the PR: \
`$ git checkout pull/1414` \
`$ git pull https://git.openjdk.org/skara pull/1414/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1414`

View PR using the GUI difftool: \
`$ git pr show -t 1414`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1414.diff">https://git.openjdk.org/skara/pull/1414.diff</a>

</details>
