### PR TITLE
1741: Change the logic of removing CSR label when CSR label is added via '/csr needed' command

### DIFF
--- a/bots/csr/src/test/java/org/openjdk/skara/bots/csr/CSRBotTests.java
+++ b/bots/csr/src/test/java/org/openjdk/skara/bots/csr/CSRBotTests.java
@@ -613,7 +613,7 @@ class CSRBotTests {
             csr2.setProperty("resolution", JSON.object().put("name", "Withdrawn"));
             TestBotRunner.runPeriodicItems(csrIssueBot);
             assertTrue(pr.store().body().contains(CSR_UPDATE_MARKER));
-            // PR should not contain csr label because CSR label is not added via '/csr needed'
+            // PR should not contain csr label
             assertFalse(pr.store().labelNames().contains("csr"));
 
             // Add a csr to issue3


### PR DESCRIPTION
Assuming there is such a situation: 

1. One pr solves issue1 and issue2. 
2. One user thought this pr needs CSR Issue and commented '/csr needed'. 
3. Author of this pr created csr1 of issue1, but then he thought it is not right to create csr of issue1 and withdrawn csr1. 
4. Author of this pr created csr2 of issue2 and csr2 got approved. 
5. In my opinion, the csr label should be removed(But due to [SKARA-1729](https://bugs.openjdk.org/browse/SKARA-1729), it is not removed) 

To sum, 

There are two ways that CSR label can be added to a PR 
1. via '/csr needed' command 
2. A CSR issue is discovered 

For the first case, if the CSR label is added via '/csr needed', there will be a CSR_NEEDED_MARKER. 
In this case, if we want to remove the csr label. there are two ways 
(1) No active CSR Issue exists and use '/csr unneeded' command 
(2) all of the CSR issues are approved or withdrawn(at least 1 CSR Issue is approved) 

For the second case, if the CSR label is added because a CSR Issue is discovered, there will not be CSR_NEEDED_MARKER. 
In this case, if we want to remove the csr label, there is only one way 
(1) all of the CSR issues are approved or withdrawn

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1741](https://bugs.openjdk.org/browse/SKARA-1741): Change the logic of removing CSR label when CSR label is added via '/csr needed' command


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1454/head:pull/1454` \
`$ git checkout pull/1454`

Update a local copy of the PR: \
`$ git checkout pull/1454` \
`$ git pull https://git.openjdk.org/skara pull/1454/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1454`

View PR using the GUI difftool: \
`$ git pr show -t 1454`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1454.diff">https://git.openjdk.org/skara/pull/1454.diff</a>

</details>
