### PR TITLE
1655: A PR/commit with an invalid jcheck config should be caught by jcheck

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
@@ -285,4 +285,10 @@ class PullRequestCheckIssueVisitor implements IssueVisitor {
     public void visit(ProblemListsIssue issue) {
         addFailureMessage(issue.check(), issue.issue() + " is used in problem lists: " + issue.files());
     }
+
+    @Override
+    public void visit(JCheckConfIssue issue) {
+        addFailureMessage(issue.check(), ".jcheck/conf is invalid: " + issue.getErrorMessage());
+        readyForReview = false;
+    }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -2292,6 +2292,7 @@ class CheckTests {
             assertEquals(1, checks.size());
             var check = checks.get("jcheck");
             assertEquals(CheckStatus.SUCCESS, check.status());
+            assertTrue(pr.store().labelNames().contains("rfr"));
 
             // Make .jcheck/conf invalid
             try (var output = new FileWriter(checkConf.toFile(), true)) {
@@ -2307,6 +2308,7 @@ class CheckTests {
             check = checks.get("jcheck");
             assertEquals(CheckStatus.FAILURE, check.status());
             assertTrue(pr.store().body().contains(".jcheck/conf is invalid: line 17: entry must be of form 'key = value'"));
+            assertFalse(pr.store().labelNames().contains("rfr"));
 
             // Restore .jcheck/conf
             try (var output = Files.newBufferedWriter(checkConf)) {
@@ -2337,6 +2339,7 @@ class CheckTests {
             assertEquals(1, checks.size());
             check = checks.get("jcheck");
             assertEquals(CheckStatus.SUCCESS, check.status());
+            assertTrue(pr.store().labelNames().contains("rfr"));
         }
     }
 }

--- a/cli/src/main/java/org/openjdk/skara/cli/JCheckCLIVisitor.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/JCheckCLIVisitor.java
@@ -308,4 +308,12 @@ class JCheckCLIVisitor implements IssueVisitor {
     public boolean hasDisplayedErrors() {
         return hasDisplayedErrors;
     }
+
+    @Override
+    public void visit(JCheckConfIssue i) {
+        if (!ignore.contains(i.check().name())) {
+            println(i, ".jcheck/conf is invalid: " + i.getErrorMessage());
+            hasDisplayedErrors = true;
+        }
+    }
 }

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/JCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/JCheck.java
@@ -77,7 +77,8 @@ public class JCheck {
             new ExecutableCheck(),
             new SymlinkCheck(),
             new BinaryCheck(),
-            new ProblemListsCheck(repository)
+            new ProblemListsCheck(repository),
+            new JCheckConfCheck(repository)
         );
         repositoryChecks = List.of(
             new BranchesCheck(allowedBranches),

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/JCheckConfCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/JCheckConfCheck.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.jcheck;
+
+import org.openjdk.skara.census.Census;
+import org.openjdk.skara.vcs.Commit;
+import org.openjdk.skara.vcs.ReadOnlyRepository;
+import org.openjdk.skara.vcs.openjdk.CommitMessage;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Path;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.logging.Logger;
+
+public class JCheckConfCheck extends CommitCheck {
+    private final Logger log = Logger.getLogger("org.openjdk.skara.jcheck.jcheckconf");
+
+    private final ReadOnlyRepository repo;
+
+    public JCheckConfCheck(ReadOnlyRepository repo) {
+        this.repo = repo;
+    }
+
+    @Override
+    Iterator<Issue> check(Commit commit, CommitMessage message, JCheckConfiguration conf, Census census) {
+        var metadata = CommitIssue.metadata(commit, message, conf, this);
+        var hash = commit.hash();
+
+        Optional<List<String>> lines;
+        try {
+            lines = repo.lines(Path.of(".jcheck/conf"), hash);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        if (lines.isEmpty()) {
+            log.finer(".jcheck/conf is missing");
+            return iterator(new JCheckConfIssue(metadata, ".jcheck/conf is missing"));
+        }
+        try {
+            JCheckConfiguration.parse(lines.get());
+        } catch (RuntimeException e) {
+            log.finer(".jcheck/conf is not valid");
+            return iterator(new JCheckConfIssue(metadata, e.getMessage()));
+        }
+        return iterator();
+    }
+
+    @Override
+    public String name() {
+        return "jcheckconf";
+    }
+
+    @Override
+    public String description() {
+        return "Change must contain valid jcheck configuration";
+    }
+}

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/JCheckConfIssue.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/JCheckConfIssue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,27 +22,20 @@
  */
 package org.openjdk.skara.jcheck;
 
-public interface IssueVisitor {
-    void visit(TagIssue issue);
-    void visit(BranchIssue issue);
-    void visit(DuplicateIssuesIssue issue);
-    void visit(SelfReviewIssue issue);
-    void visit(TooFewReviewersIssue issue);
-    void visit(InvalidReviewersIssue issue);
-    void visit(MergeMessageIssue issue);
-    void visit(HgTagCommitIssue issue);
-    void visit(CommitterIssue issue);
-    void visit(CommitterNameIssue issue);
-    void visit(CommitterEmailIssue issue);
-    void visit(AuthorNameIssue issue);
-    void visit(AuthorEmailIssue issue);
-    void visit(WhitespaceIssue issue);
-    void visit(MessageIssue issue);
-    void visit(MessageWhitespaceIssue issue);
-    void visit(IssuesIssue issue);
-    void visit(ExecutableIssue issue);
-    void visit(BinaryIssue issue);
-    void visit(SymlinkIssue issue);
-    void visit(ProblemListsIssue problemListIssue);
-    void visit(JCheckConfIssue issue);
+public class JCheckConfIssue extends CommitIssue {
+    String errorMessage;
+
+    public JCheckConfIssue(Metadata metadata, String errorMessage) {
+        super(metadata);
+        this.errorMessage = errorMessage;
+    }
+
+    @Override
+    public void accept(IssueVisitor v) {
+        v.visit(this);
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
 }

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/JCheckConfCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/JCheckConfCheckTests.java
@@ -18,7 +18,7 @@ public class JCheckConfCheckTests {
         List<String> conf;
 
         public JCheckConfTestRepository(List<String> text) {
-            conf = text;
+            conf = List.copyOf(text);
         }
 
         @Override
@@ -30,7 +30,7 @@ public class JCheckConfCheckTests {
         }
 
         public void setConf(List<String> text) {
-            conf = text;
+            conf = List.copyOf(text);
         }
     }
 

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/JCheckConfCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/JCheckConfCheckTests.java
@@ -14,7 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class JCheckConfCheckTests {
 
-    private class JCheckConfTestRepository extends TestRepository {
+    private static class JCheckConfTestRepository extends TestRepository {
         List<String> conf;
 
         public JCheckConfTestRepository(List<String> text) {
@@ -43,7 +43,7 @@ public class JCheckConfCheckTests {
 
     private static final JCheckConfiguration conf = JCheckConfiguration.parse(CONFIGURATION);
 
-    private ReadOnlyRepository repo = new JCheckConfTestRepository(CONFIGURATION);
+    private static ReadOnlyRepository repo = new JCheckConfTestRepository(CONFIGURATION);
 
     private List<Issue> toList(Iterator<Issue> i) {
         var list = new ArrayList<Issue>();

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/JCheckConfCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/JCheckConfCheckTests.java
@@ -14,7 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class JCheckConfCheckTests {
 
-    private static class JCheckConfTestRepository extends TestRepository {
+    private class JCheckConfTestRepository extends TestRepository {
         List<String> conf;
 
         public JCheckConfTestRepository(List<String> text) {
@@ -43,8 +43,6 @@ public class JCheckConfCheckTests {
 
     private static final JCheckConfiguration conf = JCheckConfiguration.parse(CONFIGURATION);
 
-    private static ReadOnlyRepository repo = new JCheckConfTestRepository(CONFIGURATION);
-
     private List<Issue> toList(Iterator<Issue> i) {
         var list = new ArrayList<Issue>();
         while (i.hasNext()) {
@@ -70,7 +68,7 @@ public class JCheckConfCheckTests {
     void validJCheckConfTest() {
         var commit = commit(0, "Bugfix");
         var message = message(commit);
-        var check = new JCheckConfCheck(repo);
+        var check = new JCheckConfCheck(new JCheckConfTestRepository(CONFIGURATION));
         var issues = toList(check.check(commit, message, conf, null));
         assertEquals(0, issues.size());
     }
@@ -79,9 +77,10 @@ public class JCheckConfCheckTests {
     void invalidJCheckConfTest() {
         var commit = commit(0, "Bugfix");
         var message = message(commit);
+        var repo = new JCheckConfTestRepository(CONFIGURATION);
         var check = new JCheckConfCheck(repo);
 
-        ((JCheckConfTestRepository) repo).setConf(List.of(
+        repo.setConf(List.of(
                 "[general] 36542",
                 "project = test",
                 "[checks]",
@@ -91,7 +90,7 @@ public class JCheckConfCheckTests {
         assertEquals(1, issues.size());
         assertEquals("line 0: section header must end with ']'", ((JCheckConfIssue) issues.get(0)).getErrorMessage());
 
-        ((JCheckConfTestRepository) repo).setConf(List.of(
+        repo.setConf(List.of(
                 "[general]",
                 "project = test",
                 "[checks]",

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/JCheckConfCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/JCheckConfCheckTests.java
@@ -18,19 +18,19 @@ public class JCheckConfCheckTests {
         List<String> conf;
 
         public JCheckConfTestRepository(List<String> text) {
-            conf = List.copyOf(text);
+            conf = text;
         }
 
         @Override
         public Optional<List<String>> lines(Path p, Hash h) throws IOException {
-            if (p.toString().equals(".jcheck/conf")) {
+            if (p.toString().contains("conf")) {
                 return Optional.of(conf);
             }
             return super.lines(p, h);
         }
 
         public void setConf(List<String> text) {
-            conf = List.copyOf(text);
+            conf = text;
         }
     }
 

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/JCheckConfCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/JCheckConfCheckTests.java
@@ -1,0 +1,105 @@
+package org.openjdk.skara.jcheck;
+
+import org.junit.jupiter.api.Test;
+import org.openjdk.skara.vcs.*;
+import org.openjdk.skara.vcs.openjdk.CommitMessage;
+import org.openjdk.skara.vcs.openjdk.CommitMessageParsers;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.ZonedDateTime;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class JCheckConfCheckTests {
+
+    private class JCheckConfTestRepository extends TestRepository {
+        List<String> conf;
+
+        public JCheckConfTestRepository(List<String> text) {
+            conf = text;
+        }
+
+        @Override
+        public Optional<List<String>> lines(Path p, Hash h) throws IOException {
+            if (p.toString().equals(".jcheck/conf")) {
+                return Optional.of(conf);
+            }
+            return super.lines(p, h);
+        }
+
+        public void setConf(List<String> text) {
+            conf = text;
+        }
+    }
+
+    private static final List<String> CONFIGURATION = List.of(
+            "[general]",
+            "project = test",
+            "[checks]",
+            "error = jcheckconf"
+    );
+
+    private static final JCheckConfiguration conf = JCheckConfiguration.parse(CONFIGURATION);
+
+    private ReadOnlyRepository repo = new JCheckConfTestRepository(CONFIGURATION);
+
+    private List<Issue> toList(Iterator<Issue> i) {
+        var list = new ArrayList<Issue>();
+        while (i.hasNext()) {
+            list.add(i.next());
+        }
+        return list;
+    }
+
+    private static Commit commit(int id, String... message) {
+        var author = new Author("foo", "foo@host.org");
+        var hash = new Hash(("" + id).repeat(40));
+        var parents = List.of(Hash.zero());
+        var authored = ZonedDateTime.now();
+        var metadata = new CommitMetadata(hash, parents, author, authored, author, authored, List.of(message));
+        return new Commit(metadata, List.of());
+    }
+
+    private static CommitMessage message(Commit c) {
+        return CommitMessageParsers.v1.parse(c);
+    }
+
+    @Test
+    void validJCheckConfTest() {
+        var commit = commit(0, "Bugfix");
+        var message = message(commit);
+        var check = new JCheckConfCheck(repo);
+        var issues = toList(check.check(commit, message, conf, null));
+        assertEquals(0, issues.size());
+    }
+
+    @Test
+    void invalidJCheckConfTest() {
+        var commit = commit(0, "Bugfix");
+        var message = message(commit);
+        var check = new JCheckConfCheck(repo);
+
+        ((JCheckConfTestRepository) repo).setConf(List.of(
+                "[general] 36542",
+                "project = test",
+                "[checks]",
+                "error = jcheckconf"
+        ));
+        var issues = toList(check.check(commit, message, conf, null));
+        assertEquals(1, issues.size());
+        assertEquals("line 0: section header must end with ']'", ((JCheckConfIssue) issues.get(0)).getErrorMessage());
+
+        ((JCheckConfTestRepository) repo).setConf(List.of(
+                "[general]",
+                "project = test",
+                "[checks]",
+                "error = jcheckconf",
+                "randomrandom"
+        ));
+        issues = toList(check.check(commit, message, conf, null));
+        assertEquals(1, issues.size());
+        assertEquals("line 4: entry must be of form 'key = value'", ((JCheckConfIssue) issues.get(0)).getErrorMessage());
+    }
+}

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/JCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/JCheckTests.java
@@ -238,6 +238,11 @@ class JCheckTests {
             issues.add(e);
         }
 
+        @Override
+        public void visit(JCheckConfIssue e) {
+            issues.add(e);
+        }
+
         Set<Issue> issues() {
             return issues;
         }


### PR DESCRIPTION
SKARA-1655 describes a problem related with invalid jcheck config in a new change.

Currently, Skara never checks if the jcheck config is changed in a new change. So for example, if we accidentally
changed the jcheck config in a change and it was bad formatted, the bot will be in a retry loop and stuck.

In this patch, `JCheckConfCheck` is added to JCheck. If this check is configured, jcheck will check whether the jcheck config is still valid in the new change. If it is not, the specific problem will be added to the PR body and this PR will be blocked to be `ready for review`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1655](https://bugs.openjdk.org/browse/SKARA-1655): A PR/commit with an invalid jcheck config should be caught by jcheck


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to [f5831548](https://git.openjdk.org/skara/pull/1415/files/f5831548c195c034631f6f0433cd48b8f63a8f87)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1415/head:pull/1415` \
`$ git checkout pull/1415`

Update a local copy of the PR: \
`$ git checkout pull/1415` \
`$ git pull https://git.openjdk.org/skara pull/1415/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1415`

View PR using the GUI difftool: \
`$ git pr show -t 1415`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1415.diff">https://git.openjdk.org/skara/pull/1415.diff</a>

</details>
