### PR TITLE
1678: Missed calling lastBatchHandled in TestInfoBot

### DIFF
--- a/bots/testinfo/src/main/java/org/openjdk/skara/bots/testinfo/TestInfoBot.java
+++ b/bots/testinfo/src/main/java/org/openjdk/skara/bots/testinfo/TestInfoBot.java
@@ -63,11 +63,13 @@ public class TestInfoBot implements Bot {
     @Override
     public List<WorkItem> getPeriodicItems() {
         var prs = poller.updatedPullRequests();
-        return prs.stream()
+        var workItems = prs.stream()
                 .filter(pr -> pr.sourceRepository().isPresent())
                 .map(pr -> (WorkItem) new TestInfoBotWorkItem(pr,
                         delay -> poller.retryPullRequest(pr, Instant.now().plus(delay))))
                 .toList();
+        poller.lastBatchHandled();
+        return workItems;
     }
 
     @Override

--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequestPoller.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequestPoller.java
@@ -136,9 +136,9 @@ public class PullRequestPoller {
     }
 
     /**
-     * After calling getUpdatedPullRequests(), this method must be called to acknowledge
+     * After calling updatedPullRequests(), this method must be called to acknowledge
      * that all the PRs returned have been handled. If not, the previous results will be
-     * included in the next call to getUpdatedPullRequests() again.
+     * included in the next call to updatedPullRequests() again.
      * <p>
      * This method must be called before any retry/quarantine method is called for a pr
      * returned by the last updatedPullRequest call, otherwise retries may be lost.

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/IssuePoller.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/IssuePoller.java
@@ -87,9 +87,9 @@ public class IssuePoller {
     }
 
     /**
-     * After calling getUpdatedIssues(), this method must be called to acknowledge
+     * After calling updatedIssues(), this method must be called to acknowledge
      * that all the issues returned have been handled. If not, the previous results will be
-     * included in the next call to getUpdatedIssues() again.
+     * included in the next call to updatedIssues() again.
      */
     public synchronized void lastBatchHandled() {
         if (current != null) {


### PR DESCRIPTION
After spending the extra time documenting the need for calling "lastBatchHandled" on the PullRequestPoller, I still managed to forget in the TestInfoBot.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1678](https://bugs.openjdk.org/browse/SKARA-1678): Missed calling lastBatchHandled in TestInfoBot


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1420/head:pull/1420` \
`$ git checkout pull/1420`

Update a local copy of the PR: \
`$ git checkout pull/1420` \
`$ git pull https://git.openjdk.org/skara pull/1420/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1420`

View PR using the GUI difftool: \
`$ git pr show -t 1420`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1420.diff">https://git.openjdk.org/skara/pull/1420.diff</a>

</details>
