### PR TITLE
1726: PROGRESS_MARKER should be added before the CSR bot add CSR_UPDATE_MARKER

### DIFF
--- a/bots/csr/src/main/java/org/openjdk/skara/bots/csr/PullRequestWorkItem.java
+++ b/bots/csr/src/main/java/org/openjdk/skara/bots/csr/PullRequestWorkItem.java
@@ -123,7 +123,9 @@ class PullRequestWorkItem implements WorkItem {
 
     private void addUpdateMarker(PullRequest pr) {
         var statusMessage = getStatusMessage(pr);
-        if (!statusMessage.contains(CSR_UPDATE_MARKER)) {
+        if (statusMessage.isEmpty()) {
+            log.info("No PROGRESS_MARKER found in PR body, wait for first CheckRun before adding csr update marker.");
+        } else if (!statusMessage.contains(CSR_UPDATE_MARKER)) {
             pr.setBody(pr.body() + "\n" + CSR_UPDATE_MARKER + "\n");
         } else {
             log.info("The pull request " + describe(pr) + " has already had a csr update marker. Do not need to add it again.");

--- a/bots/csr/src/test/java/org/openjdk/skara/bots/csr/CSRBotTests.java
+++ b/bots/csr/src/test/java/org/openjdk/skara/bots/csr/CSRBotTests.java
@@ -466,8 +466,8 @@ class CSRBotTests {
             assertFalse(pr.store().body().contains(csrUpdateMarker));
             // Run csr issue bot to trigger updates on the CSR issue
             TestBotRunner.runPeriodicItems(csrIssueBot);
-            // The bot should add the csr update marker
-            assertTrue(pr.store().body().contains(csrUpdateMarker));
+            // The bot should not add the csr update marker
+            assertFalse(pr.store().body().contains(csrUpdateMarker));
 
             // Add csr issue and progress to the PR body
             pr.setBody("PR body\n" + progressMarker + csr.id() + csr.webUrl().toString() + csr.title() + " (**CSR**)"


### PR DESCRIPTION
While testing [SKARA-1714](https://bugs.openjdk.org/browse/SKARA-1714) in this pull request (https://github.com/openjdk/playground/pull/112), we discovered that if a CSR issue already exists for a main issue and a pull request is then created for the main issue, the CSR and PR bots become stuck in an endless loop and are unable to update the pull request body. 

After further investigation, we determined that the cause of this issue is that the CSR bot checks for the presence of the CSR_UPDATE_MARKER in the pull request body before adding it, but first checks for the PROGRESS_MARKER. However, when the CSR bot's pullRequestWorkItem runs for the first time, it is likely that the PR bot's CheckWorkItem has not yet run, resulting in the absence of the PROGRESS_MARKER in the pull request body. In this case, the CSR bot continues to add the CSR_UPDATE_MARKER, while the PR bot attempts to update the pull request body but finds that it has been recently updated and therefore gives up on the update. 

The correct fix is to only add CSR_UPDATE_MARKER if we find a PROGRESS_MARKER.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1726](https://bugs.openjdk.org/browse/SKARA-1726): PROGRESS_MARKER should be added before the CSR bot add CSR_UPDATE_MARKER


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1447/head:pull/1447` \
`$ git checkout pull/1447`

Update a local copy of the PR: \
`$ git checkout pull/1447` \
`$ git pull https://git.openjdk.org/skara pull/1447/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1447`

View PR using the GUI difftool: \
`$ git pr show -t 1447`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1447.diff">https://git.openjdk.org/skara/pull/1447.diff</a>

</details>
