### PR TITLE
1679: Make username and prefix optional config options for slack log handler

### DIFF
--- a/bots/cli/src/main/java/org/openjdk/skara/bots/cli/BotLauncher.java
+++ b/bots/cli/src/main/java/org/openjdk/skara/bots/cli/BotLauncher.java
@@ -78,8 +78,8 @@ public class BotLauncher {
             var username = slack.get("username");
             var prefix = slack.get("prefix");
             var handler = new BotSlackHandler(URIBuilder.base(slack.get("webhook").asString()).build(),
-                    username.isNull() ? null : username.asString(),
-                    prefix.isNull() ? null : prefix.asString(),
+                    username == null ? null : username.asString(),
+                    prefix == null ? null : prefix.asString(),
                     maxRate,
                     details);
             handler.setLevel(level);

--- a/bots/cli/src/main/java/org/openjdk/skara/bots/cli/BotLauncher.java
+++ b/bots/cli/src/main/java/org/openjdk/skara/bots/cli/BotLauncher.java
@@ -64,19 +64,22 @@ public class BotLauncher {
 
         if (config.get("log").asObject().contains("slack")) {
             var maxRate = Duration.ofMinutes(10);
-            if (config.get("log").get("slack").asObject().contains("maxrate")) {
-                maxRate = Duration.parse(config.get("log").get("slack").get("maxrate").asString());
+            JSONValue slack = config.get("log").get("slack");
+            if (slack.asObject().contains("maxrate")) {
+                maxRate = Duration.parse(slack.get("maxrate").asString());
             }
-            var level = Level.parse(config.get("log").get("slack").get("level").asString());
+            var level = Level.parse(slack.get("level").asString());
             Map<String, String> details = new HashMap<>();
-            if (config.get("log").get("slack").asObject().contains("details")) {
-                details = config.get("log").get("slack").get("details").asArray().stream()
+            if (slack.asObject().contains("details")) {
+                details = slack.get("details").asArray().stream()
                                 .collect(Collectors.toMap(o -> o.get("pattern").asString(),
                                                           o -> o.get("link").asString()));
             }
-            var handler = new BotSlackHandler(URIBuilder.base(config.get("log").get("slack").get("webhook").asString()).build(),
-                    config.get("log").get("slack").get("username").asString(),
-                    config.get("log").get("slack").get("prefix").asString(),
+            var username = slack.get("username");
+            var prefix = slack.get("prefix");
+            var handler = new BotSlackHandler(URIBuilder.base(slack.get("webhook").asString()).build(),
+                    username.isNull() ? null : username.asString(),
+                    prefix.isNull() ? null : prefix.asString(),
                     maxRate,
                     details);
             handler.setLevel(level);


### PR DESCRIPTION
In [SKARA-1660](https://bugs.openjdk.org/browse/SKARA-1660) I added the new "prefix" config option for the slack log handler. This will be used instead of the username field. The problem is that neither field was made optional in the config parser, so now we have to configure both, regardless of if we want them or not. The actual handler logic treats them as optional, but the config parser throws NPE.

This patch adds null checks to avoid the NPEs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1679](https://bugs.openjdk.org/browse/SKARA-1679): Make username and prefix optional config options for slack log handler


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1421/head:pull/1421` \
`$ git checkout pull/1421`

Update a local copy of the PR: \
`$ git checkout pull/1421` \
`$ git pull https://git.openjdk.org/skara pull/1421/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1421`

View PR using the GUI difftool: \
`$ git pr show -t 1421`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1421.diff">https://git.openjdk.org/skara/pull/1421.diff</a>

</details>
