### PR TITLE
1695: Set GitHub API date version header

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -67,7 +67,8 @@ public class GitHubRepository implements HostedRepository {
                 "Accept", "application/vnd.github.antiope-preview+json",
                 "Accept", "application/vnd.github.shadow-cat-preview+json",
                 "Accept", "application/vnd.github.comfort-fade-preview+json",
-                "Accept", "application/vnd.github.mockingbird-preview+json"));
+                "Accept", "application/vnd.github.mockingbird-preview+json",
+                "X-GitHub-Api-Version", "2022-11-28"));
             var token = gitHubHost.getInstallationToken();
             if (token.isPresent()) {
                 headers.add("Authorization");


### PR DESCRIPTION
In this patch, added new Header `X-GitHub-Api-Version` to all GitHub API calls.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1695](https://bugs.openjdk.org/browse/SKARA-1695): Set GitHub API date version header


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1440/head:pull/1440` \
`$ git checkout pull/1440`

Update a local copy of the PR: \
`$ git checkout pull/1440` \
`$ git pull https://git.openjdk.org/skara pull/1440/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1440`

View PR using the GUI difftool: \
`$ git pr show -t 1440`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1440.diff">https://git.openjdk.org/skara/pull/1440.diff</a>

</details>
