### PR TITLE
1737: Draft PR for clean backport mistakenly marked as ready

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -383,24 +383,26 @@ class CheckRun {
         }
     }
 
-    private void updateReadyForReview(PullRequestCheckIssueVisitor visitor, List<String> additionalErrors) {
+    private boolean updateReadyForReview(PullRequestCheckIssueVisitor visitor, List<String> additionalErrors) {
         // Additional errors are not allowed
         if (!additionalErrors.isEmpty()) {
             newLabels.remove("rfr");
-            return;
+            return false;
         }
 
         // Draft requests are not for review
         if (pr.isDraft()) {
             newLabels.remove("rfr");
-            return;
+            return false;
         }
 
         // Check if the visitor found any issues that should be resolved before reviewing
         if (visitor.isReadyForReview()) {
             newLabels.add("rfr");
+            return true;
         } else {
             newLabels.remove("rfr");
+            return false;
         }
     }
 
@@ -1147,7 +1149,7 @@ class CheckRun {
                 additionalProgresses = botSpecificProgresses();
             }
             updateCheckBuilder(checkBuilder, visitor, additionalErrors);
-            updateReadyForReview(visitor, additionalErrors);
+            var readyForReview = updateReadyForReview(visitor, additionalErrors);
 
             var integrationBlockers = botSpecificIntegrationBlockers();
             integrationBlockers.addAll(secondJCheckMessage);
@@ -1160,16 +1162,13 @@ class CheckRun {
             var amendedHash = checkablePullRequest.amendManualReviewers(localHash, censusInstance.namespace(), original.map(Commit::hash).orElse(null));
             var commit = localRepo.lookup(amendedHash).orElseThrow();
             var commitMessage = String.join("\n", commit.message());
-            var readyForIntegration = newLabels.contains("rfr") &&
+            var readyForIntegration = readyForReview &&
                                       visitor.messages().isEmpty() &&
-                                      additionalErrors.isEmpty() &&
                                       !additionalProgresses.containsValue(false) &&
                                       integrationBlockers.isEmpty();
             if (isCleanBackport) {
                 // Reviews are not needed for clean backports
-                readyForIntegration = newLabels.contains("rfr") &&
-                                      visitor.isReadyForReview() &&
-                                      additionalErrors.isEmpty() &&
+                readyForIntegration = readyForReview &&
                                       !additionalProgresses.containsValue(false) &&
                                       integrationBlockers.isEmpty();
             }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -1160,13 +1160,15 @@ class CheckRun {
             var amendedHash = checkablePullRequest.amendManualReviewers(localHash, censusInstance.namespace(), original.map(Commit::hash).orElse(null));
             var commit = localRepo.lookup(amendedHash).orElseThrow();
             var commitMessage = String.join("\n", commit.message());
-            var readyForIntegration = visitor.messages().isEmpty() &&
+            var readyForIntegration = newLabels.contains("rfr") &&
+                                      visitor.messages().isEmpty() &&
                                       additionalErrors.isEmpty() &&
                                       !additionalProgresses.containsValue(false) &&
                                       integrationBlockers.isEmpty();
             if (isCleanBackport) {
                 // Reviews are not needed for clean backports
-                readyForIntegration = visitor.isReadyForReview() &&
+                readyForIntegration = newLabels.contains("rfr") &&
+                                      visitor.isReadyForReview() &&
                                       additionalErrors.isEmpty() &&
                                       !additionalProgresses.containsValue(false) &&
                                       integrationBlockers.isEmpty();


### PR DESCRIPTION
1. readyForIntegration for normal pr is determined by 
(1) whether there is any failed check 
(2) whether there is any additional errors 
(3) whether there is any uncompleted additional progress 
(4) whether there is any integration blocker 

So if there is a draft normal pr, there will always exist a failed check(ReviewersCheck will always fail because the pr is in draft mode and nobody will approve this pr) 
Therefore, a draft normal pr will not be marked as 'ready' because there is a failed check not because this pr is in draft mode. 

2. readyForIntegration for clean backport is determined by 
(1) whether this pr is ready for review(TooFewReviewersIssue won't make it false) 
(2) whether there is any additional errors 
(3) whether there is any uncompleted additional progress 
(4) whether there is any integration blocker 

So if there is a draft clean backport pr, readyForIntegration will be true in most cases. 
Therefore, the clean backport pr will be marked as 'ready' whether it is in draft mode or not.

In this patch, whether there is an rfr label will determine whether readyforintegration is true or false.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1737](https://bugs.openjdk.org/browse/SKARA-1737): Draft PR for clean backport mistakenly marked as ready


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1456/head:pull/1456` \
`$ git checkout pull/1456`

Update a local copy of the PR: \
`$ git checkout pull/1456` \
`$ git pull https://git.openjdk.org/skara pull/1456/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1456`

View PR using the GUI difftool: \
`$ git pr show -t 1456`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1456.diff">https://git.openjdk.org/skara/pull/1456.diff</a>

</details>
