### PR TITLE
1715: Configure custom default security level for new backport issues in notifier

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
@@ -79,6 +79,9 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
     // when parsing a version from a tag).
     private final boolean tagMatchPrefix;
 
+    record BranchSecurity(Pattern branch, String securityId) {}
+    private final List<BranchSecurity> defaultSecurity;
+
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots.notify");
 
     // Lazy loaded
@@ -89,7 +92,7 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
                   JbsBackport jbsBackport, boolean prOnly, boolean repoOnly, String buildName,
                   HostedRepository censusRepository, String censusRef, String namespace, boolean useHeadVersion,
                   HostedRepository originalRepository, boolean resolve, Set<String> tagIgnoreOpt,
-                  boolean tagMatchPrefix) {
+                  boolean tagMatchPrefix, List<BranchSecurity> defaultSecurity) {
         this.issueProject = issueProject;
         this.reviewLink = reviewLink;
         this.reviewIcon = reviewIcon;
@@ -110,6 +113,7 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
         this.resolve = resolve;
         this.tagIgnoreOpt = tagIgnoreOpt;
         this.tagMatchPrefix = tagMatchPrefix;
+        this.defaultSecurity = defaultSecurity;
     }
 
     static IssueNotifierBuilder newBuilder() {
@@ -301,7 +305,7 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
                             var existing = Backports.findIssue(issue, fixVersion);
                             if (existing.isEmpty()) {
                                 log.info("Creating new backport for " + issue.id() + " with fixVersion " + requestedVersion);
-                                issue = jbsBackport.createBackport(issue, requestedVersion, username.orElse(null));
+                                issue = jbsBackport.createBackport(issue, requestedVersion, username.orElse(null), defaultSecurity(branch));
                             } else {
                                 log.info("Found existing backport for " + issue.id() + " and requested fixVersion "
                                         + requestedVersion + " " + existing.get().id());
@@ -368,6 +372,14 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
                     .findFirst());
         }
         return Optional.empty();
+    }
+
+    private String defaultSecurity(Branch branch) {
+        return defaultSecurity.stream()
+                .filter(branchSecurity -> branchSecurity.branch.matcher(branch.name()).matches())
+                .map(BranchSecurity::securityId)
+                .findFirst()
+                .orElse(null);
     }
 
     @Override

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierBuilder.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierBuilder.java
@@ -50,6 +50,7 @@ class IssueNotifierBuilder {
     private boolean resolve = true;
     private Set<String> tagIgnoreOpt = Set.of();
     private boolean tagMatchPrefix = false;
+    private List<IssueNotifier.BranchSecurity> defaultSecurity = List.of();
 
     IssueNotifierBuilder issueProject(IssueProject issueProject) {
         this.issueProject = issueProject;
@@ -152,6 +153,11 @@ class IssueNotifierBuilder {
         return this;
     }
 
+    public IssueNotifierBuilder defaultSecurity(List<IssueNotifier.BranchSecurity> defaultSecurity) {
+        this.defaultSecurity = defaultSecurity;
+        return this;
+    }
+
     public boolean prOnly() {
         return prOnly;
     }
@@ -165,6 +171,6 @@ class IssueNotifierBuilder {
         return new IssueNotifier(issueProject, reviewLink, reviewIcon, commitLink, commitIcon,
                 setFixVersion, fixVersions, altFixVersions, jbsBackport, prOnly,
                 repoOnly, buildName, censusRepository, censusRef, namespace, useHeadVersion, originalRepository,
-                resolve, tagIgnoreOpt, tagMatchPrefix);
+                resolve, tagIgnoreOpt, tagMatchPrefix, defaultSecurity);
     }
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierFactory.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierFactory.java
@@ -141,6 +141,13 @@ public class IssueNotifierFactory implements NotifierFactory {
             }
         }
 
+        if (notifierConfiguration.contains("defaultsecurity")) {
+            var defaultSecurity = notifierConfiguration.get("defaultsecurity").fields().stream()
+                    .map(e -> new IssueNotifier.BranchSecurity(Pattern.compile(e.name()), e.value().asString()))
+                    .toList();
+            builder.defaultSecurity(defaultSecurity);
+        }
+
         return builder.build();
     }
 }

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
@@ -78,7 +78,7 @@ public class IssueNotifierTests {
                              .addConfiguration("repositories", JSON.object()
                                                                    .put("hostedrepo", JSON.object()
                                                                                           .put("basename", "test")
-                                                                                          .put("branches", "master|other")
+                                                                                          .put("branches", "master|other|other2")
                                                                                           .put("issue", notifierConfig)));
     }
 
@@ -1716,10 +1716,103 @@ public class IssueNotifierTests {
 
             // Labels should not
             assertEquals(0, backport.labelNames().size());
+        }
+    }
 
-            // If the parent issue has a security level (can be configured when running a test manually) it should be propagated
-            if (level != null) {
-                assertEquals(level.asString(), backport.properties().get("security").asString());
+    @Test
+    void testIssueBackportDefaultSecurity(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var repo = credentials.getHostedRepository();
+            var repoFolder = tempFolder.path().resolve("repo");
+            var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType(), Path.of("appendable.txt"), Set.of(), null);
+            credentials.commitLock(localRepo);
+            localRepo.pushAll(repo.url());
+            // Initialize other branches
+            var initialHead = localRepo.head();
+            localRepo.push(initialHead, repo.url(), "other");
+            localRepo.push(initialHead, repo.url(), "other2");
+
+            var storageFolder = tempFolder.path().resolve("storage");
+            var issueProject = credentials.getIssueProject();
+            var jbsNotifierConfig = JSON.object()
+                    .put("fixversions", JSON.object()
+                            .put(".*aster", "20.0.2")
+                            .put("other", "20.0.1")
+                            .put("other2", "19.0.2"))
+                    .put("defaultsecurity", JSON.object()
+                            .put("othe.*", "100"));
+
+            var notifyBot = testBotBuilder(repo, issueProject, storageFolder, jbsNotifierConfig).create("notify", JSON.object());
+
+            // Initialize history
+            TestBotRunner.runPeriodicItems(notifyBot);
+
+            // Create an issue and commit a fix
+            var issue = issueProject.createIssue("This is an issue", List.of("Indeed"),
+                    Map.of("issuetype", JSON.of("Enhancement"),
+                            SUBCOMPONENT, JSON.of("java.io"),
+                            RESOLVED_IN_BUILD, JSON.of("b07")
+                    ));
+            var level = issue.properties().get("security");
+            issue.setProperty("fixVersions", JSON.array().add("21"));
+            issue.setProperty("priority", JSON.of("1"));
+
+            var authorEmailAddress = issueProject.issueTracker().currentUser().username() + "@openjdk.org";
+            var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", issue.id() + ": Fix that issue", "Duke", authorEmailAddress);
+            localRepo.push(editHash, repo.url(), "master");
+            TestBotRunner.runPeriodicItems(notifyBot);
+
+            {
+                // The fixVersion should not have been updated
+                var updatedIssue = issueProject.issue(issue.id()).orElseThrow();
+                assertEquals(Set.of("21"), fixVersions(updatedIssue));
+                assertEquals(OPEN, updatedIssue.state());
+                assertEquals(List.of(), updatedIssue.assignees());
+
+                // There should be a link
+                var links = updatedIssue.links();
+                assertEquals(1, links.size());
+                var link = links.get(0);
+                var backport = link.issue().orElseThrow();
+
+                // The backport issue should have a correct fixVersion and no security
+                assertEquals(Set.of("20.0.2"), fixVersions(backport));
+                assertNull(backport.properties().get("security"));
+            }
+
+            // Push the fix to other branch
+            localRepo.push(editHash, repo.url(), "other");
+            TestBotRunner.runPeriodicItems(notifyBot);
+
+            {
+                // Find the new backport
+                var updatedIssue = issueProject.issue(issue.id()).orElseThrow();
+                var links = updatedIssue.links();
+                assertEquals(2, links.size());
+                var backport = links.get(1).issue().orElseThrow();
+
+                // The backport issue should have a correct fixVersion and security
+                assertEquals(Set.of("20.0.1"), fixVersions(backport));
+                assertEquals("100", backport.properties().get("security").asString());
+            }
+
+            // Set security on the original issue
+            issue.setProperty("security", JSON.of("200"));
+            // Push to another branch
+            localRepo.push(editHash, repo.url(), "other2");
+            TestBotRunner.runPeriodicItems(notifyBot);
+
+            {
+                // Find the new backport
+                var updatedIssue = issueProject.issue(issue.id()).orElseThrow();
+                var links = updatedIssue.links();
+                assertEquals(3, links.size());
+                var backport = links.get(2).issue().orElseThrow();
+
+                // The backport issue should have a correct fixVersion and security
+                assertEquals(Set.of("19.0.2"), fixVersions(backport));
+                assertEquals("200", backport.properties().get("security").asString());
             }
         }
     }

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraProject.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraProject.java
@@ -280,7 +280,8 @@ public class JiraProject implements IssueProject {
                                                       .collect(Collectors.toList())));
             case "issuetype":
                 return Optional.of(JSON.object().put("id", issueTypeId(value.asString())));
-            case "priority":
+            case "priority": // fall-through
+            case "security":
                 return Optional.of(JSON.object().put("id", value.asString()));
             default:
                 return Optional.of(value);


### PR DESCRIPTION
This patch makes it possible to configure a default security level to use for any newly created backport in the IssueNotifier. The configuration is done per repository and branch, with a regex for matching branch names. This is what it would look like in the bot configuration.

```
"issue": {
  "project": "bugs/JDK",
  "fixversions": {},
  "buildname": "master",
  "headversion": true,
  "defaultsecurity": {  // <- new
    "jdk.*": "10000",
  }
}
```

If the parent bug already has a security level, then that is inherited, just like today, otherwise this new default value is used.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1715](https://bugs.openjdk.org/browse/SKARA-1715): Configure custom default security level for new backport issues in notifier


### Reviewers
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - Committer)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1445/head:pull/1445` \
`$ git checkout pull/1445`

Update a local copy of the PR: \
`$ git checkout pull/1445` \
`$ git pull https://git.openjdk.org/skara pull/1445/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1445`

View PR using the GUI difftool: \
`$ git pr show -t 1445`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1445.diff">https://git.openjdk.org/skara/pull/1445.diff</a>

</details>
