### PR TITLE
1708: Print more log to investigate SKARA-1707

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -291,6 +291,8 @@ public class GitLabRepository implements HostedRepository {
         var conf = request.get("repository/files/" + confName)
                           .param("ref", ref)
                           .onError(response -> {
+                              log.warning("First time request returned bad status: " + response.statusCode());
+                              log.info("First time response body: " + response.body());
                               // Retry once with additional escaping of the path fragment
                               var escapedConfName = URLEncoder.encode(confName, StandardCharsets.UTF_8);
                               return Optional.of(request.get("repository/files/" + escapedConfName)


### PR DESCRIPTION
Now, in method GitLabRepository#fileContents, first, it will try to read the content with once encoded filename, and if failed, it will try to read the content with double encoded filename. However, we don't print the log for the first try, so we couldn't know what happens in the first try.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1708](https://bugs.openjdk.org/browse/SKARA-1708): Print more log to investigate SKARA-1707


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1432/head:pull/1432` \
`$ git checkout pull/1432`

Update a local copy of the PR: \
`$ git checkout pull/1432` \
`$ git pull https://git.openjdk.org/skara pull/1432/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1432`

View PR using the GUI difftool: \
`$ git pr show -t 1432`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1432.diff">https://git.openjdk.org/skara/pull/1432.diff</a>

</details>
