### PR TITLE
1801: Exclude some GraphQL calls from RestRequestCache rate limiter

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -144,6 +144,8 @@ public class GitHubPullRequest implements PullRequest {
         var data = host.graphQL()
                 .post()
                 .body(JSON.object().put("query", query))
+                // This is a single point graphql query so shouldn't need to be limited to once a second
+                .skipLimiter(true)
                 .execute()
                 .get("data");
         return data.get("repository").get("pullRequest").get("timelineItems").get("nodes").stream()

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -423,6 +423,8 @@ public class GitHubRepository implements HostedRepository {
         var data = gitHubHost.graphQL()
                              .post()
                              .body(JSON.object().put("query", query))
+                             // This is a single point graphql query so shouldn't need to be limited to once a second
+                             .skipLimiter(true)
                              .execute()
                              .get("data");
         var comments = data.get("repository")


### PR DESCRIPTION
In [SKARA-1731](https://bugs.openjdk.org/browse/SKARA-1731), the best practices regarding non GET requests on Github became better enforced. Unfortunately that has lead to some unexpected performance issues. I believe this is mostly caused by GraphQL requests, which are always POST, being treated as a non GET REST requests by the limiter and limited to one per second. This limitation on a subset of our github queries is currently causing a queue buildup for that lock, which stabilizes to about 1m wait time. This delay is slowing down response times from the bots massively.

Reading the Integrator best practices document again (https://docs.github.com/en/rest/guides/best-practices-for-integrators?apiVersion=2022-11-28) and the GraphQL resource limitations (https://docs.github.com/en/graphql/overview/resource-limitations) I'm pretty sure you aren't supposed to limit GraphQL to one call per second, but rather just make sure you stay within the points limit. The one per second recommendation is for the REST API.

I want to make it possible to exclude certain calls from this rate limiter to see if this can alleviate the contention we are currently seeing. I have run with this patch for the pr bot since yesterday afternoon (PT) and it seems to be working well.

Two PRs were unable to integrate yesterday due to this contention:
https://github.com/openjdk/jdk/pull/12139
https://github.com/openjdk/jdk/pull/11922

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1801](https://bugs.openjdk.org/browse/SKARA-1801): Exclude some GraphQL calls from RestRequestCache rate limiter


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1461/head:pull/1461` \
`$ git checkout pull/1461`

Update a local copy of the PR: \
`$ git checkout pull/1461` \
`$ git pull https://git.openjdk.org/skara pull/1461/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1461`

View PR using the GUI difftool: \
`$ git pr show -t 1461`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1461.diff">https://git.openjdk.org/skara/pull/1461.diff</a>

</details>
