### PR TITLE
1803: GitLabRepository.canPush only checks direct members

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -763,7 +763,7 @@ public class GitLabRepository implements HostedRepository {
 
     @Override
     public boolean canPush(HostUser user) {
-        var accessLevel = request.get("members/" + user.id())
+        var accessLevel = request.get("members/all/" + user.id())
                                  .onError(r -> r.statusCode() == 404 ?
                                                    Optional.of(JSON.object().put("access_level", 0)) :
                                                    Optional.empty())


### PR DESCRIPTION
The method `canPush` on GitLabRepository uses the wrong endpoint for the query. It only checks for direct members and not inherited members (https://docs.gitlab.com/ee/api/members.html).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1803](https://bugs.openjdk.org/browse/SKARA-1803): GitLabRepository.canPush only checks direct members


### Reviewers
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - Committer)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1462/head:pull/1462` \
`$ git checkout pull/1462`

Update a local copy of the PR: \
`$ git checkout pull/1462` \
`$ git pull https://git.openjdk.org/skara pull/1462/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1462`

View PR using the GUI difftool: \
`$ git pr show -t 1462`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1462.diff">https://git.openjdk.org/skara/pull/1462.diff</a>

</details>
