### PR TITLE
1725: Clarify "no known role" error message

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -491,9 +491,9 @@ class CheckRun {
             ret.append("@");
             ret.append(user.username());
             ret.append(" (no known ");
-            var censusRepoName = workItem.bot.censusRepo().name();
-            var index = censusRepoName.lastIndexOf("-");
-            ret.append(censusRepoName.substring(index + 1));
+            var censusDomain = censusInstance.configuration().census().domain();
+            var index = censusDomain.lastIndexOf('.');
+            ret.append(censusDomain, 0, index);
             ret.append(" user name / role)");
         } else {
             // The HostUser is null and the Contributor is not null

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -491,9 +491,7 @@ class CheckRun {
             ret.append("@");
             ret.append(user.username());
             ret.append(" (no known ");
-            var censusDomain = censusInstance.configuration().census().domain();
-            var index = censusDomain.lastIndexOf('.');
-            ret.append(censusDomain, 0, index);
+            ret.append(censusInstance.configuration().census().domain());
             ret.append(" user name / role)");
         } else {
             // The HostUser is null and the Contributor is not null

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -491,7 +491,9 @@ class CheckRun {
             ret.append("@");
             ret.append(user.username());
             ret.append(" (no known ");
-            ret.append(censusInstance.namespace().name());
+            var censusRepoName = workItem.bot.censusRepo().name();
+            var index = censusRepoName.lastIndexOf("-");
+            ret.append(censusRepoName.substring(index + 1));
             ret.append(" user name / role)");
         } else {
             // The HostUser is null and the Contributor is not null


### PR DESCRIPTION
A user reported that when people review PRs, the bot adds a list of reviewers into description. If a user is not registered in OpenJDK Census, a note is added: 

(no known github.com user name / role) 

What it actually means is "no known OpenJDK user name / role".

Github.com is being used here because we are utilizing the name of the namespace. However, the purpose of the namespace is to map users from this namespace to either openjdk or internal. Actually, we couldn't find the user in openjdk or internal, not in the namespace. The census repository name can indicate whether it is openjdk or internal.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1725](https://bugs.openjdk.org/browse/SKARA-1725): Clarify "no known role" error message


### Reviewers
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer) ⚠️ Review applies to [d6479ee3](https://git.openjdk.org/skara/pull/1459/files/d6479ee38263c5fa46f41c23b64bf3aecea851eb)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1459/head:pull/1459` \
`$ git checkout pull/1459`

Update a local copy of the PR: \
`$ git checkout pull/1459` \
`$ git pull https://git.openjdk.org/skara pull/1459/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1459`

View PR using the GUI difftool: \
`$ git pr show -t 1459`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1459.diff">https://git.openjdk.org/skara/pull/1459.diff</a>

</details>
