### PR TITLE
1701: Make use of Etag optional for MailingListArchiveReaderBot

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotFactory.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotFactory.java
@@ -97,7 +97,11 @@ public class MailingListBridgeBotFactory implements BotFactory {
                 .collect(Collectors.toMap(obj -> obj.get("user").asString(),
                                           obj -> Pattern.compile(obj.get("pattern").asString())));
         var cooldown = specific.contains("cooldown") ? Duration.parse(specific.get("cooldown").asString()) : Duration.ofMinutes(1);
-        var mailmanServer = MailingListServerFactory.createMailmanServer(listArchive, listSmtp, Duration.ZERO);
+        boolean useEtag = false;
+        if (specific.get("server").contains("etag")) {
+            useEtag = specific.get("server").get("etag").asBoolean();
+        }
+        var mailmanServer = MailingListServerFactory.createMailmanServer(listArchive, listSmtp, Duration.ZERO, useEtag);
 
         var mailingListReaderMap = new HashMap<List<String>, MailingListReader>();
 

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotFactoryTest.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotFactoryTest.java
@@ -46,7 +46,8 @@ class MailingListBridgeBotFactoryTest {
                       "server": {
                         "archive": "https://mail.test.org/test/",
                         "smtp": "0.0.0.0",
-                        "interval": "PT5S"
+                        "interval": "PT5S",
+                        "etag": true,
                       },
                       "webrevs": {
                         "repository": {

--- a/build.gradle
+++ b/build.gradle
@@ -80,7 +80,7 @@ configure(subprojects.findAll() { it.name != 'bots' }) {
             exceptionFormat "full"
         }
 
-        reports.html.enabled = false
+        reports.html.required = false
     }
 
     tasks.withType(Test).configureEach {
@@ -92,8 +92,8 @@ configure(subprojects.findAll() { it.name != 'bots' }) {
     }
 
     tasks.withType(Test).configureEach {
-        reports.html.enabled = false
-        reports.junitXml.enabled = false
+        reports.html.required = false
+        reports.junitXml.required = false
     }
 
     tasks.withType(JavaCompile).configureEach {

--- a/mailinglist/src/main/java/org/openjdk/skara/mailinglist/MailingListServerFactory.java
+++ b/mailinglist/src/main/java/org/openjdk/skara/mailinglist/MailingListServerFactory.java
@@ -31,8 +31,13 @@ import java.time.Duration;
 
 public class MailingListServerFactory {
     public static MailingListServer createMailmanServer(URI archive, String smtp, Duration sendInterval) {
-        return new MailmanServer(archive, smtp, sendInterval);
+        return new MailmanServer(archive, smtp, sendInterval, false);
     }
+
+    public static MailingListServer createMailmanServer(URI archive, String smtp, Duration sendInterval, boolean useEtag) {
+        return new MailmanServer(archive, smtp, sendInterval, useEtag);
+    }
+
     public static MailingListServer createMboxFileServer(Path file) {
         return new MboxFileListServer(file);
     }

--- a/mailinglist/src/main/java/org/openjdk/skara/mailinglist/mailman/MailmanListReader.java
+++ b/mailinglist/src/main/java/org/openjdk/skara/mailinglist/mailman/MailmanListReader.java
@@ -37,6 +37,7 @@ import org.openjdk.skara.metrics.Counter;
 
 public class MailmanListReader implements MailingListReader {
     private final MailmanServer server;
+    private final boolean useEtag;
     private final List<String> names = new ArrayList<>();
     private final Logger log = Logger.getLogger("org.openjdk.skara.mailinglist");
     private final ConcurrentMap<URI, HttpResponse<String>> pageCache = new ConcurrentHashMap<>();
@@ -48,8 +49,9 @@ public class MailmanListReader implements MailingListReader {
     private static final Counter.WithOneLabel POLLING_COUNTER =
             Counter.name("skara_mailman_polling").labels("code").register();
 
-    MailmanListReader(MailmanServer server, Collection<String> names) {
+    MailmanListReader(MailmanServer server, Collection<String> names, boolean useEtag) {
         this.server = server;
+        this.useEtag = useEtag;
         for (var name : names) {
             if (name.contains("@")) {
                 this.names.add(EmailAddress.parse(name).localPart());
@@ -87,7 +89,7 @@ public class MailmanListReader implements MailingListReader {
                                         .GET();
 
         var cached = pageCache.get(uri);
-        if (cached != null) {
+        if (useEtag && cached != null) {
             var etag = cached.headers().firstValue("ETag");
             etag.ifPresent(s -> requestBuilder.header("If-None-Match", s));
         }

--- a/mailinglist/src/main/java/org/openjdk/skara/mailinglist/mailman/MailmanServer.java
+++ b/mailinglist/src/main/java/org/openjdk/skara/mailinglist/mailman/MailmanServer.java
@@ -36,12 +36,14 @@ public class MailmanServer implements MailingListServer {
     private final URI archive;
     private final String smtpServer;
     private final Duration sendInterval;
+    private final boolean useEtag;
     private volatile Instant lastSend;
 
-    public MailmanServer(URI archive, String smtpServer, Duration sendInterval) {
+    public MailmanServer(URI archive, String smtpServer, Duration sendInterval, boolean useEtag) {
         this.archive = archive;
         this.smtpServer = smtpServer;
         this.sendInterval = sendInterval;
+        this.useEtag = useEtag;
         lastSend = Instant.EPOCH;
     }
 
@@ -72,6 +74,6 @@ public class MailmanServer implements MailingListServer {
 
     @Override
     public MailingListReader getListReader(String... listNames) {
-        return new MailmanListReader(this, Arrays.asList(listNames));
+        return new MailmanListReader(this, Arrays.asList(listNames), useEtag);
     }
 }

--- a/mailinglist/src/test/java/org/openjdk/skara/mailinglist/MailmanTests.java
+++ b/mailinglist/src/test/java/org/openjdk/skara/mailinglist/MailmanTests.java
@@ -109,7 +109,7 @@ class MailmanTests {
         try (var testServer = new TestMailmanServer()) {
             var listAddress = testServer.createList("test");
             var mailmanServer = MailingListServerFactory.createMailmanServer(testServer.getArchive(), testServer.getSMTP(),
-                                                                             Duration.ZERO);
+                                                                             Duration.ZERO, true);
             var mailmanList = mailmanServer.getListReader(listAddress);
             var sender = EmailAddress.from("Test", "test@test.email");
             var mail = Email.create(sender, "Subject", "Body")


### PR DESCRIPTION
We are experiencing long delays from when a user posts an email to a PR thread to when the MailingListArchiveReaderBot posts it as a comment to the PR. I think this is caused by the service provider for the mailinglists archive not handling Etags correctly. While that is sorted out, we need to be able to turn the use of etags off. This patch makes it a configuration parameter.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1701](https://bugs.openjdk.org/browse/SKARA-1701): Make use of Etag optional for MailingListArchiveReaderBot


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**) ⚠️ Review applies to [fe4f7b79](https://git.openjdk.org/skara/pull/1430/files/fe4f7b79cf4ec5a99c31ce51f7820389c9e33aef)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1430/head:pull/1430` \
`$ git checkout pull/1430`

Update a local copy of the PR: \
`$ git checkout pull/1430` \
`$ git pull https://git.openjdk.org/skara pull/1430/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1430`

View PR using the GUI difftool: \
`$ git pr show -t 1430`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1430.diff">https://git.openjdk.org/skara/pull/1430.diff</a>

</details>
