### PR TITLE
1598: GitRepository.isHealthy takes a long time in ArchiveWorkItem

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
@@ -239,18 +239,17 @@ class ArchiveWorkItem implements WorkItem {
         return ret.toString();
     }
 
+    private String mboxFile() {
+        return bot.codeRepo().name() + "/" + pr.id() + ".mbox";
+    }
+
     @Override
     public Collection<WorkItem> run(Path scratchPath) {
         var path = scratchPath.resolve("mlbridge");
-        var archiveRepo = materializeArchive(path);
-        var mboxBasePath = path.resolve(bot.codeRepo().name());
 
         var sentMails = new ArrayList<Email>();
-        try {
-            var archiveContents = Files.readString(mboxBasePath.resolve(pr.id() + ".mbox"), StandardCharsets.UTF_8);
-            sentMails.addAll(Mbox.splitMbox(archiveContents, bot.emailAddress()));
-        } catch (IOException ignored) {
-        }
+        var archiveContents = bot.archiveRepo().fileContents(mboxFile(), bot.archiveRef());
+        archiveContents.ifPresent(s -> sentMails.addAll(Mbox.splitMbox(s, bot.emailAddress())));
 
         var labels = new HashSet<>(pr.labelNames());
 
@@ -382,14 +381,17 @@ class ArchiveWorkItem implements WorkItem {
             }
 
             // Push all new mails to the archive repository
-            var mbox = MailingListServerFactory.createMboxFileServer(mboxBasePath);
+            var newArchivedContents = new StringBuilder();
+            archiveContents.ifPresent(newArchivedContents::append);
             for (var newMail : newMails) {
                 var forArchiving = Email.from(newMail)
                                         .recipient(EmailAddress.from(pr.id() + "@mbox"))
                                         .build();
-                mbox.post(forArchiving);
+                newArchivedContents.append(Mbox.fromMail(forArchiving));
             }
-            pushMbox(archiveRepo, "Adding comments for PR " + bot.codeRepo().name() + "/" + pr.id());
+            bot.archiveRepo().writeFileContents(newArchivedContents.toString(), mboxFile(), new Branch(bot.archiveRef()),
+                    "Adding comments for PR " + bot.codeRepo().name() + "/" + pr.id(),
+                    bot.emailAddress().fullName().orElseThrow(), bot.emailAddress().address());
 
             // Finally post all new mails to the actual list
             for (var newMail : newMails) {

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
@@ -32,7 +32,6 @@ import org.openjdk.skara.mailinglist.*;
 import org.openjdk.skara.vcs.*;
 
 import java.io.*;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.time.*;
 import java.util.*;
@@ -248,6 +247,7 @@ class ArchiveWorkItem implements WorkItem {
         var path = scratchPath.resolve("mlbridge");
 
         var sentMails = new ArrayList<Email>();
+        // Load in already sent emails from the archive, if there are any.
         var archiveContents = bot.archiveRepo().fileContents(mboxFile(), bot.archiveRef());
         archiveContents.ifPresent(s -> sentMails.addAll(Mbox.splitMbox(s, bot.emailAddress())));
 
@@ -389,7 +389,7 @@ class ArchiveWorkItem implements WorkItem {
                                         .build();
                 newArchivedContents.append(Mbox.fromMail(forArchiving));
             }
-            bot.archiveRepo().writeFileContents(newArchivedContents.toString(), mboxFile(), new Branch(bot.archiveRef()),
+            bot.archiveRepo().writeFileContents(mboxFile(), newArchivedContents.toString(), new Branch(bot.archiveRef()),
                     "Adding comments for PR " + bot.codeRepo().name() + "/" + pr.id(),
                     bot.emailAddress().fullName().orElseThrow(), bot.emailAddress().address());
 

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
@@ -134,7 +134,7 @@ class InMemoryHostedRepository implements HostedRepository {
     }
 
     @Override
-    public void writeFileContents(String content, String filename, Branch branch, String message, String authorName, String authorEmail) {
+    public void writeFileContents(String filename, String content, Branch branch, String message, String authorName, String authorEmail) {
     }
 
     @Override

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
@@ -134,6 +134,10 @@ class InMemoryHostedRepository implements HostedRepository {
     }
 
     @Override
+    public void writeFileContents(String content, String filename, Branch branch, String message, String authorName, String authorEmail) {
+    }
+
+    @Override
     public String namespace() {
         return null;
     }

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
@@ -90,14 +90,15 @@ public interface HostedRepository {
 
     /**
      * Writes new contents to a file in the repo by creating a new commit.
-     * @param content New file content to write, always replacing existing content
-     * @param filename Name of file inside repository to write to
-     * @param branch Branch to add commit on top of
-     * @param message Commit message
-     * @param authorName Name of author and committer for commit
+     *
+     * @param filename    Name of file inside repository to write to
+     * @param content     New file content to write, always replacing existing content
+     * @param branch      Branch to add commit on top of
+     * @param message     Commit message
+     * @param authorName  Name of author and committer for commit
      * @param authorEmail Email of author and committer for commit
      */
-    void writeFileContents(String content, String filename, Branch branch, String message, String authorName, String authorEmail);
+    void writeFileContents(String filename, String content, Branch branch, String message, String authorName, String authorEmail);
     String namespace();
     Optional<WebHook> parseWebHook(JSONValue body);
     HostedRepository fork();

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
@@ -87,6 +87,17 @@ public interface HostedRepository {
      * Returns contents of the file, if the file does not exist, returns Optional.empty().
      */
     Optional<String> fileContents(String filename, String ref);
+
+    /**
+     * Writes new contents to a file in the repo by creating a new commit.
+     * @param content New file content to write, always replacing existing content
+     * @param filename Name of file inside repository to write to
+     * @param branch Branch to add commit on top of
+     * @param message Commit message
+     * @param authorName Name of author and committer for commit
+     * @param authorEmail Email of author and committer for commit
+     */
+    void writeFileContents(String content, String filename, Branch branch, String message, String authorName, String authorEmail);
     String namespace();
     Optional<WebHook> parseWebHook(JSONValue body);
     HostedRepository fork();

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubHost.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubHost.java
@@ -273,7 +273,7 @@ public class GitHubHost implements Forge {
                 log.fine("Error during GitHub host validation: unexpected endpoint list: " + endpoints);
                 return false;
             }
-        } catch (IOException e) {
+        } catch (IOException | UncheckedRestException e) {
             log.fine("Error during GitHub host validation: " + e);
             return false;
         }

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -269,7 +269,7 @@ public class GitHubRepository implements HostedRepository {
                     .executeUnparsed();
             return Optional.of(content);
         } catch (UncheckedRestException e) {
-            // The onError handler is not used with executeParsed, so have to
+            // The onError handler is not used with executeUnparsed, so have to
             // resort to catching exception for 404 handling.
             if (e.getStatusCode() == 404) {
                 return Optional.empty();

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -261,7 +261,7 @@ public class GitHubRepository implements HostedRepository {
     @Override
     public Optional<String> fileContents(String filename, String ref) {
         // Get file contents using raw format. This allows us to get files of
-        // size up to 10MB (up from 1MB if getting in object from).
+        // size up to 100MB (up from 1MB if getting in object from).
         try {
             var content = request.get("contents/" + filename)
                     .param("ref", ref)
@@ -282,7 +282,7 @@ public class GitHubRepository implements HostedRepository {
     }
 
     @Override
-    public void writeFileContents(String content, String filename, Branch branch, String message, String authorName, String authorEmail) {
+    public void writeFileContents(String filename, String content, Branch branch, String message, String authorName, String authorEmail) {
         var body = JSON.object()
                 .put("message", message)
                 .put("branch", branch.name())

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -22,6 +22,8 @@
  */
 package org.openjdk.skara.forge.github;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.regex.Matcher;
 import org.openjdk.skara.forge.*;
 import org.openjdk.skara.host.HostUser;
@@ -63,11 +65,6 @@ public class GitHubRepository implements HostedRepository {
                 .build();
         request = new RestRequest(apiBase, gitHubHost.authId().orElse(null), (r) -> {
             var headers = new ArrayList<>(List.of(
-                "Accept", "application/vnd.github.machine-man-preview+json",
-                "Accept", "application/vnd.github.antiope-preview+json",
-                "Accept", "application/vnd.github.shadow-cat-preview+json",
-                "Accept", "application/vnd.github.comfort-fade-preview+json",
-                "Accept", "application/vnd.github.mockingbird-preview+json",
                 "X-GitHub-Api-Version", "2022-11-28"));
             var token = gitHubHost.getInstallationToken();
             if (token.isPresent()) {
@@ -263,18 +260,49 @@ public class GitHubRepository implements HostedRepository {
 
     @Override
     public Optional<String> fileContents(String filename, String ref) {
-        var content = request.get("contents/" + filename)
-                .param("ref", ref)
-                .onError(r -> r.statusCode() == 404 && JSON.parse(r.body()).get("message").asString().equals("Not Found")
-                        ? Optional.of(JSON.object().put("NOT_FOUND", true)) : Optional.empty())
-                .execute();
-        if (content.contains("NOT_FOUND")) {
-            return Optional.empty();
+        // Get file contents using raw format. This allows us to get files of
+        // size up to 10MB (up from 1MB if getting in object from).
+        try {
+            var content = request.get("contents/" + filename)
+                    .param("ref", ref)
+                    .header("Accept", "application/vnd.github.raw+json")
+                    .executeUnparsed();
+            return Optional.of(content);
+        } catch (UncheckedRestException e) {
+            // The onError handler is not used with executeParsed, so have to
+            // resort to catching exception for 404 handling.
+            if (e.getStatusCode() == 404) {
+                return Optional.empty();
+            } else {
+                throw e;
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
         }
-        // Content may contain newline characters
-        return Optional.of(content.asObject().get("content").asString().lines()
-                .map(line -> new String(Base64.getDecoder().decode(line), StandardCharsets.UTF_8))
-                .collect(Collectors.joining()));
+    }
+
+    @Override
+    public void writeFileContents(String content, String filename, Branch branch, String message, String authorName, String authorEmail) {
+        var body = JSON.object()
+                .put("message", message)
+                .put("branch", branch.name())
+                .put("committer", JSON.object()
+                        .put("name", authorName)
+                        .put("email", authorEmail))
+                .put("content", new String(Base64.getEncoder().encode(content.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8));
+
+        // If the file exists, we have to supply the current sha with the update request.
+        var curentFileData = request.get("contents/" + filename)
+                .param("ref", branch.name())
+                .onError(r -> r.statusCode() == 404 ? Optional.of(JSON.object().put("NOT_FOUND", true)) : Optional.empty())
+                .execute();
+        if (curentFileData.contains("sha")) {
+            body.put("sha", curentFileData.get("sha").asString());
+        }
+
+        request.put("contents/" + filename)
+                .body(body)
+                .execute();
     }
 
     @Override

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -314,6 +314,31 @@ public class GitLabRepository implements HostedRepository {
     }
 
     @Override
+    public void writeFileContents(String content, String filename, Branch branch, String message, String authorName, String authorEmail) {
+        var encodedFileName = URLEncoder.encode(filename, StandardCharsets.UTF_8);
+        var body = JSON.object()
+                .put("commit_message", message)
+                .put("branch", branch.name())
+                .put("author_name", authorName)
+                .put("author_email", authorEmail)
+                .put("encoding", "base64")
+                .put("content", new String(Base64.getEncoder().encode(content.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8));
+        request.put("repository/files/" + encodedFileName)
+                .body(body)
+                .onError(response -> {
+                    // Gitlab requires POST for creating new files and PUT for updating existing.
+                    // Retry with POST if we get 400 response.
+                    if (response.statusCode() == 400) {
+                        return Optional.of(request.post("repository/files/" + encodedFileName)
+                                .body(body)
+                                .execute());
+                    }
+                    return Optional.empty();
+                })
+                .execute();
+    }
+
+    @Override
     public String namespace() {
         return URIBuilder.base(gitLabHost.getUri()).build().getHost();
     }

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -314,7 +314,7 @@ public class GitLabRepository implements HostedRepository {
     }
 
     @Override
-    public void writeFileContents(String content, String filename, Branch branch, String message, String authorName, String authorEmail) {
+    public void writeFileContents(String filename, String content, Branch branch, String message, String authorName, String authorEmail) {
         var encodedFileName = URLEncoder.encode(filename, StandardCharsets.UTF_8);
         var body = JSON.object()
                 .put("commit_message", message)

--- a/forge/src/test/java/org/openjdk/skara/forge/github/GitHubRestApiTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/github/GitHubRestApiTests.java
@@ -183,7 +183,7 @@ public class GitHubRestApiTests {
         // Create new file
         {
             var fileContent = "File content";
-            gitHubRepo.writeFileContents(fileContent, fileName, branch,
+            gitHubRepo.writeFileContents(fileName, fileContent, branch,
                     "First commit message", "Duke", "duke@openjdk.org");
             var returnedContents = gitHubRepo.fileContents(fileName, branch.name());
             assertEquals(fileContent, returnedContents.orElseThrow());
@@ -192,7 +192,7 @@ public class GitHubRestApiTests {
         // Update file
         {
             var fileContent = "New file content";
-            gitHubRepo.writeFileContents(fileContent, fileName, branch,
+            gitHubRepo.writeFileContents(fileName, fileContent, branch,
                     "Second commit message", "Duke", "duke@openjdk.org");
             var returnedContents = gitHubRepo.fileContents(fileName, branch.name());
             assertEquals(fileContent, returnedContents.orElseThrow());
@@ -201,7 +201,7 @@ public class GitHubRestApiTests {
         // Make the file huge
         {
             var fileContent = "a".repeat(1024 * 1024 * 10);
-            gitHubRepo.writeFileContents(fileContent, fileName, branch,
+            gitHubRepo.writeFileContents(fileName, fileContent, branch,
                     "Third commit message", "Duke", "duke@openjdk.org");
             var returnedContents = gitHubRepo.fileContents(fileName, branch.name());
             assertTrue(returnedContents.isPresent());

--- a/forge/src/test/java/org/openjdk/skara/forge/github/GitHubRestApiTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/github/GitHubRestApiTests.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.skara.forge.github;
 
+import java.util.Properties;
 import org.junit.jupiter.api.*;
 import org.openjdk.skara.forge.Forge;
 import org.openjdk.skara.forge.HostedRepository;
@@ -30,6 +31,7 @@ import org.openjdk.skara.issuetracker.Comment;
 import org.openjdk.skara.network.URIBuilder;
 import org.openjdk.skara.proxy.HttpProxy;
 import org.openjdk.skara.test.ManualTestSettings;
+import org.openjdk.skara.vcs.Branch;
 import org.openjdk.skara.vcs.Diff;
 import org.openjdk.skara.vcs.DiffComparator;
 import org.openjdk.skara.vcs.Hash;
@@ -49,11 +51,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class GitHubRestApiTests {
     private static final String GITHUB_REST_URI = "https://github.com";
     Forge githubHost;
+    private Properties settings;
 
     @BeforeEach
     void setupHost() throws IOException {
         HttpProxy.setup();
-        var settings = ManualTestSettings.loadManualTestSettings();
+        settings = ManualTestSettings.loadManualTestSettings();
         // Here use the OAuth2 token. To use a GitHub App, please see ManualForgeTests#gitHubLabels.
         var username = settings.getProperty("github.user");
         var token = settings.getProperty("github.pat");
@@ -159,5 +162,53 @@ public class GitHubRestApiTests {
 
         // Won't get the force push time when if the force push is during draft period
         assertEquals(Optional.empty(), testPr.lastForcePushTime());
+    }
+
+    @Test
+    void fileContentsNonExisting() {
+        var gitHubRepo = githubHost.repository(settings.getProperty("github.repository")).orElseThrow();
+        var branch = new Branch(settings.getProperty("github.repository.branch"));
+        var fileName = "testfile-that-does-not-exist.txt";
+        var returnedContents = gitHubRepo.fileContents(fileName, branch.name());
+        assertTrue(returnedContents.isEmpty());
+    }
+
+    @Test
+    void writeFileContents() {
+        var gitHubRepo = githubHost.repository(settings.getProperty("github.repository")).orElseThrow();
+        var branch = new Branch(settings.getProperty("github.repository.branch"));
+
+        var fileName = "testfile.txt";
+
+        // Create new file
+        {
+            var fileContent = "File content";
+            gitHubRepo.writeFileContents(fileContent, fileName, branch,
+                    "First commit message", "Duke", "duke@openjdk.org");
+            var returnedContents = gitHubRepo.fileContents(fileName, branch.name());
+            assertEquals(fileContent, returnedContents.orElseThrow());
+        }
+
+        // Update file
+        {
+            var fileContent = "New file content";
+            gitHubRepo.writeFileContents(fileContent, fileName, branch,
+                    "Second commit message", "Duke", "duke@openjdk.org");
+            var returnedContents = gitHubRepo.fileContents(fileName, branch.name());
+            assertEquals(fileContent, returnedContents.orElseThrow());
+        }
+
+        // Make the file huge
+        {
+            var fileContent = "a".repeat(1024 * 1024 * 10);
+            gitHubRepo.writeFileContents(fileContent, fileName, branch,
+                    "Third commit message", "Duke", "duke@openjdk.org");
+            var returnedContents = gitHubRepo.fileContents(fileName, branch.name());
+            assertTrue(returnedContents.isPresent());
+            assertEquals(fileContent.length(), returnedContents.get().length());
+            assertTrue(fileContent.equals(returnedContents.get()),
+                    "Diff for huge file contents, printing first 50 chars of each '"
+                    + fileContent.substring(0, 50) + "' '" + returnedContents.get().substring(0, 50) + "'");
+        }
     }
 }

--- a/forge/src/test/java/org/openjdk/skara/forge/gitlab/GitLabRestApiTest.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/gitlab/GitLabRestApiTest.java
@@ -163,7 +163,7 @@ public class GitLabRestApiTest {
         // Create new file
         {
             var fileContent = "File content";
-            gitLabRepo.writeFileContents(fileContent, fileName, branch,
+            gitLabRepo.writeFileContents(fileName, fileContent, branch,
                     "First commit message", "Duke", "duke@openjdk.org");
             var returnedContents = gitLabRepo.fileContents(fileName, branch.name());
             assertEquals(fileContent, returnedContents.orElseThrow());
@@ -172,7 +172,7 @@ public class GitLabRestApiTest {
         // Update file
         {
             var fileContent = "New file content";
-            gitLabRepo.writeFileContents(fileContent, fileName, branch,
+            gitLabRepo.writeFileContents(fileName, fileContent, branch,
                     "Second commit message", "Duke", "duke@openjdk.org");
             var returnedContents = gitLabRepo.fileContents(fileName, branch.name());
             assertEquals(fileContent, returnedContents.orElseThrow());
@@ -181,7 +181,7 @@ public class GitLabRestApiTest {
         // Make the file huge
         {
             var fileContent = "a".repeat(1024 * 1024 * 10);
-            gitLabRepo.writeFileContents(fileContent, fileName, branch,
+            gitLabRepo.writeFileContents(fileName, fileContent, branch,
                     "Third commit message", "Duke", "duke@openjdk.org");
             var returnedContents = gitLabRepo.fileContents(fileName, branch.name());
             assertEquals(fileContent, returnedContents.orElseThrow());

--- a/network/src/main/java/org/openjdk/skara/network/RestRequest.java
+++ b/network/src/main/java/org/openjdk/skara/network/RestRequest.java
@@ -517,7 +517,7 @@ public class RestRequest {
         var response = sendRequest(request);
         responseCounter.labels(Integer.toString(response.statusCode()), Boolean.toString(false)).inc();
         if (response.statusCode() >= 400) {
-            throw new IOException("Bad response: " + response.statusCode());
+            throw new UncheckedRestException("Bad response: " + response.statusCode(), response.statusCode());
         }
         return response.body();
     }

--- a/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
@@ -22,12 +22,14 @@
  */
 package org.openjdk.skara.test;
 
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
 import org.openjdk.skara.forge.*;
 import org.openjdk.skara.host.HostUser;
 import org.openjdk.skara.issuetracker.Issue;
 import org.openjdk.skara.issuetracker.Label;
 import org.openjdk.skara.json.JSONValue;
-import org.openjdk.skara.network.UncheckedRestException;
 import org.openjdk.skara.vcs.*;
 
 import java.io.*;
@@ -199,12 +201,29 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
     @Override
     public Optional<String> fileContents(String filename, String ref) {
         try {
-            var lines = localRepository.lines(Path.of(filename), localRepository.resolve(ref).orElseThrow());
-            return lines.map(content -> String.join("\n", content));
+            var bytes = localRepository.show(Path.of(filename), localRepository.resolve(ref).orElseThrow());
+            return bytes.map(b -> new String(b, StandardCharsets.UTF_8));
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         } catch (NoSuchElementException e) {
             return Optional.empty();
+        }
+    }
+
+    @Override
+    public void writeFileContents(String content, String filename, Branch branch, String message, String authorName, String authorEmail) {
+        try {
+            localRepository.checkout(branch);
+            Path absPath = localRepository.root().resolve(filename);
+            Files.createDirectories(absPath.getParent());
+            Files.writeString(absPath, content, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+            localRepository.add(absPath);
+            var hash = localRepository.commit(message, authorName, authorEmail);
+            // Don't leave the repository having a branch checked out as that would
+            // prevent pushing to that branch.
+            localRepository.checkout(hash);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
         }
     }
 

--- a/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
@@ -211,7 +211,7 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
     }
 
     @Override
-    public void writeFileContents(String content, String filename, Branch branch, String message, String authorName, String authorEmail) {
+    public void writeFileContents(String filename, String content, Branch branch, String message, String authorName, String authorEmail) {
         try {
             localRepository.checkout(branch);
             Path absPath = localRepository.root().resolve(filename);


### PR DESCRIPTION
In the mlbridge bot, the `ArchiveWorkItem` is spending an inordinate amount of time running `git fsck --connectivity-only`. This is part of a rather sane strategy of verifying a repository before using it. This is done when a repository is materialized using the `HostedRepositoryPool`, if a previous local copy is found and reused, it's first checked using `Repository::isHealthy`, which runs the fsck. In the `ArchiveWorkItem` case, the repository in question is the archive repository, where all sent emails are stored for reference (and to prevent resending duplicate messages). The repository is materialized first in every `ArchiveWorkItem::run` call as it needs to read the current archive for the PR. Especially on bot restart, this triggers a lot of extra work.

This repository is growing quite fast as it contains every PR for every repository we have Skara running against on GitHub. Having every ArchiveWorkItem verifying all this contents just doesn't scale well, when each work item will only ever read and write to a single file in the repository.

To eliminate this inefficiency, I'm changing `ArchiveWorkItem` to read and write the single file over REST API instead. This does introduce another level of inefficiency, where the complete file must be transferred to and from the server each time, instead of just diffs, but I think given the size of the repo, and the rate at which it is growing (not to mention the fsck checks), this is the better tradeoff. 

The patch adds a new method `HostedRepository::writeFileContents` (that pairs with the existing `::fileContents`). I've added manual tests that verifies these two methods together for both GitHub and GitLab. This prompted rewriting of `GitHubRepository::fileContents` to use "raw" mode for retrieving file contents. This in turn made me discover that we could remove all the preview feature `Accept` headers, as all those GitHub APIs are stable by now. (There is currently a bug in `RestRequest` causing only the last header with the same key to be used, so only the last of the list of preview headers was ever actually in effect. This bug was also preventing me from using raw mode, as that requires another `Accept` header. Given this, and that the mockingbird API is verified to be stable now, I'm confident in removing all of them. I will file a separate issue for the bug in `RestRequest`.)

To use "raw" mode, I needed to use `RestRequest::executeUnparsed` and discovered that it wasn't behaving quite the same as the normal `::execute`. I changed it to throw `UncheckedRestException` like its sibling. I inspected all uses of the method and made adjustments where needed.

`TestHostedRepository::fileContents` didn't return the raw contents of files. Specifically it didn't preserve trailing newlines. To fix this, I changed it to no longer convert to lines and then joining them again.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1598](https://bugs.openjdk.org/browse/SKARA-1598): GitRepository.isHealthy takes a long time in ArchiveWorkItem


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1442/head:pull/1442` \
`$ git checkout pull/1442`

Update a local copy of the PR: \
`$ git checkout pull/1442` \
`$ git pull https://git.openjdk.org/skara pull/1442/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1442`

View PR using the GUI difftool: \
`$ git pr show -t 1442`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1442.diff">https://git.openjdk.org/skara/pull/1442.diff</a>

</details>
