### PR TITLE
1797: Add support for /backport pull request command

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
@@ -96,7 +96,7 @@ public class BackportCommand implements CommandHandler {
                 labelsToRemove.add(backportLabel);
                 reply.println("Backport for repo `" + targetRepoName + "` on branch `" + targetBranchName + "` was successfully disabled.");
             } else {
-                reply.println("Backport for repo `" + targetRepoName + "` on branch `" + targetBranchName + "` was not enabled, so you can not disable it.");
+                reply.println("Backport for repo `" + targetRepoName + "` on branch `" + targetBranchName + "` was already disabled.");
             }
         } else {
             // Add label

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 package org.openjdk.skara.bots.pr;
 
 import org.openjdk.skara.forge.HostedCommit;
+import org.openjdk.skara.forge.HostedRepository;
 import org.openjdk.skara.forge.PullRequest;
 import org.openjdk.skara.host.HostUser;
 import org.openjdk.skara.issuetracker.Comment;
@@ -63,7 +64,8 @@ public class BackportCommand implements CommandHandler {
             + "(https://wiki.openjdk.org/display/skara#Skara-AssociatingyourGitHubaccountandyourOpenJDKusername)).";
 
     @Override
-    public void handle(PullRequestBot bot, PullRequest pr, CensusInstance censusInstance, Path scratchPath, CommandInvocation command, List<Comment> allComments, PrintWriter reply, List<String> labelsToAdd, List<String> labelsToRemove) {
+    public void handle(PullRequestBot bot, PullRequest pr, CensusInstance censusInstance, Path scratchPath, CommandInvocation command,
+                       List<Comment> allComments, PrintWriter reply, List<String> labelsToAdd, List<String> labelsToRemove) {
         if (censusInstance.contributor(command.user()).isEmpty()) {
             reply.println(USER_INVALID_WARNING);
             return;
@@ -99,51 +101,71 @@ public class BackportCommand implements CommandHandler {
                 reply.println("Backport for repo `" + targetRepoName + "` on branch `" + targetBranchName + "` was already disabled.");
             }
         } else {
+            // Get target repo
+            var targetRepo = getTargetRepo(bot, parts, reply);
+            if (targetRepo == null) {
+                return;
+            }
+            var targetRepoName = targetRepo.name();
+
+            // Get target branch
+            var targetBranch = getTargetBranch(parts, targetRepo, reply);
+            if (targetBranch == null) {
+                return;
+            }
+            var targetBranchName = targetBranch.name();
+
             // Add label
-            var forge = bot.repo().forge();
-            var repoNameArg = parts[0].replace("http://", "")
-                    .replace("https://", "")
-                    .replace(forge.hostname() + "/", "");
-            // If the arg is given with a namespace prefix, look for an exact match,
-            // otherwise cut off the namespace prefix before comparing with the forks
-            // config.
-            var includesNamespace = repoNameArg.contains("/");
-            var repoNameOptional = bot.forks().keySet().stream()
-                    .filter(s -> includesNamespace
-                            ? s.equals(repoNameArg)
-                            : s.substring(s.indexOf("/") + 1).equals(repoNameArg))
-                    .findAny();
-            String targetRepoName = repoNameOptional.orElse("<not found>");
-
-            var potentialTargetRepo = repoNameOptional.flatMap(forge::repository);
-            if (potentialTargetRepo.isEmpty()) {
-                reply.println("The target repository `" + repoNameArg + "` is not a valid target for backports. ");
-                reply.print("List of valid target repositories: ");
-                reply.println(String.join(", ", bot.forks().keySet().stream().sorted().toList()) + ".");
-                reply.println("Supplying the organization/group prefix is optional.");
-                return;
-            }
-            var targetRepo = potentialTargetRepo.get();
-
-            var targetBranchName = parts.length == 2 ? parts[1] : "master";
-            var targetBranches = targetRepo.branches();
-            if (targetBranches.stream().noneMatch(b -> b.name().equals(targetBranchName))) {
-                reply.println("The target branch `" + targetBranchName + "` does not exist");
-                return;
-            }
             var backportLabel = generateBackportLabel(targetRepoName, targetBranchName);
             if (pr.labelNames().contains(backportLabel)) {
                 reply.println("Backport for repo `" + targetRepoName + "` on branch `" + targetBranchName + "` has already been enabled.");
             } else {
                 labelsToAdd.add(backportLabel);
                 reply.println("Backport for repo `" + targetRepoName + "` on branch `" + targetBranchName + "` was successfully enabled and will be performed once this pull request has been integrated.");
-                reply.println(" Further instructions will be provided at that time.");
+                reply.println("Further instructions will be provided at that time.");
+                reply.println("<!-- " + command.user().username() + " -->");
             }
         }
     }
 
     private String generateBackportLabel(String targetRepo, String targetBranchName) {
         return "Backport=" + targetRepo + ":" + targetBranchName;
+    }
+
+    private HostedRepository getTargetRepo(PullRequestBot bot, String[] parts, PrintWriter reply) {
+        var forge = bot.repo().forge();
+        var repoNameArg = parts[0].replace("http://", "")
+                .replace("https://", "")
+                .replace(forge.hostname() + "/", "");
+        // If the arg is given with a namespace prefix, look for an exact match,
+        // otherwise cut off the namespace prefix before comparing with the forks
+        // config.
+        var includesNamespace = repoNameArg.contains("/");
+        var repoNameOptional = bot.forks().keySet().stream()
+                .filter(s -> includesNamespace
+                        ? s.equals(repoNameArg)
+                        : s.substring(s.indexOf("/") + 1).equals(repoNameArg))
+                .findAny();
+
+        var potentialTargetRepo = repoNameOptional.flatMap(forge::repository);
+        if (potentialTargetRepo.isEmpty()) {
+            reply.println("The target repository `" + repoNameArg + "` is not a valid target for backports. ");
+            reply.print("List of valid target repositories: ");
+            reply.println(String.join(", ", bot.forks().keySet().stream().sorted().toList()) + ".");
+            reply.println("Supplying the organization/group prefix is optional.");
+            return null;
+        }
+        return potentialTargetRepo.get();
+    }
+
+    private Branch getTargetBranch(String[] parts, HostedRepository targetRepo, PrintWriter reply) {
+        var targetBranchName = parts.length == 2 ? parts[1] : "master";
+        var targetBranches = targetRepo.branches();
+        if (targetBranches.stream().noneMatch(b -> b.name().equals(targetBranchName))) {
+            reply.println("The target branch `" + targetBranchName + "` does not exist");
+            return null;
+        }
+        return new Branch(targetBranchName);
     }
 
     @Override
@@ -166,50 +188,31 @@ public class BackportCommand implements CommandHandler {
             return;
         }
 
-        var forge = bot.repo().forge();
-        var repoNameArg = parts[0].replace("http://", "")
-                               .replace("https://", "")
-                               .replace(forge.hostname() + "/", "");
-        // If the arg is given with a namespace prefix, look for an exact match,
-        // otherwise cut off the namespace prefix before comparing with the forks
-        // config.
-        var includesNamespace = repoNameArg.contains("/");
-        var repoNameOptional = bot.forks().keySet().stream()
-                .filter(s -> includesNamespace
-                        ? s.equals(repoNameArg)
-                        : s.substring(s.indexOf("/") + 1).equals(repoNameArg))
-                .findAny();
-        String repoName = repoNameOptional.orElse("<not found>");
-
-        var potentialTargetRepo = repoNameOptional.flatMap(forge::repository);
-        if (potentialTargetRepo.isEmpty()) {
-            reply.println("The target repository `" + repoNameArg + "` is not a valid target for backports. ");
-            reply.print("List of valid target repositories: ");
-            reply.println(String.join(", ", bot.forks().keySet().stream().sorted().toList()) + ".");
-            reply.println("Supplying the organization/group prefix is optional.");
+        // Get target repo
+        var targetRepo = getTargetRepo(bot, parts, reply);
+        if (targetRepo == null) {
             return;
         }
-        var targetRepo = potentialTargetRepo.get();
+        var targetRepoName = targetRepo.name();
         var fork = bot.forks().get(targetRepo.name());
 
-        var targetBranchName = parts.length == 2 ? parts[1] : "master";
-        var targetBranches = targetRepo.branches();
-        if (targetBranches.stream().noneMatch(b -> b.name().equals(targetBranchName))) {
-            reply.println("The target branch `" + targetBranchName + "` does not exist");
+        // Get target branch
+        var targetBranch = getTargetBranch(parts, targetRepo, reply);
+        if (targetBranch == null) {
             return;
         }
-        var targetBranch = new Branch(targetBranchName);
+        var targetBranchName = targetBranch.name();
 
         // Find real user when the command user is bot
         HostUser realUser = command.user();
         if (realUser.equals(bot.repo().forge().currentUser())) {
             var botComment = allComments.stream()
                     .filter(comment -> comment.author().equals(bot.repo().forge().currentUser()))
-                    .filter(comment -> comment.body().contains("Backport for repo `" + repoName + "` on branch `" + targetBranchName + "` was successfully enabled."))
+                    .filter(comment -> comment.body().contains("Backport for repo `" + targetRepoName + "` on branch `" + targetBranchName + "` was successfully enabled"))
                     .reduce((first, second) -> second).orElse(null);
             if (botComment != null) {
                 String[] lines = botComment.body().split("\\n");
-                String userName = lines[1].split(" ")[0].substring(1);
+                String userName = lines[lines.length - 1].split(" ")[1];
                 var user = bot.repo().forge().user(userName);
                 if (user.isPresent()) {
                     realUser = user.get();
@@ -217,7 +220,7 @@ public class BackportCommand implements CommandHandler {
                     reply.print(realUser.username());
                     reply.print(" ");
                 } else {
-                    reply.println("Error: can not find the real user of Backport for repo `" + repoName + "` on branch `" + targetBranchName);
+                    reply.println("Error: can not find the real user of Backport for repo `" + targetRepoName + "` on branch `" + targetBranchName);
                     return;
                 }
             }
@@ -243,7 +246,7 @@ public class BackportCommand implements CommandHandler {
                 if (!didApply) {
                     var lines = new ArrayList<String>();
                     lines.add("Could **not** automatically backport `" + hash.abbreviate() + "` to " +
-                              "[" + repoName + "](" + targetRepo.webUrl() + ") due to conflicts in the following files:");
+                              "[" + targetRepoName + "](" + targetRepo.webUrl() + ") due to conflicts in the following files:");
                     lines.add("");
                     var unmerged = localRepo.status()
                                             .stream()
@@ -255,7 +258,7 @@ public class BackportCommand implements CommandHandler {
                     }
                     lines.add("");
                     lines.add("Please fetch the appropriate branch/commit and manually resolve these conflicts "
-                            + "by using the following commands in your personal fork of [" + repoName + "](" + targetRepo.webUrl()
+                            + "by using the following commands in your personal fork of [" + targetRepoName + "](" + targetRepo.webUrl()
                             + "). Note: these commands are just some suggestions and you can use other equivalent commands you know.");
                     lines.add("");
                     lines.add("```");
@@ -278,7 +281,7 @@ public class BackportCommand implements CommandHandler {
                     lines.add("$ git commit -m 'Backport " + hash.hex() + "'");
                     lines.add("```");
                     lines.add("");
-                    lines.add("Once you have resolved the conflicts as explained above continue with creating a pull request towards the [" + repoName + "](" + targetRepo.webUrl() + ") with the title `Backport " + hash.hex() + "`.");
+                    lines.add("Once you have resolved the conflicts as explained above continue with creating a pull request towards the [" + targetRepoName + "](" + targetRepo.webUrl() + ") with the title `Backport " + hash.hex() + "`.");
 
                     reply.println(String.join("\n", lines));
                     localRepo.reset(head, true);
@@ -287,7 +290,7 @@ public class BackportCommand implements CommandHandler {
                 // Check that applying the change actually created a diff
                 if (localRepo.diff(head).patches().isEmpty()) {
                     reply.println("Could **not** apply backport `" + hash.abbreviate() + "` to " +
-                            "[" + repoName + "](" + targetRepo.webUrl() + ") because the change is already present in the target.");
+                            "[" + targetRepoName + "](" + targetRepo.webUrl() + ") because the change is already present in the target.");
                     localRepo.reset(head, true);
                     return;
                 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
@@ -123,6 +123,7 @@ public class BackportCommand implements CommandHandler {
                 labelsToAdd.add(backportLabel);
                 reply.print("Backport for repo `" + targetRepoName + "` on branch `" + targetBranchName + "` was successfully enabled and will be performed once this pull request has been integrated.");
                 reply.println(" Further instructions will be provided at that time.");
+                reply.println("<!-- add backport " + targetRepoName + ":" + targetBranchName + " -->");
                 reply.println("<!-- " + command.user().username() + " -->");
             }
         }
@@ -208,7 +209,7 @@ public class BackportCommand implements CommandHandler {
         if (realUser.equals(bot.repo().forge().currentUser())) {
             var botComment = allComments.stream()
                     .filter(comment -> comment.author().equals(bot.repo().forge().currentUser()))
-                    .filter(comment -> comment.body().contains("Backport for repo `" + targetRepoName + "` on branch `" + targetBranchName + "` was successfully enabled"))
+                    .filter(comment -> comment.body().contains("<!-- add backport " + targetRepoName + ":" + targetBranchName + " -->"))
                     .reduce((first, second) -> second).orElse(null);
             if (botComment != null) {
                 String[] lines = botComment.body().split("\\n");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
@@ -121,8 +121,8 @@ public class BackportCommand implements CommandHandler {
                 reply.println("Backport for repo `" + targetRepoName + "` on branch `" + targetBranchName + "` has already been enabled.");
             } else {
                 labelsToAdd.add(backportLabel);
-                reply.println("Backport for repo `" + targetRepoName + "` on branch `" + targetBranchName + "` was successfully enabled and will be performed once this pull request has been integrated.");
-                reply.println("Further instructions will be provided at that time.");
+                reply.print("Backport for repo `" + targetRepoName + "` on branch `" + targetBranchName + "` was successfully enabled and will be performed once this pull request has been integrated.");
+                reply.println(" Further instructions will be provided at that time.");
                 reply.println("<!-- " + command.user().username() + " -->");
             }
         }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
@@ -70,7 +70,7 @@ public class BackportCommand implements CommandHandler {
         }
 
         if (pr.isClosed() && !pr.labelNames().contains("integrated")) {
-            reply.println("`/backport` command can not be used in closed but not integrated PR");
+            reply.println("`/backport` command can not be used in a closed but not integrated pull request");
             return;
         }
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
@@ -44,7 +44,7 @@ public class BackportCommand implements CommandHandler {
     }
 
     private void showHelpInPR(PrintWriter reply) {
-        reply.println("Usage: `/backport <repository> [<branch>]` `/backport disable <repository> [<branch>]`");
+        reply.println("Usage: `/backport [disable] <repository> [<branch>]`");
     }
 
     @Override

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
@@ -129,7 +129,7 @@ public class BackportCommand implements CommandHandler {
     }
 
     private String generateBackportLabel(String targetRepo, String targetBranchName) {
-        return "Backport=" + targetRepo + ":" + targetBranchName;
+        return "backport=" + targetRepo + ":" + targetBranchName;
     }
 
     private HostedRepository getTargetRepo(PullRequestBot bot, String[] parts, PrintWriter reply) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
@@ -136,8 +136,8 @@ public class BackportCommand implements CommandHandler {
                 reply.println("Backport for repo `" + targetRepoName + "` on branch `" + targetBranchName + "` has already been enabled.");
             } else {
                 labelsToAdd.add(backportLabel);
-                reply.println("Backport for repo `" + targetRepoName + "` on branch `" + targetBranchName + "` was successfully enabled.");
-                reply.println("Please note that instructions for creating backports will be provided once this PR is integrated.");
+                reply.println("Backport for repo `" + targetRepoName + "` on branch `" + targetBranchName + "` was successfully enabled and will be performed once this pull request has been integrated.");
+                reply.println(" Further instructions will be provided at that time.");
             }
         }
     }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
@@ -41,7 +41,7 @@ public class IntegrateCommand implements CommandHandler {
     private final static Logger log = Logger.getLogger("org.openjdk.skara.bots.pr");
     private static final String PRE_PUSH_MARKER = "<!-- prepush %s -->";
     private static final Pattern PRE_PUSH_PATTERN = Pattern.compile("<!-- prepush ([0-9a-z]{40}) -->");
-    private static final Pattern BACKPORT_LABEL_PATTERN = Pattern.compile("Backport=(.+):(.+)");
+    private static final Pattern BACKPORT_LABEL_PATTERN = Pattern.compile("backport=(.+):(.+)");
 
     private enum Command {
         auto,

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
@@ -49,7 +49,7 @@ public class SponsorCommand implements CommandHandler {
 
         Optional<Hash> prePushHash = IntegrateCommand.checkForPrePushHash(bot, pr, scratchPath, allComments, "sponsor");
         if (prePushHash.isPresent()) {
-            markIntegratedAndClosed(pr, prePushHash.get(), reply);
+            markIntegratedAndClosed(pr, prePushHash.get(), reply, allComments);
             return;
         }
 
@@ -131,7 +131,7 @@ public class SponsorCommand implements CommandHandler {
                 var amendedHash = checkablePr.amendManualReviewers(localHash, censusInstance.namespace(), original);
                 IntegrateCommand.addPrePushComment(pr, amendedHash, rebaseMessage.toString());
                 localRepo.push(amendedHash, pr.repository().url(), pr.targetRef());
-                markIntegratedAndClosed(pr, amendedHash, reply);
+                markIntegratedAndClosed(pr, amendedHash, reply, allComments);
             } else {
                 reply.print("Warning! This commit did not result in any changes! ");
                 reply.println("No push attempt will be made.");
@@ -144,7 +144,8 @@ public class SponsorCommand implements CommandHandler {
         }
     }
 
-    private void markIntegratedAndClosed(PullRequest pr, Hash amendedHash, PrintWriter reply) {
+    private void markIntegratedAndClosed(PullRequest pr, Hash amendedHash, PrintWriter reply, List<Comment> allComments) {
+        IntegrateCommand.processBackportLabel(pr, allComments);
         IntegrateCommand.markIntegratedAndClosed(pr, amendedHash, reply);
     }
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
@@ -145,8 +145,7 @@ public class SponsorCommand implements CommandHandler {
     }
 
     private void markIntegratedAndClosed(PullRequest pr, Hash amendedHash, PrintWriter reply, List<Comment> allComments) {
-        IntegrateCommand.processBackportLabel(pr, allComments);
-        IntegrateCommand.markIntegratedAndClosed(pr, amendedHash, reply);
+        IntegrateCommand.markIntegratedAndClosed(pr, amendedHash, reply, allComments);
     }
 
     @Override

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportPRCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportPRCommandTests.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
 package org.openjdk.skara.bots.pr;
 
 import org.junit.jupiter.api.Test;
@@ -52,7 +74,7 @@ public class BackportPRCommandTests {
             // Enable backport for targetRepo on master
             pr.addComment("/backport targetRepo");
             TestBotRunner.runPeriodicItems(prBot);
-            assertLastCommentContains(pr, "Backport for repo `targetRepo` on branch `master` was successfully enabled.");
+            assertLastCommentContains(pr, "Backport for repo `targetRepo` on branch `master` was successfully enabled");
             assertTrue(pr.store().labelNames().contains("Backport=targetRepo:master"));
 
             // Enable backport for targetRepo2 on dev, but dev does not exist
@@ -65,7 +87,7 @@ public class BackportPRCommandTests {
             localRepo.push(masterHash, targetRepo2.url(), "dev", true);
             pr.addComment("/backport targetRepo2 dev");
             TestBotRunner.runPeriodicItems(prBot);
-            assertLastCommentContains(pr, "Backport for repo `targetRepo2` on branch `dev` was successfully enabled.");
+            assertLastCommentContains(pr, "Backport for repo `targetRepo2` on branch `dev` was successfully enabled");
             assertTrue(pr.store().labelNames().contains("Backport=targetRepo2:dev"));
 
             // disable backport for targetRepo on master
@@ -77,13 +99,13 @@ public class BackportPRCommandTests {
             // disable backport for targetRepo again
             reviewerPr.addComment("/backport disable targetRepo");
             TestBotRunner.runPeriodicItems(prBot);
-            assertLastCommentContains(pr, "Backport for repo `targetRepo` on branch `master` was not enabled, so you can not disable it.");
+            assertLastCommentContains(pr, "Backport for repo `targetRepo` on branch `master` was already disabled.");
             assertFalse(pr.store().labelNames().contains("Backport=targetRepo:master"));
 
             // Enable backport for targetRepo on master as reviewer
             reviewerPr.addComment("/backport targetRepo");
             TestBotRunner.runPeriodicItems(prBot);
-            assertLastCommentContains(pr, "Backport for repo `targetRepo` on branch `master` was successfully enabled.");
+            assertLastCommentContains(pr, "Backport for repo `targetRepo` on branch `master` was successfully enabled");
             assertTrue(pr.store().labelNames().contains("Backport=targetRepo:master"));
 
             // Approve this PR
@@ -94,8 +116,10 @@ public class BackportPRCommandTests {
             // Integrate
             pr.addComment("/integrate");
             TestBotRunner.runPeriodicItems(prBot);
+            assertLastCommentContains(pr, "@user1");
             assertLastCommentContains(pr, "was successfully created on the branch");
             TestBotRunner.runPeriodicItems(prBot);
+            assertLastCommentContains(pr, "@user2");
             assertLastCommentContains(pr, "Could **not** automatically backport");
 
             // Resolve conflict
@@ -143,7 +167,7 @@ public class BackportPRCommandTests {
             pr.store().setState(Issue.State.CLOSED);
             pr.addComment("/backport targetRepo");
             TestBotRunner.runPeriodicItems(prBot);
-            assertLastCommentContains(pr, "`/backport` command can not be used in closed but not integrated PR");
+            assertLastCommentContains(pr, "`/backport` command can not be used in a closed but not integrated pull request");
         }
     }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportPRCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportPRCommandTests.java
@@ -1,0 +1,149 @@
+package org.openjdk.skara.bots.pr;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.openjdk.skara.forge.Review;
+import org.openjdk.skara.issuetracker.Issue;
+import org.openjdk.skara.test.*;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.openjdk.skara.bots.pr.PullRequestAsserts.assertLastCommentContains;
+
+public class BackportPRCommandTests {
+    @Test
+    void simple(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var integrator = credentials.getHostedRepository();
+            var bot = credentials.getHostedRepository();
+            var targetRepo = credentials.getHostedRepository("targetRepo");
+            var targetRepo2 = credentials.getHostedRepository("targetRepo2");
+            var seedFolder = tempFolder.path().resolve("seed");
+
+            var censusBuilder = credentials.getCensusBuilder()
+                    .addReviewer(integrator.forge().currentUser().id())
+                    .addReviewer(bot.forge().currentUser().id())
+                    .addCommitter(author.forge().currentUser().id());
+            var prBot = PullRequestBot.newBuilder()
+                    .repo(bot)
+                    .censusRepo(censusBuilder.build())
+                    .seedStorage(seedFolder)
+                    .forks(Map.of("targetRepo", targetRepo, "targetRepo2", targetRepo2))
+                    .build();
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
+            var masterHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(masterHash, author.url(), "master", true);
+
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "123: This is a pull request");
+
+            var reviewerPr = (TestPullRequest) integrator.pullRequest(pr.id());
+
+            // Enable backport for targetRepo on master
+            pr.addComment("/backport targetRepo");
+            TestBotRunner.runPeriodicItems(prBot);
+            assertLastCommentContains(pr, "Backport for repo `targetRepo` on branch `master` was successfully enabled.");
+            assertTrue(pr.store().labelNames().contains("Backport=targetRepo:master"));
+
+            // Enable backport for targetRepo2 on dev, but dev does not exist
+            pr.addComment("/backport targetRepo2 dev");
+            TestBotRunner.runPeriodicItems(prBot);
+            assertLastCommentContains(pr, "The target branch `dev` does not exist");
+            assertFalse(pr.store().labelNames().contains("Backport=targetRepo2:dev"));
+
+            // Enable backport for targetRepo2 on dev
+            localRepo.push(masterHash, targetRepo2.url(), "dev", true);
+            pr.addComment("/backport targetRepo2 dev");
+            TestBotRunner.runPeriodicItems(prBot);
+            assertLastCommentContains(pr, "Backport for repo `targetRepo2` on branch `dev` was successfully enabled.");
+            assertTrue(pr.store().labelNames().contains("Backport=targetRepo2:dev"));
+
+            // disable backport for targetRepo on master
+            reviewerPr.addComment("/backport disable targetRepo");
+            TestBotRunner.runPeriodicItems(prBot);
+            assertLastCommentContains(pr, "Backport for repo `targetRepo` on branch `master` was successfully disabled.");
+            assertFalse(pr.store().labelNames().contains("Backport=targetRepo:master"));
+
+            // disable backport for targetRepo again
+            reviewerPr.addComment("/backport disable targetRepo");
+            TestBotRunner.runPeriodicItems(prBot);
+            assertLastCommentContains(pr, "Backport for repo `targetRepo` on branch `master` was not enabled, so you can not disable it.");
+            assertFalse(pr.store().labelNames().contains("Backport=targetRepo:master"));
+
+            // Enable backport for targetRepo on master as reviewer
+            reviewerPr.addComment("/backport targetRepo");
+            TestBotRunner.runPeriodicItems(prBot);
+            assertLastCommentContains(pr, "Backport for repo `targetRepo` on branch `master` was successfully enabled.");
+            assertTrue(pr.store().labelNames().contains("Backport=targetRepo:master"));
+
+            // Approve this PR
+            reviewerPr.addReview(Review.Verdict.APPROVED, "");
+            TestBotRunner.runPeriodicItems(prBot);
+            assertTrue(pr.store().labelNames().contains("ready"));
+
+            // Integrate
+            pr.addComment("/integrate");
+            TestBotRunner.runPeriodicItems(prBot);
+            assertLastCommentContains(pr, "was successfully created on the branch");
+            TestBotRunner.runPeriodicItems(prBot);
+            assertLastCommentContains(pr, "Could **not** automatically backport");
+
+            // Resolve conflict
+            localRepo.push(masterHash, targetRepo.url(), "master", true);
+            // Use /backport after the pr is integrated
+            reviewerPr.addComment("/backport targetRepo");
+            TestBotRunner.runPeriodicItems(prBot);
+            assertLastCommentContains(pr, "was successfully created on the branch");
+        }
+    }
+
+    @Test
+    void testBackportCommandWhenPrIsClosed(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var integrator = credentials.getHostedRepository();
+            var bot = credentials.getHostedRepository();
+            var targetRepo = credentials.getHostedRepository("targetRepo");
+            var targetRepo2 = credentials.getHostedRepository("targetRepo2");
+            var seedFolder = tempFolder.path().resolve("seed");
+
+            var censusBuilder = credentials.getCensusBuilder()
+                    .addReviewer(integrator.forge().currentUser().id())
+                    .addReviewer(bot.forge().currentUser().id())
+                    .addCommitter(author.forge().currentUser().id());
+            var prBot = PullRequestBot.newBuilder()
+                    .repo(bot)
+                    .censusRepo(censusBuilder.build())
+                    .seedStorage(seedFolder)
+                    .forks(Map.of("targetRepo", targetRepo, "targetRepo2", targetRepo2))
+                    .build();
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
+            var masterHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(masterHash, author.url(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "123: This is a pull request");
+
+            //close the pr
+            pr.store().setState(Issue.State.CLOSED);
+            pr.addComment("/backport targetRepo");
+            TestBotRunner.runPeriodicItems(prBot);
+            assertLastCommentContains(pr, "`/backport` command can not be used in closed but not integrated PR");
+        }
+    }
+}

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportPRCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportPRCommandTests.java
@@ -75,38 +75,38 @@ public class BackportPRCommandTests {
             pr.addComment("/backport targetRepo");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(pr, "Backport for repo `targetRepo` on branch `master` was successfully enabled");
-            assertTrue(pr.store().labelNames().contains("Backport=targetRepo:master"));
+            assertTrue(pr.store().labelNames().contains("backport=targetRepo:master"));
 
             // Enable backport for targetRepo2 on dev, but dev does not exist
             pr.addComment("/backport targetRepo2 dev");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(pr, "The target branch `dev` does not exist");
-            assertFalse(pr.store().labelNames().contains("Backport=targetRepo2:dev"));
+            assertFalse(pr.store().labelNames().contains("backport=targetRepo2:dev"));
 
             // Enable backport for targetRepo2 on dev
             localRepo.push(masterHash, targetRepo2.url(), "dev", true);
             pr.addComment("/backport targetRepo2 dev");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(pr, "Backport for repo `targetRepo2` on branch `dev` was successfully enabled");
-            assertTrue(pr.store().labelNames().contains("Backport=targetRepo2:dev"));
+            assertTrue(pr.store().labelNames().contains("backport=targetRepo2:dev"));
 
             // disable backport for targetRepo on master
             reviewerPr.addComment("/backport disable targetRepo");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(pr, "Backport for repo `targetRepo` on branch `master` was successfully disabled.");
-            assertFalse(pr.store().labelNames().contains("Backport=targetRepo:master"));
+            assertFalse(pr.store().labelNames().contains("backport=targetRepo:master"));
 
             // disable backport for targetRepo again
             reviewerPr.addComment("/backport disable targetRepo");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(pr, "Backport for repo `targetRepo` on branch `master` was already disabled.");
-            assertFalse(pr.store().labelNames().contains("Backport=targetRepo:master"));
+            assertFalse(pr.store().labelNames().contains("backport=targetRepo:master"));
 
             // Enable backport for targetRepo on master as reviewer
             reviewerPr.addComment("/backport targetRepo");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(pr, "Backport for repo `targetRepo` on branch `master` was successfully enabled");
-            assertTrue(pr.store().labelNames().contains("Backport=targetRepo:master"));
+            assertTrue(pr.store().labelNames().contains("backport=targetRepo:master"));
 
             // Approve this PR
             reviewerPr.addReview(Review.Verdict.APPROVED, "");

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CommitCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CommitCommandTests.java
@@ -119,7 +119,7 @@ public class CommitCommandTests {
             pr.addComment("/backport jdk17u-dev");
             TestBotRunner.runPeriodicItems(bot);
             // The `backport` command is invalid because the pull request is not integrated.
-            PullRequestAsserts.assertLastCommentContains(pr, "Backport for repo `jdk17u-dev` on branch `master` was successfully enabled.");
+            PullRequestAsserts.assertLastCommentContains(pr, "Backport for repo `jdk17u-dev` on branch `master` was successfully enabled");
 
             // Simulate an integration
             var botPr = botRepo.pullRequest(pr.id());

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CommitCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CommitCommandTests.java
@@ -119,7 +119,7 @@ public class CommitCommandTests {
             pr.addComment("/backport jdk17u-dev");
             TestBotRunner.runPeriodicItems(bot);
             // The `backport` command is invalid because the pull request is not integrated.
-            PullRequestAsserts.assertLastCommentContains(pr, "The command `backport` can only be used in a pull request that has been integrated.");
+            PullRequestAsserts.assertLastCommentContains(pr, "Backport for repo `jdk17u-dev` on branch `master` was successfully enabled.");
 
             // Simulate an integration
             var botPr = botRepo.pullRequest(pr.id());


### PR DESCRIPTION
This patch introduces support for the /backport command in pull requests. (ErikJ and ErikH proposed the idea and came up with this implementation.)

Usage of /backport in pull request:

Syntax: `/backport <repo> [<branch>] ` ` /backport disable <repo> [<branch>]` (default branch is master)

1. If the `/backport` command is used in an **open** pull request, it adds a label `Backport=repo:branch` to the PR. If the PR is later integrated, the PR bot scans for backport labels, creates the backport branch and provides a link for creating the backport. To cancel the backport, the user can use `/backport disable repo master` to remove the label before the PR is integrated.
2.  If the `/backport` command is used in an **integrated** PR, it creates the backport branch and comments on the PR. This process is similar to using the /backport command in commits. (This feature was implemented in [SKARA-1495](https://bugs.openjdk.org/browse/SKARA-1495) by guoxiong li, but the usage was not documented on the[ wiki page](https://wiki.openjdk.org/display/SKARA/Pull+Request+Commands), so seems like few people use this command)
3.  If the `/backport` command is used in a **closed** (not integrated) PR, the user will receive an error message stating that the command cannot be used in a closed but not integrated PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1797](https://bugs.openjdk.org/browse/SKARA-1797): Add support for /backport pull request command


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1466/head:pull/1466` \
`$ git checkout pull/1466`

Update a local copy of the PR: \
`$ git checkout pull/1466` \
`$ git pull https://git.openjdk.org/skara pull/1466/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1466`

View PR using the GUI difftool: \
`$ git pr show -t 1466`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1466.diff">https://git.openjdk.org/skara/pull/1466.diff</a>

</details>
