### PR TITLE
1722: Add duration logging for RestRequestCache lock

### DIFF
--- a/network/src/main/java/org/openjdk/skara/network/RestRequestCache.java
+++ b/network/src/main/java/org/openjdk/skara/network/RestRequestCache.java
@@ -201,12 +201,15 @@ enum RestRequestCache {
             }
             var finalRequest = requestBuilder.build();
             HttpResponse<String> response;
+            var beforeLock = Instant.now();
             try (var ignored = new LockWithTimeout(authLock)) {
                 // Perform requests using a certain account serially
-                var before = Instant.now();
+                var beforeCall = Instant.now();
+                var lockDelay = Duration.between(beforeLock, beforeCall);
+                log.log(Level.FINE, "Taking lock for GET " + finalRequest.uri() + " took " + lockDelay, lockDelay);
                 response = client.send(finalRequest, HttpResponse.BodyHandlers.ofString());
-                var duration = Duration.between(before, Instant.now());
-                log.log(Level.FINE, "Calling GET " + finalRequest.uri().toString() + " took " + duration, duration);
+                var callDuration = Duration.between(beforeCall, Instant.now());
+                log.log(Level.FINE, "Calling GET " + finalRequest.uri().toString() + " took " + callDuration, callDuration);
             }
             if (cached != null && response.statusCode() == 304) {
                 cacheHitsCounter.inc();
@@ -222,6 +225,7 @@ enum RestRequestCache {
             var finalRequest = requestBuilder.build();
             log.finer("Not using response cache for " + finalRequest + " (" + authId + ")");
             Instant lastUpdate;
+            var beforeLock = Instant.now();
             try (var ignored = new LockWithTimeout(authLock)) {
                 lastUpdate = lastUpdates.getOrDefault(authId, Instant.now().minus(Duration.ofDays(1)));
                 lastUpdates.put(authId, Instant.now());
@@ -235,10 +239,12 @@ enum RestRequestCache {
                 }
             }
             try (var ignored = new LockWithTimeout(authLock)) {
-                var before = Instant.now();
+                var beforeCall = Instant.now();
+                var lockDelay = Duration.between(beforeLock, beforeCall);
+                log.log(Level.FINE, "Taking lock and adding required delay for " + finalRequest.method() + " " + finalRequest.uri() + " took " + lockDelay, lockDelay);
                 var response = client.send(finalRequest, HttpResponse.BodyHandlers.ofString());
-                var duration = Duration.between(before, Instant.now());
-                log.log(Level.FINE, "Calling " + finalRequest.method() + " " + finalRequest.uri().toString() + " took " + duration, duration);
+                var callDuration = Duration.between(beforeCall, Instant.now());
+                log.log(Level.FINE, "Calling " + finalRequest.method() + " " + finalRequest.uri().toString() + " took " + callDuration, callDuration);
                 return response;
             } finally {
                 // Invalidate any related GET caches


### PR DESCRIPTION
This patch adds additional logging of durations for things that take time. In this case it's measuring how long it takes to get the lock before calling a remote REST API.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1722](https://bugs.openjdk.org/browse/SKARA-1722): Add duration logging for RestRequestCache lock


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1444/head:pull/1444` \
`$ git checkout pull/1444`

Update a local copy of the PR: \
`$ git checkout pull/1444` \
`$ git pull https://git.openjdk.org/skara pull/1444/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1444`

View PR using the GUI difftool: \
`$ git pr show -t 1444`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1444.diff">https://git.openjdk.org/skara/pull/1444.diff</a>

</details>
