### PR TITLE
1686: Warning message for backport mistakes is not clear

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -642,9 +642,9 @@ class CheckRun {
                                         (issueType == null || !List.of("CSR", "JEP").contains(issueType.asString()))) {
                                     if (iss.get().isFixed()) {
                                         progressBody.append(" ⚠️ Issue is already resolved. " +
-                                                "Please consider using a Backport-style pull request. " +
-                                                "You can set the PR title to `Backport <hash>` with the hash of the original fix or " +
-                                                "refer to [Backports](https://wiki.openjdk.org/display/SKARA/Backports)");
+                                                "Consider making this a \"backport pull request\" by setting " +
+                                                "the PR title to `Backport <hash>` with the hash of the original commit. " +
+                                                "See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).");
                                     } else {
                                         progressBody.append(" ⚠️ Issue is not open.");
                                     }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -641,7 +641,7 @@ class CheckRun {
                                 if (!pr.labelNames().contains("backport") &&
                                         (issueType == null || !List.of("CSR", "JEP").contains(issueType.asString()))) {
                                     if (iss.get().isFixed()) {
-                                        progressBody.append("⚠️ " + iss.get().id() + " is already resolved. " +
+                                        progressBody.append(" ⚠️ Issue is already resolved. " +
                                                 "Please consider using a Backport-style pull request. " +
                                                 "You can set the PR title to `Backport <hash>` with the hash of the original fix or " +
                                                 "refer to [Backports](https://wiki.openjdk.org/display/SKARA/Backports)");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -637,10 +637,17 @@ class CheckRun {
                                 progressBody.append(" ⚠️ Title mismatch between PR and JBS.");
                                 setExpiration(Duration.ofMinutes(10));
                             }
-                            if (iss.get().state() != org.openjdk.skara.issuetracker.Issue.State.OPEN) {
+                            if (!iss.get().isOpen()) {
                                 if (!pr.labelNames().contains("backport") &&
                                         (issueType == null || !List.of("CSR", "JEP").contains(issueType.asString()))) {
-                                    progressBody.append(" ⚠️ Issue is not open.");
+                                    if (iss.get().isFixed()) {
+                                        progressBody.append("⚠️ " + iss.get().id() + " is already resolved. " +
+                                                "Please consider using a Backport-style pull request. " +
+                                                "You can set the PR title to `Backport <hash>` with the hash of the original fix or " +
+                                                "refer to [Backports](https://wiki.openjdk.org/display/SKARA/Backports)");
+                                    } else {
+                                        progressBody.append(" ⚠️ Issue is not open.");
+                                    }
                                 }
                             }
                         } else {

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IssueTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IssueTests.java
@@ -454,7 +454,7 @@ class IssueTests {
             assertTrue(pr.store().body().contains(issue1.id()));
             assertTrue(pr.store().body().contains("First"));
             assertTrue(pr.store().body().contains("## Issue\n"));
-            assertTrue(pr.store().body().contains("Please consider using a Backport-style pull request."));
+            assertTrue(pr.store().body().contains("Consider making this a \"backport pull request\" by setting"));
         }
     }
 


### PR DESCRIPTION
A user reported that he found many PR with "issue is not open" warning. After discussing in slack, we found that this happens because backport-style PR wasn't used. 

To improve the experience of user, we need to give some useful information to the user instead of just telling them "Issue is not open".

In this patch, when a user is trying to create a PR related with a resolved issue, we will assume that the user wants to create a backport PR but in the wrong way. So in this case, we will tell the user how to create a correct backport pr. In other case, for example, the issue is closed with "Not an Issue", we will still just tell the user "Issue is not open".

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1686](https://bugs.openjdk.org/browse/SKARA-1686): Warning message for backport mistakes is not clear


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1425/head:pull/1425` \
`$ git checkout pull/1425`

Update a local copy of the PR: \
`$ git checkout pull/1425` \
`$ git pull https://git.openjdk.org/skara pull/1425/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1425`

View PR using the GUI difftool: \
`$ git pr show -t 1425`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1425.diff">https://git.openjdk.org/skara/pull/1425.diff</a>

</details>
