### PR TITLE
1683: The force push notifier needs an overhaul

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifier.java
@@ -32,12 +32,6 @@ import java.nio.file.Path;
 import java.util.logging.Logger;
 
 public class PullRequestBranchNotifier implements Notifier, PullRequestListener {
-    protected static final String FORCE_PUSH_MARKER = "<!-- force-push suggestion -->";
-    protected static final String FORCE_PUSH_SUGGESTION= """
-            Please do not rebase or force-push to an active PR as it invalidates existing review comments. \
-            All changes will be squashed into a single commit automatically when integrating. \
-            See [OpenJDK Developers’ Guide](https://openjdk.org/guide/#working-with-pull-requests) for more information.
-            """;
     private final Path seedFolder;
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots.notify");
 
@@ -137,19 +131,5 @@ public class PullRequestBranchNotifier implements Notifier, PullRequestListener 
         if (pr.state() == Issue.State.OPEN) {
             pushBranch(pr);
         }
-        var lastForcePushTime = pr.lastForcePushTime();
-        if (lastForcePushTime.isPresent()) {
-            var lastForcePushSuggestion = pr.comments().stream()
-                    .filter(comment -> comment.body().contains(FORCE_PUSH_MARKER))
-                    .reduce((a, b) -> b);
-            if (lastForcePushSuggestion.isEmpty() || lastForcePushSuggestion.get().createdAt().isBefore(lastForcePushTime.get())) {
-                log.info("Found force-push for " + describe(pr) + ", adding force-push suggestion");
-                pr.addComment("@" + pr.author().username() + " " + FORCE_PUSH_SUGGESTION + FORCE_PUSH_MARKER);
-            }
-        }
-    }
-
-    private String describe(PullRequest pr) {
-        return pr.repository().name() + "#" + pr.id();
     }
 }

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifierTests.java
@@ -34,8 +34,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.openjdk.skara.bots.notify.prbranch.PullRequestBranchNotifier.FORCE_PUSH_MARKER;
-import static org.openjdk.skara.bots.notify.prbranch.PullRequestBranchNotifier.FORCE_PUSH_SUGGESTION;
 
 public class PullRequestBranchNotifierTests {
     private TestBotFactory testBotBuilder(HostedRepository hostedRepository, Path storagePath) {
@@ -310,93 +308,6 @@ public class PullRequestBranchNotifierTests {
                     + "pull request depends on has now been integrated"), lastComment.body());
             assertTrue(lastComment.body().contains("git checkout another-followup"), lastComment.body());
             assertTrue(lastComment.body().contains("git commit -m \"Merge master\""), lastComment.body());
-        }
-    }
-
-    @Test
-    void testForcePush(TestInfo testInfo) throws IOException {
-        try (var credentials = new HostCredentials(testInfo);
-             var tempFolder = new TemporaryDirectory()) {
-            var repo = credentials.getHostedRepository();
-            var repoFolder = tempFolder.path().resolve("repo");
-            var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
-            var storageFolder = tempFolder.path().resolve("storage");
-            var notifyBot = testBotBuilder(repo, storageFolder).create("notify", JSON.object());
-
-            // Create a PR
-            var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line");
-            localRepo.push(editHash, repo.url(), "source", true);
-            var pr = credentials.createPullRequest(repo, "master", "source", "This is a PR", false);
-            pr.addLabel("rfr");
-            pr.addComment("initial");
-            TestBotRunner.runPeriodicItems(notifyBot);
-
-            // The PR shouldn't have the force-push suggestion comment
-            assertEquals(1, pr.comments().size());
-            var lastComment = pr.comments().get(pr.comments().size() - 1);
-            assertTrue(lastComment.body().contains("initial"));
-            assertFalse(lastComment.body().contains(FORCE_PUSH_MARKER));
-            assertFalse(lastComment.body().contains(FORCE_PUSH_SUGGESTION));
-
-            // Normally push.
-            var updatedHash = CheckableRepository.appendAndCommit(localRepo, "Normally push");
-            localRepo.push(updatedHash, repo.url(), "source", false);
-            pr.addComment("Normally push");
-            TestBotRunner.runPeriodicItems(notifyBot);
-
-            // The PR shouldn't have the force-push suggestion comment.
-            assertEquals(2, pr.comments().size());
-            lastComment = pr.comments().get(pr.comments().size() - 1);
-            assertTrue(lastComment.body().contains("Normally push"));
-            assertFalse(lastComment.body().contains(FORCE_PUSH_MARKER));
-            assertFalse(lastComment.body().contains(FORCE_PUSH_SUGGESTION));
-
-            // Simulate force-push.
-            updatedHash = CheckableRepository.appendAndCommit(localRepo, "test force-push");
-            localRepo.checkout(editHash);
-            localRepo.squash(updatedHash);
-            var forcePushHash = localRepo.commit("test force-push", "duke", "duke@openjdk.org");
-            localRepo.push(forcePushHash, repo.url(), "source", true);
-            pr.setLastForcePushTime(ZonedDateTime.now());
-            pr.addComment("Force-push");
-            TestBotRunner.runPeriodicItems(notifyBot);
-
-            // The last comment of the PR should be the force-push suggestion comment.
-            assertEquals(4, pr.comments().size());
-            lastComment = pr.comments().get(pr.comments().size() - 1);
-            assertFalse(lastComment.body().contains("Force-push"));
-            assertTrue(lastComment.body().contains(FORCE_PUSH_MARKER));
-            assertTrue(lastComment.body().contains(FORCE_PUSH_SUGGESTION));
-
-            // Normally push again.
-            updatedHash = CheckableRepository.appendAndCommit(localRepo, "Normally push");
-            localRepo.push(updatedHash, repo.url(), "source", false);
-            pr.addComment("Normally push again");
-            TestBotRunner.runPeriodicItems(notifyBot);
-
-            // The last comment of the PR shouldn't be the force-push suggestion comment.
-            assertEquals(5, pr.comments().size());
-            lastComment = pr.comments().get(pr.comments().size() - 1);
-            assertTrue(lastComment.body().contains("Normally push again"));
-            assertFalse(lastComment.body().contains(FORCE_PUSH_MARKER));
-            assertFalse(lastComment.body().contains(FORCE_PUSH_SUGGESTION));
-
-            // Simulate force-push again.
-            updatedHash = CheckableRepository.appendAndCommit(localRepo, "test force-push again");
-            localRepo.checkout(editHash);
-            localRepo.squash(updatedHash);
-            forcePushHash = localRepo.commit("test force-push again", "duke", "duke@openjdk.org");
-            localRepo.push(forcePushHash, repo.url(), "source", true);
-            pr.setLastForcePushTime(ZonedDateTime.now());
-            pr.addComment("Force-push again");
-            TestBotRunner.runPeriodicItems(notifyBot);
-
-            // The last comment of the PR should be the force-push suggestion comment.
-            assertEquals(7, pr.comments().size());
-            lastComment = pr.comments().get(pr.comments().size() - 1);
-            assertFalse(lastComment.body().contains("Force-push again"));
-            assertTrue(lastComment.body().contains(FORCE_PUSH_MARKER));
-            assertTrue(lastComment.body().contains(FORCE_PUSH_SUGGESTION));
         }
     }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -389,11 +389,11 @@ class CheckWorkItem extends PullRequestWorkItem {
                 return List.of(new CheckWorkItem(bot, prId, errorHandler, prUpdatedAt));
             }
 
-            // Check Force push
+            // Check force push
             if (!pr.isDraft()) {
                 var lastForcePushTime = pr.lastForcePushTime();
                 if (lastForcePushTime.isPresent()) {
-                    var lastForcePushSuggestion = pr.comments().stream()
+                    var lastForcePushSuggestion = comments.stream()
                             .filter(comment -> comment.body().contains(FORCE_PUSH_MARKER))
                             .reduce((a, b) -> b);
                     if (lastForcePushSuggestion.isEmpty() || lastForcePushSuggestion.get().createdAt().isBefore(lastForcePushTime.get())) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -51,6 +51,13 @@ class CheckWorkItem extends PullRequestWorkItem {
     private static final Pattern BACKPORT_ISSUE_TITLE_PATTERN = Pattern.compile("^Backport\\s*(?:(?<prefix>[A-Za-z][A-Za-z0-9]+)-)?(?<id>[0-9]+)\\s*$");
     private static final String ELLIPSIS = "…";
 
+    protected static final String FORCE_PUSH_MARKER = "<!-- force-push suggestion -->";
+    protected static final String FORCE_PUSH_SUGGESTION= """
+            Please do not rebase or force-push to an active PR as it invalidates existing review comments. \
+            All changes will be squashed into a single commit automatically when integrating. \
+            See [OpenJDK Developers’ Guide](https://openjdk.org/guide/#working-with-pull-requests) for more information.
+            """;
+
     CheckWorkItem(PullRequestBot bot, String prId, Consumer<RuntimeException> errorHandler, ZonedDateTime prUpdatedAt) {
         super(bot, prId, errorHandler, prUpdatedAt);
     }
@@ -380,6 +387,20 @@ class CheckWorkItem extends PullRequestWorkItem {
                 var updatedPr = bot.repo().pullRequest(prId);
                 logLatency("Time from PR updated to title corrected ", updatedPr.updatedAt(), log);
                 return List.of(new CheckWorkItem(bot, prId, errorHandler, prUpdatedAt));
+            }
+
+            // Check Force push
+            if (!pr.isDraft()) {
+                var lastForcePushTime = pr.lastForcePushTime();
+                if (lastForcePushTime.isPresent()) {
+                    var lastForcePushSuggestion = pr.comments().stream()
+                            .filter(comment -> comment.body().contains(FORCE_PUSH_MARKER))
+                            .reduce((a, b) -> b);
+                    if (lastForcePushSuggestion.isEmpty() || lastForcePushSuggestion.get().createdAt().isBefore(lastForcePushTime.get())) {
+                        log.info("Found force-push for " + pr.repository().name() + "#" + pr.id() + ", adding force-push suggestion");
+                        pr.addComment("@" + pr.author().username() + " " + FORCE_PUSH_SUGGESTION + FORCE_PUSH_MARKER);
+                    }
+                }
             }
 
             try {

--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
@@ -182,8 +182,8 @@ public interface PullRequest extends Issue {
 
     /**
      * Return the last time something was force pushed while not in draft state.
-     * If there is no force-push in pull request
-     * or the restful api doesn't support force-push, return empty.
+     * If there is no force-push in pull request or the restful api doesn't
+     * support force-push, return empty.
      */
     Optional<ZonedDateTime> lastForcePushTime();
 

--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
@@ -182,7 +182,8 @@ public interface PullRequest extends Issue {
 
     /**
      * Return the last time something was force pushed while not in draft state.
-     * If there is no force-push in pull request or the restful api doesn't support force-push, return empty.
+     * If there is no force-push in pull request
+     * or the restful api doesn't support force-push, return empty.
      */
     Optional<ZonedDateTime> lastForcePushTime();
 

--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
@@ -181,8 +181,8 @@ public interface PullRequest extends Issue {
     }
 
     /**
-     * Get the last force-push time. If there is no force-push in pull request
-     * or the restful api doesn't support force-push, return empty.
+     * Return the last time something was force pushed while not in draft state.
+     * If there is no force-push in pull request or the restful api doesn't support force-push, return empty.
      */
     Optional<ZonedDateTime> lastForcePushTime();
 

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -765,8 +765,6 @@ public class GitHubPullRequest implements PullRequest {
 
     @Override
     public Optional<ZonedDateTime> lastForcePushTime() {
-
-
         return request.get("issues/" + json.get("number").toString() + "/timeline")
                       .execute()
                       .stream()

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -799,17 +799,13 @@ public class GitHubPullRequest implements PullRequest {
     }
 
     private ZonedDateTime lastMarkedAsReadyTime(JSONValue timelineJSON) {
-        ZonedDateTime readyTime = createdAt();
-        Optional<ZonedDateTime> latestTime = timelineJSON
+        return timelineJSON
                 .stream()
                 .map(JSONValue::asObject)
                 .filter(obj -> obj.contains("event"))
                 .filter(obj -> obj.get("event").asString().equals("ready_for_review"))
                 .reduce((a, b) -> b)
-                .map(obj -> ZonedDateTime.parse(obj.get("created_at").asString()));
-        if (latestTime.isPresent()) {
-            readyTime = latestTime.get();
-        }
-        return readyTime;
+                .map(obj -> ZonedDateTime.parse(obj.get("created_at").asString()))
+                .orElseGet(this::createdAt);
     }
 }

--- a/forge/src/test/java/org/openjdk/skara/forge/github/GitHubRestApiTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/github/GitHubRestApiTests.java
@@ -36,6 +36,7 @@ import org.openjdk.skara.vcs.Hash;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -147,5 +148,16 @@ public class GitHubRestApiTests {
         Comment updateComment = testPr.updateComment(comment.id(), "2".repeat(2_000_000));
         assertTrue(updateComment.body().contains("..."));
         assertTrue(updateComment.body().contains("2"));
+    }
+
+    @Test
+    void testForcePushTimeWhenPRInDraft() {
+        var testRepoOpt = githubHost.repository("openjdk/playground");
+        assumeTrue(testRepoOpt.isPresent());
+        var testRepo = testRepoOpt.get();
+        var testPr = (GitHubPullRequest) testRepo.pullRequest("107");
+
+        // Won't get the force push time when if the force push is during draft period
+        assertEquals(Optional.empty(), testPr.lastForcePushTime());
     }
 }

--- a/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
@@ -272,7 +272,10 @@ public class TestPullRequest extends TestIssue implements PullRequest {
 
     @Override
     public Optional<ZonedDateTime> lastForcePushTime() {
-        return Optional.ofNullable(store().lastForcePushTime());
+        if(store().lastForcePushTime()!= null && store().lastForcePushTime().isAfter(store().lastMarkedAsReadyTime())) {
+            return Optional.ofNullable(store().lastForcePushTime());
+        }
+        return Optional.empty();
     }
 
     public void setLastForcePushTime(ZonedDateTime lastForcePushTime) {

--- a/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
@@ -272,7 +272,7 @@ public class TestPullRequest extends TestIssue implements PullRequest {
 
     @Override
     public Optional<ZonedDateTime> lastForcePushTime() {
-        if(store().lastForcePushTime()!= null && store().lastForcePushTime().isAfter(store().lastMarkedAsReadyTime())) {
+        if (store().lastForcePushTime() != null && store().lastForcePushTime().isAfter(store().lastMarkedAsReadyTime())) {
             return Optional.ofNullable(store().lastForcePushTime());
         }
         return Optional.empty();

--- a/test/src/main/java/org/openjdk/skara/test/TestPullRequestStore.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestPullRequestStore.java
@@ -47,6 +47,8 @@ public class TestPullRequestStore extends TestIssueStore {
     private Hash headHash;
     private final List<ReferenceChange> targetReferenceChanges = new ArrayList<>();
 
+    private ZonedDateTime lastMarkedAsReadyTime;
+
     public TestPullRequestStore(String id, HostUser author, String title, List<String> body,
             TestHostedRepository sourceRepository, String targetRef, String sourceRef, boolean draft) {
         super(id, null, author, title, body, null);
@@ -54,6 +56,9 @@ public class TestPullRequestStore extends TestIssueStore {
         this.targetRef = targetRef;
         this.sourceRef = sourceRef;
         this.draft = draft;
+        if(!draft){
+            lastMarkedAsReadyTime = ZonedDateTime.now();
+        }
     }
 
     public TestHostedRepository sourceRepository() {
@@ -124,9 +129,16 @@ public class TestPullRequestStore extends TestIssueStore {
 
     public void setDraft(boolean draft) {
         this.draft = draft;
+        if(!draft){
+            lastMarkedAsReadyTime = ZonedDateTime.now();
+        }
     }
 
     public void setLastForcePushTime(ZonedDateTime lastForcePushTime) {
         this.lastForcePushTime = lastForcePushTime;
+    }
+
+    public ZonedDateTime lastMarkedAsReadyTime() {
+        return lastMarkedAsReadyTime;
     }
 }

--- a/test/src/main/java/org/openjdk/skara/test/TestPullRequestStore.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestPullRequestStore.java
@@ -56,7 +56,7 @@ public class TestPullRequestStore extends TestIssueStore {
         this.targetRef = targetRef;
         this.sourceRef = sourceRef;
         this.draft = draft;
-        if(!draft){
+        if (!draft) {
             lastMarkedAsReadyTime = ZonedDateTime.now();
         }
     }
@@ -129,7 +129,7 @@ public class TestPullRequestStore extends TestIssueStore {
 
     public void setDraft(boolean draft) {
         this.draft = draft;
-        if(!draft){
+        if (!draft) {
             lastMarkedAsReadyTime = ZonedDateTime.now();
         }
     }


### PR DESCRIPTION
A user reported a bug related with the force-push notification. Erik investigated it and found the implementation of this notification should not be in the `PullRequestBranchNotifier`. Also, users preferred to not get force-push notification if the force-push happens when the pr is in draft state.

In this patch, the implementation of checking force-push and notifying user are moved to `CheckWorkItem`. Also, force-pushing or rebasing a draft pr will not warn user any more.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1683](https://bugs.openjdk.org/browse/SKARA-1683): The force push notifier needs an overhaul


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1426/head:pull/1426` \
`$ git checkout pull/1426`

Update a local copy of the PR: \
`$ git checkout pull/1426` \
`$ git pull https://git.openjdk.org/skara pull/1426/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1426`

View PR using the GUI difftool: \
`$ git pr show -t 1426`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1426.diff">https://git.openjdk.org/skara/pull/1426.diff</a>

</details>
