### PR TITLE
1806: Optimize the CSR progress message and log when CSR not found

### DIFF
--- a/bots/common/src/main/java/org/openjdk/skara/bots/common/BotUtils.java
+++ b/bots/common/src/main/java/org/openjdk/skara/bots/common/BotUtils.java
@@ -43,7 +43,7 @@ public class BotUtils {
     public static Optional<JdkVersion> getVersion(PullRequest pr) {
         var confFile = pr.repository().fileContents(".jcheck/conf", pr.headHash().hex())
                 .orElse(pr.repository().fileContents(".jcheck/conf", pr.targetRef()).orElse(null));
-        if(confFile == null){
+        if (confFile == null) {
             return Optional.empty();
         }
         var configuration = JCheckConfiguration.parse(confFile.lines().toList());

--- a/bots/common/src/main/java/org/openjdk/skara/bots/common/BotUtils.java
+++ b/bots/common/src/main/java/org/openjdk/skara/bots/common/BotUtils.java
@@ -42,8 +42,10 @@ public class BotUtils {
      */
     public static Optional<JdkVersion> getVersion(PullRequest pr) {
         var confFile = pr.repository().fileContents(".jcheck/conf", pr.headHash().hex())
-                .orElse(pr.repository().fileContents(".jcheck/conf", pr.targetRef())
-                        .orElseThrow(() -> new RuntimeException("Could not find .jcheck/conf in neither src or target of PR " + pr)));
+                .orElse(pr.repository().fileContents(".jcheck/conf", pr.targetRef()).orElse(null));
+        if(confFile == null){
+            return Optional.empty();
+        }
         var configuration = JCheckConfiguration.parse(confFile.lines().toList());
         var version = configuration.general().version().orElse(null);
         if (version == null || "".equals(version)) {

--- a/bots/csr/src/main/java/org/openjdk/skara/bots/csr/PullRequestWorkItem.java
+++ b/bots/csr/src/main/java/org/openjdk/skara/bots/csr/PullRequestWorkItem.java
@@ -176,7 +176,7 @@ class PullRequestWorkItem implements WorkItem {
 
             var csrOptional = Backports.findCsr(jbsIssueOpt.get(), versionOpt.get());
             if (csrOptional.isEmpty()) {
-                log.info("No CSR found for issue " + jbsIssueOpt.get().id() + " for " + describe(pr));
+                log.info("No CSR found for issue " + jbsIssueOpt.get().id() + " for " + describe(pr) + " with fixVersion " + versionOpt.get().raw());
                 continue;
             }
             var csr = csrOptional.get();

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -1124,7 +1124,11 @@ class CheckRun {
             }
             PullRequestCheckIssueVisitor visitor = checkablePullRequest.createVisitor();
 
-            var version = BotUtils.getVersion(pr).orElse(null);
+            JdkVersion version = null;
+            try {
+                version = BotUtils.getVersion(pr).orElse(null);
+            } catch (Exception e) {
+            }
             // issues without CSR issues and JEP issues
             var issues = issues();
             var csrIssueTrackerIssues = getCsrIssueTrackerIssues(issues, version);

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -166,7 +166,7 @@ class CheckRun {
      */
     private List<Issue> getCsrIssues(List<org.openjdk.skara.issuetracker.Issue> csrIssueTrackerIssues) {
 
-        return CsrIssueTrackerIssues.stream()
+        return csrIssueTrackerIssues.stream()
                 .map(perIssue -> Issue.fromStringRelaxed(perIssue.id() + ": " + perIssue.title()))
                 .filter(Optional::isPresent)
                 .map(Optional::get)

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -164,7 +164,7 @@ class CheckRun {
     /**
      * Get the csr issue. Note: this `Issue` is not the issue in module `issuetracker`.
      */
-    private List<Issue> getCsrIssues(List<org.openjdk.skara.issuetracker.Issue> CsrIssueTrackerIssues) {
+    private List<Issue> getCsrIssues(List<org.openjdk.skara.issuetracker.Issue> csrIssueTrackerIssues) {
 
         return CsrIssueTrackerIssues.stream()
                 .map(perIssue -> Issue.fromStringRelaxed(perIssue.id() + ": " + perIssue.title()))

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CSRTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CSRTests.java
@@ -79,7 +79,7 @@ class CSRTests {
                                           "is needed for this pull request.");
             assertTrue(pr.store().labelNames().contains("csr"));
             // The PR body should contain the progress about CSR request
-            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request (needs to be created) to be approved"));
+            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion 0.1 to be approved (needs to be created)"));
 
             // No longer require CSR
             prAsReviewer.addComment("/csr unneeded");
@@ -90,7 +90,7 @@ class CSRTests {
                                           "is not needed for this pull request.");
             assertFalse(pr.store().labelNames().contains("csr"));
             // The PR body shouldn't contain the progress about CSR request
-            assertFalse(pr.store().body().contains("Change requires a CSR request (needs to be created) to be approved"));
+            assertFalse(pr.store().body().contains("Change requires a CSR request matching fixVersion 0.1 to be approved (needs to be created)"));
 
             // Require CSR again with long form
             prAsReviewer.addComment("/csr needed");
@@ -102,7 +102,7 @@ class CSRTests {
                                           "is needed for this pull request.");
             assertTrue(pr.store().labelNames().contains("csr"));
             // The PR body should contain the progress about CSR request
-            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request (needs to be created) to be approved"));
+            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion 0.1 to be approved (needs to be created)"));
         }
     }
 
@@ -195,7 +195,7 @@ class CSRTests {
             assertLastCommentContains(pr, "To refer this pull request to an issue in JBS");
             assertTrue(pr.store().labelNames().contains("csr"));
             // The PR body should contain the progress about CSR request
-            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request (needs to be created) to be approved"));
+            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion 0.1 to be approved (needs to be created)"));
         }
     }
 
@@ -234,7 +234,7 @@ class CSRTests {
             assertLastCommentContains(prAsAnother, "are allowed to use the `csr` command.");
             assertFalse(pr.store().labelNames().contains("csr"));
             // The PR body shouldn't contain the progress about CSR request
-            assertFalse(pr.store().body().contains("Change requires a CSR request (needs to be created) to be approved"));
+            assertFalse(pr.store().body().contains("Change requires a CSR request matching fixVersion 0.1 to be approved (needs to be created)"));
 
             // Stating that a CSR is not needed should not work
             prAsAnother.addComment("/csr unneeded");
@@ -243,7 +243,7 @@ class CSRTests {
             assertLastCommentContains(prAsAnother, "are allowed to use the `csr` command.");
             assertFalse(pr.store().labelNames().contains("csr"));
             // The PR body shouldn't contain the progress about CSR request
-            assertFalse(pr.store().body().contains("Change requires a CSR request (needs to be created) to be approved"));
+            assertFalse(pr.store().body().contains("Change requires a CSR request matching fixVersion 0.1 to be approved (needs to be created)"));
 
             // Require CSR as committer
             pr.addComment("/csr");
@@ -255,7 +255,7 @@ class CSRTests {
                                           "is needed for this pull request.");
             assertTrue(pr.store().labelNames().contains("csr"));
             // The PR body should contain the progress about CSR request
-            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request (needs to be created) to be approved"));
+            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion 0.1 to be approved (needs to be created)"));
 
             // Stating that a CSR is not needed should not work
             pr.addComment("/csr unneeded");
@@ -264,7 +264,7 @@ class CSRTests {
             assertLastCommentContains(pr, "can determine that a CSR is not needed.");
             assertTrue(pr.store().labelNames().contains("csr"));
             // The PR body should contain the progress about CSR request
-            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request (needs to be created) to be approved"));
+            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion 0.1 to be approved (needs to be created)"));
 
             // Stating that a CSR is not needed should not work
             prAsAnother.addComment("/csr unneeded");
@@ -273,7 +273,7 @@ class CSRTests {
             assertLastCommentContains(prAsAnother, "are allowed to use the `csr` command.");
             assertTrue(pr.store().labelNames().contains("csr"));
             // The PR body should contain the progress about CSR request
-            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request (needs to be created) to be approved"));
+            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion 0.1 to be approved (needs to be created)"));
         }
     }
 
@@ -312,7 +312,7 @@ class CSRTests {
                                           "to an approved [CSR](https://wiki.openjdk.org/display/csr/Main) request.");
             assertFalse(pr.store().labelNames().contains("csr"));
             // The PR body shouldn't contain the progress about CSR request
-            assertFalse(pr.store().body().contains("Change requires a CSR request (needs to be created) to be approved"));
+            assertFalse(pr.store().body().contains("Change requires a CSR request matching fixVersion 0.1 to be approved (needs to be created)"));
         }
     }
 
@@ -355,7 +355,7 @@ class CSRTests {
             assertLastCommentContains(pr, "to be able to link it to a [CSR](https://wiki.openjdk.org/display/csr/Main) request. To refer this pull request to an issue in JBS");
             assertTrue(pr.store().labelNames().contains("csr"));
             // The PR body should contain the progress about CSR request
-            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request (needs to be created) to be approved"));
+            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion 0.1 to be approved (needs to be created)"));
         }
     }
 
@@ -397,7 +397,7 @@ class CSRTests {
                                           "is needed for this pull request.");
             assertTrue(pr.store().labelNames().contains("csr"));
             // The PR body should contain the progress about CSR request
-            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request (needs to be created) to be approved"));
+            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion 0.1 to be approved (needs to be created)"));
 
             // Require a CSR again
             prAsReviewer.addComment("/csr");
@@ -408,7 +408,7 @@ class CSRTests {
             assertLastCommentContains(pr, "request is already required for this pull request.");
             assertTrue(pr.store().labelNames().contains("csr"));
             // The PR body should contain the progress about CSR request
-            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request (needs to be created) to be approved"));
+            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion 0.1 to be approved (needs to be created)"));
         }
     }
 
@@ -593,7 +593,7 @@ class CSRTests {
                                           "is needed for this pull request.");
             assertTrue(pr.store().labelNames().contains("csr"));
             // The PR body should contain the progress about CSR request
-            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request (needs to be created) to be approved"));
+            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion 0.1 to be approved (needs to be created)"));
         }
     }
 
@@ -633,7 +633,7 @@ class CSRTests {
             var prAsAuthor = author.pullRequest(pr.id());
             assertTrue(prAsAuthor.labelNames().contains("ready"));
             // The PR body shouldn't contain the progress about CSR request
-            assertFalse(pr.store().body().contains("Change requires a CSR request (needs to be created) to be approved"));
+            assertFalse(pr.store().body().contains("Change requires a CSR request matching fixVersion 0.1 to be approved (needs to be created)"));
 
             // Require CSR
             prAsReviewer = reviewer.pullRequest(pr.id());
@@ -653,7 +653,7 @@ class CSRTests {
             assertFalse(prAsAuthor.labelNames().contains("ready"));
 
             // The PR body should contain the progress about CSR request
-            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request (needs to be created) to be approved"));
+            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion 0.1 to be approved (needs to be created)"));
         }
     }
 
@@ -686,7 +686,7 @@ class CSRTests {
             TestBotRunner.runPeriodicItems(disableCsrBot);
             assertLastCommentContains(pr, "This repository has not been configured to use the `csr` command.");
             assertFalse(pr.store().labelNames().contains("csr"));
-            assertFalse(pr.store().body().contains("Change requires a CSR request (needs to be created) to be approved"));
+            assertFalse(pr.store().body().contains("Change requires a CSR request matching fixVersion 0.1 to be approved (needs to be created)"));
 
             // Test the pull request bot with csr enable
             var enableCsrBot = PullRequestBot.newBuilder().repo(bot).issueProject(issues)
@@ -697,7 +697,7 @@ class CSRTests {
                     "[compatibility and specification](https://wiki.openjdk.org/display/csr/Main) (CSR) request " +
                     "is needed for this pull request.");
             assertTrue(pr.store().labelNames().contains("csr"));
-            assertTrue(pr.store().body().contains("Change requires a CSR request (needs to be created) to be approved"));
+            assertTrue(pr.store().body().contains("Change requires a CSR request matching fixVersion 0.1 to be approved (needs to be created)"));
         }
     }
 
@@ -757,7 +757,7 @@ class CSRTests {
             // Run bot. Request a CSR.
             pr.addComment("/csr");
             TestBotRunner.runPeriodicItems(bot);
-            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request (needs to be created) to be approved"));
+            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion (No fixVersion in .jcheck/conf) to be approved (needs to be created)"));
             assertTrue(pr.store().labelNames().contains("csr"));
             assertLastCommentContains(pr, "has indicated that a " +
                     "[compatibility and specification](https://wiki.openjdk.org/display/csr/Main) (CSR) request " +
@@ -768,7 +768,7 @@ class CSRTests {
             // Use `/csr unneeded` to revert the change.
             pr.addComment("/csr unneeded");
             TestBotRunner.runPeriodicItems(bot);
-            assertFalse(pr.store().body().contains("Change requires a CSR request (needs to be created) to be approved"));
+            assertFalse(pr.store().body().contains("Change requires a CSR request matching fixVersion (No fixVersion in .jcheck/conf) to be approved (needs to be created)"));
             assertFalse(pr.store().labelNames().contains("csr"));
             assertLastCommentContains(pr, "determined that a [CSR](https://wiki.openjdk.org/display/csr/Main) request " +
                     "is not needed for this pull request.");
@@ -786,7 +786,7 @@ class CSRTests {
             // Run bot. Request a CSR.
             pr.addComment("/csr");
             TestBotRunner.runPeriodicItems(bot);
-            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request (needs to be created) to be approved"));
+            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion (No fixVersion in .jcheck/conf) to be approved (needs to be created)"));
             assertTrue(pr.store().labelNames().contains("csr"));
             assertLastCommentContains(pr, "has indicated that a " +
                     "[compatibility and specification](https://wiki.openjdk.org/display/csr/Main) (CSR) request " +
@@ -797,7 +797,7 @@ class CSRTests {
             // Use `/csr unneeded` to revert the change.
             pr.addComment("/csr unneeded");
             TestBotRunner.runPeriodicItems(bot);
-            assertFalse(pr.store().body().contains("Change requires a CSR request (needs to be created) to be approved"));
+            assertFalse(pr.store().body().contains("Change requires a CSR request matching fixVersion (No fixVersion in .jcheck/conf) to be approved (needs to be created)"));
             assertFalse(pr.store().labelNames().contains("csr"));
             assertLastCommentContains(pr, "determined that a [CSR](https://wiki.openjdk.org/display/csr/Main) request " +
                     "is not needed for this pull request.");
@@ -815,7 +815,7 @@ class CSRTests {
             // Run bot. Request a CSR.
             pr.addComment("/csr");
             TestBotRunner.runPeriodicItems(bot);
-            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request (needs to be created) to be approved"));
+            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion 17 to be approved (needs to be created)"));
             assertTrue(pr.store().labelNames().contains("csr"));
             assertLastCommentContains(pr, "has indicated that a " +
                     "[compatibility and specification](https://wiki.openjdk.org/display/csr/Main) (CSR) request " +
@@ -826,7 +826,7 @@ class CSRTests {
             // Use `/csr unneeded` to revert the change.
             pr.addComment("/csr unneeded");
             TestBotRunner.runPeriodicItems(bot);
-            assertFalse(pr.store().body().contains("Change requires a CSR request (needs to be created) to be approved"));
+            assertFalse(pr.store().body().contains("Change requires a CSR request matching fixVersion 17 to be approved (needs to be created)"));
             assertFalse(pr.store().labelNames().contains("csr"));
             assertLastCommentContains(pr, "determined that a [CSR](https://wiki.openjdk.org/display/csr/Main) request " +
                     "is not needed for this pull request.");
@@ -861,7 +861,7 @@ class CSRTests {
             // Run bot. Request a CSR.
             pr.addComment("/csr");
             TestBotRunner.runPeriodicItems(bot);
-            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request (needs to be created) to be approved"));
+            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion 17 to be approved (needs to be created)"));
             assertTrue(pr.store().labelNames().contains("csr"));
             assertLastCommentContains(pr, "has indicated that a " +
                     "[compatibility and specification](https://wiki.openjdk.org/display/csr/Main) (CSR) request " +
@@ -872,7 +872,7 @@ class CSRTests {
             // Use `/csr unneeded` to revert the change.
             pr.addComment("/csr unneeded");
             TestBotRunner.runPeriodicItems(bot);
-            assertFalse(pr.store().body().contains("Change requires a CSR request (needs to be created) to be approved"));
+            assertFalse(pr.store().body().contains("Change requires a CSR request matching fixVersion 17 to be approved (needs to be created)"));
             assertFalse(pr.store().labelNames().contains("csr"));
             assertLastCommentContains(pr, "determined that a [CSR](https://wiki.openjdk.org/display/csr/Main) request " +
                     "is not needed for this pull request.");
@@ -935,7 +935,7 @@ class CSRTests {
             // re-run bot.
             pr.addComment("/csr");
             TestBotRunner.runPeriodicItems(bot);
-            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request (needs to be created) to be approved"));
+            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion 11 to be approved (needs to be created)"));
             assertTrue(pr.store().labelNames().contains("csr"));
             assertLastCommentContains(pr, "has indicated that a " +
                     "[compatibility and specification](https://wiki.openjdk.org/display/csr/Main) (CSR) request " +
@@ -995,7 +995,7 @@ class CSRTests {
                     "is needed for this pull request.");
             assertTrue(pr.store().labelNames().contains("csr"));
             // The PR body should contain the progress about CSR request
-            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request (needs to be created) to be approved"));
+            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion 0.1 to be approved (needs to be created)"));
 
             var issue2 = issues.createIssue("This is an issue2", List.of(), Map.of());
             // create a csr for issue2
@@ -1035,7 +1035,7 @@ class CSRTests {
                     "is needed for this pull request.");
             assertTrue(pr.store().labelNames().contains("csr"));
             // The PR body should contain the progress about CSR request
-            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request (needs to be created) to be approved"));
+            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion 0.1 to be approved (needs to be created)"));
 
             // Create a csr for main issue
             var csr1 = issues.createIssue("This is a CSR1", List.of(), Map.of("resolution",
@@ -1151,7 +1151,7 @@ class CSRTests {
             assertLastCommentContains(pr, "has indicated that a " +
                     "[compatibility and specification](https://wiki.openjdk.org/display/csr/Main) (CSR) request " +
                     "is needed for this pull request.");
-            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request (needs to be created) to be approved"));
+            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion 0.1 to be approved (needs to be created)"));
             assertFalse(pr.store().body().contains(generateCSRProgressMessage(csr)));
             assertFalse(pr.store().body().contains(generateCSRProgressMessage(csr2)));
         }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -2333,6 +2333,14 @@ class CheckTests {
             var restoreHash = localRepo.commit("restore conf", "testauthor", "ta@none.none");
             localRepo.push(restoreHash, author.url(), "master", true);
 
+            // Restore .jcheck/conf in source branch
+            localRepo.checkout(editHash);
+            Files.createDirectories(tempFolder.path().resolve(".jcheck"));
+            writeToCheckConf(checkConf);
+            localRepo.add(checkConf);
+            var restoreEditHash = localRepo.commit("restore source branch conf", "testauthor", "ta@none.none");
+            localRepo.push(restoreEditHash, author.url(), "edit", true);
+
             pr.addComment(".jcheck/conf is uploaded");
             TestBotRunner.runPeriodicItems(checkBot);
             assertTrue(pr.store().labelNames().contains("rfr"));


### PR DESCRIPTION
A user reported that she have a PR which can't find its corresponding CSR. 
Erik found that the issue was caused by the user not updating their branch in a long time, and the fixVersion in the .jcheck/conf file was still set at 20. However, the fixVersion of the CSR was 21, make the bot unable to locate the corresponding CSR. 

In this patch, I optimized the CSR progress message and log.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1806](https://bugs.openjdk.org/browse/SKARA-1806): Optimize the CSR progress message and log when CSR not found


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1463/head:pull/1463` \
`$ git checkout pull/1463`

Update a local copy of the PR: \
`$ git checkout pull/1463` \
`$ git pull https://git.openjdk.org/skara pull/1463/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1463`

View PR using the GUI difftool: \
`$ git pr show -t 1463`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1463.diff">https://git.openjdk.org/skara/pull/1463.diff</a>

</details>
