### PR TITLE
1673: CSR bot should be able to handle a withdrawn CSR properly

### DIFF
--- a/bots/csr/src/main/java/org/openjdk/skara/bots/csr/PullRequestWorkItem.java
+++ b/bots/csr/src/main/java/org/openjdk/skara/bots/csr/PullRequestWorkItem.java
@@ -164,7 +164,7 @@ class PullRequestWorkItem implements WorkItem {
         var csr = csrOptional.get();
 
         log.info("Found CSR " + csr.id() + " for " + describe(pr));
-        if (!hasCsrIssueAndProgress(pr, csr)) {
+        if (!hasCsrIssueAndProgress(pr, csr) && !isWithdrawnCSR(csr)) {
             // If the PR body doesn't have the CSR issue or doesn't have the CSR progress,
             // this bot need to add the csr update marker so that the PR bot can update the message of the PR body.
             log.info("The PR body doesn't have the CSR issue or progress, adding the csr update marker for " + describe(pr));
@@ -252,5 +252,18 @@ class PullRequestWorkItem implements WorkItem {
     @Override
     public String workItemName() {
         return "pr";
+    }
+
+    private boolean isWithdrawnCSR(Issue csr) {
+        if (csr.isClosed()) {
+            var resolution = csr.properties().get("resolution");
+            if (resolution != null && !resolution.isNull()) {
+                var name = resolution.get("name");
+                if (name != null && !name.isNull() && name.asString().equals("Withdrawn")) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
A user reported that skara bot keeps changing the description in his MR.

After investigation, we found a bug related with CSR bot.

The user linked a CSR issue with the main issue, and after that, he found CSR unneeded and withdrawn the CSR issue.

However, our logic about handling withdrawn CSR issue has some problem.

In PullRequestWorkItem#run, the bot would add updateMarker(<!-- csr: ‘update’ -->) to the PR body regardless of the state of CSR issue.  And if a PR body contains the updateMarker, it will be updated periodically until the body contains a CSR progress. However, since our CSR issue is withdrawn, the CSR label would not be added to the pr and CSR progress would not be added to the PR body. So it will be an endless loop.

In summary, the bug would happen in such a case, the user withdraw the csr issue before the csr issue bot first time run.

In this patch, before the CSR Issue bot is trying to add the updateMarker, it will check the resolution of the CSR Issue first, if the CSR Issue is already withdrawn, then updateMarker would not be added to the PR body.  And PR bot would work normally.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1673](https://bugs.openjdk.org/browse/SKARA-1673): CSR bot should be able to handle a withdrawn CSR properly


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to [bc486797](https://git.openjdk.org/skara/pull/1418/files/bc4867976b9d53e6a6cb067f2410cf7f458bc824)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1418/head:pull/1418` \
`$ git checkout pull/1418`

Update a local copy of the PR: \
`$ git checkout pull/1418` \
`$ git pull https://git.openjdk.org/skara pull/1418/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1418`

View PR using the GUI difftool: \
`$ git pr show -t 1418`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1418.diff">https://git.openjdk.org/skara/pull/1418.diff</a>

</details>
