### PR TITLE
1789: Skara PR commands are not interpreted on Github review comments

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -179,7 +179,7 @@ public class PullRequestCommandWorkItem extends PullRequestWorkItem {
     public Collection<WorkItem> prRun(Path scratchPath) {
         log.info("Looking for PR commands");
 
-        var comments = prComments();
+        var comments = getAllComments();
         var nextCommand = nextCommand(pr, comments);
 
         if (nextCommand.isEmpty()) {
@@ -227,5 +227,22 @@ public class PullRequestCommandWorkItem extends PullRequestWorkItem {
     @Override
     public String workItemName() {
         return "pr-command";
+    }
+
+    /**
+     * This method returns all the comments in the pr including comments in reviews(review body) and file specific comments
+     */
+    private List<Comment> getAllComments() {
+        // Regular comments
+        List<Comment> comments = new ArrayList<>(prComments());
+        // Comments in reviews
+        comments.addAll(pr.reviews().stream()
+                .map(review -> new Comment("Review" + review.id(), review.body().orElse(""), review.reviewer(), review.createdAt(), null))
+                .toList());
+        // File specific comments
+        comments.addAll(pr.reviewComments().stream()
+                .map(reviewComment -> new Comment("ReviewComment" + reviewComment.id(), reviewComment.body(), reviewComment.author(), reviewComment.createdAt(), reviewComment.updatedAt()))
+                .toList());
+        return comments;
     }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
@@ -240,9 +240,10 @@ public class PullRequestCommandWorkItem extends PullRequestWorkItem {
                 .map(review -> new Comment("Review" + review.id(), review.body().orElse(""), review.reviewer(), review.createdAt(), null))
                 .toList());
         // File specific comments
-        comments.addAll(pr.reviewComments().stream()
-                .map(reviewComment -> new Comment("ReviewComment" + reviewComment.id(), reviewComment.body(), reviewComment.author(), reviewComment.createdAt(), reviewComment.updatedAt()))
-                .toList());
+//        comments.addAll(pr.reviewComments().stream()
+//                .map(reviewComment -> new Comment("ReviewComment" + reviewComment.id(), reviewComment.body(), reviewComment.author(), reviewComment.createdAt(), reviewComment.updatedAt()))
+//                .toList());
+        comments = comments.stream().sorted(Comparator.comparing(Comment::createdAt)).toList();
         return comments;
     }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
@@ -233,13 +233,8 @@ public class PullRequestCommandWorkItem extends PullRequestWorkItem {
      * This method returns all the comments in the pr including comments in reviews(review body)
      */
     private List<Comment> getAllComments() {
-        // Regular comments
-        List<Comment> comments = new ArrayList<>(prComments());
-        // Comments in reviews
-        comments.addAll(pr.reviews().stream()
-                .map(review -> new Comment("Review" + review.id(), review.body().orElse(""), review.reviewer(), review.createdAt(), null))
-                .toList());
-        comments = comments.stream().sorted(Comparator.comparing(Comment::createdAt)).toList();
-        return comments;
+        return Stream.concat(prComments().stream(),
+                        pr.reviews().stream().map(review -> new Comment("Review" + review.id(), review.body().orElse(""), review.reviewer(), review.createdAt(), null)))
+                .sorted(Comparator.comparing(Comment::createdAt)).toList();
     }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
@@ -230,7 +230,7 @@ public class PullRequestCommandWorkItem extends PullRequestWorkItem {
     }
 
     /**
-     * This method returns all the comments in the pr including comments in reviews(review body) and file specific comments
+     * This method returns all the comments in the pr including comments in reviews(review body)
      */
     private List<Comment> getAllComments() {
         // Regular comments
@@ -239,10 +239,6 @@ public class PullRequestCommandWorkItem extends PullRequestWorkItem {
         comments.addAll(pr.reviews().stream()
                 .map(review -> new Comment("Review" + review.id(), review.body().orElse(""), review.reviewer(), review.createdAt(), null))
                 .toList());
-        // File specific comments
-//        comments.addAll(pr.reviewComments().stream()
-//                .map(reviewComment -> new Comment("ReviewComment" + reviewComment.id(), reviewComment.body(), reviewComment.author(), reviewComment.createdAt(), reviewComment.updatedAt()))
-//                .toList());
         comments = comments.stream().sorted(Comparator.comparing(Comment::createdAt)).toList();
         return comments;
     }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestCommandTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,9 +23,11 @@
 package org.openjdk.skara.bots.pr;
 
 import org.junit.jupiter.api.*;
+import org.openjdk.skara.forge.Review;
 import org.openjdk.skara.test.*;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Map;
 import java.util.List;
 
@@ -355,6 +357,42 @@ class PullRequestCommandTests {
                                           "\n" +
                                           "Even a final one at the end\n" +
                                           "```\n");
+        }
+    }
+
+    @Test
+    void interpretCommandFromReviewsAndReviewComments(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var integrator = credentials.getHostedRepository();
+
+            var censusBuilder = credentials.getCensusBuilder()
+                    .addAuthor(author.forge().currentUser().id());
+            var prBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
+
+            // Test command in review
+            pr.addReview(Review.Verdict.APPROVED, "/reviewers 3");
+            // Run the bot
+            TestBotRunner.runPeriodicItems(prBot);
+            assertLastCommentContains(pr, "The total number of required reviews for this PR (including the jcheck configuration and the last /reviewers command) is now set to 3");
+
+            //Test command in reviewComment
+            pr.addReviewComment(masterHash, editHash, Path.of("appendable.txt").toString(), 2, "/reviewers 4");
+            // Run the bot
+            TestBotRunner.runPeriodicItems(prBot);
+            assertLastCommentContains(pr, "The total number of required reviews for this PR (including the jcheck configuration and the last /reviewers command) is now set to 4");
         }
     }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestCommandTests.java
@@ -388,11 +388,18 @@ class PullRequestCommandTests {
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(pr, "The total number of required reviews for this PR (including the jcheck configuration and the last /reviewers command) is now set to 3");
 
-            //Test command in reviewComment
-//            pr.addReviewComment(masterHash, editHash, Path.of("appendable.txt").toString(), 2, "/reviewers 4");
-//            // Run the bot
-//            TestBotRunner.runPeriodicItems(prBot);
-//            assertLastCommentContains(pr, "The total number of required reviews for this PR (including the jcheck configuration and the last /reviewers command) is now set to 4");
+            // This should work
+            pr.addReview(Review.Verdict.APPROVED, "first line \n  /reviewers 4");
+            // Run the bot
+            TestBotRunner.runPeriodicItems(prBot);
+            assertLastCommentContains(pr, "The total number of required reviews for this PR (including the jcheck configuration and the last /reviewers command) is now set to 4");
+
+            // This should not work
+            pr.addReview(Review.Verdict.APPROVED, "first line \n  second line /reviewers 5");
+            // Run the bot
+            TestBotRunner.runPeriodicItems(prBot);
+            // Reviewer number is still 4
+            assertLastCommentContains(pr, "The total number of required reviews for this PR (including the jcheck configuration and the last /reviewers command) is now set to 4");
         }
     }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestCommandTests.java
@@ -360,7 +360,7 @@ class PullRequestCommandTests {
     }
 
     @Test
-    void interpretCommandFromReviewsAndReviewComments(TestInfo testInfo) throws IOException {
+    void interpretCommandFromReviews(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
              var tempFolder = new TemporaryDirectory()) {
             var author = credentials.getHostedRepository();

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestCommandTests.java
@@ -389,10 +389,10 @@ class PullRequestCommandTests {
             assertLastCommentContains(pr, "The total number of required reviews for this PR (including the jcheck configuration and the last /reviewers command) is now set to 3");
 
             //Test command in reviewComment
-            pr.addReviewComment(masterHash, editHash, Path.of("appendable.txt").toString(), 2, "/reviewers 4");
-            // Run the bot
-            TestBotRunner.runPeriodicItems(prBot);
-            assertLastCommentContains(pr, "The total number of required reviews for this PR (including the jcheck configuration and the last /reviewers command) is now set to 4");
+//            pr.addReviewComment(masterHash, editHash, Path.of("appendable.txt").toString(), 2, "/reviewers 4");
+//            // Run the bot
+//            TestBotRunner.runPeriodicItems(prBot);
+//            assertLastCommentContains(pr, "The total number of required reviews for this PR (including the jcheck configuration and the last /reviewers command) is now set to 4");
         }
     }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestCommandTests.java
@@ -27,7 +27,6 @@ import org.openjdk.skara.forge.Review;
 import org.openjdk.skara.test.*;
 
 import java.io.IOException;
-import java.nio.file.Path;
 import java.util.Map;
 import java.util.List;
 


### PR DESCRIPTION
A user reported that Skara bots were not responding to commands in review comments or the body of a review. 

This patch addresses that issue by ensuring that the Skara bots can correctly detect and interpret commands.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1789](https://bugs.openjdk.org/browse/SKARA-1789): Skara PR commands are not interpreted on Github review comments


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1458/head:pull/1458` \
`$ git checkout pull/1458`

Update a local copy of the PR: \
`$ git checkout pull/1458` \
`$ git pull https://git.openjdk.org/skara pull/1458/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1458`

View PR using the GUI difftool: \
`$ git pr show -t 1458`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1458.diff">https://git.openjdk.org/skara/pull/1458.diff</a>

</details>
