### PR TITLE
1807: Escape HTML in source code hosting provider's web UI as required

### DIFF
--- a/bots/censussync/build.gradle
+++ b/bots/censussync/build.gradle
@@ -44,6 +44,9 @@ dependencies {
     implementation project(':storage')
     implementation project(':xml')
     implementation project(':metrics')
+    implementation project(':bots:common')
+    implementation project(':jbs')
+    implementation project(':jcheck')
 
     testImplementation project(':test')
 }

--- a/bots/censussync/src/main/java/module-info.java
+++ b/bots/censussync/src/main/java/module-info.java
@@ -31,6 +31,9 @@ module org.openjdk.skara.bots.censussync {
     requires java.logging;
     requires java.xml;
     requires java.net.http;
+    requires org.openjdk.skara.jcheck;
+    requires org.openjdk.skara.jbs;
+    requires org.openjdk.skara.bots.common;
 
     provides org.openjdk.skara.bot.BotFactory with org.openjdk.skara.bots.censussync.CensusSyncBotFactory;
 }

--- a/bots/censussync/src/main/java/org/openjdk/skara/bots/censussync/CensusSyncSplitBot.java
+++ b/bots/censussync/src/main/java/org/openjdk/skara/bots/censussync/CensusSyncSplitBot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 package org.openjdk.skara.bots.censussync;
 
 import org.openjdk.skara.bot.*;
+import org.openjdk.skara.bots.common.BotUtils;
 import org.openjdk.skara.forge.HostedRepository;
 import org.openjdk.skara.network.RestRequest;
 import org.openjdk.skara.vcs.*;
@@ -75,10 +76,6 @@ public class CensusSyncSplitBot implements Bot, WorkItem {
 
     private static PrintWriter newPrintWriter(Path p) throws IOException {
         return new PrintWriter(Files.newBufferedWriter(p));
-    }
-
-    private static String escape(String s) {
-        return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
     }
 
     private static List<Path> syncVersion(Element census, Path to) throws IOException {
@@ -133,7 +130,7 @@ public class CensusSyncSplitBot implements Bot, WorkItem {
             var filename = dir.resolve(name + ".xml");
             try (var file = newPrintWriter(filename)) {
                 file.format("<?xml version=\"1.0\" encoding=\"UTF-8\" ?>%n");
-                file.format("<group name=\"%s\" full-name=\"%s\">%n", name, escape(fullName));
+                file.format("<group name=\"%s\" full-name=\"%s\">%n", name, BotUtils.escape(fullName));
                 file.format("    <lead username=\"%s\" />%n", lead);
                 for (var member : members) {
                     file.format("    <member username=\"%s\" />%n", member);
@@ -191,7 +188,7 @@ public class CensusSyncSplitBot implements Bot, WorkItem {
             var filename = dir.resolve(name + ".xml");
             try (var file = newPrintWriter(filename)) {
                 file.format("<?xml version=\"1.0\" encoding=\"UTF-8\" ?>%n");
-                file.format("<project name=\"%s\" full-name=\"%s\" sponsor=\"%s\">%n", name, escape(fullName), sponsor);
+                file.format("<project name=\"%s\" full-name=\"%s\" sponsor=\"%s\">%n", name, BotUtils.escape(fullName), sponsor);
                 file.format("    <lead username=\"%s\" since=\"0\" />%n", lead);
 
                 for (var reviewer : reviewers) {

--- a/bots/censussync/src/main/java/org/openjdk/skara/bots/censussync/CensusSyncUnifyBot.java
+++ b/bots/censussync/src/main/java/org/openjdk/skara/bots/censussync/CensusSyncUnifyBot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 package org.openjdk.skara.bots.censussync;
 
 import org.openjdk.skara.bot.*;
+import org.openjdk.skara.bots.common.BotUtils;
 import org.openjdk.skara.census.Census;
 import org.openjdk.skara.forge.*;
 import org.openjdk.skara.vcs.*;
@@ -47,10 +48,6 @@ public class CensusSyncUnifyBot implements Bot, WorkItem {
         this.to = to;
         this.version = version;
         this.last = null;
-    }
-
-    private static String escape(String s) {
-        return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
     }
 
     @Override
@@ -102,7 +99,7 @@ public class CensusSyncUnifyBot implements Bot, WorkItem {
                 }
                 for (var group : census.groups()) {
                     file.println("<group name=\"" + group.name() + "\">");
-                    file.println("  <full-name>" + escape(group.fullName()) + "</full-name>");
+                    file.println("  <full-name>" + BotUtils.escape(group.fullName()) + "</full-name>");
                     file.println("  <person ref=\"" + group.lead().username() + "\" role=\"lead\" />");
                     for (var member : group.members()) {
                         if (!member.username().equals(group.lead().username())) {
@@ -113,7 +110,7 @@ public class CensusSyncUnifyBot implements Bot, WorkItem {
                 }
                 for (var project : census.projects()) {
                     file.println("<project name=\"" + project.name() + "\">");
-                    file.println("  <full-name>" + escape(project.fullName()) + "</full-name>");
+                    file.println("  <full-name>" + BotUtils.escape(project.fullName()) + "</full-name>");
                     file.println("  <sponsor ref=\"" + project.sponsor().name() + "\" />");
 
                     var roles = project.roles(version);

--- a/bots/common/src/main/java/org/openjdk/skara/bots/common/BotUtils.java
+++ b/bots/common/src/main/java/org/openjdk/skara/bots/common/BotUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,5 +50,9 @@ public class BotUtils {
             return Optional.empty();
         }
         return JdkVersion.parse(version);
+    }
+
+    public static String escape(String s) {
+        return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
     }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -662,7 +662,7 @@ class CheckRun {
                             progressBody.append("](");
                             progressBody.append(iss.get().webUrl());
                             progressBody.append("): ");
-                            progressBody.append(iss.get().title());
+                            progressBody.append(BotUtils.escape(iss.get().title()));
                             var issueType = iss.get().properties().get("issuetype");
                             if (issueType != null && "CSR".equals(issueType.asString())) {
                                 progressBody.append(" (**CSR**)");


### PR DESCRIPTION
To avoid format errors caused by '<' and '>' in PR Body, the PR bot should properly escape the issue title in PR body on GitHub or GitLab.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1807](https://bugs.openjdk.org/browse/SKARA-1807): Escape HTML in source code hosting provider's web UI as required


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1465/head:pull/1465` \
`$ git checkout pull/1465`

Update a local copy of the PR: \
`$ git checkout pull/1465` \
`$ git pull https://git.openjdk.org/skara pull/1465/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1465`

View PR using the GUI difftool: \
`$ git pr show -t 1465`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1465.diff">https://git.openjdk.org/skara/pull/1465.diff</a>

</details>
