### PR TITLE
1728: Should iterate over all issues in PullRequestWorkItem in CSR bot

### DIFF
--- a/bots/csr/src/main/java/org/openjdk/skara/bots/csr/PullRequestWorkItem.java
+++ b/bots/csr/src/main/java/org/openjdk/skara/bots/csr/PullRequestWorkItem.java
@@ -49,8 +49,8 @@ import org.openjdk.skara.jbs.Backports;
  */
 class PullRequestWorkItem implements WorkItem {
     private final static String CSR_LABEL = "csr";
-    protected final static String CSR_UPDATE_MARKER = "<!-- csr: 'update' -->";
-    protected static final String PROGRESS_MARKER = "<!-- Anything below this marker will be automatically updated, please do not edit manually! -->";
+    final static String CSR_UPDATE_MARKER = "<!-- csr: 'update' -->";
+    static final String PROGRESS_MARKER = "<!-- Anything below this marker will be automatically updated, please do not edit manually! -->";
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots.csr");
     private final HostedRepository repository;
     private final String prId;

--- a/bots/csr/src/main/java/org/openjdk/skara/bots/csr/PullRequestWorkItem.java
+++ b/bots/csr/src/main/java/org/openjdk/skara/bots/csr/PullRequestWorkItem.java
@@ -49,8 +49,8 @@ import org.openjdk.skara.jbs.Backports;
  */
 class PullRequestWorkItem implements WorkItem {
     private final static String CSR_LABEL = "csr";
-    private final static String CSR_UPDATE_MARKER = "<!-- csr: 'update' -->";
-    private static final String PROGRESS_MARKER = "<!-- Anything below this marker will be automatically updated, please do not edit manually! -->";
+    protected final static String CSR_UPDATE_MARKER = "<!-- csr: 'update' -->";
+    protected static final String PROGRESS_MARKER = "<!-- Anything below this marker will be automatically updated, please do not edit manually! -->";
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots.csr");
     private final HostedRepository repository;
     private final String prId;

--- a/bots/csr/src/main/java/org/openjdk/skara/bots/csr/PullRequestWorkItem.java
+++ b/bots/csr/src/main/java/org/openjdk/skara/bots/csr/PullRequestWorkItem.java
@@ -163,8 +163,7 @@ class PullRequestWorkItem implements WorkItem {
                 allCSRApproved = false;
                 var issueId = issue.project().isEmpty() ? (project.name() + "-" + issue.id()) : issue.id();
                 log.info(issueId + " for " + describe(pr) + " not found");
-                // allCSRApproved is now false, so there is no point in continuing
-                break;
+                continue;
             }
 
             var csrOptional = Backports.findCsr(jbsIssueOpt.get(), versionOpt.get());
@@ -193,8 +192,7 @@ class PullRequestWorkItem implements WorkItem {
                 } else {
                     log.info("CSR issue resolution is null for csr issue " + csr.id() + " for " + describe(pr) + ", not removing the CSR label");
                 }
-                // allCSRApproved is now false, so there is no point in continuing
-                break;
+                continue;
             }
 
             var name = resolution.get("name");
@@ -206,8 +204,7 @@ class PullRequestWorkItem implements WorkItem {
                 } else {
                     log.info("CSR issue resolution name is null for csr issue " + csr.id() + " for " + describe(pr) + ", not removing the CSR label");
                 }
-                // allCSRApproved is now false, so there is no point in continuing
-                break;
+                continue;
             }
 
             if (csr.state() != Issue.State.CLOSED) {
@@ -218,8 +215,7 @@ class PullRequestWorkItem implements WorkItem {
                 } else {
                     log.info("CSR issue state is not closed for csr issue" + csr.id() + " for " + describe(pr) + ", not removing the CSR label");
                 }
-                // allCSRApproved is now false, so there is no point in continuing
-                break;
+                continue;
             }
 
             if (!name.asString().equals("Approved")) {
@@ -228,8 +224,8 @@ class PullRequestWorkItem implements WorkItem {
                     // And the bot can't remove the CSR label automatically here.
                     // Because the PR author with the role of Committer may withdraw a CSR that
                     // a Reviewer had requested and integrate it without satisfying that requirement.
+                    needToAddUpdateMarker = true;
                     log.info("CSR closed and withdrawn for csr issue " + csr.id() + " for " + describe(pr));
-                    continue;
                 } else if (!pr.labelNames().contains(CSR_LABEL)) {
                     allCSRApproved = false;
                     log.info("CSR issue resolution is not 'Approved' for csr issue " + csr.id() + " for " + describe(pr) + ", adding the CSR label");
@@ -238,7 +234,7 @@ class PullRequestWorkItem implements WorkItem {
                     allCSRApproved = false;
                     log.info("CSR issue resolution is not 'Approved' for csr issue " + csr.id() + " for " + describe(pr) + ", not removing the CSR label");
                 }
-                break;
+                continue;
             }
 
             // The CSR issue has been closed and approved

--- a/bots/csr/src/test/java/org/openjdk/skara/bots/csr/CSRBotTests.java
+++ b/bots/csr/src/test/java/org/openjdk/skara/bots/csr/CSRBotTests.java
@@ -39,6 +39,9 @@ import java.util.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 class CSRBotTests {
+    private final static String CSR_UPDATE_MARKER = "<!-- csr: 'update' -->";
+    private static final String PROGRESS_MARKER = "<!-- Anything below this marker will be automatically updated, please do not edit manually! -->";
+
     @Test
     void removeLabelForApprovedCSR(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
@@ -422,8 +425,6 @@ class CSRBotTests {
 
     @Test
     void testCsrUpdateMarker(TestInfo testInfo) throws IOException {
-        String csrUpdateMarker = "<!-- csr: 'update' -->";
-        String progressMarker = "<!-- Anything below this marker will be automatically updated, please do not edit manually! -->";
         try (var credentials = new HostCredentials(testInfo);
              var tempFolder = new TemporaryDirectory()) {
             var repo = credentials.getHostedRepository();
@@ -453,7 +454,7 @@ class CSRBotTests {
             // Run bot
             TestBotRunner.runPeriodicItems(csrPullRequestBot);
             // The bot shouldn't add the csr update marker
-            assertFalse(pr.store().body().contains(csrUpdateMarker));
+            assertFalse(pr.store().body().contains(CSR_UPDATE_MARKER));
 
             // Add the csr issue.
             var csr = issueProject.createIssue("This is an CSR", List.of(), Map.of());
@@ -463,19 +464,19 @@ class CSRBotTests {
             // Run just the pull request bot
             TestBotRunner.runPeriodicItems(csrPullRequestBot);
             // Nothing should have happened
-            assertFalse(pr.store().body().contains(csrUpdateMarker));
+            assertFalse(pr.store().body().contains(CSR_UPDATE_MARKER));
             // Run csr issue bot to trigger updates on the CSR issue
             TestBotRunner.runPeriodicItems(csrIssueBot);
             // The bot should not add the csr update marker
-            assertFalse(pr.store().body().contains(csrUpdateMarker));
+            assertFalse(pr.store().body().contains(CSR_UPDATE_MARKER));
 
             // Add csr issue and progress to the PR body
-            pr.setBody("PR body\n" + progressMarker + csr.id() + csr.webUrl().toString() + csr.title() + " (**CSR**)"
+            pr.setBody("PR body\n" + PROGRESS_MARKER + csr.id() + csr.webUrl().toString() + csr.title() + " (**CSR**)"
                     + "- [ ] " + generateCSRProgressMessage(csr));
             // Run bot
             TestBotRunner.runPeriodicItems(csrPullRequestBot);
             // The bot shouldn't add the csr update marker
-            assertFalse(pr.store().body().contains(csrUpdateMarker));
+            assertFalse(pr.store().body().contains(CSR_UPDATE_MARKER));
 
             // Set csr status to closed and approved.
             csr.setState(Issue.State.CLOSED);
@@ -483,30 +484,29 @@ class CSRBotTests {
             // un csr issue bot to trigger updates on the CSR issue
             TestBotRunner.runPeriodicItems(csrIssueBot);
             // The bot should add the csr update marker
-            assertTrue(pr.store().body().contains(csrUpdateMarker));
+            assertTrue(pr.store().body().contains(CSR_UPDATE_MARKER));
 
             // Add csr issue and selected progress to the PR body
-            pr.setBody("PR body\n" + progressMarker + csr.id() + csr.webUrl().toString() + csr.title() + " (**CSR**)"
+            pr.setBody("PR body\n" + PROGRESS_MARKER + csr.id() + csr.webUrl().toString() + csr.title() + " (**CSR**)"
                     + "- [x] " + generateCSRProgressMessage(csr));
             // Run bot
             TestBotRunner.runPeriodicItems(csrPullRequestBot);
             // The bot shouldn't add the csr update marker
-            assertFalse(pr.store().body().contains(csrUpdateMarker));
+            assertFalse(pr.store().body().contains(CSR_UPDATE_MARKER));
 
             // Add csr update marker to the pull request body manually.
-            pr.setBody("PR body\n" + progressMarker + csr.id() + csr.webUrl().toString() + csr.title() + " (**CSR**)"
+            pr.setBody("PR body\n" + PROGRESS_MARKER + csr.id() + csr.webUrl().toString() + csr.title() + " (**CSR**)"
                     + "- [ ] " + generateCSRProgressMessage(csr));
             // Run bot
             TestBotRunner.runPeriodicItems(csrPullRequestBot);
             // The bot shouldn't add the csr update marker again. The PR should have only one csr update marker.
-            assertTrue(pr.store().body().contains(csrUpdateMarker));
-            assertEquals(pr.store().body().indexOf(csrUpdateMarker), pr.store().body().lastIndexOf(csrUpdateMarker));
+            assertTrue(pr.store().body().contains(CSR_UPDATE_MARKER));
+            assertEquals(pr.store().body().indexOf(CSR_UPDATE_MARKER), pr.store().body().lastIndexOf(CSR_UPDATE_MARKER));
         }
     }
 
     @Test
     void testCsrUpdateMarkerWithWithdrawnCSRIssue(TestInfo testInfo) throws IOException {
-        String csrUpdateMarker = "<!-- csr: 'update' -->";
         try (var credentials = new HostCredentials(testInfo);
              var tempFolder = new TemporaryDirectory()) {
             var repo = credentials.getHostedRepository();
@@ -536,7 +536,7 @@ class CSRBotTests {
             // Run bot
             TestBotRunner.runPeriodicItems(csrPullRequestBot);
             // The bot shouldn't add the csr update marker
-            assertFalse(pr.store().body().contains(csrUpdateMarker));
+            assertFalse(pr.store().body().contains(CSR_UPDATE_MARKER));
 
             // Add a withdrawn csr issue.
             var csr = issueProject.createIssue("This is an CSR", List.of(), Map.of());
@@ -547,11 +547,11 @@ class CSRBotTests {
             // Run just the pull request bot
             TestBotRunner.runPeriodicItems(csrPullRequestBot);
             // Nothing should have happened
-            assertFalse(pr.store().body().contains(csrUpdateMarker));
+            assertFalse(pr.store().body().contains(CSR_UPDATE_MARKER));
             // Run csr issue bot to trigger updates on the CSR issue
             TestBotRunner.runPeriodicItems(csrIssueBot);
             // The bot should not add the csr update marker
-            assertFalse(pr.store().body().contains(csrUpdateMarker));
+            assertFalse(pr.store().body().contains(CSR_UPDATE_MARKER));
         }
     }
 
@@ -580,13 +580,14 @@ class CSRBotTests {
             var editHash = CheckableRepository.appendAndCommit(localRepo);
             localRepo.push(editHash, repo.url(), "edit", true);
             var pr = credentials.createPullRequest(repo, "master", "edit", issue.id() + ": This is an issue");
+            pr.setBody("PR body\n" + PROGRESS_MARKER);
             // Add the notification link to the PR in the issue. This is needed for the CSRIssueBot to
             // be able to trigger on CSR issue updates
             PullRequestUtils.postPullRequestLinkComment(issue, pr);
             // Run bot
             TestBotRunner.runPeriodicItems(csrPullRequestBot);
 
-            // Add an issue to this pr
+            // Add another issue to this pr
             var issue2 = issueProject.createIssue("This is an issue 2", List.of(), Map.of());
             issue2.setProperty("issuetype", JSON.of("Bug"));
             pr.addComment(SolvesTracker.setSolvesMarker(new org.openjdk.skara.vcs.openjdk.Issue(issue2.id(), issue2.title())));
@@ -612,6 +613,7 @@ class CSRBotTests {
             csr2.setState(Issue.State.CLOSED);
             csr2.setProperty("resolution", JSON.object().put("name", "Withdrawn"));
             TestBotRunner.runPeriodicItems(csrIssueBot);
+            assertTrue(pr.store().body().contains(CSR_UPDATE_MARKER));
             // PR should not contain csr label
             assertFalse(pr.store().labelNames().contains("csr"));
 

--- a/bots/csr/src/test/java/org/openjdk/skara/bots/csr/CSRBotTests.java
+++ b/bots/csr/src/test/java/org/openjdk/skara/bots/csr/CSRBotTests.java
@@ -37,11 +37,10 @@ import java.nio.file.Files;
 import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.openjdk.skara.bots.csr.PullRequestWorkItem.CSR_UPDATE_MARKER;
+import static org.openjdk.skara.bots.csr.PullRequestWorkItem.PROGRESS_MARKER;
 
 class CSRBotTests {
-    private final static String CSR_UPDATE_MARKER = "<!-- csr: 'update' -->";
-    private static final String PROGRESS_MARKER = "<!-- Anything below this marker will be automatically updated, please do not edit manually! -->";
-
     @Test
     void removeLabelForApprovedCSR(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);


### PR DESCRIPTION
While testing [SKARA-1714](https://bugs.openjdk.org/browse/SKARA-1714) on the staging environment, I discovered a bug in the PullRequestWorkItem in the CSR bot. The issue is that the for loop does not always iterate over all CSR issues for a pull request. 

For example, if we have two active CSR issues (csr1 and csr2) for one pull request, and we withdraw csr2, the loop will exit early after iterating over csr1 and CSR_UPDATE_MARKER will not be added, which means the PR body will not be updated and the status change of csr2 will not be displayed. 

Also, if we find a withdrawn pr, we need to add CSR_UPDATE_MARKER to the pr body.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1728](https://bugs.openjdk.org/browse/SKARA-1728): Should iterate over all issues in PullRequestWorkItem in CSR bot


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1449/head:pull/1449` \
`$ git checkout pull/1449`

Update a local copy of the PR: \
`$ git checkout pull/1449` \
`$ git pull https://git.openjdk.org/skara pull/1449/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1449`

View PR using the GUI difftool: \
`$ git pr show -t 1449`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1449.diff">https://git.openjdk.org/skara/pull/1449.diff</a>

</details>
