### PR TITLE
1680: NotifyBot::getPeriodicItems takes too long

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifier.java
@@ -65,9 +65,7 @@ public class PullRequestBranchNotifier implements Notifier, PullRequestListener 
 
     private void deleteBranch(PullRequest pr) {
         String branch = PreIntegrations.preIntegrateBranch(pr);
-        var branchExists = pr.repository().branches().stream()
-                         .map(HostedBranch::name)
-                         .anyMatch(name -> name.equals(branch));
+        var branchExists = pr.repository().branchHash(branch).isPresent();
         if (!branchExists) {
             log.info("Pull request pre-integration branch " + branch + " doesn't exist on remote - ignoring");
             return;

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
@@ -722,7 +722,7 @@ public class IssueNotifierTests {
 
             // Initialize history
             TestBotRunner.runPeriodicItems(notifyBot);
-            var blankHistory = repo.branchHash("history");
+            var blankHistory = repo.branchHash("history").orElseThrow();
 
             // Create an issue and commit a fix
             var authorEmailAddress = issueProject.issueTracker().currentUser().username() + "@openjdk.org";

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
@@ -154,8 +154,8 @@ class InMemoryHostedRepository implements HostedRepository {
     }
 
     @Override
-    public Hash branchHash(String ref) {
-        return null;
+    public Optional<Hash> branchHash(String ref) {
+        return Optional.empty();
     }
 
     @Override

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
@@ -87,7 +87,7 @@ public interface HostedRepository {
     Optional<WebHook> parseWebHook(JSONValue body);
     HostedRepository fork();
     long id();
-    Hash branchHash(String ref);
+    Optional<Hash> branchHash(String ref);
     List<HostedBranch> branches();
     void deleteBranch(String ref);
     List<CommitComment> commitComments(Hash hash);

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -737,7 +737,7 @@ public class GitHubPullRequest implements PullRequest {
         var files = request.get("pulls/" + json.get("number").toString() + "/files")
                            .param("per_page", "50")
                            .execute();
-        var targetHash = repository.branchHash(targetRef());
+        var targetHash = repository.branchHash(targetRef()).orElseThrow();
         return repository.toDiff(targetHash, headHash(), files);
     }
 

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -293,9 +293,14 @@ public class GitHubRepository implements HostedRepository {
     }
 
     @Override
-    public Hash branchHash(String ref) {
-        var branch = request.get("branches/" + ref).execute();
-        return new Hash(branch.get("commit").get("sha").asString());
+    public Optional<Hash> branchHash(String ref) {
+        var branch = request.get("branches/" + ref)
+                .onError(r -> r.statusCode() == 404 ? Optional.of(JSON.object().put("NOT_FOUND", true)) : Optional.empty())
+                .execute();
+        if (branch.contains("NOT_FOUND")) {
+            return Optional.empty();
+        }
+        return Optional.of(new Hash(branch.get("commit").get("sha").asString()));
     }
 
     @Override

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -814,7 +814,7 @@ public class GitLabMergeRequest implements PullRequest {
     @Override
     public Diff diff() {
         var changes = request.get("changes").execute();
-        var targetHash = repository.branchHash(targetRef());
+        var targetHash = repository.branchHash(targetRef()).orElseThrow();
         return repository.toDiff(targetHash, headHash(), changes.get("changes"));
     }
 

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -331,9 +331,14 @@ public class GitLabRepository implements HostedRepository {
     }
 
     @Override
-    public Hash branchHash(String ref) {
-        var branch = request.get("repository/branches/" + ref).execute();
-        return new Hash(branch.get("commit").get("id").asString());
+    public Optional<Hash> branchHash(String ref) {
+        var branch = request.get("repository/branches/" + ref)
+                .onError(r -> r.statusCode() == 404 ? Optional.of(JSON.object().put("NOT_FOUND", true)) : Optional.empty())
+                .execute();
+        if (branch.contains("NOT_FOUND")) {
+            return Optional.empty();
+        }
+        return Optional.of(new Hash(branch.get("commit").get("id").asString()));
     }
 
     @Override

--- a/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
@@ -230,10 +230,9 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
     }
 
     @Override
-    public Hash branchHash(String ref) {
+    public Optional<Hash> branchHash(String ref) {
         try {
-            var hash = localRepository.resolve(ref).orElseThrow();
-            return hash;
+            return localRepository.resolve(ref);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
@@ -258,7 +258,7 @@ public class TestPullRequest extends TestIssue implements PullRequest {
                 sourceHash = targetLocalRepository.fetch(sourceUri, sourceRef);
             }
             // Find the base hash of the source and target branches.
-            var baseHash = targetLocalRepository.mergeBase(sourceHash, targetRepository.branchHash(targetRef()));
+            var baseHash = targetLocalRepository.mergeBase(sourceHash, targetRepository.branchHash(targetRef()).orElseThrow());
             return targetLocalRepository.diff(baseHash, sourceHash);
         } catch (IOException e) {
             throw new UncheckedIOException(e);


### PR DESCRIPTION
When starting up the notify bot, the first round of `getPeriodicItems` was observed to make >2500 calls to github for repository branches (taking a total of 18 minutes). This call originates from `NotifyBot::isOfInterest`, which looks for pre-integration branches matching the PR. There is one call for every PR being considered, plus pagination. The JDK repository has so many open PRs at the moment that this call needs 8 pages. ~250 PRs x 8 pages is 2000 calls just for that repo. On top of this, there is also another check in `isOfInterest` that looks for a "ready comment". This check needs to parse all comments of a PR, which there can also be quite a few of, making it deceptively expensive.

The method `Bot::getPeriodicItems` is expected to a be a quick method that gets called at a set interval to spawn new `WorkItem` instances. The `BotRunner` calls all the `getPeriodicItems` serially, so if they start taking significant time, it adds up pretty quickly. This is especially true in the very first round after a bot restart, where a lot of PRs need to be evaluated. The intent of having this "quick" discarding of PRs in `getPeriodicItems` was to avoid the overhead of spawning WorkItems for PRs that could easily be identified as not needing it, but in this case, it seems to have backfired.

To fix this, I'm moving the `isOfInterest` method away from `NotifyBot` and into `PullRequestWorkItem::run` and making it the first thing to be called. By doing this, we add the overhead of always spawning a `WorkItem`, but we move the heavy processing into the WorkItems, who execute with high concurrency, away from the serially executed `getPeriodicItem`. Looking at metrics data, it's pretty clear that the initial `getPeriodicItems` isn't able to saturate the thread pool with enough WorkItems today due to all these expensive checks, so this change alone should improve latency quite significantly for the first round.

To further reduce unnecessary work, I'm rearranging `isOfInterest` a bit, and only checking branches if the labels aren't found on the PR, and the prbranch notifier is actually configured on the repo. I'm also changing how we check for the existence of the pre integration branch. Instead of fetching all branches (which may result in 8+ pages), I'm rewriting the `HostedRepository::branchHash` method to return an `Optional<Hash>` that will be empty on 404. That makes it usable for checking if a branch exists.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1680](https://bugs.openjdk.org/browse/SKARA-1680): NotifyBot::getPeriodicItems takes too long


### Reviewers
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - Committer)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1422/head:pull/1422` \
`$ git checkout pull/1422`

Update a local copy of the PR: \
`$ git checkout pull/1422` \
`$ git pull https://git.openjdk.org/skara pull/1422/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1422`

View PR using the GUI difftool: \
`$ git pr show -t 1422`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1422.diff">https://git.openjdk.org/skara/pull/1422.diff</a>

</details>
