### PR TITLE
GitRepository#revert does not work as intended

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -469,7 +469,7 @@ public class GitRepository implements Repository {
 
     @Override
     public void revert(Hash h) throws IOException {
-        try (var p = capture("git", "checkout", "--recurse-submodules", h.hex(), "--", ".")) {
+        try (var p = capture("git", "restore", "--recurse-submodules", "--source", h.hex(), "--", ".")) {
             await(p);
         }
     }


### PR DESCRIPTION
The `Repository#revert` interface is meant to allow for rolling the Repository back to a specific commit, but the Git implementation in `GitRepository#revert` implements this via a checkout, which can cause issues, especially with newer versions of Git where it doesn't have any effect at all. More appropriate would be using `git restore --source` to implement the GitRepository variant instead, which is actually the encouraged way to do so nowadays

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1450/head:pull/1450` \
`$ git checkout pull/1450`

Update a local copy of the PR: \
`$ git checkout pull/1450` \
`$ git pull https://git.openjdk.org/skara pull/1450/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1450`

View PR using the GUI difftool: \
`$ git pr show -t 1450`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1450.diff">https://git.openjdk.org/skara/pull/1450.diff</a>

</details>
