### PR TITLE
1699: CommitCommentsWorkItem does excessive unnecessary work

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
@@ -116,6 +116,7 @@ public class PullRequestBotFactory implements BotFactory {
                                            .externalPullRequestCommands(externalPullRequestCommands)
                                            .externalCommitCommands(externalCommitCommands)
                                            .seedStorage(configuration.storageFolder().resolve("seeds"))
+                                           .excludeCommitCommentsFrom(excludeCommitCommentsFrom)
                                            .forks(forks);
 
             if (repo.value().contains("labels")) {

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
@@ -206,7 +206,8 @@ class InMemoryHostedRepository implements HostedRepository {
     }
 
     @Override
-    public List<CommitComment> recentCommitComments(Map<String, Set<Hash>> commitTitleToCommits, Set<Integer> excludeAuthors) {
+    public List<CommitComment> recentCommitComments(ReadOnlyRepository unused, Set<Integer> excludeAuthors,
+            List<Branch> branches, ZonedDateTime updatedAfter) {
         return List.of();
     }
 

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.skara.forge;
 
+import java.time.Duration;
 import org.openjdk.skara.host.HostUser;
 import org.openjdk.skara.json.JSONValue;
 import org.openjdk.skara.issuetracker.Label;
@@ -108,9 +109,21 @@ public interface HostedRepository {
     void deleteBranch(String ref);
     List<CommitComment> commitComments(Hash hash);
     default List<CommitComment> recentCommitComments() {
-        return recentCommitComments(Map.of(), Set.of());
+        return recentCommitComments(null, Set.of(), null, ZonedDateTime.now().minus(Duration.ofDays(4)));
     }
-    List<CommitComment> recentCommitComments(Map<String, Set<Hash>> commitTitleToCommits, Set<Integer> excludeAuthors);
+
+    /**
+     * Fetch recent commit comments from the forge.
+     * @param localRepo Only needed for certain implementations. Needs to be a
+     *                  reasonably up-to-date clone of this repository
+     * @param excludeAuthors Set of authors to exclude from the results
+     * @param Branches Optional list of branches to limit the search to if
+     *                 supported by the implementation.
+     * @param updatedAfter Filter out comments older than this
+     * @return A list of CommitComments
+     */
+    List<CommitComment> recentCommitComments(ReadOnlyRepository localRepo, Set<Integer> excludeAuthors,
+            List<Branch> Branches, ZonedDateTime updatedAfter);
     CommitComment addCommitComment(Hash hash, String body);
     void updateCommitComment(String id, String body);
 

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -376,7 +376,8 @@ public class GitHubRepository implements HostedRepository {
     }
 
     @Override
-    public List<CommitComment> recentCommitComments(Map<String, Set<Hash>> commitTitleToCommits, Set<Integer> excludeAuthors) {
+    public List<CommitComment> recentCommitComments(ReadOnlyRepository unused, Set<Integer> excludeAuthors,
+            List<Branch> branches, ZonedDateTime updatedAfter) {
         var parts = name().split("/");
         var owner = parts[0];
         var name = parts[1];
@@ -439,6 +440,10 @@ public class GitHubRepository implements HostedRepository {
                                                         createdAt,
                                                         updatedAt);
                            })
+                           // It's not possible to filter on timestamp in the GraphQL API, but we
+                           // can at least filter here to limit the amount of data returned to the
+                           // caller.
+                           .filter(c -> c.updatedAt().isAfter(updatedAfter))
                            .collect(Collectors.toList());
         Collections.reverse(comments);
         return comments;

--- a/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
@@ -287,12 +287,14 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
     }
 
     @Override
-    public List<CommitComment> recentCommitComments(Map<String, Set<Hash>> commitTitleToCommits, Set<Integer> excludeAuthors) {
+    public List<CommitComment> recentCommitComments(ReadOnlyRepository unused, Set<Integer> excludeAuthors,
+            List<Branch> branches, ZonedDateTime updatedAfter) {
         return commitComments.values()
                              .stream()
                              .flatMap(e -> e.stream())
                              .sorted((c1, c2) -> c2.updatedAt().compareTo(c1.updatedAt()))
                              .filter(c -> !excludeAuthors.contains(Integer.valueOf(c.author().id())))
+                             .filter(c -> c.updatedAt().isAfter(updatedAfter))
                              .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
The `CommitCommentsWorkItem` gets scheduled once for each repository by `PullRequestBot::getPeriodicItems`. It's responsible for querying the repository for new comments on commits, and if any are found, spawn `CommitCommandWorkItem` for them. It's unfortunately not very straight forward to query forges for new commit comments. For GitHub we have a rather complicated GraphQL that does the trick, but for GitLab, we need to jump through some rather nasty hoops.

The main issue is that the data we get from the "events" query from GitLab contains notes posted to commits, but without the commit hash. We only get the commit "title" to identify which commit was commented on. To solve this, we have a rather elaborate logic that first builds a complete map from title to set of hashes for every commit in the repo. This is done preemptively on a local clone of the repo. Using this map and some clever comparisons, we can figure out which commit each comment belongs to.

I don't have data on how long it takes to build this map for a big repository, like the JDK, but it's likely not trivially short. In addition to this, before using any local clone of a repository, we always run the git fsck check (see [SKARA-1598](https://bugs.openjdk.org/browse/SKARA-1598)), which can take around 20s for the JDK repo. The local clone is unfortunately also used to check if the commits for the found comments belong to a valid branch. However, both of these operations are read only, so we shouldn't really need a clone for this. We should be fine just using the seed repository directly from the `HostedRepositoryPool`.

This patch tries to make this situation better in several ways.

1. Use the seed repository instead of a clone in `CommitCommentsWorkItem`. (Removes ~20s fsck time every time this is scheduled for a jdk repository, which is in the order of once a minute times the numer of JDK repo clones that Skara operates on)
2. Refactored `HostedRepository::recentCommitComments` to take a `ReadOnlyRepository` instead of the pre calculated map. `GitLabRepository` is then responsible for using this repository to build the map itself.
3. `HostedRepository::recentCommitComments` now takes an `updatedAfter` arg to limit the number of comments that get returned. In `GitLabRepository` this was already limited to last 4 days, but in `GitHubRepository`, we just got the last 100 comments, regardless of age (due to a limitation in GraphQL). We can still filter the returned comments on updatedAt so that we get less comments to process in many cases. This should make a big impact on bot restarts. 
4. `CommitCommentsWorkItem` has a configuration option to ignore comments from certain users (typically meant for bot users, e.g. the notifier who posts a comment on every commit). This configuration wasn't working due to a bug in the factory. (Together with 3, should bring down the number of scheduled `CommitCommandWorkItem` on bot restart from 100 per repo to a handful and often 0.)
5. `GitLabRepository` keeps a cached copy of the commitTitleToHash map. It will also only build or update the map if any new notes are actually found. (This won't have a huge impact, but should speed things up a little bit more)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1699](https://bugs.openjdk.org/browse/SKARA-1699): CommitCommentsWorkItem does excessive unnecessary work


### Reviewers
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - Committer)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1446/head:pull/1446` \
`$ git checkout pull/1446`

Update a local copy of the PR: \
`$ git checkout pull/1446` \
`$ git pull https://git.openjdk.org/skara pull/1446/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1446`

View PR using the GUI difftool: \
`$ git pr show -t 1446`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1446.diff">https://git.openjdk.org/skara/pull/1446.diff</a>

</details>
