### PR TITLE
1698: Warning not to force push/rebase can be made clearer

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -53,7 +53,7 @@ class CheckWorkItem extends PullRequestWorkItem {
     protected static final String FORCE_PUSH_MARKER = "<!-- force-push suggestion -->";
     protected static final String FORCE_PUSH_SUGGESTION= """
             Please do not rebase or force-push to an active PR as it invalidates existing review comments. \
-            All changes will be squashed into a single commit automatically when integrating. \
+            Note for future reference, the bots always squash all changes into a single commit automatically as part of the integration. \
             See [OpenJDK Developers’ Guide](https://openjdk.org/guide/#working-with-pull-requests) for more information.
             """;
 


### PR DESCRIPTION
Rephrased the second sentence of the warning not to force push/rebase.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1698](https://bugs.openjdk.org/browse/SKARA-1698): Warning not to force push/rebase can be made clearer


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1441/head:pull/1441` \
`$ git checkout pull/1441`

Update a local copy of the PR: \
`$ git checkout pull/1441` \
`$ git pull https://git.openjdk.org/skara pull/1441/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1441`

View PR using the GUI difftool: \
`$ git pr show -t 1441`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1441.diff">https://git.openjdk.org/skara/pull/1441.diff</a>

</details>
