### PR TITLE
1799: Do not notify on Withdrawn  CSR issue

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/PullRequestWorkItem.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/PullRequestWorkItem.java
@@ -149,7 +149,7 @@ public class PullRequestWorkItem implements WorkItem {
         }
         var issueMatcher = issuePattern.matcher(issuesBlockMatcher.group(1));
         return issueMatcher.results()
-                           .filter(mr -> !mr.group(2).endsWith(" (**CSR**)") && !mr.group(2).endsWith(" (**JEP**)"))
+                           .filter(mr -> !mr.group(2).endsWith(" (**CSR**)") && !mr.group(2).endsWith(" (**CSR**) (Withdrawn)") && !mr.group(2).endsWith(" (**JEP**)"))
                            .map(mo -> mo.group(1))
                            .collect(Collectors.toSet());
     }


### PR DESCRIPTION
In [SKARA-1714](https://bugs.openjdk.org/browse/SKARA-1714), we will add '(Withdrawn)' to withdrawn CSR issues shown in the pr body. However, this will cause a small bug in the notify bot which the issueNotifier will add a review link to withdrawn CSR issues. To fix this, simply update the filter in the notify/PullRequestWorkItem#parseIssues method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1799](https://bugs.openjdk.org/browse/SKARA-1799): Do not notify on Withdrawn  CSR issue


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1460/head:pull/1460` \
`$ git checkout pull/1460`

Update a local copy of the PR: \
`$ git checkout pull/1460` \
`$ git pull https://git.openjdk.org/skara pull/1460/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1460`

View PR using the GUI difftool: \
`$ git pr show -t 1460`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1460.diff">https://git.openjdk.org/skara/pull/1460.diff</a>

</details>
