### PR TITLE
1785: Do not always add CSR_UPDATE_MARKER when CSR bot finds withdrawn CSR Issue

### DIFF
--- a/bots/csr/src/main/java/org/openjdk/skara/bots/csr/PullRequestWorkItem.java
+++ b/bots/csr/src/main/java/org/openjdk/skara/bots/csr/PullRequestWorkItem.java
@@ -113,6 +113,12 @@ class PullRequestWorkItem implements WorkItem {
                 statusMessage.contains(csr.title() + " (**CSR**)");
     }
 
+    private boolean hasWithdrawnCsrIssue(String statusMessage, Issue csr) {
+        return statusMessage.contains(csr.id()) &&
+                statusMessage.contains(csr.webUrl().toString()) &&
+                statusMessage.contains(csr.title() + " (**CSR**) (Withdrawn)");
+    }
+
     private String getStatusMessage(PullRequest pr) {
         var lastIndex = pr.body().lastIndexOf(PROGRESS_MARKER);
         if (lastIndex == -1) {
@@ -226,7 +232,7 @@ class PullRequestWorkItem implements WorkItem {
                     // And the bot can't remove the CSR label automatically here.
                     // Because the PR author with the role of Committer may withdraw a CSR that
                     // a Reviewer had requested and integrate it without satisfying that requirement.
-                    if (!hasCsrIssue(getStatusMessage(pr), csr)) {
+                    if (!hasWithdrawnCsrIssue(getStatusMessage(pr), csr)) {
                         needToAddUpdateMarker = true;
                     }
                     log.info("CSR closed and withdrawn for csr issue " + csr.id() + " for " + describe(pr));

--- a/bots/csr/src/main/java/org/openjdk/skara/bots/csr/PullRequestWorkItem.java
+++ b/bots/csr/src/main/java/org/openjdk/skara/bots/csr/PullRequestWorkItem.java
@@ -226,7 +226,9 @@ class PullRequestWorkItem implements WorkItem {
                     // And the bot can't remove the CSR label automatically here.
                     // Because the PR author with the role of Committer may withdraw a CSR that
                     // a Reviewer had requested and integrate it without satisfying that requirement.
-                    needToAddUpdateMarker = true;
+                    if (!hasCsrIssue(getStatusMessage(pr), csr)) {
+                        needToAddUpdateMarker = true;
+                    }
                     log.info("CSR closed and withdrawn for csr issue " + csr.id() + " for " + describe(pr));
                 } else if (!pr.labelNames().contains(CSR_LABEL)) {
                     notExistingUnresolvedCSR = false;


### PR DESCRIPTION
In [SKARA-1728](https://bugs.openjdk.org/browse/SKARA-1728), I said that 'if we find a withdrawn pr, we need to add CSR_UPDATE_MARKER to the pr body.', yes, we need to add CSR_UPDATE_MARKER, but there is a prerequisite which is that our status message **doesn't** contain this withdrawn issue. Without the prerequisite, the CSR bot will always add CSR_UPDATE_MARKER when it finds a withdrawn CSR Issue and the pr body will be updated very frequently(looks like the bot go berserk). 

This issue is same as [SKARA-1673](https://bugs.openjdk.org/browse/SKARA-1673). I discovered this issue and fixed it, but I am silly enough to make the same mistake again.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1785](https://bugs.openjdk.org/browse/SKARA-1785): Do not always add CSR_UPDATE_MARKER when CSR bot finds withdrawn CSR Issue


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1455/head:pull/1455` \
`$ git checkout pull/1455`

Update a local copy of the PR: \
`$ git checkout pull/1455` \
`$ git pull https://git.openjdk.org/skara pull/1455/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1455`

View PR using the GUI difftool: \
`$ git pr show -t 1455`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1455.diff">https://git.openjdk.org/skara/pull/1455.diff</a>

</details>
