### PR TITLE
1670: Make body handling consistent in all Issue implementations

### DIFF
--- a/bots/csr/src/test/java/org/openjdk/skara/bots/csr/CSRBotTests.java
+++ b/bots/csr/src/test/java/org/openjdk/skara/bots/csr/CSRBotTests.java
@@ -455,7 +455,7 @@ class CSRBotTests {
             // Run bot
             TestBotRunner.runPeriodicItems(csrPullRequestBot);
             // The bot shouldn't add the csr update marker
-            assertFalse(pr.body().contains(csrUpdateMarker));
+            assertFalse(pr.store().body().contains(csrUpdateMarker));
 
             // Add the csr issue.
             var csr = issueProject.createIssue("This is an CSR", List.of(), Map.of());
@@ -465,11 +465,11 @@ class CSRBotTests {
             // Run just the pull request bot
             TestBotRunner.runPeriodicItems(csrPullRequestBot);
             // Nothing should have happened
-            assertFalse(pr.body().contains(csrUpdateMarker));
+            assertFalse(pr.store().body().contains(csrUpdateMarker));
             // Run csr issue bot to trigger updates on the CSR issue
             TestBotRunner.runPeriodicItems(csrIssueBot);
             // The bot should add the csr update marker
-            assertTrue(pr.body().contains(csrUpdateMarker));
+            assertTrue(pr.store().body().contains(csrUpdateMarker));
 
             // Add csr issue and progress to the PR body
             pr.setBody("PR body\n" + progressMarker + csr.id() + csr.webUrl().toString() + csr.title() + " (**CSR**)"
@@ -477,7 +477,7 @@ class CSRBotTests {
             // Run bot
             TestBotRunner.runPeriodicItems(csrPullRequestBot);
             // The bot shouldn't add the csr update marker
-            assertFalse(pr.body().contains(csrUpdateMarker));
+            assertFalse(pr.store().body().contains(csrUpdateMarker));
 
             // Set csr status to closed and approved.
             csr.setState(Issue.State.CLOSED);
@@ -485,7 +485,7 @@ class CSRBotTests {
             // un csr issue bot to trigger updates on the CSR issue
             TestBotRunner.runPeriodicItems(csrIssueBot);
             // The bot should add the csr update marker
-            assertTrue(pr.body().contains(csrUpdateMarker));
+            assertTrue(pr.store().body().contains(csrUpdateMarker));
 
             // Add csr issue and selected progress to the PR body
             pr.setBody("PR body\n" + progressMarker + csr.id() + csr.webUrl().toString() + csr.title() + " (**CSR**)"
@@ -493,7 +493,7 @@ class CSRBotTests {
             // Run bot
             TestBotRunner.runPeriodicItems(csrPullRequestBot);
             // The bot shouldn't add the csr update marker
-            assertFalse(pr.body().contains(csrUpdateMarker));
+            assertFalse(pr.store().body().contains(csrUpdateMarker));
 
             // Add csr update marker to the pull request body manually.
             pr.setBody("PR body\n" + progressMarker + csr.id() + csr.webUrl().toString() + csr.title() + " (**CSR**)"
@@ -501,8 +501,8 @@ class CSRBotTests {
             // Run bot
             TestBotRunner.runPeriodicItems(csrPullRequestBot);
             // The bot shouldn't add the csr update marker again. The PR should have only one csr update marker.
-            assertTrue(pr.body().contains(csrUpdateMarker));
-            assertEquals(pr.body().indexOf(csrUpdateMarker), pr.body().lastIndexOf(csrUpdateMarker));
+            assertTrue(pr.store().body().contains(csrUpdateMarker));
+            assertEquals(pr.store().body().indexOf(csrUpdateMarker), pr.store().body().lastIndexOf(csrUpdateMarker));
         }
     }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportTests.java
@@ -578,8 +578,8 @@ class BackportTests {
             assertTrue(backportComment.contains("<!-- backport " + releaseHash.hex() + " -->"));
             assertEquals(issue1Number + ": An issue", pr.store().title());
             assertTrue(pr.store().labelNames().contains("backport"));
-            assertFalse(pr.body().contains(ReviewersCheck.DESCRIPTION), "Reviewer requirement found in pr body");
-            assertFalse(pr.body().contains(CheckRun.MSG_EMPTY_BODY), "Body not empty requirement found in pr body");
+            assertFalse(pr.store().body().contains(ReviewersCheck.DESCRIPTION), "Reviewer requirement found in pr body");
+            assertFalse(pr.store().body().contains(CheckRun.MSG_EMPTY_BODY), "Body not empty requirement found in pr body");
 
             // The bot should have added the "clean" label
             assertTrue(pr.store().labelNames().contains("clean"));
@@ -720,7 +720,7 @@ class BackportTests {
             assertTrue(backportComment.contains("<!-- backport " + upstreamHash.hex() + " -->"));
             assertEquals(issue2Number + ": Another issue", pr.store().title());
             assertTrue(pr.store().labelNames().contains("backport"));
-            assertTrue(pr.body().contains(ReviewersCheck.DESCRIPTION), "Reviewer requirement not found in pr body");
+            assertTrue(pr.store().body().contains(ReviewersCheck.DESCRIPTION), "Reviewer requirement not found in pr body");
 
             // The bot should not have added the "clean" label
             assertFalse(pr.store().labelNames().contains("clean"));

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ContributorTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ContributorTests.java
@@ -379,7 +379,7 @@ class ContributorTests {
             assertLastCommentContains(pr, "successfully added.");
 
             // Verify that body is updated
-            var body = pr.body().split("\n");
+            var body = pr.store().body().split("\n");
             var contributorsHeaderIndex = -1;
             for (var i = 0; i < body.length; i++) {
                 var line = body[i];
@@ -402,7 +402,7 @@ class ContributorTests {
             assertLastCommentContains(pr, "successfully removed.");
 
             // Verify that body does not contain "Contributors" section
-            for (var line : pr.body().split("\n")) {
+            for (var line : pr.store().body().split("\n")) {
                 assertNotEquals("### Contributors", line);
             }
         }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IssueTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IssueTests.java
@@ -366,9 +366,9 @@ class IssueTests {
 
             // First check
             TestBotRunner.runPeriodicItems(prBot);
-            assertTrue(pr.body().contains(issue1.id()));
-            assertTrue(pr.body().contains("First"));
-            assertTrue(pr.body().contains("## Issue\n"));
+            assertTrue(pr.store().body().contains(issue1.id()));
+            assertTrue(pr.store().body().contains("First"));
+            assertTrue(pr.store().body().contains("## Issue\n"));
 
             // Add an extra issue
             var issue2 = issues.createIssue("Second", List.of("There"), Map.of());
@@ -377,12 +377,12 @@ class IssueTests {
             // Check that the body was updated
             TestBotRunner.runPeriodicItems(prBot);
             TestBotRunner.runPeriodicItems(prBot);
-            assertTrue(pr.body().contains(issue1.id()));
-            assertTrue(pr.body().contains("First"));
-            assertTrue(pr.body().contains(issue2.id()));
-            assertTrue(pr.body().contains("Second"));
-            assertFalse(pr.body().contains("## Issue\n"));
-            assertTrue(pr.body().contains("## Issues\n"));
+            assertTrue(pr.store().body().contains(issue1.id()));
+            assertTrue(pr.store().body().contains("First"));
+            assertTrue(pr.store().body().contains(issue2.id()));
+            assertTrue(pr.store().body().contains("Second"));
+            assertFalse(pr.store().body().contains("## Issue\n"));
+            assertTrue(pr.store().body().contains("## Issues\n"));
         }
     }
 
@@ -414,10 +414,10 @@ class IssueTests {
 
             // First check
             TestBotRunner.runPeriodicItems(prBot);
-            assertTrue(pr.body().contains(issue1.id()));
-            assertTrue(pr.body().contains("First"));
-            assertTrue(pr.body().contains("## Issue\n"));
-            assertTrue(pr.body().contains("Issue is not open"));
+            assertTrue(pr.store().body().contains(issue1.id()));
+            assertTrue(pr.store().body().contains("First"));
+            assertTrue(pr.store().body().contains("## Issue\n"));
+            assertTrue(pr.store().body().contains("Issue is not open"));
         }
     }
 
@@ -450,10 +450,10 @@ class IssueTests {
 
             // First check
             TestBotRunner.runPeriodicItems(prBot);
-            assertTrue(pr.body().contains(issue1.id()));
-            assertTrue(pr.body().contains("First"));
-            assertTrue(pr.body().contains("## Issue\n"));
-            assertFalse(pr.body().contains("Issue is not open"));
+            assertTrue(pr.store().body().contains(issue1.id()));
+            assertTrue(pr.store().body().contains("First"));
+            assertTrue(pr.store().body().contains("## Issue\n"));
+            assertFalse(pr.store().body().contains("Issue is not open"));
         }
     }
 
@@ -727,8 +727,8 @@ class IssueTests {
                     .findFirst();
             assertEquals(Optional.empty(), previewComment, "Preview comment should not have been posted");
             // Body should contain integration blocker
-            assertTrue(pr.body().contains("Integration blocker"), "Body does not report integration blocker");
-            assertTrue(pr.body().contains("Failed to retrieve information on issue `123`"),
+            assertTrue(pr.store().body().contains("Integration blocker"), "Body does not report integration blocker");
+            assertTrue(pr.store().body().contains("Failed to retrieve information on issue `123`"),
                     "Body does not contain specific message");
         }
     }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/JEPCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/JEPCommandTests.java
@@ -85,7 +85,7 @@ public class JEPCommandTests {
             assertTrue(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
             assertLastCommentContains(pr, "This pull request will not be integrated until the [JEP-");
             assertLastCommentContains(pr, "has been targeted.");
-            assertTrue(pr.body().contains("- [ ] Change requires a JEP request to be targeted"));
+            assertTrue(pr.store().body().contains("- [ ] Change requires a JEP request to be targeted"));
 
             // Not require jep
             prAsReviewer.addComment("/jep unneeded");
@@ -94,7 +94,7 @@ public class JEPCommandTests {
             TestBotRunner.runPeriodicItems(prBot);
             assertFalse(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
             assertLastCommentContains(pr, "determined that the JEP request is not needed for this pull request.");
-            assertFalse(pr.body().contains("Change requires a JEP request to be targeted"));
+            assertFalse(pr.store().body().contains("Change requires a JEP request to be targeted"));
 
             // Require jep by using `jep-<id>`
             pr.addComment("/jep jep-123");
@@ -104,7 +104,7 @@ public class JEPCommandTests {
             assertTrue(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
             assertLastCommentContains(pr, "This pull request will not be integrated until the [JEP-");
             assertLastCommentContains(pr, "has been targeted.");
-            assertTrue(pr.body().contains("- [ ] Change requires a JEP request to be targeted"));
+            assertTrue(pr.store().body().contains("- [ ] Change requires a JEP request to be targeted"));
 
             // Not require jep
             prAsReviewer.addComment("/jep unneeded");
@@ -113,7 +113,7 @@ public class JEPCommandTests {
             TestBotRunner.runPeriodicItems(prBot);
             assertFalse(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
             assertLastCommentContains(pr, "determined that the JEP request is not needed for this pull request.");
-            assertFalse(pr.body().contains("Change requires a JEP request to be targeted"));
+            assertFalse(pr.store().body().contains("Change requires a JEP request to be targeted"));
 
             // Require jep by using `Jep-<id>`
             pr.addComment("/jep Jep-123");
@@ -123,7 +123,7 @@ public class JEPCommandTests {
             assertTrue(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
             assertLastCommentContains(pr, "This pull request will not be integrated until the [JEP-");
             assertLastCommentContains(pr, "has been targeted.");
-            assertTrue(pr.body().contains("- [ ] Change requires a JEP request to be targeted"));
+            assertTrue(pr.store().body().contains("- [ ] Change requires a JEP request to be targeted"));
 
             // Not require jep
             prAsReviewer.addComment("/jep unneeded");
@@ -132,7 +132,7 @@ public class JEPCommandTests {
             TestBotRunner.runPeriodicItems(prBot);
             assertFalse(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
             assertLastCommentContains(pr, "determined that the JEP request is not needed for this pull request.");
-            assertFalse(pr.body().contains("Change requires a JEP request to be targeted"));
+            assertFalse(pr.store().body().contains("Change requires a JEP request to be targeted"));
 
             // Require jep with strange jep prefix
             pr.addComment("/jep jEP-123");
@@ -142,7 +142,7 @@ public class JEPCommandTests {
             assertTrue(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
             assertLastCommentContains(pr, "This pull request will not be integrated until the [JEP-");
             assertLastCommentContains(pr, "has been targeted.");
-            assertTrue(pr.body().contains("- [ ] Change requires a JEP request to be targeted"));
+            assertTrue(pr.store().body().contains("- [ ] Change requires a JEP request to be targeted"));
 
             // Not require jep
             prAsReviewer.addComment("/jep unneeded");
@@ -151,7 +151,7 @@ public class JEPCommandTests {
             TestBotRunner.runPeriodicItems(prBot);
             assertFalse(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
             assertLastCommentContains(pr, "determined that the JEP request is not needed for this pull request.");
-            assertFalse(pr.body().contains("Change requires a JEP request to be targeted"));
+            assertFalse(pr.store().body().contains("Change requires a JEP request to be targeted"));
 
             // Require jep by using `issue-id`(<ProjectName>-<id>)
             pr.addComment("/jep TEST-3");
@@ -161,7 +161,7 @@ public class JEPCommandTests {
             assertFalse(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
             assertLastCommentContains(pr, "The JEP for this pull request, [JEP-");
             assertLastCommentContains(pr, "has already been targeted.");
-            assertTrue(pr.body().contains("- [x] Change requires a JEP request to be targeted"));
+            assertTrue(pr.store().body().contains("- [x] Change requires a JEP request to be targeted"));
 
             // Not require jep by using `uneeded`
             prAsReviewer.addComment("/jep uneeded");
@@ -170,7 +170,7 @@ public class JEPCommandTests {
             TestBotRunner.runPeriodicItems(prBot);
             assertFalse(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
             assertLastCommentContains(pr, "determined that the JEP request is not needed for this pull request.");
-            assertFalse(pr.body().contains("Change requires a JEP request to be targeted"));
+            assertFalse(pr.store().body().contains("Change requires a JEP request to be targeted"));
 
             // Require jep by using `issue-id` which doesn't have the project name
             pr.addComment("/jep 3");
@@ -180,7 +180,7 @@ public class JEPCommandTests {
             assertFalse(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
             assertLastCommentContains(pr, "The JEP for this pull request, [JEP-");
             assertLastCommentContains(pr, "has already been targeted.");
-            assertTrue(pr.body().contains("- [x] Change requires a JEP request to be targeted"));
+            assertTrue(pr.store().body().contains("- [x] Change requires a JEP request to be targeted"));
 
             // Not require jep
             prAsReviewer.addComment("/jep unneeded");
@@ -189,7 +189,7 @@ public class JEPCommandTests {
             TestBotRunner.runPeriodicItems(prBot);
             assertFalse(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
             assertLastCommentContains(pr, "determined that the JEP request is not needed for this pull request.");
-            assertFalse(pr.body().contains("Change requires a JEP request to be targeted"));
+            assertFalse(pr.store().body().contains("Change requires a JEP request to be targeted"));
 
             // Require jep with right JEP ID without prefix
             pr.addComment("/jep 123");
@@ -199,7 +199,7 @@ public class JEPCommandTests {
             assertTrue(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
             assertLastCommentContains(pr, "This pull request will not be integrated until the [JEP-");
             assertLastCommentContains(pr, "has been targeted.");
-            assertTrue(pr.body().contains("- [ ] Change requires a JEP request to be targeted"));
+            assertTrue(pr.store().body().contains("- [ ] Change requires a JEP request to be targeted"));
         }
     }
 
@@ -257,7 +257,7 @@ public class JEPCommandTests {
             assertTrue(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
             assertLastCommentContains(pr, "This pull request will not be integrated until the [JEP-");
             assertLastCommentContains(pr, "has been targeted.");
-            assertTrue(pr.body().contains("- [ ] Change requires a JEP request to be targeted"));
+            assertTrue(pr.store().body().contains("- [ ] Change requires a JEP request to be targeted"));
 
             // Require jep by a reviewer
             prAsReviewer.addComment("/jep TEST-2");
@@ -267,7 +267,7 @@ public class JEPCommandTests {
             assertTrue(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
             assertLastCommentContains(pr, "This pull request will not be integrated until the [JEP-");
             assertLastCommentContains(pr, "has been targeted.");
-            assertTrue(pr.body().contains("- [ ] Change requires a JEP request to be targeted"));
+            assertTrue(pr.store().body().contains("- [ ] Change requires a JEP request to be targeted"));
 
             // Not require jep by a committer
             prAsCommitter.addComment("/jep unneeded");
@@ -277,7 +277,7 @@ public class JEPCommandTests {
             assertTrue(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
             assertLastCommentContains(pr, "Only the pull request author and [Reviewers]" +
                     "(https://openjdk.org/bylaws#reviewer) are allowed to use the `jep` command.");
-            assertTrue(pr.body().contains("- [ ] Change requires a JEP request to be targeted"));
+            assertTrue(pr.store().body().contains("- [ ] Change requires a JEP request to be targeted"));
 
             // Not require jep by a reviewer
             prAsReviewer.addComment("/jep unneeded");
@@ -286,7 +286,7 @@ public class JEPCommandTests {
             TestBotRunner.runPeriodicItems(prBot);
             assertFalse(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
             assertLastCommentContains(pr, "determined that the JEP request is not needed for this pull request.");
-            assertFalse(pr.body().contains("Change requires a JEP request to be targeted"));
+            assertFalse(pr.store().body().contains("Change requires a JEP request to be targeted"));
         }
     }
 
@@ -333,7 +333,7 @@ public class JEPCommandTests {
             // Test the symbol `\` of the text block
             assertLastCommentContains(pr, "The prefix (i.e. `JDK-`, `JEP-` or `jep-`) is optional. If the argument is given without prefix, "
                     + "it will be tried first as a JEP ID and second as an issue ID. The issue type must be `JEP`.");
-            assertFalse(pr.body().contains("Change requires a JEP request to be targeted"));
+            assertFalse(pr.store().body().contains("Change requires a JEP request to be targeted"));
 
             // Require jep with blank space
             pr.addComment("/jep   ");
@@ -347,7 +347,7 @@ public class JEPCommandTests {
             // Test the symbol `\` of the text block
             assertLastCommentContains(pr, "The prefix (i.e. `JDK-`, `JEP-` or `jep-`) is optional. If the argument is given without prefix, "
                     + "it will be tried first as a JEP ID and second as an issue ID. The issue type must be `JEP`.");
-            assertFalse(pr.body().contains("Change requires a JEP request to be targeted"));
+            assertFalse(pr.store().body().contains("Change requires a JEP request to be targeted"));
 
             // Require jep with wrong jep prefix
             pr.addComment("/jep je-123");
@@ -357,7 +357,7 @@ public class JEPCommandTests {
             assertFalse(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
             assertEquals(7, pr.comments().size());
             assertLastCommentContains(pr, "The JEP issue was not found. Please make sure you have entered it correctly.");
-            assertFalse(pr.body().contains("Change requires a JEP request to be targeted"));
+            assertFalse(pr.store().body().contains("Change requires a JEP request to be targeted"));
 
             // Require jep with wrong jep id without prefix
             pr.addComment("/jep 1");
@@ -367,7 +367,7 @@ public class JEPCommandTests {
             assertFalse(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
             assertEquals(9, pr.comments().size());
             assertLastCommentContains(pr, "The issue `TEST-1` is not a JEP. Please make sure you have entered it correctly.");
-            assertFalse(pr.body().contains("Change requires a JEP request to be targeted"));
+            assertFalse(pr.store().body().contains("Change requires a JEP request to be targeted"));
 
             // Require jep with wrong project prefix
             pr.addComment("/jep TESt-2");
@@ -377,7 +377,7 @@ public class JEPCommandTests {
             assertFalse(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
             assertEquals(11, pr.comments().size());
             assertLastCommentContains(pr, "The JEP issue was not found. Please make sure you have entered it correctly.");
-            assertFalse(pr.body().contains("Change requires a JEP request to be targeted"));
+            assertFalse(pr.store().body().contains("Change requires a JEP request to be targeted"));
 
             // Require jep with wrong `jep-id`
             pr.addComment("/jep jep-1");
@@ -387,7 +387,7 @@ public class JEPCommandTests {
             assertFalse(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
             assertEquals(13, pr.comments().size());
             assertLastCommentContains(pr, "The JEP issue was not found. Please make sure you have entered it correctly.");
-            assertFalse(pr.body().contains("Change requires a JEP request to be targeted"));
+            assertFalse(pr.store().body().contains("Change requires a JEP request to be targeted"));
 
             // Require jep with wrong issue type
             pr.addComment("/jep TEST-1");
@@ -397,7 +397,7 @@ public class JEPCommandTests {
             assertFalse(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
             assertEquals(15, pr.comments().size());
             assertLastCommentContains(pr, "The issue `TEST-1` is not a JEP. Please make sure you have entered it correctly.");
-            assertFalse(pr.body().contains("Change requires a JEP request to be targeted"));
+            assertFalse(pr.store().body().contains("Change requires a JEP request to be targeted"));
         }
     }
 
@@ -447,7 +447,7 @@ public class JEPCommandTests {
                 assertEquals(i * 2 + 1, pr.comments().size());
                 assertLastCommentContains(pr, "This pull request will not be integrated until the [JEP-");
                 assertLastCommentContains(pr, "has been targeted.");
-                assertTrue(pr.body().contains("- [ ] Change requires a JEP request to be targeted"));
+                assertTrue(pr.store().body().contains("- [ ] Change requires a JEP request to be targeted"));
             }
 
             // Test targeted/integrated/completed/closedWithDelivered JEPs
@@ -458,7 +458,7 @@ public class JEPCommandTests {
                 assertEquals(i * 2 + 1, pr.comments().size());
                 assertLastCommentContains(pr, "The JEP for this pull request, [JEP-");
                 assertLastCommentContains(pr, "has already been targeted.");
-                assertTrue(pr.body().contains("- [x] Change requires a JEP request to be targeted"));
+                assertTrue(pr.store().body().contains("- [x] Change requires a JEP request to be targeted"));
             }
         }
     }
@@ -495,7 +495,7 @@ public class JEPCommandTests {
             TestBotRunner.runPeriodicItems(disableJepBot);
             assertLastCommentContains(pr, "This repository has not been configured to use the `jep` command.");
             assertFalse(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
-            assertFalse(pr.body().contains("- [ ] Change requires a JEP request to be targeted"));
+            assertFalse(pr.store().body().contains("- [ ] Change requires a JEP request to be targeted"));
 
             // Test the PR bot with jep enable
             var enableJepBot = PullRequestBot.newBuilder().repo(bot).issueProject(issueProject)
@@ -504,7 +504,7 @@ public class JEPCommandTests {
             TestBotRunner.runPeriodicItems(enableJepBot);
             assertLastCommentContains(pr, "pull request will not be integrated until the");
             assertTrue(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
-            assertTrue(pr.body().contains("- [ ] Change requires a JEP request to be targeted"));
+            assertTrue(pr.store().body().contains("- [ ] Change requires a JEP request to be targeted"));
         }
     }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestCommandTests.java
@@ -233,7 +233,7 @@ class PullRequestCommandTests {
             assertLastCommentContains(pr, "Contributor `B <b@c.d>` successfully added.");
 
             // The first command should also be reflected in the body
-            assertTrue(pr.body().contains("A `<a@b.c>`"));
+            assertTrue(pr.store().body().contains("A `<a@b.c>`"));
         }
     }
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ReviewerTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ReviewerTests.java
@@ -374,7 +374,7 @@ class ReviewerTests {
             assertLastCommentContains(pr, "successfully credited.");
 
             // Verify that body is updated
-            var body = pr.body().split("\n");
+            var body = pr.store().body().split("\n");
             var contributorsHeaderIndex = -1;
             for (var i = 0; i < body.length; i++) {
                 var line = body[i];
@@ -397,17 +397,17 @@ class ReviewerTests {
             assertLastCommentContains(pr, "successfully removed.");
 
             // Verify that body does not contain a "Reviewers" section
-            for (var line : pr.body().split("\n")) {
+            for (var line : pr.store().body().split("\n")) {
                 assertNotEquals("### Reviewers", line);
             }
-            assertFalse(pr.body().contains("Added manually"));
+            assertFalse(pr.store().body().contains("Added manually"));
 
             // Add it once more
             pr.addComment("/reviewer credit integrationauthor1");
             TestBotRunner.runPeriodicItems(prBot);
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(pr, "successfully credited.");
-            assertTrue(pr.body().contains(" * Generated Author 1 - Author ⚠️ Added manually"));
+            assertTrue(pr.store().body().contains(" * Generated Author 1 - Author ⚠️ Added manually"));
 
             // Now add an authenticated review from the same reviewer
             var integratorPr = integrator.pullRequest(pr.id());
@@ -415,8 +415,8 @@ class ReviewerTests {
             TestBotRunner.runPeriodicItems(prBot);
 
             // The reviewer should no longer be listed as added manually
-            assertFalse(pr.body().contains("Added manually"));
-            assertTrue(pr.body().contains(" * Generated Author 1 (@user2 - Author)"));
+            assertFalse(pr.store().body().contains("Added manually"));
+            assertTrue(pr.store().body().contains(" * Generated Author 1 (@user2 - Author)"));
         }
     }
 
@@ -453,8 +453,8 @@ class ReviewerTests {
             TestBotRunner.runPeriodicItems(prBot);
 
             // The reviewer is not added manually
-            assertFalse(pr.body().contains("Added manually"));
-            assertTrue(pr.body().contains(" * Generated Reviewer 1 (@user2 - **Reviewer**)"));
+            assertFalse(pr.store().body().contains("Added manually"));
+            assertTrue(pr.store().body().contains(" * Generated Reviewer 1 (@user2 - **Reviewer**)"));
 
             // Try to add it manually as well
             pr.addComment("/reviewer credit integrationreviewer1");
@@ -465,8 +465,8 @@ class ReviewerTests {
             assertLastCommentContains(pr,"Reviewer `integrationreviewer1` has already made an authenticated review of this PR");
 
             // The reviewer is not added manually
-            assertFalse(pr.body().contains("Added manually"));
-            assertTrue(pr.body().contains(" * Generated Reviewer 1 (@user2 - **Reviewer**)"));
+            assertFalse(pr.store().body().contains("Added manually"));
+            assertTrue(pr.store().body().contains(" * Generated Reviewer 1 (@user2 - **Reviewer**)"));
         }
     }
 
@@ -501,8 +501,8 @@ class ReviewerTests {
             TestBotRunner.runPeriodicItems(prBot);
 
             // Check the PR body
-            assertTrue(pr.body().contains(" * Generated Reviewer 1 - **Reviewer** ⚠️ Added manually"));
-            assertTrue(pr.body().contains(" * Generated Committer 3 - Committer ⚠️ Added manually"));
+            assertTrue(pr.store().body().contains(" * Generated Reviewer 1 - **Reviewer** ⚠️ Added manually"));
+            assertTrue(pr.store().body().contains(" * Generated Committer 3 - Committer ⚠️ Added manually"));
 
             // Add a real review
             var approvalPr = extra.pullRequest(pr.id());
@@ -513,10 +513,10 @@ class ReviewerTests {
             assertLastCommentContains(pr, "Reviewed-by: integrationreviewer2, integrationreviewer1, integrationcommitter3");
 
             // Check the PR body
-            assertTrue(pr.body().contains(" * Generated Reviewer 1 - **Reviewer** ⚠️ Added manually"));
-            assertTrue(pr.body().contains(" * Generated Committer 3 - Committer ⚠️ Added manually"));
-            assertTrue(pr.body().contains(" * Generated Reviewer 2 (@user3 - **Reviewer**)"));
-            assertFalse(pr.body().contains(" * Generated Reviewer 2 (@user3 - **Reviewer**) ⚠️ Added manually"));
+            assertTrue(pr.store().body().contains(" * Generated Reviewer 1 - **Reviewer** ⚠️ Added manually"));
+            assertTrue(pr.store().body().contains(" * Generated Committer 3 - Committer ⚠️ Added manually"));
+            assertTrue(pr.store().body().contains(" * Generated Reviewer 2 (@user3 - **Reviewer**)"));
+            assertFalse(pr.store().body().contains(" * Generated Reviewer 2 (@user3 - **Reviewer**) ⚠️ Added manually"));
 
             // Remove both reviewers
             pr.addComment("/reviewer remove integrationreviewer1 integrationcommitter3");
@@ -527,10 +527,10 @@ class ReviewerTests {
             assertLastCommentContains(pr, "Reviewer `integrationcommitter3` successfully removed");
 
             // Check the PR body
-            assertFalse(pr.body().contains(" * Generated Reviewer 1 - **Reviewer**"));
-            assertFalse(pr.body().contains(" * Generated Committer 3 - Committer"));
-            assertTrue(pr.body().contains(" * Generated Reviewer 2 (@user3 - **Reviewer**)"));
-            assertFalse(pr.body().contains(" * Generated Reviewer 2 (@user3 - **Reviewer**) ⚠️ Added manually"));
+            assertFalse(pr.store().body().contains(" * Generated Reviewer 1 - **Reviewer**"));
+            assertFalse(pr.store().body().contains(" * Generated Committer 3 - Committer"));
+            assertTrue(pr.store().body().contains(" * Generated Reviewer 2 (@user3 - **Reviewer**)"));
+            assertFalse(pr.store().body().contains(" * Generated Reviewer 2 (@user3 - **Reviewer**) ⚠️ Added manually"));
         }
     }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ReviewersTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ReviewersTests.java
@@ -73,7 +73,7 @@ public class ReviewersTests {
             localRepo.push(editHash, author.url(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "123: This is a pull request");
 
-            var reviewerPr = integrator.pullRequest(pr.id());
+            var reviewerPr = (TestPullRequest)integrator.pullRequest(pr.id());
 
             // No arguments
             reviewerPr.addComment("/reviewers");
@@ -81,7 +81,7 @@ public class ReviewersTests {
 
             // The bot should reply with a help message
             assertLastCommentContains(reviewerPr,"is the number of required reviewers");
-            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 1, 0, 0, 0)));
+            assertTrue(reviewerPr.store().body().contains(getReviewersExpectedProgress(0, 1, 0, 0, 0)));
 
             // Invalid syntax
             reviewerPr.addComment("/reviewers two");
@@ -89,25 +89,25 @@ public class ReviewersTests {
 
             // The bot should reply with a help message
             assertLastCommentContains(reviewerPr,"is the number of required reviewers");
-            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 1, 0, 0, 0)));
+            assertTrue(reviewerPr.store().body().contains(getReviewersExpectedProgress(0, 1, 0, 0, 0)));
 
             // Too many
             reviewerPr.addComment("/reviewers 7001");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr,"Cannot increase the required number of reviewers above 10 (requested: 7001)");
-            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 1, 0, 0, 0)));
+            assertTrue(reviewerPr.store().body().contains(getReviewersExpectedProgress(0, 1, 0, 0, 0)));
 
             // Too few
             reviewerPr.addComment("/reviewers -3");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr,"Cannot decrease the required number of reviewers below 0 (requested: -3)");
-            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 1, 0, 0, 0)));
+            assertTrue(reviewerPr.store().body().contains(getReviewersExpectedProgress(0, 1, 0, 0, 0)));
 
             // Unknown role
             reviewerPr.addComment("/reviewers 2 penguins");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr,"Unknown role `penguins` specified");
-            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 1, 0, 0, 0)));
+            assertTrue(reviewerPr.store().body().contains(getReviewersExpectedProgress(0, 1, 0, 0, 0)));
 
             // Set the number
             reviewerPr.addComment("/reviewers 2");
@@ -115,7 +115,7 @@ public class ReviewersTests {
 
             // The bot should reply with a success message
             assertLastCommentContains(reviewerPr, getReviewersExpectedComment(0, 1, 0, 1, 0));
-            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 1, 0, 1, 0)));
+            assertTrue(reviewerPr.store().body().contains(getReviewersExpectedProgress(0, 1, 0, 1, 0)));
 
             // Set 2 of role committers
             reviewerPr.addComment("/reviewers 2 committer");
@@ -123,7 +123,7 @@ public class ReviewersTests {
 
             // The bot should reply with a success message
             assertLastCommentContains(reviewerPr, getReviewersExpectedComment(0, 1, 1, 0, 0));
-            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 1, 1, 0, 0)));
+            assertTrue(reviewerPr.store().body().contains(getReviewersExpectedProgress(0, 1, 1, 0, 0)));
 
             // Set 2 of role reviewers
             reviewerPr.addComment("/reviewers 2 reviewer");
@@ -131,7 +131,7 @@ public class ReviewersTests {
 
             // The bot should reply with a success message
             assertLastCommentContains(reviewerPr, getReviewersExpectedComment(0, 2, 0, 0, 0));
-            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 2, 0, 0, 0)));
+            assertTrue(reviewerPr.store().body().contains(getReviewersExpectedProgress(0, 2, 0, 0, 0)));
 
             // Approve it as another user
             reviewerPr.addReview(Review.Verdict.APPROVED, "Approved");
@@ -141,7 +141,7 @@ public class ReviewersTests {
             // The PR should not yet be considered as ready for review
             var updatedPr = author.pullRequest(pr.id());
             assertFalse(updatedPr.labelNames().contains("ready"));
-            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 2, 0, 0, 0)));
+            assertTrue(reviewerPr.store().body().contains(getReviewersExpectedProgress(0, 2, 0, 0, 0)));
 
             // Now reduce the number of required reviewers
             reviewerPr.addComment("/reviewers 1");
@@ -151,14 +151,14 @@ public class ReviewersTests {
             // The PR should now be considered as ready for review
             updatedPr = author.pullRequest(pr.id());
             assertTrue(updatedPr.labelNames().contains("ready"));
-            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 1, 0, 0, 0)));
+            assertTrue(reviewerPr.store().body().contains(getReviewersExpectedProgress(0, 1, 0, 0, 0)));
 
             // Now request that the lead reviews
             reviewerPr.addComment("/reviewers 1 lead");
             TestBotRunner.runPeriodicItems(prBot);
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr, getReviewersExpectedComment(1, 0, 0, 0, 0));
-            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(1, 0, 0, 0, 0)));
+            assertTrue(reviewerPr.store().body().contains(getReviewersExpectedProgress(1, 0, 0, 0, 0)));
 
             // The PR should no longer be considered as ready for review
             updatedPr = author.pullRequest(pr.id());
@@ -169,7 +169,7 @@ public class ReviewersTests {
             TestBotRunner.runPeriodicItems(prBot);
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr, getReviewersExpectedComment(0, 1, 0, 0, 0));
-            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 1, 0, 0, 0)));
+            assertTrue(reviewerPr.store().body().contains(getReviewersExpectedProgress(0, 1, 0, 0, 0)));
 
             // The PR should now be considered as ready for review yet again
             updatedPr = author.pullRequest(pr.id());
@@ -202,7 +202,7 @@ public class ReviewersTests {
             localRepo.push(editHash, author.url(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "123: This is a pull request");
 
-            var reviewerPr = integrator.pullRequest(pr.id());
+            var reviewerPr = (TestPullRequest) integrator.pullRequest(pr.id());
 
             // Set the number
             reviewerPr.addComment("/reviewers 2");
@@ -210,7 +210,7 @@ public class ReviewersTests {
 
             // The bot should reply with a success message
             assertLastCommentContains(reviewerPr, getReviewersExpectedComment(0, 1, 0, 1, 0));
-            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 1, 0, 1, 0)));
+            assertTrue(reviewerPr.store().body().contains(getReviewersExpectedProgress(0, 1, 0, 1, 0)));
 
             // Approve it as another user
             reviewerPr.addReview(Review.Verdict.APPROVED, "Approved");
@@ -221,18 +221,18 @@ public class ReviewersTests {
             pr.addComment("/integrate");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr,"pull request has not yet been marked as ready for integration");
-            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 1, 0, 1, 0)));
+            assertTrue(reviewerPr.store().body().contains(getReviewersExpectedProgress(0, 1, 0, 1, 0)));
 
             // Relax the requirement
             reviewerPr.addComment("/reviewers 1");
             TestBotRunner.runPeriodicItems(prBot);
-            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 1, 0, 0, 0)));
+            assertTrue(reviewerPr.store().body().contains(getReviewersExpectedProgress(0, 1, 0, 0, 0)));
 
             // It should now work fine
             pr.addComment("/integrate");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr,"Pushed as commit");
-            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 1, 0, 0, 0)));
+            assertTrue(reviewerPr.store().body().contains(getReviewersExpectedProgress(0, 1, 0, 0, 0)));
         }
     }
 
@@ -261,19 +261,19 @@ public class ReviewersTests {
             localRepo.push(editHash, author.url(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "123: This is a pull request");
 
-            var reviewerPr = integrator.pullRequest(pr.id());
+            var reviewerPr = (TestPullRequest)integrator.pullRequest(pr.id());
 
             // Approve it as another user
             reviewerPr.addReview(Review.Verdict.APPROVED, "Approved");
             TestBotRunner.runPeriodicItems(prBot);
             TestBotRunner.runPeriodicItems(prBot);
-            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 1, 0, 0, 0)));
+            assertTrue(reviewerPr.store().body().contains(getReviewersExpectedProgress(0, 1, 0, 0, 0)));
 
             // Flag it as ready for integration
             pr.addComment("/integrate");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr,"now ready to be sponsored");
-            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 1, 0, 0, 0)));
+            assertTrue(reviewerPr.store().body().contains(getReviewersExpectedProgress(0, 1, 0, 0, 0)));
 
             // Set the number
             reviewerPr.addComment("/reviewers 2");
@@ -281,24 +281,24 @@ public class ReviewersTests {
 
             // The bot should reply with a success message
             assertLastCommentContains(reviewerPr, getReviewersExpectedComment(0, 1, 0, 1, 0));
-            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 1, 0, 1, 0)));
+            assertTrue(reviewerPr.store().body().contains(getReviewersExpectedProgress(0, 1, 0, 1, 0)));
 
             // It should not be possible to sponsor
             reviewerPr.addComment("/sponsor");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr,"PR has not yet been marked as ready for integration");
-            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 1, 0, 1, 0)));
+            assertTrue(reviewerPr.store().body().contains(getReviewersExpectedProgress(0, 1, 0, 1, 0)));
 
             // Relax the requirement
             reviewerPr.addComment("/reviewers 1");
             TestBotRunner.runPeriodicItems(prBot);
-            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 1, 0, 0, 0)));
+            assertTrue(reviewerPr.store().body().contains(getReviewersExpectedProgress(0, 1, 0, 0, 0)));
 
             // It should now work fine
             reviewerPr.addComment("/sponsor");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr,"Pushed as commit");
-            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 1, 0, 0, 0)));
+            assertTrue(reviewerPr.store().body().contains(getReviewersExpectedProgress(0, 1, 0, 0, 0)));
         }
     }
 
@@ -325,7 +325,7 @@ public class ReviewersTests {
             localRepo.push(editHash, author.url(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "123: This is a pull request");
 
-            var authorPR = author.pullRequest(pr.id());
+            var authorPR = (TestPullRequest)author.pullRequest(pr.id());
 
             // The author deems that two reviewers are required
             authorPR.addComment("/reviewers 2");
@@ -333,7 +333,7 @@ public class ReviewersTests {
             // The bot should reply with a success message
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(authorPR, getReviewersExpectedComment(0, 1, 0, 1, 0));
-            assertTrue(authorPR.body().contains(getReviewersExpectedProgress(0, 1, 0, 1, 0)));
+            assertTrue(authorPR.store().body().contains(getReviewersExpectedProgress(0, 1, 0, 1, 0)));
         }
     }
 
@@ -362,7 +362,7 @@ public class ReviewersTests {
             localRepo.push(editHash, author.url(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "123: This is a pull request");
 
-            var authorPR = author.pullRequest(pr.id());
+            var authorPR = (TestPullRequest)author.pullRequest(pr.id());
 
             // The author deems that two reviewers are required
             authorPR.addComment("/reviewers 2");
@@ -370,33 +370,33 @@ public class ReviewersTests {
             // The bot should reply with a success message
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(authorPR, getReviewersExpectedComment(0, 1, 0, 1, 0));
-            assertTrue(authorPR.body().contains(getReviewersExpectedProgress(0, 1, 0, 1, 0)));
+            assertTrue(authorPR.store().body().contains(getReviewersExpectedProgress(0, 1, 0, 1, 0)));
             // The author should not be allowed to decrease even its own /reviewers command
             authorPR.addComment("/reviewers 1");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(authorPR, "Only [Reviewers](https://openjdk.org/bylaws#reviewer) "
                     + "are allowed to decrease the number of required reviewers.");
-            assertTrue(authorPR.body().contains(getReviewersExpectedProgress(0, 1, 0, 1, 0)));
+            assertTrue(authorPR.store().body().contains(getReviewersExpectedProgress(0, 1, 0, 1, 0)));
 
             // Reviewer should be allowed to decrease
-            var reviewerPr = integrator.pullRequest(pr.id());
+            var reviewerPr = (TestPullRequest)integrator.pullRequest(pr.id());
             reviewerPr.addComment("/reviewers 1");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr, getReviewersExpectedComment(0, 1, 0, 0, 0));
-            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 1, 0, 0, 0)));
+            assertTrue(reviewerPr.store().body().contains(getReviewersExpectedProgress(0, 1, 0, 0, 0)));
 
             // The author should not be allowed to lower the role of the reviewers
             authorPR.addComment("/reviewers 1 contributors");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(authorPR, "Only [Reviewers](https://openjdk.org/bylaws#reviewer) "
                     + "are allowed to lower the role for additional reviewers.");
-            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 1, 0, 0, 0)));
+            assertTrue(reviewerPr.store().body().contains(getReviewersExpectedProgress(0, 1, 0, 0, 0)));
 
             // Reviewer should be allowed to lower the role of the reviewers
             reviewerPr.addComment("/reviewers 1 contributors");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(reviewerPr, getReviewersExpectedComment(0, 1, 0, 0, 0));
-            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 1, 0, 0, 0)));
+            assertTrue(reviewerPr.store().body().contains(getReviewersExpectedProgress(0, 1, 0, 0, 0)));
         }
     }
 
@@ -425,9 +425,9 @@ public class ReviewersTests {
 
             TestBotRunner.runPeriodicItems(prBot);
 
-            var authorPR = author.pullRequest(pr.id());
+            var authorPR = (TestPullRequest)author.pullRequest(pr.id());
             assertLastCommentContains(authorPR, getReviewersExpectedComment(0, 1, 0, 1, 0));
-            assertTrue(authorPR.body().contains(getReviewersExpectedProgress(0, 1, 0, 1, 0)));
+            assertTrue(authorPR.store().body().contains(getReviewersExpectedProgress(0, 1, 0, 1, 0)));
         }
     }
 
@@ -472,7 +472,7 @@ public class ReviewersTests {
             localRepo.push(editHash, author.url(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "123: This is a pull request");
 
-            var reviewerPr = integrator.pullRequest(pr.id());
+            var reviewerPr = (TestPullRequest)integrator.pullRequest(pr.id());
 
             // test role contributor
             for (int i = 1; i <= 10; i++) {
@@ -519,11 +519,11 @@ public class ReviewersTests {
         }
     }
 
-    private void verifyReviewersCommentAndProgress(PullRequest reviewerPr, PullRequestBot prBot, String command, String expectedComment, String expectedProgress) throws IOException {
+    private void verifyReviewersCommentAndProgress(TestPullRequest reviewerPr, PullRequestBot prBot, String command, String expectedComment, String expectedProgress) throws IOException {
         reviewerPr.addComment(command);
         TestBotRunner.runPeriodicItems(prBot);
         assertLastCommentContains(reviewerPr, expectedComment);
-        assertTrue(reviewerPr.body().contains(expectedProgress));
+        assertTrue(reviewerPr.store().body().contains(expectedProgress));
     }
 
     private String getReviewersExpectedComment(int leadNum, int reviewerNum, int committerNum, int authorNum, int contributorNum) {
@@ -598,19 +598,19 @@ public class ReviewersTests {
             var editHash = CheckableRepository.appendAndCommit(localRepo);
             localRepo.push(editHash, author.url(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "123: This is a pull request", List.of(""));
-            var reviewerPr = reviewer.pullRequest(pr.id());
+            var reviewerPr = (TestPullRequest)reviewer.pullRequest(pr.id());
 
             TestBotRunner.runPeriodicItems(prBot);
             var authorPR = author.pullRequest(pr.id());
-            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 0, 0, 0, 0)));
+            assertTrue(reviewerPr.store().body().contains(getReviewersExpectedProgress(0, 0, 0, 0, 0)));
 
             authorPR.addComment("/reviewers 2 reviewer");
             TestBotRunner.runPeriodicItems(prBot);
-            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 2, 0, 0, 0)));
+            assertTrue(reviewerPr.store().body().contains(getReviewersExpectedProgress(0, 2, 0, 0, 0)));
 
             reviewerPr.addComment("/reviewers 0");
             TestBotRunner.runPeriodicItems(prBot);
-            assertTrue(reviewerPr.body().contains(getReviewersExpectedProgress(0, 0, 0, 0, 0)));
+            assertTrue(reviewerPr.store().body().contains(getReviewersExpectedProgress(0, 0, 0, 0, 0)));
         }
     }
 

--- a/test/src/main/java/org/openjdk/skara/test/TestIssue.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestIssue.java
@@ -91,7 +91,7 @@ public class TestIssue implements Issue {
 
     @Override
     public String body() {
-        return store.body();
+        return body;
     }
 
     @Override


### PR DESCRIPTION
When fixing [SKARA-1658](https://bugs.openjdk.org/browse/SKARA-1658), I found the `TestIssue#body` didn't mimic `GitHubPullRequest#body` and` GitLabMergeRequest#body` properly. So this will block SKARA-1658.

The `body()` method in `TestIssue` always returns the latest body from the 'remote' instead of the cache. So it behaves different from GitHubPullRequest and GitLabMergeRequest.

In this patch, `TestIssue#body` will return the cached body like `GitHubPullRequest#body` and `GitLabMergeRequest#body`. Also updated related tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1670](https://bugs.openjdk.org/browse/SKARA-1670): Make body handling consistent in all Issue implementations


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1417/head:pull/1417` \
`$ git checkout pull/1417`

Update a local copy of the PR: \
`$ git checkout pull/1417` \
`$ git pull https://git.openjdk.org/skara pull/1417/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1417`

View PR using the GUI difftool: \
`$ git pr show -t 1417`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1417.diff">https://git.openjdk.org/skara/pull/1417.diff</a>

</details>
