### PR TITLE
1682: PullRequestBot::getPeriodicItems takes too long

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -51,8 +51,9 @@ class CheckWorkItem extends PullRequestWorkItem {
     private static final Pattern BACKPORT_ISSUE_TITLE_PATTERN = Pattern.compile("^Backport\\s*(?:(?<prefix>[A-Za-z][A-Za-z0-9]+)-)?(?<id>[0-9]+)\\s*$");
     private static final String ELLIPSIS = "…";
 
-    CheckWorkItem(PullRequestBot bot, String prId, Consumer<RuntimeException> errorHandler, ZonedDateTime prUpdatedAt) {
-        super(bot, prId, errorHandler, prUpdatedAt);
+    CheckWorkItem(PullRequestBot bot, String prId, Consumer<RuntimeException> errorHandler, ZonedDateTime prUpdatedAt,
+            boolean needsReadyCheck) {
+        super(bot, prId, errorHandler, prUpdatedAt, needsReadyCheck);
     }
 
     private String encodeReviewer(HostUser reviewer, CensusInstance censusInstance) {
@@ -268,7 +269,7 @@ class CheckWorkItem extends PullRequestWorkItem {
                 log.info("Skipping check of integrated PR");
                 // We still need to make sure any commands get run or are able to finish a
                 // previously interrupted run
-                return List.of(new PullRequestCommandWorkItem(bot, prId, errorHandler, prUpdatedAt));
+                return List.of(new PullRequestCommandWorkItem(bot, prId, errorHandler, prUpdatedAt, false));
             }
 
             var backportHashMatcher = BACKPORT_HASH_TITLE_PATTERN.matcher(pr.title());
@@ -332,7 +333,7 @@ class CheckWorkItem extends PullRequestWorkItem {
                     comment.add(text);
                     pr.addComment(String.join("\n", comment));
                     pr.addLabel("backport");
-                    return List.of(new CheckWorkItem(bot, prId, errorHandler, prUpdatedAt));
+                    return List.of(new CheckWorkItem(bot, prId, errorHandler, prUpdatedAt, false));
                 } else {
                     var botUser = pr.repository().forge().currentUser();
                     var text = "<!-- backport error -->\n" +
@@ -372,14 +373,14 @@ class CheckWorkItem extends PullRequestWorkItem {
                 var comment = pr.addComment(text);
                 pr.addLabel("backport");
                 logLatency("Time from PR updated to backport comment posted ", comment.createdAt(), log);
-                return List.of(new CheckWorkItem(bot, prId, errorHandler, prUpdatedAt));
+                return List.of(new CheckWorkItem(bot, prId, errorHandler, prUpdatedAt, false));
             }
 
             // If the title needs updating, we run the check again
             if (updateTitle()) {
                 var updatedPr = bot.repo().pullRequest(prId);
                 logLatency("Time from PR updated to title corrected ", updatedPr.updatedAt(), log);
-                return List.of(new CheckWorkItem(bot, prId, errorHandler, prUpdatedAt));
+                return List.of(new CheckWorkItem(bot, prId, errorHandler, prUpdatedAt, false));
             }
 
             try {
@@ -412,7 +413,7 @@ class CheckWorkItem extends PullRequestWorkItem {
             log.log(Level.INFO, "Time from labels added to /integrate posted " + latency, latency);
         }
 
-        return List.of(new PullRequestCommandWorkItem(bot, prId, errorHandler, prUpdatedAt));
+        return List.of(new PullRequestCommandWorkItem(bot, prId, errorHandler, prUpdatedAt, false));
     }
 
     /**

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
@@ -39,7 +39,7 @@ public class LabelerWorkItem extends PullRequestWorkItem {
 
     LabelerWorkItem(PullRequestBot bot, String prId, Consumer<RuntimeException> errorHandler,
             ZonedDateTime prUpdatedAt) {
-        super(bot, prId, errorHandler, prUpdatedAt);
+        super(bot, prId, errorHandler, prUpdatedAt, false);
     }
 
     @Override

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -112,7 +112,7 @@ class PullRequestBot implements Bot {
         return new PullRequestBotBuilder();
     }
 
-    private boolean isReady(PullRequest pr) {
+    boolean isReady(PullRequest pr) {
         var labels = new HashSet<>(pr.labelNames());
         for (var readyLabel : readyLabels) {
             if (!labels.contains(readyLabel)) {
@@ -152,9 +152,6 @@ class PullRequestBot implements Bot {
         ret.add(new CommitCommentsWorkItem(this, remoteRepo, excludeCommitCommentsFrom));
 
         for (var pr : pullRequests) {
-            if (!isReady(pr)) {
-                continue;
-            }
             if (pr.state() == Issue.State.OPEN) {
                 ret.add(new CheckWorkItem(this, pr.id(), e -> poller.retryPullRequest(pr), pr.updatedAt()));
             } else {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -112,36 +112,6 @@ class PullRequestBot implements Bot {
         return new PullRequestBotBuilder();
     }
 
-    boolean isReady(PullRequest pr) {
-        var labels = new HashSet<>(pr.labelNames());
-        for (var readyLabel : readyLabels) {
-            if (!labels.contains(readyLabel)) {
-                log.fine("PR is not yet ready - missing label '" + readyLabel + "'");
-                return false;
-            }
-        }
-
-        var comments = pr.comments();
-        for (var readyComment : readyComments.entrySet()) {
-            var commentFound = false;
-            for (var comment : comments) {
-                if (comment.author().username().equals(readyComment.getKey())) {
-                    var matcher = readyComment.getValue().matcher(comment.body());
-                    if (matcher.find()) {
-                        commentFound = true;
-                        break;
-                    }
-                }
-            }
-            if (!commentFound) {
-                log.fine("PR is not yet ready - missing ready comment from '" + readyComment.getKey() +
-                                 "containing '" + readyComment.getValue().pattern() + "'");
-                return false;
-            }
-        }
-        return true;
-    }
-
     void scheduleRecheckAt(PullRequest pr, Instant expiresAt) {
         log.info("Setting check metadata expiration to: " + expiresAt + " for PR #" + pr.id());
         poller.retryPullRequest(pr, expiresAt);
@@ -153,10 +123,10 @@ class PullRequestBot implements Bot {
 
         for (var pr : pullRequests) {
             if (pr.state() == Issue.State.OPEN) {
-                ret.add(new CheckWorkItem(this, pr.id(), e -> poller.retryPullRequest(pr), pr.updatedAt()));
+                ret.add(new CheckWorkItem(this, pr.id(), e -> poller.retryPullRequest(pr), pr.updatedAt(), true));
             } else {
                 // Closed PR's do not need to be checked
-                ret.add(new PullRequestCommandWorkItem(this, pr.id(), e -> poller.retryPullRequest(pr), pr.updatedAt()));
+                ret.add(new PullRequestCommandWorkItem(this, pr.id(), e -> poller.retryPullRequest(pr), pr.updatedAt(), true));
             }
         }
 
@@ -209,12 +179,20 @@ class PullRequestBot implements Bot {
         return blockingCheckLabels;
     }
 
+    public Set<String> readyLabels() {
+        return readyLabels;
+    }
+
     Set<String> twoReviewersLabels() {
         return twoReviewersLabels;
     }
 
     Set<String> twentyFourHoursLabels() {
         return twentyFourHoursLabels;
+    }
+
+    public Map<String, Pattern> readyComments() {
+        return readyComments;
     }
 
     IssueProject issueProject() {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
@@ -46,8 +46,8 @@ public class PullRequestCommandWorkItem extends PullRequestWorkItem {
     public static final String VALID_BOT_COMMAND_MARKER = "<!-- Valid self-command -->";
 
     PullRequestCommandWorkItem(PullRequestBot bot, String prId, Consumer<RuntimeException> errorHandler,
-            ZonedDateTime prUpdatedAt) {
-        super(bot, prId, errorHandler, prUpdatedAt);
+            ZonedDateTime prUpdatedAt, boolean needsReadyCheck) {
+        super(bot, prId, errorHandler, prUpdatedAt, needsReadyCheck);
     }
 
     private static class InvalidBodyCommandHandler implements CommandHandler {
@@ -212,7 +212,7 @@ public class PullRequestCommandWorkItem extends PullRequestWorkItem {
         if (!pr.labelNames().contains("integrated") || pr.findIntegratedCommitHash().isEmpty()) {
             processCommand(pr, census, scratchPath.resolve("pr").resolve("command"), command, comments, false);
             // Run another check to reflect potential changes from commands
-            return List.of(new CheckWorkItem(bot, prId, errorHandler, prUpdatedAt));
+            return List.of(new CheckWorkItem(bot, prId, errorHandler, prUpdatedAt, false));
         } else {
             processCommand(pr, census, scratchPath.resolve("pr").resolve("command"), command, comments, true);
             return List.of();

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestWorkItem.java
@@ -116,8 +116,7 @@ abstract class PullRequestWorkItem implements WorkItem {
     @Override
     public final Collection<WorkItem> run(Path scratchPath) {
         pr = bot.repo().pullRequest(prId);
-        // Check if PR is ready to be evaluated at all. This check is too expensive to run
-        // in getPeriodicItems, so call the bot from here.
+        // Check if PR is ready to be evaluated at all.
         if (!isReady()) {
             return List.of();
         }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestWorkItem.java
@@ -26,6 +26,7 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.Collection;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.openjdk.skara.bot.WorkItem;
@@ -78,6 +79,11 @@ abstract class PullRequestWorkItem implements WorkItem {
     @Override
     public final Collection<WorkItem> run(Path scratchPath) {
         pr = bot.repo().pullRequest(prId);
+        // Check if PR is ready to be evaluated at all. This check is too expensive to run
+        // in getPeriodicItems, so call the bot from here.
+        if (!bot.isReady(pr)) {
+            return List.of();
+        }
         return prRun(scratchPath);
     }
 


### PR DESCRIPTION
Similar to the NotifyBot in [SKARA-1680](https://bugs.openjdk.org/browse/SKARA-1680), the PullRequestBot is also suffering from spending a very long time in the very first round of getPeriodicItems after a bot restart. The last time we redeployed this bot, it took ~40 minutes. This was long enough to trigger several users to ask if Skara was having issues.

The cause is similar. There is an `isReady` call for each PR, which checks for comments. The comment checking here is even worse than for the NotifyBot because every PR is checked for comments, not just those that match the "rfr" or "integrated" labels.

My proposed solution is similar. We need to move this expensive evaluation to the relevant WorkItems where they can run concurrently instead of serially in `getPeriodicItems`. I chose to make the call from the abstract superclass `PullRequestWorkItem`. This does add the check unnecessarily to the `LabelerWorkItem`, but that one is running so rarely that I don't think it matters performance wise. For correctness, I don't think it hurts checking an extra time.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1682](https://bugs.openjdk.org/browse/SKARA-1682): PullRequestBot::getPeriodicItems takes too long


### Reviewers
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - Committer) ⚠️ Review applies to [1ead6076](https://git.openjdk.org/skara/pull/1423/files/1ead6076eb1f747904b759cecc9b28ec813432ec)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**) ⚠️ Review applies to [43272b56](https://git.openjdk.org/skara/pull/1423/files/43272b5692f728a9b59a5089be79c799e684c661)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1423/head:pull/1423` \
`$ git checkout pull/1423`

Update a local copy of the PR: \
`$ git checkout pull/1423` \
`$ git pull https://git.openjdk.org/skara pull/1423/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1423`

View PR using the GUI difftool: \
`$ git pr show -t 1423`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1423.diff">https://git.openjdk.org/skara/pull/1423.diff</a>

</details>
