### PR TITLE
1709: Only fetch comments once in PullRequestWorkItem in pr bot

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -29,9 +29,6 @@ import org.openjdk.skara.forge.*;
 import org.openjdk.skara.host.HostUser;
 import org.openjdk.skara.issuetracker.*;
 import org.openjdk.skara.jbs.Backports;
-import org.openjdk.skara.jbs.JdkVersion;
-import org.openjdk.skara.jcheck.JCheckConfiguration;
-import org.openjdk.skara.network.UncheckedRestException;
 import org.openjdk.skara.vcs.*;
 import org.openjdk.skara.vcs.openjdk.Issue;
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
@@ -126,7 +126,7 @@ public class LabelerWorkItem extends PullRequestWorkItem {
             return List.of();
         }
 
-        var comments = pr.comments();
+        var comments = prComments();
         var manuallyAdded = LabelTracker.currentAdded(pr.repository().forge().currentUser(), comments);
         var manuallyRemoved = LabelTracker.currentRemoved(pr.repository().forge().currentUser(), comments);
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
@@ -179,7 +179,7 @@ public class PullRequestCommandWorkItem extends PullRequestWorkItem {
     public Collection<WorkItem> prRun(Path scratchPath) {
         log.info("Looking for PR commands");
 
-        var comments = pr.comments();
+        var comments = prComments();
         var nextCommand = nextCommand(pr, comments);
 
         if (nextCommand.isEmpty()) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestWorkItem.java
@@ -34,6 +34,7 @@ import org.openjdk.skara.bot.WorkItem;
 import org.openjdk.skara.forge.PullRequest;
 
 import java.util.function.Consumer;
+import org.openjdk.skara.issuetracker.Comment;
 
 abstract class PullRequestWorkItem implements WorkItem {
     private static final Logger log = Logger.getLogger(PullRequestWorkItem.class.getName());
@@ -51,6 +52,7 @@ abstract class PullRequestWorkItem implements WorkItem {
      */
     final ZonedDateTime prUpdatedAt;
     PullRequest pr;
+    private List<Comment> comments;
 
     PullRequestWorkItem(PullRequestBot bot, String prId, Consumer<RuntimeException> errorHandler,
             ZonedDateTime prUpdatedAt, boolean needsReadyCheck) {
@@ -84,7 +86,7 @@ abstract class PullRequestWorkItem implements WorkItem {
             }
         }
 
-        var comments = pr.comments();
+        var comments = prComments();
         for (var readyComment : bot.readyComments().entrySet()) {
             var commentFound = false;
             for (var comment : comments) {
@@ -121,6 +123,16 @@ abstract class PullRequestWorkItem implements WorkItem {
             return List.of();
         }
         return prRun(scratchPath);
+    }
+
+    /**
+     * Lazy fetching of pr comments to avoid multiple fetch calls.
+     */
+    protected List<Comment> prComments() {
+        if (comments == null) {
+            comments = pr.comments();
+        }
+        return comments;
     }
 
     abstract Collection<WorkItem> prRun(Path scratchPath);


### PR DESCRIPTION
This patch provides a minor optimization for `PullRequestWorkItem` subclasses in the pr bot by avoiding re-fetching of pr.comments(). I initially started this patch with a much bigger optimization in mind, but it turned out to not work. I still think it worth applying the remaining patch since I've gone through the trouble of implementing it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1709](https://bugs.openjdk.org/browse/SKARA-1709): Only fetch comments once in PullRequestWorkItem in pr bot


### Reviewers
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - Committer)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1437/head:pull/1437` \
`$ git checkout pull/1437`

Update a local copy of the PR: \
`$ git checkout pull/1437` \
`$ git pull https://git.openjdk.org/skara pull/1437/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1437`

View PR using the GUI difftool: \
`$ git pr show -t 1437`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1437.diff">https://git.openjdk.org/skara/pull/1437.diff</a>

</details>
