### PR TITLE
1674: Skara bot is not closing the bug after merge request is integrated

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
@@ -319,11 +319,7 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
                 } else {
                     log.info("The issue was already resolved");
                 }
-                var assignees = issue.assignees();
-                // Due to a bug in the backport plugin, certain users can't be assigned directly.
-                // Work around this by overwriting the assignee afterwards if the current assignee
-                // is the bot user.
-                if (assignees.isEmpty() || (assignees.size() == 1 && assignees.get(0).equals(issueProject.issueTracker().currentUser()))) {
+                if (issue.assignees().isEmpty()) {
                     if (username.isPresent()) {
                         var assignee = issueProject.issueTracker().user(username.get());
                         if (assignee.isPresent()) {


### PR DESCRIPTION
This is a tentative fix for [SKARA-1674](https://bugs.openjdk.org/browse/SKARA-1674). This fix simply reverts [SKARA-1479](https://bugs.openjdk.org/browse/SKARA-1479). It will (most likely) fix the more urgent issue of the bots not being able to close pull requests, at the expense of reintroducing the problem with the Dukebot user assignment that SKARA-1479 tried to fix.

Unfortunately Erik is out of office, so I think this is the best we can do at the moment, and then we can file a REDO bug for SKARA-1479, to re-implement it but more robustly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1674](https://bugs.openjdk.org/browse/SKARA-1674): Skara bot is not closing the bug after merge request is integrated


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1419/head:pull/1419` \
`$ git checkout pull/1419`

Update a local copy of the PR: \
`$ git checkout pull/1419` \
`$ git pull https://git.openjdk.org/skara pull/1419/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1419`

View PR using the GUI difftool: \
`$ git pr show -t 1419`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1419.diff">https://git.openjdk.org/skara/pull/1419.diff</a>

</details>
