### PR TITLE
1713: Fix gradle deprecations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,7 +80,7 @@ configure(subprojects.findAll() { it.name != 'bots' }) {
             exceptionFormat "full"
         }
 
-        reports.html.enabled = false
+        reports.html.required = false
     }
 
     tasks.withType(Test).configureEach {
@@ -92,8 +92,8 @@ configure(subprojects.findAll() { it.name != 'bots' }) {
     }
 
     tasks.withType(Test).configureEach {
-        reports.html.enabled = false
-        reports.junitXml.enabled = false
+        reports.html.required = false
+        reports.junitXml.required = false
     }
 
     tasks.withType(JavaCompile).configureEach {
@@ -130,8 +130,8 @@ task test {
 }
 
 task testReport(type: TestReport) {
-    destinationDir = file("$buildDir/reports/allTests")
-    reportOn subprojects.findAll()*.getTasksByName('test', false)
+    destinationDirectory = file("$buildDir/reports/allTests")
+    getTestResults().from(subprojects.findAll()*.getTasksByName('test', false))
 }
 
 task clean {

--- a/gradle/plugins/skara-module/src/main/java/org/openjdk/skara/gradle/module/ModulePlugin.java
+++ b/gradle/plugins/skara-module/src/main/java/org/openjdk/skara/gradle/module/ModulePlugin.java
@@ -23,22 +23,19 @@
 
 package org.openjdk.skara.gradle.module;
 
-import org.gradle.api.Plugin;
-import org.gradle.api.Project;
-import org.gradle.api.GradleException;
-import org.gradle.api.Action;
-import org.gradle.api.DefaultTask;
-import org.gradle.api.Task;
-import org.gradle.api.tasks.compile.JavaCompile;
-import org.gradle.api.tasks.SourceSet;
-import org.gradle.api.tasks.testing.Test;
-import org.gradle.api.plugins.JavaPluginConvention;
-
-import java.util.List;
+import java.io.File;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import java.io.File;
+import org.gradle.api.Action;
+import org.gradle.api.GradleException;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.plugins.JavaPluginExtension;
+import org.gradle.api.tasks.compile.JavaCompile;
+import org.gradle.api.tasks.testing.Test;
 
 public class ModulePlugin implements Plugin<Project> {
     public void apply(Project project) {
@@ -47,8 +44,7 @@ public class ModulePlugin implements Plugin<Project> {
 
         project.afterEvaluate(p -> {
             for (var task : project.getTasksByName("compileJava", false)) {
-                if (task instanceof JavaCompile) {
-                    var compileJavaTask = (JavaCompile) task;
+                if (task instanceof JavaCompile compileJavaTask) {
                     compileJavaTask.doFirst(new Action<>() {
                         @Override
                         public void execute(Task at) {
@@ -62,18 +58,16 @@ public class ModulePlugin implements Plugin<Project> {
             }
 
             for (var task : project.getTasksByName("compileTestJava", false)) {
-                if (task instanceof JavaCompile) {
-                    var compileTestJavaTask = (JavaCompile) task;
+                if (task instanceof JavaCompile compileTestJavaTask) {
                     compileTestJavaTask.doFirst(new Action<>() {
                         @Override
                         public void execute(Task at) {
-                            var t = (JavaCompile) at;
-                            var maybeModuleName = extension.getName().get();
-                            if (maybeModuleName == null) {
+                            var maybeModuleName = extension.getName();
+                            if (!maybeModuleName.isPresent()) {
                                 throw new GradleException("project " + p.getName() + " has not set ext.moduleName");
                             }
-                            var moduleName = maybeModuleName.toString();
-                            var testSourceSet = project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets().getByName("test");
+                            var moduleName = maybeModuleName.get();
+                            var testSourceSet = project.getExtensions().getByType(JavaPluginExtension.class).getSourceSets().getByName("test");
                             var testSourceDirs = testSourceSet.getAllJava().getSrcDirs().stream().map(File::toString).collect(Collectors.joining(":"));
                             var classpath = compileTestJavaTask.getClasspath().getAsPath();
 
@@ -98,22 +92,24 @@ public class ModulePlugin implements Plugin<Project> {
             }
 
             for (var task : project.getTasksByName("test", false)) {
-                if (task instanceof Test) {
-                    var testTask = (Test) task;
+                if (task instanceof Test testTask) {
                     testTask.doFirst(new Action<>() {
                         @Override
                         public void execute(Task at) {
                             var t = (Test) at;
-                            var maybeModuleName = extension.getName().get();
-                            if (maybeModuleName == null) {
+                            var maybeModuleName = extension.getName();
+                            if (!maybeModuleName.isPresent()) {
                                 throw new GradleException("project " + p.getName() + " has not set ext.moduleName");
                             }
-                            var moduleName = maybeModuleName.toString();
-                            var testSourceSet = project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets().getByName("test");
-                            var outputDir = testSourceSet.getJava().getOutputDir().toString();
+                            var moduleName = maybeModuleName.get();
+                            var testSourceSet = project.getExtensions().getByType(JavaPluginExtension.class).getSourceSets().getByName("test");
+                            var outputDir = testSourceSet.getJava().getClassesDirectory().get().toString();
                             var classpath = testTask.getClasspath().getAsPath();
 
-                            var jvmArgs = new ArrayList<>(testTask.getJvmArgs());
+                            var jvmArgs = new ArrayList<>();
+                            if (testTask.getJvmArgs() != null) {
+                                jvmArgs.addAll(testTask.getJvmArgs());
+                            }
                             jvmArgs.addAll(List.of(
                                     "-Djunit.jupiter.extensions.autodetection.enabled=true",
                                     "--module-path", classpath,

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -19,5 +19,5 @@
 # or visit www.oracle.com if you need additional information or have any
 # questions.
 
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
-distributionSha256Sum=f581709a9c35e9cb92e16f585d2c4bc99b2b1a5f85d2badbd3dc6bff59e1e6dd
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionSha256Sum=29e49b10984e585d8118b7d0bc452f944e386458df27371b49b4ac1dec4b7fda


### PR DESCRIPTION
This patch tries to fix the deprecation warnings currently printed by Gradle when building Skara.

* enabled -> required: a simple rename of an attribute
* TestReport was a little trickier, but as far as I can tell, this is how it's supposed to be done now, and it works just as well/bad as it did before this change. It's not clear to me what the testReport task is good for here, as it seems to me that it will only run if all tests are successful.
* ModulePlugin.java: Was using some deprecated APIs. While at it I let Intellij fix some things that it was warning about. The null checks I removed were weird as the returned object was essentially an `Optional` (a different implementation of the same thing). Switched to using the modern instanceof assignment.
* I updated gradle-wrapper.properties to match the version used by the Skara gradlew wrapper script. Intellij will by default pick the version from the properties file, so as long as we have that file around, we should make sure they match. I needed to do this to make the build succeed in Intellij as some of these changes didn't work in Gradle 7.2.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1713](https://bugs.openjdk.org/browse/SKARA-1713): Fix gradle deprecations


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1433/head:pull/1433` \
`$ git checkout pull/1433`

Update a local copy of the PR: \
`$ git checkout pull/1433` \
`$ git pull https://git.openjdk.org/skara pull/1433/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1433`

View PR using the GUI difftool: \
`$ git pr show -t 1433`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1433.diff">https://git.openjdk.org/skara/pull/1433.diff</a>

</details>
