### PR TITLE
1727: Ability to control whether clean backports require review

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -1170,7 +1170,7 @@ class CheckRun {
                                       !additionalProgresses.containsValue(false) &&
                                       integrationBlockers.isEmpty();
             if (isCleanBackport && !requiresReviewForBackport) {
-                // Reviews are not needed for clean backports if the repo is not configured with requiresReviewForBackport
+                // Reviews are not needed for clean backports if this repo is not configured with requiresReviewForBackport enabled
                 readyForIntegration = readyForReview &&
                                       !additionalProgresses.containsValue(false) &&
                                       integrationBlockers.isEmpty();

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -1172,7 +1172,7 @@ class CheckRun {
                                       !additionalProgresses.containsValue(false) &&
                                       integrationBlockers.isEmpty();
             if (!reviewNeeded) {
-                // Reviews are not needed for clean backports if this repo is not configured with reviewCleanBackport enabled
+                // Reviews are not needed for clean backports unless this repo is configured with reviewCleanBackport enabled
                 readyForIntegration = readyForReview &&
                                       !additionalProgresses.containsValue(false) &&
                                       integrationBlockers.isEmpty();

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -407,7 +407,8 @@ class CheckWorkItem extends PullRequestWorkItem {
             try {
                 Repository localRepo = materializeLocalRepo(scratchPath, hostedRepositoryPool);
 
-                var expiresAt = CheckRun.execute(this, pr, localRepo, comments, allReviews, activeReviews, labels, census, bot.ignoreStaleReviews(), bot.integrators());
+                var expiresAt = CheckRun.execute(this, pr, localRepo, comments, allReviews,
+                        activeReviews, labels, census, bot.ignoreStaleReviews(), bot.integrators(), bot.requiresReviewForBackport());
                 if (log.isLoggable(Level.INFO)) {
                     // Log latency from the original updatedAt of the PR when this WorkItem
                     // was triggered to when it was just updated by the CheckRun.execute above.

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -408,7 +408,7 @@ class CheckWorkItem extends PullRequestWorkItem {
                 Repository localRepo = materializeLocalRepo(scratchPath, hostedRepositoryPool);
 
                 var expiresAt = CheckRun.execute(this, pr, localRepo, comments, allReviews,
-                        activeReviews, labels, census, bot.ignoreStaleReviews(), bot.integrators(), bot.requiresReviewForBackport());
+                        activeReviews, labels, census, bot.ignoreStaleReviews(), bot.integrators(), bot.reviewCleanBackport());
                 if (log.isLoggable(Level.INFO)) {
                     // Log latency from the original updatedAt of the PR when this WorkItem
                     // was triggered to when it was just updated by the CheckRun.execute above.

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -64,6 +64,7 @@ class PullRequestBot implements Bot {
     private final boolean enableJep;
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots.pr");
     private final PullRequestPoller poller;
+    private final boolean requiresReviewForBackport;
 
     private Instant lastFullUpdate;
 
@@ -75,7 +76,8 @@ class PullRequestBot implements Bot {
                    boolean ignoreStaleReviews, Pattern allowedTargetBranches,
                    Path seedStorage, HostedRepository confOverrideRepo, String confOverrideName,
                    String confOverrideRef, String censusLink, Map<String, HostedRepository> forks,
-                   Set<String> integrators, Set<Integer> excludeCommitCommentsFrom, boolean enableCsr, boolean enableJep) {
+                   Set<String> integrators, Set<Integer> excludeCommitCommentsFrom, boolean enableCsr, boolean enableJep,
+                   boolean requiresReviewForBackport) {
         remoteRepo = repo;
         this.censusRepo = censusRepo;
         this.censusRef = censusRef;
@@ -100,7 +102,7 @@ class PullRequestBot implements Bot {
         this.excludeCommitCommentsFrom = excludeCommitCommentsFrom;
         this.enableCsr = enableCsr;
         this.enableJep = enableJep;
-
+        this.requiresReviewForBackport = requiresReviewForBackport;
         autoLabelled = new HashSet<>();
         poller = new PullRequestPoller(repo, true);
 
@@ -260,6 +262,10 @@ class PullRequestBot implements Bot {
         synchronized (autoLabelled) {
             autoLabelled.add(pr.id());
         }
+    }
+
+    public boolean requiresReviewForBackport() {
+        return requiresReviewForBackport;
     }
 
     public Set<String> integrators() {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -64,7 +64,7 @@ class PullRequestBot implements Bot {
     private final boolean enableJep;
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots.pr");
     private final PullRequestPoller poller;
-    private final boolean requiresReviewForBackport;
+    private final boolean reviewCleanBackport;
 
     private Instant lastFullUpdate;
 
@@ -77,7 +77,7 @@ class PullRequestBot implements Bot {
                    Path seedStorage, HostedRepository confOverrideRepo, String confOverrideName,
                    String confOverrideRef, String censusLink, Map<String, HostedRepository> forks,
                    Set<String> integrators, Set<Integer> excludeCommitCommentsFrom, boolean enableCsr, boolean enableJep,
-                   boolean requiresReviewForBackport) {
+                   boolean reviewCleanBackport) {
         remoteRepo = repo;
         this.censusRepo = censusRepo;
         this.censusRef = censusRef;
@@ -102,7 +102,7 @@ class PullRequestBot implements Bot {
         this.excludeCommitCommentsFrom = excludeCommitCommentsFrom;
         this.enableCsr = enableCsr;
         this.enableJep = enableJep;
-        this.requiresReviewForBackport = requiresReviewForBackport;
+        this.reviewCleanBackport = reviewCleanBackport;
         autoLabelled = new HashSet<>();
         poller = new PullRequestPoller(repo, true);
 
@@ -264,8 +264,8 @@ class PullRequestBot implements Bot {
         }
     }
 
-    public boolean requiresReviewForBackport() {
-        return requiresReviewForBackport;
+    public boolean reviewCleanBackport() {
+        return reviewCleanBackport;
     }
 
     public Set<String> integrators() {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
@@ -55,6 +55,7 @@ public class PullRequestBotBuilder {
     private Map<String, HostedRepository> forks = Map.of();
     private Set<String> integrators = Set.of();
     private Set<Integer> excludeCommitCommentsFrom = Set.of();
+    private boolean requiresReviewForBackport = false;
 
     PullRequestBotBuilder() {
     }
@@ -179,12 +180,18 @@ public class PullRequestBotBuilder {
         return this;
     }
 
+    public PullRequestBotBuilder requiresReviewForBackport(boolean requiresReviewForBackport) {
+        this.requiresReviewForBackport = requiresReviewForBackport;
+        return this;
+    }
+
     public PullRequestBot build() {
         return new PullRequestBot(repo, censusRepo, censusRef, labelConfiguration,
                                   externalPullRequestCommands, externalCommitCommands,
                                   blockingCheckLabels, readyLabels, twoReviewersLabels, twentyFourHoursLabels,
                                   readyComments, issueProject, ignoreStaleReviews,
                                   allowedTargetBranches, seedStorage, confOverrideRepo, confOverrideName,
-                                  confOverrideRef, censusLink, forks, integrators, excludeCommitCommentsFrom, enableCsr, enableJep);
+                                  confOverrideRef, censusLink, forks, integrators, excludeCommitCommentsFrom,
+                                  enableCsr, enableJep, requiresReviewForBackport);
     }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
@@ -55,7 +55,7 @@ public class PullRequestBotBuilder {
     private Map<String, HostedRepository> forks = Map.of();
     private Set<String> integrators = Set.of();
     private Set<Integer> excludeCommitCommentsFrom = Set.of();
-    private boolean requiresReviewForBackport = false;
+    private boolean reviewCleanBackport = false;
 
     PullRequestBotBuilder() {
     }
@@ -180,8 +180,8 @@ public class PullRequestBotBuilder {
         return this;
     }
 
-    public PullRequestBotBuilder requiresReviewForBackport(boolean requiresReviewForBackport) {
-        this.requiresReviewForBackport = requiresReviewForBackport;
+    public PullRequestBotBuilder reviewCleanBackport(boolean reviewCleanBackport) {
+        this.reviewCleanBackport = reviewCleanBackport;
         return this;
     }
 
@@ -192,6 +192,6 @@ public class PullRequestBotBuilder {
                                   readyComments, issueProject, ignoreStaleReviews,
                                   allowedTargetBranches, seedStorage, confOverrideRepo, confOverrideName,
                                   confOverrideRef, censusLink, forks, integrators, excludeCommitCommentsFrom,
-                                  enableCsr, enableJep, requiresReviewForBackport);
+                                  enableCsr, enableJep, reviewCleanBackport);
     }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
@@ -171,6 +171,9 @@ public class PullRequestBotFactory implements BotFactory {
                         .collect(Collectors.toSet());
                 botBuilder.integrators(integrators);
             }
+            if (repo.value().contains("requiresReviewForBackport")) {
+                botBuilder.requiresReviewForBackport(repo.value().get("requiresReviewForBackport").asBoolean());
+            }
 
             ret.add(botBuilder.build());
         }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
@@ -171,8 +171,8 @@ public class PullRequestBotFactory implements BotFactory {
                         .collect(Collectors.toSet());
                 botBuilder.integrators(integrators);
             }
-            if (repo.value().contains("requiresReviewForBackport")) {
-                botBuilder.requiresReviewForBackport(repo.value().get("requiresReviewForBackport").asBoolean());
+            if (repo.value().contains("reviewCleanBackport")) {
+                botBuilder.reviewCleanBackport(repo.value().get("reviewCleanBackport").asBoolean());
             }
 
             ret.add(botBuilder.build());

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportTests.java
@@ -1695,4 +1695,106 @@ class BackportTests {
             assertEquals(List.of(), message.additional());
         }
     }
+
+    @Test
+    void cleanBackportRequiresReview(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+
+            var author = credentials.getHostedRepository();
+            var integrator = credentials.getHostedRepository();
+            var reviewer = credentials.getHostedRepository();
+            var issues = credentials.getIssueProject();
+            var censusBuilder = credentials.getCensusBuilder()
+                    .addCommitter(author.forge().currentUser().id())
+                    .addReviewer(integrator.forge().currentUser().id())
+                    .addReviewer(reviewer.forge().currentUser().id());
+            var bot = PullRequestBot.newBuilder()
+                    .repo(integrator)
+                    .censusRepo(censusBuilder.build())
+                    .issueProject(issues)
+                    .requiresReviewForBackport(true)
+                    .build();
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            var releaseBranch = localRepo.branch(masterHash, "release");
+            localRepo.checkout(releaseBranch);
+            var newFile = localRepo.root().resolve("a_new_file.txt");
+            Files.writeString(newFile, "hello");
+            localRepo.add(newFile);
+            var issue1 = credentials.createIssue(issues, "An issue");
+            var issue1Number = issue1.id().split("-")[1];
+            var originalMessage = issue1Number + ": An issue\n" +
+                    "\n" +
+                    "Reviewed-by: integrationreviewer2";
+            var releaseHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
+            localRepo.push(releaseHash, author.url(), "refs/heads/release", true);
+
+            // "backport" the new file to the master branch
+            localRepo.checkout(localRepo.defaultBranch());
+            var editBranch = localRepo.branch(masterHash, "edit");
+            localRepo.checkout(editBranch);
+            var newFile2 = localRepo.root().resolve("a_new_file.txt");
+            Files.writeString(newFile2, "hello");
+            localRepo.add(newFile2);
+            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
+            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "Backport " + releaseHash.hex());
+
+            // The bot should reply with a backport message and that the PR is not ready
+            TestBotRunner.runPeriodicItems(bot);
+            var backportComment = pr.comments().get(0).body();
+            assertTrue(backportComment.contains("This backport pull request has now been updated with issue"));
+            assertTrue(backportComment.contains("<!-- backport " + releaseHash.hex() + " -->"));
+            assertEquals(issue1Number + ": An issue", pr.store().title());
+            assertTrue(pr.store().labelNames().contains("rfr"));
+            assertTrue(pr.store().labelNames().contains("clean"));
+            assertTrue(pr.store().labelNames().contains("backport"));
+            assertTrue(pr.store().body().contains("Change must be properly reviewed"));
+
+            // Approve this pr as a reviewer
+            var approvalPr = reviewer.pullRequest(pr.id());
+            approvalPr.addReview(Review.Verdict.APPROVED, "Approved");
+            TestBotRunner.runPeriodicItems(bot);
+            assertTrue(pr.store().labelNames().contains("ready"));
+
+            // Integrate
+            author.pullRequest(pr.id());
+            pr.addComment("/integrate");
+            TestBotRunner.runPeriodicItems(bot);
+
+            // Find the commit
+            assertLastCommentContains(pr, "Pushed as commit");
+
+            String hex = null;
+            var comment = pr.comments().get(pr.comments().size() - 1);
+            var lines = comment.body().split("\n");
+            var pattern = Pattern.compile(".* Pushed as commit ([0-9a-z]{40}).*");
+            for (var line : lines) {
+                var m = pattern.matcher(line);
+                if (m.matches()) {
+                    hex = m.group(1);
+                    break;
+                }
+            }
+            assertNotNull(hex);
+            assertEquals(40, hex.length());
+            localRepo.checkout(localRepo.defaultBranch());
+            localRepo.pull(author.url().toString(), "master", false);
+            var commit = localRepo.lookup(new Hash(hex)).orElseThrow();
+
+            var message = CommitMessageParsers.v1.parse(commit);
+            assertEquals(1, message.issues().size());
+            assertEquals("An issue", message.issues().get(0).description());
+            assertEquals(List.of("integrationreviewer3"), message.reviewers());
+            assertEquals(Optional.of(releaseHash), message.original());
+            assertEquals(List.of(), message.contributors());
+            assertEquals(List.of(), message.summaries());
+            assertEquals(List.of(), message.additional());
+        }
+    }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportTests.java
@@ -1713,7 +1713,7 @@ class BackportTests {
                     .repo(integrator)
                     .censusRepo(censusBuilder.build())
                     .issueProject(issues)
-                    .requiresReviewForBackport(true)
+                    .reviewCleanBackport(true)
                     .build();
 
             // Populate the projects repository

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestBotFactoryTest.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestBotFactoryTest.java
@@ -78,7 +78,7 @@ class PullRequestBotFactoryTest {
                             "integrator1",
                             "integrator2"
                           ],
-                          "requiresReviewForBackport": true
+                          "reviewCleanBackport": true
                         }
                       },
                       "forks": {
@@ -121,7 +121,7 @@ class PullRequestBotFactoryTest {
             assertEquals(2, integrators.size());
             assertTrue(integrators.contains("integrator1"));
             assertTrue(integrators.contains("integrator2"));
-            assertTrue(pullRequestBot1.requiresReviewForBackport());
+            assertTrue(pullRequestBot1.reviewCleanBackport());
         }
     }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestBotFactoryTest.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestBotFactoryTest.java
@@ -77,7 +77,8 @@ class PullRequestBotFactoryTest {
                           "integrators": [
                             "integrator1",
                             "integrator2"
-                          ]
+                          ],
+                          "requiresReviewForBackport": true
                         }
                       },
                       "forks": {
@@ -120,6 +121,7 @@ class PullRequestBotFactoryTest {
             assertEquals(2, integrators.size());
             assertTrue(integrators.contains("integrator1"));
             assertTrue(integrators.contains("integrator2"));
+            assertTrue(pullRequestBot1.requiresReviewForBackport());
         }
     }
 }


### PR DESCRIPTION
In this patch, PR bot has been added with the capability to control the requirement of reviews for clean backports. 

By default, no review is necessary for clean backports. 

However, if it is desired to enable the requirement of reviews for backports in a repo, the configuration can be added to the PR bot configuration as follows:
```
{
  "pr": {
      "repositories": {
          "repo1": {
               "reviewCleanBackport": true
          }
       }
  }
}
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1727](https://bugs.openjdk.org/browse/SKARA-1727): Ability to control whether clean backports require review


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to [8f1719ef](https://git.openjdk.org/skara/pull/1457/files/8f1719ef7ea25819b422e54eb8b36ebde5be7012)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1457/head:pull/1457` \
`$ git checkout pull/1457`

Update a local copy of the PR: \
`$ git checkout pull/1457` \
`$ git pull https://git.openjdk.org/skara pull/1457/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1457`

View PR using the GUI difftool: \
`$ git pr show -t 1457`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1457.diff">https://git.openjdk.org/skara/pull/1457.diff</a>

</details>
