### PR TITLE
1547: Collect PR specific constants in single shared class

### DIFF
--- a/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestCloserBot.java
+++ b/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestCloserBot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,14 +44,14 @@ class PullRequestCloserBotWorkItem implements WorkItem {
         this.errorHandler = errorHandler;
     }
 
-    private final String welcomeMarker = "<!-- PullrequestCloserBot welcome message -->";
+    private static final String WELCOME_MARKER = "<!-- PullrequestCloserBot welcome message -->";
 
     private void checkWelcomeMessage() {
         log.info("Checking welcome message of " + pr);
 
         var comments = pr.comments();
         var welcomePosted = comments.stream()
-                                    .anyMatch(comment -> comment.body().contains(welcomeMarker));
+                                    .anyMatch(comment -> comment.body().contains(WELCOME_MARKER));
 
         if (!welcomePosted) {
             String message = null;
@@ -74,7 +74,7 @@ class PullRequestCloserBotWorkItem implements WorkItem {
             }
 
             log.fine("Posting welcome message");
-            pr.addComment(welcomeMarker + "\n\n" + message);
+            pr.addComment(WELCOME_MARKER + "\n\n" + message);
         }
         pr.setState(PullRequest.State.CLOSED);
     }

--- a/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestPrunerBot.java
+++ b/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestPrunerBot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,14 +70,14 @@ class PullRequestPrunerBotWorkItem implements WorkItem {
         return count + " " + unit;
     }
 
-    private final String noticeMarker = "<!-- PullrequestCloserBot auto close notification -->";
+    private static final String NOTICE_MARKER = "<!-- PullrequestCloserBot auto close notification -->";
 
     @Override
     public Collection<WorkItem> run(Path scratchPath) {
         var comments = pr.comments();
         if (comments.size() > 0) {
             var lastComment = comments.get(comments.size() - 1);
-            if (lastComment.author().equals(pr.repository().forge().currentUser()) && lastComment.body().contains(noticeMarker)) {
+            if (lastComment.author().equals(pr.repository().forge().currentUser()) && lastComment.body().contains(NOTICE_MARKER)) {
                 var message = "@" + pr.author().username() + " This pull request has been inactive for more than " +
                         formatDuration(maxAge.multipliedBy(2)) + " and will now be automatically closed. If you would " +
                         "like to continue working on this pull request in the future, feel free to reopen it! This can be done " +
@@ -95,7 +95,7 @@ class PullRequestPrunerBotWorkItem implements WorkItem {
                 "to ask for assistance if you need help with progressing this pull request towards integration!";
 
         log.fine("Posting prune notification message");
-        pr.addComment(noticeMarker + "\n\n" + message);
+        pr.addComment(NOTICE_MARKER + "\n\n" + message);
         return List.of();
     }
 

--- a/bots/common/src/main/java/org/openjdk/skara/bots/common/PullRequestConstants.java
+++ b/bots/common/src/main/java/org/openjdk/skara/bots/common/PullRequestConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,28 +21,22 @@
  * questions.
  */
 
-module {
-    name = 'org.openjdk.skara.bots.jep'
-    test {
-        requires 'org.junit.jupiter.api'
-        requires 'org.openjdk.skara.test'
-        opens 'org.openjdk.skara.bots.jep' to 'org.junit.platform.commons'
-    }
-}
+package org.openjdk.skara.bots.common;
 
-dependencies {
-    implementation project(':host')
-    implementation project(':bot')
-    implementation project(':forge')
-    implementation project(':issuetracker')
-    implementation project(':census')
-    implementation project(':ci')
-    implementation project(':json')
-    implementation project(':vcs')
-    implementation project(':metrics')
-    implementation project(':bots:common')
-    implementation project(':jbs')
-    implementation project(':jcheck')
+import java.util.regex.Pattern;
 
-    testImplementation project(':test')
+public class PullRequestConstants {
+    // MARKERS
+    public static final String PROGRESS_MARKER = "<!-- Anything below this marker will be automatically updated, please do not edit manually! -->";
+    public static final String CSR_UPDATE_MARKER = "<!-- csr: 'update' -->";
+    public static final String CSR_NEEDED_MARKER = "<!-- csr: 'needed' -->";
+    public static final String CSR_UNNEEDED_MARKER = "<!-- csr: 'unneeded' -->";
+    public static final String JEP_MARKER = "<!-- jep: '%s' '%s' '%s' -->"; // <!-- jep: 'JEP-ID' 'ISSUE-ID' 'ISSUE-TITLE' -->
+
+    // LABELS
+    public static final String CSR_LABEL = "csr";
+    public static final String JEP_LABEL = "jep";
+
+    // PATTERNS
+    public static final Pattern JEP_MARKER_PATTERN = Pattern.compile("<!-- jep: '(.*?)' '(.*?)' '(.*?)' -->");
 }

--- a/bots/common/src/main/java/org/openjdk/skara/bots/common/SolvesTracker.java
+++ b/bots/common/src/main/java/org/openjdk/skara/bots/common/SolvesTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,23 +32,23 @@ import java.util.regex.*;
 import java.util.stream.Collectors;
 
 public class SolvesTracker {
-    private final static String solvesMarker = "<!-- solves: '%s' '%s' -->";
-    private final static Pattern markerPattern = Pattern.compile("<!-- solves: '(.*?)' '(.*?)' -->");
+    private static final String SOLVES_MARKER = "<!-- solves: '%s' '%s' -->";
+    private static final Pattern MARKER_PATTERN = Pattern.compile("<!-- solves: '(.*?)' '(.*?)' -->");
 
     public static String setSolvesMarker(Issue issue) {
         var encodedDescription = Base64.getEncoder().encodeToString(issue.description().getBytes(StandardCharsets.UTF_8));
-        return String.format(solvesMarker, issue.shortId(), encodedDescription);
+        return String.format(SOLVES_MARKER, issue.shortId(), encodedDescription);
     }
 
     public static String removeSolvesMarker(Issue issue) {
-        return String.format(solvesMarker, issue.shortId(), "");
+        return String.format(SOLVES_MARKER, issue.shortId(), "");
     }
 
     public static List<Issue> currentSolved(HostUser botUser, List<Comment> comments) {
         var solvesActions = comments.stream()
                 .filter(comment -> comment.author().equals(botUser))
                 .flatMap(comment -> comment.body().lines())
-                .map(markerPattern::matcher)
+                .map(MARKER_PATTERN::matcher)
                 .filter(Matcher::find)
                 .collect(Collectors.toList());
         var current = new LinkedHashMap<String, Issue>();

--- a/bots/csr/src/main/java/org/openjdk/skara/bots/csr/PullRequestWorkItem.java
+++ b/bots/csr/src/main/java/org/openjdk/skara/bots/csr/PullRequestWorkItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,6 +42,8 @@ import org.openjdk.skara.issuetracker.Issue;
 import org.openjdk.skara.issuetracker.IssueProject;
 import org.openjdk.skara.jbs.Backports;
 
+import static org.openjdk.skara.bots.common.PullRequestConstants.*;
+
 /**
  * The PullRequestWorkItem is the work horse of the CSRBot. It gets triggered when
  * either the pull request itself, or any CSR issue associated with it have been
@@ -49,9 +51,6 @@ import org.openjdk.skara.jbs.Backports;
  * for it.
  */
 class PullRequestWorkItem implements WorkItem {
-    private final static String CSR_LABEL = "csr";
-    final static String CSR_UPDATE_MARKER = "<!-- csr: 'update' -->";
-    static final String PROGRESS_MARKER = "<!-- Anything below this marker will be automatically updated, please do not edit manually! -->";
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots.csr");
     private final HostedRepository repository;
     private final String prId;
@@ -274,10 +273,10 @@ class PullRequestWorkItem implements WorkItem {
     private boolean isCSRNeeded(List<Comment> comments) {
         for (int i = comments.size() - 1; i >= 0; i--) {
             var comment = comments.get(i);
-            if (comment.body().contains("<!-- csr: 'needed' -->")) {
+            if (comment.body().contains(CSR_NEEDED_MARKER)) {
                 return true;
             }
-            if (comment.body().contains("<!-- csr: 'unneeded' -->")) {
+            if (comment.body().contains(CSR_UNNEEDED_MARKER)) {
                 return false;
             }
         }

--- a/bots/csr/src/test/java/org/openjdk/skara/bots/csr/CSRBotTests.java
+++ b/bots/csr/src/test/java/org/openjdk/skara/bots/csr/CSRBotTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,8 +37,7 @@ import java.nio.file.Files;
 import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.openjdk.skara.bots.csr.PullRequestWorkItem.CSR_UPDATE_MARKER;
-import static org.openjdk.skara.bots.csr.PullRequestWorkItem.PROGRESS_MARKER;
+import static org.openjdk.skara.bots.common.PullRequestConstants.*;
 
 class CSRBotTests {
     @Test

--- a/bots/jep/src/main/java/module-info.java
+++ b/bots/jep/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,9 @@ module org.openjdk.skara.bots.jep {
     requires org.openjdk.skara.forge;
     requires org.openjdk.skara.issuetracker;
     requires java.logging;
+    requires org.openjdk.skara.bots.common;
+    requires org.openjdk.skara.jcheck;
+    requires org.openjdk.skara.jbs;
 
     provides org.openjdk.skara.bot.BotFactory with org.openjdk.skara.bots.jep.JEPBotFactory;
 }

--- a/bots/jep/src/main/java/org/openjdk/skara/bots/jep/JEPBot.java
+++ b/bots/jep/src/main/java/org/openjdk/skara/bots/jep/JEPBot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,14 +34,12 @@ import java.util.Collection;
 import java.util.List;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import static org.openjdk.skara.bots.jep.JEPBotFactory.NAME;
+import static org.openjdk.skara.bots.common.PullRequestConstants.*;
 
 public class JEPBot implements Bot, WorkItem {
-    final static String JEP_LABEL = "jep";
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots");
-    private final static Pattern jepMarkerPattern = Pattern.compile("<!-- jep: '(.*?)' '(.*?)' '(.*?)' -->");
     private final HostedRepository repo;
     private final IssueProject issueProject;
 
@@ -65,7 +63,7 @@ public class JEPBot implements Bot, WorkItem {
             var jepComment = pr.comments().stream()
                     .filter(comment -> comment.author().equals(pr.repository().forge().currentUser()))
                     .flatMap(comment -> comment.body().lines())
-                    .map(jepMarkerPattern::matcher)
+                    .map(JEP_MARKER_PATTERN::matcher)
                     .filter(Matcher::find)
                     .reduce((first, second) -> second)
                     .orElse(null);

--- a/bots/jep/src/test/java/org/openjdk/skara/bots/jep/JEPBotTests.java
+++ b/bots/jep/src/test/java/org/openjdk/skara/bots/jep/JEPBotTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,9 +38,9 @@ import java.util.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.openjdk.skara.issuetracker.jira.JiraProject.JEP_NUMBER;
+import static org.openjdk.skara.bots.common.PullRequestConstants.*;
 
 public class JEPBotTests {
-    private static final String jepMarker = "<!-- jep: '%s' '%s' '%s' -->"; // <!-- jep: 'JEP-ID' 'ISSUE-ID' 'ISSUE-TITLE' -->
 
     @Test
     void testJepIssueStatus(TestInfo testInfo) throws IOException {
@@ -75,28 +75,28 @@ public class JEPBotTests {
 
             // PR should not have the `jep` label at first
             TestBotRunner.runPeriodicItems(jepBot);
-            assertFalse(pr.store().labelNames().contains(JEPBot.JEP_LABEL));
+            assertFalse(pr.store().labelNames().contains(JEP_LABEL));
 
             // Test draft/submitted/candidate/proposedToTarget/proposedToDrop/closedWithoutDelivered JEPs
             for (int i = 1; i <= 6; i++) {
-                pr.addComment(String.format(jepMarker, i, issueLists.get(i - 1).id(), issueLists.get(i - 1).title()));
-                pr.removeLabel(JEPBot.JEP_LABEL);
+                pr.addComment(String.format(JEP_MARKER, i, issueLists.get(i - 1).id(), issueLists.get(i - 1).title()));
+                pr.removeLabel(JEP_LABEL);
                 TestBotRunner.runPeriodicItems(jepBot);
-                assertTrue(pr.store().labelNames().contains(JEPBot.JEP_LABEL));
+                assertTrue(pr.store().labelNames().contains(JEP_LABEL));
             }
 
             // PR should have the `jep` label
             TestBotRunner.runPeriodicItems(jepBot);
-            assertTrue(pr.store().labelNames().contains(JEPBot.JEP_LABEL));
+            assertTrue(pr.store().labelNames().contains(JEP_LABEL));
             // Remove the `jep` label for the following test
-            pr.removeLabel(JEPBot.JEP_LABEL);
+            pr.removeLabel(JEP_LABEL);
 
             // Test targeted/integrated/completed/closedWithDelivered JEPs
             for (int i = 7; i <= 10; i++) {
-                pr.addComment(String.format(jepMarker, i, issueLists.get(i - 1).id(), issueLists.get(i - 1).title()));
-                pr.addLabel(JEPBot.JEP_LABEL);
+                pr.addComment(String.format(JEP_MARKER, i, issueLists.get(i - 1).id(), issueLists.get(i - 1).title()));
+                pr.addLabel(JEP_LABEL);
                 TestBotRunner.runPeriodicItems(jepBot);
-                assertFalse(pr.store().labelNames().contains(JEPBot.JEP_LABEL));
+                assertFalse(pr.store().labelNames().contains(JEP_LABEL));
             }
         }
     }
@@ -126,14 +126,14 @@ public class JEPBotTests {
 
             // PR should not have the `jep` label at first
             TestBotRunner.runPeriodicItems(jepBot);
-            assertFalse(pr.store().labelNames().contains(JEPBot.JEP_LABEL));
+            assertFalse(pr.store().labelNames().contains(JEP_LABEL));
 
             // Add the `jep` label and don't add the jep comment
-            pr.addLabel(JEPBot.JEP_LABEL);
-            assertTrue(pr.store().labelNames().contains(JEPBot.JEP_LABEL));
+            pr.addLabel(JEP_LABEL);
+            assertTrue(pr.store().labelNames().contains(JEP_LABEL));
 
             TestBotRunner.runPeriodicItems(jepBot);
-            assertFalse(pr.store().labelNames().contains(JEPBot.JEP_LABEL));
+            assertFalse(pr.store().labelNames().contains(JEP_LABEL));
         }
     }
 
@@ -162,15 +162,15 @@ public class JEPBotTests {
 
             // PR should not have the `jep` label at first
             TestBotRunner.runPeriodicItems(jepBot);
-            assertFalse(pr.store().labelNames().contains(JEPBot.JEP_LABEL));
+            assertFalse(pr.store().labelNames().contains(JEP_LABEL));
 
             // Add the `jep` label and add the jep unneeded comment
-            pr.addComment(String.format(jepMarker, "unneeded", "unneeded", "unneeded"));
-            pr.addLabel(JEPBot.JEP_LABEL);
-            assertTrue(pr.store().labelNames().contains(JEPBot.JEP_LABEL));
+            pr.addComment(String.format(JEP_MARKER, "unneeded", "unneeded", "unneeded"));
+            pr.addLabel(JEP_LABEL);
+            assertTrue(pr.store().labelNames().contains(JEP_LABEL));
 
             TestBotRunner.runPeriodicItems(jepBot);
-            assertFalse(pr.store().labelNames().contains(JEPBot.JEP_LABEL));
+            assertFalse(pr.store().labelNames().contains(JEP_LABEL));
         }
     }
 
@@ -199,15 +199,15 @@ public class JEPBotTests {
 
             // PR should not have the `jep` label at first
             TestBotRunner.runPeriodicItems(jepBot);
-            assertFalse(pr.store().labelNames().contains(JEPBot.JEP_LABEL));
+            assertFalse(pr.store().labelNames().contains(JEP_LABEL));
 
             // Add the `jep` label and add the non-existing jep comment
-            pr.addComment(String.format(jepMarker, "100", "TEST-100", "Demo jep"));
-            pr.addLabel(JEPBot.JEP_LABEL);
-            assertTrue(pr.store().labelNames().contains(JEPBot.JEP_LABEL));
+            pr.addComment(String.format(JEP_MARKER, "100", "TEST-100", "Demo jep"));
+            pr.addLabel(JEP_LABEL);
+            assertTrue(pr.store().labelNames().contains(JEP_LABEL));
 
             TestBotRunner.runPeriodicItems(jepBot);
-            assertTrue(pr.store().labelNames().contains(JEPBot.JEP_LABEL));
+            assertTrue(pr.store().labelNames().contains(JEP_LABEL));
         }
     }
 
@@ -236,15 +236,15 @@ public class JEPBotTests {
 
             // PR should not have the `jep` label at first
             TestBotRunner.runPeriodicItems(jepBot);
-            assertFalse(pr.store().labelNames().contains(JEPBot.JEP_LABEL));
+            assertFalse(pr.store().labelNames().contains(JEP_LABEL));
 
             // Add the `jep` label and add the wrong type issue comment
-            pr.addComment(String.format(jepMarker, "1", "TEST-2", "Demo jep"));
-            pr.addLabel(JEPBot.JEP_LABEL);
-            assertTrue(pr.store().labelNames().contains(JEPBot.JEP_LABEL));
+            pr.addComment(String.format(JEP_MARKER, "1", "TEST-2", "Demo jep"));
+            pr.addLabel(JEP_LABEL);
+            assertTrue(pr.store().labelNames().contains(JEP_LABEL));
 
             TestBotRunner.runPeriodicItems(jepBot);
-            assertTrue(pr.store().labelNames().contains(JEPBot.JEP_LABEL));
+            assertTrue(pr.store().labelNames().contains(JEP_LABEL));
         }
     }
 }

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,18 +38,17 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 class ArchiveMessages {
-    private static final Pattern commentPattern = Pattern.compile("<!--.*?-->",
+    private static final Pattern COMMENT_PATTERN = Pattern.compile("<!--.*?-->",
                                                                   Pattern.DOTALL | Pattern.MULTILINE);
-    private static final Pattern commandPattern = Pattern.compile("^\\s*/([A-Za-z]+).*$", Pattern.MULTILINE | Pattern.DOTALL);
-
+    static final Pattern COMMAND_PATTERN = Pattern.compile("^\\s*/([A-Za-z]+).*$", Pattern.MULTILINE | Pattern.DOTALL);
     private static String filterCommentsAndCommands(String body) {
         var parsedBody = PullRequestBody.parse(body);
         body = parsedBody.bodyText();
 
-        var commentMatcher = commentPattern.matcher(body);
+        var commentMatcher = COMMENT_PATTERN.matcher(body);
         body = commentMatcher.replaceAll("");
 
-        var commandLineMatcher = commandPattern.matcher(body);
+        var commandLineMatcher = COMMAND_PATTERN.matcher(body);
         body = commandLineMatcher.replaceAll("");
 
         body = MarkdownToText.removeFormatting(body);

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,8 +37,9 @@ import java.time.*;
 import java.util.*;
 import java.util.function.*;
 import java.util.logging.Logger;
-import java.util.regex.*;
 import java.util.stream.Collectors;
+
+import static org.openjdk.skara.bots.mlbridge.ArchiveMessages.COMMAND_PATTERN;
 
 class ArchiveWorkItem implements WorkItem {
     private final PullRequest pr;
@@ -116,8 +117,6 @@ class ArchiveWorkItem implements WorkItem {
         }
     }
 
-    private static final Pattern commandPattern = Pattern.compile("^\\s*/([A-Za-z]+).*$", Pattern.MULTILINE | Pattern.DOTALL);
-
     private boolean ignoreComment(HostUser author, String body) {
         if (pr.repository().forge().currentUser().equals(author)) {
             return true;
@@ -126,7 +125,7 @@ class ArchiveWorkItem implements WorkItem {
             return true;
         }
         // Check if this comment only contains command lines
-        var commandLineMatcher = commandPattern.matcher(body);
+        var commandLineMatcher = COMMAND_PATTERN.matcher(body);
         if (commandLineMatcher.find()) {
             var filteredBody = commandLineMatcher.replaceAll("");
             if (filteredBody.strip().isEmpty()) {

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/BridgedComment.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/BridgedComment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,9 +38,9 @@ public class BridgedComment {
     private final HostUser author;
     private final ZonedDateTime created;
 
-    private final static String bridgedMailMarker = "<!-- Bridged id (%s) -->";
-    final static Pattern bridgedMailId = Pattern.compile("^<!-- Bridged id \\(([=+/\\w]+)\\) -->");
-    private final static Pattern bridgedSender = Pattern.compile("Mailing list message from \\[(.*?)]\\(mailto:(\\S+)\\)");
+    private static final String BRIDGED_MAIL_MARKER = "<!-- Bridged id (%s) -->";
+    static final Pattern BRIDGED_MAIL_ID = Pattern.compile("^<!-- Bridged id \\(([=+/\\w]+)\\) -->");
+    private static final Pattern BRIDGED_SENDER = Pattern.compile("Mailing list message from \\[(.*?)]\\(mailto:(\\S+)\\)");
 
     private BridgedComment(String body, EmailAddress messageId, HostUser author, ZonedDateTime created) {
         this.messageId = messageId;
@@ -53,12 +53,12 @@ public class BridgedComment {
         if (!comment.author().equals(botUser)) {
             return Optional.empty();
         }
-        var matcher = bridgedMailId.matcher(comment.body());
+        var matcher = BRIDGED_MAIL_ID.matcher(comment.body());
         if (!matcher.find()) {
             return Optional.empty();
         }
         var id = new String(Base64.getDecoder().decode(matcher.group(1)), StandardCharsets.UTF_8);
-        var senderMatcher = bridgedSender.matcher(comment.body());
+        var senderMatcher = BRIDGED_SENDER.matcher(comment.body());
         if (!senderMatcher.find()) {
             return Optional.empty();
         }
@@ -74,7 +74,7 @@ public class BridgedComment {
     }
 
     static BridgedComment post(PullRequest pr, Email email) {
-        var marker = String.format(bridgedMailMarker,
+        var marker = String.format(BRIDGED_MAIL_MARKER,
                                    Base64.getEncoder().encodeToString(email.id().address().getBytes(StandardCharsets.UTF_8)));
 
         var filteredEmail = QuoteFilter.stripLinkBlock(email.body(), pr.webUrl());

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBot.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,7 @@ public class MailingListArchiveReaderBot implements Bot {
     private final Map<EmailAddress, PullRequest> resolvedPullRequests = new HashMap<>();
     private final Set<EmailAddress> parsedEmailIds = new HashSet<>();
     private final Queue<CommentPosterWorkItem> commentQueue = new ConcurrentLinkedQueue<>();
-    private final Pattern pullRequestLinkPattern = Pattern.compile("^(?:PR: |Pull request:\\R)(.*?)$", Pattern.MULTILINE);
+    private static final Pattern PULL_REQUEST_LINK_PATTERN = Pattern.compile("^(?:PR: |Pull request:\\R)(.*?)$", Pattern.MULTILINE);
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots.mlbridge");
 
     MailingListArchiveReaderBot(MailingListReader list, HostedRepository repository) {
@@ -74,7 +74,7 @@ public class MailingListArchiveReaderBot implements Bot {
             }
 
             // Look for a pull request link
-            var matcher = pullRequestLinkPattern.matcher(first.body());
+            var matcher = PULL_REQUEST_LINK_PATTERN.matcher(first.body());
             if (!matcher.find()) {
                 log.fine("RFR email without valid pull request link: " + first.date() + " - " + first.subject());
                 return;

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MarkdownToText.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MarkdownToText.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,34 +25,34 @@ package org.openjdk.skara.bots.mlbridge;
 import java.util.regex.*;
 
 public class MarkdownToText {
-    private static final Pattern emojiPattern = Pattern.compile("(:([0-9a-z_+-]+):)");
-    private static final Pattern suggestionPattern = Pattern.compile("^```suggestion$", Pattern.MULTILINE);
-    private static final Pattern codePattern = Pattern.compile("^```+(?:\\w+)?$", Pattern.MULTILINE);
-    private static final Pattern escapesPattern = Pattern.compile("\\\\([!\"#$%&'()*+,\\-./:;<=?@\\[\\]^_`{|}~])", Pattern.MULTILINE);
-    private static final Pattern entitiesPattern = Pattern.compile("&#32;", Pattern.MULTILINE);
+    private static final Pattern EMOJI_PATTERN = Pattern.compile("(:([0-9a-z_+-]+):)");
+    private static final Pattern SUGGESTION_PATTERN = Pattern.compile("^```suggestion$", Pattern.MULTILINE);
+    private static final Pattern CODE_PATTERN = Pattern.compile("^```+(?:\\w+)?$", Pattern.MULTILINE);
+    private static final Pattern ESCAPES_PATTERN = Pattern.compile("\\\\([!\"#$%&'()*+,\\-./:;<=?@\\[\\]^_`{|}~])", Pattern.MULTILINE);
+    private static final Pattern ENTITIES_PATTERN = Pattern.compile("&#32;", Pattern.MULTILINE);
 
     private static String removeEmojis(String markdown) {
-        var emojiMatcher = emojiPattern.matcher(markdown);
+        var emojiMatcher = EMOJI_PATTERN.matcher(markdown);
         return emojiMatcher.replaceAll(mr -> EmojiTable.mapping.getOrDefault(mr.group(2), mr.group(1)));
     }
 
     private static String removeSuggestions(String markdown) {
-        var suggestionMatcher = suggestionPattern.matcher(markdown);
+        var suggestionMatcher = SUGGESTION_PATTERN.matcher(markdown);
         return suggestionMatcher.replaceAll("Suggestion:\n");
     }
 
     private static String removeCode(String markdown) {
-        var codeMatcher = codePattern.matcher(markdown);
+        var codeMatcher = CODE_PATTERN.matcher(markdown);
         return codeMatcher.replaceAll("");
     }
 
     static String removeEscapes(String markdown) {
-        var escapesMatcher = escapesPattern.matcher(markdown);
+        var escapesMatcher = ESCAPES_PATTERN.matcher(markdown);
         return escapesMatcher.replaceAll(mr -> Matcher.quoteReplacement(mr.group(1)));
     }
 
     static String removeEntities(String markdown) {
-        var entitiesMatcher = entitiesPattern.matcher(markdown);
+        var entitiesMatcher = ENTITIES_PATTERN.matcher(markdown);
         return entitiesMatcher.replaceAll(" ");
     }
 

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/QuoteFilter.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/QuoteFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,10 +27,10 @@ import java.util.*;
 import java.util.regex.Pattern;
 
 class QuoteFilter {
-    private static final Pattern leadingQuotesPattern = Pattern.compile("^([>\\s]+).*");
+    private static final Pattern LEADING_QUOTES_PATTERN = Pattern.compile("^([>\\s]+).*");
 
     private static Optional<String> leadingQuotes(String line) {
-        var leadingQuotesMatcher = leadingQuotesPattern.matcher(line);
+        var leadingQuotesMatcher = LEADING_QUOTES_PATTERN.matcher(line);
         if (leadingQuotesMatcher.matches()) {
             if (leadingQuotesMatcher.group(1).contains(">")) {
                 return Optional.of(leadingQuotesMatcher.group(1).trim());

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -80,12 +80,12 @@ class ReviewArchive {
                         .findAny();
     }
 
-    private final static Pattern pushedPattern = Pattern.compile("Pushed as commit ([a-f0-9]{40})\\.");
+    public static final Pattern PUSHED_PATTERN = Pattern.compile("Pushed as commit ([a-f0-9]{40})\\.");
 
     private Optional<Hash> findIntegratedHash() {
         return ignoredComments.stream()
                               .map(Comment::body)
-                              .map(pushedPattern::matcher)
+                              .map(PUSHED_PATTERN::matcher)
                               .filter(Matcher::find)
                               .map(m -> m.group(1))
                               .map(Hash::new)

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/TextToMarkdown.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/TextToMarkdown.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,21 +26,21 @@ import java.util.ArrayList;
 import java.util.regex.*;
 
 public class TextToMarkdown {
-    private static final Pattern punctuationPattern = Pattern.compile("([!\"#$%&'()*+,\\-./:;<=?@\\[\\]^_`{|}~])", Pattern.MULTILINE);
-    private static final Pattern indentedPattern = Pattern.compile("^ {4}", Pattern.MULTILINE);
-    private static final Pattern mentionPattern = Pattern.compile("@(\\w+)", Pattern.MULTILINE);
+    private static final Pattern PUNCTUATION_PATTERN = Pattern.compile("([!\"#$%&'()*+,\\-./:;<=?@\\[\\]^_`{|}~])", Pattern.MULTILINE);
+    private static final Pattern INDENTED_PATTERN = Pattern.compile("^ {4}", Pattern.MULTILINE);
+    private static final Pattern MENTION_PATTERN = Pattern.compile("@(\\w+)", Pattern.MULTILINE);
 
     private static String escapeBackslashes(String text) {
         return text.replace("\\", "\\\\");
     }
 
     private static String escapePunctuation(String text) {
-        var punctuationMatcher = punctuationPattern.matcher(text);
+        var punctuationMatcher = PUNCTUATION_PATTERN.matcher(text);
         return punctuationMatcher.replaceAll(mr -> "\\\\" + Matcher.quoteReplacement(mr.group(1)));
     }
 
     private static String escapeIndention(String text) {
-        var indentedMatcher = indentedPattern.matcher(text);
+        var indentedMatcher = INDENTED_PATTERN.matcher(text);
         return indentedMatcher.replaceAll("&#32;   ");
     }
 
@@ -62,7 +62,7 @@ public class TextToMarkdown {
     }
 
     private static String escapeMention(String text) {
-        var mentionMatcher = mentionPattern.matcher(text);
+        var mentionMatcher = MENTION_PATTERN.matcher(text);
         return mentionMatcher.replaceAll("@<!-- -->$1");
     }
 

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/BridgedCommentTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/BridgedCommentTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,13 +30,13 @@ public class BridgedCommentTests {
 
     @Test
     public void bridgeMailPattern() {
-        assertFalse(BridgedComment.bridgedMailId.matcher("foo").find());
-        assertFalse(BridgedComment.bridgedMailId.matcher("<-- foo -->").find());
-        assertTrue(BridgedComment.bridgedMailId.matcher("<!-- Bridged id (foo=) -->").find());
-        assertTrue(BridgedComment.bridgedMailId.matcher("<!-- Bridged id (PEEzNDJBNUQwLTM" +
+        assertFalse(BridgedComment.BRIDGED_MAIL_ID.matcher("foo").find());
+        assertFalse(BridgedComment.BRIDGED_MAIL_ID.matcher("<-- foo -->").find());
+        assertTrue(BridgedComment.BRIDGED_MAIL_ID.matcher("<!-- Bridged id (foo=) -->").find());
+        assertTrue(BridgedComment.BRIDGED_MAIL_ID.matcher("<!-- Bridged id (PEEzNDJBNUQwLTM" +
                 "4MjItNEM2Ni05MDc4LUY5QThDOTA2NTRBNkBjYmZpZGRsZS5jb20+RnJvbSB0aGUgQ1NSIHJldmlldzo=) -->").find());
 
-        var matcher = BridgedComment.bridgedMailId.matcher("<!-- Bridged id (fo+/o=) -->");
+        var matcher = BridgedComment.BRIDGED_MAIL_ID.matcher("<!-- Bridged id (fo+/o=) -->");
         assertTrue(matcher.find());
         assertEquals("fo+/o=", matcher.group(1));
     }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CSRCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CSRCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,10 +34,9 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.openjdk.skara.bots.common.PullRequestConstants.*;
+
 public class CSRCommand implements CommandHandler {
-    private static final String CSR_LABEL = "csr";
-    private static final String CSR_NEEDED_MARKER = "<!-- csr: 'needed' -->";
-    private static final String CSR_UNNEEDED_MARKER = "<!-- csr: 'unneeded' -->";
 
     private static void showHelp(PrintWriter writer) {
         writer.println("usage: `/csr [needed|unneeded]`, requires that the issue the pull request refers to links to an approved [CSR](https://wiki.openjdk.org/display/csr/Main) request.");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,12 +44,12 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 class CheckWorkItem extends PullRequestWorkItem {
-    private final Pattern metadataComments = Pattern.compile("<!-- (?:backport)|(?:(add|remove) (?:contributor|reviewer))|(?:summary: ')|(?:solves: ')|(?:additional required reviewers)|(?:jep: ')|(?:csr: ')");
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots.pr");
     static final Pattern ISSUE_ID_PATTERN = Pattern.compile("^(?:(?<prefix>[A-Za-z][A-Za-z0-9]+)-)?(?<id>[0-9]+)"
             + "(?::(?<space>[\\s\u00A0\u2007\u202F]+)(?<title>.+))?$");
     private static final Pattern BACKPORT_HASH_TITLE_PATTERN = Pattern.compile("^Backport\\s*([0-9a-z]{40})\\s*$");
     private static final Pattern BACKPORT_ISSUE_TITLE_PATTERN = Pattern.compile("^Backport\\s*(?:(?<prefix>[A-Za-z][A-Za-z0-9]+)-)?(?<id>[0-9]+)\\s*$");
+    private static final Pattern METADATA_COMMENTS_PATTERN = Pattern.compile("<!-- (?:backport)|(?:(add|remove) (?:contributor|reviewer))|(?:summary: ')|(?:solves: ')|(?:additional required reviewers)|(?:jep: ')|(?:csr: ')");
     private static final String ELLIPSIS = "…";
     protected static final String FORCE_PUSH_MARKER = "<!-- force-push suggestion -->";
     protected static final String FORCE_PUSH_SUGGESTION= """
@@ -92,7 +92,7 @@ class CheckWorkItem extends PullRequestWorkItem {
             var commentString = comments.stream()
                                         .filter(comment -> comment.author().id().equals(pr.repository().forge().currentUser().id()))
                                         .flatMap(comment -> comment.body().lines())
-                                        .filter(line -> metadataComments.matcher(line).find())
+                                        .filter(line -> METADATA_COMMENTS_PATTERN.matcher(line).find())
                                         .collect(Collectors.joining());
             var labelString = labels.stream()
                                     .sorted()

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandExtractor.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandExtractor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 public class CommandExtractor {
-    private static final Pattern commandPattern = Pattern.compile("^\\s*/([A-Za-z]+)(?:\\s+(.*))?");
+    private static final Pattern COMMAND_PATTERN = Pattern.compile("^\\s*/([A-Za-z]+)(?:\\s+(.*))?");
 
     private static String formatId(String baseId, int subId) {
         if (subId > 0) {
@@ -108,7 +108,7 @@ public class CommandExtractor {
         String multiLineCommand = null;
         int subId = 0;
         for (var line : text.split("\\R")) {
-            var commandMatcher = commandPattern.matcher(line);
+            var commandMatcher = COMMAND_PATTERN.matcher(line);
             if (commandMatcher.matches()) {
                 if (multiLineHandler != null) {
                     ret.add(new CommandInvocation(formatId(baseId, subId++), user, multiLineHandler, multiLineCommand,

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommitCommandWorkItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,8 +40,8 @@ public class CommitCommandWorkItem implements WorkItem {
     private final CommitComment commitComment;
     private final Consumer<RuntimeException> onError;
 
-    private static final String commandReplyMarker = "<!-- Jmerge command reply message (%s) -->";
-    private static final Pattern commandReplyPattern = Pattern.compile("<!-- Jmerge command reply message \\((\\S+)\\) -->");
+    static final String COMMAND_REPLY_MARKER = "<!-- Jmerge command reply message (%s) -->";
+    static final Pattern COMMAND_REPLY_PATTERN = Pattern.compile("<!-- Jmerge command reply message \\((\\S+)\\) -->");
 
     private static final Logger log = Logger.getLogger("org.openjdk.skara.bots.pr");
 
@@ -75,7 +75,7 @@ public class CommitCommandWorkItem implements WorkItem {
 
         var handled = allComments.stream()
                               .filter(c -> c.author().equals(self))
-                              .map(c -> commandReplyPattern.matcher(c.body()))
+                              .map(c -> COMMAND_REPLY_PATTERN.matcher(c.body()))
                               .filter(Matcher::find)
                               .map(matcher -> matcher.group(1))
                               .collect(Collectors.toSet());
@@ -92,7 +92,7 @@ public class CommitCommandWorkItem implements WorkItem {
         var writer = new StringWriter();
         var printer = new PrintWriter(writer);
 
-        printer.println(String.format(commandReplyMarker, command.id()));
+        printer.println(String.format(COMMAND_REPLY_MARKER, command.id()));
         printer.print("@");
         printer.print(command.user().username());
         printer.print(" ");
@@ -141,7 +141,7 @@ public class CommitCommandWorkItem implements WorkItem {
             } catch (MissingJCheckConfException e) {
                 if (bot.confOverrideRepository().isEmpty()) {
                     log.log(Level.SEVERE, "No .jcheck/conf found in repo " + bot.repo().name(), e);
-                    var comment = String.format(commandReplyMarker, command.id()) + "\n" +
+                    var comment = String.format(COMMAND_REPLY_MARKER, command.id()) + "\n" +
                             "@" + command.user().username() +
                             " There is no `.jcheck/conf` present at revision " +
                             hash.abbreviate() + " - cannot process command.";
@@ -149,7 +149,7 @@ public class CommitCommandWorkItem implements WorkItem {
                 } else {
                     log.log(Level.SEVERE, "Jcheck configuration file " + bot.confOverrideName()
                             + " not found in external repo " + bot.confOverrideRepository().get().name(), e);
-                    var comment = String.format(commandReplyMarker, command.id()) + "\n" +
+                    var comment = String.format(COMMAND_REPLY_MARKER, command.id()) + "\n" +
                             "@" + command.user().username() +
                             " There is no Jcheck configuration file " + bot.confOverrideName()
                             + " present in external repo " + bot.confOverrideRepository().get().name() + " at revision "
@@ -160,7 +160,7 @@ public class CommitCommandWorkItem implements WorkItem {
             } catch (InvalidJCheckConfException e) {
                 if (bot.confOverrideRepository().isEmpty()) {
                     log.log(Level.SEVERE, "Invalid .jcheck/conf found in repo " + bot.repo().name(), e);
-                    var comment = String.format(commandReplyMarker, command.id()) + "\n" +
+                    var comment = String.format(COMMAND_REPLY_MARKER, command.id()) + "\n" +
                             "@" + command.user().username() +
                             " Invalid `.jcheck/conf` present at revision " +
                             hash.abbreviate() + " - cannot process command.";
@@ -168,7 +168,7 @@ public class CommitCommandWorkItem implements WorkItem {
                 } else {
                     log.log(Level.SEVERE, "Invalid Jcheck configuration file " + bot.confOverrideName()
                             + " in external repo " + bot.confOverrideRepository().get().name(), e);
-                    var comment = String.format(commandReplyMarker, command.id()) + "\n" +
+                    var comment = String.format(COMMAND_REPLY_MARKER, command.id()) + "\n" +
                             "@" + command.user().username() +
                             " Invalid Jcheck configuration file " + bot.confOverrideName() + " present in external repo "
                             + bot.confOverrideRepository().get().name() + " at revision " +

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ContributorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ContributorCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,7 @@ import java.util.*;
 import java.util.regex.Pattern;
 
 public class ContributorCommand implements CommandHandler {
-    private static final Pattern commandPattern = Pattern.compile("^(add|remove)\\s+(.+)$");
+    private static final Pattern COMMAND_PATTERN = Pattern.compile("^(add|remove)\\s+(.+)$");
 
     private void showHelp(PullRequest pr, PrintWriter reply) {
         reply.println("Syntax: `/contributor (add|remove) [@user | openjdk-user | Full Name <email@address>]`. For example:");
@@ -100,7 +100,7 @@ public class ContributorCommand implements CommandHandler {
             return;
         }
 
-        var matcher = commandPattern.matcher(command.args());
+        var matcher = COMMAND_PATTERN.matcher(command.args());
         if (!matcher.matches()) {
             showHelp(pr, reply);
             return;

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/Contributors.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/Contributors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,22 +31,22 @@ import java.util.regex.*;
 import java.util.stream.Collectors;
 
 class Contributors {
-    private final static String addMarker = "<!-- add contributor: '%s' -->";
-    private final static String removeMarker = "<!-- remove contributor: '%s' -->";
-    private final static Pattern markerPattern = Pattern.compile("<!-- (add|remove) contributor: '(.*?)' -->");
+    private static final String ADD_MARKER = "<!-- add contributor: '%s' -->";
+    private static final String REMOVE_MARKER = "<!-- remove contributor: '%s' -->";
+    private static final Pattern MARKER_PATTERN = Pattern.compile("<!-- (add|remove) contributor: '(.*?)' -->");
 
     static String addContributorMarker(EmailAddress contributor) {
-        return String.format(addMarker, contributor.toString());
+        return String.format(ADD_MARKER, contributor.toString());
     }
 
     static String removeContributorMarker(EmailAddress contributor) {
-        return String.format(removeMarker, contributor.toString());
+        return String.format(REMOVE_MARKER, contributor.toString());
     }
 
     static List<EmailAddress> contributors(HostUser botUser, List<Comment> comments) {
         var contributorActions = comments.stream()
                                          .filter(comment -> comment.author().equals(botUser))
-                                         .map(comment -> markerPattern.matcher(comment.body()))
+                                         .map(comment -> MARKER_PATTERN.matcher(comment.body()))
                                          .filter(Matcher::find)
                                          .collect(Collectors.toList());
         var contributors = new LinkedHashSet<EmailAddress>();

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IssueCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IssueCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -77,8 +77,8 @@ public class IssueCommand implements CommandHandler {
         reply.println("Separate multiple issue IDs using either spaces or commas.");
     }
 
-    private static final Pattern shortIssuePattern = Pattern.compile("((?:[A-Za-z]+-)?[0-9]+)(?:,| |$)");
-    private final static Pattern subCommandPattern = Pattern.compile("^(add|remove|delete|create|(?:[A-Za-z]+-)?[0-9]+:?)[ ,]?.*$");
+    private static final Pattern SHORT_ISSUE_PATTERN = Pattern.compile("((?:[A-Za-z]+-)?[0-9]+)(?:,| |$)");
+    private static final Pattern SUBCOMMAND_PATTERN = Pattern.compile("^(add|remove|delete|create|(?:[A-Za-z]+-)?[0-9]+:?)[ ,]?.*$");
 
     private List<Issue> parseIssueList(String allowedPrefix, String issueList) throws InvalidIssue {
         List<Issue> ret;
@@ -87,7 +87,7 @@ public class IssueCommand implements CommandHandler {
         if (singleIssue.isPresent()) {
             ret = List.of(singleIssue.get());
         } else {
-            var shortIssueMatcher = shortIssuePattern.matcher(issueList);
+            var shortIssueMatcher = SHORT_ISSUE_PATTERN.matcher(issueList);
             ret = shortIssueMatcher.results()
                                    .map(matchResult -> matchResult.group(1))
                                    .map(identifier -> new Issue(identifier, null))
@@ -281,7 +281,7 @@ public class IssueCommand implements CommandHandler {
             showHelp(reply);
             return;
         }
-        var subCommandMatcher = subCommandPattern.matcher(args);
+        var subCommandMatcher = SUBCOMMAND_PATTERN.matcher(args);
         if (!subCommandMatcher.matches()) {
             showHelp(reply);
             return;

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/JEPCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/JEPCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,15 +31,12 @@ import java.io.PrintWriter;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
-import java.util.regex.Pattern;
 
 import static org.openjdk.skara.issuetracker.jira.JiraProject.JEP_NUMBER;
+import static org.openjdk.skara.bots.common.PullRequestConstants.*;
 
 public class JEPCommand implements CommandHandler {
-    static final String JEP_LABEL = "jep";
-    private static final String jepMarker = "<!-- jep: '%s' '%s' '%s' -->"; // <!-- jep: 'JEP-ID' 'ISSUE-ID' 'ISSUE-TITLE' -->
-    static final Pattern jepMarkerPattern = Pattern.compile("<!-- jep: '(.*?)' '(.*?)' '(.*?)' -->");
-    private static final String unneededMarker = "<!-- jep: 'unneeded' 'unneeded' 'unneeded' -->";
+    private static final String UNNEEDED_MARKER = "<!-- jep: 'unneeded' 'unneeded' 'unneeded' -->";
 
     private void showHelp(PrintWriter reply) {
         reply.println("""
@@ -109,7 +106,7 @@ public class JEPCommand implements CommandHandler {
             if (labelNames.contains(JEP_LABEL)) {
                 labelsToRemove.add(JEP_LABEL);
             }
-            reply.println(unneededMarker);
+            reply.println(UNNEEDED_MARKER);
             reply.println("determined that the JEP request is not needed for this pull request.");
             return;
         }
@@ -142,7 +139,7 @@ public class JEPCommand implements CommandHandler {
 
         // Set the marker and output the result
         var jepNumber = jbsIssue.properties().get(JEP_NUMBER).asString();
-        reply.println(String.format(jepMarker, jepNumber, jbsIssue.id(), jbsIssue.title()));
+        reply.println(String.format(JEP_MARKER, jepNumber, jbsIssue.id(), jbsIssue.title()));
         if ("Targeted".equals(issueStatus) || "Integrated".equals(issueStatus) ||
             "Completed".equals(issueStatus) || ("Closed".equals(issueStatus) && "Delivered".equals(resolutionName))) {
             reply.println("The JEP for this pull request, [JEP-" + jepNumber + "](" + jbsIssue.webUrl() + "), has already been targeted.");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,9 +34,9 @@ import java.util.stream.Collectors;
 public class LabelCommand implements CommandHandler {
     private final String commandName;
 
-    private static final Pattern argumentPattern = Pattern.compile("(?:(add|remove)\\s+)((?:[A-Za-z0-9_@.-]+[\\s,]*)+)");
-    private static final Pattern shortArgumentPattern = Pattern.compile("((?:[-+]?[A-Za-z0-9_@.-]+[\\s,]*)+)");
-    private static final Pattern ignoredSuffixes = Pattern.compile("^(.*)(?:-dev(?:@openjdk.org)?)$");
+    private static final Pattern ARGUMENT_PATTERN = Pattern.compile("(?:(add|remove)\\s+)((?:[A-Za-z0-9_@.-]+[\\s,]*)+)");
+    private static final Pattern SHORT_ARGUMENT_PATTERN = Pattern.compile("((?:[-+]?[A-Za-z0-9_@.-]+[\\s,]*)+)");
+    private static final Pattern IGNORED_SUFFIXES = Pattern.compile("^(.*)(?:-dev(?:@openjdk.org)?)$");
 
     LabelCommand() {
         this("label");
@@ -61,8 +61,8 @@ public class LabelCommand implements CommandHandler {
             return;
         }
 
-        var argumentMatcher = argumentPattern.matcher(command.args());
-        var shortArgumentMatcher = shortArgumentPattern.matcher(command.args());
+        var argumentMatcher = ARGUMENT_PATTERN.matcher(command.args());
+        var shortArgumentMatcher = SHORT_ARGUMENT_PATTERN.matcher(command.args());
         if (!argumentMatcher.matches() && !shortArgumentMatcher.matches()) {
             showHelp(bot.labelConfiguration(), reply);
             return;
@@ -133,7 +133,7 @@ public class LabelCommand implements CommandHandler {
         List<String> invalidLabels = new ArrayList<>();
         for (int i = 0; i < labels.size(); ++i) {
             var label = labels.get(i);
-            var ignoredSuffixMatcher = ignoredSuffixes.matcher(label);
+            var ignoredSuffixMatcher = IGNORED_SUFFIXES.matcher(label);
             if (ignoredSuffixMatcher.matches()) {
                 label = ignoredSuffixMatcher.group(1);
                 labels.set(i, label);

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelTracker.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,16 +30,16 @@ import java.util.regex.*;
 import java.util.stream.Collectors;
 
 public class LabelTracker {
-    private final static String addMarker = "<!-- added label: '%s' -->";
-    private final static String removeMarker = "<!-- removed label: '%s' -->";
-    private final static Pattern labelMarkerPattern = Pattern.compile("<!-- (added|removed) label: '(.*?)' -->");
+    private static final String ADD_MARKER = "<!-- added label: '%s' -->";
+    private static final String REMOVE_MARKER = "<!-- removed label: '%s' -->";
+    private static final Pattern LABEL_MARKER_PATTERN = Pattern.compile("<!-- (added|removed) label: '(.*?)' -->");
 
     static String addLabelMarker(String label) {
-        return String.format(addMarker, label);
+        return String.format(ADD_MARKER, label);
     }
 
     static String removeLabelMarker(String label) {
-        return String.format(removeMarker, label);
+        return String.format(REMOVE_MARKER, label);
     }
 
     // Return all manually added labels, but filter any explicitly removed ones
@@ -47,7 +47,7 @@ public class LabelTracker {
         var labelActions = comments.stream()
                 .filter(comment -> comment.author().equals(botUser))
                 .flatMap(comment -> comment.body().lines())
-                .map(labelMarkerPattern::matcher)
+                .map(LABEL_MARKER_PATTERN::matcher)
                 .filter(Matcher::find)
                 .collect(Collectors.toList());
 
@@ -69,7 +69,7 @@ public class LabelTracker {
         var labelActions = comments.stream()
                                    .filter(comment -> comment.author().equals(botUser))
                                    .flatMap(comment -> comment.body().lines())
-                                   .map(labelMarkerPattern::matcher)
+                                   .map(LABEL_MARKER_PATTERN::matcher)
                                    .filter(Matcher::find)
                                    .collect(Collectors.toList());
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 public class LabelerWorkItem extends PullRequestWorkItem {
-    private static final String initialLabelMessage = "<!-- PullRequestBot initial label help comment -->";
+    private static final String INITIAL_LABEL_MESSAGE = "<!-- PullRequestBot initial label help comment -->";
 
     LabelerWorkItem(PullRequestBot bot, String prId, Consumer<RuntimeException> errorHandler,
             ZonedDateTime prUpdatedAt) {
@@ -61,7 +61,7 @@ public class LabelerWorkItem extends PullRequestWorkItem {
     }
 
     private void updateLabelMessage(List<Comment> comments, List<String> newLabels) {
-        var existing = findComment(comments, initialLabelMessage);
+        var existing = findComment(comments, INITIAL_LABEL_MESSAGE);
         if (existing.isPresent()) {
             // Only add the comment once per PR
             return;
@@ -111,7 +111,7 @@ public class LabelerWorkItem extends PullRequestWorkItem {
         }
 
         message.append("\n");
-        message.append(initialLabelMessage);
+        message.append(INITIAL_LABEL_MESSAGE);
         pr.addComment(message.toString());
     }
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
@@ -37,13 +37,12 @@ import java.util.logging.Logger;
 import java.util.regex.*;
 import java.util.stream.*;
 
+import static org.openjdk.skara.bots.pr.CommitCommandWorkItem.COMMAND_REPLY_MARKER;
+import static org.openjdk.skara.bots.pr.CommitCommandWorkItem.COMMAND_REPLY_PATTERN;
+
 public class PullRequestCommandWorkItem extends PullRequestWorkItem {
     private static final Logger log = Logger.getLogger("org.openjdk.skara.bots.pr");
-
-    private static final String commandReplyMarker = "<!-- Jmerge command reply message (%s) -->";
-    private static final Pattern commandReplyPattern = Pattern.compile("<!-- Jmerge command reply message \\((\\S+)\\) -->");
-
-    public static final String VALID_BOT_COMMAND_MARKER = "<!-- Valid self-command -->";
+    static final String VALID_BOT_COMMAND_MARKER = "<!-- Valid self-command -->";
 
     PullRequestCommandWorkItem(PullRequestBot bot, String prId, Consumer<RuntimeException> errorHandler,
             ZonedDateTime prUpdatedAt, boolean needsReadyCheck) {
@@ -85,7 +84,7 @@ public class PullRequestCommandWorkItem extends PullRequestWorkItem {
         var self = pr.repository().forge().currentUser();
         return comments.stream()
                 .filter(comment -> comment.author().equals(self))
-                .map(comment -> commandReplyPattern.matcher(comment.body()))
+                .map(comment -> COMMAND_REPLY_PATTERN.matcher(comment.body()))
                 .filter(Matcher::find)
                 .map(matcher -> matcher.group(1))
                 .collect(Collectors.toSet());
@@ -119,7 +118,7 @@ public class PullRequestCommandWorkItem extends PullRequestWorkItem {
         var writer = new StringWriter();
         var printer = new PrintWriter(writer);
 
-        printer.println(String.format(commandReplyMarker, command.id()));
+        printer.println(String.format(COMMAND_REPLY_MARKER, command.id()));
         printer.print("@");
         printer.print(command.user().username());
         printer.print(" ");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReadyForSponsorTracker.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReadyForSponsorTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,17 +31,17 @@ import java.util.regex.*;
 import java.util.stream.Collectors;
 
 class ReadyForSponsorTracker {
-    private final static String marker = "<!-- integration requested: '%s' -->";
-    private final static Pattern markerPattern = Pattern.compile("<!-- integration requested: '(.*?)' -->");
+    private static final String MARKER = "<!-- integration requested: '%s' -->";
+    private static final Pattern MARKER_PATTERN = Pattern.compile("<!-- integration requested: '(.*?)' -->");
 
     static String addIntegrationMarker(Hash hash) {
-        return String.format(marker, hash.hex());
+        return String.format(MARKER, hash.hex());
     }
 
     static Optional<Hash> latestReadyForSponsor(HostUser botUser, List<Comment> comments) {
         var ready = comments.stream()
                                          .filter(comment -> comment.author().equals(botUser))
-                                         .map(comment -> markerPattern.matcher(comment.body()))
+                                         .map(comment -> MARKER_PATTERN.matcher(comment.body()))
                                          .filter(Matcher::find)
                             .map(matcher -> matcher.group(1))
                             .map(Hash::new)

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewerCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewerCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,7 @@ import java.util.*;
 import java.util.regex.Pattern;
 
 public class ReviewerCommand implements CommandHandler {
-    private static final Pattern commandPattern = Pattern.compile("^(credit|remove)\\s+(.+)$");
+    private static final Pattern COMMAND_PATTERN = Pattern.compile("^(credit|remove)\\s+(.+)$");
 
     private void showHelp(PullRequest pr, PrintWriter reply) {
         reply.println("Syntax: `/reviewer (credit|remove) [@user | openjdk-user]+`. For example:");
@@ -73,7 +73,7 @@ public class ReviewerCommand implements CommandHandler {
             return;
         }
 
-        var matcher = commandPattern.matcher(command.args());
+        var matcher = COMMAND_PATTERN.matcher(command.args());
         if (!matcher.matches()) {
             showHelp(pr, reply);
             return;

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/Reviewers.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/Reviewers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,27 +32,27 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 class Reviewers {
-    private final static String addMarker = "<!-- add reviewer: '%s' -->";
-    private final static String removeMarker = "<!-- remove reviewer: '%s' -->";
-    private final static Pattern markerPattern = Pattern.compile("<!-- (add|remove) reviewer: '(.*?)' -->");
+    private static final String ADD_MARKER = "<!-- add reviewer: '%s' -->";
+    private static final String REMOVE_MARKER = "<!-- remove reviewer: '%s' -->";
+    private static final Pattern MARKER_PATTERN = Pattern.compile("<!-- (add|remove) reviewer: '(.*?)' -->");
 
     static String addReviewerMarker(Contributor contributor) {
-        return String.format(addMarker, contributor.username());
+        return String.format(ADD_MARKER, contributor.username());
     }
 
     static String addReviewerMarker(String username) {
-        return String.format(addMarker, username);
+        return String.format(ADD_MARKER, username);
     }
 
     static String removeReviewerMarker(Contributor contributor) {
-        return String.format(removeMarker, contributor.username());
+        return String.format(REMOVE_MARKER, contributor.username());
     }
 
     static List<String> reviewers(HostUser botUser, List<Comment> comments) {
         var reviewerActions = comments.stream()
                                          .filter(comment -> comment.author().equals(botUser))
                                          .flatMap(comment -> Stream.of(comment.body().split("\n")))
-                                         .map(line -> markerPattern.matcher(line))
+                                         .map(line -> MARKER_PATTERN.matcher(line))
                                          .filter(Matcher::find)
                                          .collect(Collectors.toList());
         var contributors = new LinkedHashSet<String>();

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewersCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewersCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
 import static org.openjdk.skara.jcheck.ReviewersConfiguration.BYLAWS_URL;
 
 public class ReviewersCommand implements CommandHandler {
-    private static final Map<String, String> roleMappings = Map.of(
+    private static final Map<String, String> ROLE_MAPPINGS = Map.of(
             "lead", "lead",
             "reviewers", "reviewers",
             "reviewer", "reviewers",
@@ -107,12 +107,12 @@ public class ReviewersCommand implements CommandHandler {
 
         String role = "authors";
         if (splitArgs.length > 1) {
-            if (!roleMappings.containsKey(splitArgs[1].toLowerCase())) {
+            if (!ROLE_MAPPINGS.containsKey(splitArgs[1].toLowerCase())) {
                 showHelp(reply);
                 reply.println("Unknown role `" + splitArgs[1] + "` specified.");
                 return;
             }
-            role = roleMappings.get(splitArgs[1].toLowerCase());
+            role = ROLE_MAPPINGS.get(splitArgs[1].toLowerCase());
         }
 
         if (pr.author().equals(command.user()) && !censusInstance.isReviewer(command.user())) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewersTracker.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewersTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,12 +31,12 @@ import java.util.regex.*;
 import java.util.stream.Collectors;
 
 class ReviewersTracker {
-    private final static String reviewersMarker = "<!-- additional required reviewers id marker (%d) (%s) -->";
-    private final static Pattern reviewersMarkerPattern = Pattern.compile(
+    private static final String REVIEWERS_MARKER = "<!-- additional required reviewers id marker (%d) (%s) -->";
+    private static final Pattern REVIEWERS_MARKER_PATTERN = Pattern.compile(
             "<!-- additional required reviewers id marker \\((\\d+)\\) \\((\\w+)\\) -->");
 
     static String setReviewersMarker(int numReviewers, String role) {
-        return String.format(reviewersMarker, numReviewers, role);
+        return String.format(REVIEWERS_MARKER, numReviewers, role);
     }
 
     static LinkedHashMap<String, Integer> updatedRoleLimits(JCheckConfiguration checkConfiguration, int count, String role) {
@@ -114,7 +114,7 @@ class ReviewersTracker {
         var ret = new HashMap<String, Integer>();
         var reviewersActions = comments.stream()
                                        .filter(comment -> comment.author().equals(botUser))
-                                       .map(comment -> reviewersMarkerPattern.matcher(comment.body()))
+                                       .map(comment -> REVIEWERS_MARKER_PATTERN.matcher(comment.body()))
                                        .filter(Matcher::find)
                                        .collect(Collectors.toList());
         if (reviewersActions.isEmpty()) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/Summary.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/Summary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,18 +31,18 @@ import java.util.regex.*;
 import java.util.stream.Collectors;
 
 public class Summary {
-    private final static String summaryMarker = "<!-- summary: '%s' -->";
-    private final static Pattern markerPattern = Pattern.compile("<!-- summary: '(.*?)' -->");
+    private static final String SUMMARY_MARKER = "<!-- summary: '%s' -->";
+    private static final Pattern MARKER_PATTERN = Pattern.compile("<!-- summary: '(.*?)' -->");
 
     static String setSummaryMarker(String summary) {
         var encodedSummary = Base64.getEncoder().encodeToString(summary.getBytes(StandardCharsets.UTF_8));
-        return String.format(summaryMarker, encodedSummary);
+        return String.format(SUMMARY_MARKER, encodedSummary);
     }
 
     static Optional<String> summary(HostUser botUser, List<Comment> comments) {
         var summaryActions = comments.stream()
                                          .filter(comment -> comment.author().equals(botUser))
-                                         .map(comment -> markerPattern.matcher(comment.body()))
+                                         .map(comment -> MARKER_PATTERN.matcher(comment.body()))
                                          .filter(Matcher::find)
                                          .collect(Collectors.toList());
         String summary = null;

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,6 +41,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.openjdk.skara.bots.pr.CheckWorkItem.FORCE_PUSH_MARKER;
 import static org.openjdk.skara.bots.pr.CheckWorkItem.FORCE_PUSH_SUGGESTION;
 import static org.openjdk.skara.issuetracker.jira.JiraProject.JEP_NUMBER;
+import static org.openjdk.skara.bots.common.PullRequestConstants.*;
 
 class CheckTests {
     @Test
@@ -1973,7 +1974,6 @@ class CheckTests {
                     .addReviewer(reviewer.forge().currentUser().id());
             var bot = PullRequestBot.newBuilder().repo(botRepo)
                     .censusRepo(censusBuilder.build()).issueProject(issueProject).build();
-            var csrUpdateMarker = "\n<!-- csr: 'update' -->\n";
 
             var issue = issueProject.createIssue("This is the primary issue", List.of(), Map.of());
             issue.setState(Issue.State.CLOSED);
@@ -2022,7 +2022,7 @@ class CheckTests {
             var confHash = localRepo.commit("Set version as null", "duke", "duke@openjdk.org");
             localRepo.push(confHash, author.url(), "edit", true);
             // Simulate the CSRBot.
-            pr.setBody(pr.store().body() + csrUpdateMarker);
+            pr.setBody(pr.store().body() + CSR_UPDATE_MARKER);
             // Run bot. The bot won't get a CSR.
             TestBotRunner.runPeriodicItems(bot);
             // The PR should have primary issue and shouldn't have primary CSR.
@@ -2041,7 +2041,7 @@ class CheckTests {
             confHash = localRepo.commit("Set the version as a wrong value", "duke", "duke@openjdk.org");
             localRepo.push(confHash, author.url(), "edit", true);
             // Simulate the CSRBot.
-            pr.setBody(pr.store().body() + csrUpdateMarker);
+            pr.setBody(pr.store().body() + CSR_UPDATE_MARKER);
             // Run bot. The bot won't get a CSR.
             TestBotRunner.runPeriodicItems(bot);
             // The PR should have primary issue and shouldn't have primary CSR.
@@ -2060,7 +2060,7 @@ class CheckTests {
             confHash = localRepo.commit("Set the version as 17", "duke", "duke@openjdk.org");
             localRepo.push(confHash, author.url(), "edit", true);
             // Simulate the CSRBot.
-            pr.setBody(pr.store().body() + csrUpdateMarker);
+            pr.setBody(pr.store().body() + CSR_UPDATE_MARKER);
             // Run bot. The primary CSR doesn't have the fix version `17`, so the bot won't get a CSR.
             TestBotRunner.runPeriodicItems(bot);
             // The PR should have primary issue and shouldn't have primary CSR.
@@ -2074,7 +2074,7 @@ class CheckTests {
             // Set the fix versions of the primary CSR to 17 and 18.
             csr.setProperty("fixVersions", JSON.array().add("17").add("18"));
             // Simulate the CSRBot.
-            pr.setBody(pr.store().body() + csrUpdateMarker);
+            pr.setBody(pr.store().body() + CSR_UPDATE_MARKER);
             // Run bot. The primary CSR has the fix version `17`, so it would be used.
             TestBotRunner.runPeriodicItems(bot);
             // The bot should have primary issue and primary CSR
@@ -2093,7 +2093,7 @@ class CheckTests {
             backportIssue.setState(Issue.State.OPEN);
             issue.addLink(Link.create(backportIssue, "backported by").build());
             // Simulate the CSRBot.
-            pr.setBody(pr.store().body() + csrUpdateMarker);
+            pr.setBody(pr.store().body() + CSR_UPDATE_MARKER);
             // Run bot. The bot can find a backport issue but can't find a backport CSR.
             TestBotRunner.runPeriodicItems(bot);
             // The bot should have primary issue and shouldn't have primary CSR.
@@ -2113,7 +2113,7 @@ class CheckTests {
             backportCsr.setState(Issue.State.OPEN);
             backportIssue.addLink(Link.create(backportCsr, "csr for").build());
             // Simulate the CSRBot.
-            pr.setBody(pr.store().body() + csrUpdateMarker);
+            pr.setBody(pr.store().body() + CSR_UPDATE_MARKER);
             // Run bot. The bot can find a backport issue and a backport CSR.
             TestBotRunner.runPeriodicItems(bot);
             // The bot should have primary issue and backport CSR.
@@ -2138,7 +2138,7 @@ class CheckTests {
             confHash = localRepo.commit("Set the version as 11", "duke", "duke@openjdk.org");
             localRepo.push(confHash, author.url(), "edit", true);
             // Simulate the CSRBot.
-            pr.setBody(pr.store().body() + csrUpdateMarker);
+            pr.setBody(pr.store().body() + CSR_UPDATE_MARKER);
             // Run bot.
             TestBotRunner.runPeriodicItems(bot);
             // The PR should have primary issue and backport CSR.
@@ -2155,7 +2155,7 @@ class CheckTests {
             // Set the backport CSR to have multiple fix versions, excluded 11.
             backportCsr.setProperty("fixVersions", JSON.array().add("17").add("8"));
             // Simulate the CSRBot.
-            pr.setBody(pr.store().body() + csrUpdateMarker);
+            pr.setBody(pr.store().body() + CSR_UPDATE_MARKER);
             // Run bot.
             TestBotRunner.runPeriodicItems(bot);
             // The bot should have primary issue and shouldn't have CSR.

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/JEPCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/JEPCommandTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,6 +39,7 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.openjdk.skara.bots.pr.PullRequestAsserts.assertLastCommentContains;
 import static org.openjdk.skara.issuetracker.jira.JiraProject.JEP_NUMBER;
+import static org.openjdk.skara.bots.common.PullRequestConstants.*;
 
 public class JEPCommandTests {
     @Test
@@ -75,14 +76,14 @@ public class JEPCommandTests {
 
             // PR should not have the `jep` label
             TestBotRunner.runPeriodicItems(prBot);
-            assertFalse(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
+            assertFalse(pr.store().labelNames().contains(JEP_LABEL));
 
             // Require jep by using `JEP-<id>`
             pr.addComment("/jep JEP-123");
 
             // Verify the behavior
             TestBotRunner.runPeriodicItems(prBot);
-            assertTrue(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
+            assertTrue(pr.store().labelNames().contains(JEP_LABEL));
             assertLastCommentContains(pr, "This pull request will not be integrated until the [JEP-");
             assertLastCommentContains(pr, "has been targeted.");
             assertTrue(pr.store().body().contains("- [ ] Change requires a JEP request to be targeted"));
@@ -92,7 +93,7 @@ public class JEPCommandTests {
 
             // Verify the behavior
             TestBotRunner.runPeriodicItems(prBot);
-            assertFalse(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
+            assertFalse(pr.store().labelNames().contains(JEP_LABEL));
             assertLastCommentContains(pr, "determined that the JEP request is not needed for this pull request.");
             assertFalse(pr.store().body().contains("Change requires a JEP request to be targeted"));
 
@@ -101,7 +102,7 @@ public class JEPCommandTests {
 
             // Verify the behavior
             TestBotRunner.runPeriodicItems(prBot);
-            assertTrue(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
+            assertTrue(pr.store().labelNames().contains(JEP_LABEL));
             assertLastCommentContains(pr, "This pull request will not be integrated until the [JEP-");
             assertLastCommentContains(pr, "has been targeted.");
             assertTrue(pr.store().body().contains("- [ ] Change requires a JEP request to be targeted"));
@@ -111,7 +112,7 @@ public class JEPCommandTests {
 
             // Verify the behavior
             TestBotRunner.runPeriodicItems(prBot);
-            assertFalse(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
+            assertFalse(pr.store().labelNames().contains(JEP_LABEL));
             assertLastCommentContains(pr, "determined that the JEP request is not needed for this pull request.");
             assertFalse(pr.store().body().contains("Change requires a JEP request to be targeted"));
 
@@ -120,7 +121,7 @@ public class JEPCommandTests {
 
             // Verify the behavior
             TestBotRunner.runPeriodicItems(prBot);
-            assertTrue(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
+            assertTrue(pr.store().labelNames().contains(JEP_LABEL));
             assertLastCommentContains(pr, "This pull request will not be integrated until the [JEP-");
             assertLastCommentContains(pr, "has been targeted.");
             assertTrue(pr.store().body().contains("- [ ] Change requires a JEP request to be targeted"));
@@ -130,7 +131,7 @@ public class JEPCommandTests {
 
             // Verify the behavior
             TestBotRunner.runPeriodicItems(prBot);
-            assertFalse(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
+            assertFalse(pr.store().labelNames().contains(JEP_LABEL));
             assertLastCommentContains(pr, "determined that the JEP request is not needed for this pull request.");
             assertFalse(pr.store().body().contains("Change requires a JEP request to be targeted"));
 
@@ -139,7 +140,7 @@ public class JEPCommandTests {
 
             // Verify the behavior
             TestBotRunner.runPeriodicItems(prBot);
-            assertTrue(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
+            assertTrue(pr.store().labelNames().contains(JEP_LABEL));
             assertLastCommentContains(pr, "This pull request will not be integrated until the [JEP-");
             assertLastCommentContains(pr, "has been targeted.");
             assertTrue(pr.store().body().contains("- [ ] Change requires a JEP request to be targeted"));
@@ -149,7 +150,7 @@ public class JEPCommandTests {
 
             // Verify the behavior
             TestBotRunner.runPeriodicItems(prBot);
-            assertFalse(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
+            assertFalse(pr.store().labelNames().contains(JEP_LABEL));
             assertLastCommentContains(pr, "determined that the JEP request is not needed for this pull request.");
             assertFalse(pr.store().body().contains("Change requires a JEP request to be targeted"));
 
@@ -158,7 +159,7 @@ public class JEPCommandTests {
 
             // Verify the behavior
             TestBotRunner.runPeriodicItems(prBot);
-            assertFalse(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
+            assertFalse(pr.store().labelNames().contains(JEP_LABEL));
             assertLastCommentContains(pr, "The JEP for this pull request, [JEP-");
             assertLastCommentContains(pr, "has already been targeted.");
             assertTrue(pr.store().body().contains("- [x] Change requires a JEP request to be targeted"));
@@ -168,7 +169,7 @@ public class JEPCommandTests {
 
             // Verify the behavior
             TestBotRunner.runPeriodicItems(prBot);
-            assertFalse(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
+            assertFalse(pr.store().labelNames().contains(JEP_LABEL));
             assertLastCommentContains(pr, "determined that the JEP request is not needed for this pull request.");
             assertFalse(pr.store().body().contains("Change requires a JEP request to be targeted"));
 
@@ -177,7 +178,7 @@ public class JEPCommandTests {
 
             // Verify the behavior
             TestBotRunner.runPeriodicItems(prBot);
-            assertFalse(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
+            assertFalse(pr.store().labelNames().contains(JEP_LABEL));
             assertLastCommentContains(pr, "The JEP for this pull request, [JEP-");
             assertLastCommentContains(pr, "has already been targeted.");
             assertTrue(pr.store().body().contains("- [x] Change requires a JEP request to be targeted"));
@@ -187,7 +188,7 @@ public class JEPCommandTests {
 
             // Verify the behavior
             TestBotRunner.runPeriodicItems(prBot);
-            assertFalse(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
+            assertFalse(pr.store().labelNames().contains(JEP_LABEL));
             assertLastCommentContains(pr, "determined that the JEP request is not needed for this pull request.");
             assertFalse(pr.store().body().contains("Change requires a JEP request to be targeted"));
 
@@ -196,7 +197,7 @@ public class JEPCommandTests {
 
             // Verify the behavior
             TestBotRunner.runPeriodicItems(prBot);
-            assertTrue(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
+            assertTrue(pr.store().labelNames().contains(JEP_LABEL));
             assertLastCommentContains(pr, "This pull request will not be integrated until the [JEP-");
             assertLastCommentContains(pr, "has been targeted.");
             assertTrue(pr.store().body().contains("- [ ] Change requires a JEP request to be targeted"));
@@ -238,14 +239,14 @@ public class JEPCommandTests {
 
             // PR should not have the `jep` label
             TestBotRunner.runPeriodicItems(prBot);
-            assertFalse(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
+            assertFalse(pr.store().labelNames().contains(JEP_LABEL));
 
             // Require jep by a committer who is not the PR author
             prAsCommitter.addComment("/jep JEP-123");
 
             // Verify the behavior
             TestBotRunner.runPeriodicItems(prBot);
-            assertFalse(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
+            assertFalse(pr.store().labelNames().contains(JEP_LABEL));
             assertLastCommentContains(pr, "Only the pull request author and [Reviewers]" +
                     "(https://openjdk.org/bylaws#reviewer) are allowed to use the `jep` command.");
 
@@ -254,7 +255,7 @@ public class JEPCommandTests {
 
             // Verify the behavior
             TestBotRunner.runPeriodicItems(prBot);
-            assertTrue(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
+            assertTrue(pr.store().labelNames().contains(JEP_LABEL));
             assertLastCommentContains(pr, "This pull request will not be integrated until the [JEP-");
             assertLastCommentContains(pr, "has been targeted.");
             assertTrue(pr.store().body().contains("- [ ] Change requires a JEP request to be targeted"));
@@ -264,7 +265,7 @@ public class JEPCommandTests {
 
             // Verify the behavior
             TestBotRunner.runPeriodicItems(prBot);
-            assertTrue(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
+            assertTrue(pr.store().labelNames().contains(JEP_LABEL));
             assertLastCommentContains(pr, "This pull request will not be integrated until the [JEP-");
             assertLastCommentContains(pr, "has been targeted.");
             assertTrue(pr.store().body().contains("- [ ] Change requires a JEP request to be targeted"));
@@ -274,7 +275,7 @@ public class JEPCommandTests {
 
             // Verify the behavior
             TestBotRunner.runPeriodicItems(prBot);
-            assertTrue(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
+            assertTrue(pr.store().labelNames().contains(JEP_LABEL));
             assertLastCommentContains(pr, "Only the pull request author and [Reviewers]" +
                     "(https://openjdk.org/bylaws#reviewer) are allowed to use the `jep` command.");
             assertTrue(pr.store().body().contains("- [ ] Change requires a JEP request to be targeted"));
@@ -284,7 +285,7 @@ public class JEPCommandTests {
 
             // Verify the behavior
             TestBotRunner.runPeriodicItems(prBot);
-            assertFalse(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
+            assertFalse(pr.store().labelNames().contains(JEP_LABEL));
             assertLastCommentContains(pr, "determined that the JEP request is not needed for this pull request.");
             assertFalse(pr.store().body().contains("Change requires a JEP request to be targeted"));
         }
@@ -319,14 +320,14 @@ public class JEPCommandTests {
 
             // PR should not have the `jep` label
             TestBotRunner.runPeriodicItems(prBot);
-            assertFalse(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
+            assertFalse(pr.store().labelNames().contains(JEP_LABEL));
 
             // Require jep with blank value
             pr.addComment("/jep");
 
             // Verify the behavior
             TestBotRunner.runPeriodicItems(prBot);
-            assertFalse(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
+            assertFalse(pr.store().labelNames().contains(JEP_LABEL));
             assertEquals(3, pr.comments().size());
             assertLastCommentContains(pr, "Command syntax:");
             assertLastCommentContains(pr, "Some examples:");
@@ -340,7 +341,7 @@ public class JEPCommandTests {
 
             // Verify the behavior
             TestBotRunner.runPeriodicItems(prBot);
-            assertFalse(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
+            assertFalse(pr.store().labelNames().contains(JEP_LABEL));
             assertEquals(5, pr.comments().size());
             assertLastCommentContains(pr, "Command syntax:");
             assertLastCommentContains(pr, "Some examples:");
@@ -354,7 +355,7 @@ public class JEPCommandTests {
 
             // Verify the behavior
             TestBotRunner.runPeriodicItems(prBot);
-            assertFalse(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
+            assertFalse(pr.store().labelNames().contains(JEP_LABEL));
             assertEquals(7, pr.comments().size());
             assertLastCommentContains(pr, "The JEP issue was not found. Please make sure you have entered it correctly.");
             assertFalse(pr.store().body().contains("Change requires a JEP request to be targeted"));
@@ -364,7 +365,7 @@ public class JEPCommandTests {
 
             // Verify the behavior
             TestBotRunner.runPeriodicItems(prBot);
-            assertFalse(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
+            assertFalse(pr.store().labelNames().contains(JEP_LABEL));
             assertEquals(9, pr.comments().size());
             assertLastCommentContains(pr, "The issue `TEST-1` is not a JEP. Please make sure you have entered it correctly.");
             assertFalse(pr.store().body().contains("Change requires a JEP request to be targeted"));
@@ -374,7 +375,7 @@ public class JEPCommandTests {
 
             // Verify the behavior
             TestBotRunner.runPeriodicItems(prBot);
-            assertFalse(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
+            assertFalse(pr.store().labelNames().contains(JEP_LABEL));
             assertEquals(11, pr.comments().size());
             assertLastCommentContains(pr, "The JEP issue was not found. Please make sure you have entered it correctly.");
             assertFalse(pr.store().body().contains("Change requires a JEP request to be targeted"));
@@ -384,7 +385,7 @@ public class JEPCommandTests {
 
             // Verify the behavior
             TestBotRunner.runPeriodicItems(prBot);
-            assertFalse(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
+            assertFalse(pr.store().labelNames().contains(JEP_LABEL));
             assertEquals(13, pr.comments().size());
             assertLastCommentContains(pr, "The JEP issue was not found. Please make sure you have entered it correctly.");
             assertFalse(pr.store().body().contains("Change requires a JEP request to be targeted"));
@@ -394,7 +395,7 @@ public class JEPCommandTests {
 
             // Verify the behavior
             TestBotRunner.runPeriodicItems(prBot);
-            assertFalse(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
+            assertFalse(pr.store().labelNames().contains(JEP_LABEL));
             assertEquals(15, pr.comments().size());
             assertLastCommentContains(pr, "The issue `TEST-1` is not a JEP. Please make sure you have entered it correctly.");
             assertFalse(pr.store().body().contains("Change requires a JEP request to be targeted"));
@@ -437,13 +438,13 @@ public class JEPCommandTests {
 
             // PR should not have the `jep` label
             TestBotRunner.runPeriodicItems(prBot);
-            assertFalse(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
+            assertFalse(pr.store().labelNames().contains(JEP_LABEL));
 
             // Test draft/submitted/candidate/proposedToTarget/proposedToDrop/closedWithoutDelivered JEPs
             for (int i = 1; i <= 6; i++) {
                 pr.addComment("/jep jep-" + i);
                 TestBotRunner.runPeriodicItems(prBot);
-                assertTrue(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
+                assertTrue(pr.store().labelNames().contains(JEP_LABEL));
                 assertEquals(i * 2 + 1, pr.comments().size());
                 assertLastCommentContains(pr, "This pull request will not be integrated until the [JEP-");
                 assertLastCommentContains(pr, "has been targeted.");
@@ -454,7 +455,7 @@ public class JEPCommandTests {
             for (int i = 7; i <= 10; i++) {
                 pr.addComment("/jep jep-" + i);
                 TestBotRunner.runPeriodicItems(prBot);
-                assertFalse(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
+                assertFalse(pr.store().labelNames().contains(JEP_LABEL));
                 assertEquals(i * 2 + 1, pr.comments().size());
                 assertLastCommentContains(pr, "The JEP for this pull request, [JEP-");
                 assertLastCommentContains(pr, "has already been targeted.");
@@ -494,7 +495,7 @@ public class JEPCommandTests {
             pr.addComment("/jep TEST-2");
             TestBotRunner.runPeriodicItems(disableJepBot);
             assertLastCommentContains(pr, "This repository has not been configured to use the `jep` command.");
-            assertFalse(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
+            assertFalse(pr.store().labelNames().contains(JEP_LABEL));
             assertFalse(pr.store().body().contains("- [ ] Change requires a JEP request to be targeted"));
 
             // Test the PR bot with jep enable
@@ -503,7 +504,7 @@ public class JEPCommandTests {
             pr.addComment("/jep TEST-2");
             TestBotRunner.runPeriodicItems(enableJepBot);
             assertLastCommentContains(pr, "pull request will not be integrated until the");
-            assertTrue(pr.store().labelNames().contains(JEPCommand.JEP_LABEL));
+            assertTrue(pr.store().labelNames().contains(JEP_LABEL));
             assertTrue(pr.store().body().contains("- [ ] Change requires a JEP request to be targeted"));
         }
     }


### PR DESCRIPTION
There are numerous string literals and constants duplicated and spread around different bots. This includes markers (used in PR body and comments) for various bot functionality as well as label names.

In this patch,  I cleaned the constants in different bots according to this standard:

1. If a constant is used by multiple bots, it should be placed in bots.common.PullRequestConstants.
2. If a constant is used by different classes within a single bot, it should be placed in a single class within the bot, and other classes should import the constant.
3. If a constant is only used by one class within a single bot, it should be made private to that class.

Also, I have renamed the constants that were previously named in an inconsistent manner.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1547](https://bugs.openjdk.org/browse/SKARA-1547): Collect PR specific constants in single shared class


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1464/head:pull/1464` \
`$ git checkout pull/1464`

Update a local copy of the PR: \
`$ git checkout pull/1464` \
`$ git pull https://git.openjdk.org/skara pull/1464/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1464`

View PR using the GUI difftool: \
`$ git pr show -t 1464`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1464.diff">https://git.openjdk.org/skara/pull/1464.diff</a>

</details>
