### PR TITLE
SKARA-1690

### DIFF
--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/JCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/JCheck.java
@@ -256,7 +256,8 @@ public class JCheck {
     public static Issues check(ReadOnlyRepository repository,
                                Census census,
                                CommitMessageParser parser,
-                               String revisionRange) throws IOException {
+                               String revisionRange,
+                               JCheckConfiguration overridingConfig) throws IOException {
         if (repository.isEmpty()) {
             return new Issues(new ArrayList<Issue>().iterator(), null);
         }
@@ -270,7 +271,7 @@ public class JCheck {
         var branchRegex = conf.isPresent() ? conf.get().repository().branches() : ".*";
         var tagRegex = conf.isPresent() ? conf.get().repository().tags() : ".*";
 
-        return check(repository, parser, branchRegex, tagRegex, revisionRange, List.of(), null, census);
+        return check(repository, parser, branchRegex, tagRegex, revisionRange, List.of(), overridingConfig, census);
     }
 
     public static Set<Check> checksFor(ReadOnlyRepository repository, Hash hash) throws IOException {

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/JCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/JCheckTests.java
@@ -296,7 +296,7 @@ class JCheckTests {
             var census = Census.parse(censusPath);
 
             var visitor = new TestVisitor();
-            try (var issues = JCheck.check(repo, census, CommitMessageParsers.v1, first.hex() + ".." + second.hex())) {
+            try (var issues = JCheck.check(repo, census, CommitMessageParsers.v1, first.hex() + ".." + second.hex(), null)) {
                 for (var issue : issues) {
                     issue.accept(visitor);
                 }
@@ -329,7 +329,7 @@ class JCheckTests {
             // Check the last commit without reviewers, should pass since .jcheck/conf was updated
             var range = initialCommit.hash().hex() + ".." + secondCommit.hex();
             var visitor = new TestVisitor();
-            try (var issues = JCheck.check(repo, census, CommitMessageParsers.v1, range)) {
+            try (var issues = JCheck.check(repo, census, CommitMessageParsers.v1, range, null)) {
                 for (var issue : issues) {
                     issue.accept(visitor);
                 }

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/TestRepository.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/TestRepository.java
@@ -347,4 +347,9 @@ class TestRepository implements ReadOnlyRepository {
     public Hash initialHash() {
         return null;
     }
+
+    @Override
+    public Optional<Hash> wholeHash(String hash) {
+        return Optional.empty();
+    }
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
@@ -174,4 +174,6 @@ public interface ReadOnlyRepository {
      * Returns the special hash that references the virtual commit before the first real commit in a repository.
      */
     Hash initialHash();
+
+    Optional<Hash> wholeHash(String hash);
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -1659,4 +1659,15 @@ public class GitRepository implements Repository {
     public Hash initialHash() {
         return EMPTY_TREE;
     }
+
+    @Override
+    public Optional<Hash> wholeHash(String hash) {
+        try (var p = capture("git", "rev-parse", hash)) {
+            var res = p.await();
+            if (res.status() == 0 && res.stdout().size() == 1) {
+                return Optional.of(new Hash(res.stdout().get(0)));
+            }
+            return Optional.empty();
+        }
+    }
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -1508,4 +1508,10 @@ public class HgRepository implements Repository {
     public Hash initialHash() {
         return NULL_REVISION;
     }
+
+    @Override
+    public Optional<Hash> wholeHash(String hash) {
+        //TODO: implement it later or not
+        return Optional.empty();
+    }
 }


### PR DESCRIPTION
Currently, the command `git skara jcheck` can only use the `.jcheck/conf` configuration file in the current checking commit.
However, sometimes users want to run jcheck with different configurations to validate their commits. Therefore, we need to upgrade `git skara jcheck`.

In this patch, `git skara jcheck` would be able to support following usecases.

1. Run jcheck on a commit or a series of commits using the .jcheck/conf in the same commit. (what we do by default today)
`git skara jcheck`

2. Run jcheck on a commit or a series of commits using the .jcheck/conf in a different specified commit. 
`git skara jcheck --specified-conf-commit <COMMIT HASH>`

3. Run jcheck on a commit or a series of commits using the .jcheck/conf in my workspace. 
`git skara jcheck --workspace-conf`

4. Run jcheck on a commit or a series of commits using a config file that I point to directly, that may have any name. 
`git skara jcheck --workspace-conf --conf-file <FILENAME>`

5. Run jcheck on the diff in my current workspace, either --staged or not using the .jcheck/conf in my workspace.
`git skara jcheck --workspace-diff`