### PR TITLE
SKARA-1658

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -738,9 +738,14 @@ class CheckRun {
         }
         var newBody = originalBody + "\n\n" + progressMarker + "\n" + message;
 
-        // TODO? Retrieve the body again here to lower the chance of concurrent updates
-        log.info("Updating PR body");
-        pr.setBody(newBody);
+        // Retrieve the body again here to lower the chance of concurrent updates
+        if (pr.body().equals(pr.latestBody())) {
+            log.info("Updating PR body");
+            pr.setBody(newBody);
+        } else {
+            log.info("PR body has been modified, won't update PR body this time");
+            return description;
+        }
         return newBody;
     }
 

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
@@ -347,4 +347,9 @@ class InMemoryPullRequest implements PullRequest {
     public List<ReferenceChange> targetRefChanges() {
         return List.of();
     }
+
+    @Override
+    public String latestBody() {
+        return null;
+    }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
@@ -248,4 +248,6 @@ public interface PullRequest extends Issue {
                 })
                 .toList();
     }
+
+    String latestBody();
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -795,4 +795,9 @@ public class GitHubPullRequest implements PullRequest {
         }
         return body;
     }
+
+    @Override
+    public String latestBody() {
+        return request.get("pulls/" + json.get("number").toString()).execute().get("body").asString();
+    }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -901,4 +901,9 @@ public class GitLabMergeRequest implements PullRequest {
         }
         return body;
     }
+
+    @Override
+    public String latestBody() {
+        return request.get().execute().get("description").asString();
+    }
 }

--- a/forge/src/test/java/org/openjdk/skara/forge/github/GitHubRestApiTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/github/GitHubRestApiTests.java
@@ -148,4 +148,15 @@ public class GitHubRestApiTests {
         assertTrue(updateComment.body().contains("..."));
         assertTrue(updateComment.body().contains("2"));
     }
+
+    @Test
+    void testLatestBody(){
+        var testRepoOpt = githubHost.repository("openjdk/playground");
+        assumeTrue(testRepoOpt.isPresent());
+        var testRepo = testRepoOpt.get();
+        var testPr = testRepo.pullRequest("99");
+
+        String latestBody = testPr.latestBody();
+        assertEquals("test", latestBody);
+    }
 }

--- a/forge/src/test/java/org/openjdk/skara/forge/gitlab/GitLabRestApiTest.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/gitlab/GitLabRestApiTest.java
@@ -129,4 +129,19 @@ public class GitLabRestApiTest {
         assertTrue(updateComment.body().contains("..."));
         assertTrue(updateComment.body().contains("2"));
     }
+
+    @Test
+    void testLatestBody() throws IOException {
+        var settings = ManualTestSettings.loadManualTestSettings();
+        var username = settings.getProperty("gitlab.user");
+        var token = settings.getProperty("gitlab.pat");
+        var credential = new Credential(username, token);
+        var uri = URIBuilder.base(settings.getProperty("gitlab.uri")).build();
+        var gitLabHost = new GitLabHost("gitlab", uri, false, credential, Set.of());
+        var gitLabRepo = gitLabHost.repository(settings.getProperty("gitlab.repository")).orElseThrow();
+        var gitLabMergeRequest = gitLabRepo.pullRequest(settings.getProperty("gitlab.merge.request.id"));
+
+        String latestBody = gitLabMergeRequest.latestBody();
+        assertEquals("This is a body", latestBody);
+    }
 }

--- a/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
@@ -327,4 +327,9 @@ public class TestPullRequest extends TestIssue implements PullRequest {
     public int hashCode() {
         return Objects.hash(super.hashCode(), headHash, sourceRef, targetRef, draft);
     }
+
+    @Override
+    public String latestBody() {
+        return store().body();
+    }
 }


### PR DESCRIPTION
Currently, when the pr bot tries to update the PR body, users are also likely to update the PR body at the same time. Therefore, users' updates are likely to be overwritten by bot.  

This is a race between the bot and user and the race window is a little big right now.

To reduce the race window, in this patch, when PR bot is trying to update PR body, it will check whether the PR body has been modified by user. And if the PR bot has been modified, PR bot would not overwrite it. 