### PR TITLE
1729: CSR bot should not remove CSR label if one of the CSR issues is withdrawn

### DIFF
--- a/bots/csr/src/main/java/org/openjdk/skara/bots/csr/PullRequestWorkItem.java
+++ b/bots/csr/src/main/java/org/openjdk/skara/bots/csr/PullRequestWorkItem.java
@@ -37,6 +37,7 @@ import org.openjdk.skara.bots.common.BotUtils;
 import org.openjdk.skara.bots.common.SolvesTracker;
 import org.openjdk.skara.forge.HostedRepository;
 import org.openjdk.skara.forge.PullRequest;
+import org.openjdk.skara.issuetracker.Comment;
 import org.openjdk.skara.issuetracker.Issue;
 import org.openjdk.skara.issuetracker.IssueProject;
 import org.openjdk.skara.jbs.Backports;
@@ -155,7 +156,7 @@ class PullRequestWorkItem implements WorkItem {
         boolean allCSRApproved = true;
         boolean needToAddUpdateMarker = false;
         boolean existingCSR = false;
-        boolean existingWithdrawnCSR = false;
+        boolean withdrawnCSRWhenCSRNeeded = false;
 
         for (var issue : issues) {
             var jbsIssueOpt = project.issue(issue.shortId());
@@ -226,7 +227,9 @@ class PullRequestWorkItem implements WorkItem {
                     // Because the PR author with the role of Committer may withdraw a CSR that
                     // a Reviewer had requested and integrate it without satisfying that requirement.
                     needToAddUpdateMarker = true;
-                    existingWithdrawnCSR = true;
+                    if (CSRNeeded(pr.comments())) {
+                        withdrawnCSRWhenCSRNeeded = true;
+                    }
                     log.info("CSR closed and withdrawn for csr issue " + csr.id() + " for " + describe(pr));
                 } else if (!pr.labelNames().contains(CSR_LABEL)) {
                     allCSRApproved = false;
@@ -250,12 +253,28 @@ class PullRequestWorkItem implements WorkItem {
         if (needToAddUpdateMarker) {
             addUpdateMarker(pr);
         }
-        if (allCSRApproved && existingCSR && !existingWithdrawnCSR && pr.labelNames().contains(CSR_LABEL)) {
+        if (allCSRApproved && existingCSR && !withdrawnCSRWhenCSRNeeded && pr.labelNames().contains(CSR_LABEL)) {
             log.info("All CSR issues closed and approved for " + describe(pr) + ", removing CSR label");
             pr.removeLabel(CSR_LABEL);
         }
         logLatency();
         return List.of();
+    }
+
+    /**
+     * Determine whether the CSR label is added via '/csr needed' command
+     */
+    private boolean CSRNeeded(List<Comment> comments) {
+        var CSRNeededCommentCount = 0;
+        for (var comment : comments) {
+            if (comment.body().contains("<!-- csr: 'needed' -->")) {
+                CSRNeededCommentCount++;
+            }
+            if (comment.body().contains("<!-- csr: 'unneeded' -->") && CSRNeededCommentCount > 0) {
+                CSRNeededCommentCount--;
+            }
+        }
+        return CSRNeededCommentCount > 0;
     }
 
     private void logLatency() {

--- a/bots/csr/src/main/java/org/openjdk/skara/bots/csr/PullRequestWorkItem.java
+++ b/bots/csr/src/main/java/org/openjdk/skara/bots/csr/PullRequestWorkItem.java
@@ -227,7 +227,7 @@ class PullRequestWorkItem implements WorkItem {
                     // Because the PR author with the role of Committer may withdraw a CSR that
                     // a Reviewer had requested and integrate it without satisfying that requirement.
                     needToAddUpdateMarker = true;
-                    if (CSRNeeded(pr.comments())) {
+                    if (isCSRNeeded(pr.comments())) {
                         withdrawnCSRWhenCSRNeeded = true;
                     }
                     log.info("CSR closed and withdrawn for csr issue " + csr.id() + " for " + describe(pr));
@@ -264,17 +264,17 @@ class PullRequestWorkItem implements WorkItem {
     /**
      * Determine whether the CSR label is added via '/csr needed' command
      */
-    private boolean CSRNeeded(List<Comment> comments) {
-        var CSRNeededCommentCount = 0;
-        for (var comment : comments) {
+    private boolean isCSRNeeded(List<Comment> comments) {
+        for (int i = comments.size() - 1; i >= 0; i--) {
+            var comment = comments.get(i);
             if (comment.body().contains("<!-- csr: 'needed' -->")) {
-                CSRNeededCommentCount++;
+                return true;
             }
-            if (comment.body().contains("<!-- csr: 'unneeded' -->") && CSRNeededCommentCount > 0) {
-                CSRNeededCommentCount--;
+            if (comment.body().contains("<!-- csr: 'unneeded' -->")) {
+                return false;
             }
         }
-        return CSRNeededCommentCount > 0;
+        return false;
     }
 
     private void logLatency() {

--- a/bots/csr/src/main/java/org/openjdk/skara/bots/csr/PullRequestWorkItem.java
+++ b/bots/csr/src/main/java/org/openjdk/skara/bots/csr/PullRequestWorkItem.java
@@ -155,6 +155,7 @@ class PullRequestWorkItem implements WorkItem {
         boolean allCSRApproved = true;
         boolean needToAddUpdateMarker = false;
         boolean existingCSR = false;
+        boolean existingWithdrawnCSR = false;
 
         for (var issue : issues) {
             var jbsIssueOpt = project.issue(issue.shortId());
@@ -225,6 +226,7 @@ class PullRequestWorkItem implements WorkItem {
                     // Because the PR author with the role of Committer may withdraw a CSR that
                     // a Reviewer had requested and integrate it without satisfying that requirement.
                     needToAddUpdateMarker = true;
+                    existingWithdrawnCSR = true;
                     log.info("CSR closed and withdrawn for csr issue " + csr.id() + " for " + describe(pr));
                 } else if (!pr.labelNames().contains(CSR_LABEL)) {
                     allCSRApproved = false;
@@ -248,7 +250,7 @@ class PullRequestWorkItem implements WorkItem {
         if (needToAddUpdateMarker) {
             addUpdateMarker(pr);
         }
-        if (allCSRApproved && existingCSR && pr.labelNames().contains(CSR_LABEL)) {
+        if (allCSRApproved && existingCSR && !existingWithdrawnCSR && pr.labelNames().contains(CSR_LABEL)) {
             log.info("All CSR issues closed and approved for " + describe(pr) + ", removing CSR label");
             pr.removeLabel(CSR_LABEL);
         }

--- a/bots/csr/src/test/java/org/openjdk/skara/bots/csr/CSRBotTests.java
+++ b/bots/csr/src/test/java/org/openjdk/skara/bots/csr/CSRBotTests.java
@@ -613,8 +613,8 @@ class CSRBotTests {
             csr2.setProperty("resolution", JSON.object().put("name", "Withdrawn"));
             TestBotRunner.runPeriodicItems(csrIssueBot);
             assertTrue(pr.store().body().contains(CSR_UPDATE_MARKER));
-            // PR should still contain csr label
-            assertTrue(pr.store().labelNames().contains("csr"));
+            // PR should not contain csr label because CSR label is not added via '/csr needed'
+            assertFalse(pr.store().labelNames().contains("csr"));
 
             // Add a csr to issue3
             var csr3 = issueProject.createIssue("This is an CSR for issue3", List.of(), Map.of());
@@ -630,8 +630,8 @@ class CSRBotTests {
             csr3.setState(Issue.State.CLOSED);
             csr3.setProperty("resolution", JSON.object().put("name", "Approved"));
             TestBotRunner.runPeriodicItems(csrIssueBot);
-            // PR should still contain csr label
-            assertTrue(pr.store().labelNames().contains("csr"));
+            // PR should not contain csr label
+            assertFalse(pr.store().labelNames().contains("csr"));
 
             // Approve CSR2
             csr2.setProperty("resolution", JSON.object().put("name", "Approved"));

--- a/bots/csr/src/test/java/org/openjdk/skara/bots/csr/CSRBotTests.java
+++ b/bots/csr/src/test/java/org/openjdk/skara/bots/csr/CSRBotTests.java
@@ -555,7 +555,7 @@ class CSRBotTests {
     }
 
     @Test
-    void testPRWithMultipleIssues(TestInfo testInfo) throws IOException{
+    void testPRWithMultipleIssues(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
              var tempFolder = new TemporaryDirectory()) {
             var repo = credentials.getHostedRepository();
@@ -613,8 +613,8 @@ class CSRBotTests {
             csr2.setProperty("resolution", JSON.object().put("name", "Withdrawn"));
             TestBotRunner.runPeriodicItems(csrIssueBot);
             assertTrue(pr.store().body().contains(CSR_UPDATE_MARKER));
-            // PR should not contain csr label
-            assertFalse(pr.store().labelNames().contains("csr"));
+            // PR should still contain csr label
+            assertTrue(pr.store().labelNames().contains("csr"));
 
             // Add a csr to issue3
             var csr3 = issueProject.createIssue("This is an CSR for issue3", List.of(), Map.of());
@@ -629,6 +629,12 @@ class CSRBotTests {
             // Approve CSR3
             csr3.setState(Issue.State.CLOSED);
             csr3.setProperty("resolution", JSON.object().put("name", "Approved"));
+            TestBotRunner.runPeriodicItems(csrIssueBot);
+            // PR should still contain csr label
+            assertTrue(pr.store().labelNames().contains("csr"));
+
+            // Approve CSR2
+            csr2.setProperty("resolution", JSON.object().put("name", "Approved"));
             TestBotRunner.runPeriodicItems(csrIssueBot);
             // PR should not contain csr label
             assertFalse(pr.store().labelNames().contains("csr"));


### PR DESCRIPTION
While testing [SKARA-1714](https://bugs.openjdk.org/browse/SKARA-1714), I discovered a bug in the PullRequestWorkItem of the CSR bot. 

Currently, the CSR bot would remove CSR label if all the CSR issues of the pr is closed(whether approved or withdrawn). However, if the CSR label is added via using '/csr needed' command and the pr contains withdrawn CSR issues, the CSR should not remove the CSR label.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1729](https://bugs.openjdk.org/browse/SKARA-1729): CSR bot should not remove CSR label if one of the CSR issues is withdrawn


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1451/head:pull/1451` \
`$ git checkout pull/1451`

Update a local copy of the PR: \
`$ git checkout pull/1451` \
`$ git pull https://git.openjdk.org/skara pull/1451/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1451`

View PR using the GUI difftool: \
`$ git pr show -t 1451`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1451.diff">https://git.openjdk.org/skara/pull/1451.diff</a>

</details>
