### PR TITLE
1710: CommitCommandWorkItem always fetches Commit

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -391,7 +391,7 @@ class CheckRun {
         if (hash == null) {
             return Optional.empty();
         }
-        var commit = pr.repository().forge().search(hash);
+        var commit = pr.repository().forge().search(hash, true);
         if (commit.isEmpty()) {
             throw new IllegalStateException("Backport comment for PR " + pr.id() + " contains bad hash: " + hash.hex());
         }

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHost.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHost.java
@@ -68,7 +68,7 @@ class InMemoryHost implements Forge {
     }
 
     @Override
-    public Optional<HostedCommit> search(Hash hash) {
+    public Optional<HostedCommit> search(Hash hash, boolean includeDiffs) {
         return Optional.empty();
     }
 }

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
@@ -187,7 +187,7 @@ class InMemoryHostedRepository implements HostedRepository {
     }
 
     @Override
-    public Optional<HostedCommit> commit(Hash commit) {
+    public Optional<HostedCommit> commit(Hash commit, boolean includeDiffs) {
         return Optional.empty();
     }
 

--- a/forge/src/main/java/org/openjdk/skara/forge/Forge.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/Forge.java
@@ -42,7 +42,17 @@ public interface Forge extends Host {
      *         does not exist on the Forge.
      */
     Optional<HostedRepository> repository(String name);
-    Optional<HostedCommit> search(Hash hash);
+
+    /**
+     * Search the whole host for a commit by hash.
+     * @param hash Hash to search for
+     * @param includeDiffs Set to true to include parent diffs in Commit, default false
+     * @return Commit instance if found, otherwise empty
+     */
+    Optional<HostedCommit> search(Hash hash, boolean includeDiffs);
+    default Optional<HostedCommit> search(Hash hash) {
+        return search(hash, false);
+    }
 
     /**
      * Some forges do not always update the "updated_at" fields of various objects

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
@@ -97,7 +97,18 @@ public interface HostedRepository {
     List<CommitComment> recentCommitComments(Map<String, Set<Hash>> commitTitleToCommits, Set<Integer> excludeAuthors);
     CommitComment addCommitComment(Hash hash, String body);
     void updateCommitComment(String id, String body);
-    Optional<HostedCommit> commit(Hash hash);
+
+    /**
+     * Gets a Commit instance for a given hash, if present.
+     * @param hash Hash to get Commit for
+     * @param includeDiffs Set to true to include parent diffs in Commit, default false
+     * @return Commit instance for the hash in this repository, empty if not
+     * found.
+     */
+    Optional<HostedCommit> commit(Hash hash, boolean includeDiffs);
+    default Optional<HostedCommit> commit(Hash hash) {
+        return commit(hash, false);
+    }
     List<Check> allChecks(Hash hash);
     WorkflowStatus workflowStatus();
     URI createPullRequestUrl(HostedRepository target,

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubHost.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubHost.java
@@ -390,7 +390,7 @@ public class GitHubHost implements Forge {
     }
 
     @Override
-    public Optional<HostedCommit> search(Hash hash) {
+    public Optional<HostedCommit> search(Hash hash, boolean includeDiffs) {
         var orgsToSearch = orgs.stream().map(o -> "org:" + o).collect(Collectors.joining(" "));
         if (!orgsToSearch.isEmpty()) {
             orgsToSearch = " " + orgsToSearch;
@@ -407,6 +407,6 @@ public class GitHubHost implements Forge {
         var shortestName = items.stream()
                 .map(o -> o.get("repository").get("full_name").asString())
                 .min(Comparator.comparing(String::length));
-        return shortestName.flatMap(this::repository).flatMap(r -> r.commit(hash));
+        return shortestName.flatMap(this::repository).flatMap(r -> r.commit(hash, includeDiffs));
     }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -486,19 +486,33 @@ public class GitHubRepository implements HostedRepository {
     }
 
     @Override
-    public Optional<HostedCommit> commit(Hash hash) {
-        // Need to specify an explicit per_page < 70 to guarantee that we get patch information in the result set.
-        var o = request.get("commits/" + hash.hex())
-                       .param("per_page", "50")
-                       .onError(r -> Optional.of(JSON.of()))
-                       .execute();
+    public Optional<HostedCommit> commit(Hash hash, boolean includeDiffs) {
+        var queryBuilder = request.get("commits/" + hash.hex())
+                .onError(r -> Optional.of(JSON.of()));
+        if (includeDiffs) {
+            // Need to specify an explicit per_page < 70 to guarantee that we get patch information in the result set.
+            queryBuilder.param("per_page", "50");
+        } else {
+            // Minimize size of response when diffs aren't needed.
+            queryBuilder
+                    .param("per_page", "1")
+                    .maxPages(1);
+        }
+
+        var o = queryBuilder.execute();
+
         if (o.isNull()) {
             return Optional.empty();
         }
 
         var metadata = toCommitMetadata(o);
-        var diffs = toDiff(metadata.parents().get(0), hash, o.get("files"));
-        return Optional.of(new HostedCommit(metadata, List.of(diffs), URI.create(o.get("html_url").asString())));
+        List<Diff> diffs;
+        if (includeDiffs) {
+            diffs = List.of(toDiff(metadata.parents().get(0), hash, o.get("files")));
+        } else {
+            diffs = List.of();
+        }
+        return Optional.of(new HostedCommit(metadata, diffs, URI.create(o.get("html_url").asString())));
     }
 
     @Override

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabHost.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabHost.java
@@ -221,7 +221,7 @@ public class GitLabHost implements Forge {
     }
 
     @Override
-    public Optional<HostedCommit> search(Hash hash) {
+    public Optional<HostedCommit> search(Hash hash, boolean includeDiffs) {
         var hex = hash.hex();
         for (var group : groups) {
             var ids = request.get("groups/" + group + "/projects")
@@ -236,7 +236,7 @@ public class GitLabHost implements Forge {
                                   .collect(Collectors.toList());
             for (var id : ids) {
                 var project = new GitLabRepository(this, id);
-                var commit = project.commit(hash);
+                var commit = project.commit(hash, includeDiffs);
                 if (commit.isPresent()) {
                     return commit;
                 }

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -590,7 +590,7 @@ public class GitLabRepository implements HostedRepository {
     }
 
     @Override
-    public Optional<HostedCommit> commit(Hash hash) {
+    public Optional<HostedCommit> commit(Hash hash, boolean includeDiffs) {
         var c = request.get("repository/commits/" + hash.hex())
                        .onError(r -> Optional.of(JSON.of()))
                        .execute();
@@ -599,14 +599,17 @@ public class GitLabRepository implements HostedRepository {
         }
         var url = URI.create(c.get("web_url").asString());
         var metadata = toCommitMetadata(c);
-        var diff = request.get("repository/commits/" + hash.hex() + "/diff")
-                          .onError(r -> Optional.of(JSON.of()))
-                          .execute();
-        var parentDiffs = new ArrayList<Diff>();
-        if (!diff.isNull()) {
-            parentDiffs.add(toDiff(metadata.parents().get(0), hash, diff));
+
+        List<Diff> diffs = List.of();
+        if (includeDiffs) {
+            var diff = request.get("repository/commits/" + hash.hex() + "/diff")
+                    .onError(r -> Optional.of(JSON.of()))
+                    .execute();
+            if (!diff.isNull()) {
+                diffs = List.of(toDiff(metadata.parents().get(0), hash, diff));
+            }
         }
-        return Optional.of(new HostedCommit(metadata, parentDiffs, url));
+        return Optional.of(new HostedCommit(metadata, diffs, url));
     }
 
     @Override

--- a/test/src/main/java/org/openjdk/skara/test/TestHost.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHost.java
@@ -174,10 +174,10 @@ public class TestHost implements Forge, IssueTracker {
     }
 
     @Override
-    public Optional<HostedCommit> search(Hash hash) {
+    public Optional<HostedCommit> search(Hash hash, boolean includeDiffs) {
         for (var key : data.repositories.keySet()) {
             var repo = repository(key).orElseThrow();
-            var commit = repo.commit(hash);
+            var commit = repo.commit(hash, includeDiffs);
             if (commit.isPresent()) {
                 return commit;
             }

--- a/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
@@ -298,14 +298,15 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
     }
 
     @Override
-    public Optional<HostedCommit> commit(Hash hash) {
+    public Optional<HostedCommit> commit(Hash hash, boolean includeDiffs) {
         try {
             var commit = localRepository.lookup(hash);
             if (!commit.isPresent()) {
                 return Optional.empty();
             }
             var url = URI.create("file://" + localRepository.root() + "/commits/" + hash.hex());
-            return Optional.of(new HostedCommit(commit.get().metadata(), commit.get().parentDiffs(), url));
+            List<Diff> parentDiffs = includeDiffs ? commit.get().parentDiffs() : List.of();
+            return Optional.of(new HostedCommit(commit.get().metadata(), parentDiffs, url));
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }


### PR DESCRIPTION
During bot restart, quite a few CommitCommandWorkItems are spawned. Most of them will discover that nothing needs to be done. One of the first things done in the run method is fetching the commit from the remote repository. The Commit instance will always be created with the full set of diffs for the commit. In certain cases, where commits are very large, this can take considerable time. Specifically in the jfx repos, there are examples where the REST request is split into 147 pages. (e.g. https://github.com/openjdk/jfx11u/commit/4bd6877dbd46e37f6774c50dcdc98a8a1ab41214) The way these WorkItems are spawned on startup, most of these gigantic commits will be included for a long time. The Commit instance isn't needed to figure out if a new command is present, just the comments are. This means we can move this query to after we have established that a command is to be executed.

To further reduce overhead when fetching commits from remote repositories, I'm also making the inclusion of the "parentDiffs" optional. Of all the uses of `HostedRepository::commit`, there is currently only one that actually needs the diffs (BackportCommand). This will require the caller to be mindful of the state of the returned `Commit` object, especially when sending it other consumers, but I believe it's worth it to reduce unnecessary load on the system.

This also affects `Forge::search`, where there is one other use where the diffs are used (when evaluating if a backport is clean).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1710](https://bugs.openjdk.org/browse/SKARA-1710): CommitCommandWorkItem always fetches Commit


### Reviewers
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - Committer)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1436/head:pull/1436` \
`$ git checkout pull/1436`

Update a local copy of the PR: \
`$ git checkout pull/1436` \
`$ git pull https://git.openjdk.org/skara pull/1436/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1436`

View PR using the GUI difftool: \
`$ git pr show -t 1436`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1436.diff">https://git.openjdk.org/skara/pull/1436.diff</a>

</details>
