### PR TITLE
Comment detailing refspec format in GitRepository#push

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -601,6 +601,13 @@ public class GitRepository implements Repository {
 
         cmd.add(uri.toString());
 
+        /*
+         * https://git-scm.com/docs/git-push
+         * Specify what destination ref to update with what source object.
+         * The format of a <refspec> parameter is an optional plus +, followed by
+         * the source object, followed by a colon : and finally by the destination
+         * ref.
+         */
         String refspec = force ? "+" : "";
         if (!ref.startsWith("refs/")) {
             ref = "refs/heads/" + ref;


### PR DESCRIPTION
Small change to document the git refspec field in GitRepository#push via comment

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1448/head:pull/1448` \
`$ git checkout pull/1448`

Update a local copy of the PR: \
`$ git checkout pull/1448` \
`$ git pull https://git.openjdk.org/skara pull/1448/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1448`

View PR using the GUI difftool: \
`$ git pr show -t 1448`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1448.diff">https://git.openjdk.org/skara/pull/1448.diff</a>

</details>
