### PR TITLE
1173: Dependent PR feature does not work with protected branches in newer Gitlab version

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifierFactory.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifierFactory.java
@@ -35,7 +35,11 @@ public class PullRequestBranchNotifierFactory implements NotifierFactory {
     @Override
     public Notifier create(BotConfiguration botConfiguration, JSONObject notifierConfiguration) {
         var seedFolder = botConfiguration.storageFolder();
-        return new PullRequestBranchNotifier(seedFolder.resolve("seeds"));
+        var protectBranches = false;
+        if (notifierConfiguration.contains("protect")) {
+            protectBranches = notifierConfiguration.get("protect").asBoolean();
+        }
+        return new PullRequestBranchNotifier(seedFolder.resolve("seeds"), protectBranches);
     }
 
 }

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifierTests.java
@@ -52,7 +52,7 @@ public class PullRequestBranchNotifierTests {
                                                                    .put("hostedrepo", JSON.object()
                                                                                           .put("basename", "test")
                                                                                           .put("branches", "master")
-                                                                                          .put("prbranch", JSON.object())))
+                                                                                          .put("prbranch", JSON.object().put("protect", true))))
                              .build();
     }
 

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
@@ -173,6 +173,14 @@ class InMemoryHostedRepository implements HostedRepository {
     }
 
     @Override
+    public void protectBranchPattern(String ref) {
+    }
+
+    @Override
+    public void unprotectBranchPattern(String ref) {
+    }
+
+    @Override
     public void deleteBranch(String ref) {
     }
 

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
@@ -105,6 +105,20 @@ public interface HostedRepository {
     long id();
     Optional<Hash> branchHash(String ref);
     List<HostedBranch> branches();
+
+    /**
+     * Adds a branch protection rule based on a branch pattern. The rule prevents
+     * normal users from pushing to the branch, but still allows admins to force
+     * push.
+     * @param pattern Pattern for branches
+     */
+    void protectBranchPattern(String pattern);
+
+    /**
+     * Removes a branch protection rule based on the branch pattern.
+     * @param pattern Pattern for branches
+     */
+    void unprotectBranchPattern(String pattern);
     void deleteBranch(String ref);
     List<CommitComment> commitComments(Hash hash);
     default List<CommitComment> recentCommitComments() {

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -347,13 +347,13 @@ public class GitHubRepository implements HostedRepository {
     }
 
     @Override
-    public void protectBranchPattern(String ref) {
+    public void protectBranchPattern(String pattern) {
         // This could be implemented using GraphQL, but we currently don't need it for GitHub
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void unprotectBranchPattern(String ref) {
+    public void unprotectBranchPattern(String pattern) {
         // This could be implemented using GraphQL, but we currently don't need it for GitHub
         throw new UnsupportedOperationException();
     }

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -347,6 +347,18 @@ public class GitHubRepository implements HostedRepository {
     }
 
     @Override
+    public void protectBranchPattern(String ref) {
+        // This could be implemented using GraphQL, but we currently don't need it for GitHub
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void unprotectBranchPattern(String ref) {
+        // This could be implemented using GraphQL, but we currently don't need it for GitHub
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public void deleteBranch(String ref) {
         request.delete("git/refs/heads/" + ref)
                .execute();

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -426,11 +426,11 @@ public class GitLabRepository implements HostedRepository {
     }
 
     @Override
-    public void protectBranchPattern(String ref) {
+    public void protectBranchPattern(String pattern) {
         var body = JSON.object()
-                .put("name", ref)
+                .put("name", pattern)
                 .put("allow_force_push", true);
-        var existing = request.get("protected_branches/" + URLEncoder.encode(ref, StandardCharsets.US_ASCII))
+        var existing = request.get("protected_branches/" + URLEncoder.encode(pattern, StandardCharsets.US_ASCII))
                 .onError(r -> r.statusCode() == 404 ? Optional.of(JSON.of()) : Optional.empty())
                 .execute();
         // Only add protection if it doesn't already exist.
@@ -442,8 +442,8 @@ public class GitLabRepository implements HostedRepository {
     }
 
     @Override
-    public void unprotectBranchPattern(String ref) {
-        request.delete("protected_branches/" + URLEncoder.encode(ref, StandardCharsets.US_ASCII))
+    public void unprotectBranchPattern(String pattern) {
+        request.delete("protected_branches/" + URLEncoder.encode(pattern, StandardCharsets.US_ASCII))
                 .header("Content-Type", "application/json")
                 .onError(r -> r.statusCode() == 404 ? Optional.of(JSON.of()) : Optional.empty())
                 .execute();

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -407,7 +407,7 @@ public class GitLabRepository implements HostedRepository {
 
     @Override
     public Optional<Hash> branchHash(String ref) {
-        var branch = request.get("repository/branches/" + ref)
+        var branch = request.get("repository/branches/" + URLEncoder.encode(ref, StandardCharsets.US_ASCII))
                 .onError(r -> r.statusCode() == 404 ? Optional.of(JSON.object().put("NOT_FOUND", true)) : Optional.empty())
                 .execute();
         if (branch.contains("NOT_FOUND")) {

--- a/forge/src/test/java/org/openjdk/skara/forge/gitlab/GitLabRestApiTest.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/gitlab/GitLabRestApiTest.java
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * To be able to run the tests, you need to remove or comment out the @Disabled annotation first.
  */
-//@Disabled("Manual")
+@Disabled("Manual")
 public class GitLabRestApiTest {
 
     @Test

--- a/forge/src/test/java/org/openjdk/skara/forge/gitlab/GitLabRestApiTest.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/gitlab/GitLabRestApiTest.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.skara.forge.gitlab;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openjdk.skara.host.Credential;
 import org.openjdk.skara.issuetracker.Comment;

--- a/forge/src/test/java/org/openjdk/skara/forge/gitlab/GitLabRestApiTest.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/gitlab/GitLabRestApiTest.java
@@ -22,17 +22,18 @@
  */
 package org.openjdk.skara.forge.gitlab;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openjdk.skara.host.Credential;
 import org.openjdk.skara.issuetracker.Comment;
 import org.openjdk.skara.network.URIBuilder;
 import org.openjdk.skara.test.ManualTestSettings;
+import org.openjdk.skara.test.TemporaryDirectory;
 import org.openjdk.skara.vcs.Branch;
 import org.openjdk.skara.vcs.Hash;
 
 import java.io.IOException;
 import java.util.Set;
+import org.openjdk.skara.vcs.git.GitRepository;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -40,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * To be able to run the tests, you need to remove or comment out the @Disabled annotation first.
  */
-@Disabled("Manual")
+//@Disabled("Manual")
 public class GitLabRestApiTest {
 
     @Test
@@ -185,6 +186,35 @@ public class GitLabRestApiTest {
                     "Third commit message", "Duke", "duke@openjdk.org");
             var returnedContents = gitLabRepo.fileContents(fileName, branch.name());
             assertEquals(fileContent, returnedContents.orElseThrow());
+        }
+    }
+
+    @Test
+    void branchProtection() throws IOException {
+        var settings = ManualTestSettings.loadManualTestSettings();
+        var username = settings.getProperty("gitlab.user");
+        var token = settings.getProperty("gitlab.pat");
+        var credential = new Credential(username, token);
+        var uri = URIBuilder.base(settings.getProperty("gitlab.uri")).build();
+        var gitLabHost = new GitLabHost("gitlab", uri, false, credential, Set.of());
+        var gitLabRepo = gitLabHost.repository(settings.getProperty("gitlab.repository")).orElseThrow();
+        var branchName = "pr/4711";
+
+        gitLabRepo.protectBranchPattern(branchName);
+        // Don't fail on repeated invocations
+        gitLabRepo.protectBranchPattern(branchName);
+
+        try (var tempDir = new TemporaryDirectory()) {
+            var localRepoDir = tempDir.path().resolve("local");
+            var localRepo = GitRepository.clone(gitLabRepo.url(), localRepoDir, false, null);
+            var head = localRepo.head();
+            localRepo.push(head, gitLabRepo.url(), branchName, true);
+
+            gitLabRepo.unprotectBranchPattern(branchName);
+            // Don't fail on repeated invocations
+            gitLabRepo.unprotectBranchPattern(branchName);
+
+            gitLabRepo.deleteBranch(branchName);
         }
     }
 }


### PR DESCRIPTION
In GitLab, if a branch is protected, it cannot be removed. This is preventing us from using the pr/X feature of Skara to support dependent pull requests. This patch adds the ability to dynamically protect and unprotect branch patterns when creating pr/X branches. This is controlled with a new configuration option on the prbranch notifier like this:

```
        "prbranch": {
          "protect": true,
        },
```
The semantics needed for GitLab is to first add a pattern based protection rule, then create the branch. Unfortunately, I couldn't easily implement the same semantics for GitHubRepository. The REST API for branch protection in GitHub doesn't allow patterns, only existing branches. It could probably be done using GraphQL, but given how complicated that would be to implement, I chose not to, since we don't actually need this feature on GitHub. (GitHub branch protection is flexible enough so we can have a static configuration that allows admins to delete branches, and this is already in use today)

I have tested the basic branch protection functionality using the new manual test and I have run the notifier bot with the new configuration against a playground repository in GitLab and manually created and closed PRs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1173](https://bugs.openjdk.org/browse/SKARA-1173): Dependent PR feature does not work with protected branches in newer Gitlab version


### Reviewers
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - Committer)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1452/head:pull/1452` \
`$ git checkout pull/1452`

Update a local copy of the PR: \
`$ git checkout pull/1452` \
`$ git pull https://git.openjdk.org/skara pull/1452/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1452`

View PR using the GUI difftool: \
`$ git pr show -t 1452`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1452.diff">https://git.openjdk.org/skara/pull/1452.diff</a>

</details>
