### PR TITLE
1707: Warning of "No .jcheck/conf found" printed when there is no such problem actually

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LimitedCensusInstance.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LimitedCensusInstance.java
@@ -73,7 +73,8 @@ class LimitedCensusInstance {
         try {
             conf = Optional.of(Arrays.stream(remoteRepo.fileContents(name, ref).split("\n")).toList());
         } catch (UncheckedRestException e) {
-            if (e.getStatusCode() != 404) {
+            // Throw the exception if the error is not exactly "File not found"
+            if (e.getStatusCode() != 404 || e.getBody().contains("Commit Not Found") || e.getBody().contains("No commit found")) {
                 throw e;
             }
         }

--- a/network/src/main/java/org/openjdk/skara/network/RestRequest.java
+++ b/network/src/main/java/org/openjdk/skara/network/RestRequest.java
@@ -374,7 +374,8 @@ public class RestRequest {
             log.warning("Request returned bad status: " + response.statusCode());
             log.info(queryBuilder.toString());
             log.info(response.body());
-            throw new UncheckedRestException("Request returned bad status: " + response.statusCode(), response.statusCode());
+            throw new UncheckedRestException("Request returned bad status: " + response.statusCode(),
+                    response.statusCode(), response.body());
         } else {
             return Optional.empty();
         }

--- a/network/src/main/java/org/openjdk/skara/network/UncheckedRestException.java
+++ b/network/src/main/java/org/openjdk/skara/network/UncheckedRestException.java
@@ -8,12 +8,19 @@ package org.openjdk.skara.network;
 public class UncheckedRestException extends RuntimeException {
     int statusCode;
 
-    public UncheckedRestException(String message, int statusCode) {
+    String body;
+
+    public UncheckedRestException(String message, int statusCode, String body) {
         super(message);
         this.statusCode = statusCode;
+        this.body = body;
     }
 
     public int getStatusCode() {
         return statusCode;
+    }
+
+    public String getBody() {
+        return body;
     }
 }

--- a/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
@@ -205,7 +205,7 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
             throw new UncheckedIOException(e);
         } catch (NoSuchElementException e) {
             // Make this method behave more like other remote repo implementations
-            throw new UncheckedRestException("Can't find file " + filename, 404);
+            throw new UncheckedRestException("Can't find file " + filename, 404, "Not Found");
         }
     }
 


### PR DESCRIPTION
In [SKARA-1393](https://bugs.openjdk.org/browse/SKARA-1393), I added some checks to ensure the target branch of a pr contains valid jcheck configuration. This change went live on November 28, however, some users found that the warning of "No .jcheck/conf found" printed after they integrated their pr. After more investigation, I am thinking it's maybe a orahub bug and filed an issue to orahub(https://jira-sd.mc1.oracleiaas.com/browse/ORAHUB-1638). Since when the issue happens, orahub will always return "Commit Not Found", so we could have a temporary workaround right now.

For Orahub REST API:
If commit not found, it will return "404 Commit Not Found"

If file not found it will return "404 File Not Found"

For Github REST API:
If commit not found, it will return "No commit found for the ref <refname>"

If file not found it will return "Not found"

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1707](https://bugs.openjdk.org/browse/SKARA-1707): Warning of "No .jcheck/conf found" printed when there is no such problem actually


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1434/head:pull/1434` \
`$ git checkout pull/1434`

Update a local copy of the PR: \
`$ git checkout pull/1434` \
`$ git pull https://git.openjdk.org/skara pull/1434/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1434`

View PR using the GUI difftool: \
`$ git pr show -t 1434`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1434.diff">https://git.openjdk.org/skara/pull/1434.diff</a>

</details>
