### PR TITLE
1813: URLs printed by Skara should have ".git" at the end of the repo name

### DIFF
--- a/bots/bridgekeeper/src/test/java/org/openjdk/skara/bots/bridgekeeper/PullRequestCloserBotTests.java
+++ b/bots/bridgekeeper/src/test/java/org/openjdk/skara/bots/bridgekeeper/PullRequestCloserBotTests.java
@@ -43,11 +43,11 @@ class PullRequestCloserBotTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
             assertEquals(OPEN, pr.state());
 
@@ -73,11 +73,11 @@ class PullRequestCloserBotTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Let the bot see it
@@ -115,11 +115,11 @@ class PullRequestCloserBotTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Let the bot see it

--- a/bots/bridgekeeper/src/test/java/org/openjdk/skara/bots/bridgekeeper/PullRequestPrunerBotTests.java
+++ b/bots/bridgekeeper/src/test/java/org/openjdk/skara/bots/bridgekeeper/PullRequestPrunerBotTests.java
@@ -43,11 +43,11 @@ class PullRequestPrunerBotTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Make sure the timeout expires
@@ -96,11 +96,11 @@ class PullRequestPrunerBotTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Let the bot see it

--- a/bots/censussync/src/main/java/org/openjdk/skara/bots/censussync/CensusSyncSplitBot.java
+++ b/bots/censussync/src/main/java/org/openjdk/skara/bots/censussync/CensusSyncSplitBot.java
@@ -231,13 +231,13 @@ public class CensusSyncSplitBot implements Bot, WorkItem {
             }
 
             var toDir = scratch.resolve("to.git");
-            var toRepo = Repository.materialize(toDir, to.url(), Branch.defaultFor(VCS.GIT).name());
+            var toRepo = Repository.materialize(toDir, to.authenticatedUrl(), Branch.defaultFor(VCS.GIT).name());
 
             var updatedFiles = sync(currentCensus, toDir);
             if (!toRepo.isClean()) {
                 toRepo.add(updatedFiles);
                 var head = toRepo.commit("Updated census", "duke", "duke@openjdk.org");
-                toRepo.push(head, to.url(), Branch.defaultFor(VCS.GIT).name(), false);
+                toRepo.push(head, to.authenticatedUrl(), Branch.defaultFor(VCS.GIT).name(), false);
             } else {
                 log.info("New census data did not result in any changes");
             }

--- a/bots/censussync/src/main/java/org/openjdk/skara/bots/censussync/CensusSyncUnifyBot.java
+++ b/bots/censussync/src/main/java/org/openjdk/skara/bots/censussync/CensusSyncUnifyBot.java
@@ -73,7 +73,7 @@ public class CensusSyncUnifyBot implements Bot, WorkItem {
     public Collection<WorkItem> run(Path scratch) {
         try {
             var fromDir = scratch.resolve("from.git");
-            var fromRepo = Repository.materialize(fromDir, from.url(), Branch.defaultFor(VCS.GIT).name());
+            var fromRepo = Repository.materialize(fromDir, from.authenticatedUrl(), Branch.defaultFor(VCS.GIT).name());
             if (last != null && last.equals(fromRepo.head())) {
                 // Nothing to do
                 return List.of();
@@ -82,7 +82,7 @@ public class CensusSyncUnifyBot implements Bot, WorkItem {
             var census = Census.parse(fromDir);
 
             var toDir = scratch.resolve("to.git");
-            var toRepo = Repository.materialize(toDir, to.url(), Branch.defaultFor(VCS.GIT).name());
+            var toRepo = Repository.materialize(toDir, to.authenticatedUrl(), Branch.defaultFor(VCS.GIT).name());
 
             var censusXML = toRepo.root().resolve("census.xml");
             if (!Files.exists(censusXML)) {
@@ -135,7 +135,7 @@ public class CensusSyncUnifyBot implements Bot, WorkItem {
             }
             toRepo.add(censusXML);
             var head = toRepo.commit("Updated census.xml", "duke", "duke@openjdk.org");
-            toRepo.push(head, to.url(), Branch.defaultFor(VCS.GIT).name(), false);
+            toRepo.push(head, to.authenticatedUrl(), Branch.defaultFor(VCS.GIT).name(), false);
             last = fromRepo.head();
         } catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/bots/checkout/src/main/java/org/openjdk/skara/bots/checkout/CheckoutBot.java
+++ b/bots/checkout/src/main/java/org/openjdk/skara/bots/checkout/CheckoutBot.java
@@ -64,9 +64,7 @@ public class CheckoutBot implements Bot, WorkItem {
     }
 
     private URI webURI() {
-        var webURI = from.remoteUrl().toString();
-
-        return URI.create(webURI);
+        return from.remoteUrl();
     }
 
     private URI uri() {

--- a/bots/checkout/src/main/java/org/openjdk/skara/bots/checkout/CheckoutBot.java
+++ b/bots/checkout/src/main/java/org/openjdk/skara/bots/checkout/CheckoutBot.java
@@ -63,10 +63,6 @@ public class CheckoutBot implements Bot, WorkItem {
         return URLEncoder.encode(uri.toString(), StandardCharsets.UTF_8);
     }
 
-    private URI webURI() {
-        return from.remoteUrl();
-    }
-
     private URI uri() {
         var uri = from.url().toString();
         if (!uri.endsWith(".git")) {
@@ -98,7 +94,7 @@ public class CheckoutBot implements Bot, WorkItem {
     @Override
     public Collection<WorkItem> run(Path scratch) {
         try {
-            var fromDir = storage.resolve(urlEncode(webURI()));
+            var fromDir = storage.resolve(urlEncode(from.remoteUrl()));
             Repository fromRepo = null;
             if (!Files.exists(fromDir)) {
                 Files.createDirectories(fromDir);

--- a/bots/checkout/src/main/java/org/openjdk/skara/bots/checkout/CheckoutBot.java
+++ b/bots/checkout/src/main/java/org/openjdk/skara/bots/checkout/CheckoutBot.java
@@ -64,10 +64,7 @@ public class CheckoutBot implements Bot, WorkItem {
     }
 
     private URI webURI() {
-        var webURI = from.webUrl().toString();
-        if (!webURI.endsWith(".git")) {
-            webURI += ".git";
-        }
+        var webURI = from.remoteUrl().toString();
 
         return URI.create(webURI);
     }

--- a/bots/checkout/src/main/java/org/openjdk/skara/bots/checkout/CheckoutBot.java
+++ b/bots/checkout/src/main/java/org/openjdk/skara/bots/checkout/CheckoutBot.java
@@ -32,7 +32,6 @@ import org.openjdk.skara.storage.StorageBuilder;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.*;
-import java.util.stream.Collectors;
 import java.nio.file.*;
 import java.nio.charset.StandardCharsets;
 import java.net.URI;
@@ -64,7 +63,7 @@ public class CheckoutBot implements Bot, WorkItem {
     }
 
     private URI uri() {
-        var uri = from.url().toString();
+        var uri = from.authenticatedUrl().toString();
         if (!uri.endsWith(".git")) {
             uri += ".git";
         }
@@ -94,7 +93,7 @@ public class CheckoutBot implements Bot, WorkItem {
     @Override
     public Collection<WorkItem> run(Path scratch) {
         try {
-            var fromDir = storage.resolve(urlEncode(from.remoteUrl()));
+            var fromDir = storage.resolve(urlEncode(from.url()));
             Repository fromRepo = null;
             if (!Files.exists(fromDir)) {
                 Files.createDirectories(fromDir);

--- a/bots/checkout/src/main/java/org/openjdk/skara/bots/checkout/CheckoutBot.java
+++ b/bots/checkout/src/main/java/org/openjdk/skara/bots/checkout/CheckoutBot.java
@@ -62,15 +62,6 @@ public class CheckoutBot implements Bot, WorkItem {
         return URLEncoder.encode(uri.toString(), StandardCharsets.UTF_8);
     }
 
-    private URI uri() {
-        var uri = from.authenticatedUrl().toString();
-        if (!uri.endsWith(".git")) {
-            uri += ".git";
-        }
-
-        return URI.create(uri);
-    }
-
     @Override
     public boolean concurrentWith(WorkItem other) {
         if (!(other instanceof CheckoutBot)) {
@@ -98,7 +89,7 @@ public class CheckoutBot implements Bot, WorkItem {
             if (!Files.exists(fromDir)) {
                 Files.createDirectories(fromDir);
                 log.info("Cloning Git repo " + from + " to " + fromDir);
-                fromRepo = Repository.clone(uri(), fromDir);
+                fromRepo = Repository.clone(from.authenticatedUrl(), fromDir);
             } else {
                 log.info("Getting existing Git repo repository from " + fromDir);
                 fromRepo = Repository.get(fromDir).orElseThrow(() ->

--- a/bots/csr/src/test/java/org/openjdk/skara/bots/csr/CSRBotTests.java
+++ b/bots/csr/src/test/java/org/openjdk/skara/bots/csr/CSRBotTests.java
@@ -60,11 +60,11 @@ class CSRBotTests {
             var localRepo = CheckableRepository.init(localRepoFolder, repo.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, repo.url(), "master", true);
+            localRepo.push(masterHash, repo.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, repo.url(), "edit", true);
+            localRepo.push(editHash, repo.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(repo, "master", "edit", issue.id() + ": This is an issue");
 
             // Add CSR label
@@ -91,11 +91,11 @@ class CSRBotTests {
             var localRepo = CheckableRepository.init(localRepoFolder, repo.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, repo.url(), "master", true);
+            localRepo.push(masterHash, repo.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, repo.url(), "edit", true);
+            localRepo.push(editHash, repo.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(repo, "master", "edit", "This is an issue");
 
             // Add CSR label
@@ -122,11 +122,11 @@ class CSRBotTests {
             var localRepo = CheckableRepository.init(localRepoFolder, repo.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, repo.url(), "master", true);
+            localRepo.push(masterHash, repo.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, repo.url(), "edit", true);
+            localRepo.push(editHash, repo.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(repo, "master", "edit", "123: This is an issue");
 
             // Add CSR label
@@ -160,11 +160,11 @@ class CSRBotTests {
             var localRepo = CheckableRepository.init(localRepoFolder, repo.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, repo.url(), "master", true);
+            localRepo.push(masterHash, repo.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, repo.url(), "edit", true);
+            localRepo.push(editHash, repo.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(repo, "master", "edit", issue.id() + ": This is an issue");
 
             // Run bot
@@ -200,11 +200,11 @@ class CSRBotTests {
             var localRepo = CheckableRepository.init(localRepoFolder, repo.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, repo.url(), "master", true);
+            localRepo.push(masterHash, repo.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, repo.url(), "edit", true);
+            localRepo.push(editHash, repo.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(repo, "master", "edit", issue.id() + ": This is an issue");
 
             // Run bot
@@ -241,11 +241,11 @@ class CSRBotTests {
             var localRepo = CheckableRepository.init(localRepoFolder, repo.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, repo.url(), "master", true);
+            localRepo.push(masterHash, repo.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, repo.url(), "edit", true);
+            localRepo.push(editHash, repo.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(repo, "master", "edit", issue.id() + ": This is an issue");
 
             // Run bot
@@ -289,7 +289,7 @@ class CSRBotTests {
             var localRepoFolder = tempFolder.path().resolve("localrepo");
             var localRepo = CheckableRepository.init(localRepoFolder, repo.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, repo.url(), "master", true);
+            localRepo.push(masterHash, repo.authenticatedUrl(), "master", true);
 
             // Push a commit to the jdk18 branch
             var jdk18Branch = localRepo.branch(masterHash, "jdk18");
@@ -300,7 +300,7 @@ class CSRBotTests {
             var issueNumber = issue.id().split("-")[1];
             var commitMessage = issueNumber + ": This is the primary issue\n\nReviewed-by: integrationreviewer2";
             var commitHash = localRepo.commit(commitMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
-            localRepo.push(commitHash, repo.url(), "jdk18", true);
+            localRepo.push(commitHash, repo.authenticatedUrl(), "jdk18", true);
 
             // "backport" the commit to the master branch
             localRepo.checkout(localRepo.defaultBranch());
@@ -310,7 +310,7 @@ class CSRBotTests {
             Files.writeString(newFile2, "a_new_file");
             localRepo.add(newFile2);
             var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
-            localRepo.push(editHash, repo.url(), "edit", true);
+            localRepo.push(editHash, repo.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(repo, "master", "edit", issueNumber + ": This is the primary issue");
             pr.addLabel("backport");
             // Add the notification link to the PR in the issue. This is needed for the CSRIssueBot to
@@ -323,7 +323,7 @@ class CSRBotTests {
             Files.writeString(localRepo.root().resolve(".jcheck/conf"), newConf, StandardCharsets.UTF_8);
             localRepo.add(localRepo.root().resolve(".jcheck/conf"));
             var confHash = localRepo.commit("Set version as null", "duke", "duke@openjdk.org");
-            localRepo.push(confHash, repo.url(), "edit", true);
+            localRepo.push(confHash, repo.authenticatedUrl(), "edit", true);
             assertFalse(pr.store().labelNames().contains("csr"));
             // Run bot. The bot won't get a CSR.
             TestBotRunner.runPeriodicItems(csrPullRequestBot);
@@ -336,7 +336,7 @@ class CSRBotTests {
             Files.writeString(localRepo.root().resolve(".jcheck/conf"), newConf, StandardCharsets.UTF_8);
             localRepo.add(localRepo.root().resolve(".jcheck/conf"));
             confHash = localRepo.commit("Set the version as a wrong value", "duke", "duke@openjdk.org");
-            localRepo.push(confHash, repo.url(), "edit", true);
+            localRepo.push(confHash, repo.authenticatedUrl(), "edit", true);
             // Run bot. The bot won't get a CSR.
             TestBotRunner.runPeriodicItems(csrPullRequestBot);
             // The bot shouldn't add the `csr` label.
@@ -351,7 +351,7 @@ class CSRBotTests {
             Files.writeString(localRepo.root().resolve(".jcheck/conf"), newConf, StandardCharsets.UTF_8);
             localRepo.add(localRepo.root().resolve(".jcheck/conf"));
             confHash = localRepo.commit("Set the version as 17", "duke", "duke@openjdk.org");
-            localRepo.push(confHash, repo.url(), "edit", true);
+            localRepo.push(confHash, repo.authenticatedUrl(), "edit", true);
             // Run bot. The primary CSR doesn't have the fix version `17`, so the bot won't get a CSR.
             TestBotRunner.runPeriodicItems(csrPullRequestBot);
             // The bot shouldn't add the `csr` label.
@@ -400,7 +400,7 @@ class CSRBotTests {
             Files.writeString(localRepo.root().resolve(".jcheck/conf"), newConf, StandardCharsets.UTF_8);
             localRepo.add(localRepo.root().resolve(".jcheck/conf"));
             confHash = localRepo.commit("Set the version as 11", "duke", "duke@openjdk.org");
-            localRepo.push(confHash, repo.url(), "edit", true);
+            localRepo.push(confHash, repo.authenticatedUrl(), "edit", true);
             pr.removeLabel("csr");
             // Run bot.
             TestBotRunner.runPeriodicItems(csrPullRequestBot);
@@ -440,11 +440,11 @@ class CSRBotTests {
             var localRepo = CheckableRepository.init(localRepoFolder, repo.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, repo.url(), "master", true);
+            localRepo.push(masterHash, repo.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, repo.url(), "edit", true);
+            localRepo.push(editHash, repo.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(repo, "master", "edit", issue.id() + ": This is an issue");
             // Add the notification link to the PR in the issue. This is needed for the CSRIssueBot to
             // be able to trigger on CSR issue updates
@@ -522,11 +522,11 @@ class CSRBotTests {
             var localRepo = CheckableRepository.init(localRepoFolder, repo.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, repo.url(), "master", true);
+            localRepo.push(masterHash, repo.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, repo.url(), "edit", true);
+            localRepo.push(editHash, repo.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(repo, "master", "edit", issue.id() + ": This is an issue");
             // Add the notification link to the PR in the issue. This is needed for the CSRIssueBot to
             // be able to trigger on CSR issue updates
@@ -572,11 +572,11 @@ class CSRBotTests {
             var localRepo = CheckableRepository.init(localRepoFolder, repo.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, repo.url(), "master", true);
+            localRepo.push(masterHash, repo.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, repo.url(), "edit", true);
+            localRepo.push(editHash, repo.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(repo, "master", "edit", issue.id() + ": This is an issue");
             pr.setBody("PR body\n" + PROGRESS_MARKER);
             // Add the notification link to the PR in the issue. This is needed for the CSRIssueBot to

--- a/bots/forward/src/main/java/org/openjdk/skara/bots/forward/ForwardBot.java
+++ b/bots/forward/src/main/java/org/openjdk/skara/bots/forward/ForwardBot.java
@@ -72,7 +72,7 @@ class ForwardBot implements Bot, WorkItem {
             if (!Files.exists(toDir)) {
                 log.info("Cloning " + toHostedRepo.name());
                 Files.createDirectories(toDir);
-                toLocalRepo = Repository.clone(toHostedRepo.url(), toDir, true);
+                toLocalRepo = Repository.clone(toHostedRepo.authenticatedUrl(), toDir, true);
             } else {
                 log.info("Found existing scratch directory for " + toHostedRepo.name());
                 toLocalRepo = Repository.get(toDir).orElseThrow(() -> {
@@ -82,11 +82,11 @@ class ForwardBot implements Bot, WorkItem {
 
             log.info("Fetching " + fromHostedRepo.name() + ":" + fromBranch.name() +
                      " to " + toBranch.name());
-            var fetchHead = toLocalRepo.fetch(fromHostedRepo.url(),
+            var fetchHead = toLocalRepo.fetch(fromHostedRepo.authenticatedUrl(),
                                               fromBranch.name() + ":" + toBranch.name(),
                                               false);
             log.info("Pushing " + toBranch.name() + " to " + toHostedRepo.name());
-            toLocalRepo.push(fetchHead, toHostedRepo.url(), toBranch.name(), false);
+            toLocalRepo.push(fetchHead, toHostedRepo.authenticatedUrl(), toBranch.name(), false);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/bots/hgbridge/src/main/java/org/openjdk/skara/bots/hgbridge/ExporterConfig.java
+++ b/bots/hgbridge/src/main/java/org/openjdk/skara/bots/hgbridge/ExporterConfig.java
@@ -168,7 +168,7 @@ class ExporterConfig {
     }
 
     public Converter resolve(Path scratchPath) throws IOException {
-        var localRepo = Repository.materialize(scratchPath, configurationRepo.url(),
+        var localRepo = Repository.materialize(scratchPath, configurationRepo.authenticatedUrl(),
                                                "+" + configurationRef + ":hgbridge_config_" + configurationRepo.name());
 
         var replacements = parseMap(localRepo.root(), replacementsFile,

--- a/bots/hgbridge/src/main/java/org/openjdk/skara/bots/hgbridge/JBridgeBot.java
+++ b/bots/hgbridge/src/main/java/org/openjdk/skara/bots/hgbridge/JBridgeBot.java
@@ -64,7 +64,7 @@ public class JBridgeBot implements Bot, WorkItem {
     }
 
     private void pushMarks(Path markSource, String destName, Path markScratchPath) throws IOException {
-        var marksRepo = Repository.materialize(markScratchPath, exporterConfig.marksRepo().url(),
+        var marksRepo = Repository.materialize(markScratchPath, exporterConfig.marksRepo().authenticatedUrl(),
                                                "+" + exporterConfig.marksRef() + ":hgbridge_marks");
 
         // We should never change existing marks
@@ -89,7 +89,7 @@ public class JBridgeBot implements Bot, WorkItem {
         Files.writeString(markDest, updated, StandardCharsets.UTF_8);
         marksRepo.add(markDest);
         var hash = marksRepo.commit("Updated marks", exporterConfig.marksAuthorName(), exporterConfig.marksAuthorEmail());
-        marksRepo.push(hash, exporterConfig.marksRepo().url(), exporterConfig.marksRef());
+        marksRepo.push(hash, exporterConfig.marksRepo().authenticatedUrl(), exporterConfig.marksRef());
     }
 
     @Override
@@ -120,16 +120,16 @@ public class JBridgeBot implements Bot, WorkItem {
 
             IOException lastException = null;
             for (var destination : exporterConfig.destinations()) {
-                var markerBase = destination.url().getHost() + "/" + destination.name();
+                var markerBase = destination.authenticatedUrl().getHost() + "/" + destination.name();
                 var successfulPushMarker = storage.resolve(URLEncoder.encode(markerBase, StandardCharsets.UTF_8) + ".success.txt");
                 if (exported.isPresent() || !successfulPushMarker.toFile().isFile()) {
                     var repo = exported.orElse(Exporter.current(storage).orElseThrow());
                     try {
                         Files.deleteIfExists(successfulPushMarker);
-                        repo.pushAll(destination.url());
+                        repo.pushAll(destination.authenticatedUrl());
                         storage.resolve(successfulPushMarker).toFile().createNewFile();
                     } catch (IOException e) {
-                        log.log(Level.SEVERE, "Failed to push to " + destination.url(), e);
+                        log.log(Level.SEVERE, "Failed to push to " + destination.authenticatedUrl(), e);
                         lastException = e;
                     }
                 } else {

--- a/bots/hgbridge/src/main/java/org/openjdk/skara/bots/hgbridge/JBridgeBot.java
+++ b/bots/hgbridge/src/main/java/org/openjdk/skara/bots/hgbridge/JBridgeBot.java
@@ -120,7 +120,7 @@ public class JBridgeBot implements Bot, WorkItem {
 
             IOException lastException = null;
             for (var destination : exporterConfig.destinations()) {
-                var markerBase = destination.authenticatedUrl().getHost() + "/" + destination.name();
+                var markerBase = destination.url().getHost() + "/" + destination.name();
                 var successfulPushMarker = storage.resolve(URLEncoder.encode(markerBase, StandardCharsets.UTF_8) + ".success.txt");
                 if (exported.isPresent() || !successfulPushMarker.toFile().isFile()) {
                     var repo = exported.orElse(Exporter.current(storage).orElseThrow());

--- a/bots/hgbridge/src/test/java/org/openjdk/skara/bots/hgbridge/BridgeBotTests.java
+++ b/bots/hgbridge/src/test/java/org/openjdk/skara/bots/hgbridge/BridgeBotTests.java
@@ -171,7 +171,7 @@ class BridgeBotTests {
             runHgCommand(localHgRepo, "strip", "-r", "bd7a3ed1210f");
             TestBotRunner.runPeriodicItems(bridge);
 
-            var localGitRepo = Repository.materialize(gitFolder.path(), destinationRepo.url(), "master");
+            var localGitRepo = Repository.materialize(gitFolder.path(), destinationRepo.authenticatedUrl(), "master");
 
             // Only a subset of known tags should be present
             var localGitTags = getTagNames(localGitRepo);
@@ -184,7 +184,7 @@ class BridgeBotTests {
             TestBotRunner.runPeriodicItems(bridge);
 
             // There should now be more tags present
-            Repository.materialize(gitFolder.path(), destinationRepo.url(), "master");
+            Repository.materialize(gitFolder.path(), destinationRepo.authenticatedUrl(), "master");
             localGitTags = getTagNames(localGitRepo);
             assertEquals(getTagNames(localHgRepo), localGitTags);
             assertTrue(localGitTags.contains("jtreg4.1-b02"));
@@ -193,13 +193,13 @@ class BridgeBotTests {
             // Export it again with different storage to force an export from scratch
             bridge = new JBridgeBot(config, storageFolder2.path());
             TestBotRunner.runPeriodicItems(bridge);
-            Repository.materialize(gitFolder.path(), destinationRepo.url(), "master");
+            Repository.materialize(gitFolder.path(), destinationRepo.authenticatedUrl(), "master");
             var newLocalGitTags = getTagNames(localGitRepo);
             assertEquals(localGitTags, newLocalGitTags);
 
             // Export it once more when nothing has changed
             TestBotRunner.runPeriodicItems(bridge);
-            Repository.materialize(gitFolder.path(), destinationRepo.url(), "master");
+            Repository.materialize(gitFolder.path(), destinationRepo.authenticatedUrl(), "master");
             newLocalGitTags = getTagNames(localGitRepo);
             assertEquals(localGitTags, newLocalGitTags);
         }
@@ -219,7 +219,7 @@ class BridgeBotTests {
             TestBotRunner.runPeriodicItems(bridge);
 
             // Materialize it and ensure that it contains a known commit
-            var localGitRepo = Repository.materialize(gitFolder.path(), destinationRepo.url(), "master");
+            var localGitRepo = Repository.materialize(gitFolder.path(), destinationRepo.authenticatedUrl(), "master");
             var localGitCommits = getCommitHashes(localGitRepo);
             assertTrue(localGitCommits.contains("9cb6a5b843c0e9f6d45273a1a6f5c98979ab0766"));
 
@@ -237,7 +237,7 @@ class BridgeBotTests {
 
             // Now export it again - should still be intact
             TestBotRunner.runPeriodicItems(bridge);
-            Repository.materialize(gitFolder.path(), destinationRepo.url(), "master");
+            Repository.materialize(gitFolder.path(), destinationRepo.authenticatedUrl(), "master");
             localGitCommits = getCommitHashes(localGitRepo);
             assertTrue(localGitCommits.contains("9cb6a5b843c0e9f6d45273a1a6f5c98979ab0766"));
         }
@@ -264,7 +264,7 @@ class BridgeBotTests {
             TestBotRunner.runPeriodicItems(goodBridge);
 
             // Verify that it now contains a known commit
-            var localGitRepo = Repository.materialize(gitFolder.path(), destinationRepo.url(), "master");
+            var localGitRepo = Repository.materialize(gitFolder.path(), destinationRepo.authenticatedUrl(), "master");
             var localGitCommits = getCommitHashes(localGitRepo);
             assertTrue(localGitCommits.contains("9cb6a5b843c0e9f6d45273a1a6f5c98979ab0766"));
         }
@@ -287,17 +287,17 @@ class BridgeBotTests {
             TestBotRunner.runPeriodicItems(bridge);
 
             // Materialize it and ensure that it contains a known commit
-            var localGitRepo = Repository.materialize(gitFolder.path(), destinationRepo.url(), "master");
+            var localGitRepo = Repository.materialize(gitFolder.path(), destinationRepo.authenticatedUrl(), "master");
             var localGitCommits = getCommitHashes(localGitRepo);
             assertTrue(localGitCommits.contains("9cb6a5b843c0e9f6d45273a1a6f5c98979ab0766"));
 
             // Push something else to overwrite it (but retain the lock)
             var localRepo = CheckableRepository.init(gitFolder2.path(), destinationRepo.repositoryType());
             credentials.commitLock(localRepo);
-            localRepo.pushAll(destinationRepo.url());
+            localRepo.pushAll(destinationRepo.authenticatedUrl());
 
             // Materialize it again and ensure that the known commit is now gone
-            localGitRepo = Repository.materialize(gitFolder3.path(), destinationRepo.url(), "master");
+            localGitRepo = Repository.materialize(gitFolder3.path(), destinationRepo.authenticatedUrl(), "master");
             localGitCommits = getCommitHashes(localGitRepo);
             assertFalse(localGitCommits.contains("9cb6a5b843c0e9f6d45273a1a6f5c98979ab0766"));
 
@@ -305,7 +305,7 @@ class BridgeBotTests {
             TestBotRunner.runPeriodicItems(bridge);
 
             // Materialize it yet again and ensure that the known commit is still gone
-            localGitRepo = Repository.materialize(gitFolder4.path(), destinationRepo.url(), "master");
+            localGitRepo = Repository.materialize(gitFolder4.path(), destinationRepo.authenticatedUrl(), "master");
             localGitCommits = getCommitHashes(localGitRepo);
             assertFalse(localGitCommits.contains("9cb6a5b843c0e9f6d45273a1a6f5c98979ab0766"));
         }
@@ -329,16 +329,16 @@ class BridgeBotTests {
             TestBotRunner.runPeriodicItems(bridge);
 
             // Materialize it and ensure that it contains a known commit
-            var localGitRepo = Repository.materialize(gitFolder.path(), destinationRepo.url(), "master");
+            var localGitRepo = Repository.materialize(gitFolder.path(), destinationRepo.authenticatedUrl(), "master");
             var localGitCommits = getCommitHashes(localGitRepo);
             assertTrue(localGitCommits.contains("9cb6a5b843c0e9f6d45273a1a6f5c98979ab0766"));
 
             // Push something else to overwrite it
             var localRepo = CheckableRepository.init(gitFolder2.path(), destinationRepo.repositoryType());
-            localRepo.pushAll(destinationRepo.url());
+            localRepo.pushAll(destinationRepo.authenticatedUrl());
 
             // Materialize it again and ensure that the known commit is now gone
-            localGitRepo = Repository.materialize(gitFolder3.path(), destinationRepo.url(), "master");
+            localGitRepo = Repository.materialize(gitFolder3.path(), destinationRepo.authenticatedUrl(), "master");
             localGitCommits = getCommitHashes(localGitRepo);
             assertFalse(localGitCommits.contains("9cb6a5b843c0e9f6d45273a1a6f5c98979ab0766"));
 
@@ -346,7 +346,7 @@ class BridgeBotTests {
             TestBotRunner.runPeriodicItems(bridge);
 
             // Materialize it yet again and ensure that the known commit is still gone
-            localGitRepo = Repository.materialize(gitFolder4.path(), destinationRepo.url(), "master");
+            localGitRepo = Repository.materialize(gitFolder4.path(), destinationRepo.authenticatedUrl(), "master");
             localGitCommits = getCommitHashes(localGitRepo);
             assertFalse(localGitCommits.contains("9cb6a5b843c0e9f6d45273a1a6f5c98979ab0766"));
 
@@ -366,7 +366,7 @@ class BridgeBotTests {
             TestBotRunner.runPeriodicItems(bridge);
 
             // Materialize it and ensure that the known commit is back
-            localGitRepo = Repository.materialize(gitFolder5.path(), destinationRepo.url(), "master");
+            localGitRepo = Repository.materialize(gitFolder5.path(), destinationRepo.authenticatedUrl(), "master");
             localGitCommits = getCommitHashes(localGitRepo);
             assertTrue(localGitCommits.contains("9cb6a5b843c0e9f6d45273a1a6f5c98979ab0766"));
         }

--- a/bots/jep/src/test/java/org/openjdk/skara/bots/jep/JEPBotTests.java
+++ b/bots/jep/src/test/java/org/openjdk/skara/bots/jep/JEPBotTests.java
@@ -54,7 +54,7 @@ public class JEPBotTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), repo.repositoryType(),
                     Path.of("appendable.txt"), Set.of("issues"), null);
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, repo.url(), "master", true);
+            localRepo.push(masterHash, repo.authenticatedUrl(), "master", true);
 
             var mainIssue = issueProject.createIssue("The main issue", List.of("main"), Map.of("issuetype", JSON.of("Bug")));
             List<Issue> issueLists = new ArrayList<>();
@@ -70,7 +70,7 @@ public class JEPBotTests {
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, repo.url(), "edit", true);
+            localRepo.push(editHash, repo.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(repo, "master", "edit", mainIssue.id() + ": " + mainIssue.title());
 
             // PR should not have the `jep` label at first
@@ -113,7 +113,7 @@ public class JEPBotTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), repo.repositoryType(),
                     Path.of("appendable.txt"), Set.of("issues"), null);
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, repo.url(), "master", true);
+            localRepo.push(masterHash, repo.authenticatedUrl(), "master", true);
 
             var mainIssue = issueProject.createIssue("The main issue", List.of("main"), Map.of("issuetype", JSON.of("Bug")));
             issueProject.createIssue("Demo jep", List.of("Jep body"), Map.of("issuetype", JSON.of("JEP"),
@@ -121,7 +121,7 @@ public class JEPBotTests {
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, repo.url(), "edit", true);
+            localRepo.push(editHash, repo.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(repo, "master", "edit", mainIssue.id() + ": " + mainIssue.title());
 
             // PR should not have the `jep` label at first
@@ -149,7 +149,7 @@ public class JEPBotTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), repo.repositoryType(),
                     Path.of("appendable.txt"), Set.of("issues"), null);
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, repo.url(), "master", true);
+            localRepo.push(masterHash, repo.authenticatedUrl(), "master", true);
 
             var mainIssue = issueProject.createIssue("The main issue", List.of("main"), Map.of("issuetype", JSON.of("Bug")));
             issueProject.createIssue("Demo jep", List.of("Jep body"), Map.of("issuetype", JSON.of("JEP"),
@@ -157,7 +157,7 @@ public class JEPBotTests {
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, repo.url(), "edit", true);
+            localRepo.push(editHash, repo.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(repo, "master", "edit", mainIssue.id() + ": " + mainIssue.title());
 
             // PR should not have the `jep` label at first
@@ -186,7 +186,7 @@ public class JEPBotTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), repo.repositoryType(),
                     Path.of("appendable.txt"), Set.of("issues"), null);
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, repo.url(), "master", true);
+            localRepo.push(masterHash, repo.authenticatedUrl(), "master", true);
 
             var mainIssue = issueProject.createIssue("The main issue", List.of("main"), Map.of("issuetype", JSON.of("Bug")));
             issueProject.createIssue("Demo jep", List.of("Jep body"), Map.of("issuetype", JSON.of("JEP"),
@@ -194,7 +194,7 @@ public class JEPBotTests {
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, repo.url(), "edit", true);
+            localRepo.push(editHash, repo.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(repo, "master", "edit", mainIssue.id() + ": " + mainIssue.title());
 
             // PR should not have the `jep` label at first
@@ -223,7 +223,7 @@ public class JEPBotTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), repo.repositoryType(),
                     Path.of("appendable.txt"), Set.of("issues"), null);
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, repo.url(), "master", true);
+            localRepo.push(masterHash, repo.authenticatedUrl(), "master", true);
 
             var mainIssue = issueProject.createIssue("The main issue", List.of("main"), Map.of("issuetype", JSON.of("Bug")));
             issueProject.createIssue("Demo jep", List.of("Jep body"), Map.of("issuetype", JSON.of("Enhancement"),
@@ -231,7 +231,7 @@ public class JEPBotTests {
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, repo.url(), "edit", true);
+            localRepo.push(editHash, repo.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(repo, "master", "edit", mainIssue.id() + ": " + mainIssue.title());
 
             // PR should not have the `jep` label at first

--- a/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
+++ b/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
@@ -261,10 +261,10 @@ class MergeBot implements Bot, WorkItem {
         var repo = pool.materialize(fork, to);
 
         // Sync personal fork
-        var remoteBranches = repo.remoteBranches(target.url().toString());
+        var remoteBranches = repo.remoteBranches(target.authenticatedUrl().toString());
         for (var branch : remoteBranches) {
-            var fetchHead = repo.fetch(target.url(), branch.hash().hex(), false);
-            repo.push(fetchHead, fork.url(), branch.name());
+            var fetchHead = repo.fetch(target.authenticatedUrl(), branch.hash().hex(), false);
+            repo.push(fetchHead, fork.authenticatedUrl(), branch.name());
         }
 
         // Must fetch once to update refs/heads
@@ -447,7 +447,7 @@ class MergeBot implements Bot, WorkItem {
 
                 log.info("Trying to merge " + fromRepo.name() + ":" + fromBranch.name() + " to " + toBranch.name());
                 log.info("Fetching " + fromRepo.name() + ":" + fromBranch.name());
-                var fetchHead = repo.fetch(fromRepo.url(), fromBranch.name(), false);
+                var fetchHead = repo.fetch(fromRepo.authenticatedUrl(), fromBranch.name(), false);
                 var head = repo.resolve(toBranch.name()).orElseThrow(() ->
                         new IOException("Could not resolve branch " + toBranch.name())
                 );
@@ -473,7 +473,7 @@ class MergeBot implements Bot, WorkItem {
                                 "duke", "duke@openjdk.org");
                     }
                     try {
-                        repo.push(toBranch, target.url().toString(), false);
+                        repo.push(toBranch, target.authenticatedUrl().toString(), false);
                     } catch (IOException e) {
                         // A failed push can result in the local and remote branch diverging,
                         // re-create the repository from the remote.
@@ -495,7 +495,7 @@ class MergeBot implements Bot, WorkItem {
 
                     var numBranchesInFork = repo.remoteBranches(fork.webUrl().toString()).size();
                     var branchDesc = Integer.toString(numBranchesInFork + 1);
-                    repo.push(fetchHead, fork.url(), branchDesc);
+                    repo.push(fetchHead, fork.authenticatedUrl(), branchDesc);
 
                     log.info("Creating pull request to alert");
                     var mergeBase = repo.mergeBase(fetchHead, head);

--- a/bots/merge/src/test/java/org/openjdk/skara/bots/merge/MergeBotTests.java
+++ b/bots/merge/src/test/java/org/openjdk/skara/bots/merge/MergeBotTests.java
@@ -1243,14 +1243,14 @@ class MergeBotTests {
             Files.writeString(fromFileB, "Hello B\n");
             fromLocalRepo.add(fromFileB);
             var fromHashB = fromLocalRepo.commit("Adding a.txt", "duke", "duke@openjdk.org", now);
-            fromLocalRepo.push(fromHashB, fromHostedRepo.url(), "master");
+            fromLocalRepo.push(fromHashB, fromHostedRepo.authenticatedUrl(), "master");
 
             // Diverge the target with something non-conflicting
             var toFileC = toDir.resolve("c.txt");
             Files.writeString(toFileC, "Hello C\n");
             toLocalRepo.add(toFileC);
             var toHashC = toLocalRepo.commit("Adding c.txt", "duke", "duke@openjdk.org");
-            toLocalRepo.push(toHashC, toHostedRepo.url(), "master");
+            toLocalRepo.push(toHashC, toHostedRepo.authenticatedUrl(), "master");
 
             // But push something out of place to the local storage as well
             var sanitizedForkUrl = URLEncoder.encode(toFork.webUrl().toString(), StandardCharsets.UTF_8);

--- a/bots/mirror/src/main/java/org/openjdk/skara/bots/mirror/MirrorBot.java
+++ b/bots/mirror/src/main/java/org/openjdk/skara/bots/mirror/MirrorBot.java
@@ -85,7 +85,7 @@ class MirrorBot implements Bot, WorkItem {
             if (!Files.exists(dir)) {
                 log.info("Cloning " + from.name());
                 Files.createDirectories(dir);
-                repo = Repository.mirror(from.url(), dir);
+                repo = Repository.mirror(from.authenticatedUrl(), dir);
             } else {
                 log.info("Found existing scratch directory for " + to.name());
                 repo = Repository.get(dir).orElseGet(() -> {
@@ -95,7 +95,7 @@ class MirrorBot implements Bot, WorkItem {
                                 .map(Path::toFile)
                                 .sorted(Comparator.reverseOrder())
                                 .forEach(File::delete);
-                        return Repository.mirror(from.url(), dir);
+                        return Repository.mirror(from.authenticatedUrl(), dir);
                     } catch (IOException io) {
                         throw new RuntimeException(io);
                     }
@@ -103,17 +103,17 @@ class MirrorBot implements Bot, WorkItem {
             }
 
             log.info("Pulling " + from.name());
-            repo.fetchAll(from.url(), includeTags);
+            repo.fetchAll(from.authenticatedUrl(), includeTags);
             if (shouldMirrorEverything) {
                 log.info("Pushing to " + to.name());
-                repo.pushAll(to.url());
+                repo.pushAll(to.authenticatedUrl());
             } else {
                 var branches = repo.branches();
                 for (var branch : branches) {
                     if (branchPatterns.stream().anyMatch(p -> p.matcher(branch.name()).matches())) {
                         var hash = repo.resolve(branch);
                         if (hash.isPresent()) {
-                            repo.push(hash.get(), to.url(), branch.name(), true, includeTags);
+                            repo.push(hash.get(), to.authenticatedUrl(), branch.name(), true, includeTags);
                         } else {
                             log.severe("Branch " + branch + " not found in repo " + repo);
                         }

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveItem.java
@@ -177,7 +177,7 @@ class ArchiveItem {
                 return true;
             }
             if (tryFetch) {
-                localRepo.fetch(pr.repository().url(), lastHead.hex(), false);
+                localRepo.fetch(pr.repository().authenticatedUrl(), lastHead.hex(), false);
                 return true;
             }
         } catch (IOException e) {

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
@@ -186,7 +186,7 @@ class ArchiveMessages {
     }
 
     private static String fetchCommand(PullRequest pr) {
-        var repoUrl = pr.repository().webUrl();
+        var repoUrl = pr.repository().remoteUrl();
         return "git fetch " + repoUrl + " " + pr.fetchRef() + ":pull/" + pr.id();
     }
 

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
@@ -186,7 +186,7 @@ class ArchiveMessages {
     }
 
     private static String fetchCommand(PullRequest pr) {
-        var repoUrl = pr.repository().remoteUrl();
+        var repoUrl = pr.repository().url();
         return "git fetch " + repoUrl + " " + pr.fetchRef() + ":pull/" + pr.id();
     }
 

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
@@ -89,12 +89,12 @@ class ArchiveWorkItem implements WorkItem {
 
         for (int counter = 0; counter < 3; ++counter) {
             try {
-                localRepo.push(hash, bot.archiveRepo().url(), bot.archiveRef());
+                localRepo.push(hash, bot.archiveRepo().authenticatedUrl(), bot.archiveRef());
                 return;
             } catch (IOException e) {
                 log.info("Push to archive failed: " + e);
                 try {
-                    var remoteHead = localRepo.fetch(bot.archiveRepo().url(), bot.archiveRef(), false);
+                    var remoteHead = localRepo.fetch(bot.archiveRepo().authenticatedUrl(), bot.archiveRef(), false);
                     localRepo.rebase(remoteHead, bot.emailAddress().fullName().orElseThrow(), bot.emailAddress().address());
                     hash = localRepo.head();
                     log.info("Rebase successful -  new hash: " + hash);
@@ -110,7 +110,7 @@ class ArchiveWorkItem implements WorkItem {
 
     private Repository materializeArchive(Path scratchPath) {
         try {
-            return Repository.materialize(scratchPath, bot.archiveRepo().url(),
+            return Repository.materialize(scratchPath, bot.archiveRepo().authenticatedUrl(),
                                           "+" + bot.archiveRef() + ":mlbridge_archive");
         } catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/CensusInstance.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/CensusInstance.java
@@ -49,7 +49,7 @@ class CensusInstance {
 
     private static Repository initialize(HostedRepository repo, String ref, Path folder) {
         try {
-            return Repository.materialize(folder, repo.url(), "+" + ref + ":" + "mlbridge_census_" + repo.name());
+            return Repository.materialize(folder, repo.authenticatedUrl(), "+" + ref + ":" + "mlbridge_census_" + repo.name());
         } catch (IOException e) {
             throw new RuntimeException("Failed to retrieve census to " + folder, e);
         }
@@ -82,13 +82,13 @@ class CensusInstance {
     }
 
     static CensusInstance create(HostedRepository censusRepo, String censusRef, Path folder, PullRequest pr) {
-        var repoName = censusRepo.url().getHost() + "/" + censusRepo.name();
+        var repoName = censusRepo.authenticatedUrl().getHost() + "/" + censusRepo.name();
         var repoFolder = folder.resolve(URLEncoder.encode(repoName, StandardCharsets.UTF_8));
         try {
             var localRepo = Repository.get(repoFolder)
                                       .or(() -> Optional.of(initialize(censusRepo, censusRef, repoFolder)))
                                       .orElseThrow();
-            var hash = localRepo.fetch(censusRepo.url(), censusRef, false);
+            var hash = localRepo.fetch(censusRepo.authenticatedUrl(), censusRef, false);
             localRepo.checkout(hash, true);
         } catch (IOException e) {
             initialize(censusRepo, censusRef, repoFolder);

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/CensusInstance.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/CensusInstance.java
@@ -82,7 +82,7 @@ class CensusInstance {
     }
 
     static CensusInstance create(HostedRepository censusRepo, String censusRef, Path folder, PullRequest pr) {
-        var repoName = censusRepo.authenticatedUrl().getHost() + "/" + censusRepo.name();
+        var repoName = censusRepo.url().getHost() + "/" + censusRepo.name();
         var repoFolder = folder.resolve(URLEncoder.encode(repoName, StandardCharsets.UTF_8));
         try {
             var localRepo = Repository.get(repoFolder)

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBot.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBot.java
@@ -114,7 +114,7 @@ public class MailingListArchiveReaderBot implements Bot {
             pr = foundPr.get();
             resolvedPullRequests.put(first.id(), pr);
         }
-        var bridgeIdPattern = Pattern.compile("^[^.]+\\.[^.]+@" + pr.repository().authenticatedUrl().getHost() + "$");
+        var bridgeIdPattern = Pattern.compile("^[^.]+\\.[^.]+@" + pr.repository().url().getHost() + "$");
 
         // Filter out already bridged comments
         var bridgeCandidates = newMessages.stream()

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBot.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBot.java
@@ -114,7 +114,7 @@ public class MailingListArchiveReaderBot implements Bot {
             pr = foundPr.get();
             resolvedPullRequests.put(first.id(), pr);
         }
-        var bridgeIdPattern = Pattern.compile("^[^.]+\\.[^.]+@" + pr.repository().url().getHost() + "$");
+        var bridgeIdPattern = Pattern.compile("^[^.]+\\.[^.]+@" + pr.repository().authenticatedUrl().getHost() + "$");
 
         // Filter out already bridged comments
         var bridgeCandidates = newMessages.stream()

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
@@ -296,7 +296,7 @@ class ReviewArchive {
             digest.update(identifier.getBytes(StandardCharsets.UTF_8));
             var encodedCommon = Base64.getUrlEncoder().encodeToString(digest.digest());
 
-            return EmailAddress.from(encodedCommon + "." + UUID.randomUUID() + "@" + pr.repository().url().getHost());
+            return EmailAddress.from(encodedCommon + "." + UUID.randomUUID() + "@" + pr.repository().authenticatedUrl().getHost());
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException("Cannot find SHA-256");
         }

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
@@ -296,7 +296,7 @@ class ReviewArchive {
             digest.update(identifier.getBytes(StandardCharsets.UTF_8));
             var encodedCommon = Base64.getUrlEncoder().encodeToString(digest.digest());
 
-            return EmailAddress.from(encodedCommon + "." + UUID.randomUUID() + "@" + pr.repository().authenticatedUrl().getHost());
+            return EmailAddress.from(encodedCommon + "." + UUID.randomUUID() + "@" + pr.repository().url().getHost());
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException("Cannot find SHA-256");
         }

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
@@ -149,7 +149,7 @@ class WebrevStorage {
         return "This file was too large to be included in the published webrev, and has been replaced with " +
                 "this placeholder message. It is possible to generate the original content locally by " +
                 "following these instructions:\n\n" +
-                "  $ git fetch " + pr.repository().remoteUrl() + " " + pr.fetchRef() + "\n" +
+                "  $ git fetch " + pr.repository().url() + " " + pr.fetchRef() + "\n" +
                 "  $ git checkout " + head.hex() + "\n" +
                 "  $ git webrev -r " + base.hex() + "\n";
     }
@@ -292,27 +292,27 @@ class WebrevStorage {
             URI uri = null;
 
             if (generateJSON) {
-                var jsonLocalStorage = Repository.materialize(scratchPath, jsonStorage.url(),
+                var jsonLocalStorage = Repository.materialize(scratchPath, jsonStorage.authenticatedUrl(),
                                                               "+" + storageRef + ":mlbridge_webrevs");
                 if (Files.exists(outputFolder)) {
                     clearDirectory(outputFolder);
                 }
                 generateJSON(pr, localRepository, outputFolder, diff, base, head);
                 if (!jsonLocalStorage.isClean()) {
-                    push(jsonLocalStorage, jsonStorage.url(), outputFolder, baseFolder.resolve(pr.id()).toString(), placeholder);
+                    push(jsonLocalStorage, jsonStorage.authenticatedUrl(), outputFolder, baseFolder.resolve(pr.id()).toString(), placeholder);
                 }
                 var repoName = Path.of(pr.repository().name()).getFileName();
                 uri = URI.create(baseUri.toString() + "?repo=" + repoName + "&pr=" + pr.id() + "&range=" + identifier);
             }
             if (generateHTML) {
-                var htmlLocalStorage = Repository.materialize(scratchPath, htmlStorage.url(),
+                var htmlLocalStorage = Repository.materialize(scratchPath, htmlStorage.authenticatedUrl(),
                                                               "+" + storageRef + ":mlbridge_webrevs");
                 if (Files.exists(outputFolder)) {
                     clearDirectory(outputFolder);
                 }
                 generateHTML(pr, localRepository, outputFolder, diff, base, head);
                 if (!htmlLocalStorage.isClean()) {
-                    push(htmlLocalStorage, htmlStorage.url(), outputFolder, baseFolder.resolve(pr.id()).toString(), placeholder);
+                    push(htmlLocalStorage, htmlStorage.authenticatedUrl(), outputFolder, baseFolder.resolve(pr.id()).toString(), placeholder);
                 }
                 uri = URIBuilder.base(baseUri).appendPath(relativeFolder.toString().replace('\\', '/')).build();
                 awaitPublication(uri, Duration.ofMinutes(30));

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
@@ -149,7 +149,7 @@ class WebrevStorage {
         return "This file was too large to be included in the published webrev, and has been replaced with " +
                 "this placeholder message. It is possible to generate the original content locally by " +
                 "following these instructions:\n\n" +
-                "  $ git fetch " + pr.repository().webUrl() + " " + pr.fetchRef() + "\n" +
+                "  $ git fetch " + pr.repository().remoteUrl() + " " + pr.fetchRef() + "\n" +
                 "  $ git checkout " + head.hex() + "\n" +
                 "  $ git webrev -r " + base.hex() + "\n";
     }

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBotTests.java
@@ -93,13 +93,13 @@ class MailingListArchiveReaderBotTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
-            localRepo.push(masterHash, archive.url(), "webrev", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+            localRepo.push(masterHash, archive.authenticatedUrl(), "webrev", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo, "A simple change",
                                                                "Change msg\n\nWith several lines");
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(archive, "master", "edit", "This is a pull request");
             pr.setBody("This should now be ready");
 
@@ -169,13 +169,13 @@ class MailingListArchiveReaderBotTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
-            localRepo.push(masterHash, archive.url(), "webrev", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+            localRepo.push(masterHash, archive.authenticatedUrl(), "webrev", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo, "A simple change",
                                                                "Change msg\n\nWith several lines");
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(archive, "master", "edit", "This is a pull request");
             pr.setBody("This should now be ready");
 
@@ -245,13 +245,13 @@ class MailingListArchiveReaderBotTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
-            localRepo.push(masterHash, archive.url(), "webrev", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+            localRepo.push(masterHash, archive.authenticatedUrl(), "webrev", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo, "A simple change",
                                                                "Change msg\n\nWith several lines");
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(archive, "master", "edit", "This is a pull request");
             pr.setBody("This should now be ready");
 
@@ -321,14 +321,14 @@ class MailingListArchiveReaderBotTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
-            localRepo.push(masterHash, author.url(), "to_be_deleted", true);
-            localRepo.push(masterHash, archive.url(), "webrev", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "to_be_deleted", true);
+            localRepo.push(masterHash, archive.authenticatedUrl(), "webrev", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo, "A simple change",
                     "Change msg\n\nWith several lines");
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(archive, "to_be_deleted", "edit", "This is a pull request");
             pr.setBody("This should now be ready");
 

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -145,13 +145,13 @@ class MailingListBridgeBotTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
-            localRepo.push(masterHash, archive.url(), "webrev", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+            localRepo.push(masterHash, archive.authenticatedUrl(), "webrev", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo, "A simple change",
                                                                "Change msg\n\nWith several lines");
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(archive, "master", "edit", "1234: This is a pull request");
             pr.setBody("This should not be ready");
 
@@ -159,7 +159,7 @@ class MailingListBridgeBotTests {
             TestBotRunner.runPeriodicItems(mlBot);
 
             // A PR that isn't ready for review should not be archived
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertFalse(archiveContains(archiveFolder.path(), "This is a pull request"));
 
             // Flag it as ready for review
@@ -170,7 +170,7 @@ class MailingListBridgeBotTests {
             TestBotRunner.runPeriodicItems(mlBot);
 
             // But it should still not be archived
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertFalse(archiveContains(archiveFolder.path(), "This is a pull request"));
 
             // Now post a general comment - not a ready marker
@@ -181,7 +181,7 @@ class MailingListBridgeBotTests {
             TestBotRunner.runPeriodicItems(mlBot);
 
             // It should still not be archived
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertFalse(archiveContains(archiveFolder.path(), "This is a pull request"));
 
             // Now post a ready comment
@@ -191,7 +191,7 @@ class MailingListBridgeBotTests {
             TestBotRunner.runPeriodicItems(mlBot);
 
             // The archive should now contain an entry
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertTrue(archiveContains(archiveFolder.path(), "This is a pull request"));
             assertTrue(archiveContains(archiveFolder.path(), "This should now be ready"));
             assertTrue(archiveContains(archiveFolder.path(), "Patch:"));
@@ -220,7 +220,7 @@ class MailingListBridgeBotTests {
             assertEquals("val2", mail.headerValue("Extra2"));
 
             // And there should be a webrev
-            Repository.materialize(webrevFolder.path(), archive.url(), "webrev");
+            Repository.materialize(webrevFolder.path(), archive.authenticatedUrl(), "webrev");
             assertTrue(webrevContains(webrevFolder.path(), "1 lines changed"));
             var comments = pr.comments();
             var webrevComments = comments.stream()
@@ -240,7 +240,7 @@ class MailingListBridgeBotTests {
             TestBotRunner.runPeriodicItems(mlBot);
 
             // The archive should now contain the comment, but not the ignored one
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertTrue(archiveContains(archiveFolder.path(), "This is a comment"));
             assertTrue(archiveContains(archiveFolder.path(), "> This should now be ready"));
             assertFalse(archiveContains(archiveFolder.path(), "Don't mind me"));
@@ -258,7 +258,7 @@ class MailingListBridgeBotTests {
             TestBotRunner.runPeriodicItems(mlBot);
 
             // The archive should contain the additional comment
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertTrue(archiveContains(archiveFolder.path(), "This is another comment"));
             assertTrue(archiveContains(archiveFolder.path(), ">> This should now be ready"));
 
@@ -308,13 +308,13 @@ class MailingListBridgeBotTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
-            localRepo.push(masterHash, archive.url(), "webrev", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+            localRepo.push(masterHash, archive.authenticatedUrl(), "webrev", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo, "A simple change",
                                                                "Change msg\n\nWith several lines");
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(archive, "master", "edit", "1234: This is a pull request");
             pr.setBody("This is now ready");
             pr.addLabel("rfr");
@@ -324,7 +324,7 @@ class MailingListBridgeBotTests {
             TestBotRunner.runPeriodicItems(mlBot);
 
             // There should be an RFR thread
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertTrue(archiveContains(archiveFolder.path(), "Subject: RFR: 1234: This is a pull request"));
 
             // Add a comment quickly before integration - it should not be combined with the integration message
@@ -349,7 +349,7 @@ class MailingListBridgeBotTests {
             TestBotRunner.runPeriodicItems(mlBot);
 
             // The archive should now contain another entry
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertTrue(archiveContains(archiveFolder.path(), "Subject: Re: RFR: 1234: This is a pull request"));
             assertTrue(archiveContains(archiveFolder.path(), "Subject: Integrated: 1234: This is a pull request"));
             assertFalse(archiveContains(archiveFolder.path(), "\\[Closed\\]"));
@@ -390,8 +390,8 @@ class MailingListBridgeBotTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
-            localRepo.push(masterHash, archive.url(), "webrev", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+            localRepo.push(masterHash, archive.authenticatedUrl(), "webrev", true);
 
             // Make a change with a corresponding PR with a date in the past
             var editFile = tempFolder.path().resolve("change.txt");
@@ -400,7 +400,7 @@ class MailingListBridgeBotTests {
             var commitDate = ZonedDateTime.of(2020, 3, 12, 0, 0, 0, 0, ZoneId.of("UTC"));
             var editHash = localRepo.commit("An old change", "duke", "duke@openjdk.org", commitDate,
                              "duke", "duke@openjdk.org", commitDate);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(archive, "master", "edit", "1234: This is a pull request");
             pr.setBody("This is now ready");
             pr.addLabel("rfr");
@@ -410,7 +410,7 @@ class MailingListBridgeBotTests {
             TestBotRunner.runPeriodicItems(mlBot);
 
             // There should be an RFR thread
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertTrue(archiveContains(archiveFolder.path(), "Subject: RFR: 1234: This is a pull request"));
 
             // Now it has been integrated
@@ -424,7 +424,7 @@ class MailingListBridgeBotTests {
             TestBotRunner.runPeriodicItems(mlBot);
 
             // The archive should not contain another entry
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertFalse(archiveContains(archiveFolder.path(), "\\[Integrated\\]"));
             assertFalse(archiveContains(archiveFolder.path(), "\\[Closed\\]"));
         }
@@ -464,13 +464,13 @@ class MailingListBridgeBotTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
-            localRepo.push(masterHash, archive.url(), "webrev", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+            localRepo.push(masterHash, archive.authenticatedUrl(), "webrev", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo, "A simple change",
                                                                "Change msg\n\nWith several lines");
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(archive, "master", "edit", "1234: This is a pull request");
             pr.setBody("This should not be ready");
             pr.setState(Issue.State.CLOSED);
@@ -480,7 +480,7 @@ class MailingListBridgeBotTests {
             TestBotRunner.runPeriodicItems(mlBot);
 
             // A PR that isn't ready for review should not be archived
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertFalse(archiveContains(archiveFolder.path(), "This is a pull request"));
 
             // Now it has been integrated
@@ -493,17 +493,17 @@ class MailingListBridgeBotTests {
             TestBotRunner.runPeriodicItems(mlBot);
 
             // The archive should now contain an entry
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertTrue(archiveContains(archiveFolder.path(), "Subject: Integrated: 1234: This is a pull request"));
 
             var updatedHash = CheckableRepository.appendAndCommit(localRepo, "Another change");
-            localRepo.push(updatedHash, author.url(), "edit");
+            localRepo.push(updatedHash, author.authenticatedUrl(), "edit");
 
             // Run another archive pass
             TestBotRunner.runPeriodicItems(mlBot);
 
             // The archive should now contain another entry
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertTrue(archiveContains(archiveFolder.path(), "Subject: Re: Integrated: 1234: This is a pull request \\[v2\\]"));
             assertFalse(archiveContains(archiveFolder.path(), "Withdrawn"));
         }
@@ -544,13 +544,13 @@ class MailingListBridgeBotTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
-            localRepo.push(masterHash, archive.url(), "webrev", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+            localRepo.push(masterHash, archive.authenticatedUrl(), "webrev", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo, "A simple change",
                                                                "Change msg\n\nWith several lines");
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(archive, "master", "edit", "1234: This is a pull request");
             pr.setBody("This should be ready");
 
@@ -559,7 +559,7 @@ class MailingListBridgeBotTests {
             TestBotRunner.runPeriodicItems(mlBot);
 
             // A PR that isn't ready for review should not be archived
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertFalse(archiveContains(archiveFolder.path(), "This is a pull request"));
 
             // Flag it as ready for review
@@ -569,19 +569,19 @@ class MailingListBridgeBotTests {
             TestBotRunner.runPeriodicItems(mlBot);
 
             // The archive should now contain an entry
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertTrue(archiveContains(archiveFolder.path(), "Subject: RFR: 1234: This is a pull request"));
 
             // Close it and then push another change
             pr.setState(Issue.State.CLOSED);
             var updatedHash = CheckableRepository.appendAndCommit(localRepo, "Another change");
-            localRepo.push(updatedHash, author.url(), "edit");
+            localRepo.push(updatedHash, author.authenticatedUrl(), "edit");
 
             // Run another archive pass
             TestBotRunner.runPeriodicItems(mlBot);
 
             // The archive should now contain another entry - should retain the RFR thread prefix
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertTrue(archiveContains(archiveFolder.path(), "Subject: Re: RFR: 1234: This is a pull request \\[v2\\]"));
         }
     }
@@ -621,13 +621,13 @@ class MailingListBridgeBotTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
-            localRepo.push(masterHash, archive.url(), "webrev", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+            localRepo.push(masterHash, archive.authenticatedUrl(), "webrev", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo, "A simple change",
                                                                "Change msg\n\nWith several lines");
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(archive, "master", "edit", "1234: This is a pull request");
             pr.setBody("This should be ready");
 
@@ -636,7 +636,7 @@ class MailingListBridgeBotTests {
             TestBotRunner.runPeriodicItems(mlBot);
 
             // A PR that isn't ready for review should not be archived
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertFalse(archiveContains(archiveFolder.path(), "This is a pull request"));
 
             // Flag it as ready for review
@@ -646,7 +646,7 @@ class MailingListBridgeBotTests {
             TestBotRunner.runPeriodicItems(mlBot);
 
             // The archive should now contain an entry
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertTrue(archiveContains(archiveFolder.path(), "Subject: RFR: 1234: This is a pull request"));
 
             // Close it (as a separate user)
@@ -657,14 +657,14 @@ class MailingListBridgeBotTests {
             TestBotRunner.runPeriodicItems(mlBot);
 
             // The archive should now contain another entry - should say that it is closed
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertEquals(1, archiveContainsCount(archiveFolder.path(), "Subject: Withdrawn: 1234: This is a pull request"));
 
             pr.addComment("Fair enough");
 
             // Run another archive pass - only a single close notice should have been posted
             TestBotRunner.runPeriodicItems(mlBot);
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertEquals(1, archiveContainsCount(archiveFolder.path(), "Subject: Withdrawn: 1234: This is a pull request"));
             assertEquals(1, archiveContainsCount(archiveFolder.path(), "Subject: Re: RFR: 1234: This is a pull request"));
 
@@ -709,13 +709,13 @@ class MailingListBridgeBotTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
-            localRepo.push(masterHash, archive.url(), "webrev", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+            localRepo.push(masterHash, archive.authenticatedUrl(), "webrev", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo, "A simple change",
                                                                "Change msg\n\nWith several lines");
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(archive, "master", "edit", "Cannot automatically merge");
             pr.setBody("This is an automated merge PR");
             pr.addLabel("failed-auto-merge");
@@ -725,7 +725,7 @@ class MailingListBridgeBotTests {
             TestBotRunner.runPeriodicItems(mlBot);
 
             // The archive should contain an entry
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertTrue(archiveContains(archiveFolder.path(), "Subject: RFR: Cannot automatically merge"));
         }
     }
@@ -764,12 +764,12 @@ class MailingListBridgeBotTests {
             var reviewFile = Path.of("reviewfile.txt");
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(), reviewFile);
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
-            localRepo.push(masterHash, archive.url(), "webrev", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+            localRepo.push(masterHash, archive.authenticatedUrl(), "webrev", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(archive, "master", "edit", "This is a pull request");
             pr.setBody("This is now ready");
             TestBotRunner.runPeriodicItems(mlBot);
@@ -788,7 +788,7 @@ class MailingListBridgeBotTests {
             listServer.processIncoming();
 
             // The archive should now contain an entry
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertTrue(archiveContains(archiveFolder.path(), "This is a pull request"));
             assertTrue(archiveContains(archiveFolder.path(), "This is now ready"));
             assertTrue(archiveContains(archiveFolder.path(), "Review comment"));
@@ -810,7 +810,7 @@ class MailingListBridgeBotTests {
             listServer.processIncoming();
 
             // The archive should contain the additional comment (but no quoted footers)
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertTrue(archiveContains(archiveFolder.path(), "This is a review reply"));
             assertTrue(archiveContains(archiveFolder.path(), ">> This is now ready"));
             assertFalse(archiveContains(archiveFolder.path(), "^> PR:"));
@@ -830,7 +830,7 @@ class MailingListBridgeBotTests {
             listServer.processIncoming();
 
             // The archive should contain the additional comment
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertTrue(archiveContains(archiveFolder.path(), "File review comment"));
             assertTrue(archiveContains(archiveFolder.path(), reviewFile + ":"));
         }
@@ -868,12 +868,12 @@ class MailingListBridgeBotTests {
             var reviewFile = Path.of("reviewfile.txt");
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(), reviewFile);
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
-            localRepo.push(masterHash, archive.url(), "webrev", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+            localRepo.push(masterHash, archive.authenticatedUrl(), "webrev", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(archive, "master", "edit", "This is a pull request");
             pr.setBody("This is now ready");
             pr.addComment("Avoid combining");
@@ -891,7 +891,7 @@ class MailingListBridgeBotTests {
             listServer.processIncoming();
 
             // The archive should contain a combined entry
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertEquals(2, archiveContainsCount(archiveFolder.path(), "^On.*wrote:"));
 
             // As well as the mailing list
@@ -921,7 +921,7 @@ class MailingListBridgeBotTests {
             listServer.processIncoming();
 
             // The archive should contain a new entry
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertEquals(3, archiveContainsCount(archiveFolder.path(), "^On.*wrote:"));
 
             // The combined review comments should only appear unquoted once
@@ -963,12 +963,12 @@ class MailingListBridgeBotTests {
             var reviewFile = Path.of("reviewfile.txt");
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(), reviewFile);
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
-            localRepo.push(masterHash, archive.url(), "webrev", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+            localRepo.push(masterHash, archive.authenticatedUrl(), "webrev", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(archive, "master", "edit", "This is a pull request");
             pr.setBody("This is now ready");
             TestBotRunner.runPeriodicItems(mlBot);
@@ -1004,7 +1004,7 @@ class MailingListBridgeBotTests {
             listServer.processIncoming();
 
             // Sanity check the archive
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertEquals(9, archiveContainsCount(archiveFolder.path(), "^On.*wrote:"));
 
             // File specific comments should appear after the approval
@@ -1095,12 +1095,12 @@ class MailingListBridgeBotTests {
             Files.writeString(localRepo.root().resolve(reviewFile2), "1\n2\n3\n4\n5\n6\n", StandardCharsets.UTF_8);
             localRepo.add(reviewFile2);
             var masterHash = localRepo.commit("Another one", "duke", "duke@openjdk.org");
-            localRepo.push(masterHash, author.url(), "master", true);
-            localRepo.push(masterHash, archive.url(), "webrev", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+            localRepo.push(masterHash, archive.authenticatedUrl(), "webrev", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(archive, "master", "edit", "This is a pull request");
             pr.setBody("This is now ready");
             TestBotRunner.runPeriodicItems(mlBot);
@@ -1121,7 +1121,7 @@ class MailingListBridgeBotTests {
             listServer.processIncoming();
 
             // Sanity check the archive
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertEquals(2, archiveContainsCount(archiveFolder.path(), "^On.*wrote:"));
 
             var archiveText = archiveContents(archiveFolder.path(), "").orElseThrow();
@@ -1164,12 +1164,12 @@ class MailingListBridgeBotTests {
             var reviewFile = Path.of("reviewfile.txt");
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(), reviewFile);
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
-            localRepo.push(masterHash, archive.url(), "webrev", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+            localRepo.push(masterHash, archive.authenticatedUrl(), "webrev", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(archive, "master", "edit", "This is a pull request");
             pr.setBody("This is now ready");
             TestBotRunner.runPeriodicItems(mlBot);
@@ -1188,7 +1188,7 @@ class MailingListBridgeBotTests {
             listServer.processIncoming();
 
             // The first comment should be quoted more often than the second
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertEquals(2, archiveContainsCount(archiveFolder.path(), "First comment"));
             assertEquals(1, archiveContainsCount(archiveFolder.path(), "Second comment"));
         }
@@ -1228,12 +1228,12 @@ class MailingListBridgeBotTests {
             var reviewFile = Path.of("reviewfile.txt");
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(), reviewFile);
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
-            localRepo.push(masterHash, archive.url(), "webrev", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+            localRepo.push(masterHash, archive.authenticatedUrl(), "webrev", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(archive, "master", "edit", "This is a pull request");
             pr.setBody("This is now ready");
             TestBotRunner.runPeriodicItems(mlBot);
@@ -1253,7 +1253,7 @@ class MailingListBridgeBotTests {
             listServer.processIncoming();
 
             // The first comment should be quoted more often than the second
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertEquals(3, archiveContainsCount(archiveFolder.path(), "First review comment"));
             assertEquals(1, archiveContainsCount(archiveFolder.path(), "Second review comment"));
         }
@@ -1293,12 +1293,12 @@ class MailingListBridgeBotTests {
             var reviewFile = Path.of("reviewfile.txt");
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(), reviewFile);
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
-            localRepo.push(masterHash, archive.url(), "webrev", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+            localRepo.push(masterHash, archive.authenticatedUrl(), "webrev", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(archive, "master", "edit", "This is a pull request");
             pr.setBody("This is now ready");
             TestBotRunner.runPeriodicItems(mlBot);
@@ -1318,7 +1318,7 @@ class MailingListBridgeBotTests {
             listServer.processIncoming();
 
             // The first comment should be replied to once, and the original post once
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertEquals(1, archiveContainsCount(archiveFolder.path(), Pattern.quote(reviewPr.author().fullName()) + ".* wrote"));
             assertEquals(1, archiveContainsCount(archiveFolder.path(), Pattern.quote(pr.author().fullName()) + ".* wrote"));
         }
@@ -1356,12 +1356,12 @@ class MailingListBridgeBotTests {
             var reviewFile = Path.of("reviewfile.txt");
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(), reviewFile);
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
-            localRepo.push(masterHash, archive.url(), "webrev", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+            localRepo.push(masterHash, archive.authenticatedUrl(), "webrev", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Line 1\nLine 2\nLine 3\nLine 4");
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(archive, "master", "edit", "This is a pull request");
             pr.setBody("This is now ready");
             TestBotRunner.runPeriodicItems(mlBot);
@@ -1374,7 +1374,7 @@ class MailingListBridgeBotTests {
             listServer.processIncoming();
 
             // The archive should only contain context up to and including Line 2
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertTrue(archiveContains(archiveFolder.path(), "^> 2: Line 1$"));
             assertFalse(archiveContains(archiveFolder.path(), "^> 3: Line 2$"));
         }
@@ -1412,8 +1412,8 @@ class MailingListBridgeBotTests {
             var reviewFile = Path.of("reviewfile.txt");
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(), reviewFile);
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
-            localRepo.push(masterHash, archive.url(), "webrev", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+            localRepo.push(masterHash, archive.authenticatedUrl(), "webrev", true);
             var initialHash = CheckableRepository.appendAndCommit(localRepo,
                                                                   "Line 0.1\nLine 0.2\nLine 0.3\nLine 0.4\n" +
                                                                           "Line 1\nLine 2\nLine 3\nLine 4\n" +
@@ -1421,7 +1421,7 @@ class MailingListBridgeBotTests {
                                                                           "Line 8.1\nLine 8.2\nLine 8.3\nLine 8.4\n" +
                                                                           "Line 9\nLine 10\nLine 11\nLine 12\n" +
                                                                           "Line 13\nLine 14\nLine 15\nLine 16\n");
-            localRepo.push(initialHash, author.url(), "master");
+            localRepo.push(initialHash, author.authenticatedUrl(), "master");
 
             // Make a change with a corresponding PR
             var current = Files.readString(localRepo.root().resolve(reviewFile), StandardCharsets.UTF_8);
@@ -1429,7 +1429,7 @@ class MailingListBridgeBotTests {
             updated = updated.replaceAll("Line 13", "Line 12.5\nLine 13 edit");
             Files.writeString(localRepo.root().resolve(reviewFile), updated, StandardCharsets.UTF_8);
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(archive, "master", "edit", "This is a pull request");
             pr.setBody("This is now ready");
             TestBotRunner.runPeriodicItems(mlBot);
@@ -1443,7 +1443,7 @@ class MailingListBridgeBotTests {
             listServer.processIncoming();
 
             // The archive should only contain context around line 2 and 20
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertTrue(archiveContains(archiveFolder.path(), "reviewfile.txt line 7"));
             assertTrue(archiveContains(archiveFolder.path(), "^> 6: Line 1$"));
             assertTrue(archiveContains(archiveFolder.path(), "^> 7: Line 2 edit$"));
@@ -1488,12 +1488,12 @@ class MailingListBridgeBotTests {
             var reviewFile = Path.of("reviewfile.txt");
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(), reviewFile);
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
-            localRepo.push(masterHash, archive.url(), "webrev", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+            localRepo.push(masterHash, archive.authenticatedUrl(), "webrev", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(archive, "master", "edit", "This is a pull request");
             pr.setBody("This is now ready\n<!-- this is a comment -->\nAnd this is not\n" +
                                "<!-- Anything below this marker will be hidden -->\nStatus stuff");
@@ -1512,7 +1512,7 @@ class MailingListBridgeBotTests {
             TestBotRunner.runPeriodicItems(mlBot);
 
             // The archive should not contain the comment
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertTrue(archiveContains(archiveFolder.path(), "This is now ready"));
             assertFalse(archiveContains(archiveFolder.path(), "this is a comment"));
             assertFalse(archiveContains(archiveFolder.path(), "Status stuff"));
@@ -1536,7 +1536,7 @@ class MailingListBridgeBotTests {
             // And a stand-alone multiline comment should not cause another mail to be sent
             pr.addComment("/another\nmultiline\nwill not cause another mail");
             TestBotRunner.runPeriodicItems(mlBot);
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             lines = archiveContents(archiveFolder.path(), "").orElseThrow();
             var mails = Mbox.splitMbox(lines, EmailAddress.from("duke@openjdk.org"));
             assertEquals(2, mails.size());
@@ -1576,12 +1576,12 @@ class MailingListBridgeBotTests {
             var reviewFile = Path.of("reviewfile.txt");
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(), reviewFile);
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
-            localRepo.push(masterHash, archive.url(), "webrev", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+            localRepo.push(masterHash, archive.authenticatedUrl(), "webrev", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(archive, "master", "edit", "This is a pull request");
             pr.setBody("This is now ready");
 
@@ -1590,7 +1590,7 @@ class MailingListBridgeBotTests {
             listServer.processIncoming();
 
             var nextHash = CheckableRepository.appendAndCommit(localRepo, "Yet one more line", "Fixing");
-            localRepo.push(nextHash, author.url(), "edit");
+            localRepo.push(nextHash, author.authenticatedUrl(), "edit");
 
             // Run another archive pass
             TestBotRunner.runPeriodicItems(mlBot);
@@ -1599,7 +1599,7 @@ class MailingListBridgeBotTests {
             listServer.processIncoming();
 
             // The archive should reference the updated push
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertTrue(archiveContains(archiveFolder.path(), "has updated the pull request incrementally"));
             assertTrue(archiveContains(archiveFolder.path(), "full.*/" + pr.id() + "/01"));
             assertTrue(archiveContains(archiveFolder.path(), "inc.*/" + pr.id() + "/00-01"));
@@ -1638,7 +1638,7 @@ class MailingListBridgeBotTests {
             // Ensure that additional updates are only reported once
             for (int i = 0; i < 3; ++i) {
                 var anotherHash = CheckableRepository.appendAndCommit(localRepo, "Another line", "Fixing");
-                localRepo.push(anotherHash, author.url(), "edit");
+                localRepo.push(anotherHash, author.authenticatedUrl(), "edit");
 
                 TestBotRunner.runPeriodicItems(mlBot);
                 TestBotRunner.runPeriodicItems(mlBot);
@@ -1687,13 +1687,13 @@ class MailingListBridgeBotTests {
             var reviewFile = Path.of("reviewfile.txt");
             var localRepo = CheckableRepository.init(tempFolder.path().resolve("first"), author.repositoryType(), reviewFile);
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
-            localRepo.push(masterHash, main.url(), "master", true);
-            localRepo.push(masterHash, archive.url(), "webrev", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+            localRepo.push(masterHash, main.authenticatedUrl(), "master", true);
+            localRepo.push(masterHash, archive.authenticatedUrl(), "webrev", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo, "A line", "Original msg");
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, main, "master", "edit", "This is a pull request");
             pr.setBody("This is now ready");
 
@@ -1701,16 +1701,16 @@ class MailingListBridgeBotTests {
             TestBotRunner.runPeriodicItems(mlBot);
             listServer.processIncoming();
 
-            var newLocalRepo = Repository.materialize(tempFolder.path().resolve("second"), author.url(), "master");
+            var newLocalRepo = Repository.materialize(tempFolder.path().resolve("second"), author.authenticatedUrl(), "master");
             var newEditHash = CheckableRepository.appendAndCommit(newLocalRepo, "Another line", "Replaced msg");
-            newLocalRepo.push(newEditHash, author.url(), "edit", true);
+            newLocalRepo.push(newEditHash, author.authenticatedUrl(), "edit", true);
 
             // Run another archive pass
             TestBotRunner.runPeriodicItems(mlBot);
             listServer.processIncoming();
 
             // The archive should reference the rebased push
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertTrue(archiveContains(archiveFolder.path(), "has refreshed the contents of this pull request, and previous commits have been removed."));
             assertTrue(archiveContains(archiveFolder.path(), pr.id() + "/01"));
             assertTrue(archiveContains(archiveFolder.path(), "Patch"));
@@ -1774,13 +1774,13 @@ class MailingListBridgeBotTests {
             var reviewFile = Path.of("reviewfile.txt");
             var localRepo = CheckableRepository.init(tempFolder.path().resolve("first"), author.repositoryType(), reviewFile);
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
-            localRepo.push(masterHash, main.url(), "master", true);
-            localRepo.push(masterHash, archive.url(), "webrev", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+            localRepo.push(masterHash, main.authenticatedUrl(), "master", true);
+            localRepo.push(masterHash, archive.authenticatedUrl(), "webrev", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Edit line", "Original msg");
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, main, "master", "edit", "This is a pull request");
             pr.setBody("This is now ready");
 
@@ -1791,19 +1791,19 @@ class MailingListBridgeBotTests {
             // Add another change in the master
             localRepo.checkout(masterHash);
             var newMasterHash = CheckableRepository.appendAndCommit(localRepo, "New master line", "New master commit message");
-            localRepo.push(newMasterHash, main.url(), "master");
+            localRepo.push(newMasterHash, main.authenticatedUrl(), "master");
             // Add a new "rebased" version of the edit change on top of the new master and force
             // push it to the PR. This should emulate a rebase.
-            localRepo.push(newMasterHash, author.url(), "master");
+            localRepo.push(newMasterHash, author.authenticatedUrl(), "master");
             var newEditHash = CheckableRepository.appendAndCommit(localRepo, "Edit line", "New edit commit message");
-            localRepo.push(newEditHash, author.url(), "edit", true);
+            localRepo.push(newEditHash, author.authenticatedUrl(), "edit", true);
 
             // Run another archive pass
             TestBotRunner.runPeriodicItems(mlBot);
             listServer.processIncoming();
 
             // The archive should reference the rebased push
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertTrue(archiveContains(archiveFolder.path(), "has updated the pull request with a new target base"));
             assertTrue(archiveContains(archiveFolder.path(), pr.id() + "/01"));
             assertFalse(archiveContains(archiveFolder.path(), "Incremental"));
@@ -1868,13 +1868,13 @@ class MailingListBridgeBotTests {
             var reviewFile = Path.of("reviewfile.txt");
             var localRepo = CheckableRepository.init(tempFolder.path().resolve("first"), author.repositoryType(), reviewFile);
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
-            localRepo.push(masterHash, archive.url(), "webrev", true);
-            localRepo.push(masterHash, archive.url(), "archive", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+            localRepo.push(masterHash, archive.authenticatedUrl(), "webrev", true);
+            localRepo.push(masterHash, archive.authenticatedUrl(), "archive", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo, "A line", "Original msg");
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(archive, "master", "edit", "This is a pull request");
             pr.setBody("This is now ready");
 
@@ -1888,7 +1888,7 @@ class MailingListBridgeBotTests {
             Files.writeString(unrelatedFile, "Other things happens in master");
             localRepo.add(unrelatedFile);
             var newMasterHash = localRepo.commit("Unrelated change", "duke", "duke@openjdk.org");
-            localRepo.push(newMasterHash, author.url(), "master");
+            localRepo.push(newMasterHash, author.authenticatedUrl(), "master");
 
             // And more stuff to the pr branch
             localRepo.checkout(editHash, true);
@@ -1897,14 +1897,14 @@ class MailingListBridgeBotTests {
             // Merge master
             localRepo.merge(newMasterHash);
             var newEditHash = localRepo.commit("Latest changes from master", "duke", "duke@openjdk.org");
-            localRepo.push(newEditHash, author.url(), "edit");
+            localRepo.push(newEditHash, author.authenticatedUrl(), "edit");
 
             // Run another archive pass
             TestBotRunner.runPeriodicItems(mlBot);
             listServer.processIncoming();
 
             // The archive should reference the rebased push
-            Repository.materialize(archiveFolder.path(), archive.url(), "archive");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "archive");
             assertTrue(archiveContains(archiveFolder.path(), "has updated the pull request with a new target base"));
             assertTrue(archiveContains(archiveFolder.path(), "excludes"));
             assertTrue(archiveContains(archiveFolder.path(), pr.id() + "/01"));
@@ -1948,16 +1948,16 @@ class MailingListBridgeBotTests {
             var reviewFile = Path.of("reviewfile.txt");
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(), reviewFile);
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
-            localRepo.push(masterHash, archive.url(), "archive", true);
-            localRepo.push(masterHash, archive.url(), "webrev", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+            localRepo.push(masterHash, archive.authenticatedUrl(), "archive", true);
+            localRepo.push(masterHash, archive.authenticatedUrl(), "webrev", true);
 
             // Create a diverging branch
             var editOnlyFile = Path.of("editonly.txt");
             Files.writeString(localRepo.root().resolve(editOnlyFile), "Only added in the edit");
             localRepo.add(editOnlyFile);
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Edited");
-            localRepo.push(editHash, author.url(), "edit");
+            localRepo.push(editHash, author.authenticatedUrl(), "edit");
 
             // Make conflicting changes in the target
             localRepo.checkout(masterHash, true);
@@ -1965,7 +1965,7 @@ class MailingListBridgeBotTests {
             Files.writeString(localRepo.root().resolve(masterOnlyFile), "Only added in master");
             localRepo.add(masterOnlyFile);
             var updatedMasterHash = CheckableRepository.appendAndCommit(localRepo, "Master change");
-            localRepo.push(updatedMasterHash, author.url(), "master");
+            localRepo.push(updatedMasterHash, author.authenticatedUrl(), "master");
 
             // Perform the merge - resolve conflicts in our favor
             localRepo.merge(editHash, "ours");
@@ -1976,7 +1976,7 @@ class MailingListBridgeBotTests {
             Files.writeString(localRepo.root().resolve(reviewFile), "Overwriting the conflict resolution");
             localRepo.add(reviewFile);
             var appendedCommit = localRepo.amend("Updated merge commit", "duke", "duke@openjdk.org");
-            localRepo.push(appendedCommit, author.url(), "merge_of_edit", true);
+            localRepo.push(appendedCommit, author.authenticatedUrl(), "merge_of_edit", true);
 
             // Make a merge PR
             var pr = credentials.createPullRequest(archive, "master", "merge_of_edit", "Merge edit");
@@ -1987,7 +1987,7 @@ class MailingListBridgeBotTests {
             listServer.processIncoming();
 
             // The archive should contain a merge style webrev
-            Repository.materialize(archiveFolder.path(), archive.url(), "archive");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "archive");
             assertTrue(archiveContains(archiveFolder.path(), "The webrevs contain the adjustments done while merging with regards to each parent branch:"));
             assertTrue(archiveContains(archiveFolder.path(), pr.id() + "/00.0"));
             assertTrue(archiveContains(archiveFolder.path(), "3 lines in 2 files changed: 1 ins; 1 del; 1 mod"));
@@ -2034,9 +2034,9 @@ class MailingListBridgeBotTests {
             var reviewFile = Path.of("reviewfile.txt");
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(), reviewFile);
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
-            localRepo.push(masterHash, archive.url(), "archive", true);
-            localRepo.push(masterHash, archive.url(), "webrev", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+            localRepo.push(masterHash, archive.authenticatedUrl(), "archive", true);
+            localRepo.push(masterHash, archive.authenticatedUrl(), "webrev", true);
 
             // Create a merge
             var editOnlyFile = Path.of("editonly.txt");
@@ -2048,8 +2048,8 @@ class MailingListBridgeBotTests {
             Files.writeString(localRepo.root().resolve(masterOnlyFile), "Only added in master");
             localRepo.add(masterOnlyFile);
             var updatedMasterHash = CheckableRepository.appendAndCommit(localRepo, "Master change");
-            localRepo.push(updatedMasterHash, author.url(), "master");
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(updatedMasterHash, author.authenticatedUrl(), "master");
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
 
             // Make a merge PR
             var pr = credentials.createPullRequest(archive, "master", "edit", "Merge edit");
@@ -2060,7 +2060,7 @@ class MailingListBridgeBotTests {
             listServer.processIncoming();
 
             // The archive should contain a merge style webrev
-            Repository.materialize(archiveFolder.path(), archive.url(), "archive");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "archive");
             assertTrue(archiveContains(archiveFolder.path(), "The webrev contains the conflicts with master:"));
             assertTrue(archiveContains(archiveFolder.path(), pr.id() + "/00.conflicts"));
             assertTrue(archiveContains(archiveFolder.path(), "2 lines in 2 files changed: 2 ins; 0 del; 0 mod"));
@@ -2106,9 +2106,9 @@ class MailingListBridgeBotTests {
             var reviewFile = Path.of("reviewfile.txt");
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(), reviewFile);
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
-            localRepo.push(masterHash, archive.url(), "archive", true);
-            localRepo.push(masterHash, archive.url(), "webrev", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+            localRepo.push(masterHash, archive.authenticatedUrl(), "archive", true);
+            localRepo.push(masterHash, archive.authenticatedUrl(), "webrev", true);
 
             // Create a merge
             var editOnlyFile = Path.of("editonly.txt");
@@ -2120,10 +2120,10 @@ class MailingListBridgeBotTests {
             Files.writeString(localRepo.root().resolve(masterOnlyFile), "Only added in master");
             localRepo.add(masterOnlyFile);
             var updatedMasterHash = localRepo.commit("Only added in master", "duke", "duke@openjdk.org");
-            localRepo.push(updatedMasterHash, author.url(), "master");
+            localRepo.push(updatedMasterHash, author.authenticatedUrl(), "master");
             localRepo.merge(editHash);
             var mergeCommit = localRepo.commit("Merged edit", "duke", "duke@openjdk.org");
-            localRepo.push(mergeCommit, author.url(), "edit", true);
+            localRepo.push(mergeCommit, author.authenticatedUrl(), "edit", true);
 
             // Make a merge PR
             var pr = credentials.createPullRequest(archive, "master", "edit", "Merge edit");
@@ -2134,7 +2134,7 @@ class MailingListBridgeBotTests {
             listServer.processIncoming();
 
             // The archive should contain a merge style webrev
-            Repository.materialize(archiveFolder.path(), archive.url(), "archive");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "archive");
             assertTrue(archiveContains(archiveFolder.path(), "so no merge-specific webrevs have been generated"));
 
             // The PR should not contain a webrev comment
@@ -2176,13 +2176,13 @@ class MailingListBridgeBotTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
-            localRepo.push(masterHash, archive.url(), "webrev", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+            localRepo.push(masterHash, archive.authenticatedUrl(), "webrev", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo, "A simple change",
                                                                "Change msg\n\nWith several lines");
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(archive, "master", "edit", "This is a pull request");
 
             // Flag it as ready for review
@@ -2192,7 +2192,7 @@ class MailingListBridgeBotTests {
             TestBotRunner.runPeriodicItems(mlBot);
 
             // The archive should now contain an entry
-            var archiveRepo = Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            var archiveRepo = Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertTrue(archiveContains(archiveFolder.path(), editHash.abbreviate()));
 
             // And there should be a webrev comment
@@ -2206,7 +2206,7 @@ class MailingListBridgeBotTests {
             assertEquals(1, countSubstrings(webrevComments.get(0).body(), pr.id() + "/00"));
 
             // Pretend the archive didn't work out
-            archiveRepo.push(masterHash, archive.url(), "master", true);
+            archiveRepo.push(masterHash, archive.authenticatedUrl(), "master", true);
 
             // Run another archive pass
             TestBotRunner.runPeriodicItems(mlBot);
@@ -2257,12 +2257,12 @@ class MailingListBridgeBotTests {
             var reviewFile = Path.of("reviewfile.txt");
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(), reviewFile);
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
-            localRepo.push(masterHash, archive.url(), "webrev", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+            localRepo.push(masterHash, archive.authenticatedUrl(), "webrev", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(archive, "master", "edit", "This is a pull request");
             pr.setBody("This is now ready");
 
@@ -2277,7 +2277,7 @@ class MailingListBridgeBotTests {
             TestBotRunner.runPeriodicItems(mlBot);
 
             // The archive should contain a note
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertEquals(1, archiveContainsCount(archiveFolder.path(), "Changes requested by "));
             assertEquals(1, archiveContainsCount(archiveFolder.path(), " by integrationreviewer1"));
             assertEquals(1, archiveContainsCount(archiveFolder.path(), "Reason 1"));
@@ -2289,7 +2289,7 @@ class MailingListBridgeBotTests {
             TestBotRunner.runPeriodicItems(mlBot);
 
             // The archive should contain another note
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertEquals(1, archiveContainsCount(archiveFolder.path(), "Marked as reviewed by "));
             assertEquals(1, archiveContainsCount(archiveFolder.path(), "Reason 2"));
             assertEquals(2, archiveContainsCount(archiveFolder.path(), "Re: RFR:"));
@@ -2301,7 +2301,7 @@ class MailingListBridgeBotTests {
             TestBotRunner.runPeriodicItems(mlBot);
 
             // The archive should contain another note
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertEquals(2, archiveContainsCount(archiveFolder.path(), "Changes requested by "));
             assertEquals(1, archiveContainsCount(archiveFolder.path(), "Reason 3"));
         }
@@ -2342,12 +2342,12 @@ class MailingListBridgeBotTests {
             var reviewFile = Path.of("reviewfile.txt");
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(), reviewFile);
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
-            localRepo.push(masterHash, archive.url(), "webrev", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+            localRepo.push(masterHash, archive.authenticatedUrl(), "webrev", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(archive, "master", "edit", "This is a pull request");
             pr.setBody("This is now ready");
 
@@ -2364,7 +2364,7 @@ class MailingListBridgeBotTests {
             TestBotRunner.runPeriodicItems(mlBot);
 
             // The archive should not contain the ignored comments
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertTrue(archiveContains(archiveFolder.path(), "This is now ready"));
             assertFalse(archiveContains(archiveFolder.path(), "ignore this comment"));
             assertFalse(archiveContains(archiveFolder.path(), "it is time to"));
@@ -2407,12 +2407,12 @@ class MailingListBridgeBotTests {
             var reviewFile = Path.of("reviewfile.txt");
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(), reviewFile);
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
-            localRepo.push(masterHash, archive.url(), "webrev", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+            localRepo.push(masterHash, archive.authenticatedUrl(), "webrev", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(archive, "master", "edit", "This is a pull request");
             pr.setBody("This is now ready");
             TestBotRunner.runPeriodicItems(mlBot);
@@ -2429,7 +2429,7 @@ class MailingListBridgeBotTests {
             listServer.processIncoming();
 
             // The approval text should be included in the quote
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertEquals(1, archiveContainsCount(archiveFolder.path(), "^> Marked as reviewed"));
         }
     }
@@ -2467,12 +2467,12 @@ class MailingListBridgeBotTests {
             var reviewFile = Path.of("reviewfile.txt");
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(), reviewFile);
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
-            localRepo.push(masterHash, archive.url(), "webrev", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+            localRepo.push(masterHash, archive.authenticatedUrl(), "webrev", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Line 1\nLine 2\nLine 3\nLine 4");
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(archive, "master", "edit", "This is a pull request");
             pr.setBody("This is now ready");
 
@@ -2494,7 +2494,7 @@ class MailingListBridgeBotTests {
             listServer.processIncoming();
 
             // Check the archive
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertTrue(archiveContains(archiveFolder.path(), "Looks good"));
         }
     }
@@ -2532,12 +2532,12 @@ class MailingListBridgeBotTests {
             var reviewFile = Path.of("reviewfile.txt");
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(), reviewFile);
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
-            localRepo.push(masterHash, archive.url(), "webrev", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+            localRepo.push(masterHash, archive.authenticatedUrl(), "webrev", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Line 1\nLine 2\nLine 3\nLine 4");
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(archive, "master", "edit", "This is a pull request");
             pr.setBody("This is now ready");
 
@@ -2549,7 +2549,7 @@ class MailingListBridgeBotTests {
 
             // Commit another revision
             var updatedHash = CheckableRepository.appendAndCommit(localRepo, "More stuff");
-            localRepo.push(updatedHash, author.url(), "edit");
+            localRepo.push(updatedHash, author.authenticatedUrl(), "edit");
 
             // Bot with cooldown configured should not create a new webrev
             TestBotRunner.runPeriodicItems(mlBotWithCooldown);
@@ -2560,7 +2560,7 @@ class MailingListBridgeBotTests {
             listServer.processIncoming();
 
             // Check the archive
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertTrue(archiveContains(archiveFolder.path(), pr.id() + "/01"));
         }
     }
@@ -2599,12 +2599,12 @@ class MailingListBridgeBotTests {
             var reviewFile = Path.of("reviewfile.txt");
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(), reviewFile);
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
-            localRepo.push(masterHash, archive.url(), "webrev", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+            localRepo.push(masterHash, archive.authenticatedUrl(), "webrev", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Line 1\nLine 2\nLine 3\nLine 4");
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(archive, "master", "edit", "This is a pull request");
             pr.setBody("This is now ready");
 
@@ -2652,7 +2652,7 @@ class MailingListBridgeBotTests {
             listServer.processIncoming();
 
             // Check the archive
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertTrue(archiveContains(archiveFolder.path(), "Looks good - " + counter + " -"));
         }
     }
@@ -2689,13 +2689,13 @@ class MailingListBridgeBotTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
-            localRepo.push(masterHash, archive.url(), "webrev", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+            localRepo.push(masterHash, archive.authenticatedUrl(), "webrev", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo, "A simple change",
                                                                "Change msg\n\nWith several lines");
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(archive, "master", "edit", "1234: This is a pull request");
             pr.setBody("This is a PR");
 
@@ -2708,7 +2708,7 @@ class MailingListBridgeBotTests {
             listServer.processIncoming();
 
             // Check the archive
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertTrue(archiveContains(archiveFolder.path(), "Subject: \\[master\\] RFR: "));
             assertTrue(archiveContains(archiveFolder.path(), "Subject: Re: \\[master\\] RFR: "));
         }
@@ -2746,13 +2746,13 @@ class MailingListBridgeBotTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
-            localRepo.push(masterHash, archive.url(), "webrev", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+            localRepo.push(masterHash, archive.authenticatedUrl(), "webrev", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo, "A simple change",
                                                                "Change msg\n\nWith several lines");
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(archive, "master", "edit", "1234: This is a pull request");
             pr.setBody("This is a PR");
 
@@ -2765,7 +2765,7 @@ class MailingListBridgeBotTests {
             listServer.processIncoming();
 
             // Check the archive
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertTrue(archiveContains(archiveFolder.path(), "Subject: \\[" + pr.repository().name() + "\\] RFR: "));
             assertTrue(archiveContains(archiveFolder.path(), "Subject: Re: \\[" + pr.repository().name() + "\\] RFR: "));
         }
@@ -2804,13 +2804,13 @@ class MailingListBridgeBotTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
-            localRepo.push(masterHash, archive.url(), "webrev", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+            localRepo.push(masterHash, archive.authenticatedUrl(), "webrev", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo, "A simple change",
                                                                "Change msg\n\nWith several lines");
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(archive, "master", "edit", "1234: This is a pull request");
             pr.setBody("This is a PR");
 
@@ -2823,7 +2823,7 @@ class MailingListBridgeBotTests {
             listServer.processIncoming();
 
             // Check the archive
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertTrue(archiveContains(archiveFolder.path(), "Subject: \\[" + pr.repository().name() + ":master\\] RFR: "));
             assertTrue(archiveContains(archiveFolder.path(), "Subject: Re: \\[" + pr.repository().name() + ":master\\] RFR: "));
         }
@@ -2863,12 +2863,12 @@ class MailingListBridgeBotTests {
             var reviewFile = Path.of("reviewfile.txt");
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(), reviewFile);
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
-            localRepo.push(masterHash, archive.url(), "webrev", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+            localRepo.push(masterHash, archive.authenticatedUrl(), "webrev", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Line 1\nLine 2\nLine 3\nLine 4");
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(archive, "master", "edit", "This is a pull request");
             pr.setBody("This is now ready");
 
@@ -2883,7 +2883,7 @@ class MailingListBridgeBotTests {
             for (counter = 1; counter < 10; ++counter) {
                 var start = Instant.now();
                 var revHash = CheckableRepository.appendAndCommit(localRepo, "more stuff", "Update number - " + counter + " -");
-                localRepo.push(revHash, author.url(), "edit");
+                localRepo.push(revHash, author.authenticatedUrl(), "edit");
 
                 // The bot should not bridge the new revision due to cooldown
                 TestBotRunner.runPeriodicItems(mlBot);
@@ -2917,7 +2917,7 @@ class MailingListBridgeBotTests {
             listServer.processIncoming();
 
             // Check the archive
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertTrue(archiveContains(archiveFolder.path(), "Update number - " + counter + " -"));
         }
     }
@@ -2955,13 +2955,13 @@ class MailingListBridgeBotTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
-            localRepo.push(masterHash, archive.url(), "webrev", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+            localRepo.push(masterHash, archive.authenticatedUrl(), "webrev", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo, "A simple change",
                                                                "Change msg\n\nWith several lines");
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(archive, "master", "edit", "1234: This is a pull request");
             pr.setBody("This is a PR");
             pr.addLabel("list1");
@@ -3041,13 +3041,13 @@ class MailingListBridgeBotTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
-            localRepo.push(masterHash, archive.url(), "webrev", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+            localRepo.push(masterHash, archive.authenticatedUrl(), "webrev", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo, "A simple change",
                                                                "Change msg\n\nWith several lines");
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(archive, "master", "edit", "1234: This is a pull request");
             pr.setBody("This should not be ready");
 
@@ -3055,7 +3055,7 @@ class MailingListBridgeBotTests {
             TestBotRunner.runPeriodicItems(mlBot);
 
             // A PR that isn't ready for review should not be archived
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertFalse(archiveContains(archiveFolder.path(), "This is a pull request"));
 
             // Flag it as ready for review
@@ -3066,7 +3066,7 @@ class MailingListBridgeBotTests {
             TestBotRunner.runPeriodicItems(mlBot);
 
             // But it should still not be archived
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertFalse(archiveContains(archiveFolder.path(), "This is a pull request"));
 
             // Now post a general comment - not a ready marker
@@ -3077,7 +3077,7 @@ class MailingListBridgeBotTests {
             TestBotRunner.runPeriodicItems(mlBot);
 
             // It should still not be archived
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertFalse(archiveContains(archiveFolder.path(), "This is a pull request"));
 
             // Now post a ready comment
@@ -3087,7 +3087,7 @@ class MailingListBridgeBotTests {
             TestBotRunner.runPeriodicItems(mlBot);
 
             // The archive should now contain an entry
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertTrue(archiveContains(archiveFolder.path(), "This is a pull request"));
             assertTrue(archiveContains(archiveFolder.path(), "This should now be ready"));
             assertTrue(archiveContains(archiveFolder.path(), "Patch:"));
@@ -3116,7 +3116,7 @@ class MailingListBridgeBotTests {
             assertEquals("val2", mail.headerValue("Extra2"));
 
             // And there should be a JSON version of a webrev
-            Repository.materialize(webrevFolder.path(), archive.url(), "webrev");
+            Repository.materialize(webrevFolder.path(), archive.authenticatedUrl(), "webrev");
             var jsonDir = webrevFolder.path()
                                       .resolve(author.name())
                                       .resolve(pr.id())
@@ -3167,7 +3167,7 @@ class MailingListBridgeBotTests {
             TestBotRunner.runPeriodicItems(mlBot);
 
             // The archive should now contain the comment, but not the ignored one
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertTrue(archiveContains(archiveFolder.path(), "This is a comment"));
             assertTrue(archiveContains(archiveFolder.path(), "> This should now be ready"));
             assertFalse(archiveContains(archiveFolder.path(), "Don't mind me"));
@@ -3185,7 +3185,7 @@ class MailingListBridgeBotTests {
             TestBotRunner.runPeriodicItems(mlBot);
 
             // The archive should contain the additional comment
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertTrue(archiveContains(archiveFolder.path(), "This is another comment"));
             assertTrue(archiveContains(archiveFolder.path(), ">> This should now be ready"));
 
@@ -3239,13 +3239,13 @@ class MailingListBridgeBotTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
-            localRepo.push(masterHash, archive.url(), "webrev", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+            localRepo.push(masterHash, archive.authenticatedUrl(), "webrev", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo, "A simple change",
                                                                "Change msg\n\nWith several lines");
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(archive, "master", "edit", "1234: This is a pull request");
 
             // Flag it as ready for review
@@ -3253,7 +3253,7 @@ class MailingListBridgeBotTests {
             pr.addLabel("rfr");
 
             // The archive should not yet contain an entry
-            var archiveRepo = Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            var archiveRepo = Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
 
             // Interfere while creating
             webrevServer.setHandleCallback(uri -> {
@@ -3263,7 +3263,7 @@ class MailingListBridgeBotTests {
                         Files.writeString(unrelatedFile, "Unrelated");
                         archiveRepo.add(unrelatedFile);
                         var unrelatedHash = archiveRepo.commit("Unrelated", "duke", "duke@openjdk.org");
-                        archiveRepo.push(unrelatedHash, archive.url(), "master");
+                        archiveRepo.push(unrelatedHash, archive.authenticatedUrl(), "master");
                     }
                 } catch (IOException e) {
                     throw new UncheckedIOException(e);
@@ -3274,7 +3274,7 @@ class MailingListBridgeBotTests {
             TestBotRunner.runPeriodicItems(mlBot);
 
             // The archive should now contain an entry
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertTrue(archiveContains(archiveFolder.path(), "This is a pull request"));
             assertTrue(archiveContains(archiveFolder.path(), "This should now be ready"));
             assertTrue(archiveContains(archiveFolder.path(), "Patch:"));
@@ -3321,16 +3321,16 @@ class MailingListBridgeBotTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
-            localRepo.push(masterHash, archive.url(), "webrev", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+            localRepo.push(masterHash, archive.authenticatedUrl(), "webrev", true);
 
             // Create a separate change
             var depHash = CheckableRepository.appendAndCommit(localRepo, "A simple change");
-            localRepo.push(depHash, author.url(), "dep", true);
+            localRepo.push(depHash, author.authenticatedUrl(), "dep", true);
             var depPr = credentials.createPullRequest(archive, "master", "dep", "The first pr");
 
             // Simulate the pr dependency notifier creating the corresponding branch
-            localRepo.push(depHash, author.url(), "pr/" + depPr.id(), true);
+            localRepo.push(depHash, author.authenticatedUrl(), "pr/" + depPr.id(), true);
 
             // Run an archive pass
             TestBotRunner.runPeriodicItems(mlBot);
@@ -3340,7 +3340,7 @@ class MailingListBridgeBotTests {
             localRepo.checkout(masterHash, true);
             var editHash = CheckableRepository.appendAndCommit(localRepo, "A simple change",
                                                                "Change msg\n\nWith several lines");
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(archive, "pr/" + depPr.id(), "edit", "1234: This is a pull request");
             pr.setBody("This is a PR");
 
@@ -3353,7 +3353,7 @@ class MailingListBridgeBotTests {
             listServer.processIncoming();
 
             // Check the archive
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertTrue(archiveContains(archiveFolder.path(), "Subject: RFR: "), pr.id());
             assertTrue(archiveContains(archiveFolder.path(), "Subject: Re: RFR: ", pr.id()));
 
@@ -3395,12 +3395,12 @@ class MailingListBridgeBotTests {
             var reviewFile = Path.of("reviewfile.txt");
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(), reviewFile);
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
-            localRepo.push(masterHash, archive.url(), "webrev", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+            localRepo.push(masterHash, archive.authenticatedUrl(), "webrev", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(archive, "master", "edit", "This is a pull request");
             pr.setBody("This is now ready");
             TestBotRunner.runPeriodicItems(mlBot);
@@ -3429,7 +3429,7 @@ class MailingListBridgeBotTests {
             assertThrows(RuntimeException.class, () -> listServer.processIncoming(Duration.ofMillis(1)));
 
             // The first comment should be replied to once, and the original post once
-            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             assertEquals(1, archiveContainsCount(archiveFolder.path(), Pattern.quote("List User <listuser@openjdk.org>") + ".* wrote"));
             assertEquals(1, archiveContainsCount(archiveFolder.path(), Pattern.quote(pr.author().fullName()) + ".* wrote"));
 

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/WebrevStorageTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/WebrevStorageTests.java
@@ -50,15 +50,15 @@ class WebrevStorageTests {
             var repoFolder = tempFolder.path().resolve("repo");
             var localRepo = CheckableRepository.init(repoFolder, author.repositoryType(), reviewFile);
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
-            localRepo.push(masterHash, archive.url(), "webrev", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+            localRepo.push(masterHash, archive.authenticatedUrl(), "webrev", true);
 
             // Check that the web link wasn't verified yet
             assertFalse(webrevServer.isChecked());
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(archive, "master", "edit", "This is a pull request");
             pr.addLabel("rfr");
             pr.setBody("This is now ready");
@@ -68,7 +68,7 @@ class WebrevStorageTests {
                                             webrevServer.uri(), from);
 
             var prFolder = tempFolder.path().resolve("pr");
-            var prRepo = Repository.materialize(prFolder, pr.repository().url(), "edit");
+            var prRepo = Repository.materialize(prFolder, pr.repository().authenticatedUrl(), "edit");
             var scratchFolder = tempFolder.path().resolve("scratch");
             var generator = storage.generator(pr, prRepo, scratchFolder);
             generator.generate(masterHash, editHash, "00", WebrevDescription.Type.FULL);
@@ -78,12 +78,12 @@ class WebrevStorageTests {
             assertTrue(webrevServer.isRedirectFollowed());
 
             // Update the local repository and check that the webrev has been generated
-            Repository.materialize(repoFolder, archive.url(), "webrev");
+            Repository.materialize(repoFolder, archive.authenticatedUrl(), "webrev");
             assertTrue(Files.exists(repoFolder.resolve("test/" + pr.id() + "/00/index.html")));
 
             // Create it again - it will overwrite the previous one
             generator.generate(masterHash, editHash, "00", WebrevDescription.Type.FULL);
-            Repository.materialize(repoFolder, archive.url(), "webrev");
+            Repository.materialize(repoFolder, archive.authenticatedUrl(), "webrev");
             assertTrue(Files.exists(repoFolder.resolve("test/" + pr.id() + "/00/index.html")));
         }
     }
@@ -101,8 +101,8 @@ class WebrevStorageTests {
             var repoFolder = tempFolder.path().resolve("repo");
             var localRepo = CheckableRepository.init(repoFolder, author.repositoryType(), reviewFile);
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
-            localRepo.push(masterHash, archive.url(), "webrev", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+            localRepo.push(masterHash, archive.authenticatedUrl(), "webrev", true);
 
             // Make a change with a corresponding PR
             CheckableRepository.appendAndCommit(localRepo);
@@ -111,7 +111,7 @@ class WebrevStorageTests {
             localRepo.add(repoFolder.resolve("large.txt"));
             var editHash = localRepo.commit("Add large file", "duke", "duke@openjdk.org");
 
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(archive, "master", "edit", "This is a pull request");
             pr.addLabel("rfr");
             pr.setBody("This is now ready");
@@ -121,13 +121,13 @@ class WebrevStorageTests {
                                             webrevServer.uri(), from);
 
             var prFolder = tempFolder.path().resolve("pr");
-            var prRepo = Repository.materialize(prFolder, pr.repository().url(), "edit");
+            var prRepo = Repository.materialize(prFolder, pr.repository().authenticatedUrl(), "edit");
             var scratchFolder = tempFolder.path().resolve("scratch");
             var generator = storage.generator(pr, prRepo, scratchFolder);
             generator.generate(masterHash, editHash, "00", WebrevDescription.Type.FULL);
 
             // Update the local repository and check that the webrev has been generated
-            Repository.materialize(repoFolder, archive.url(), "webrev");
+            Repository.materialize(repoFolder, archive.authenticatedUrl(), "webrev");
             assertTrue(Files.exists(repoFolder.resolve("test/" + pr.id() + "/00/index.html")));
             assertTrue(Files.size(repoFolder.resolve("test/" + pr.id() + "/00/large.txt")) > 0);
             assertTrue(Files.size(repoFolder.resolve("test/" + pr.id() + "/00/large.txt")) < 1000);
@@ -159,11 +159,11 @@ class WebrevStorageTests {
                 }
 
                 try {
-                    var repo = Repository.materialize(scratchPath, archive.url(), ref);
+                    var repo = Repository.materialize(scratchPath, archive.authenticatedUrl(), ref);
                     Files.writeString(repo.root().resolve("intercept.txt"), UUID.randomUUID().toString(), StandardCharsets.UTF_8);
                     repo.add(repo.root().resolve("intercept.txt"));
                     var commit = repo.commit("Concurrent unrelated commit", "duke", "duke@openjdk.org");
-                    repo.push(commit, archive.url(), ref);
+                    repo.push(commit, archive.authenticatedUrl(), ref);
                     hasIntercepted = true;
                 } catch (IOException e) {
                     throw new UncheckedIOException(e);
@@ -189,12 +189,12 @@ class WebrevStorageTests {
             var repoFolder = tempFolder.path().resolve("repo");
             var localRepo = CheckableRepository.init(repoFolder, author.repositoryType(), reviewFile);
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
-            localRepo.push(masterHash, archive.url(), "webrev", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+            localRepo.push(masterHash, archive.authenticatedUrl(), "webrev", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(archive, "master", "edit", "This is a pull request");
             pr.addLabel("rfr");
             pr.setBody("This is now ready");
@@ -204,7 +204,7 @@ class WebrevStorageTests {
                                             webrevServer.uri(), from);
 
             var prFolder = tempFolder.path().resolve("pr");
-            var prRepo = Repository.materialize(prFolder, pr.repository().url(), "edit");
+            var prRepo = Repository.materialize(prFolder, pr.repository().authenticatedUrl(), "edit");
             var scratchFolder = tempFolder.path().resolve("scratch");
             var generatorProgressMarker = scratchFolder.resolve("test/" + pr.id() + "/00/nanoduke.ico");
             var generator = storage.generator(pr, prRepo, scratchFolder);
@@ -217,7 +217,7 @@ class WebrevStorageTests {
             generator.generate(masterHash, interceptEditHash, "00", WebrevDescription.Type.FULL);
 
             // Update the local repository and check that the webrev has been generated
-            var archiveRepo = Repository.materialize(repoFolder, archive.url(), "webrev");
+            var archiveRepo = Repository.materialize(repoFolder, archive.authenticatedUrl(), "webrev");
             assertTrue(Files.exists(repoFolder.resolve("test/" + pr.id() + "/00/index.html")));
 
             // The intercepting commit should be present in the history

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryWorkItem.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryWorkItem.java
@@ -349,11 +349,11 @@ public class RepositoryWorkItem implements WorkItem {
 
         try {
             var localRepo = repositoryPool.materializeBare(repository, scratchPath.resolve("notify").resolve("repowi").resolve(repository.name()));
-            var knownRefs = localRepo.remoteBranches(repository.url().toString())
+            var knownRefs = localRepo.remoteBranches(repository.authenticatedUrl().toString())
                                      .stream()
                                      .filter(ref -> branches.matcher(ref.name()).matches())
                                      .collect(Collectors.toList());
-            localRepo.fetchAll(repository.url(), true);
+            localRepo.fetchAll(repository.authenticatedUrl(), true);
 
             var history = UpdateHistory.create(tagStorageBuilder, historyPath.resolve("tags"), branchStorageBuilder, historyPath.resolve("branches"));
             var errors = new ArrayList<Throwable>();

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifier.java
@@ -109,7 +109,7 @@ public class PullRequestBranchNotifier implements Notifier, PullRequestListener 
                             git commit -m "Merge %s"
                             git push
                             ```
-                            """.formatted(retargeted.sourceRef(), pr.repository().webUrl(), pr.targetRef(),
+                            """.formatted(retargeted.sourceRef(), pr.repository().remoteUrl(), pr.targetRef(),
                             pr.targetRef()));
                 }
             } else {

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifier.java
@@ -50,14 +50,14 @@ public class PullRequestBranchNotifier implements Notifier, PullRequestListener 
         var hostedRepositoryPool = new HostedRepositoryPool(seedFolder);
         try {
             var seedRepo = hostedRepositoryPool.seedRepository(pr.repository(), false);
-            seedRepo.fetch(pr.repository().url(), pr.headHash().hex());
+            seedRepo.fetch(pr.repository().authenticatedUrl(), pr.headHash().hex());
             String branch = PreIntegrations.preIntegrateBranch(pr);
             if (protectBranches) {
                 log.info("Protecting branch " + branch);
                 pr.repository().protectBranchPattern(branch);
             }
             log.info("Creating new pull request pre-integration branch " + branch);
-            seedRepo.push(pr.headHash(), pr.repository().url(), branch, true);
+            seedRepo.push(pr.headHash(), pr.repository().authenticatedUrl(), branch, true);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -109,7 +109,7 @@ public class PullRequestBranchNotifier implements Notifier, PullRequestListener 
                             git commit -m "Merge %s"
                             git push
                             ```
-                            """.formatted(retargeted.sourceRef(), pr.repository().remoteUrl(), pr.targetRef(),
+                            """.formatted(retargeted.sourceRef(), pr.repository().url(), pr.targetRef(),
                             pr.targetRef()));
                 }
             } else {

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/RepositoryWorkItemTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/RepositoryWorkItemTests.java
@@ -74,7 +74,7 @@ public class RepositoryWorkItemTests {
             var repoFolder = tempFolder.path().resolve("repo");
             var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
             credentials.commitLock(localRepo);
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
@@ -94,7 +94,7 @@ public class RepositoryWorkItemTests {
             // Create an initial tag to start history tracking. The notifier will never notify the first tag
             var masterHash = localRepo.head();
             localRepo.tag(masterHash, "initial-tag", "Tagging initial tag", "testauthor", "ta@none.none");
-            localRepo.push(masterHash, repo.url(), "master", false, true);
+            localRepo.push(masterHash, repo.authenticatedUrl(), "master", false, true);
 
             // Run bot to initialize notification history
             TestBotRunner.runPeriodicItems(notifyBot);
@@ -102,7 +102,7 @@ public class RepositoryWorkItemTests {
             // Create a "pr"-branch with a commit in it and tag that commit
             var prBranchHash = CheckableRepository.appendAndCommit(localRepo, "Another line", "Change in pr branch");
             localRepo.tag(prBranchHash, "pr-tag", "Tagging change in pr branch", "testauthor", "ta@none.none");
-            localRepo.push(prBranchHash, repo.url(), "pr/4711", false, true);
+            localRepo.push(prBranchHash, repo.authenticatedUrl(), "pr/4711", false, true);
 
             // Run the bot and verify that notifier is not called
             TestBotRunner.runPeriodicItems(notifyBot);
@@ -112,7 +112,7 @@ public class RepositoryWorkItemTests {
             localRepo.checkout(masterHash);
             var masterTaggedHash = CheckableRepository.appendAndCommit(localRepo, "Master line", "Change in master branch");
             localRepo.tag(masterTaggedHash, "master-tag", "Tagging change in master branch", "testauthor", "ta@none.none");
-            localRepo.push(masterTaggedHash, repo.url(), "master", false, true);
+            localRepo.push(masterTaggedHash, repo.authenticatedUrl(), "master", false, true);
 
             // Run the bot and verify that notifier is called for master branch
             TestBotRunner.runPeriodicItems(notifyBot);

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdateHistoryTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdateHistoryTests.java
@@ -45,7 +45,7 @@ class UpdateHistoryTests {
         Files.writeString(firstFile, "First file to commit");
         localRepository.add(firstFile);
         var firstCommit = localRepository.commit("First commit", "Duke", "duke@openjdk.org");
-        localRepository.push(firstCommit, repository.url(), localRepository.defaultBranch().toString(), true);
+        localRepository.push(firstCommit, repository.authenticatedUrl(), localRepository.defaultBranch().toString(), true);
         return localRepository.defaultBranch().toString();
     }
 

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdaterTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/UpdaterTests.java
@@ -104,7 +104,7 @@ public class UpdaterTests {
             var repoFolder = tempFolder.path().resolve("repo");
             var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
             credentials.commitLock(localRepo);
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
@@ -131,7 +131,7 @@ public class UpdaterTests {
 
             // Create an issue and commit a fix
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", "Fix stuff");
-            localRepo.push(editHash, repo.url(), "master");
+            localRepo.push(editHash, repo.authenticatedUrl(), "master");
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // Both updaters should have run
@@ -139,7 +139,7 @@ public class UpdaterTests {
             assertEquals(2, nonIdempotent.updateCount);
 
             var nextEditHash = CheckableRepository.appendAndCommit(localRepo, "Yet another line", "Fix more stuff");
-            localRepo.push(nextEditHash, repo.url(), "master");
+            localRepo.push(nextEditHash, repo.authenticatedUrl(), "master");
 
             idempotent.shouldFail = true;
             nonIdempotent.shouldFail = true;

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/comment/CommitCommentNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/comment/CommitCommentNotifierTests.java
@@ -43,7 +43,7 @@ public class CommitCommentNotifierTests {
             var repoFolder = tempFolder.path().resolve("repo");
             var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
             credentials.commitLock(localRepo);
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
@@ -69,11 +69,11 @@ public class CommitCommentNotifierTests {
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // Save the state
-            var historyState = localRepo.fetch(repo.url(), "history");
+            var historyState = localRepo.fetch(repo.authenticatedUrl(), "history");
 
             // Commit a fix
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", "Fix an issue");
-            localRepo.push(editHash, repo.url(), "master");
+            localRepo.push(editHash, repo.authenticatedUrl(), "master");
             var pr = credentials.createPullRequest(repo, "master", "master", "Fix an issue");
             pr.setBody("I made a fix");
             pr.addLabel("integrated");
@@ -106,7 +106,7 @@ public class CommitCommentNotifierTests {
             var repoFolder = tempFolder.path().resolve("repo");
             var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
             credentials.commitLock(localRepo);
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
@@ -138,10 +138,10 @@ public class CommitCommentNotifierTests {
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // Save the state
-            var historyState = localRepo.fetch(repo.url(), "history");
+            var historyState = localRepo.fetch(repo.authenticatedUrl(), "history");
 
             // Commit a fix
-            localRepo.push(editHash, repo.url(), "master");
+            localRepo.push(editHash, repo.authenticatedUrl(), "master");
             var pr = credentials.createPullRequest(repo, "master", "master", commitMessageTitle);
             pr.setBody("\n\n### Issue\n * [" + issue.id() + "](http://www.test.test/): The issue");
             pr.addLabel("integrated");
@@ -181,7 +181,7 @@ public class CommitCommentNotifierTests {
             var repoFolder = tempFolder.path().resolve("repo");
             var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
             credentials.commitLock(localRepo);
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
@@ -207,11 +207,11 @@ public class CommitCommentNotifierTests {
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // Save the state
-            var historyState = localRepo.fetch(repo.url(), "history");
+            var historyState = localRepo.fetch(repo.authenticatedUrl(), "history");
 
             // Commit a fix
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", "Fix an issue");
-            localRepo.push(editHash, repo.url(), "master");
+            localRepo.push(editHash, repo.authenticatedUrl(), "master");
             var pr = credentials.createPullRequest(repo, "master", "master", "Fix an issue");
             pr.setBody("I made a fix");
             pr.addLabel("integrated");

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
@@ -94,7 +94,7 @@ public class IssueNotifierTests {
             var repoFolder = tempFolder.path().resolve("repo");
             var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
             credentials.commitLock(localRepo);
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
@@ -125,12 +125,12 @@ public class IssueNotifierTests {
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // Save the state
-            var historyState = localRepo.fetch(repo.url(), "history");
+            var historyState = localRepo.fetch(repo.authenticatedUrl(), "history");
 
             // Create an issue and commit a fix
             var issue = issueProject.createIssue("This is an issue", List.of("Indeed"), Map.of("issuetype", JSON.of("Enhancement")));
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", issue.id() + ": Fix that issue");
-            localRepo.push(editHash, repo.url(), "master");
+            localRepo.push(editHash, repo.authenticatedUrl(), "master");
             var pr = credentials.createPullRequest(repo, "master", "master", issue.id() + ": Fix that issue");
             pr.setBody("\n\n### Issue\n * [" + issue.id() + "](http://www.test.test/): The issue");
             pr.addLabel("integrated");
@@ -146,7 +146,7 @@ public class IssueNotifierTests {
             assertEquals(repo.webUrl(editHash), link.uri().orElseThrow());
 
             // Wipe the history
-            localRepo.push(historyState, repo.url(), "history", true);
+            localRepo.push(historyState, repo.authenticatedUrl(), "history", true);
 
             // Run it again
             TestBotRunner.runPeriodicItems(notifyBot);
@@ -166,7 +166,7 @@ public class IssueNotifierTests {
             var repoFolder = tempFolder.path().resolve("repo");
             var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
             credentials.commitLock(localRepo);
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
@@ -197,7 +197,7 @@ public class IssueNotifierTests {
             // Create an issue and a pull request to fix it
             var issue = issueProject.createIssue("This is an issue", List.of("Indeed"), Map.of("issuetype", JSON.of("Enhancement")));
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", "Fix that issue");
-            localRepo.push(editHash, repo.url(), "edit", true);
+            localRepo.push(editHash, repo.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(repo, "edit", "master", issue.id() + ": Fix that issue");
             pr.setBody("\n\n### Issue\n * [" + issue.id() + "](http://www.test.test/): The issue");
             TestBotRunner.runPeriodicItems(notifyBot);
@@ -328,7 +328,7 @@ public class IssueNotifierTests {
             var repoFolder = tempFolder.path().resolve("repo");
             var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
             credentials.commitLock(localRepo);
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
@@ -360,7 +360,7 @@ public class IssueNotifierTests {
             // Create an issue and a pull request to fix it
             var issue = issueProject.createIssue("This is an issue", List.of("Indeed"), Map.of("issuetype", JSON.of("Enhancement")));
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", "Fix that issue");
-            localRepo.push(editHash, repo.url(), "edit", true);
+            localRepo.push(editHash, repo.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(repo, "edit", "master", issue.id() + ": Fix that issue");
             pr.setBody("\n\n### Issue\n * [" + issue.id() + "](http://www.test.test/): The issue");
             TestBotRunner.runPeriodicItems(notifyBot);
@@ -393,7 +393,7 @@ public class IssueNotifierTests {
             var repoFolder = tempFolder.path().resolve("repo");
             var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
             credentials.commitLock(localRepo);
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             var issueProject = credentials.getIssueProject();
             var storageFolder = tempFolder.path().resolve("storage");
@@ -413,7 +413,7 @@ public class IssueNotifierTests {
             // Push a commit and create a pull request
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line",
                             issue.id() + ": This is an issue\n", "Duke", authorEmailAddress);
-            localRepo.push(editHash, repo.url(), "master");
+            localRepo.push(editHash, repo.authenticatedUrl(), "master");
             var pr = credentials.createPullRequest(repo, "edit", "master", issue.id() + ": This is an issue");
             pr.setBody("\n\n### Issues\n" +
                     " * [" + issue.id() + "](http://www.test.test/): This is an issue\n" +
@@ -468,7 +468,7 @@ public class IssueNotifierTests {
             var repoFolder = tempFolder.path().resolve("repo");
             var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
             credentials.commitLock(localRepo);
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             var issueProject = credentials.getIssueProject();
             var storageFolder = tempFolder.path().resolve("storage");
@@ -487,7 +487,7 @@ public class IssueNotifierTests {
             // Push a commit and create a pull request
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line",
                     issue.id() + ": This is an issue\n", "Duke", authorEmailAddress);
-            localRepo.push(editHash, repo.url(), "master");
+            localRepo.push(editHash, repo.authenticatedUrl(), "master");
             var pr = credentials.createPullRequest(repo, "edit", "master", issue.id() + ": This is an issue");
             pr.setBody("\n\n### Issues\n" +
                     " * [" + issue.id() + "](http://www.test.test/): This is an issue\n" +
@@ -527,7 +527,7 @@ public class IssueNotifierTests {
             var repoFolder = tempFolder.path().resolve("repo");
             var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
             credentials.commitLock(localRepo);
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             var issueProject = credentials.getIssueProject();
             var storageFolder = tempFolder.path().resolve("storage");
@@ -536,13 +536,13 @@ public class IssueNotifierTests {
             var notifyBot = testBotBuilder(repo, issueProject, storageFolder, jbsNotifierConfig).create("notify", JSON.object());
 
             // Initialize history
-            localRepo.push(localRepo.resolve("master").orElseThrow(), repo.url(), "other");
+            localRepo.push(localRepo.resolve("master").orElseThrow(), repo.authenticatedUrl(), "other");
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // Create an issue and a pull request to fix it
             var issue = issueProject.createIssue("This is an issue", List.of("Indeed"), Map.of("issuetype", JSON.of("Enhancement")));
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", issue.id() + ": Fix that issue");
-            localRepo.push(editHash, repo.url(), "edit", true);
+            localRepo.push(editHash, repo.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(repo, "other", "edit", issue.id() + ": Fix that issue");
             pr.setBody("\n\n### Issue\n * [" + issue.id() + "](http://www.test.test/): The issue");
             pr.addLabel("rfr");
@@ -562,7 +562,7 @@ public class IssueNotifierTests {
             pr.addComment("Pushed as commit " + editHash.hex() + ".");
             pr.addLabel("integrated");
             pr.setState(Issue.State.CLOSED);
-            localRepo.push(editHash, repo.url(), "other");
+            localRepo.push(editHash, repo.authenticatedUrl(), "other");
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The changeset should be reflected in another link
@@ -577,7 +577,7 @@ public class IssueNotifierTests {
             assertTrue(comments.get(0).body().contains(pr.webUrl().toString()));
 
             // Now simulate a merge to another branch
-            localRepo.push(editHash, repo.url(), "master");
+            localRepo.push(editHash, repo.authenticatedUrl(), "master");
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // No additional link should have been created
@@ -602,7 +602,7 @@ public class IssueNotifierTests {
             var repoFolder = tempFolder.path().resolve("repo");
             var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
             credentials.commitLock(localRepo);
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             var issueProject = credentials.getIssueProject();
             var storageFolder = tempFolder.path().resolve("storage");
@@ -624,7 +624,7 @@ public class IssueNotifierTests {
                                                                        issue2.id() + ": And fix the other issue\n" +
                                                                        issue3.id() + ": As well as this one\n",
                                                                "Duke", authorEmailAddress);
-            localRepo.push(editHash, repo.url(), "master");
+            localRepo.push(editHash, repo.authenticatedUrl(), "master");
             TestBotRunner.runPeriodicItems(notifyBot);
             TestBotRunner.runPeriodicItems(notifyBot);
 
@@ -669,7 +669,7 @@ public class IssueNotifierTests {
             var repoFolder = tempFolder.path().resolve("repo");
             var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
             credentials.commitLock(localRepo);
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             var issueProject = credentials.getIssueProject();
             var storageFolder = tempFolder.path().resolve("storage");
@@ -684,7 +684,7 @@ public class IssueNotifierTests {
             var authorEmailAddress = issueProject.issueTracker().currentUser().username() + "@openjdk.org";
             var issue = issueProject.createIssue("This is an issue", List.of("Indeed"), Map.of("issuetype", JSON.of("Enhancement")));
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", issue.id() + ": Fix that issue", "Duke", authorEmailAddress);
-            localRepo.push(editHash, repo.url(), "master");
+            localRepo.push(editHash, repo.authenticatedUrl(), "master");
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The changeset should be reflected in a comment
@@ -714,7 +714,7 @@ public class IssueNotifierTests {
             var repoFolder = tempFolder.path().resolve("repo");
             var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
             credentials.commitLock(localRepo);
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             var issueProject = credentials.getIssueProject();
             var storageFolder = tempFolder.path().resolve("storage");
@@ -742,7 +742,7 @@ public class IssueNotifierTests {
             var authorEmailAddress = issueProject.issueTracker().currentUser().username() + "@openjdk.org";
             var issue = issueProject.createIssue("This is an issue", List.of("Indeed"), Map.of("issuetype", JSON.of("Enhancement")));
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", issue.id() + ": Fix that issue", "Duke", authorEmailAddress);
-            localRepo.push(editHash, repo.url(), "master");
+            localRepo.push(editHash, repo.authenticatedUrl(), "master");
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The changeset should be reflected in a comment
@@ -762,8 +762,8 @@ public class IssueNotifierTests {
             assertEquals(List.of(issueProject.issueTracker().currentUser()), updatedIssue.assignees());
 
             // Restore the history to simulate looking at another repository
-            localRepo.fetch(repo.url(), "history");
-            localRepo.push(blankHistory, repo.url(), "history", true);
+            localRepo.fetch(repo.authenticatedUrl(), "history");
+            localRepo.push(blankHistory, repo.authenticatedUrl(), "history", true);
 
             // When the second notifier sees it, it should upgrade the build name
             TestBotRunner.runPeriodicItems(notifyBot2);
@@ -772,8 +772,8 @@ public class IssueNotifierTests {
             assertEquals("master", updatedIssue.properties().get(RESOLVED_IN_BUILD).asString());
 
             // Restore the history to simulate looking at another repository
-            localRepo.fetch(repo.url(), "history");
-            localRepo.push(blankHistory, repo.url(), "history", true);
+            localRepo.fetch(repo.authenticatedUrl(), "history");
+            localRepo.push(blankHistory, repo.authenticatedUrl(), "history", true);
 
             // When the third notifier sees it, it should switch to a build number
             TestBotRunner.runPeriodicItems(notifyBot3);
@@ -782,8 +782,8 @@ public class IssueNotifierTests {
             assertEquals("b04", updatedIssue.properties().get(RESOLVED_IN_BUILD).asString());
 
             // Restore the history to simulate looking at another repository
-            localRepo.fetch(repo.url(), "history");
-            localRepo.push(blankHistory, repo.url(), "history", true);
+            localRepo.fetch(repo.authenticatedUrl(), "history");
+            localRepo.push(blankHistory, repo.authenticatedUrl(), "history", true);
 
             // When the fourth notifier sees it, it should switch to a lower build number
             TestBotRunner.runPeriodicItems(notifyBot4);
@@ -792,8 +792,8 @@ public class IssueNotifierTests {
             assertEquals("b02", updatedIssue.properties().get(RESOLVED_IN_BUILD).asString());
 
             // Restore the history to simulate looking at another repository
-            localRepo.fetch(repo.url(), "history");
-            localRepo.push(blankHistory, repo.url(), "history", true);
+            localRepo.fetch(repo.authenticatedUrl(), "history");
+            localRepo.push(blankHistory, repo.authenticatedUrl(), "history", true);
 
             // When the fifth notifier sees it, it should NOT switch to a higher build number
             TestBotRunner.runPeriodicItems(notifyBot5);
@@ -812,7 +812,7 @@ public class IssueNotifierTests {
             var repoFolder = tempFolder.path().resolve("repo");
             var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
             credentials.commitLock(localRepo);
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             var issueProject = credentials.getIssueProject();
             var storageFolder = tempFolder.path().resolve("storage");
@@ -823,14 +823,14 @@ public class IssueNotifierTests {
             // Initialize history
             var current = localRepo.resolve("master").orElseThrow();
             localRepo.tag(current, "jdk-16+9", "First tag", "duke", "duke@openjdk.org");
-            localRepo.push(new Branch(repo.url().toString()), "--tags", false);
+            localRepo.push(new Branch(repo.authenticatedUrl().toString()), "--tags", false);
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // Create an issue and commit a fix
             var authorEmailAddress = issueProject.issueTracker().currentUser().username() + "@openjdk.org";
             var issue = issueProject.createIssue("This is an issue", List.of("Indeed"), Map.of("issuetype", JSON.of("Enhancement")));
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", issue.id() + ": Fix that issue", "Duke", authorEmailAddress);
-            localRepo.push(editHash, repo.url(), "master");
+            localRepo.push(editHash, repo.authenticatedUrl(), "master");
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The changeset should be reflected in a comment
@@ -851,7 +851,7 @@ public class IssueNotifierTests {
 
             // Tag it
             localRepo.tag(editHash, "jdk-16+110", "Second tag", "duke", "duke@openjdk.org");
-            localRepo.push(new Branch(repo.url().toString()), "--tags", false);
+            localRepo.push(new Branch(repo.authenticatedUrl().toString()), "--tags", false);
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The build should now be updated
@@ -860,7 +860,7 @@ public class IssueNotifierTests {
 
             // Tag it again
             localRepo.tag(editHash, "jdk-16+10", "Third tag", "duke", "duke@openjdk.org");
-            localRepo.push(new Branch(repo.url().toString()), "--tags", false);
+            localRepo.push(new Branch(repo.authenticatedUrl().toString()), "--tags", false);
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The build should now be updated
@@ -869,7 +869,7 @@ public class IssueNotifierTests {
 
             // Tag it once again
             localRepo.tag(editHash, "jdk-16+8", "Fourth tag", "duke", "duke@openjdk.org");
-            localRepo.push(new Branch(repo.url().toString()), "--tags", false);
+            localRepo.push(new Branch(repo.authenticatedUrl().toString()), "--tags", false);
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The build should now be updated
@@ -887,7 +887,7 @@ public class IssueNotifierTests {
             var repoFolder = tempFolder.path().resolve("repo");
             var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
             credentials.commitLock(localRepo);
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             var issueProject = credentials.getIssueProject();
             var storageFolder = tempFolder.path().resolve("storage");
@@ -900,9 +900,9 @@ public class IssueNotifierTests {
 
             // Initialize history
             var current = localRepo.resolve("master").orElseThrow();
-            localRepo.push(current, repo.url(), "other");
+            localRepo.push(current, repo.authenticatedUrl(), "other");
             localRepo.tag(current, "jdk-16+9", "First tag", "duke", "duke@openjdk.org");
-            localRepo.push(new Branch(repo.url().toString()), "--tags", false);
+            localRepo.push(new Branch(repo.authenticatedUrl().toString()), "--tags", false);
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // Create an issue and commit a fix
@@ -910,10 +910,10 @@ public class IssueNotifierTests {
             var issue = issueProject.createIssue("This is an issue", List.of("Indeed"), Map.of("issuetype", JSON.of("Enhancement")));
             issue.setProperty("fixVersions", JSON.of("16.0.2"));
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", issue.id() + ": Fix that issue", "Duke", authorEmailAddress);
-            localRepo.push(editHash, repo.url(), "master");
-            localRepo.push(editHash, repo.url(), "other");
+            localRepo.push(editHash, repo.authenticatedUrl(), "master");
+            localRepo.push(editHash, repo.authenticatedUrl(), "other");
             // Add an extra branch that is not configured with any fixVersion
-            localRepo.push(editHash, repo.url(), "extra");
+            localRepo.push(editHash, repo.authenticatedUrl(), "extra");
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The changeset should be reflected in a comment in the issue and in a new backport
@@ -944,7 +944,7 @@ public class IssueNotifierTests {
 
             // Tag it
             localRepo.tag(editHash, "jdk-16+110", "Second tag", "duke", "duke@openjdk.org");
-            localRepo.push(new Branch(repo.url().toString()), "--tags", false);
+            localRepo.push(new Branch(repo.authenticatedUrl().toString()), "--tags", false);
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The build should now be updated
@@ -956,7 +956,7 @@ public class IssueNotifierTests {
 
             // Tag it again
             localRepo.tag(editHash, "jdk-16+10", "Third tag", "duke", "duke@openjdk.org");
-            localRepo.push(new Branch(repo.url().toString()), "--tags", false);
+            localRepo.push(new Branch(repo.authenticatedUrl().toString()), "--tags", false);
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The build should now be updated
@@ -967,7 +967,7 @@ public class IssueNotifierTests {
 
             // Tag it once again
             localRepo.tag(editHash, "jdk-16+8", "Fourth tag", "duke", "duke@openjdk.org");
-            localRepo.push(new Branch(repo.url().toString()), "--tags", false);
+            localRepo.push(new Branch(repo.authenticatedUrl().toString()), "--tags", false);
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The build should now be updated
@@ -987,7 +987,7 @@ public class IssueNotifierTests {
             var repoFolder = tempFolder.path().resolve("repo");
             var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
             credentials.commitLock(localRepo);
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             var issueProject = credentials.getIssueProject();
             var storageFolder = tempFolder.path().resolve("storage");
@@ -999,10 +999,10 @@ public class IssueNotifierTests {
 
             // Initialize history
             var current = localRepo.resolve("master").orElseThrow();
-            localRepo.push(current, repo.url(), "other");
+            localRepo.push(current, repo.authenticatedUrl(), "other");
             localRepo.tag(current, "jdk8u342-b00", "First tag", "duke", "duke@openjdk.org");
             localRepo.tag(current, "jdk9u352-b00", "First unrelated tag", "duke", "duke@openjdk.org");
-            localRepo.push(new Branch(repo.url().toString()), "--tags", false);
+            localRepo.push(new Branch(repo.authenticatedUrl().toString()), "--tags", false);
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // Create an issue and commit a fix
@@ -1010,10 +1010,10 @@ public class IssueNotifierTests {
             var issue = issueProject.createIssue("This is an issue", List.of("Indeed"), Map.of("issuetype", JSON.of("Enhancement")));
             issue.setProperty("fixVersions", JSON.of("openjdk8u352"));
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", issue.id() + ": Fix that issue", "Duke", authorEmailAddress);
-            localRepo.push(editHash, repo.url(), "master");
-            localRepo.push(editHash, repo.url(), "other");
+            localRepo.push(editHash, repo.authenticatedUrl(), "master");
+            localRepo.push(editHash, repo.authenticatedUrl(), "other");
             // Add an extra branch that is not configured with any fixVersion
-            localRepo.push(editHash, repo.url(), "extra");
+            localRepo.push(editHash, repo.authenticatedUrl(), "extra");
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The changeset should be reflected in a comment in the issue and in a new backport
@@ -1044,7 +1044,7 @@ public class IssueNotifierTests {
 
             // Tag it
             localRepo.tag(editHash, "jdk8u342-b01", "Second tag", "duke", "duke@openjdk.org");
-            localRepo.push(new Branch(repo.url().toString()), "--tags", false);
+            localRepo.push(new Branch(repo.authenticatedUrl().toString()), "--tags", false);
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The build should now be updated
@@ -1056,7 +1056,7 @@ public class IssueNotifierTests {
 
             // Tag it with an unrelated tag
             localRepo.tag(editHash, "jdk9u352-b01", "Second tag", "duke", "duke@openjdk.org");
-            localRepo.push(new Branch(repo.url().toString()), "--tags", false);
+            localRepo.push(new Branch(repo.authenticatedUrl().toString()), "--tags", false);
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The build should not change
@@ -1077,7 +1077,7 @@ public class IssueNotifierTests {
             var repoFolder = tempFolder.path().resolve("repo");
             var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
             credentials.commitLock(localRepo);
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             var issueProject = credentials.getIssueProject();
             var storageFolder = tempFolder.path().resolve("storage");
@@ -1089,10 +1089,10 @@ public class IssueNotifierTests {
 
             // Initialize history
             var current = localRepo.resolve("master").orElseThrow();
-            localRepo.push(current, repo.url(), "other");
+            localRepo.push(current, repo.authenticatedUrl(), "other");
             localRepo.tag(current, "jdk8u341-b00", "First tag", "duke", "duke@openjdk.org");
             localRepo.tag(current, "jdk8u341-foo-b00", "First foo tag", "duke", "duke@openjdk.org");
-            localRepo.push(new Branch(repo.url().toString()), "--tags", false);
+            localRepo.push(new Branch(repo.authenticatedUrl().toString()), "--tags", false);
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // Create an issue and commit a fix
@@ -1100,8 +1100,8 @@ public class IssueNotifierTests {
             var issue = issueProject.createIssue("This is an issue", List.of("Indeed"), Map.of("issuetype", JSON.of("Enhancement")));
             issue.setProperty("fixVersions", JSON.of("8u341"));
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", issue.id() + ": Fix that issue", "Duke", authorEmailAddress);
-            localRepo.push(editHash, repo.url(), "master");
-            localRepo.push(editHash, repo.url(), "other");
+            localRepo.push(editHash, repo.authenticatedUrl(), "master");
+            localRepo.push(editHash, repo.authenticatedUrl(), "other");
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The changeset should be reflected in a comment in the issue and in a new backport
@@ -1132,7 +1132,7 @@ public class IssueNotifierTests {
 
             // Tag it
             localRepo.tag(editHash, "jdk8u341-b01", "Second tag", "duke", "duke@openjdk.org");
-            localRepo.push(new Branch(repo.url().toString()), "--tags", false);
+            localRepo.push(new Branch(repo.authenticatedUrl().toString()), "--tags", false);
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The build should now be updated
@@ -1144,7 +1144,7 @@ public class IssueNotifierTests {
 
             // Tag it with a properly formatted tag for the foo version
             localRepo.tag(editHash, "jdk8u341-foo-b01", "Second foo tag", "duke", "duke@openjdk.org");
-            localRepo.push(new Branch(repo.url().toString()), "--tags", false);
+            localRepo.push(new Branch(repo.authenticatedUrl().toString()), "--tags", false);
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The build should now be updated
@@ -1167,7 +1167,7 @@ public class IssueNotifierTests {
             var repoFolder = tempFolder.path().resolve("repo");
             var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
             credentials.commitLock(localRepo);
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             var issueProject = credentials.getIssueProject();
             var storageFolder = tempFolder.path().resolve("storage");
@@ -1181,10 +1181,10 @@ public class IssueNotifierTests {
 
             // Initialize history
             var current = localRepo.resolve("master").orElseThrow();
-            localRepo.push(current, repo.url(), "other");
+            localRepo.push(current, repo.authenticatedUrl(), "other");
             localRepo.tag(current, "jdk8u341-b00", "First tag", "duke", "duke@openjdk.org");
             localRepo.tag(current, "foo8u341-b00", "First foo tag", "duke", "duke@openjdk.org");
-            localRepo.push(new Branch(repo.url().toString()), "--tags", false);
+            localRepo.push(new Branch(repo.authenticatedUrl().toString()), "--tags", false);
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // Create an issue and commit a fix
@@ -1192,8 +1192,8 @@ public class IssueNotifierTests {
             var issue = issueProject.createIssue("This is an issue", List.of("Indeed"), Map.of("issuetype", JSON.of("Enhancement")));
             issue.setProperty("fixVersions", JSON.of("8u341"));
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", issue.id() + ": Fix that issue", "Duke", authorEmailAddress);
-            localRepo.push(editHash, repo.url(), "master");
-            localRepo.push(editHash, repo.url(), "other");
+            localRepo.push(editHash, repo.authenticatedUrl(), "master");
+            localRepo.push(editHash, repo.authenticatedUrl(), "other");
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The changeset should be reflected in a comment in the issue and in a new backport
@@ -1224,7 +1224,7 @@ public class IssueNotifierTests {
 
             // Tag it
             localRepo.tag(editHash, "jdk8u341-b01", "Second tag", "duke", "duke@openjdk.org");
-            localRepo.push(new Branch(repo.url().toString()), "--tags", false);
+            localRepo.push(new Branch(repo.authenticatedUrl().toString()), "--tags", false);
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The notifier requires prefix to be matched, but the default tag prefix of "jdk"
@@ -1237,7 +1237,7 @@ public class IssueNotifierTests {
 
             // Tag it with a properly formatted tag for the foo version
             localRepo.tag(editHash, "foo8u341-b02", "Second foo tag", "duke", "duke@openjdk.org");
-            localRepo.push(new Branch(repo.url().toString()), "--tags", false);
+            localRepo.push(new Branch(repo.authenticatedUrl().toString()), "--tags", false);
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The build should now be updated
@@ -1258,7 +1258,7 @@ public class IssueNotifierTests {
             var repoFolder = tempFolder.path().resolve("repo");
             var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
             credentials.commitLock(localRepo);
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             var issueProject = credentials.getIssueProject();
             var storageFolder = tempFolder.path().resolve("storage");
@@ -1269,14 +1269,14 @@ public class IssueNotifierTests {
             // Initialize history
             var current = localRepo.resolve("master").orElseThrow();
             localRepo.tag(current, "jdk-16+9", "First tag", "duke", "duke@openjdk.org");
-            localRepo.push(new Branch(repo.url().toString()), "--tags", false);
+            localRepo.push(new Branch(repo.authenticatedUrl().toString()), "--tags", false);
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // Create an issue and commit a fix
             var authorEmailAddress = issueProject.issueTracker().currentUser().username() + "@openjdk.org";
             var issue = issueProject.createIssue("This is an issue", List.of("Indeed"), Map.of("issuetype", JSON.of("Enhancement")));
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", issue.id() + ": Fix that issue", "Duke", authorEmailAddress);
-            localRepo.push(editHash, repo.url(), "master");
+            localRepo.push(editHash, repo.authenticatedUrl(), "master");
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The changeset should be reflected in a comment
@@ -1297,7 +1297,7 @@ public class IssueNotifierTests {
 
             // Tag it
             localRepo.tag(editHash, "jdk-16+110", "Second tag", "duke", "duke@openjdk.org");
-            localRepo.push(new Branch(repo.url().toString()), "--tags", false);
+            localRepo.push(new Branch(repo.authenticatedUrl().toString()), "--tags", false);
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The build should now be updated
@@ -1306,10 +1306,10 @@ public class IssueNotifierTests {
 
             // Tag it again
             localRepo.tag(editHash, "jdk-16+10", "Third tag", "duke", "duke@openjdk.org");
-            localRepo.push(new Branch(repo.url().toString()), "--tags", false);
+            localRepo.push(new Branch(repo.authenticatedUrl().toString()), "--tags", false);
 
             // Claim that it is already processed
-            localRepo.fetch(repo.url(), "+history:history");
+            localRepo.fetch(repo.authenticatedUrl(), "+history:history");
             localRepo.checkout(new Branch("history"), true);
             var historyFile = repoFolder.resolve("test.tags.txt");
             var processed = new ArrayList<>(Files.readAllLines(historyFile, StandardCharsets.UTF_8));
@@ -1317,7 +1317,7 @@ public class IssueNotifierTests {
             Files.writeString(historyFile, String.join("\n", processed), StandardCharsets.UTF_8);
             localRepo.add(historyFile);
             var updatedHash = localRepo.commit("Marking jdk-16+10 as done", "duke", "duke@openjdk.org");
-            localRepo.push(updatedHash, repo.url(), "history");
+            localRepo.push(updatedHash, repo.authenticatedUrl(), "history");
 
             // Now let the notifier see it
             TestBotRunner.runPeriodicItems(notifyBot);
@@ -1332,7 +1332,7 @@ public class IssueNotifierTests {
             Files.writeString(repoFolder.resolve("test.tags.txt"), String.join("\n", processed), StandardCharsets.UTF_8);
             localRepo.add(historyFile);
             var retryHash = localRepo.commit("Marking jdk-16+10 as needing retry", "duke", "duke@openjdk.org");
-            localRepo.push(retryHash, repo.url(), "history");
+            localRepo.push(retryHash, repo.authenticatedUrl(), "history");
 
             // Now let the notifier see it
             TestBotRunner.runPeriodicItems(notifyBot);
@@ -1352,7 +1352,7 @@ public class IssueNotifierTests {
             var repoFolder = tempFolder.path().resolve("repo");
             var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
             credentials.commitLock(localRepo);
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             var issueProject = credentials.getIssueProject();
             var censusBuilder = credentials.getCensusBuilder()
@@ -1373,7 +1373,7 @@ public class IssueNotifierTests {
             var authorEmailAddress = "integrationreviewer1@otherjdk.org";
             var issue = issueProject.createIssue("This is an issue", List.of("Indeed"), Map.of("issuetype", JSON.of("Enhancement")));
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", issue.id() + ": Fix that issue", "Duke", authorEmailAddress);
-            localRepo.push(editHash, repo.url(), "master");
+            localRepo.push(editHash, repo.authenticatedUrl(), "master");
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The changeset should be reflected in a comment
@@ -1401,7 +1401,7 @@ public class IssueNotifierTests {
             var repoFolder = tempFolder.path().resolve("repo");
             var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType(), Path.of("appendable.txt"), Set.of(), null);
             credentials.commitLock(localRepo);
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             var storageFolder = tempFolder.path().resolve("storage");
             var issueProject = credentials.getIssueProject();
@@ -1414,7 +1414,7 @@ public class IssueNotifierTests {
             // Create an issue and commit a fix
             var issue = issueProject.createIssue("This is an issue", List.of("Indeed"), Map.of("issuetype", JSON.of("Enhancement")));
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", issue.id() + ": Fix that issue");
-            localRepo.push(editHash, repo.url(), "master");
+            localRepo.push(editHash, repo.authenticatedUrl(), "master");
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The changeset should be reflected in a comment
@@ -1444,7 +1444,7 @@ public class IssueNotifierTests {
             var repoFolder = tempFolder.path().resolve("repo");
             var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType(), Path.of("appendable.txt"), Set.of(), "1");
             credentials.commitLock(localRepo);
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
             var baseHash = localRepo.resolve("HEAD").orElseThrow();
 
             var storageFolder = tempFolder.path().resolve("storage");
@@ -1473,7 +1473,7 @@ public class IssueNotifierTests {
             localRepo.checkout(new Branch("master"));
             localRepo.merge(newVersionHash);
             var mergeHash = localRepo.commit("Merge", "testauthor", "ta@none.none");
-            localRepo.push(mergeHash, repo.url(), "master");
+            localRepo.push(mergeHash, repo.authenticatedUrl(), "master");
 
             TestBotRunner.runPeriodicItems(notifyBot);
 
@@ -1500,7 +1500,7 @@ public class IssueNotifierTests {
             var repoFolder = tempFolder.path().resolve("repo");
             var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType(), Path.of("appendable.txt"), Set.of(), null);
             credentials.commitLock(localRepo);
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             var storageFolder = tempFolder.path().resolve("storage");
             var issueProject = credentials.getIssueProject();
@@ -1513,7 +1513,7 @@ public class IssueNotifierTests {
             // Create an issue and commit a fix
             var issue = issueProject.createIssue("This is an issue", List.of("Indeed"), Map.of("issuetype", JSON.of("Enhancement")));
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", issue.id() + ": Fix that issue");
-            localRepo.push(editHash, repo.url(), "master");
+            localRepo.push(editHash, repo.authenticatedUrl(), "master");
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The changeset should not reflected in a comment
@@ -1539,7 +1539,7 @@ public class IssueNotifierTests {
             var repoFolder = tempFolder.path().resolve("repo");
             var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
             credentials.commitLock(localRepo);
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             var storageFolder = tempFolder.path().resolve("storage");
             var issueProject = credentials.getIssueProject();
@@ -1550,12 +1550,12 @@ public class IssueNotifierTests {
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // Save the state
-            var historyState = localRepo.fetch(repo.url(), "history");
+            var historyState = localRepo.fetch(repo.authenticatedUrl(), "history");
 
             // Create an issue and commit a fix
             var issue = issueProject.createIssue("This is an issue", List.of("Indeed"), Map.of("issuetype", JSON.of("Enhancement")));
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", issue.id() + ": Fix that issue");
-            localRepo.push(editHash, repo.url(), "master");
+            localRepo.push(editHash, repo.authenticatedUrl(), "master");
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The changeset should be reflected in a comment
@@ -1568,7 +1568,7 @@ public class IssueNotifierTests {
             assertEquals(Set.of("0.1"), fixVersions(issue));
 
             // Wipe the history
-            localRepo.push(historyState, repo.url(), "history", true);
+            localRepo.push(historyState, repo.authenticatedUrl(), "history", true);
 
             // Run it again
             TestBotRunner.runPeriodicItems(notifyBot);
@@ -1594,7 +1594,7 @@ public class IssueNotifierTests {
             var repoFolder = tempFolder.path().resolve("repo");
             var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
             credentials.commitLock(localRepo);
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             var storageFolder = tempFolder.path().resolve("storage");
             var issueProject = credentials.getIssueProject();
@@ -1605,12 +1605,12 @@ public class IssueNotifierTests {
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // Save the state
-            var historyState = localRepo.fetch(repo.url(), "history");
+            var historyState = localRepo.fetch(repo.authenticatedUrl(), "history");
 
             // Create an issue and commit a fix
             var issue = issueProject.createIssue("This is an issue", List.of("Indeed"), Map.of("issuetype", JSON.of("Enhancement")));
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", issue.id() + ": Fix that issue");
-            localRepo.push(editHash, repo.url(), "master");
+            localRepo.push(editHash, repo.authenticatedUrl(), "master");
 
             // Add a comment for the fix with the old url hash format
             var lastCommit = localRepo.commits().stream().findFirst().orElseThrow();
@@ -1628,7 +1628,7 @@ public class IssueNotifierTests {
             assertEquals(Set.of("0.1"), fixVersions(issue));
 
             // Wipe the history
-            localRepo.push(historyState, repo.url(), "history", true);
+            localRepo.push(historyState, repo.authenticatedUrl(), "history", true);
 
             // Run it again
             TestBotRunner.runPeriodicItems(notifyBot);
@@ -1648,7 +1648,7 @@ public class IssueNotifierTests {
             var repoFolder = tempFolder.path().resolve("repo");
             var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType(), Path.of("appendable.txt"), Set.of(), null);
             credentials.commitLock(localRepo);
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             var storageFolder = tempFolder.path().resolve("storage");
             var issueProject = credentials.getIssueProject();
@@ -1663,7 +1663,7 @@ public class IssueNotifierTests {
             issue.setProperty("fixVersions", JSON.array().add("12-pool").add("tbd_major").add("unknown"));
 
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", issue.id() + ": Fix that issue");
-            localRepo.push(editHash, repo.url(), "master");
+            localRepo.push(editHash, repo.authenticatedUrl(), "master");
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The fixVersion should have been updated
@@ -1679,7 +1679,7 @@ public class IssueNotifierTests {
             var repoFolder = tempFolder.path().resolve("repo");
             var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType(), Path.of("appendable.txt"), Set.of(), null);
             credentials.commitLock(localRepo);
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             var storageFolder = tempFolder.path().resolve("storage");
             var issueProject = credentials.getIssueProject();
@@ -1703,7 +1703,7 @@ public class IssueNotifierTests {
 
             var authorEmailAddress = issueProject.issueTracker().currentUser().username() + "@openjdk.org";
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", issue.id() + ": Fix that issue", "Duke", authorEmailAddress);
-            localRepo.push(editHash, repo.url(), "master");
+            localRepo.push(editHash, repo.authenticatedUrl(), "master");
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The fixVersion should not have been updated
@@ -1741,11 +1741,11 @@ public class IssueNotifierTests {
             var repoFolder = tempFolder.path().resolve("repo");
             var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType(), Path.of("appendable.txt"), Set.of(), null);
             credentials.commitLock(localRepo);
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
             // Initialize other branches
             var initialHead = localRepo.head();
-            localRepo.push(initialHead, repo.url(), "other");
-            localRepo.push(initialHead, repo.url(), "other2");
+            localRepo.push(initialHead, repo.authenticatedUrl(), "other");
+            localRepo.push(initialHead, repo.authenticatedUrl(), "other2");
 
             var storageFolder = tempFolder.path().resolve("storage");
             var issueProject = credentials.getIssueProject();
@@ -1774,7 +1774,7 @@ public class IssueNotifierTests {
 
             var authorEmailAddress = issueProject.issueTracker().currentUser().username() + "@openjdk.org";
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", issue.id() + ": Fix that issue", "Duke", authorEmailAddress);
-            localRepo.push(editHash, repo.url(), "master");
+            localRepo.push(editHash, repo.authenticatedUrl(), "master");
             TestBotRunner.runPeriodicItems(notifyBot);
 
             {
@@ -1796,7 +1796,7 @@ public class IssueNotifierTests {
             }
 
             // Push the fix to other branch
-            localRepo.push(editHash, repo.url(), "other");
+            localRepo.push(editHash, repo.authenticatedUrl(), "other");
             TestBotRunner.runPeriodicItems(notifyBot);
 
             {
@@ -1814,7 +1814,7 @@ public class IssueNotifierTests {
             // Set security on the original issue
             issue.setProperty("security", JSON.of("200"));
             // Push to another branch
-            localRepo.push(editHash, repo.url(), "other2");
+            localRepo.push(editHash, repo.authenticatedUrl(), "other2");
             TestBotRunner.runPeriodicItems(notifyBot);
 
             {
@@ -1841,7 +1841,7 @@ public class IssueNotifierTests {
             var repoFolder = tempFolder.path().resolve("repo");
             var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
             credentials.commitLock(localRepo);
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             var issueProject = credentials.getIssueProject();
             var storageFolder = tempFolder.path().resolve("storage");
@@ -1861,9 +1861,9 @@ public class IssueNotifierTests {
             var authorEmailAddress = issueProject.issueTracker().currentUser().username() + "@openjdk.org";
             var issue = issueProject.createIssue("This is an issue", List.of("Indeed"), Map.of("issuetype", JSON.of("Enhancement")));
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", issue.id() + ": Fix that issue", "Duke", authorEmailAddress);
-            localRepo.push(editHash, repo.url(), "master");
+            localRepo.push(editHash, repo.authenticatedUrl(), "master");
             // Also create a pull request that should not get processed due to repoonly being set
-            localRepo.push(editHash, repo.url(), "edit", true);
+            localRepo.push(editHash, repo.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(repo, "edit", "master", issue.id() + ": Fix that issue");
             pr.setBody("\n\n### Issue\n * [" + issue.id() + "](http://www.test.test/): The issue");
             pr.addLabel("rfr");
@@ -1883,8 +1883,8 @@ public class IssueNotifierTests {
             var comment = comments.get(0);
             assertTrue(comment.body().contains(editHash.toString()));
             // Verify that the 'original' repo URL is used in the comment and not the main one
-            assertTrue(comment.body().contains(originalRepo.url().toString()));
-            assertFalse(comment.body().contains(repo.url().toString()));
+            assertTrue(comment.body().contains(originalRepo.authenticatedUrl().toString()));
+            assertFalse(comment.body().contains(repo.authenticatedUrl().toString()));
 
             // As well as a fixVersion and a resolved in build
             assertEquals(Set.of("0.1"), fixVersions(updatedIssue));
@@ -1904,7 +1904,7 @@ public class IssueNotifierTests {
             var repoFolder = tempFolder.path().resolve("repo");
             var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType(), Path.of("appendable.txt"), Set.of(), null);
             credentials.commitLock(localRepo);
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             var storageFolder = tempFolder.path().resolve("storage");
             var issueProject = credentials.getIssueProject();
@@ -1923,7 +1923,7 @@ public class IssueNotifierTests {
 
             var authorEmailAddress = issueProject.issueTracker().currentUser().username() + "@openjdk.org";
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", issue.id() + ": Fix that issue", "Duke", authorEmailAddress);
-            localRepo.push(editHash, repo.url(), "master");
+            localRepo.push(editHash, repo.authenticatedUrl(), "master");
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The fixVersion should not have been updated
@@ -1954,7 +1954,7 @@ public class IssueNotifierTests {
             var repoFolder = tempFolder.path().resolve("repo");
             var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType(), Path.of("appendable.txt"), Set.of(), null);
             credentials.commitLock(localRepo);
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             var storageFolder = tempFolder.path().resolve("storage");
             var issueProject = credentials.getIssueProject();
@@ -1973,7 +1973,7 @@ public class IssueNotifierTests {
 
             var authorEmailAddress = issueProject.issueTracker().currentUser().username() + "@openjdk.org";
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", issue.id() + ": Fix that issue", "Duke", authorEmailAddress);
-            localRepo.push(editHash, repo.url(), "master");
+            localRepo.push(editHash, repo.authenticatedUrl(), "master");
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The fixVersion should not have been updated
@@ -1986,7 +1986,7 @@ public class IssueNotifierTests {
             assertEquals(1, comments.size());
             var comment = comments.get(0);
             assertTrue(comment.body().contains(editHash.toString()));
-            assertTrue(comment.body().contains(repo.url().toString()));
+            assertTrue(comment.body().contains(repo.authenticatedUrl().toString()));
 
             // There should be no link
             var links = updatedIssue.links();
@@ -2002,7 +2002,7 @@ public class IssueNotifierTests {
             var repoFolder = tempFolder.path().resolve("repo");
             var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType(), Path.of("appendable.txt"), Set.of(), null);
             credentials.commitLock(localRepo);
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             var storageFolder = tempFolder.path().resolve("storage");
             var issueProject = credentials.getIssueProject();
@@ -2021,7 +2021,7 @@ public class IssueNotifierTests {
 
             var authorEmailAddress = issueProject.issueTracker().currentUser().username() + "@openjdk.org";
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", issue.id() + ": Fix that issue", "Duke", authorEmailAddress);
-            localRepo.push(editHash, repo.url(), "master");
+            localRepo.push(editHash, repo.authenticatedUrl(), "master");
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The fixVersion should not have been updated
@@ -2034,7 +2034,7 @@ public class IssueNotifierTests {
             assertEquals(1, comments.size());
             var comment = comments.get(0);
             assertTrue(comment.body().contains(editHash.toString()));
-            assertTrue(comment.body().contains(repo.url().toString()));
+            assertTrue(comment.body().contains(repo.authenticatedUrl().toString()));
 
             // There should be no link
             var links = updatedIssue.links();

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
@@ -1883,8 +1883,8 @@ public class IssueNotifierTests {
             var comment = comments.get(0);
             assertTrue(comment.body().contains(editHash.toString()));
             // Verify that the 'original' repo URL is used in the comment and not the main one
-            assertTrue(comment.body().contains(originalRepo.authenticatedUrl().toString()));
-            assertFalse(comment.body().contains(repo.authenticatedUrl().toString()));
+            assertTrue(comment.body().contains(originalRepo.url().toString()));
+            assertFalse(comment.body().contains(repo.url().toString()));
 
             // As well as a fixVersion and a resolved in build
             assertEquals(Set.of("0.1"), fixVersions(updatedIssue));
@@ -1986,7 +1986,7 @@ public class IssueNotifierTests {
             assertEquals(1, comments.size());
             var comment = comments.get(0);
             assertTrue(comment.body().contains(editHash.toString()));
-            assertTrue(comment.body().contains(repo.authenticatedUrl().toString()));
+            assertTrue(comment.body().contains(repo.url().toString()));
 
             // There should be no link
             var links = updatedIssue.links();
@@ -2034,7 +2034,7 @@ public class IssueNotifierTests {
             assertEquals(1, comments.size());
             var comment = comments.get(0);
             assertTrue(comment.body().contains(editHash.toString()));
-            assertTrue(comment.body().contains(repo.authenticatedUrl().toString()));
+            assertTrue(comment.body().contains(repo.url().toString()));
 
             // There should be no link
             var links = updatedIssue.links();

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/json/JsonNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/json/JsonNotifierTests.java
@@ -53,7 +53,7 @@ public class JsonNotifierTests {
             var localRepoFolder = tempFolder.path().resolve("repo");
             var localRepo = CheckableRepository.init(localRepoFolder, repo.repositoryType());
             credentials.commitLock(localRepo);
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
@@ -78,7 +78,7 @@ public class JsonNotifierTests {
             assertEquals(1, findJsonFiles(jsonFolder, "").size());
 
             var editHash = CheckableRepository.appendAndCommit(localRepo, "One more line", "12345678: Fixes");
-            localRepo.push(editHash, repo.url(), "master");
+            localRepo.push(editHash, repo.authenticatedUrl(), "master");
             TestBotRunner.runPeriodicItems(notifyBot);
             var jsonFiles = findJsonFiles(jsonFolder, "");
             assertEquals(2, jsonFiles.size());
@@ -105,7 +105,7 @@ public class JsonNotifierTests {
             credentials.commitLock(localRepo);
             var masterHash = localRepo.resolve("master").orElseThrow();
             localRepo.tag(masterHash, "jdk-12+1", "Added tag 1", "Duke", "duke@openjdk.org");
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
@@ -130,11 +130,11 @@ public class JsonNotifierTests {
             assertEquals(1, findJsonFiles(jsonFolder, "").size());
 
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", "23456789: More fixes");
-            localRepo.fetch(repo.url(), "history:history");
+            localRepo.fetch(repo.authenticatedUrl(), "history:history");
             localRepo.tag(editHash, "jdk-12+2", "Added tag 2", "Duke", "duke@openjdk.org");
             var editHash2 = CheckableRepository.appendAndCommit(localRepo, "Another line", "34567890: Even more fixes");
             localRepo.tag(editHash2, "jdk-12+4", "Added tag 3", "Duke", "duke@openjdk.org");
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             TestBotRunner.runPeriodicItems(notifyBot);
             var jsonFiles = findJsonFiles(jsonFolder, "");

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/mailinglist/MailingListNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/mailinglist/MailingListNotifierTests.java
@@ -25,7 +25,6 @@ package org.openjdk.skara.bots.notify.mailinglist;
 import org.junit.jupiter.api.*;
 import org.openjdk.skara.email.*;
 import org.openjdk.skara.bots.notify.*;
-import org.openjdk.skara.mailinglist.Conversation;
 import org.openjdk.skara.mailinglist.MailingListServerFactory;
 import org.openjdk.skara.test.*;
 
@@ -34,7 +33,6 @@ import java.nio.file.Files;
 import java.time.Duration;
 import java.util.*;
 import java.util.regex.Pattern;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.openjdk.skara.bots.notify.TestUtils.*;
@@ -50,7 +48,7 @@ public class MailingListNotifierTests {
             var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             credentials.commitLock(localRepo);
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             var listAddress = EmailAddress.parse(listServer.createList("test"));
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
@@ -86,7 +84,7 @@ public class MailingListNotifierTests {
             listServer.processIncoming();
 
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", "23456789: More fixes");
-            localRepo.push(editHash, repo.url(), "master");
+            localRepo.push(editHash, repo.authenticatedUrl(), "master");
             TestBotRunner.runPeriodicItems(notifyBot);
             listServer.processIncoming();
 
@@ -124,7 +122,7 @@ public class MailingListNotifierTests {
             var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             credentials.commitLock(localRepo);
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             var listAddress = EmailAddress.parse(listServer.createList("test"));
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
@@ -159,10 +157,10 @@ public class MailingListNotifierTests {
 
             var editHash1 = CheckableRepository.appendAndCommit(localRepo, "Another line", "23456789: More fixes",
                     "first_author", "first@author.example.com");
-            localRepo.push(editHash1, repo.url(), "master");
+            localRepo.push(editHash1, repo.authenticatedUrl(), "master");
             var editHash2 = CheckableRepository.appendAndCommit(localRepo, "Yet another line", "3456789A: Even more fixes",
                     "another_author", "another@author.example.com");
-            localRepo.push(editHash2, repo.url(), "master");
+            localRepo.push(editHash2, repo.authenticatedUrl(), "master");
 
             TestBotRunner.runPeriodicItems(notifyBot);
             listServer.processIncoming();
@@ -201,7 +199,7 @@ public class MailingListNotifierTests {
             var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             credentials.commitLock(localRepo);
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             var listAddress = EmailAddress.parse(listServer.createList("test"));
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
@@ -236,7 +234,7 @@ public class MailingListNotifierTests {
 
             var editHash1 = CheckableRepository.appendAndCommit(localRepo, "Another line", "23456789: More fixes",
                                                                 "first_author", "first@author.example.com");
-            localRepo.push(editHash1, repo.url(), "master");
+            localRepo.push(editHash1, repo.authenticatedUrl(), "master");
             var editHash2 = CheckableRepository.appendAndCommit(localRepo, "Yet another line", "3456789A: Even more fixes",
                                                                 "another_author", "another@author.example.com");
             localRepo.checkout(editHash1, true);
@@ -245,7 +243,7 @@ public class MailingListNotifierTests {
             localRepo.commit("Unrelated", "unrelated_author", "unrelated@author.example.com");
             localRepo.merge(editHash2);
             var mergeHash = localRepo.commit("Merge", "merge_author", "merge@author.example.com");
-            localRepo.push(mergeHash, repo.url(), "master");
+            localRepo.push(mergeHash, repo.authenticatedUrl(), "master");
 
             TestBotRunner.runPeriodicItems(notifyBot);
             listServer.processIncoming();
@@ -281,7 +279,7 @@ public class MailingListNotifierTests {
             var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             credentials.commitLock(localRepo);
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             var listAddress = EmailAddress.parse(listServer.createList("test"));
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
@@ -317,7 +315,7 @@ public class MailingListNotifierTests {
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", "23456789: More fixes",
                     "author", "author@test.test",
                     "committer", "committer@test.test");
-            localRepo.push(editHash, repo.url(), "master");
+            localRepo.push(editHash, repo.authenticatedUrl(), "master");
             TestBotRunner.runPeriodicItems(notifyBot);
             listServer.processIncoming();
 
@@ -347,7 +345,7 @@ public class MailingListNotifierTests {
             var masterHash = localRepo.resolve("master").orElseThrow();
             credentials.commitLock(localRepo);
             var branch = localRepo.branch(masterHash, "another");
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             var listAddress = EmailAddress.parse(listServer.createList("test"));
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
@@ -385,9 +383,9 @@ public class MailingListNotifierTests {
             listServer.processIncoming();
 
             var editHash1 = CheckableRepository.appendAndCommit(localRepo, "Another line", "23456789: More fixes");
-            localRepo.push(editHash1, repo.url(), "master");
+            localRepo.push(editHash1, repo.authenticatedUrl(), "master");
             var editHash2 = CheckableRepository.appendAndCommit(localRepo, "Yet another line", "3456789A: Even more fixes");
-            localRepo.push(editHash2, repo.url(), "master");
+            localRepo.push(editHash2, repo.authenticatedUrl(), "master");
 
             TestBotRunner.runPeriodicItems(notifyBot);
             listServer.processIncoming();
@@ -417,7 +415,7 @@ public class MailingListNotifierTests {
 
             localRepo.checkout(branch, true);
             var editHash3 = CheckableRepository.appendAndCommit(localRepo, "Another branch", "456789AB: Yet more fixes");
-            localRepo.push(editHash3, repo.url(), "another");
+            localRepo.push(editHash3, repo.authenticatedUrl(), "another");
 
             TestBotRunner.runPeriodicItems(notifyBot);
             listServer.processIncoming();
@@ -451,7 +449,7 @@ public class MailingListNotifierTests {
             var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             credentials.commitLock(localRepo);
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             var listAddress = EmailAddress.parse(listServer.createList("test"));
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
@@ -485,8 +483,8 @@ public class MailingListNotifierTests {
             updater.attachTo(notifyBot);
 
             // Populate our known branches
-            localRepo.push(masterHash, repo.url(), "master", true);
-            localRepo.push(masterHash, repo.url(), "other", true);
+            localRepo.push(masterHash, repo.authenticatedUrl(), "master", true);
+            localRepo.push(masterHash, repo.authenticatedUrl(), "other", true);
 
             // Two mails should be sent on first commit
             TestBotRunner.runPeriodicItems(notifyBot);
@@ -495,7 +493,7 @@ public class MailingListNotifierTests {
 
             localRepo.checkout(masterHash, true);
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", "23456789: More fixes");
-            localRepo.push(editHash, repo.url(), "edit");
+            localRepo.push(editHash, repo.authenticatedUrl(), "edit");
             var pr = credentials.createPullRequest(repo, "master", "edit", "RFR: My PR");
 
             // PR hasn't been integrated yet, so there should be no mail
@@ -513,7 +511,7 @@ public class MailingListNotifierTests {
             pr.addComment("Pushed as commit " + editHash.hex() + ".");
 
             // Now push the same commit to another branch
-            localRepo.push(editHash, repo.url(), "other");
+            localRepo.push(editHash, repo.authenticatedUrl(), "other");
             TestBotRunner.runPeriodicItems(notifyBot);
             listServer.processIncoming();
 
@@ -536,7 +534,7 @@ public class MailingListNotifierTests {
             var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             credentials.commitLock(localRepo);
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             var listAddress = EmailAddress.parse(listServer.createList("test"));
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
@@ -571,12 +569,12 @@ public class MailingListNotifierTests {
             listServer.processIncoming();
 
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", "23456789: More fixes");
-            localRepo.push(editHash, repo.url(), "edit");
+            localRepo.push(editHash, repo.authenticatedUrl(), "edit");
             var pr = credentials.createPullRequest(repo, "master", "edit", "RFR: My PR");
 
             // Create a potentially conflicting one
             var otherHash = CheckableRepository.appendAndCommit(localRepo, "Another line", "23456789: More fixes");
-            localRepo.push(otherHash, repo.url(), "other");
+            localRepo.push(otherHash, repo.authenticatedUrl(), "other");
             var otherPr = credentials.createPullRequest(repo, "master", "other", "RFR: My other PR");
 
             // PR hasn't been integrated yet, so there should be no mail
@@ -593,10 +591,10 @@ public class MailingListNotifierTests {
 
             // And an integration
             pr.addComment("Pushed as commit " + editHash.hex() + ".");
-            localRepo.push(editHash, repo.url(), "master");
+            localRepo.push(editHash, repo.authenticatedUrl(), "master");
 
             // Push the other one without a matching PR
-            localRepo.push(otherHash, repo.url(), "master");
+            localRepo.push(otherHash, repo.authenticatedUrl(), "master");
 
             TestBotRunner.runPeriodicItems(notifyBot);
             listServer.processIncoming();
@@ -627,7 +625,7 @@ public class MailingListNotifierTests {
             var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             credentials.commitLock(localRepo);
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             var listAddress = EmailAddress.parse(listServer.createList("test"));
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
@@ -663,7 +661,7 @@ public class MailingListNotifierTests {
 
             var editHash1 = CheckableRepository.appendAndCommit(localRepo, "Another line", "23456789: More fixes",
                                                                 "first_author", "first@author.example.com");
-            localRepo.push(editHash1, repo.url(), "edit");
+            localRepo.push(editHash1, repo.authenticatedUrl(), "edit");
             CheckableRepository.appendAndCommit(localRepo, "And another line", "12345678: And more fixes",
                                                 "second_author", "second@author.example.com");
             var editHash2 = CheckableRepository.appendAndCommit(localRepo, "Yet another line", "3456789A: Even more fixes",
@@ -674,7 +672,7 @@ public class MailingListNotifierTests {
             localRepo.commit("Unrelated", "unrelated_author", "unrelated@author.example.com");
             localRepo.merge(editHash2);
             var mergeHash = localRepo.commit("Merge", "merge_author", "merge@author.example.com");
-            localRepo.push(mergeHash, repo.url(), "edit");
+            localRepo.push(mergeHash, repo.authenticatedUrl(), "edit");
 
             var pr = credentials.createPullRequest(repo, "master", "edit", "Merge test");
 
@@ -692,7 +690,7 @@ public class MailingListNotifierTests {
 
             // And an integration
             pr.addComment("Pushed as commit " + mergeHash.hex() + ".");
-            localRepo.push(mergeHash, repo.url(), "master");
+            localRepo.push(mergeHash, repo.authenticatedUrl(), "master");
 
             TestBotRunner.runPeriodicItems(notifyBot);
             listServer.processIncoming();
@@ -726,7 +724,7 @@ public class MailingListNotifierTests {
             var masterHash = localRepo.resolve("master").orElseThrow();
             localRepo.branch(masterHash, "other");
             credentials.commitLock(localRepo);
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             var listAddress = EmailAddress.parse(listServer.createList("test"));
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
@@ -764,7 +762,7 @@ public class MailingListNotifierTests {
 
             localRepo.checkout(masterHash, true);
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", "23456789: More fixes");
-            localRepo.push(editHash, repo.url(), "edit");
+            localRepo.push(editHash, repo.authenticatedUrl(), "edit");
             var pr = credentials.createPullRequest(repo, "master", "edit", "RFR: My PR");
 
             // PR hasn't been integrated yet, so there should be no mail
@@ -781,7 +779,7 @@ public class MailingListNotifierTests {
 
             // And an integration
             pr.addComment("Pushed as commit " + editHash.hex() + ".");
-            localRepo.push(editHash, repo.url(), "master", true);
+            localRepo.push(editHash, repo.authenticatedUrl(), "master", true);
 
             TestBotRunner.runPeriodicItems(notifyBot);
             assertThrows(RuntimeException.class, () -> listServer.processIncoming(Duration.ofMillis(1)));
@@ -794,7 +792,7 @@ public class MailingListNotifierTests {
             assertEquals(1, prConversation.allMessages().size());
 
             // Now push the change to another monitored branch
-            localRepo.push(editHash, repo.url(), "other", true);
+            localRepo.push(editHash, repo.authenticatedUrl(), "other", true);
             TestBotRunner.runPeriodicItems(notifyBot);
             listServer.processIncoming();
 
@@ -824,7 +822,7 @@ public class MailingListNotifierTests {
             credentials.commitLock(localRepo);
             var masterHash = localRepo.resolve("master").orElseThrow();
             localRepo.tag(masterHash, "jdk-12+1", "Added tag 1", "Duke Tagger", "tagger@openjdk.org");
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             var listAddress = EmailAddress.parse(listServer.createList("test"));
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
@@ -867,7 +865,7 @@ public class MailingListNotifierTests {
             listServer.processIncoming();
 
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", "23456789: More fixes");
-            localRepo.fetch(repo.url(), "history:history");
+            localRepo.fetch(repo.authenticatedUrl(), "history:history");
             localRepo.tag(editHash, "jdk-12+2", "Added tag 2", "Duke Tagger", "tagger@openjdk.org");
             CheckableRepository.appendAndCommit(localRepo, "Another line 1", "34567890: Even more fixes");
             CheckableRepository.appendAndCommit(localRepo, "Another line 2", "45678901: Yet even more fixes");
@@ -876,7 +874,7 @@ public class MailingListNotifierTests {
             CheckableRepository.appendAndCommit(localRepo, "Another line 4", "67890123: Brand new fixes");
             var editHash3 = CheckableRepository.appendAndCommit(localRepo, "Another line 5", "78901234: More brand new fixes");
             localRepo.tag(editHash3, "jdk-13+0", "Added tag 4", "Duke Tagger", "tagger@openjdk.org");
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             TestBotRunner.runPeriodicItems(notifyBot, scratchFolder.path());
             listServer.processIncoming();
@@ -947,7 +945,7 @@ public class MailingListNotifierTests {
             credentials.commitLock(localRepo);
             var masterHash = localRepo.resolve("master").orElseThrow();
             localRepo.tag(masterHash, "jdk-12+1", "Added tag 1", "Duke Tagger", "tagger@openjdk.org");
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             var listAddress = EmailAddress.parse(listServer.createList("test"));
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
@@ -990,7 +988,7 @@ public class MailingListNotifierTests {
             listServer.processIncoming();
 
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", "23456789: More fixes");
-            localRepo.fetch(repo.url(), "history:history");
+            localRepo.fetch(repo.authenticatedUrl(), "history:history");
             localRepo.tag(editHash, "jdk-12+2", "Added tag 2", "Duke Tagger", "tagger@openjdk.org");
             CheckableRepository.appendAndCommit(localRepo, "Another line 1", "34567890: Even more fixes");
             CheckableRepository.appendAndCommit(localRepo, "Another line 2", "45678901: Yet even more fixes");
@@ -999,7 +997,7 @@ public class MailingListNotifierTests {
             CheckableRepository.appendAndCommit(localRepo, "Another line 4", "67890123: Brand new fixes");
             var editHash3 = CheckableRepository.appendAndCommit(localRepo, "Another line 5", "78901234: More brand new fixes");
             localRepo.tag(editHash3, "jdk-13+0", "Added tag 4", "Duke Tagger", "tagger@openjdk.org");
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             TestBotRunner.runPeriodicItems(notifyBot);
             listServer.processIncoming();
@@ -1043,7 +1041,7 @@ public class MailingListNotifierTests {
             var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             credentials.commitLock(localRepo);
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             var listAddress = EmailAddress.parse(listServer.createList("test"));
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
@@ -1078,7 +1076,7 @@ public class MailingListNotifierTests {
 
             CheckableRepository.appendAndCommit(localRepo, "Another line", "12345678: Some fixes");
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", "23456789: More fixes");
-            localRepo.push(editHash, repo.url(), "newbranch1");
+            localRepo.push(editHash, repo.authenticatedUrl(), "newbranch1");
             TestBotRunner.runPeriodicItems(notifyBot);
             listServer.processIncoming();
 
@@ -1098,7 +1096,7 @@ public class MailingListNotifierTests {
             TestBotRunner.runPeriodicItems(notifyBot);
             assertThrows(RuntimeException.class, () -> listServer.processIncoming(Duration.ofMillis(1)));
 
-            localRepo.push(editHash, repo.url(), "newbranch2");
+            localRepo.push(editHash, repo.authenticatedUrl(), "newbranch2");
             TestBotRunner.runPeriodicItems(notifyBot);
             listServer.processIncoming();
 
@@ -1123,7 +1121,7 @@ public class MailingListNotifierTests {
             var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             credentials.commitLock(localRepo);
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             var listAddress = EmailAddress.parse(listServer.createList("test"));
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
@@ -1159,10 +1157,10 @@ public class MailingListNotifierTests {
             listServer.processIncoming();
 
             // Save history state
-            var historyHash = localRepo.fetch(repo.url(), "history");
+            var historyHash = localRepo.fetch(repo.authenticatedUrl(), "history");
 
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", "23456789: More fixes");
-            localRepo.push(editHash, repo.url(), "master");
+            localRepo.push(editHash, repo.authenticatedUrl(), "master");
             TestBotRunner.runPeriodicItems(notifyBot);
             listServer.processIncoming();
 
@@ -1170,7 +1168,7 @@ public class MailingListNotifierTests {
             assertEquals(2, conversations.size());
 
             // Reset the history
-            localRepo.push(historyHash, repo.url(), "history", true);
+            localRepo.push(historyHash, repo.authenticatedUrl(), "history", true);
             TestBotRunner.runPeriodicItems(notifyBot);
             listServer.processIncoming();
 
@@ -1190,7 +1188,7 @@ public class MailingListNotifierTests {
             var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             credentials.commitLock(localRepo);
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             var listAddress = EmailAddress.parse(listServer.createList("test"));
             var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
@@ -1224,14 +1222,14 @@ public class MailingListNotifierTests {
             CheckableRepository.appendAndCommit(localRepo,"commit1", "commit1");
             CheckableRepository.appendAndCommit(localRepo,"commit2", "commit2");
             var updateHash = CheckableRepository.appendAndCommit(localRepo,"commit3", "commit3");
-            localRepo.push(updateHash,repo.url(),"master");
+            localRepo.push(updateHash,repo.authenticatedUrl(),"master");
 
             // No mail should be sent on first commit because it has a long history(commit count > 5)
             TestBotRunner.runPeriodicItems(notifyBot);
             assertThrows(RuntimeException.class, () -> listServer.processIncoming());
 
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", "23456789: More fixes");
-            localRepo.push(editHash, repo.url(), "master");
+            localRepo.push(editHash, repo.authenticatedUrl(), "master");
             TestBotRunner.runPeriodicItems(notifyBot);
             listServer.processIncoming();
 

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifierTests.java
@@ -22,7 +22,6 @@
  */
 package org.openjdk.skara.bots.notify.prbranch;
 
-import java.time.ZonedDateTime;
 import org.junit.jupiter.api.*;
 import org.openjdk.skara.forge.*;
 import org.openjdk.skara.issuetracker.Issue;
@@ -65,7 +64,7 @@ public class PullRequestBranchNotifierTests {
             var repoFolder = tempFolder.path().resolve("repo");
             var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
             credentials.commitLock(localRepo);
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             var storageFolder = tempFolder.path().resolve("storage");
             var notifyBot = testBotBuilder(repo, storageFolder).create("notify", JSON.object());
@@ -75,13 +74,13 @@ public class PullRequestBranchNotifierTests {
 
             // Create a PR
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line");
-            localRepo.push(editHash, repo.url(), "source", true);
+            localRepo.push(editHash, repo.authenticatedUrl(), "source", true);
             var pr = credentials.createPullRequest(repo, "master", "source", "This is a PR", false);
             pr.addLabel("rfr");
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The target repo should now contain the new branch
-            var hash = localRepo.fetch(repo.url(), PreIntegrations.preIntegrateBranch(pr));
+            var hash = localRepo.fetch(repo.authenticatedUrl(), PreIntegrations.preIntegrateBranch(pr));
             assertEquals(editHash, hash);
 
             // Close the PR
@@ -89,14 +88,14 @@ public class PullRequestBranchNotifierTests {
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The target repo should no longer contain the branch
-            assertThrows(IOException.class, () -> localRepo.fetch(repo.url(), PreIntegrations.preIntegrateBranch(pr)));
+            assertThrows(IOException.class, () -> localRepo.fetch(repo.authenticatedUrl(), PreIntegrations.preIntegrateBranch(pr)));
 
             // Reopen the PR
             pr.setState(Issue.State.OPEN);
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The branch should have reappeared
-            hash = localRepo.fetch(repo.url(), PreIntegrations.preIntegrateBranch(pr));
+            hash = localRepo.fetch(repo.authenticatedUrl(), PreIntegrations.preIntegrateBranch(pr));
             assertEquals(editHash, hash);
         }
     }
@@ -110,7 +109,7 @@ public class PullRequestBranchNotifierTests {
             var repoFolder = tempFolder.path().resolve("repo");
             var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
             credentials.commitLock(localRepo);
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             var storageFolder = tempFolder.path().resolve("storage");
             var notifyBot = testBotBuilder(repo, storageFolder).create("notify", JSON.object());
@@ -120,13 +119,13 @@ public class PullRequestBranchNotifierTests {
 
             // Create a PR
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line");
-            localRepo.push(editHash, repo.url(), "source", true);
+            localRepo.push(editHash, repo.authenticatedUrl(), "source", true);
             var pr = credentials.createPullRequest(repo, "master", "source", "This is a PR", false);
             pr.addLabel("rfr");
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The target repo should now contain the new branch
-            var hash = localRepo.fetch(repo.url(), PreIntegrations.preIntegrateBranch(pr));
+            var hash = localRepo.fetch(repo.authenticatedUrl(), PreIntegrations.preIntegrateBranch(pr));
             assertEquals(editHash, hash);
 
             // remove label `rfr`
@@ -137,21 +136,21 @@ public class PullRequestBranchNotifierTests {
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The target repo should no longer contain the branch
-            assertThrows(IOException.class, () -> localRepo.fetch(repo.url(), PreIntegrations.preIntegrateBranch(pr)));
+            assertThrows(IOException.class, () -> localRepo.fetch(repo.authenticatedUrl(), PreIntegrations.preIntegrateBranch(pr)));
 
             // Reopen the PR
             pr.setState(Issue.State.OPEN);
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The target repo should not contain the branch, because the pr doesn't have label `rfr`.
-            assertThrows(IOException.class, () -> localRepo.fetch(repo.url(), PreIntegrations.preIntegrateBranch(pr)));
+            assertThrows(IOException.class, () -> localRepo.fetch(repo.authenticatedUrl(), PreIntegrations.preIntegrateBranch(pr)));
 
             // add label `rfr`
             pr.addLabel("rfr");
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The branch should have reappeared
-            hash = localRepo.fetch(repo.url(), PreIntegrations.preIntegrateBranch(pr));
+            hash = localRepo.fetch(repo.authenticatedUrl(), PreIntegrations.preIntegrateBranch(pr));
             assertEquals(editHash, hash);
         }
     }
@@ -165,7 +164,7 @@ public class PullRequestBranchNotifierTests {
             var repoFolder = tempFolder.path().resolve("repo");
             var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
             credentials.commitLock(localRepo);
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             var storageFolder = tempFolder.path().resolve("storage");
             var notifyBot = testBotBuilder(repo, storageFolder).create("notify", JSON.object());
@@ -175,23 +174,23 @@ public class PullRequestBranchNotifierTests {
 
             // Create a PR
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line");
-            localRepo.push(editHash, repo.url(), "source", true);
+            localRepo.push(editHash, repo.authenticatedUrl(), "source", true);
             var pr = credentials.createPullRequest(repo, "master", "source", "This is a PR", false);
             pr.addLabel("rfr");
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The target repo should now contain the new branch
-            var hash = localRepo.fetch(repo.url(), PreIntegrations.preIntegrateBranch(pr));
+            var hash = localRepo.fetch(repo.authenticatedUrl(), PreIntegrations.preIntegrateBranch(pr));
             assertEquals(editHash, hash);
 
             // Push another change
             var updatedHash = CheckableRepository.appendAndCommit(localRepo, "Yet another line");
-            localRepo.push(updatedHash, repo.url(), "source");
+            localRepo.push(updatedHash, repo.authenticatedUrl(), "source");
 
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The branch should have been updated
-            hash = localRepo.fetch(repo.url(), PreIntegrations.preIntegrateBranch(pr));
+            hash = localRepo.fetch(repo.authenticatedUrl(), PreIntegrations.preIntegrateBranch(pr));
             assertEquals(updatedHash, hash);
         }
     }
@@ -205,7 +204,7 @@ public class PullRequestBranchNotifierTests {
             var repoFolder = tempFolder.path().resolve("repo");
             var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
             credentials.commitLock(localRepo);
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             var storageFolder = tempFolder.path().resolve("storage");
             var notifyBot = testBotBuilder(repo, storageFolder).create("notify", JSON.object());
@@ -215,16 +214,16 @@ public class PullRequestBranchNotifierTests {
 
             // Create a PR
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line");
-            localRepo.push(editHash, repo.url(), "source", true);
+            localRepo.push(editHash, repo.authenticatedUrl(), "source", true);
             var pr = credentials.createPullRequest(repo, "master", "source", "This is a PR", false);
             pr.addLabel("rfr");
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The target repo should now contain the new branch
-            var hash = localRepo.fetch(repo.url(), PreIntegrations.preIntegrateBranch(pr));
+            var hash = localRepo.fetch(repo.authenticatedUrl(), PreIntegrations.preIntegrateBranch(pr));
             assertEquals(editHash, hash);
             try {
-                localRepo.prune(new Branch(PreIntegrations.preIntegrateBranch(pr)), repo.url().toString());
+                localRepo.prune(new Branch(PreIntegrations.preIntegrateBranch(pr)), repo.authenticatedUrl().toString());
             } catch (IOException ignored) {
             }
 
@@ -243,7 +242,7 @@ public class PullRequestBranchNotifierTests {
             var repoFolder = tempFolder.path().resolve("repo");
             var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
             credentials.commitLock(localRepo);
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             var storageFolder = tempFolder.path().resolve("storage");
             var notifyBot = testBotBuilder(repo, storageFolder).create("notify", JSON.object());
@@ -253,18 +252,18 @@ public class PullRequestBranchNotifierTests {
 
             // Create a PR
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line");
-            localRepo.push(editHash, repo.url(), "source", true);
+            localRepo.push(editHash, repo.authenticatedUrl(), "source", true);
             var pr = credentials.createPullRequest(repo, "master", "source", "This is a PR", false);
             pr.addLabel("rfr");
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The target repo should now contain the new branch
-            var hash = localRepo.fetch(repo.url(), PreIntegrations.preIntegrateBranch(pr));
+            var hash = localRepo.fetch(repo.authenticatedUrl(), PreIntegrations.preIntegrateBranch(pr));
             assertEquals(editHash, hash);
 
             // Create follow-up work
             var followUp = CheckableRepository.appendAndCommit(localRepo, "Follow-up work", "Follow-up change");
-            localRepo.push(followUp, repo.url(), "followup", true);
+            localRepo.push(followUp, repo.authenticatedUrl(), "followup", true);
             var followUpPr = credentials.createPullRequest(repo, PreIntegrations.preIntegrateBranch(pr), "followup", "This is another pull request");
             followUpPr.addLabel("rfr");
             assertEquals(PreIntegrations.preIntegrateBranch(pr), followUpPr.targetRef());
@@ -274,7 +273,7 @@ public class PullRequestBranchNotifierTests {
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The target repo should no longer contain the branch
-            assertThrows(IOException.class, () -> localRepo.fetch(repo.url(), PreIntegrations.preIntegrateBranch(pr)));
+            assertThrows(IOException.class, () -> localRepo.fetch(repo.authenticatedUrl(), PreIntegrations.preIntegrateBranch(pr)));
 
             // The follow-up PR should have been retargeted
             assertEquals("master", followUpPr.store().targetRef());
@@ -286,7 +285,7 @@ public class PullRequestBranchNotifierTests {
 
             // Create another follow-up work
             var anotherFollowUp = CheckableRepository.appendAndCommit(localRepo, "another follow-up work", "another follow-up change");
-            localRepo.push(anotherFollowUp, repo.url(), "another-followup", true);
+            localRepo.push(anotherFollowUp, repo.authenticatedUrl(), "another-followup", true);
             var anotherFollowUpPr = credentials.createPullRequest(repo, PreIntegrations.preIntegrateBranch(followUpPr), "another-followup", "This is another follow-up pull request");
             anotherFollowUpPr.addLabel("rfr");
             assertEquals(PreIntegrations.preIntegrateBranch(followUpPr), anotherFollowUpPr.targetRef());
@@ -299,7 +298,7 @@ public class PullRequestBranchNotifierTests {
 
             // The target repo should no longer contain the branch
             var targetBranch = PreIntegrations.preIntegrateBranch(followUpPr);
-            assertThrows(IOException.class, () -> localRepo.fetch(repo.url(), targetBranch));
+            assertThrows(IOException.class, () -> localRepo.fetch(repo.authenticatedUrl(), targetBranch));
 
             // The another follow-up PR should have been retargeted
             assertEquals("master", anotherFollowUpPr.store().targetRef());

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
@@ -239,8 +239,8 @@ public class BackportCommand implements CommandHandler {
                 var localRepo = bot.hostedRepositoryPool()
                                    .orElseThrow(() -> new IllegalStateException("Missing repository pool for PR bot"))
                                    .materialize(targetRepo, localRepoDir);
-                var fetchHead = localRepo.fetch(bot.repo().url(), hash.hex(), false);
-                var head = localRepo.fetch(targetRepo.url(), targetBranchName, false);
+                var fetchHead = localRepo.fetch(bot.repo().authenticatedUrl(), hash.hex(), false);
+                var head = localRepo.fetch(targetRepo.authenticatedUrl(), targetBranchName, false);
                 var backportBranch = localRepo.branch(head, backportBranchName);
                 localRepo.checkout(backportBranch);
                 var didApply = localRepo.cherryPick(fetchHead);
@@ -264,14 +264,14 @@ public class BackportCommand implements CommandHandler {
                     lines.add("");
                     lines.add("```");
                     lines.add("# Fetch the up-to-date version of the target branch");
-                    lines.add("$ git fetch --no-tags " + targetRepo.remoteUrl() + " " + targetBranch.name() + ":" + targetBranch.name());
+                    lines.add("$ git fetch --no-tags " + targetRepo.url() + " " + targetBranch.name() + ":" + targetBranch.name());
                     lines.add("");
                     lines.add("# Check out the target branch and create your own branch to backport");
                     lines.add("$ git checkout " + targetBranch.name());
                     lines.add("$ git checkout -b " + backportBranchName);
                     lines.add("");
                     lines.add("# Fetch the commit you want to backport");
-                    lines.add("$ git fetch --no-tags " + bot.repo().remoteUrl() + " " + hash.hex());
+                    lines.add("$ git fetch --no-tags " + bot.repo().url() + " " + hash.hex());
                     lines.add("");
                     lines.add("# Backport the commit");
                     lines.add("$ git cherry-pick --no-commit " + hash.hex());
@@ -297,7 +297,7 @@ public class BackportCommand implements CommandHandler {
                 }
 
                 backportHash = localRepo.commit("Backport " + hash.hex(), "duke", "duke@openjdk.org");
-                localRepo.push(backportHash, fork.url(), backportBranchName, false);
+                localRepo.push(backportHash, fork.authenticatedUrl(), backportBranchName, false);
             } else {
                 backportHash = hostedBackportBranch.get().hash();
             }
@@ -364,12 +364,12 @@ public class BackportCommand implements CommandHandler {
                           "[" + targetRepo.name() + "](" + targetRepo.webUrl() + "):\n" +
                           "\n" +
                           "```\n" +
-                          "$ git fetch " + fork.remoteUrl() + " " + backportBranchName + ":" + backportBranchName + "\n" +
+                          "$ git fetch " + fork.url() + " " + backportBranchName + ":" + backportBranchName + "\n" +
                           "$ git checkout " + backportBranchName + "\n" +
                           "# make changes\n" +
                           "$ git add paths/to/changed/files\n" +
                           "$ git commit --message 'Describe additional changes made'\n" +
-                          "$ git push " + fork.remoteUrl() + " " + backportBranchName + "\n" +
+                          "$ git push " + fork.url() + " " + backportBranchName + "\n" +
                           "```");
         } catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
@@ -264,14 +264,14 @@ public class BackportCommand implements CommandHandler {
                     lines.add("");
                     lines.add("```");
                     lines.add("# Fetch the up-to-date version of the target branch");
-                    lines.add("$ git fetch --no-tags " + targetRepo.webUrl() + " " + targetBranch.name() + ":" + targetBranch.name());
+                    lines.add("$ git fetch --no-tags " + targetRepo.remoteUrl() + " " + targetBranch.name() + ":" + targetBranch.name());
                     lines.add("");
                     lines.add("# Check out the target branch and create your own branch to backport");
                     lines.add("$ git checkout " + targetBranch.name());
                     lines.add("$ git checkout -b " + backportBranchName);
                     lines.add("");
                     lines.add("# Fetch the commit you want to backport");
-                    lines.add("$ git fetch --no-tags " + bot.repo().webUrl() + " " + hash.hex());
+                    lines.add("$ git fetch --no-tags " + bot.repo().remoteUrl() + " " + hash.hex());
                     lines.add("");
                     lines.add("# Backport the commit");
                     lines.add("$ git cherry-pick --no-commit " + hash.hex());
@@ -364,12 +364,12 @@ public class BackportCommand implements CommandHandler {
                           "[" + targetRepo.name() + "](" + targetRepo.webUrl() + "):\n" +
                           "\n" +
                           "```\n" +
-                          "$ git fetch " + fork.webUrl() + " " + backportBranchName + ":" + backportBranchName + "\n" +
+                          "$ git fetch " + fork.remoteUrl() + " " + backportBranchName + ":" + backportBranchName + "\n" +
                           "$ git checkout " + backportBranchName + "\n" +
                           "# make changes\n" +
                           "$ git add paths/to/changed/files\n" +
                           "$ git commit --message 'Describe additional changes made'\n" +
-                          "$ git push " + fork.webUrl() + " " + backportBranchName + "\n" +
+                          "$ git push " + fork.remoteUrl() + " " + backportBranchName + "\n" +
                           "```");
         } catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -1055,7 +1055,7 @@ class CheckRun {
                 "and update this pull request you can run the following commands in the local repository for your personal fork:\n" +
                 "```bash\n" +
                 "git checkout " + pr.sourceRef() + "\n" +
-                "git fetch " + pr.repository().webUrl() + " " + pr.targetRef() + "\n" +
+                "git fetch " + pr.repository().remoteUrl() + " " + pr.targetRef() + "\n" +
                 "git merge FETCH_HEAD\n" +
                 "# resolve conflicts and follow the instructions given by git merge\n" +
                 "git commit -m \"Merge " + pr.targetRef() + "\"\n" +

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -1213,7 +1213,7 @@ class CheckRun {
 
             if (pr.sourceRepository().isPresent()) {
                 var branchNames = pr.repository().branches().stream().map(HostedBranch::name).collect(Collectors.toSet());
-                if (!pr.repository().authenticatedUrl().equals(pr.sourceRepository().get().authenticatedUrl()) && branchNames.contains(pr.sourceRef())) {
+                if (!pr.repository().url().equals(pr.sourceRepository().get().url()) && branchNames.contains(pr.sourceRef())) {
                     addSourceBranchWarningComment();
                 }
             }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -737,7 +737,7 @@ class CheckRun {
     }
 
     private String reviewUsingGitHelp() {
-        var repoUrl = pr.repository().remoteUrl();
+        var repoUrl = pr.repository().url();
         var firstTime =
            "`$ git fetch " + repoUrl + " " + pr.fetchRef() + ":pull/" + pr.id() + "` \\\n" +
            "`$ git checkout pull/" + pr.id() + "`\n";
@@ -1055,7 +1055,7 @@ class CheckRun {
                 "and update this pull request you can run the following commands in the local repository for your personal fork:\n" +
                 "```bash\n" +
                 "git checkout " + pr.sourceRef() + "\n" +
-                "git fetch " + pr.repository().remoteUrl() + " " + pr.targetRef() + "\n" +
+                "git fetch " + pr.repository().url() + " " + pr.targetRef() + "\n" +
                 "git merge FETCH_HEAD\n" +
                 "# resolve conflicts and follow the instructions given by git merge\n" +
                 "git commit -m \"Merge " + pr.targetRef() + "\"\n" +
@@ -1213,7 +1213,7 @@ class CheckRun {
 
             if (pr.sourceRepository().isPresent()) {
                 var branchNames = pr.repository().branches().stream().map(HostedBranch::name).collect(Collectors.toSet());
-                if (!pr.repository().url().equals(pr.sourceRepository().get().url()) && branchNames.contains(pr.sourceRef())) {
+                if (!pr.repository().authenticatedUrl().equals(pr.sourceRepository().get().authenticatedUrl()) && branchNames.contains(pr.sourceRef())) {
                     addSourceBranchWarningComment();
                 }
             }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -739,11 +739,11 @@ class CheckRun {
     private String reviewUsingGitHelp() {
         var repoUrl = pr.repository().webUrl();
         var firstTime =
-           "`$ git fetch " + repoUrl + " " + pr.fetchRef() + ":pull/" + pr.id() + "` \\\n" +
+           "`$ git fetch " + repoUrl + ".git " + pr.fetchRef() + ":pull/" + pr.id() + "` \\\n" +
            "`$ git checkout pull/" + pr.id() + "`\n";
         var updating =
            "`$ git checkout pull/" + pr.id() + "` \\\n" +
-           "`$ git pull " + repoUrl + " " + pr.fetchRef() + "`\n";
+           "`$ git pull " + repoUrl + ".git " + pr.fetchRef() + "`\n";
 
         return "Checkout this PR locally: \\\n" +
                 firstTime +

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -737,13 +737,13 @@ class CheckRun {
     }
 
     private String reviewUsingGitHelp() {
-        var repoUrl = pr.repository().webUrl();
+        var repoUrl = pr.repository().remoteUrl();
         var firstTime =
-           "`$ git fetch " + repoUrl + ".git " + pr.fetchRef() + ":pull/" + pr.id() + "` \\\n" +
+           "`$ git fetch " + repoUrl + " " + pr.fetchRef() + ":pull/" + pr.id() + "` \\\n" +
            "`$ git checkout pull/" + pr.id() + "`\n";
         var updating =
            "`$ git checkout pull/" + pr.id() + "` \\\n" +
-           "`$ git pull " + repoUrl + ".git " + pr.fetchRef() + "`\n";
+           "`$ git pull " + repoUrl + " " + pr.fetchRef() + "`\n";
 
         return "Checkout this PR locally: \\\n" +
                 firstTime +

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
@@ -241,7 +241,7 @@ public class IntegrateCommand implements CommandHandler {
             if (!localHash.equals(checkablePr.targetHash())) {
                 var amendedHash = checkablePr.amendManualReviewers(localHash, censusInstance.namespace(), original);
                 addPrePushComment(pr, amendedHash, rebaseMessage.toString());
-                localRepo.push(amendedHash, pr.repository().url(), pr.targetRef());
+                localRepo.push(amendedHash, pr.repository().authenticatedUrl(), pr.targetRef());
                 markIntegratedAndClosed(pr, amendedHash, reply, allComments);
             } else {
                 reply.print("Warning! Your commit did not result in any changes! ");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LimitedCensusInstance.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LimitedCensusInstance.java
@@ -28,7 +28,6 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Optional;
 import org.openjdk.skara.census.Census;
 import org.openjdk.skara.census.Contributor;
@@ -115,7 +114,7 @@ class LimitedCensusInstance {
     }
 
     private static Path getRepoFolder(HostedRepositoryPool hostedRepositoryPool, HostedRepository censusRepo, String censusRef, Path folder) {
-        var repoName = censusRepo.url().getHost() + "/" + censusRepo.name();
+        var repoName = censusRepo.authenticatedUrl().getHost() + "/" + censusRepo.name();
         var repoFolder = folder.resolve(URLEncoder.encode(repoName, StandardCharsets.UTF_8));
         try {
             hostedRepositoryPool.checkoutAllowStale(censusRepo, censusRef, repoFolder);

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LimitedCensusInstance.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LimitedCensusInstance.java
@@ -114,7 +114,7 @@ class LimitedCensusInstance {
     }
 
     private static Path getRepoFolder(HostedRepositoryPool hostedRepositoryPool, HostedRepository censusRepo, String censusRef, Path folder) {
-        var repoName = censusRepo.authenticatedUrl().getHost() + "/" + censusRepo.name();
+        var repoName = censusRepo.url().getHost() + "/" + censusRepo.name();
         var repoFolder = folder.resolve(URLEncoder.encode(repoName, StandardCharsets.UTF_8));
         try {
             hostedRepositoryPool.checkoutAllowStale(censusRepo, censusRef, repoFolder);

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
@@ -130,7 +130,7 @@ public class SponsorCommand implements CommandHandler {
             if (!localHash.equals(checkablePr.targetHash())) {
                 var amendedHash = checkablePr.amendManualReviewers(localHash, censusInstance.namespace(), original);
                 IntegrateCommand.addPrePushComment(pr, amendedHash, rebaseMessage.toString());
-                localRepo.push(amendedHash, pr.repository().url(), pr.targetRef());
+                localRepo.push(amendedHash, pr.repository().authenticatedUrl(), pr.targetRef());
                 markIntegratedAndClosed(pr, amendedHash, reply, allComments);
             } else {
                 reply.print("Warning! This commit did not result in any changes! ");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/TagCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/TagCommand.java
@@ -23,20 +23,16 @@
 package org.openjdk.skara.bots.pr;
 
 import org.openjdk.skara.forge.HostedCommit;
-import org.openjdk.skara.forge.PullRequest;
 import org.openjdk.skara.issuetracker.Comment;
 import org.openjdk.skara.vcs.*;
-import org.openjdk.skara.vcs.openjdk.CommitMessageParsers;
 import org.openjdk.skara.jcheck.JCheckConfiguration;
 
 import java.io.PrintWriter;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-import java.time.format.DateTimeFormatter;
 
 public class TagCommand implements CommandHandler {
     private void showHelp(PrintWriter reply) {
@@ -114,7 +110,7 @@ public class TagCommand implements CommandHandler {
             var email = contributor.username() + "@" + domain;
             var message = "Added tag " + tagName + " for changeset " + commit.hash().abbreviate();
             var tag = localRepo.tag(commit.hash(), tagName, message, contributor.username(), email);
-            localRepo.push(tag, bot.repo().url(), false);
+            localRepo.push(tag, bot.repo().authenticatedUrl(), false);
             reply.println("The tag [" + tag.name() + "](" + bot.repo().webUrl(tag) + ") was successfully created.");
         } catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportCommitCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportCommitCommandTests.java
@@ -55,14 +55,14 @@ public class BackportCommitCommandTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Initiate the fork repo
-            localRepo.push(masterHash, fork.url(), "master", true);
+            localRepo.push(masterHash, fork.authenticatedUrl(), "master", true);
 
             // Make a change in another branch
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit");
+            localRepo.push(editHash, author.authenticatedUrl(), "edit");
 
             // Add a backport command
             author.addCommitComment(editHash, "/backport " + author.name());
@@ -102,11 +102,11 @@ public class BackportCommitCommandTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change in another branch
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit");
+            localRepo.push(editHash, author.authenticatedUrl(), "edit");
 
             // Add a backport command
             author.addCommitComment(editHash, "/backport foobar/non-existing-repo");
@@ -144,11 +144,11 @@ public class BackportCommitCommandTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change in another branch
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit");
+            localRepo.push(editHash, author.authenticatedUrl(), "edit");
 
             // Add a backport command
             author.addCommitComment(editHash, "/backport " + author.name());
@@ -185,11 +185,11 @@ public class BackportCommitCommandTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change in another branch
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit");
+            localRepo.push(editHash, author.authenticatedUrl(), "edit");
 
             // Add a backport command
             author.addCommitComment(editHash, "/backport " + author.name() + " non-existing-branch");
@@ -230,16 +230,16 @@ public class BackportCommitCommandTests {
             var initialHash = localRepo.head();
 
             // Initiate the fork repository
-            localRepo.push(initialHash, fork.url(), "master", true);
+            localRepo.push(initialHash, fork.authenticatedUrl(), "master", true);
 
             // Make a change and push it to edit branch
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
 
             // Add another conflicting change in the master branch
             localRepo.checkout(initialHash);
             var masterHash2 = CheckableRepository.appendAndCommit(localRepo, "a different line");
-            localRepo.push(masterHash2, author.url(), "master", true);
+            localRepo.push(masterHash2, author.authenticatedUrl(), "master", true);
 
             // Add a backport command
             author.addCommitComment(editHash, "/backport " + author.name() + " master");
@@ -278,11 +278,11 @@ public class BackportCommitCommandTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change in another branch
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit");
+            localRepo.push(editHash, author.authenticatedUrl(), "edit");
 
             // Add a backport command
             author.addCommitComment(editHash, "/backport " + author.name());
@@ -338,32 +338,32 @@ public class BackportCommitCommandTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Initiate the fork repo
-            localRepo.push(masterHash, fork.url(), "master", true);
+            localRepo.push(masterHash, fork.authenticatedUrl(), "master", true);
 
             // Make an unrelated change in master
             var unrelated = localRepo.root().resolve("unrelated.txt");
             Files.writeString(unrelated, "Hello");
             localRepo.add(unrelated);
             var unrelatedHash = localRepo.commit("Unrelated", "X", "x@y.z");
-            localRepo.push(unrelatedHash, author.url(), "master");
+            localRepo.push(unrelatedHash, author.authenticatedUrl(), "master");
 
             // Make a change in edit branch, without the unrelated change
             localRepo.checkout(masterHash);
             var editHashCommon = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHashCommon, author.url(), "edit");
+            localRepo.push(editHashCommon, author.authenticatedUrl(), "edit");
 
             // Make the same change in master
             localRepo.checkout(unrelatedHash);
             var masterHashCommon = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(masterHashCommon, author.url(), "master");
+            localRepo.push(masterHashCommon, author.authenticatedUrl(), "master");
 
             // Make another change in edit branch that will be the source of the backport
             localRepo.checkout(editHashCommon);
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit");
+            localRepo.push(editHash, author.authenticatedUrl(), "edit");
 
             // Add a backport command
             author.addCommitComment(editHash, "/backport " + author.name());
@@ -401,14 +401,14 @@ public class BackportCommitCommandTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change in another branch
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit");
+            localRepo.push(editHash, author.authenticatedUrl(), "edit");
 
             // Make the same change in the master branch
-            localRepo.push(editHash, author.url(), "master");
+            localRepo.push(editHash, author.authenticatedUrl(), "master");
 
             // Add a backport command
             author.addCommitComment(editHash, "/backport " + author.name());

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportPRCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportPRCommandTests.java
@@ -61,12 +61,12 @@ public class BackportPRCommandTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "123: This is a pull request");
 
             var reviewerPr = (TestPullRequest) integrator.pullRequest(pr.id());
@@ -84,7 +84,7 @@ public class BackportPRCommandTests {
             assertFalse(pr.store().labelNames().contains("backport=targetRepo2:dev"));
 
             // Enable backport for targetRepo2 on dev
-            localRepo.push(masterHash, targetRepo2.url(), "dev", true);
+            localRepo.push(masterHash, targetRepo2.authenticatedUrl(), "dev", true);
             pr.addComment("/backport targetRepo2 dev");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(pr, "Backport for repo `targetRepo2` on branch `dev` was successfully enabled");
@@ -123,7 +123,7 @@ public class BackportPRCommandTests {
             assertLastCommentContains(pr, "Could **not** automatically backport");
 
             // Resolve conflict
-            localRepo.push(masterHash, targetRepo.url(), "master", true);
+            localRepo.push(masterHash, targetRepo.authenticatedUrl(), "master", true);
             // Use /backport after the pr is integrated
             reviewerPr.addComment("/backport targetRepo");
             TestBotRunner.runPeriodicItems(prBot);
@@ -156,11 +156,11 @@ public class BackportPRCommandTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "123: This is a pull request");
 
             //close the pr

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportTests.java
@@ -60,7 +60,7 @@ class BackportTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             var releaseBranch = localRepo.branch(masterHash, "release");
             localRepo.checkout(releaseBranch);
@@ -73,7 +73,7 @@ class BackportTests {
                                   "\n" +
                                   "Reviewed-by: integrationreviewer2";
             var releaseHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
-            localRepo.push(releaseHash, author.url(), "refs/heads/release", true);
+            localRepo.push(releaseHash, author.authenticatedUrl(), "refs/heads/release", true);
 
             // "backport" the new file to the master branch
             localRepo.checkout(localRepo.defaultBranch());
@@ -83,7 +83,7 @@ class BackportTests {
             Files.writeString(newFile2, "hello");
             localRepo.add(newFile2);
             var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Backport " + releaseHash.hex());
 
             // The bot should reply with a backport message
@@ -122,7 +122,7 @@ class BackportTests {
             assertNotNull(hex);
             assertEquals(40, hex.length());
             localRepo.checkout(localRepo.defaultBranch());
-            localRepo.pull(author.url().toString(), "master", false);
+            localRepo.pull(author.authenticatedUrl().toString(), "master", false);
             var commit = localRepo.lookup(new Hash(hex)).orElseThrow();
 
             var message = CommitMessageParsers.v1.parse(commit);
@@ -158,7 +158,7 @@ class BackportTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             var releaseBranch = localRepo.branch(masterHash, "release");
             localRepo.checkout(releaseBranch);
@@ -173,7 +173,7 @@ class BackportTests {
                                   "\n" +
                                   "Reviewed-by: integrationreviewer2";
             var releaseHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
-            localRepo.push(releaseHash, author.url(), "refs/heads/release", true);
+            localRepo.push(releaseHash, author.authenticatedUrl(), "refs/heads/release", true);
 
             // "backport" the new file to the master branch
             localRepo.checkout(localRepo.defaultBranch());
@@ -183,7 +183,7 @@ class BackportTests {
             Files.writeString(newFile2, "hello");
             localRepo.add(newFile2);
             var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Backport " + releaseHash.hex());
 
             // The bot should reply with a backport message
@@ -223,7 +223,7 @@ class BackportTests {
             assertNotNull(hex);
             assertEquals(40, hex.length());
             localRepo.checkout(localRepo.defaultBranch());
-            localRepo.pull(author.url().toString(), "master", false);
+            localRepo.pull(author.authenticatedUrl().toString(), "master", false);
             var commit = localRepo.lookup(new Hash(hex)).orElseThrow();
 
             var message = CommitMessageParsers.v1.parse(commit);
@@ -259,7 +259,7 @@ class BackportTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             var releaseBranch = localRepo.branch(masterHash, "release");
             localRepo.checkout(releaseBranch);
@@ -277,7 +277,7 @@ class BackportTests {
                                   "\n" +
                                   "Reviewed-by: integrationreviewer2";
             var releaseHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
-            localRepo.push(releaseHash, author.url(), "refs/heads/release", true);
+            localRepo.push(releaseHash, author.authenticatedUrl(), "refs/heads/release", true);
 
             // "backport" the new file to the master branch
             localRepo.checkout(localRepo.defaultBranch());
@@ -287,7 +287,7 @@ class BackportTests {
             Files.writeString(newFile2, "hello");
             localRepo.add(newFile2);
             var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Backport " + releaseHash.hex());
 
             // The bot should reply with a backport message
@@ -326,7 +326,7 @@ class BackportTests {
             assertNotNull(hex);
             assertEquals(40, hex.length());
             localRepo.checkout(localRepo.defaultBranch());
-            localRepo.pull(author.url().toString(), "master", false);
+            localRepo.pull(author.authenticatedUrl().toString(), "master", false);
             var commit = localRepo.lookup(new Hash(hex)).orElseThrow();
 
             var message = CommitMessageParsers.v1.parse(commit);
@@ -363,11 +363,11 @@ class BackportTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding backport PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Backport 0123456789012345678901234567890123456789");
 
             // The bot should reply with a backport error
@@ -409,7 +409,7 @@ class BackportTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             var releaseBranch = localRepo.branch(masterHash, "release");
             localRepo.checkout(releaseBranch);
@@ -422,7 +422,7 @@ class BackportTests {
                     "\n" +
                     "Reviewed-by: integrationreviewer2";
             var releaseHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
-            localRepo.push(releaseHash, author.url(), "refs/heads/release", true);
+            localRepo.push(releaseHash, author.authenticatedUrl(), "refs/heads/release", true);
 
             // "backport" the new file to the master branch
             localRepo.checkout(localRepo.defaultBranch());
@@ -432,7 +432,7 @@ class BackportTests {
             Files.writeString(newFile2, "hello");
             localRepo.add(newFile2);
             var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             // Create the backport with the hash from the PR branch
             var pr = credentials.createPullRequest(author, "master", "edit", "Backport " + editHash.hex());
 
@@ -477,7 +477,7 @@ class BackportTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             var releaseBranch = localRepo.branch(masterHash, "release");
             localRepo.checkout(releaseBranch);
@@ -490,7 +490,7 @@ class BackportTests {
                     "\n" +
                     "Reviewed-by: integrationreviewer2";
             var releaseHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
-            localRepo.push(releaseHash, author.url(), "refs/heads/release", true);
+            localRepo.push(releaseHash, author.authenticatedUrl(), "refs/heads/release", true);
 
             // "backport" the new file to the master branch
             localRepo.checkout(localRepo.defaultBranch());
@@ -500,10 +500,10 @@ class BackportTests {
             Files.writeString(newFile2, "hello");
             localRepo.add(newFile2);
             var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             // Add another change on top of the backport
             var editHash2 = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash2, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash2, author.authenticatedUrl(), "refs/heads/edit", true);
             // Create the backport with the hash from the PR branch
             var pr = credentials.createPullRequest(author, "master", "edit", "Backport " + editHash.hex());
 
@@ -544,7 +544,7 @@ class BackportTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             var releaseBranch = localRepo.branch(masterHash, "release");
             localRepo.checkout(releaseBranch);
@@ -557,7 +557,7 @@ class BackportTests {
                                   "\n" +
                                   "Reviewed-by: integrationreviewer2";
             var releaseHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
-            localRepo.push(releaseHash, author.url(), "refs/heads/release", true);
+            localRepo.push(releaseHash, author.authenticatedUrl(), "refs/heads/release", true);
 
             // "backport" the new file to the master branch
             localRepo.checkout(localRepo.defaultBranch());
@@ -567,7 +567,7 @@ class BackportTests {
             Files.writeString(newFile2, "hello");
             localRepo.add(newFile2);
             var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Backport " + releaseHash.hex(), List.of());
 
             // The bot should reply with a backport message
@@ -618,7 +618,7 @@ class BackportTests {
                                   "Reviewed-by: integrationreviewer2";
             var masterHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
 
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             var releaseBranch = localRepo.branch(masterHash, "release");
             localRepo.checkout(releaseBranch);
@@ -630,7 +630,7 @@ class BackportTests {
                                   "\n" +
                                   "Reviewed-by: integrationreviewer2";
             var upstreamHash = localRepo.commit(upstreamMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
-            localRepo.push(upstreamHash, author.url(), "refs/heads/release", true);
+            localRepo.push(upstreamHash, author.authenticatedUrl(), "refs/heads/release", true);
 
             // "backport" the new file to the master branch
             localRepo.checkout(localRepo.defaultBranch());
@@ -639,7 +639,7 @@ class BackportTests {
             Files.writeString(newFile, "a\nb\nc\ne\nd\n");
             localRepo.add(newFile);
             var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Backport " + upstreamHash.hex());
 
             // The bot should reply with a backport message
@@ -688,7 +688,7 @@ class BackportTests {
                                   "Reviewed-by: integrationreviewer2";
             var masterHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
 
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             var releaseBranch = localRepo.branch(masterHash, "release");
             localRepo.checkout(releaseBranch);
@@ -700,7 +700,7 @@ class BackportTests {
                                   "\n" +
                                   "Reviewed-by: integrationreviewer2";
             var upstreamHash = localRepo.commit(upstreamMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
-            localRepo.push(upstreamHash, author.url(), "refs/heads/release", true);
+            localRepo.push(upstreamHash, author.authenticatedUrl(), "refs/heads/release", true);
 
             // "backport" the new file to the master branch
             localRepo.checkout(localRepo.defaultBranch());
@@ -709,7 +709,7 @@ class BackportTests {
             Files.writeString(newFile, "a\nb\nc\nd\nd");
             localRepo.add(newFile);
             var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Backport " + upstreamHash.hex());
 
             // The bot should reply with a backport message
@@ -759,7 +759,7 @@ class BackportTests {
                                   "Reviewed-by: integrationreviewer2";
             var masterHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
 
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             var releaseBranch = localRepo.branch(masterHash, "release");
             localRepo.checkout(releaseBranch);
@@ -771,7 +771,7 @@ class BackportTests {
                                   "\n" +
                                   "Reviewed-by: integrationreviewer2";
             var upstreamHash = localRepo.commit(upstreamMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
-            localRepo.push(upstreamHash, author.url(), "refs/heads/release", true);
+            localRepo.push(upstreamHash, author.authenticatedUrl(), "refs/heads/release", true);
 
             // "backport" the new file to the master branch
             localRepo.checkout(localRepo.defaultBranch());
@@ -783,7 +783,7 @@ class BackportTests {
             Files.writeString(anotherFile, "f\ng\nh\ni");
             localRepo.add(anotherFile);
             var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Backport " + upstreamHash.hex());
 
             // The bot should reply with a backport message
@@ -822,7 +822,7 @@ class BackportTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             var releaseBranch = localRepo.branch(masterHash, "release");
             localRepo.checkout(releaseBranch);
@@ -835,7 +835,7 @@ class BackportTests {
                                   "\n" +
                                   "Reviewed-by: integrationreviewer2";
             var releaseHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
-            localRepo.push(releaseHash, author.url(), "refs/heads/release", true);
+            localRepo.push(releaseHash, author.authenticatedUrl(), "refs/heads/release", true);
 
             // "backport" the new file to the master branch
             localRepo.checkout(localRepo.defaultBranch());
@@ -845,7 +845,7 @@ class BackportTests {
             Files.writeString(newFile2, "hello");
             localRepo.add(newFile2);
             var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Backport " + releaseHash.hex());
 
             // The bot should reply with a backport message and that the PR is ready
@@ -882,7 +882,7 @@ class BackportTests {
             assertNotNull(hex);
             assertEquals(40, hex.length());
             localRepo.checkout(localRepo.defaultBranch());
-            localRepo.pull(author.url().toString(), "master", false);
+            localRepo.pull(author.authenticatedUrl().toString(), "master", false);
             var commit = localRepo.lookup(new Hash(hex)).orElseThrow();
 
             var message = CommitMessageParsers.v1.parse(commit);
@@ -918,7 +918,7 @@ class BackportTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             var releaseBranch = localRepo.branch(masterHash, "release");
             localRepo.checkout(releaseBranch);
@@ -931,7 +931,7 @@ class BackportTests {
                                   "\n" +
                                   "Reviewed-by: integrationreviewer2";
             var releaseHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
-            localRepo.push(releaseHash, author.url(), "refs/heads/release", true);
+            localRepo.push(releaseHash, author.authenticatedUrl(), "refs/heads/release", true);
 
             // "backport" the new file to the master branch
             localRepo.checkout(localRepo.defaultBranch());
@@ -941,7 +941,7 @@ class BackportTests {
             Files.writeString(newFile2, "hello");
             localRepo.add(newFile2);
             var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Backport " + releaseHash.hex());
 
             // The bot should reply with a backport message and that the PR is ready
@@ -990,7 +990,7 @@ class BackportTests {
             assertNotNull(hex);
             assertEquals(40, hex.length());
             localRepo.checkout(localRepo.defaultBranch());
-            localRepo.pull(author.url().toString(), "master", false);
+            localRepo.pull(author.authenticatedUrl().toString(), "master", false);
             var commit = localRepo.lookup(new Hash(hex)).orElseThrow();
 
             var message = CommitMessageParsers.v1.parse(commit);
@@ -1027,7 +1027,7 @@ class BackportTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             var releaseBranch = localRepo.branch(masterHash, "release");
             localRepo.checkout(releaseBranch);
@@ -1040,7 +1040,7 @@ class BackportTests {
                                   "\n" +
                                   "Reviewed-by: integrationreviewer2";
             var releaseHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
-            localRepo.push(releaseHash, author.url(), "refs/heads/release", true);
+            localRepo.push(releaseHash, author.authenticatedUrl(), "refs/heads/release", true);
 
             // "backport" the new file to the master branch
             localRepo.checkout(localRepo.defaultBranch());
@@ -1050,7 +1050,7 @@ class BackportTests {
             Files.writeString(newFile2, "hello");
             localRepo.add(newFile2);
             var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Backport  " + releaseHash.hex());
 
             // The bot should reply with a backport message
@@ -1085,7 +1085,7 @@ class BackportTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             var releaseBranch = localRepo.branch(masterHash, "release");
             localRepo.checkout(releaseBranch);
@@ -1098,7 +1098,7 @@ class BackportTests {
                                   "\n" +
                                   "Reviewed-by: integrationreviewer2";
             var releaseHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
-            localRepo.push(releaseHash, author.url(), "refs/heads/release", true);
+            localRepo.push(releaseHash, author.authenticatedUrl(), "refs/heads/release", true);
 
             // "backport" the new file to the master branch
             localRepo.checkout(localRepo.defaultBranch());
@@ -1108,7 +1108,7 @@ class BackportTests {
             Files.writeString(newFile2, "hello");
             localRepo.add(newFile2);
             var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Backport " + releaseHash.hex() + " ");
 
             // The bot should reply with a backport message
@@ -1143,7 +1143,7 @@ class BackportTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             var releaseBranch = localRepo.branch(masterHash, "release");
             localRepo.checkout(releaseBranch);
@@ -1156,7 +1156,7 @@ class BackportTests {
                                   "\n" +
                                   "Reviewed-by: integrationreviewer2";
             var releaseHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
-            localRepo.push(releaseHash, author.url(), "refs/heads/release", true);
+            localRepo.push(releaseHash, author.authenticatedUrl(), "refs/heads/release", true);
 
             // "backport" the new file to the master branch
             localRepo.checkout(localRepo.defaultBranch());
@@ -1166,7 +1166,7 @@ class BackportTests {
             Files.writeString(newFile2, "hello");
             localRepo.add(newFile2);
             var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Backport" + releaseHash.hex());
 
             // The bot should reply with a backport message
@@ -1201,7 +1201,7 @@ class BackportTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             var releaseBranch = localRepo.branch(masterHash, "release");
             localRepo.checkout(releaseBranch);
@@ -1214,7 +1214,7 @@ class BackportTests {
                                   "\n" +
                                   "Reviewed-by: integrationreviewer2";
             var releaseHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
-            localRepo.push(releaseHash, author.url(), "refs/heads/release", true);
+            localRepo.push(releaseHash, author.authenticatedUrl(), "refs/heads/release", true);
 
             // "backport" the new file to the master branch
             localRepo.checkout(localRepo.defaultBranch());
@@ -1224,7 +1224,7 @@ class BackportTests {
             Files.writeString(newFile2, "hello");
             localRepo.add(newFile2);
             var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Backport " + releaseHash.hex());
 
             // The bot should reply with a backport message
@@ -1263,7 +1263,7 @@ class BackportTests {
             assertNotNull(hex);
             assertEquals(40, hex.length());
             localRepo.checkout(localRepo.defaultBranch());
-            localRepo.pull(author.url().toString(), "master", false);
+            localRepo.pull(author.authenticatedUrl().toString(), "master", false);
             var commit = localRepo.lookup(new Hash(hex)).orElseThrow();
 
             var message = CommitMessageParsers.v1.parse(commit);
@@ -1299,7 +1299,7 @@ class BackportTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             var releaseBranch = localRepo.branch(masterHash, "release");
             localRepo.checkout(releaseBranch);
@@ -1312,7 +1312,7 @@ class BackportTests {
                                   "\n" +
                                   "Reviewed-by: integrationreviewer2";
             var releaseHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
-            localRepo.push(releaseHash, author.url(), "refs/heads/release", true);
+            localRepo.push(releaseHash, author.authenticatedUrl(), "refs/heads/release", true);
 
             // "backport" the new file to the master branch
             localRepo.checkout(localRepo.defaultBranch());
@@ -1322,7 +1322,7 @@ class BackportTests {
             Files.writeString(newFile2, "hello");
             localRepo.add(newFile2);
             var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Backport " + releaseHash.hex());
 
             // The bot should reply with a backport message
@@ -1356,7 +1356,7 @@ class BackportTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             var issue1 = credentials.createIssue(issues, "An issue");
             var issue1Number = issue1.id().split("-")[1];
@@ -1369,7 +1369,7 @@ class BackportTests {
             Files.writeString(newFile2, "hello");
             localRepo.add(newFile2);
             var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
 
             // Create various kinds of bad pull request titles
             // Use a bad project
@@ -1432,7 +1432,7 @@ class BackportTests {
             assertNotNull(hex);
             assertEquals(40, hex.length());
             localRepo.checkout(localRepo.defaultBranch());
-            localRepo.pull(author.url().toString(), "master", false);
+            localRepo.pull(author.authenticatedUrl().toString(), "master", false);
             var commit = localRepo.lookup(new Hash(hex)).orElseThrow();
 
             var message = CommitMessageParsers.v1.parse(commit);
@@ -1472,7 +1472,7 @@ class BackportTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             var releaseBranch = localRepo.branch(masterHash, "release");
             localRepo.checkout(releaseBranch);
@@ -1485,7 +1485,7 @@ class BackportTests {
                     "\n" +
                     "Reviewed-by: integrationreviewer2";
             var releaseHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
-            localRepo.push(releaseHash, author.url(), "refs/heads/release", true);
+            localRepo.push(releaseHash, author.authenticatedUrl(), "refs/heads/release", true);
 
             // Create the same fix in another release branch
             var releaseBranch2 = localRepo.branch(masterHash, "release2");
@@ -1494,7 +1494,7 @@ class BackportTests {
             Files.writeString(newFile2, "hello2");
             localRepo.add(newFile);
             var releaseHash2 = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
-            localRepo.push(releaseHash2, author.url(), "refs/heads/release2", true);
+            localRepo.push(releaseHash2, author.authenticatedUrl(), "refs/heads/release2", true);
 
             // "backport" the new file to the master branch
             localRepo.checkout(localRepo.defaultBranch());
@@ -1504,7 +1504,7 @@ class BackportTests {
             Files.writeString(newFile3, "hello");
             localRepo.add(newFile3);
             var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Backport " + releaseHash.hex());
 
             // The bot should reply with a backport message
@@ -1562,7 +1562,7 @@ class BackportTests {
             assertNotNull(hex);
             assertEquals(40, hex.length());
             localRepo.checkout(localRepo.defaultBranch());
-            localRepo.pull(author.url().toString(), "master", false);
+            localRepo.pull(author.authenticatedUrl().toString(), "master", false);
             var commit = localRepo.lookup(new Hash(hex)).orElseThrow();
 
             var message = CommitMessageParsers.v1.parse(commit);
@@ -1599,7 +1599,7 @@ class BackportTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             var releaseBranch = localRepo.branch(masterHash, "release");
             localRepo.checkout(releaseBranch);
@@ -1612,13 +1612,13 @@ class BackportTests {
                     "\n" +
                     "Reviewed-by: integrationreviewer2";
             var releaseHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
-            localRepo.push(releaseHash, author.url(), "refs/heads/release", true);
+            localRepo.push(releaseHash, author.authenticatedUrl(), "refs/heads/release", true);
 
             var newFileSZ = localRepo.root().resolve("a_new_file2.txt");
             Files.writeString(newFileSZ, "hello2");
             localRepo.add(newFileSZ);
             var releaseHash2 =localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
-            localRepo.push(releaseHash2, author.url(), "refs/heads/release", true);
+            localRepo.push(releaseHash2, author.authenticatedUrl(), "refs/heads/release", true);
 
 
             // "backport" the new file to the master branch
@@ -1629,7 +1629,7 @@ class BackportTests {
             Files.writeString(newFile2, "hello");
             localRepo.add(newFile2);
             var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             // create a pr with wrong hash
             var pr = credentials.createPullRequest(author, "master", "edit", "Backport " + releaseHash2.hex());
 
@@ -1682,7 +1682,7 @@ class BackportTests {
             assertNotNull(hex);
             assertEquals(40, hex.length());
             localRepo.checkout(localRepo.defaultBranch());
-            localRepo.pull(author.url().toString(), "master", false);
+            localRepo.pull(author.authenticatedUrl().toString(), "master", false);
             var commit = localRepo.lookup(new Hash(hex)).orElseThrow();
 
             var message = CommitMessageParsers.v1.parse(commit);
@@ -1719,7 +1719,7 @@ class BackportTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             var releaseBranch = localRepo.branch(masterHash, "release");
             localRepo.checkout(releaseBranch);
@@ -1732,7 +1732,7 @@ class BackportTests {
                     "\n" +
                     "Reviewed-by: integrationreviewer2";
             var releaseHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
-            localRepo.push(releaseHash, author.url(), "refs/heads/release", true);
+            localRepo.push(releaseHash, author.authenticatedUrl(), "refs/heads/release", true);
 
             // "backport" the new file to the master branch
             localRepo.checkout(localRepo.defaultBranch());
@@ -1742,7 +1742,7 @@ class BackportTests {
             Files.writeString(newFile2, "hello");
             localRepo.add(newFile2);
             var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Backport " + releaseHash.hex());
 
             // The bot should reply with a backport message and that the PR is not ready
@@ -1784,7 +1784,7 @@ class BackportTests {
             assertNotNull(hex);
             assertEquals(40, hex.length());
             localRepo.checkout(localRepo.defaultBranch());
-            localRepo.pull(author.url().toString(), "master", false);
+            localRepo.pull(author.authenticatedUrl().toString(), "master", false);
             var commit = localRepo.lookup(new Hash(hex)).orElseThrow();
 
             var message = CommitMessageParsers.v1.parse(commit);

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CSRTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CSRTests.java
@@ -27,7 +27,6 @@ import org.openjdk.skara.forge.HostedRepository;
 import org.openjdk.skara.forge.Review;
 import org.openjdk.skara.issuetracker.*;
 import org.openjdk.skara.json.JSON;
-import org.openjdk.skara.json.JSONValue;
 import org.openjdk.skara.test.*;
 import org.openjdk.skara.vcs.Hash;
 import org.openjdk.skara.vcs.Repository;
@@ -61,11 +60,11 @@ class CSRTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", issue.id() + ": This is an issue");
 
             // Require CSR
@@ -136,11 +135,11 @@ class CSRTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", issue.id() + ": This is an issue");
 
             // Require CSR
@@ -175,11 +174,11 @@ class CSRTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Just a patch");
 
             // Require CSR
@@ -219,11 +218,11 @@ class CSRTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Just a patch");
 
             // Require CSR from another person who is not a reviewer and is not the author
@@ -295,11 +294,11 @@ class CSRTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Just a patch");
 
             // Require CSR with bad argument
@@ -335,11 +334,11 @@ class CSRTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "123: This is an issue");
 
             // Require CSR
@@ -379,11 +378,11 @@ class CSRTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", issue.id() + ": This is an issue");
 
             // Require CSR
@@ -438,11 +437,11 @@ class CSRTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", issue.id() + ": This is an issue");
 
             // Require CSR
@@ -512,11 +511,11 @@ class CSRTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", issue.id() + ": This is an issue");
 
             // Require CSR
@@ -577,11 +576,11 @@ class CSRTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR and require CSR in PR body
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Just a patch", List.of("/csr"));
 
             // Run bot
@@ -615,11 +614,11 @@ class CSRTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Just a patch");
 
             // Approve the PR
@@ -672,11 +671,11 @@ class CSRTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Just a patch");
 
             // Test the pull request bot with csr disable
@@ -731,7 +730,7 @@ class CSRTests {
             var localRepoFolder = tempFolder.path().resolve("localrepo");
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Push a commit to the jdk18 branch
             var jdk18Branch = localRepo.branch(masterHash, "jdk18");
@@ -742,7 +741,7 @@ class CSRTests {
             var issueNumber = issue.id().split("-")[1];
             var commitMessage = issueNumber + ": This is the primary issue\n\nReviewed-by: integrationreviewer2";
             var commitHash = localRepo.commit(commitMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
-            localRepo.push(commitHash, author.url(), "jdk18", true);
+            localRepo.push(commitHash, author.authenticatedUrl(), "jdk18", true);
 
             // Remove `version=0.1` from `.jcheck/conf`, set the version as null
             localRepo.checkout(localRepo.defaultBranch());
@@ -751,7 +750,7 @@ class CSRTests {
             Files.writeString(localRepo.root().resolve(".jcheck/conf"), newConf, StandardCharsets.UTF_8);
             localRepo.add(localRepo.root().resolve(".jcheck/conf"));
             var confHash = localRepo.commit("Set version as null", "duke", "duke@openjdk.org");
-            localRepo.push(confHash, author.url(), "master", true);
+            localRepo.push(confHash, author.authenticatedUrl(), "master", true);
             createBackport(localRepo, author, confHash, "edit1");
             var pr = credentials.createPullRequest(author, "master", "edit1", "Backport " + commitHash);
             // Run bot. Request a CSR.
@@ -780,7 +779,7 @@ class CSRTests {
             Files.writeString(localRepo.root().resolve(".jcheck/conf"), newConf, StandardCharsets.UTF_8);
             localRepo.add(localRepo.root().resolve(".jcheck/conf"));
             confHash = localRepo.commit("Set the version as a wrong value", "duke", "duke@openjdk.org");
-            localRepo.push(confHash, author.url(), "master", true);
+            localRepo.push(confHash, author.authenticatedUrl(), "master", true);
             createBackport(localRepo, author, confHash, "edit2");
             pr = credentials.createPullRequest(author, "master", "edit2", "Backport " + commitHash);
             // Run bot. Request a CSR.
@@ -809,7 +808,7 @@ class CSRTests {
             Files.writeString(localRepo.root().resolve(".jcheck/conf"), newConf, StandardCharsets.UTF_8);
             localRepo.add(localRepo.root().resolve(".jcheck/conf"));
             confHash = localRepo.commit("Set the version as 17", "duke", "duke@openjdk.org");
-            localRepo.push(confHash, author.url(), "master", true);
+            localRepo.push(confHash, author.authenticatedUrl(), "master", true);
             createBackport(localRepo, author, confHash, "edit3");
             pr = credentials.createPullRequest(author, "master", "edit3", "Backport " + commitHash);
             // Run bot. Request a CSR.
@@ -911,7 +910,7 @@ class CSRTests {
             Files.writeString(localRepo.root().resolve(".jcheck/conf"), newConf, StandardCharsets.UTF_8);
             localRepo.add(localRepo.root().resolve(".jcheck/conf"));
             confHash = localRepo.commit("Set the version as 11", "duke", "duke@openjdk.org");
-            localRepo.push(confHash, author.url(), "master", true);
+            localRepo.push(confHash, author.authenticatedUrl(), "master", true);
             createBackport(localRepo, author, confHash, "edit4");
             pr = credentials.createPullRequest(author, "master", "edit4", "Backport " + commitHash);
             // Run bot.
@@ -954,7 +953,7 @@ class CSRTests {
         Files.writeString(newFile2, "a_new_file");
         localRepo.add(newFile2);
         var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
-        localRepo.push(editHash, author.url(), branchName, true);
+        localRepo.push(editHash, author.authenticatedUrl(), branchName, true);
     }
 
     @Test
@@ -977,11 +976,11 @@ class CSRTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", issue.id() + ": This is an issue");
 
             // Require CSR
@@ -1074,11 +1073,11 @@ class CSRTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", issue.id() + ": This is an issue");
 
             var issue2 = issues.createIssue("This is an issue2", List.of(), Map.of());
@@ -1126,11 +1125,11 @@ class CSRTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", issue.id() + ": This is an issue");
 
             var issue2 = issues.createIssue("This is an issue2", List.of(), Map.of());

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -65,11 +65,11 @@ class CheckTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Check the status
@@ -120,11 +120,11 @@ class CheckTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo, "A line with a trailing whitespace   ");
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Check the status
@@ -151,7 +151,7 @@ class CheckTests {
 
             // Remove the trailing whitespace in a new commit
             editHash = CheckableRepository.replaceAndCommit(localRepo, "A line without a trailing whitespace");
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
 
             // Check the status again
             TestBotRunner.runPeriodicItems(checkBot);
@@ -186,11 +186,11 @@ class CheckTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var authorPr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Let the status bot inspect the PR
@@ -207,7 +207,7 @@ class CheckTests {
 
             // Update the file after approval
             editHash = CheckableRepository.appendAndCommit(localRepo, "Now I've gone and changed it");
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
 
             // Check that the review is flagged as stale
             TestBotRunner.runPeriodicItems(checkBot);
@@ -256,11 +256,11 @@ class CheckTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var authorPr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Let the status bot inspect the PR
@@ -297,11 +297,11 @@ class CheckTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Check the status
@@ -335,7 +335,7 @@ class CheckTests {
             assertTrue(pr.store().labelNames().contains("ready"));
 
             var addedHash = CheckableRepository.appendAndCommit(localRepo, "trailing whitespace   ");
-            localRepo.push(addedHash, author.url(), "edit");
+            localRepo.push(addedHash, author.authenticatedUrl(), "edit");
 
             // Check the status
             TestBotRunner.runPeriodicItems(checkBot);
@@ -368,11 +368,11 @@ class CheckTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Approve it as another user
@@ -388,7 +388,7 @@ class CheckTests {
             Files.writeString(unrelated, "Hello");
             localRepo.add(unrelated);
             var unrelatedHash = localRepo.commit("Unrelated", "X", "x@y.z");
-            localRepo.push(unrelatedHash, author.url(), "master");
+            localRepo.push(unrelatedHash, author.authenticatedUrl(), "master");
 
             // Let the bot see the changes
             pr.setBody(pr.store().body() + "recheck");
@@ -420,11 +420,11 @@ class CheckTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Approve it as another user
@@ -438,7 +438,7 @@ class CheckTests {
             // Push something conflicting to master
             localRepo.checkout(masterHash, true);
             var conflictingHash = CheckableRepository.appendAndCommit(localRepo, "This looks like a conflict");
-            localRepo.push(conflictingHash, author.url(), "master");
+            localRepo.push(conflictingHash, author.authenticatedUrl(), "master");
 
             // Let the bot see the changes
             pr.setBody(pr.store().body() + "recheck");
@@ -467,7 +467,7 @@ class CheckTests {
             assertEquals(CheckStatus.SUCCESS, check.status());
 
             // Restore the master branch
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Let the bot see the changes
             pr.setBody(pr.store().body() + "recheck");
@@ -500,11 +500,11 @@ class CheckTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
             pr.addLabel("block");
 
@@ -551,11 +551,11 @@ class CheckTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Another PR");
             pr.setBody("    ");
 
@@ -616,14 +616,14 @@ class CheckTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(),
                     Path.of("executable.exe"), Set.of("reviewers", "executable"), "0.1");
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             Files.writeString(tempFolder.path().resolve("executable.exe"), "Executable file contents", StandardCharsets.UTF_8);
             Files.setPosixFilePermissions(tempFolder.path().resolve("executable.exe"), Set.of(PosixFilePermission.OWNER_EXECUTE, PosixFilePermission.OWNER_READ));
             localRepo.add(Path.of("executable.exe"));
             var editHash = localRepo.commit("Make it executable", "duke", "duke@openjdk.org");
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Another PR");
             pr.setBody("This should now be ready");
 
@@ -649,7 +649,7 @@ class CheckTests {
             Files.setPosixFilePermissions(tempFolder.path().resolve("executable.exe"), Set.of(PosixFilePermission.OWNER_READ));
             localRepo.add(Path.of("executable.exe"));
             var updatedHash = localRepo.commit("Make it unexecutable", "duke", "duke@openjdk.org");
-            localRepo.push(updatedHash, author.url(), "edit");
+            localRepo.push(updatedHash, author.authenticatedUrl(), "edit");
             TestBotRunner.runPeriodicItems(checkBot);
 
             // The PR should now be ready for review
@@ -677,11 +677,11 @@ class CheckTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Check the status
@@ -718,11 +718,11 @@ class CheckTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Check the status
@@ -761,11 +761,11 @@ class CheckTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(), Path.of("appendable.txt"),
                                                      Set.of("issues"), null);
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Check the status
@@ -808,14 +808,14 @@ class CheckTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(), Path.of("appendable.txt"),
                     Set.of("issues"), null);
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Verify that a cut-off title is corrected
             var issue1 = issues.createIssue("My first issue with a very long title that is going to be cut off by the Git Forge provider", List.of("Hello"), Map.of());
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var prBadTitle =  credentials.createPullRequest(author, "master", "edit", issue1.id() + ": My OTHER issue with a very long title that is going to be cut off by …", List.of("…the Git Forge provider"), false);
 
             // Check the status
@@ -840,7 +840,7 @@ class CheckTests {
 
             // Make a change with a corresponding PR
             var editHash2 = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash2, author.url(), "edit", true);
+            localRepo.push(editHash2, author.authenticatedUrl(), "edit", true);
 
             var prCutOff2 =  credentials.createPullRequest(author, "master", "edit", issue2.id() + ": My second issue ending in space", List.of(), false);
 
@@ -869,13 +869,13 @@ class CheckTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(), Path.of("appendable.txt"),
                                                      Set.of("issues"), null);
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             var issue1 = issues.createIssue("My first issue", List.of("Hello"), Map.of("issuetype", JSON.of("Bug")));
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", issue1.id() + ": This is a pull request");
 
             // Check the status
@@ -966,13 +966,13 @@ class CheckTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(), Path.of("appendable.txt"),
                                                      Set.of("issues"), null);
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             var issue1 = issues.createIssue("My first issue", List.of("Hello"), Map.of("issuetype", JSON.of("Bug")));
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", issue1.id() + ": This is a pull request");
 
             // Check the status
@@ -1045,7 +1045,7 @@ class CheckTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(),
                                     Path.of("appendable.txt"), Set.of("issues"), null);
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Set the version to 17
             localRepo.checkout(localRepo.defaultBranch());
@@ -1054,14 +1054,14 @@ class CheckTests {
             Files.writeString(localRepo.root().resolve(".jcheck/conf"), newConf, StandardCharsets.UTF_8);
             localRepo.add(localRepo.root().resolve(".jcheck/conf"));
             var confHash = localRepo.commit("Set version as 17", "duke", "duke@openjdk.org");
-            localRepo.push(confHash, author.url(), "master", true);
+            localRepo.push(confHash, author.authenticatedUrl(), "master", true);
 
             var mainIssue = issues.createIssue("The main issue", List.of("main"), Map.of("issuetype", JSON.of("Bug")));
             var csrIssue = issues.createIssue("The csr issue", List.of("csr"), Map.of("issuetype", JSON.of("CSR")));
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", mainIssue.id() + ": " + mainIssue.title());
 
             // PR should have one issue
@@ -1085,7 +1085,7 @@ class CheckTests {
             csrIssue.setState(Issue.State.CLOSED);
             // Push a commit to trigger the check which can update the PR body.
             var newHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(newHash, author.url(), "edit", false);
+            localRepo.push(newHash, author.authenticatedUrl(), "edit", false);
 
             // PR should have two issues
             TestBotRunner.runPeriodicItems(checkBot);
@@ -1115,7 +1115,7 @@ class CheckTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(),
                     Path.of("appendable.txt"), Set.of("issues"), null);
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             var mainIssue = issueProject.createIssue("The main issue", List.of("main"), Map.of("issuetype", JSON.of("Bug")));
             var jepIssue = issueProject.createIssue("The jep issue", List.of("Jep body"),
@@ -1123,7 +1123,7 @@ class CheckTests {
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", mainIssue.id() + ": " + mainIssue.title());
 
             // PR should have one issue
@@ -1152,7 +1152,7 @@ class CheckTests {
 
             // Push a commit to trigger the check which can update the PR body.
             var newHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(newHash, author.url(), "edit", false);
+            localRepo.push(newHash, author.authenticatedUrl(), "edit", false);
 
             // PR should have two issues even though the jep issue has been targeted
             TestBotRunner.runPeriodicItems(checkBot);
@@ -1166,7 +1166,7 @@ class CheckTests {
 
             // Push a commit to trigger the check which can update the PR body.
             newHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(newHash, author.url(), "edit", false);
+            localRepo.push(newHash, author.authenticatedUrl(), "edit", false);
 
             // PR should have two issues even though the jep issue has been Closed
             TestBotRunner.runPeriodicItems(checkBot);
@@ -1187,11 +1187,11 @@ class CheckTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Verify no checks exists
@@ -1240,11 +1240,11 @@ class CheckTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Enable a new check in the target branch
@@ -1252,7 +1252,7 @@ class CheckTests {
             CheckableRepository.init(tempFolder.path(), author.repositoryType(), Path.of("appendable.txt"),
                                      Set.of("author", "reviewers", "whitespace", "issues"), null);
             var headHash = localRepo.resolve("HEAD").orElseThrow();
-            localRepo.push(headHash, author.url(), "master", true);
+            localRepo.push(headHash, author.authenticatedUrl(), "master", true);
 
             // Check the status
             TestBotRunner.runPeriodicItems(checkBot);
@@ -1291,11 +1291,11 @@ class CheckTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit",
                                                    "This is a pull request", true);
 
@@ -1329,12 +1329,12 @@ class CheckTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR containing more errors than at least GitHub can handle in a check
             var badContent = "\tline   \n".repeat(200);
             var editHash = CheckableRepository.appendAndCommit(localRepo, badContent);
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit",
                                                    "This is a pull request", true);
 
@@ -1364,14 +1364,14 @@ class CheckTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Break the jcheck configuration on the "edit" branch
             var confPath = tempFolder.path().resolve(".jcheck/conf");
             Files.writeString(confPath, "Hello there!", StandardCharsets.UTF_8);
             localRepo.add(confPath);
             var editHash = CheckableRepository.appendAndCommit(localRepo, "A change");
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit",
                                                    "This is a pull request", true);
 
@@ -1404,12 +1404,12 @@ class CheckTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "master");
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "master");
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Check the status
@@ -1439,15 +1439,15 @@ class CheckTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make the same change with different messages in master and edit
             String identicalChangeBody = "identical change";
             var editHash = CheckableRepository.appendAndCommit(localRepo, identicalChangeBody, "edit message");
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             localRepo.checkout(masterHash, true);
             masterHash = CheckableRepository.appendAndCommit(localRepo, identicalChangeBody, "master message");
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Create PR
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
@@ -1480,11 +1480,11 @@ class CheckTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo, "A line with");
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Check the status
@@ -1503,7 +1503,7 @@ class CheckTests {
 
             // Add another commit
             editHash = CheckableRepository.replaceAndCommit(localRepo, "Another line");
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
 
             // Check the status again
             TestBotRunner.runPeriodicItems(checkBot);
@@ -1517,7 +1517,7 @@ class CheckTests {
             approvalPr.addReview(Review.Verdict.APPROVED, "Approved again");
 
             // Change the target ref of the PR
-            localRepo.push(masterHash, author.url(), "other-branch", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "other-branch", true);
             pr.setTargetRef("other-branch");
 
             // Check the status again
@@ -1567,12 +1567,12 @@ class CheckTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
-            localRepo.push(masterHash, author.url(), "notmaster", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "notmaster", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit",
                                                    "This is a pull request", true);
 
@@ -1629,11 +1629,11 @@ class CheckTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var bugHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(bugHash, author.url(), "bug", true);
+            localRepo.push(bugHash, author.authenticatedUrl(), "bug", true);
             var bugPR = credentials.createPullRequest(author, "master", "bug",
                                                       bug.id() + ": My first bug", true);
 
@@ -1648,7 +1648,7 @@ class CheckTests {
 
             // Make a change with a corresponding PR
             var backportHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(backportHash, author.url(), "backport", true);
+            localRepo.push(backportHash, author.authenticatedUrl(), "backport", true);
             var backportPR = credentials.createPullRequest(author, "master", "backport",
                                                            backport.id() + ": My first backport", true);
 
@@ -1684,11 +1684,11 @@ class CheckTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var bugHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(bugHash, author.url(), "bug", true);
+            localRepo.push(bugHash, author.authenticatedUrl(), "bug", true);
             var bugPR = credentials.createPullRequest(author, "master", "bug", numericId, true);
             assertEquals(numericId, bugPR.store().title());
 
@@ -1722,11 +1722,11 @@ class CheckTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var bugHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(bugHash, author.url(), "bug", true);
+            localRepo.push(bugHash, author.authenticatedUrl(), "bug", true);
             var bugPR = credentials.createPullRequest(author, "master", "bug", bug.id(), true);
             assertEquals(bug.id(), bugPR.store().title());
 
@@ -1763,11 +1763,11 @@ class CheckTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(),
                                                      Path.of("appendable.txt"), Set.of("issues"), "0.9");
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var bugHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(bugHash, author.url(), "bug", true);
+            localRepo.push(bugHash, author.authenticatedUrl(), "bug", true);
 
             var bugPR = credentials.createPullRequest(author, "master", "bug", "bad title", true);
 
@@ -1812,11 +1812,11 @@ class CheckTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var bugHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(bugHash, author.url(), "bug", true);
+            localRepo.push(bugHash, author.authenticatedUrl(), "bug", true);
             var bugPR = credentials.createPullRequest(author, "master", "bug",
                     bug.id() + ":\u00A0" + bug.title(), true);
 
@@ -1849,7 +1849,7 @@ class CheckTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Create a different conf on a different branch
             var defaultConf = Files.readString(localRepo.root().resolve(".jcheck/conf"), StandardCharsets.UTF_8);
@@ -1857,12 +1857,12 @@ class CheckTests {
             Files.writeString(localRepo.root().resolve("jcheck.conf"), newConf, StandardCharsets.UTF_8);
             localRepo.add(localRepo.root().resolve("jcheck.conf"));
             var confHash = localRepo.commit("Separate conf", "duke", "duke@openjdk.org");
-            localRepo.push(confHash, author.url(), "jcheck-branch", true);
+            localRepo.push(confHash, author.authenticatedUrl(), "jcheck-branch", true);
             localRepo.checkout(masterHash, true);
 
             // Make a change with a corresponding PR
             var testHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(testHash, author.url(), "test", true);
+            localRepo.push(testHash, author.authenticatedUrl(), "test", true);
             var pr = credentials.createPullRequest(author, "master", "test", "This is a PR");
 
             // Check the status (should become ready immediately as reviewercount is overridden to 0)
@@ -1891,7 +1891,7 @@ class CheckTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Create a different conf on a different branch
             var defaultConf = Files.readString(localRepo.root().resolve(".jcheck/conf"), StandardCharsets.UTF_8);
@@ -1899,17 +1899,17 @@ class CheckTests {
             Files.writeString(localRepo.root().resolve("jcheck.conf"), newConf, StandardCharsets.UTF_8);
             localRepo.add(localRepo.root().resolve("jcheck.conf"));
             var confHash = localRepo.commit("Separate conf", "duke", "duke@openjdk.org");
-            localRepo.push(confHash, author.url(), "jcheck-branch", true);
+            localRepo.push(confHash, author.authenticatedUrl(), "jcheck-branch", true);
             localRepo.checkout(masterHash, true);
 
             // Remove the default one
             localRepo.remove(localRepo.root().resolve(".jcheck/conf"));
             var newMasterHash = localRepo.commit("No more conf", "duke", "duke@openjdk.org");
-            localRepo.push(newMasterHash, author.url(), "master");
+            localRepo.push(newMasterHash, author.authenticatedUrl(), "master");
 
             // Make a change with a corresponding PR
             var testHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(testHash, author.url(), "test", true);
+            localRepo.push(testHash, author.authenticatedUrl(), "test", true);
             var pr = credentials.createPullRequest(author, "master", "test", "This is a PR");
 
             // Check the status (should become ready immediately as reviewercount is overridden to 0)
@@ -1935,11 +1935,11 @@ class CheckTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR with an empty e-mail
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Content", "A commit", "A Random User", "a.random.user@foo.com");
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Approve the PR
@@ -1990,7 +1990,7 @@ class CheckTests {
             var localRepoFolder = tempFolder.path().resolve("localrepo");
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Push a commit to the jdk18 branch
             var jdk18Branch = localRepo.branch(masterHash, "jdk18");
@@ -2001,7 +2001,7 @@ class CheckTests {
             var issueNumber = issue.id().split("-")[1];
             var commitMessage = issueNumber + ": This is the primary issue\n\nReviewed-by: integrationreviewer2";
             var commitHash = localRepo.commit(commitMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
-            localRepo.push(commitHash, author.url(), "jdk18", true);
+            localRepo.push(commitHash, author.authenticatedUrl(), "jdk18", true);
 
             // "backport" the commit to the master branch
             localRepo.checkout(localRepo.defaultBranch());
@@ -2011,7 +2011,7 @@ class CheckTests {
             Files.writeString(newFile2, "a_new_file");
             localRepo.add(newFile2);
             var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Backport " + commitHash);
 
             // Remove `version=0.1` from `.jcheck/conf`, set the version as null
@@ -2020,7 +2020,7 @@ class CheckTests {
             Files.writeString(localRepo.root().resolve(".jcheck/conf"), newConf, StandardCharsets.UTF_8);
             localRepo.add(localRepo.root().resolve(".jcheck/conf"));
             var confHash = localRepo.commit("Set version as null", "duke", "duke@openjdk.org");
-            localRepo.push(confHash, author.url(), "edit", true);
+            localRepo.push(confHash, author.authenticatedUrl(), "edit", true);
             // Simulate the CSRBot.
             pr.setBody(pr.store().body() + CSR_UPDATE_MARKER);
             // Run bot. The bot won't get a CSR.
@@ -2039,7 +2039,7 @@ class CheckTests {
             Files.writeString(localRepo.root().resolve(".jcheck/conf"), newConf, StandardCharsets.UTF_8);
             localRepo.add(localRepo.root().resolve(".jcheck/conf"));
             confHash = localRepo.commit("Set the version as a wrong value", "duke", "duke@openjdk.org");
-            localRepo.push(confHash, author.url(), "edit", true);
+            localRepo.push(confHash, author.authenticatedUrl(), "edit", true);
             // Simulate the CSRBot.
             pr.setBody(pr.store().body() + CSR_UPDATE_MARKER);
             // Run bot. The bot won't get a CSR.
@@ -2058,7 +2058,7 @@ class CheckTests {
             Files.writeString(localRepo.root().resolve(".jcheck/conf"), newConf, StandardCharsets.UTF_8);
             localRepo.add(localRepo.root().resolve(".jcheck/conf"));
             confHash = localRepo.commit("Set the version as 17", "duke", "duke@openjdk.org");
-            localRepo.push(confHash, author.url(), "edit", true);
+            localRepo.push(confHash, author.authenticatedUrl(), "edit", true);
             // Simulate the CSRBot.
             pr.setBody(pr.store().body() + CSR_UPDATE_MARKER);
             // Run bot. The primary CSR doesn't have the fix version `17`, so the bot won't get a CSR.
@@ -2136,7 +2136,7 @@ class CheckTests {
             Files.writeString(localRepo.root().resolve(".jcheck/conf"), newConf, StandardCharsets.UTF_8);
             localRepo.add(localRepo.root().resolve(".jcheck/conf"));
             confHash = localRepo.commit("Set the version as 11", "duke", "duke@openjdk.org");
-            localRepo.push(confHash, author.url(), "edit", true);
+            localRepo.push(confHash, author.authenticatedUrl(), "edit", true);
             // Simulate the CSRBot.
             pr.setBody(pr.store().body() + CSR_UPDATE_MARKER);
             // Run bot.
@@ -2201,11 +2201,11 @@ class CheckTests {
             localRepo.add(problemList);
             localRepo.commit("add problemList.txt", "testauthor", "ta@none.none");
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo, "A line");
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
 
             var issue = issueProject.createIssue("The main issue", List.of("main"), Map.of("issuetype", JSON.of("Bug")));
 
@@ -2244,13 +2244,13 @@ class CheckTests {
             localRepo.remove(localRepo.root().resolve(".jcheck/conf"));
             localRepo.commit("no conf", "testauthor", "ta@none.none");
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Create a new branch
             var editBranch = localRepo.branch(masterHash, "edit");
             localRepo.checkout(editBranch);
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
 
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
@@ -2271,7 +2271,7 @@ class CheckTests {
             writeToCheckConf(checkConf);
             localRepo.add(checkConf);
             var restoreHash = localRepo.commit("add conf to master", "testauthor", "ta@none.none");
-            localRepo.push(restoreHash, author.url(), "master", true);
+            localRepo.push(restoreHash, author.authenticatedUrl(), "master", true);
 
             pr.addComment(".jcheck/conf is uploaded");
             TestBotRunner.runPeriodicItems(checkBot);
@@ -2305,13 +2305,13 @@ class CheckTests {
             Files.writeString(checkConf, "\nRandomCharacters", StandardOpenOption.APPEND);
             localRepo.add(checkConf);
             var masterHash = localRepo.commit("make .jcheck/conf invalid", "testauthor", "ta@none.none");
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Create a new branch
             var editBranch = localRepo.branch(masterHash, "edit");
             localRepo.checkout(editBranch);
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
 
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
@@ -2331,7 +2331,7 @@ class CheckTests {
             writeToCheckConf(checkConf);
             localRepo.add(checkConf);
             var restoreHash = localRepo.commit("restore conf", "testauthor", "ta@none.none");
-            localRepo.push(restoreHash, author.url(), "master", true);
+            localRepo.push(restoreHash, author.authenticatedUrl(), "master", true);
 
             // Restore .jcheck/conf in source branch
             localRepo.checkout(editHash);
@@ -2339,7 +2339,7 @@ class CheckTests {
             writeToCheckConf(checkConf);
             localRepo.add(checkConf);
             var restoreEditHash = localRepo.commit("restore source branch conf", "testauthor", "ta@none.none");
-            localRepo.push(restoreEditHash, author.url(), "edit", true);
+            localRepo.push(restoreEditHash, author.authenticatedUrl(), "edit", true);
 
             pr.addComment(".jcheck/conf is uploaded");
             TestBotRunner.runPeriodicItems(checkBot);
@@ -2367,18 +2367,18 @@ class CheckTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Remove conf
             localRepo.remove(localRepo.root().resolve(".jcheck/conf"));
             var newMasterHash = localRepo.commit("No more conf", "duke", "duke@openjdk.org");
-            localRepo.push(newMasterHash, author.url(), "master");
+            localRepo.push(newMasterHash, author.authenticatedUrl(), "master");
 
             // Create a new branch
             var editBranch = localRepo.branch(masterHash, "edit");
             localRepo.checkout(editBranch);
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
 
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
@@ -2398,7 +2398,7 @@ class CheckTests {
             writeToCheckConf(checkConf);
             localRepo.add(checkConf);
             var restoreHash = localRepo.commit("restore conf", "testauthor", "ta@none.none");
-            localRepo.push(restoreHash, conf.url(), "jcheck-branch", true);
+            localRepo.push(restoreHash, conf.authenticatedUrl(), "jcheck-branch", true);
 
             pr.addComment("jcheck.conf is uploaded");
             TestBotRunner.runPeriodicItems(checkBot);
@@ -2426,12 +2426,12 @@ class CheckTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Remove conf
             localRepo.remove(localRepo.root().resolve(".jcheck/conf"));
             var newMasterHash = localRepo.commit("No more conf", "duke", "duke@openjdk.org");
-            localRepo.push(newMasterHash, author.url(), "master");
+            localRepo.push(newMasterHash, author.authenticatedUrl(), "master");
 
             // Upload invalid jcheck.conf to conf repo
             var jCheckBranch = localRepo.branch(masterHash, "jcheck-branch");
@@ -2440,13 +2440,13 @@ class CheckTests {
             Files.writeString(checkConf, "\nRandomCharacters", StandardOpenOption.CREATE);
             localRepo.add(checkConf);
             var confHash = localRepo.commit("restore conf", "testauthor", "ta@none.none");
-            localRepo.push(confHash, conf.url(), "jcheck-branch", true);
+            localRepo.push(confHash, conf.authenticatedUrl(), "jcheck-branch", true);
 
             // Create a new branch
             var editBranch = localRepo.branch(masterHash, "edit");
             localRepo.checkout(editBranch);
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
 
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
@@ -2465,7 +2465,7 @@ class CheckTests {
             writeToCheckConf(checkConf);
             localRepo.add(checkConf);
             var restoreHash = localRepo.commit("restore conf", "testauthor", "ta@none.none");
-            localRepo.push(restoreHash, conf.url(), "jcheck-branch", true);
+            localRepo.push(restoreHash, conf.authenticatedUrl(), "jcheck-branch", true);
 
             pr.addComment("jcheck.conf is uploaded");
             TestBotRunner.runPeriodicItems(checkBot);
@@ -2516,11 +2516,11 @@ class CheckTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
             pr.addComment("initial");
             TestBotRunner.runPeriodicItems(checkBot);
@@ -2534,7 +2534,7 @@ class CheckTests {
 
             // Normally push.
             var updatedHash = CheckableRepository.appendAndCommit(localRepo, "Normally push");
-            localRepo.push(updatedHash, author.url(), "edit", false);
+            localRepo.push(updatedHash, author.authenticatedUrl(), "edit", false);
             pr.addComment("Normally push");
             TestBotRunner.runPeriodicItems(checkBot);
 
@@ -2550,7 +2550,7 @@ class CheckTests {
             localRepo.checkout(editHash);
             localRepo.squash(updatedHash);
             var forcePushHash = localRepo.commit("test force-push", "duke", "duke@openjdk.org");
-            localRepo.push(forcePushHash, author.url(), "edit", true);
+            localRepo.push(forcePushHash, author.authenticatedUrl(), "edit", true);
             pr.addComment("Force-push");
             pr.setLastForcePushTime(ZonedDateTime.now());
             TestBotRunner.runPeriodicItems(checkBot);
@@ -2567,7 +2567,7 @@ class CheckTests {
 
             // Normally push again.
             updatedHash = CheckableRepository.appendAndCommit(localRepo, "Normally push");
-            localRepo.push(updatedHash, author.url(), "edit", false);
+            localRepo.push(updatedHash, author.authenticatedUrl(), "edit", false);
             pr.addComment("Normally push in draft");
             TestBotRunner.runPeriodicItems(checkBot);
 
@@ -2583,7 +2583,7 @@ class CheckTests {
             localRepo.checkout(editHash);
             localRepo.squash(updatedHash);
             forcePushHash = localRepo.commit("test force-push in draft", "duke", "duke@openjdk.org");
-            localRepo.push(forcePushHash, author.url(), "edit", true);
+            localRepo.push(forcePushHash, author.authenticatedUrl(), "edit", true);
             pr.setLastForcePushTime(ZonedDateTime.now());
             pr.addComment("Force-push in draft");
             TestBotRunner.runPeriodicItems(checkBot);
@@ -2611,7 +2611,7 @@ class CheckTests {
             localRepo.checkout(editHash);
             localRepo.squash(updatedHash);
             forcePushHash = localRepo.commit("test force-push again", "duke", "duke@openjdk.org");
-            localRepo.push(forcePushHash, author.url(), "edit", true);
+            localRepo.push(forcePushHash, author.authenticatedUrl(), "edit", true);
             pr.setLastForcePushTime(ZonedDateTime.now());
             pr.addComment("Force-push again");
             TestBotRunner.runPeriodicItems(checkBot);
@@ -2646,11 +2646,11 @@ class CheckTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             CheckWorkItem checkWorkItem = (CheckWorkItem) checkBot.getPeriodicItems().get(1);
@@ -2698,11 +2698,11 @@ class CheckTests {
             // set the .jcheck/conf without whitespace check
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(), Path.of("appendable.txt"), Set.of("author", "reviewers"), "0.1");
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR, add a line with whitespace issue
             var editHash = CheckableRepository.appendAndCommit(localRepo, "An additional line\r\n");
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Check the status
@@ -2721,7 +2721,7 @@ class CheckTests {
             writeToCheckConf(checkConf);
             localRepo.add(checkConf);
             var updateHash = localRepo.commit("enable whitespace issue check", "testauthor", "ta@none.none");
-            localRepo.push(updateHash, author.url(), "edit", true);
+            localRepo.push(updateHash, author.authenticatedUrl(), "edit", true);
 
             TestBotRunner.runPeriodicItems(checkBot);
 
@@ -2761,11 +2761,11 @@ class CheckTests {
             // set the .jcheck/conf without whitespace check
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(), Path.of("appendable.txt"), Set.of("author", "reviewers"), "0.1");
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR, add a line with whitespace issue
             var editHash = CheckableRepository.appendAndCommit(localRepo, "An additional line\r\n");
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Check the status
@@ -2784,7 +2784,7 @@ class CheckTests {
             Files.writeString(checkConf, "\nRandomCharacters", StandardOpenOption.APPEND);
             localRepo.add(checkConf);
             var updateHash = localRepo.commit("make .jcheck/conf invalid", "testauthor", "ta@none.none");
-            localRepo.push(updateHash, author.url(), "edit", true);
+            localRepo.push(updateHash, author.authenticatedUrl(), "edit", true);
 
             TestBotRunner.runPeriodicItems(checkBot);
 
@@ -2795,7 +2795,7 @@ class CheckTests {
             writeToCheckConf(checkConf);
             localRepo.add(checkConf);
             updateHash = localRepo.commit("enable whitespace issue check", "testauthor", "ta@none.none");
-            localRepo.push(updateHash, author.url(), "edit", true);
+            localRepo.push(updateHash, author.authenticatedUrl(), "edit", true);
 
             TestBotRunner.runPeriodicItems(checkBot);
             // pr body should have the integrationBlocker for whitespace and reviewer check

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CleanCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CleanCommandTests.java
@@ -22,14 +22,11 @@
  */
 package org.openjdk.skara.bots.pr;
 
-import org.openjdk.skara.forge.*;
 import org.junit.jupiter.api.*;
 import org.openjdk.skara.test.*;
 
 import java.io.IOException;
 import java.nio.file.*;
-import java.util.*;
-import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.openjdk.skara.bots.pr.PullRequestAsserts.assertLastCommentContains;
@@ -56,11 +53,11 @@ public class CleanCommandTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "123: This is a pull request");
             TestBotRunner.runPeriodicItems(prBot);
 
@@ -98,7 +95,7 @@ public class CleanCommandTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             var releaseBranch = localRepo.branch(masterHash, "release");
             localRepo.checkout(releaseBranch);
@@ -111,7 +108,7 @@ public class CleanCommandTests {
                                   "\n" +
                                   "Reviewed-by: integrationreviewer2";
             var releaseHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
-            localRepo.push(releaseHash, author.url(), "refs/heads/release", true);
+            localRepo.push(releaseHash, author.authenticatedUrl(), "refs/heads/release", true);
 
             // "backport" the new file to the master branch
             localRepo.checkout(localRepo.defaultBranch());
@@ -121,7 +118,7 @@ public class CleanCommandTests {
             Files.writeString(newFile2, "hello");
             localRepo.add(newFile2);
             var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Backport " + releaseHash.hex());
 
             // The bot should reply with a backport message
@@ -175,7 +172,7 @@ public class CleanCommandTests {
                                   "Reviewed-by: integrationreviewer2";
             var masterHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
 
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             var releaseBranch = localRepo.branch(masterHash, "release");
             localRepo.checkout(releaseBranch);
@@ -187,7 +184,7 @@ public class CleanCommandTests {
                                   "\n" +
                                   "Reviewed-by: integrationreviewer2";
             var upstreamHash = localRepo.commit(upstreamMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
-            localRepo.push(upstreamHash, author.url(), "refs/heads/release", true);
+            localRepo.push(upstreamHash, author.authenticatedUrl(), "refs/heads/release", true);
 
             // "backport" the new file to the master branch
             localRepo.checkout(localRepo.defaultBranch());
@@ -196,7 +193,7 @@ public class CleanCommandTests {
             Files.writeString(newFile, "a\nb\nc\nd\nd");
             localRepo.add(newFile);
             var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Backport " + upstreamHash.hex());
 
             // The bot should reply with a backport message
@@ -254,7 +251,7 @@ public class CleanCommandTests {
                                   "Reviewed-by: integrationreviewer2";
             var masterHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
 
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             var releaseBranch = localRepo.branch(masterHash, "release");
             localRepo.checkout(releaseBranch);
@@ -266,7 +263,7 @@ public class CleanCommandTests {
                                   "\n" +
                                   "Reviewed-by: integrationreviewer2";
             var upstreamHash = localRepo.commit(upstreamMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
-            localRepo.push(upstreamHash, author.url(), "refs/heads/release", true);
+            localRepo.push(upstreamHash, author.authenticatedUrl(), "refs/heads/release", true);
 
             // "backport" the new file to the master branch
             localRepo.checkout(localRepo.defaultBranch());
@@ -275,7 +272,7 @@ public class CleanCommandTests {
             Files.writeString(newFile, "a\nb\nc\nd\nd");
             localRepo.add(newFile);
             var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Backport " + upstreamHash.hex());
 
             // The bot should reply with a backport message
@@ -322,13 +319,13 @@ public class CleanCommandTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             var issue = credentials.createIssue(issues, "An issue");
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Backport " + issue.id());
             TestBotRunner.runPeriodicItems(prBot);
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CommitCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CommitCommandTests.java
@@ -55,11 +55,11 @@ public class CommitCommandTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change directly on master
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "master");
+            localRepo.push(editHash, author.authenticatedUrl(), "master");
 
             // Add a help command
             author.addCommitComment(editHash, "/help");
@@ -108,11 +108,11 @@ public class CommitCommandTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Add a `backport` command
@@ -123,7 +123,7 @@ public class CommitCommandTests {
 
             // Simulate an integration
             var botPr = botRepo.pullRequest(pr.id());
-            localRepo.push(editHash, author.url(), "master");
+            localRepo.push(editHash, author.authenticatedUrl(), "master");
             botPr.addComment("Pushed as commit " + editHash.hex() + ".");
             botPr.addLabel("integrated");
             botPr.setState(Issue.State.CLOSED);
@@ -168,15 +168,15 @@ public class CommitCommandTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change directly on master
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "master");
+            localRepo.push(editHash, author.authenticatedUrl(), "master");
 
             // Make a commit only present in pr branch
             var prHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(prHash, author.url(), "pr/1", true);
+            localRepo.push(prHash, author.authenticatedUrl(), "pr/1", true);
 
             // Add a help command to commit in pr branch
             var comment = author.addCommitComment(prHash, "/help");
@@ -209,11 +209,11 @@ public class CommitCommandTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change directly on master
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "master");
+            localRepo.push(editHash, author.authenticatedUrl(), "master");
 
             // Add a help command
             author.addCommitComment(editHash, "/help");
@@ -252,7 +252,7 @@ public class CommitCommandTests {
             Files.writeString(readme, "Hello, world!");
             localRepo.add(readme);
             var masterHash = localRepo.commit("Added README", "duke", "duke@openjdk.org");
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Add a help command
             author.addCommitComment(masterHash, "/help");

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ContributorTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ContributorTests.java
@@ -52,11 +52,11 @@ class ContributorTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Issue an invalid command
@@ -133,7 +133,7 @@ class ContributorTests {
 
             // The change should now be present on the master branch
             var pushedFolder = tempFolder.path().resolve("pushed");
-            var pushedRepo = Repository.materialize(pushedFolder, author.url(), "master");
+            var pushedRepo = Repository.materialize(pushedFolder, author.authenticatedUrl(), "master");
             assertTrue(CheckableRepository.hasBeenEdited(pushedRepo));
 
             var headHash = pushedRepo.resolve("HEAD").orElseThrow();
@@ -164,11 +164,11 @@ class ContributorTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Issue a contributor command not as the PR author
@@ -201,11 +201,11 @@ class ContributorTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Use an invalid full name
@@ -252,11 +252,11 @@ class ContributorTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Use a platform name
@@ -285,11 +285,11 @@ class ContributorTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Use a platform name
@@ -318,11 +318,11 @@ class ContributorTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Remove a contributor that hasn't been added
@@ -366,11 +366,11 @@ class ContributorTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Add a contributor

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrateTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrateTests.java
@@ -55,11 +55,11 @@ class IntegrateTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Approve it as another user
@@ -88,7 +88,7 @@ class IntegrateTests {
             assertEquals(1, pushed);
 
             // The change should now be present on the master branch
-            var pushedRepo = Repository.materialize(pushedFolder.path(), author.url(), "master");
+            var pushedRepo = Repository.materialize(pushedFolder.path(), author.authenticatedUrl(), "master");
             assertTrue(CheckableRepository.hasBeenEdited(pushedRepo));
 
             var headHash = pushedRepo.resolve("HEAD").orElseThrow();
@@ -125,11 +125,11 @@ class IntegrateTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Review it twice
@@ -149,7 +149,7 @@ class IntegrateTests {
             assertEquals(1, pushed);
 
             // The change should now be present on the master branch
-            var pushedRepo = Repository.materialize(pushedFolder.path(), author.url(), "master");
+            var pushedRepo = Repository.materialize(pushedFolder.path(), author.authenticatedUrl(), "master");
             assertTrue(CheckableRepository.hasBeenEdited(pushedRepo));
             var headCommit = pushedRepo.commits("HEAD").asList().get(0);
             assertTrue(String.join("", headCommit.message())
@@ -172,11 +172,11 @@ class IntegrateTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Attempt a merge, but point the check at some other commit
@@ -213,11 +213,11 @@ class IntegrateTests {
                                                      Set.of(), null);
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Now enable checks
@@ -225,7 +225,7 @@ class IntegrateTests {
             CheckableRepository.init(tempFolder.path(), author.repositoryType(), Path.of("appendable.txt"),
                                      Set.of("author", "reviewers", "whitespace"), null);
             var updatedHash = localRepo.resolve("HEAD").orElseThrow();
-            localRepo.push(updatedHash, author.url(), "master", true);
+            localRepo.push(updatedHash, author.authenticatedUrl(), "master", true);
 
             // Attempt a merge
             pr.addComment("/integrate");
@@ -250,11 +250,11 @@ class IntegrateTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo, "trailing whitespace   ");
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Attempt a merge
@@ -285,11 +285,11 @@ class IntegrateTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Flag it as checked
@@ -300,7 +300,7 @@ class IntegrateTests {
 
             // Now push another change
             var updatedHash = CheckableRepository.appendAndCommit(localRepo, "Yet another line");
-            localRepo.push(updatedHash, author.url(), "edit", true);
+            localRepo.push(updatedHash, author.authenticatedUrl(), "edit", true);
 
             // Attempt a merge, but point the check at some other commit
             pr.addComment("/integrate");
@@ -338,11 +338,11 @@ class IntegrateTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Approve it as another user
@@ -418,11 +418,11 @@ class IntegrateTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Issue a merge command not as the PR author
@@ -456,11 +456,11 @@ class IntegrateTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Approve it as another user
@@ -504,11 +504,11 @@ class IntegrateTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Approve it as another user
@@ -521,7 +521,7 @@ class IntegrateTests {
             Files.writeString(unrelated, "Hello");
             localRepo.add(unrelated);
             var unrelatedHash = localRepo.commit("Unrelated", "X", "x@y.z");
-            localRepo.push(unrelatedHash, author.url(), "master");
+            localRepo.push(unrelatedHash, author.authenticatedUrl(), "master");
 
             // Attempt a merge (the bot should only process the first one)
             pr.addComment("/integrate");
@@ -541,7 +541,7 @@ class IntegrateTests {
             assertEquals(1, pushed);
 
             // The change should now be present on the master branch
-            var pushedRepo = Repository.materialize(pushedFolder.path(), author.url(), "master");
+            var pushedRepo = Repository.materialize(pushedFolder.path(), author.authenticatedUrl(), "master");
             assertTrue(CheckableRepository.hasBeenEdited(pushedRepo));
         }
     }
@@ -564,11 +564,11 @@ class IntegrateTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Approve it as another user
@@ -579,19 +579,19 @@ class IntegrateTests {
             TestBotRunner.runPeriodicItems(mergeBot);
 
             // Break the census to cause an exception
-            var localCensus = Repository.materialize(censusFolder.path(), censusRepo.url(), "+master:current_census");
+            var localCensus = Repository.materialize(censusFolder.path(), censusRepo.authenticatedUrl(), "+master:current_census");
             var currentCensusHash = localCensus.resolve("current_census").orElseThrow();
             Files.writeString(censusFolder.path().resolve("contributors.xml"), "This is not xml", StandardCharsets.UTF_8);
             localCensus.add(censusFolder.path().resolve("contributors.xml"));
             var badCensusHash = localCensus.commit("Bad census update", "duke", "duke@openjdk.org");
-            localCensus.push(badCensusHash, censusRepo.url(), "master", true);
+            localCensus.push(badCensusHash, censusRepo.authenticatedUrl(), "master", true);
 
             // Attempt a merge
             pr.addComment("/integrate");
             assertThrows(RuntimeException.class, () -> TestBotRunner.runPeriodicItems(mergeBot));
 
             // Restore the census
-            localCensus.push(currentCensusHash, censusRepo.url(), "master", true);
+            localCensus.push(currentCensusHash, censusRepo.authenticatedUrl(), "master", true);
 
             // The bot should now retry
             TestBotRunner.runPeriodicItems(mergeBot);
@@ -620,11 +620,11 @@ class IntegrateTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Approve it as another user
@@ -634,7 +634,7 @@ class IntegrateTests {
             // Push something conflicting to master
             localRepo.checkout(masterHash, true);
             var conflictingHash = CheckableRepository.appendAndCommit(localRepo, "This looks like a conflict");
-            localRepo.push(conflictingHash, author.url(), "master");
+            localRepo.push(conflictingHash, author.authenticatedUrl(), "master");
 
             // Trigger a new check run
             pr.setBody(pr.body() + " recheck");
@@ -670,11 +670,11 @@ class IntegrateTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Approve it as another user
@@ -687,7 +687,7 @@ class IntegrateTests {
             Files.writeString(unrelated, "Hello");
             localRepo.add(unrelated);
             var unrelatedHash = localRepo.commit("Unrelated", "X", "x@y.z");
-            localRepo.push(unrelatedHash, author.url(), "master");
+            localRepo.push(unrelatedHash, author.authenticatedUrl(), "master");
 
             // Attempt a merge
             pr.addComment("/integrate " + masterHash);
@@ -704,7 +704,7 @@ class IntegrateTests {
             assertLastCommentContains(pr, "Pushed as commit");
 
             // The change should now be present on the master branch
-            var pushedRepo = Repository.materialize(pushedFolder.path(), author.url(), "master");
+            var pushedRepo = Repository.materialize(pushedFolder.path(), author.authenticatedUrl(), "master");
             assertTrue(CheckableRepository.hasBeenEdited(pushedRepo));
         }
     }
@@ -726,11 +726,11 @@ class IntegrateTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Approve it as another user
@@ -766,11 +766,11 @@ class IntegrateTests {
             localRepo.commit("Add CONTRIBUTING.md", "duke", "duke@openjdk.org");
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Approve it as another user
@@ -803,12 +803,12 @@ class IntegrateTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR with an empty e-mail
             var authorFullName = author.forge().currentUser().fullName();
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Content", "A commit", authorFullName, "");
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Run the bot
@@ -845,11 +845,11 @@ class IntegrateTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Approve it as another user
@@ -899,11 +899,11 @@ class IntegrateTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR with auto integration
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "PR Title", List.of("/integrate auto"));
 
             // The bot should add the auto label and reply
@@ -929,7 +929,7 @@ class IntegrateTests {
             assertEquals(1, pushed);
 
             // The change should now be present on the master branch
-            var pushedRepo = Repository.materialize(pushedFolder.path(), author.url(), "master");
+            var pushedRepo = Repository.materialize(pushedFolder.path(), author.authenticatedUrl(), "master");
             assertTrue(CheckableRepository.hasBeenEdited(pushedRepo));
 
             var headHash = pushedRepo.resolve("HEAD").orElseThrow();
@@ -966,11 +966,11 @@ class IntegrateTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR with auto integration
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "PR Title");
 
             // The bot should add the auto label and reply
@@ -997,7 +997,7 @@ class IntegrateTests {
             assertEquals(1, pushed);
 
             // The change should now be present on the master branch
-            var pushedRepo = Repository.materialize(pushedFolder.path(), author.url(), "master");
+            var pushedRepo = Repository.materialize(pushedFolder.path(), author.authenticatedUrl(), "master");
             assertTrue(CheckableRepository.hasBeenEdited(pushedRepo));
 
             var headHash = pushedRepo.resolve("HEAD").orElseThrow();
@@ -1034,11 +1034,11 @@ class IntegrateTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR with auto integration
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "PR Title", List.of("/integrate auto"));
 
             // The bot should add the auto label and reply
@@ -1088,7 +1088,7 @@ class IntegrateTests {
             assertEquals(1, pushed);
 
             // The change should now be present on the master branch
-            var pushedRepo = Repository.materialize(pushedFolder.path(), author.url(), "master");
+            var pushedRepo = Repository.materialize(pushedFolder.path(), author.authenticatedUrl(), "master");
             assertTrue(CheckableRepository.hasBeenEdited(pushedRepo));
 
             var headHash = pushedRepo.resolve("HEAD").orElseThrow();
@@ -1127,11 +1127,11 @@ class IntegrateTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Approve it as another user
@@ -1158,7 +1158,7 @@ class IntegrateTests {
             pr.addLabel("ready");
             pr.setState(Issue.State.OPEN);
             pr.removeLabel("integrated");
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
             // The bot should now retry
             TestBotRunner.runPeriodicItems(mergeBot);
             // The bot should reply with an ok message
@@ -1253,13 +1253,13 @@ class IntegrateTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editBranch = localRepo.branch(masterHash, "edit");
             localRepo.checkout(editBranch);
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Approve it as another user
@@ -1286,12 +1286,12 @@ class IntegrateTests {
 
             // Add a new commit to master branch
             localRepo.checkout(new Branch("master"));
-            localRepo.fetch(author.url(), "master");
+            localRepo.fetch(author.authenticatedUrl(), "master");
             localRepo.merge(new Branch("FETCH_HEAD"));
             var integratedHash = localRepo.resolve("master");
             var newMasterHash = CheckableRepository.appendAndCommit(localRepo, "Another line",
                     "New master commit");
-            localRepo.push(newMasterHash, author.url(), "master", true);
+            localRepo.push(newMasterHash, author.authenticatedUrl(), "master", true);
 
             // The bot should now retry
             TestBotRunner.runPeriodicItems(mergeBot);
@@ -1329,11 +1329,11 @@ class IntegrateTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var authorPr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Approve it as another user
@@ -1422,7 +1422,7 @@ class IntegrateTests {
             TestBotRunner.runPeriodicItems(mergeBot);
 
             // The change should now be present on the master branch
-            var pushedRepo = Repository.materialize(pushedFolder.path(), author.url(), "master");
+            var pushedRepo = Repository.materialize(pushedFolder.path(), author.authenticatedUrl(), "master");
             assertTrue(CheckableRepository.hasBeenEdited(pushedRepo));
 
             var headHash = pushedRepo.resolve("HEAD").orElseThrow();
@@ -1465,11 +1465,11 @@ class IntegrateTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var authorPr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Approve it as another user
@@ -1520,7 +1520,7 @@ class IntegrateTests {
             assertFalse(authorPr.store().labelNames().contains("ready"));
 
             // The change should now be present on the master branch
-            var pushedRepo = Repository.materialize(pushedFolder.path(), author.url(), "master");
+            var pushedRepo = Repository.materialize(pushedFolder.path(), author.authenticatedUrl(), "master");
             assertTrue(CheckableRepository.hasBeenEdited(pushedRepo));
 
             var headHash = pushedRepo.resolve("HEAD").orElseThrow();

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrationLockTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrationLockTests.java
@@ -40,11 +40,11 @@ public class IntegrationLockTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             var l1 = IntegrationLock.create(pr, Duration.ofSeconds(10));

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IssueTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IssueTests.java
@@ -55,11 +55,11 @@ class IssueTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "123: This is a pull request");
 
             // No arguments
@@ -146,7 +146,7 @@ class IssueTests {
 
             // The change should now be present on the master branch
             var pushedFolder = tempFolder.path().resolve("pushed");
-            var pushedRepo = Repository.materialize(pushedFolder, author.url(), "master");
+            var pushedRepo = Repository.materialize(pushedFolder, author.authenticatedUrl(), "master");
             assertTrue(CheckableRepository.hasBeenEdited(pushedRepo));
 
             var headHash = pushedRepo.resolve("HEAD").orElseThrow();
@@ -183,11 +183,11 @@ class IssueTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var issue1 = credentials.createIssue(issues, "Main");
             var issue1Number = Integer.parseInt(issue1.id().split("-")[1]);
             var pr = credentials.createPullRequest(author, "master", "edit", issue1Number + ": Main");
@@ -248,7 +248,7 @@ class IssueTests {
 
             // The change should now be present on the master branch
             var pushedFolder = tempFolder.path().resolve("pushed");
-            var pushedRepo = Repository.materialize(pushedFolder, author.url(), "master");
+            var pushedRepo = Repository.materialize(pushedFolder, author.authenticatedUrl(), "master");
             assertTrue(CheckableRepository.hasBeenEdited(pushedRepo));
 
             var headHash = pushedRepo.resolve("HEAD").orElseThrow();
@@ -278,11 +278,11 @@ class IssueTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Issue a solves command not as the PR author
@@ -313,11 +313,11 @@ class IssueTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Add an issue
@@ -356,11 +356,11 @@ class IssueTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var issue1 = issues.createIssue("First", List.of("Hello"), Map.of());
             var pr = credentials.createPullRequest(author, "master", "edit",
                                                    issue1.id() + ": This is a pull request");
@@ -403,11 +403,11 @@ class IssueTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var issue1 = (TestIssue)issues.createIssue("First", List.of("Hello"), Map.of());
             issue1.setState(Issue.State.CLOSED);
             issue1.store().properties().put("resolution", JSON.object().put("name", JSON.of("Not an Issue")));
@@ -439,11 +439,11 @@ class IssueTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var issue1 = (TestIssue)issues.createIssue("First", List.of("Hello"), Map.of());
             issue1.setState(Issue.State.RESOLVED);
             var pr = credentials.createPullRequest(author, "master", "edit",
@@ -474,11 +474,11 @@ class IssueTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var issue1 = issues.createIssue("First", List.of("Hello"), Map.of());
             issue1.setState(Issue.State.RESOLVED);
             var pr = credentials.createPullRequest(author, "master", "edit",
@@ -520,11 +520,11 @@ class IssueTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
             pr.setBody("This is the body");
 
@@ -560,11 +560,11 @@ class IssueTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Create an issue
@@ -627,7 +627,7 @@ class IssueTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Create issues
             var issue1 = credentials.createIssue(issueProject, "Issue 1");
@@ -635,7 +635,7 @@ class IssueTests {
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", issue1.id() + ": This is a pull request");
             TestBotRunner.runPeriodicItems(prBot);
 
@@ -694,7 +694,7 @@ class IssueTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             var issue1 = credentials.createIssue(issueProject, "Issue 1");
             var issue2 = credentials.createIssue(issueProject, "Issue 2");
@@ -702,7 +702,7 @@ class IssueTests {
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Pull request title",
                      List.of("/issue add " + issue1.id(),
                              "/issue add " + issue2.id(),
@@ -744,11 +744,11 @@ class IssueTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR with a non-existing issue ID
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "123: This is a PR");
 
             // Approve it as another user

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/JEPCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/JEPCommandTests.java
@@ -60,7 +60,7 @@ public class JEPCommandTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(),
                     Path.of("appendable.txt"), Set.of("issues"), null);
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             var mainIssue = issueProject.createIssue("The main issue", List.of("main"), Map.of("issuetype", JSON.of("Bug")));
             var jepIssue = issueProject.createIssue("The jep issue", List.of("Jep body"),
@@ -70,7 +70,7 @@ public class JEPCommandTests {
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", mainIssue.id() + ": " + mainIssue.title());
             var prAsReviewer = reviewer.pullRequest(pr.id());
 
@@ -224,7 +224,7 @@ public class JEPCommandTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(),
                     Path.of("appendable.txt"), Set.of("issues"), null);
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             var mainIssue = issueProject.createIssue("The main issue", List.of("main"), Map.of("issuetype", JSON.of("Bug")));
             var jepIssue = issueProject.createIssue("The jep issue", List.of("Jep body"),
@@ -232,7 +232,7 @@ public class JEPCommandTests {
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", mainIssue.id() + ": " + mainIssue.title());
             var prAsReviewer = reviewer.pullRequest(pr.id());
             var prAsCommitter = committer.pullRequest(pr.id());
@@ -307,7 +307,7 @@ public class JEPCommandTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(),
                     Path.of("appendable.txt"), Set.of("issues"), null);
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             var mainIssue = issueProject.createIssue("The main issue", List.of("main"), Map.of("issuetype", JSON.of("Bug")));
             var jepIssue = issueProject.createIssue("The jep issue", List.of("Jep body"),
@@ -315,7 +315,7 @@ public class JEPCommandTests {
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", mainIssue.id() + ": " + mainIssue.title());
 
             // PR should not have the `jep` label
@@ -418,7 +418,7 @@ public class JEPCommandTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(),
                     Path.of("appendable.txt"), Set.of("issues"), null);
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             var mainIssue = issueProject.createIssue("The main issue", List.of("main"), Map.of("issuetype", JSON.of("Bug")));
             var statusList = List.of("Draft", "Submitted", "Candidate", "Proposed to Target",
@@ -433,7 +433,7 @@ public class JEPCommandTests {
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", mainIssue.id() + ": " + mainIssue.title());
 
             // PR should not have the `jep` label
@@ -478,7 +478,7 @@ public class JEPCommandTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(),
                     Path.of("appendable.txt"), Set.of("issues"), null);
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             var mainIssue = issueProject.createIssue("The main issue", List.of("main"), Map.of("issuetype", JSON.of("Bug")));
             var jepIssue = issueProject.createIssue("The jep issue", List.of("Jep body"),
@@ -486,7 +486,7 @@ public class JEPCommandTests {
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", mainIssue.id() + ": " + mainIssue.title());
 
             // Test the PR bot with jep disable

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelTests.java
@@ -62,11 +62,11 @@ public class LabelTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "123: This is a pull request");
             TestBotRunner.runPeriodicItems(prBot);
 
@@ -153,11 +153,11 @@ public class LabelTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType(), Path.of("test.hpp"));
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "123: This is a pull request");
 
             // The bot should have applied one label automatically
@@ -175,7 +175,7 @@ public class LabelTests {
             Files.writeString(localRepoFolder.resolve("test.cpp"), "Hello there");
             localRepo.add(Path.of("test.cpp"));
             editHash = localRepo.commit("Another one", "duke", "duke@openjdk.org");
-            localRepo.push(editHash, author.url(), "edit");
+            localRepo.push(editHash, author.authenticatedUrl(), "edit");
 
             // The bot should not apply labels since the user has manually removed labels
             TestBotRunner.runPeriodicItems(prBot);
@@ -216,11 +216,11 @@ public class LabelTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType(), Path.of("test.hpp"));
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "123: This is a pull request");
             pr.setBody("/cc 1");
 
@@ -234,7 +234,7 @@ public class LabelTests {
             Files.writeString(localRepoFolder.resolve("test.cpp"), "Hello there");
             localRepo.add(Path.of("test.cpp"));
             editHash = localRepo.commit("Another one", "duke", "duke@openjdk.org");
-            localRepo.push(editHash, author.url(), "edit");
+            localRepo.push(editHash, author.authenticatedUrl(), "edit");
 
             // The bot will still not do any automatic labelling
             TestBotRunner.runPeriodicItems(prBot);
@@ -280,11 +280,11 @@ public class LabelTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "123: This is a pull request");
             TestBotRunner.runPeriodicItems(prBot);
 
@@ -334,11 +334,11 @@ public class LabelTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "123: This is a pull request");
 
             // Add a label with -dev suffix
@@ -385,11 +385,11 @@ public class LabelTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "123: This is a pull request");
 
             // Add a label with -dev suffix
@@ -439,11 +439,11 @@ public class LabelTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "123: This is a pull request");
 
             // Add a label with 24h hint
@@ -493,11 +493,11 @@ public class LabelTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "123: This is a pull request");
             TestBotRunner.runPeriodicItems(prBot);
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelerTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelerTests.java
@@ -60,11 +60,11 @@ class LabelerTests {
             var localRepoFolder = tempFolder.path();
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Check the status - only the rfr label should be set
@@ -103,17 +103,17 @@ class LabelerTests {
             var localRepoFolder = tempFolder.path();
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
 
             var fileA = localRepoFolder.resolve("a.txt");
             Files.writeString(fileA, "Hello");
             localRepo.add(fileA);
             var hashA = localRepo.commit("test1", "test", "test@test");
-            localRepo.push(hashA, author.url(), "edit");
+            localRepo.push(hashA, author.authenticatedUrl(), "edit");
 
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
@@ -147,24 +147,24 @@ class LabelerTests {
             var localRepoFolder = tempFolder.path();
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Add an unrelated file to master
             var fileB = localRepoFolder.resolve("b.txt");
             Files.writeString(fileB, "Hello");
             localRepo.add(fileB);
             var hashB = localRepo.commit("test1", "test", "test@test");
-            localRepo.push(hashB, author.url(), "master");
+            localRepo.push(hashB, author.authenticatedUrl(), "master");
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
 
             var fileA = localRepoFolder.resolve("a.txt");
             Files.writeString(fileA, "Hello");
             localRepo.add(fileA);
             var hashA = localRepo.commit("test1", "test", "test@test");
-            localRepo.push(hashA, author.url(), "edit");
+            localRepo.push(hashA, author.authenticatedUrl(), "edit");
 
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
@@ -198,17 +198,17 @@ class LabelerTests {
             var localRepoFolder = tempFolder.path();
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
 
             var fileA = localRepoFolder.resolve("a.txt");
             Files.writeString(fileA, "Hello");
             localRepo.add(fileA);
             var hashA = localRepo.commit("test1", "test", "test@test");
-            localRepo.push(hashA, author.url(), "edit");
+            localRepo.push(hashA, author.authenticatedUrl(), "edit");
 
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
@@ -246,17 +246,17 @@ class LabelerTests {
             var localRepoFolder = tempFolder.path();
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
 
             var fileA = localRepoFolder.resolve("a.txt");
             Files.writeString(fileA, "Hello");
             localRepo.add(fileA);
             var hashA = localRepo.commit("test1", "test", "test@test");
-            localRepo.push(hashA, author.url(), "edit");
+            localRepo.push(hashA, author.authenticatedUrl(), "edit");
 
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
@@ -293,17 +293,17 @@ class LabelerTests {
             var localRepoFolder = tempFolder.path();
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
 
             var fileA = localRepoFolder.resolve("a.txt");
             Files.writeString(fileA, "Hello");
             localRepo.add(fileA);
             var hashA = localRepo.commit("test1", "test", "test@test");
-            localRepo.push(hashA, author.url(), "edit");
+            localRepo.push(hashA, author.authenticatedUrl(), "edit");
 
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
@@ -59,15 +59,15 @@ class MergeTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make more changes in another branch
             var otherHash1 = CheckableRepository.appendAndCommit(localRepo, "First change in other_/-1.2",
                                                                 "First other_/-1.2\n\nReviewed-by: integrationreviewer2");
-            localRepo.push(otherHash1, author.url(), "other_/-1.2", true);
+            localRepo.push(otherHash1, author.authenticatedUrl(), "other_/-1.2", true);
             var otherHash2 = CheckableRepository.appendAndCommit(localRepo, "Second change in other_/-1.2",
                                                                 "Second other_/-1.2\n\nReviewed-by: integrationreviewer2");
-            localRepo.push(otherHash2, author.url(), "other_/-1.2");
+            localRepo.push(otherHash2, author.authenticatedUrl(), "other_/-1.2");
 
             // Go back to the original master
             localRepo.checkout(masterHash, true);
@@ -77,10 +77,10 @@ class MergeTests {
             localRepo.add(unrelated);
             var updatedMaster = localRepo.commit("Unrelated", "some", "some@one");
             localRepo.merge(otherHash2);
-            localRepo.push(updatedMaster, author.url(), "master");
+            localRepo.push(updatedMaster, author.authenticatedUrl(), "master");
 
             var mergeHash = localRepo.commit("Merge commit", "some", "some@one");
-            localRepo.push(mergeHash, author.url(), "edit", true);
+            localRepo.push(mergeHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Merge " + author.name() + ":other_/-1.2");
 
             // Approve it as another user
@@ -102,7 +102,7 @@ class MergeTests {
 
             // The change should now be present on the master branch
             var pushedRepoFolder = tempFolder.path().resolve("pushedrepo");
-            var pushedRepo = Repository.materialize(pushedRepoFolder, author.url(), "master");
+            var pushedRepo = Repository.materialize(pushedRepoFolder, author.authenticatedUrl(), "master");
             assertTrue(CheckableRepository.hasBeenEdited(pushedRepo));
 
             // The commits from the "other" branch should be preserved and not squashed (but not the merge commit)
@@ -148,15 +148,15 @@ class MergeTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make more changes in another branch
             var otherHash1 = CheckableRepository.appendAndCommit(localRepo, "First change in other",
                                                                  "First other\n\nReviewed-by: integrationreviewer2");
-            localRepo.push(otherHash1, author.url(), "other", true);
+            localRepo.push(otherHash1, author.authenticatedUrl(), "other", true);
             var otherHash2 = CheckableRepository.appendAndCommit(localRepo, "Second change in other",
                                                                  "Second other\n\nReviewed-by: integrationreviewer2");
-            localRepo.push(otherHash2, author.url(), "other");
+            localRepo.push(otherHash2, author.authenticatedUrl(), "other");
 
             // Go back to the original master
             localRepo.checkout(masterHash, true);
@@ -166,10 +166,10 @@ class MergeTests {
             localRepo.add(unrelated);
             var updatedMaster = localRepo.commit("Unrelated", "some", "some@one");
             localRepo.merge(otherHash2);
-            localRepo.push(updatedMaster, author.url(), "master");
+            localRepo.push(updatedMaster, author.authenticatedUrl(), "master");
 
             var mergeHash = localRepo.commit("Merge commit", "some", "some@one");
-            localRepo.push(mergeHash, author.url(), "edit", true);
+            localRepo.push(mergeHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Merge " + author.name() + ":other");
 
             // Approve it as another user
@@ -209,15 +209,15 @@ class MergeTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make more changes in another branch
             var otherHash1 = CheckableRepository.appendAndCommit(localRepo, "First change in other",
                                                                  "First other\n\nReviewed-by: integrationreviewer2");
-            localRepo.push(otherHash1, author.url(), "other", true);
+            localRepo.push(otherHash1, author.authenticatedUrl(), "other", true);
             var otherHash2 = CheckableRepository.appendAndCommit(localRepo, "Second change in other",
                                                                  "Second other\n\nReviewed-by: integrationreviewer2");
-            localRepo.push(otherHash2, author.url(), "other");
+            localRepo.push(otherHash2, author.authenticatedUrl(), "other");
 
             // Go back to the original master
             localRepo.checkout(masterHash, true);
@@ -227,10 +227,10 @@ class MergeTests {
             localRepo.add(unrelated);
             var updatedMaster = localRepo.commit("Unrelated", "some", "some@one");
             localRepo.merge(otherHash2);
-            localRepo.push(updatedMaster, author.url(), "master");
+            localRepo.push(updatedMaster, author.authenticatedUrl(), "master");
 
             var mergeHash = localRepo.commit("Merge commit", "some", "some@one");
-            localRepo.push(mergeHash, author.url(), "edit", true);
+            localRepo.push(mergeHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Merge " + author.name() + ":other");
 
             // Approve it as another user
@@ -266,15 +266,15 @@ class MergeTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make more changes in another branch
             var otherHash1 = CheckableRepository.appendAndCommit(localRepo, "First change in other",
                                                                  "First other\n\nReviewed-by: integrationreviewer2");
-            localRepo.push(otherHash1, author.url(), "other", true);
+            localRepo.push(otherHash1, author.authenticatedUrl(), "other", true);
             var otherHash2 = CheckableRepository.appendAndCommit(localRepo, "Second change in other",
                                                                  "Second other\n\nReviewed-by: integrationreviewer2");
-            localRepo.push(otherHash2, author.url(), "other");
+            localRepo.push(otherHash2, author.authenticatedUrl(), "other");
 
             // Go back to the original master
             localRepo.checkout(masterHash, true);
@@ -284,10 +284,10 @@ class MergeTests {
             localRepo.add(unrelated);
             var updatedMaster = localRepo.commit("Unrelated", "some", "some@one");
             localRepo.merge(otherHash2);
-            localRepo.push(updatedMaster, author.url(), "master");
+            localRepo.push(updatedMaster, author.authenticatedUrl(), "master");
 
             var mergeHash = localRepo.commit("Merge commit", "some", "some@one");
-            localRepo.push(mergeHash, author.url(), "edit", true);
+            localRepo.push(mergeHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Merge " + otherHash2.hex());
 
             // Approve it as another user
@@ -309,7 +309,7 @@ class MergeTests {
 
             // The change should now be present on the master branch
             var pushedRepoFolder = tempFolder.path().resolve("pushedrepo");
-            var pushedRepo = Repository.materialize(pushedRepoFolder, author.url(), "master");
+            var pushedRepo = Repository.materialize(pushedRepoFolder, author.authenticatedUrl(), "master");
             assertTrue(CheckableRepository.hasBeenEdited(pushedRepo));
 
             // The commits from the "other" branch should be preserved and not squashed (but not the merge commit)
@@ -351,18 +351,18 @@ class MergeTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make more changes in another branch
             var otherHash1 = CheckableRepository.appendAndCommit(localRepo, "First change in other",
                                                                  "First other\n\nReviewed-by: integrationreviewer2");
-            localRepo.push(otherHash1, author.url(), "other", true);
+            localRepo.push(otherHash1, author.authenticatedUrl(), "other", true);
             var otherHash2 = CheckableRepository.appendAndCommit(localRepo, "Second change in other",
                                                                  "Second other\n\nReviewed-by: integrationreviewer2");
-            localRepo.push(otherHash2, author.url(), "other");
+            localRepo.push(otherHash2, author.authenticatedUrl(), "other");
 
             // Push the new commits to master and then return to the original one
-            localRepo.push(otherHash2, author.url(), "master");
+            localRepo.push(otherHash2, author.authenticatedUrl(), "master");
             localRepo.checkout(masterHash, true);
 
             // Make a change with a corresponding PR
@@ -371,7 +371,7 @@ class MergeTests {
             var updatedMaster = localRepo.commit("Unrelated", "some", "some@one");
             localRepo.merge(otherHash2);
             var mergeHash = localRepo.commit("Merge commit", "some", "some@one");
-            localRepo.push(mergeHash, author.url(), "edit", true);
+            localRepo.push(mergeHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Merge " + otherHash2.hex());
 
             // Approve it as another user
@@ -414,15 +414,15 @@ class MergeTests {
                                                      Path.of("appendable.txt"), Set.of("merge"), "1.0");
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make more changes in another branch
             var otherHash1 = CheckableRepository.appendAndCommit(localRepo, "First change in other",
                                                                  "First other\n\nReviewed-by: integrationreviewer2");
-            localRepo.push(otherHash1, author.url(), "other", true);
+            localRepo.push(otherHash1, author.authenticatedUrl(), "other", true);
             var otherHash2 = CheckableRepository.appendAndCommit(localRepo, "Second change in other",
                                                                  "Second other\n\nReviewed-by: integrationreviewer2");
-            localRepo.push(otherHash2, author.url(), "other");
+            localRepo.push(otherHash2, author.authenticatedUrl(), "other");
 
             // Go back to the original master
             localRepo.checkout(masterHash, true);
@@ -432,10 +432,10 @@ class MergeTests {
             localRepo.add(unrelated);
             var updatedMaster = localRepo.commit("Unrelated", "some", "some@one");
             localRepo.merge(otherHash2);
-            localRepo.push(updatedMaster, author.url(), "master");
+            localRepo.push(updatedMaster, author.authenticatedUrl(), "master");
 
             var mergeHash = localRepo.commit("Merge commit", "some", "some@one");
-            localRepo.push(mergeHash, author.url(), "edit", true);
+            localRepo.push(mergeHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Merge " + author.name() + ":other");
 
             // Approve it as another user
@@ -454,7 +454,7 @@ class MergeTests {
 
             // The change should now be present on the master branch
             var pushedRepoFolder = tempFolder.path().resolve("pushedrepo");
-            var pushedRepo = Repository.materialize(pushedRepoFolder, author.url(), "master");
+            var pushedRepo = Repository.materialize(pushedRepoFolder, author.authenticatedUrl(), "master");
             assertTrue(CheckableRepository.hasBeenEdited(pushedRepo));
 
             // The commits from the "other" branch should be preserved and not squashed (but not the merge commit)
@@ -496,15 +496,15 @@ class MergeTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make more changes in another branch
             var otherHash1 = CheckableRepository.appendAndCommit(localRepo, "First change in other",
                                                                  "First other\n\nReviewed-by: integrationreviewer2");
-            localRepo.push(otherHash1, author.url(), "other", true);
+            localRepo.push(otherHash1, author.authenticatedUrl(), "other", true);
             var otherHash2 = CheckableRepository.appendAndCommit(localRepo, "Second change in other",
                                                                  "Second other\n\nReviewed-by: integrationreviewer2");
-            localRepo.push(otherHash2, author.url(), "other");
+            localRepo.push(otherHash2, author.authenticatedUrl(), "other");
 
             // Go back to the original master
             localRepo.checkout(masterHash, true);
@@ -513,11 +513,11 @@ class MergeTests {
             var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated", StandardCharsets.UTF_8);
             localRepo.add(unrelated);
             var updatedMaster = localRepo.commit("Unrelated", "some", "some@one");
-            localRepo.push(updatedMaster, author.url(), "master");
+            localRepo.push(updatedMaster, author.authenticatedUrl(), "master");
 
             localRepo.merge(otherHash2);
             var mergeHash = localRepo.commit("Merge commit", "some", "some@one");
-            localRepo.push(mergeHash, author.url(), "edit", true);
+            localRepo.push(mergeHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Merge other");
 
             // Approve it as another user
@@ -539,7 +539,7 @@ class MergeTests {
 
             // The change should now be present on the master branch
             var pushedRepoFolder = tempFolder.path().resolve("pushedrepo");
-            var pushedRepo = Repository.materialize(pushedRepoFolder, author.url(), "master");
+            var pushedRepo = Repository.materialize(pushedRepoFolder, author.authenticatedUrl(), "master");
             assertTrue(CheckableRepository.hasBeenEdited(pushedRepo));
 
             // The commits from the "other" branch should be preserved and not squashed (but not the merge commit)
@@ -580,17 +580,17 @@ class MergeTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make more changes in another branch
             var otherHash1 = CheckableRepository.appendAndCommit(localRepo, "First change in other",
                                                                  "First other\n\nReviewed-by: integrationreviewer2");
-            localRepo.push(otherHash1, author.url(), "other", true);
+            localRepo.push(otherHash1, author.authenticatedUrl(), "other", true);
             var otherHash2 = CheckableRepository.appendAndCommit(localRepo, "Second change in other",
                                                                  "Second other\n\nReviewed-by: integrationreviewer2");
             var tag = localRepo.tag(otherHash2, "othertag", "Tagging other", "tagger", "tagger@one");
             var tagHash = localRepo.lookup(tag).orElseThrow().hash();
-            localRepo.push(tagHash, author.url(), "refs/tags/othertag");
+            localRepo.push(tagHash, author.authenticatedUrl(), "refs/tags/othertag");
 
             // Go back to the original master
             localRepo.checkout(masterHash, true);
@@ -599,11 +599,11 @@ class MergeTests {
             var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated", StandardCharsets.UTF_8);
             localRepo.add(unrelated);
             var updatedMaster = localRepo.commit("Unrelated", "some", "some@one");
-            localRepo.push(updatedMaster, author.url(), "master");
+            localRepo.push(updatedMaster, author.authenticatedUrl(), "master");
 
             localRepo.merge(otherHash2);
             var mergeHash = localRepo.commit("Merge commit", "some", "some@one");
-            localRepo.push(mergeHash, author.url(), "edit", true);
+            localRepo.push(mergeHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Merge othertag");
 
             // Approve it as another user
@@ -625,7 +625,7 @@ class MergeTests {
 
             // The change should now be present on the master branch
             var pushedRepoFolder = tempFolder.path().resolve("pushedrepo");
-            var pushedRepo = Repository.materialize(pushedRepoFolder, author.url(), "master");
+            var pushedRepo = Repository.materialize(pushedRepoFolder, author.authenticatedUrl(), "master");
             assertTrue(CheckableRepository.hasBeenEdited(pushedRepo));
 
             // The commits from the "other" branch should be preserved and not squashed (but not the merge commit)
@@ -666,15 +666,15 @@ class MergeTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make more changes in another branch
             var otherHash1 = CheckableRepository.appendAndCommit(localRepo, "First change in other",
                                                                  "First other\n\nReviewed-by: integrationreviewer2");
-            localRepo.push(otherHash1, author.url(), "other", true);
+            localRepo.push(otherHash1, author.authenticatedUrl(), "other", true);
             var otherHash2 = CheckableRepository.appendAndCommit(localRepo, "Second change in other",
                                                                  "Second other\n\nReviewed-by: integrationreviewer2");
-            localRepo.push(otherHash2, author.url(), "other");
+            localRepo.push(otherHash2, author.authenticatedUrl(), "other");
 
             // Go back to the original master
             localRepo.checkout(masterHash, true);
@@ -683,11 +683,11 @@ class MergeTests {
             var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated", StandardCharsets.UTF_8);
             localRepo.add(unrelated);
             var updatedMaster = localRepo.commit("Unrelated", "some", "some@one");
-            localRepo.push(updatedMaster, author.url(), "master");
+            localRepo.push(updatedMaster, author.authenticatedUrl(), "master");
 
             localRepo.merge(otherHash2);
             var mergeHash = localRepo.commit("Merge commit", "some", "some@one");
-            localRepo.push(mergeHash, author.url(), "edit", true);
+            localRepo.push(mergeHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Merge " + author.name() + ":other");
 
             // Approve it as another user
@@ -702,7 +702,7 @@ class MergeTests {
             var newMaster = Files.writeString(localRepo.root().resolve("newmaster.txt"), "New on master", StandardCharsets.UTF_8);
             localRepo.add(newMaster);
             var newMasterHash = localRepo.commit("New commit on master", "some", "some@one");
-            localRepo.push(newMasterHash, author.url(), "master");
+            localRepo.push(newMasterHash, author.authenticatedUrl(), "master");
 
             // Let the bot notice
             TestBotRunner.runPeriodicItems(mergeBot);
@@ -719,7 +719,7 @@ class MergeTests {
 
             // The change should now be present on the master branch
             var pushedRepoFolder = tempFolder.path().resolve("pushedrepo");
-            var pushedRepo = Repository.materialize(pushedRepoFolder, author.url(), "master");
+            var pushedRepo = Repository.materialize(pushedRepoFolder, author.authenticatedUrl(), "master");
             assertTrue(CheckableRepository.hasBeenEdited(pushedRepo));
 
             // The commits from the "other" branch should be preserved and not squashed (but not the merge commit)
@@ -760,15 +760,15 @@ class MergeTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make more changes in another branch
             var otherHash1 = CheckableRepository.appendAndCommit(localRepo, "First change in other",
                                                                  "First other\n\nReviewed-by: integrationreviewer2");
-            localRepo.push(otherHash1, author.url(), "other", true);
+            localRepo.push(otherHash1, author.authenticatedUrl(), "other", true);
             var otherHash2 = CheckableRepository.appendAndCommit(localRepo, "Second change in other",
                                                                  "Second other\n\nReviewed-by: integrationreviewer2");
-            localRepo.push(otherHash2, author.url(), "other");
+            localRepo.push(otherHash2, author.authenticatedUrl(), "other");
 
             // Go back to the original master
             localRepo.checkout(masterHash, true);
@@ -777,11 +777,11 @@ class MergeTests {
             var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated", StandardCharsets.UTF_8);
             localRepo.add(unrelated);
             var updatedMaster = localRepo.commit("Unrelated", "some", "some@one");
-            localRepo.push(updatedMaster, author.url(), "master");
+            localRepo.push(updatedMaster, author.authenticatedUrl(), "master");
 
             localRepo.merge(otherHash2);
             var mergeHash = localRepo.commit("Our own merge commit", "some", "some@one");
-            localRepo.push(mergeHash, author.url(), "edit", true);
+            localRepo.push(mergeHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Merge " + author.name() + ":other");
 
             // Approve it as another user
@@ -796,7 +796,7 @@ class MergeTests {
             var newMaster = Files.writeString(localRepo.root().resolve("newmaster.txt"), "New on master", StandardCharsets.UTF_8);
             localRepo.add(newMaster);
             var newMasterHash = localRepo.commit("New commit on master", "some", "some@one");
-            localRepo.push(newMasterHash, author.url(), "master");
+            localRepo.push(newMasterHash, author.authenticatedUrl(), "master");
 
             // Let the bot notice
             TestBotRunner.runPeriodicItems(mergeBot);
@@ -804,7 +804,7 @@ class MergeTests {
             // Add another commit on top of the merge commit
             localRepo.checkout(mergeHash, true);
             var extraHash = CheckableRepository.appendAndCommit(localRepo, "Fixing up stuff after merge");
-            localRepo.push(extraHash, author.url(), "edit");
+            localRepo.push(extraHash, author.authenticatedUrl(), "edit");
 
             // Let the bot notice again
             TestBotRunner.runPeriodicItems(mergeBot);
@@ -812,7 +812,7 @@ class MergeTests {
             // Merge the latest from master
             localRepo.merge(newMasterHash);
             var latestMergeHash = localRepo.commit("Our to be squashed merge commit", "some", "some@one");
-            localRepo.push(latestMergeHash, author.url(), "edit");
+            localRepo.push(latestMergeHash, author.authenticatedUrl(), "edit");
 
             // Let the bot notice again
             TestBotRunner.runPeriodicItems(mergeBot);
@@ -829,7 +829,7 @@ class MergeTests {
 
             // The change should now be present on the master branch
             var pushedRepoFolder = tempFolder.path().resolve("pushedrepo");
-            var pushedRepo = Repository.materialize(pushedRepoFolder, author.url(), "master");
+            var pushedRepo = Repository.materialize(pushedRepoFolder, author.authenticatedUrl(), "master");
             assertTrue(CheckableRepository.hasBeenEdited(pushedRepo));
 
             // The commits from the "other" branch should be preserved and not squashed (but not the merge commit)
@@ -874,12 +874,12 @@ class MergeTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change in another branch
             var otherHash = CheckableRepository.appendAndCommit(localRepo, "Change in other",
                                                                 "Other\n\nReviewed-by: integrationreviewer2");
-            localRepo.push(otherHash, author.url(), "other", true);
+            localRepo.push(otherHash, author.authenticatedUrl(), "other", true);
 
             // Go back to the original master
             localRepo.checkout(masterHash, true);
@@ -890,7 +890,7 @@ class MergeTests {
             localRepo.commit("Unrelated", "some", "some@one");
             localRepo.merge(otherHash);
             var mergeHash = localRepo.commit("Merge commit", "some", "some@one");
-            localRepo.push(mergeHash, author.url(), "edit", true);
+            localRepo.push(mergeHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Merge " + author.name() + ":other");
 
             // Approve it as another user
@@ -912,7 +912,7 @@ class MergeTests {
 
             // The change should now be present with correct parents on the master branch
             var pushedRepoFolder = tempFolder.path().resolve("pushedrepo");
-            var pushedRepo = Repository.materialize(pushedRepoFolder, author.url(), "master");
+            var pushedRepo = Repository.materialize(pushedRepoFolder, author.authenticatedUrl(), "master");
             assertTrue(CheckableRepository.hasBeenEdited(pushedRepo));
 
             var head = pushedRepo.commitMetadata("HEAD^!").get(0);
@@ -939,12 +939,12 @@ class MergeTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change in another branch
             var otherHash = CheckableRepository.appendAndCommit(localRepo, "Change in other",
                                                                 "Other\n\nReviewed-by: integrationreviewer2");
-            localRepo.push(otherHash, author.url(), "other", true);
+            localRepo.push(otherHash, author.authenticatedUrl(), "other", true);
 
             // Go back to the original master
             localRepo.checkout(masterHash, true);
@@ -953,11 +953,11 @@ class MergeTests {
             var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated", StandardCharsets.UTF_8);
             localRepo.add(unrelated);
             var updatedMaster = localRepo.commit("Unrelated", "some", "some@one");
-            localRepo.push(updatedMaster, author.url(), "master");
+            localRepo.push(updatedMaster, author.authenticatedUrl(), "master");
 
             localRepo.merge(otherHash);
             var mergeHash = localRepo.commit("Merge commit", "some", "some@one");
-            localRepo.push(mergeHash, author.url(), "edit", true);
+            localRepo.push(mergeHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Merge " + TestHost.NON_EXISTING_REPO + ":other");
 
             // Approve it as another user
@@ -999,12 +999,12 @@ class MergeTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change in another branch
             var otherHash = CheckableRepository.appendAndCommit(localRepo, "Change in other",
                                                                 "Other\n\nReviewed-by: integrationreviewer2");
-            localRepo.push(otherHash, author.url(), "other", true);
+            localRepo.push(otherHash, author.authenticatedUrl(), "other", true);
 
             // Go back to the original master
             localRepo.checkout(masterHash, true);
@@ -1013,11 +1013,11 @@ class MergeTests {
             var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated", StandardCharsets.UTF_8);
             localRepo.add(unrelated);
             var updatedMaster = localRepo.commit("Unrelated", "some", "some@one");
-            localRepo.push(updatedMaster, author.url(), "master");
+            localRepo.push(updatedMaster, author.authenticatedUrl(), "master");
 
             localRepo.merge(otherHash);
             var mergeHash = localRepo.commit("Merge commit", "some", "some@one");
-            localRepo.push(mergeHash, author.url(), "edit", true);
+            localRepo.push(mergeHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Merge " + author.name() + ":otherxyz");
 
             // Approve it as another user
@@ -1059,12 +1059,12 @@ class MergeTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change in another branch
             var otherHash = CheckableRepository.appendAndCommit(localRepo, "Change in other",
                                                                 "Other\n\nReviewed-by: integrationreviewer2");
-            localRepo.push(otherHash, author.url(), "other", true);
+            localRepo.push(otherHash, author.authenticatedUrl(), "other", true);
 
             // Go back to the original master
             localRepo.checkout(masterHash, true);
@@ -1073,11 +1073,11 @@ class MergeTests {
             var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated", StandardCharsets.UTF_8);
             localRepo.add(unrelated);
             var updatedMaster = localRepo.commit("Unrelated", "some", "some@one");
-            localRepo.push(updatedMaster, author.url(), "master");
+            localRepo.push(updatedMaster, author.authenticatedUrl(), "master");
 
             localRepo.merge(otherHash);
             var mergeHash = localRepo.commit("Merge commit", "some", "some@one");
-            localRepo.push(mergeHash, author.url(), "edit", true);
+            localRepo.push(mergeHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Merge " + TestHost.NON_EXISTING_REPO);
 
             // Approve it as another user
@@ -1119,12 +1119,12 @@ class MergeTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change in another branch
             var other1Hash = CheckableRepository.appendAndCommit(localRepo, "Change in other1",
                                                                 "Other\n\nReviewed-by: integrationreviewer2");
-            localRepo.push(other1Hash, author.url(), "other1", true);
+            localRepo.push(other1Hash, author.authenticatedUrl(), "other1", true);
 
             // Go back to the original master
             localRepo.checkout(masterHash, true);
@@ -1132,18 +1132,18 @@ class MergeTests {
             // Make yet another change in another branch
             var other2Hash = CheckableRepository.appendAndCommit(localRepo, "Change in other2",
                                                                 "Unrelated\n\nReviewed-by: integrationreviewer2");
-            localRepo.push(other2Hash, author.url(), "other2", true);
+            localRepo.push(other2Hash, author.authenticatedUrl(), "other2", true);
 
             // Make a change with a corresponding PR
             localRepo.checkout(masterHash, true);
             var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated", StandardCharsets.UTF_8);
             localRepo.add(unrelated);
             var updatedMaster = localRepo.commit("Unrelated", "some", "some@one");
-            localRepo.push(updatedMaster, author.url(), "master");
+            localRepo.push(updatedMaster, author.authenticatedUrl(), "master");
 
             localRepo.merge(other1Hash, "ours");
             var mergeHash = localRepo.commit("Merge commit", "some", "some@one");
-            localRepo.push(mergeHash, author.url(), "edit", true);
+            localRepo.push(mergeHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Merge " + author.name() + ":other2");
 
             // Approve it as another user
@@ -1185,12 +1185,12 @@ class MergeTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change in another branch
             var otherHash = CheckableRepository.appendAndCommit(localRepo, "Change in other",
                                                                 "Other\n\nReviewed-by: integrationreviewer2");
-            localRepo.push(otherHash, author.url(), "other", true);
+            localRepo.push(otherHash, author.authenticatedUrl(), "other", true);
 
             // Go back to the original master
             localRepo.checkout(masterHash, true);
@@ -1199,11 +1199,11 @@ class MergeTests {
             var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated", StandardCharsets.UTF_8);
             localRepo.add(unrelated);
             var updatedMaster = localRepo.commit("Unrelated", "some", "some@one");
-            localRepo.push(updatedMaster, author.url(), "master");
+            localRepo.push(updatedMaster, author.authenticatedUrl(), "master");
 
             localRepo.merge(otherHash);
             var mergeHash = localRepo.commit("Merge commit", "some", "some@one");
-            localRepo.push(mergeHash, author.url(), "edit", true);
+            localRepo.push(mergeHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Merge " + author.name() + ":other");
 
             // Approve it as another user
@@ -1246,7 +1246,7 @@ class MergeTests {
             var masterHash = localRepo.resolve("master").orElseThrow();
 
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make an unrelated change in another branch
             var unrelatedRepoFolder = tempFolder.path().resolve("unrelated");
@@ -1254,8 +1254,8 @@ class MergeTests {
             unrelatedRepo.amend("Unrelated initial commit\n\nReviewed-by: integrationreviewer2", "some", "one@mail");
             var otherHash = CheckableRepository.appendAndCommit(unrelatedRepo, "Change in other",
                                                                 "Other\n\nReviewed-by: integrationreviewer2");
-            unrelatedRepo.push(otherHash, author.url(), "other", true);
-            localRepo.fetch(author.url(), "other");
+            unrelatedRepo.push(otherHash, author.authenticatedUrl(), "other", true);
+            localRepo.fetch(author.authenticatedUrl(), "other");
 
             // Go back to the original master
             localRepo.checkout(masterHash, true);
@@ -1275,7 +1275,7 @@ class MergeTests {
 
             //localRepo.merge(otherHash);
             var mergeHash = localRepo.commit("Merge commit", "some", "some@one");
-            localRepo.push(mergeHash, author.url(), "edit", true);
+            localRepo.push(mergeHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Merge " + author.name() + ":other");
 
             // Approve it as another user
@@ -1317,12 +1317,12 @@ class MergeTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType(), Path.of("appendable.txt"), Set.of("merge"), "1.0");
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change in another branch
             var otherHash = CheckableRepository.appendAndCommit(localRepo, "Change in other",
                                                                 "Other\n\nReviewed-by: integrationreviewer2");
-            localRepo.push(otherHash, author.url(), "other", true);
+            localRepo.push(otherHash, author.authenticatedUrl(), "other", true);
 
             // Go back to the original master
             localRepo.checkout(masterHash, true);
@@ -1331,11 +1331,11 @@ class MergeTests {
             var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated", StandardCharsets.UTF_8);
             localRepo.add(unrelated);
             var updatedMaster = localRepo.commit("Unrelated", "some", "some@one");
-            localRepo.push(updatedMaster, author.url(), "master");
+            localRepo.push(updatedMaster, author.authenticatedUrl(), "master");
 
             localRepo.merge(otherHash);
             var mergeHash = localRepo.commit("Merge commit", "some", "some@one");
-            localRepo.push(mergeHash, author.url(), "edit", true);
+            localRepo.push(mergeHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Merge this or that");
 
             // Let the bot check the status
@@ -1373,12 +1373,12 @@ class MergeTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType(), Path.of("appendable.txt"), Set.of("merge"), "1.0");
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change in another branch
             var otherHash = CheckableRepository.appendAndCommit(localRepo, "Change in other",
                                                                 "Other\n\nReviewed-by: integrationreviewer2");
-            localRepo.push(otherHash, author.url(), "branch-a+b", true);
+            localRepo.push(otherHash, author.authenticatedUrl(), "branch-a+b", true);
 
             // Go back to the original master
             localRepo.checkout(masterHash, true);
@@ -1387,11 +1387,11 @@ class MergeTests {
             var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated", StandardCharsets.UTF_8);
             localRepo.add(unrelated);
             var updatedMaster = localRepo.commit("Unrelated", "some", "some@one");
-            localRepo.push(updatedMaster, author.url(), "master");
+            localRepo.push(updatedMaster, author.authenticatedUrl(), "master");
 
             localRepo.merge(otherHash);
             var mergeHash = localRepo.commit("Merge commit", "some", "some@one");
-            localRepo.push(mergeHash, author.url(), "edit", true);
+            localRepo.push(mergeHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Merge branch-a+b");
 
             // Let the bot check the status
@@ -1420,15 +1420,15 @@ class MergeTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make more changes in another branch
             var otherHash1 = CheckableRepository.appendAndCommit(localRepo, "First change in other",
                                                                  "First other\n\nReviewed-by: integrationreviewer2");
-            localRepo.push(otherHash1, author.url(), "other", true);
+            localRepo.push(otherHash1, author.authenticatedUrl(), "other", true);
             var otherHash2 = CheckableRepository.appendAndCommit(localRepo, "Second change in other",
                                                                  "Second other\n\nReviewed-by: integrationreviewer2");
-            localRepo.push(otherHash2, author.url(), "other");
+            localRepo.push(otherHash2, author.authenticatedUrl(), "other");
 
             // Go back to the original master
             localRepo.checkout(masterHash, true);
@@ -1437,7 +1437,7 @@ class MergeTests {
             var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated", StandardCharsets.UTF_8);
             localRepo.add(unrelated);
             var updatedMaster = localRepo.commit( "Unrelated", "some", "some@one");
-            localRepo.push(updatedMaster, author.url(), "master");
+            localRepo.push(updatedMaster, author.authenticatedUrl(), "master");
 
             // Go back to the original master again
             localRepo.checkout(masterHash, true);
@@ -1448,7 +1448,7 @@ class MergeTests {
             // Merge the latest commit from master
             localRepo.merge(updatedMaster);
             var masterMergeHash = localRepo.commit("Master merge commit", "some", "some@one");
-            localRepo.push(masterMergeHash, author.url(), "edit", true);
+            localRepo.push(masterMergeHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "1234: A change");
 
             // Let the bot check the status
@@ -1459,7 +1459,7 @@ class MergeTests {
 
             localRepo.merge(otherHash2);
             var mergeHash = localRepo.commit("Merge commit", "some", "some@one");
-            localRepo.push(mergeHash, author.url(), "edit", true);
+            localRepo.push(mergeHash, author.authenticatedUrl(), "edit", true);
 
             // Let the bot check the status
             TestBotRunner.runPeriodicItems(mergeBot);

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/OpenCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/OpenCommandTests.java
@@ -22,15 +22,11 @@
  */
 package org.openjdk.skara.bots.pr;
 
-import org.openjdk.skara.forge.*;
 import org.openjdk.skara.issuetracker.Issue;
 import org.junit.jupiter.api.*;
 import org.openjdk.skara.test.*;
 
 import java.io.IOException;
-import java.nio.file.*;
-import java.util.*;
-import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.openjdk.skara.bots.pr.PullRequestAsserts.assertLastCommentContains;
@@ -57,11 +53,11 @@ public class OpenCommandTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "123: This is a pull request");
             TestBotRunner.runPeriodicItems(prBot);
 
@@ -101,11 +97,11 @@ public class OpenCommandTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "123: This is a pull request");
             TestBotRunner.runPeriodicItems(prBot);
 
@@ -144,11 +140,11 @@ public class OpenCommandTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "123: This is a pull request");
             TestBotRunner.runPeriodicItems(prBot);
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestCommandTests.java
@@ -50,11 +50,11 @@ class PullRequestCommandTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Issue a commit command
@@ -90,11 +90,11 @@ class PullRequestCommandTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Issue an invalid command
@@ -127,11 +127,11 @@ class PullRequestCommandTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Issue multiple commands in a comment
@@ -170,11 +170,11 @@ class PullRequestCommandTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Issue an command using the bot account
@@ -219,11 +219,11 @@ class PullRequestCommandTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Issue an invalid body command
@@ -253,11 +253,11 @@ class PullRequestCommandTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Issue an invalid body command
@@ -289,11 +289,11 @@ class PullRequestCommandTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Issue an external command
@@ -330,11 +330,11 @@ class PullRequestCommandTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request", List.of(
                 "/summary",
                 "This is a multi-line summary",
@@ -374,11 +374,11 @@ class PullRequestCommandTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Test command in review

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ReviewerTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ReviewerTests.java
@@ -53,11 +53,11 @@ class ReviewerTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Issue an invalid command
@@ -132,7 +132,7 @@ class ReviewerTests {
 
             // The change should now be present on the master branch
             var pushedFolder = tempFolder.path().resolve("pushed");
-            var pushedRepo = Repository.materialize(pushedFolder, author.url(), "master");
+            var pushedRepo = Repository.materialize(pushedFolder, author.authenticatedUrl(), "master");
             assertTrue(CheckableRepository.hasBeenEdited(pushedRepo));
 
             var headHash = pushedRepo.resolve("HEAD").orElseThrow();
@@ -163,11 +163,11 @@ class ReviewerTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Issue a contributor command not as the PR author
@@ -200,11 +200,11 @@ class ReviewerTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Use a full name
@@ -246,11 +246,11 @@ class ReviewerTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Use a platform name
@@ -279,11 +279,11 @@ class ReviewerTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Use a platform name
@@ -312,11 +312,11 @@ class ReviewerTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Remove a reviewer that hasn't been added
@@ -360,11 +360,11 @@ class ReviewerTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Add a reviewer
@@ -439,11 +439,11 @@ class ReviewerTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Add the review the old-fashioned way
@@ -489,11 +489,11 @@ class ReviewerTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Credit two additional reviewers

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ReviewersTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ReviewersTests.java
@@ -22,7 +22,6 @@
  */
 package org.openjdk.skara.bots.pr;
 
-import org.openjdk.skara.forge.PullRequest;
 import org.openjdk.skara.forge.Review;
 import org.openjdk.skara.test.*;
 
@@ -66,11 +65,11 @@ public class ReviewersTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "123: This is a pull request");
 
             var reviewerPr = (TestPullRequest)integrator.pullRequest(pr.id());
@@ -195,11 +194,11 @@ public class ReviewersTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "123: This is a pull request");
 
             var reviewerPr = (TestPullRequest) integrator.pullRequest(pr.id());
@@ -254,11 +253,11 @@ public class ReviewersTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "123: This is a pull request");
 
             var reviewerPr = (TestPullRequest)integrator.pullRequest(pr.id());
@@ -318,11 +317,11 @@ public class ReviewersTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "123: This is a pull request");
 
             var authorPR = (TestPullRequest)author.pullRequest(pr.id());
@@ -355,11 +354,11 @@ public class ReviewersTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "123: This is a pull request");
 
             var authorPR = (TestPullRequest)author.pullRequest(pr.id());
@@ -416,11 +415,11 @@ public class ReviewersTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "123: This is a pull request", List.of("/reviewers 2"));
 
             TestBotRunner.runPeriodicItems(prBot);
@@ -449,7 +448,7 @@ public class ReviewersTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Change the jcheck configuration
             var confPath = localRepo.root().resolve(".jcheck/conf");
@@ -465,11 +464,11 @@ public class ReviewersTests {
             Files.writeString(confPath, newConf);
             localRepo.add(confPath);
             var confHash = localRepo.commit("Change conf", "duke", "duke@openjdk.org");
-            localRepo.push(confHash, author.url(), "master", true);
+            localRepo.push(confHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "123: This is a pull request");
 
             var reviewerPr = (TestPullRequest)integrator.pullRequest(pr.id());
@@ -576,7 +575,7 @@ public class ReviewersTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Change the jcheck configuration
             var confPath = localRepo.root().resolve(".jcheck/conf");
@@ -592,11 +591,11 @@ public class ReviewersTests {
             Files.writeString(confPath, newConf);
             localRepo.add(confPath);
             var confHash = localRepo.commit("Change conf", "duke", "duke@openjdk.org");
-            localRepo.push(confHash, author.url(), "master", true);
+            localRepo.push(confHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "123: This is a pull request", List.of(""));
             var reviewerPr = (TestPullRequest)reviewer.pullRequest(pr.id());
 
@@ -632,11 +631,11 @@ public class ReviewersTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "123: This is a pull request");
 
             var reviewerPr = integrator.pullRequest(pr.id());

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/SponsorTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/SponsorTests.java
@@ -56,13 +56,13 @@ class SponsorTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var authorFullName = author.forge().currentUser().fullName();
             var authorEmail = "ta@none.none";
             var editHash = CheckableRepository.appendAndCommit(localRepo, "This is a new line", "Append commit", authorFullName, authorEmail);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Approve it as another user
@@ -101,7 +101,7 @@ class SponsorTests {
             assertEquals(1, pushed);
 
             // The change should now be present on the master branch
-            var pushedRepo = Repository.materialize(pushedFolder.path(), author.url(), "master");
+            var pushedRepo = Repository.materialize(pushedFolder.path(), author.authenticatedUrl(), "master");
             var headHash = pushedRepo.resolve("HEAD").orElseThrow();
             var headCommit = pushedRepo.commits(headHash.hex() + "^.." + headHash.hex()).asList().get(0);
 
@@ -146,11 +146,11 @@ class SponsorTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Issue an invalid command
@@ -180,11 +180,11 @@ class SponsorTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Issue an invalid command
@@ -216,11 +216,11 @@ class SponsorTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Reviewer now tries to sponsor
@@ -252,12 +252,12 @@ class SponsorTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var authorFullName = author.forge().currentUser().fullName();
             var editHash = CheckableRepository.appendAndCommit(localRepo, "This is a new line", "Append commit", authorFullName, "ta@none.none");
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Approve it as another user
@@ -281,7 +281,7 @@ class SponsorTests {
 
             // Push another change
             var updateHash = CheckableRepository.appendAndCommit(localRepo, "Yet more stuff", "Append commit", authorFullName, "ta@none.none");
-            localRepo.push(updateHash, author.url(), "edit");
+            localRepo.push(updateHash, author.authenticatedUrl(), "edit");
 
             // The label should have been dropped
             TestBotRunner.runPeriodicItems(mergeBot);
@@ -335,11 +335,11 @@ class SponsorTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Approve it as another user
@@ -352,7 +352,7 @@ class SponsorTests {
             Files.writeString(unrelated, "Hello");
             localRepo.add(unrelated);
             var unrelatedHash = localRepo.commit("Unrelated", "X", "x@y.z");
-            localRepo.push(unrelatedHash, author.url(), "master");
+            localRepo.push(unrelatedHash, author.authenticatedUrl(), "master");
 
             // Issue a merge command without being a Committer
             pr.addComment("/integrate");
@@ -382,7 +382,7 @@ class SponsorTests {
             assertEquals(1, pushed);
 
             // The change should now be present on the master branch
-            var pushedRepo = Repository.materialize(pushedFolder.path(), author.url(), "master");
+            var pushedRepo = Repository.materialize(pushedFolder.path(), author.authenticatedUrl(), "master");
             assertTrue(CheckableRepository.hasBeenEdited(pushedRepo));
         }
     }
@@ -406,11 +406,11 @@ class SponsorTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Approve it as another user
@@ -423,7 +423,7 @@ class SponsorTests {
             Files.writeString(unrelated, "Hello");
             localRepo.add(unrelated);
             var unrelatedHash = localRepo.commit("Unrelated", "X", "x@y.z");
-            localRepo.push(unrelatedHash, author.url(), "master");
+            localRepo.push(unrelatedHash, author.authenticatedUrl(), "master");
 
             // Issue a merge command without being a Committer
             pr.addComment("/integrate " + masterHash);
@@ -443,7 +443,7 @@ class SponsorTests {
             Files.writeString(unrelated, "Hello again");
             localRepo.add(unrelated);
             var unrelatedHash2 = localRepo.commit("Unrelated 2", "X", "x@y.z");
-            localRepo.push(unrelatedHash2, author.url(), "master");
+            localRepo.push(unrelatedHash2, author.authenticatedUrl(), "master");
 
             // Reviewer now agrees to sponsor
             var reviewerPr = reviewer.pullRequest(pr.id());
@@ -461,7 +461,7 @@ class SponsorTests {
             assertLastCommentContains(pr, "Pushed as commit");
 
             // The change should now be present on the master branch
-            var pushedRepo = Repository.materialize(pushedFolder.path(), author.url(), "master");
+            var pushedRepo = Repository.materialize(pushedFolder.path(), author.authenticatedUrl(), "master");
             assertTrue(CheckableRepository.hasBeenEdited(pushedRepo));
         }
     }
@@ -482,12 +482,12 @@ class SponsorTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var authorFullName = author.forge().currentUser().fullName();
             var editHash = CheckableRepository.appendAndCommit(localRepo, "This is a new line", "Append commit", authorFullName, "ta@none.none");
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Approve it as another user
@@ -559,11 +559,11 @@ class SponsorTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Approve it as another user
@@ -593,7 +593,7 @@ class SponsorTests {
             // Push something conflicting to master
             localRepo.checkout(masterHash, true);
             var conflictingHash = CheckableRepository.appendAndCommit(localRepo, "This looks like a conflict");
-            localRepo.push(conflictingHash, author.url(), "master");
+            localRepo.push(conflictingHash, author.authenticatedUrl(), "master");
 
             // Trigger a new check run
             pr.setBody(pr.body() + " recheck");
@@ -634,13 +634,13 @@ class SponsorTests {
             Files.writeString(anotherFile, "A string\n");
             localRepo.add(anotherFile);
             var masterHash = localRepo.commit("Another commit\n\nReviewed-by: " + reviewerId, "duke", "duke@openjdk.org");
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Create a new branch, new commit and publish it
             var editBranch = localRepo.branch(initialHash, "edit");
             localRepo.checkout(editBranch);
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
 
             // Prepare to merge edit into master
             localRepo.checkout(new Branch("master"));
@@ -648,7 +648,7 @@ class SponsorTests {
             localRepo.checkout(editToMasterBranch);
             localRepo.merge(editHash);
             var mergeHash = localRepo.commit("Merge edit", "duke", "duke@openjdk.org");
-            localRepo.push(mergeHash, author.url(), "edit->master", true);
+            localRepo.push(mergeHash, author.authenticatedUrl(), "edit->master", true);
 
 
             var pr = credentials.createPullRequest(author, "master", "edit->master", "Merge edit");
@@ -693,7 +693,7 @@ class SponsorTests {
                            .count();
             assertEquals(1, pushed);
 
-            var targetRepo = Repository.clone(author.url(), tempFolder.path().resolve("target.git"));
+            var targetRepo = Repository.clone(author.authenticatedUrl(), tempFolder.path().resolve("target.git"));
             var masterHead = targetRepo.lookup(new Branch("origin/master")).orElseThrow();
             assertEquals("Merge edit", masterHead.message().get(0));
         }
@@ -715,12 +715,12 @@ class SponsorTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var authorFullName = author.forge().currentUser().fullName();
             var editHash = CheckableRepository.appendAndCommit(localRepo, "This is a new line", "Append commit", authorFullName, "ta@none.none");
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Flag it as ready for integration automatically
@@ -778,12 +778,12 @@ class SponsorTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var authorFullName = author.forge().currentUser().fullName();
             var editHash = CheckableRepository.appendAndCommit(localRepo, "This is a new line", "Append commit", authorFullName, "ta@none.none");
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Approve it as another user
@@ -852,13 +852,13 @@ class SponsorTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var authorFullName = author.forge().currentUser().fullName();
             var authorEmail = "ta@none.none";
             var editHash = CheckableRepository.appendAndCommit(localRepo, "This is a new line", "Append commit", authorFullName, authorEmail);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Approve it as another user
@@ -901,7 +901,7 @@ class SponsorTests {
                     .filter(comment -> comment.body().contains("Pushed as commit"))
                     .findAny().orElseThrow();
             pr.removeComment(commitComment);
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // The bot should now retry
             TestBotRunner.runPeriodicItems(mergeBot);

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/SummaryTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/SummaryTests.java
@@ -51,11 +51,11 @@ class SummaryTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Try setting a summary when none has been set yet
@@ -119,7 +119,7 @@ class SummaryTests {
 
             // The change should now be present on the master branch
             var pushedFolder = tempFolder.path().resolve("pushed");
-            var pushedRepo = Repository.materialize(pushedFolder, author.url(), "master");
+            var pushedRepo = Repository.materialize(pushedFolder, author.authenticatedUrl(), "master");
             assertTrue(CheckableRepository.hasBeenEdited(pushedRepo));
 
             var headHash = pushedRepo.resolve("HEAD").orElseThrow();
@@ -150,11 +150,11 @@ class SummaryTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "refs/heads/edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Issue a contributor command not as the PR author
@@ -187,11 +187,11 @@ class SummaryTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Try setting a summary when none has been set yet
@@ -273,11 +273,11 @@ class SummaryTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Try setting a summary when none has been set yet
@@ -319,11 +319,11 @@ class SummaryTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Try setting a summary when none has been set yet
@@ -365,11 +365,11 @@ class SummaryTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Try setting a summary when none has been set yet
@@ -404,11 +404,11 @@ class SummaryTests {
             var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             assertFalse(CheckableRepository.hasBeenEdited(localRepo));
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             pr.addComment("/summary Co-authored-by: user1");

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/TagCommitCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/TagCommitCommandTests.java
@@ -24,7 +24,6 @@ package org.openjdk.skara.bots.pr;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
-import org.openjdk.skara.issuetracker.Issue;
 import org.openjdk.skara.test.*;
 import org.openjdk.skara.vcs.Tag;
 import org.openjdk.skara.vcs.Repository;
@@ -62,7 +61,7 @@ public class TagCommitCommandTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Add a tag command
             author.addCommitComment(masterHash, "/tag v1.0");
@@ -75,7 +74,7 @@ public class TagCommitCommandTests {
             assertTrue(botReply.body().contains("was successfully created"));
 
             var localAuthorRepoDir = tempFolder.path().resolve("author");
-            var localAuthorRepo = Repository.clone(author.url(), localAuthorRepoDir);
+            var localAuthorRepo = Repository.clone(author.authenticatedUrl(), localAuthorRepoDir);
             var tags = localAuthorRepo.tags();
             assertEquals(List.of(new Tag("v1.0")), tags);
         }
@@ -104,7 +103,7 @@ public class TagCommitCommandTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Add a tag command
             author.addCommitComment(masterHash, "/tag");
@@ -116,7 +115,7 @@ public class TagCommitCommandTests {
             assertTrue(botReply.body().contains("Usage: `/tag <name>`"));
 
             var localAuthorRepoDir = tempFolder.path().resolve("author");
-            var localAuthorRepo = Repository.clone(author.url(), localAuthorRepoDir);
+            var localAuthorRepo = Repository.clone(author.authenticatedUrl(), localAuthorRepoDir);
             var tags = localAuthorRepo.tags();
             assertEquals(List.of(), tags);
         }
@@ -145,7 +144,7 @@ public class TagCommitCommandTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Add a tag command
             author.addCommitComment(masterHash, "/tag a b c");
@@ -157,7 +156,7 @@ public class TagCommitCommandTests {
             assertTrue(botReply.body().contains("Usage: `/tag <name>`"));
 
             var localAuthorRepoDir = tempFolder.path().resolve("author");
-            var localAuthorRepo = Repository.clone(author.url(), localAuthorRepoDir);
+            var localAuthorRepo = Repository.clone(author.authenticatedUrl(), localAuthorRepoDir);
             var tags = localAuthorRepo.tags();
             assertEquals(List.of(), tags);
         }
@@ -186,7 +185,7 @@ public class TagCommitCommandTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Add a tag command
             author.addCommitComment(masterHash, "/tag v1.0");
@@ -199,13 +198,13 @@ public class TagCommitCommandTests {
             assertTrue(botReply.body().contains("was successfully created"));
 
             var localAuthorRepoDir = tempFolder.path().resolve("author");
-            var localAuthorRepo = Repository.clone(author.url(), localAuthorRepoDir);
+            var localAuthorRepo = Repository.clone(author.authenticatedUrl(), localAuthorRepoDir);
             var tags = localAuthorRepo.tags();
             assertEquals(List.of(new Tag("v1.0")), tags);
 
             // Make another commit
             var anotherHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(anotherHash, author.url(), "master", true);
+            localRepo.push(anotherHash, author.authenticatedUrl(), "master", true);
 
             // Try to re-create an existing tag
             author.addCommitComment(anotherHash, "/tag v1.0");
@@ -242,7 +241,7 @@ public class TagCommitCommandTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Add a tag command
             author.addCommitComment(masterHash, "/tag v1.0");
@@ -254,7 +253,7 @@ public class TagCommitCommandTests {
             assertTrue(botReply.body().contains("Only integrators for this repository are allowed to use the `/tag` command"));
 
             var localAuthorRepoDir = tempFolder.path().resolve("author");
-            var localAuthorRepo = Repository.clone(author.url(), localAuthorRepoDir);
+            var localAuthorRepo = Repository.clone(author.authenticatedUrl(), localAuthorRepoDir);
             var tags = localAuthorRepo.tags();
             assertEquals(List.of(), tags);
         }
@@ -287,7 +286,7 @@ public class TagCommitCommandTests {
             localRepo.add(List.of(Path.of(".jcheck", "conf")));
             localRepo.commit("Added tags spec", "testauthor", "ta@none.none");
             var masterHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Add a tag command
             author.addCommitComment(masterHash, "/tag bar");
@@ -300,7 +299,7 @@ public class TagCommitCommandTests {
             assertTrue(botReply.body().contains("The given tag name `bar` is not of the form `foo`"));
 
             var localAuthorRepoDir = tempFolder.path().resolve("author");
-            var localAuthorRepo = Repository.clone(author.url(), localAuthorRepoDir);
+            var localAuthorRepo = Repository.clone(author.authenticatedUrl(), localAuthorRepoDir);
             var tags = localAuthorRepo.tags();
             assertEquals(List.of(), tags);
         }

--- a/bots/submit/src/main/java/org/openjdk/skara/bots/submit/SubmitBotWorkItem.java
+++ b/bots/submit/src/main/java/org/openjdk/skara/bots/submit/SubmitBotWorkItem.java
@@ -82,9 +82,9 @@ public class SubmitBotWorkItem implements WorkItem {
 
         // Materialize the PR's target ref
         try {
-            var localRepo = Repository.materialize(prFolder, pr.repository().url(),
+            var localRepo = Repository.materialize(prFolder, pr.repository().authenticatedUrl(),
                                                    "+" + pr.targetRef() + ":submit_" + pr.repository().name());
-            var headHash = localRepo.fetch(pr.repository().url(), pr.headHash().hex(), false);
+            var headHash = localRepo.fetch(pr.repository().authenticatedUrl(), pr.headHash().hex(), false);
 
             var checkBuilder = CheckBuilder.create(executor.checkName(), headHash);
             pr.createCheck(checkBuilder.build());

--- a/bots/submit/src/test/java/org/openjdk/skara/bots/submit/CheckUpdaterTests.java
+++ b/bots/submit/src/test/java/org/openjdk/skara/bots/submit/CheckUpdaterTests.java
@@ -42,11 +42,11 @@ class CheckUpdaterTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             var builder = CheckBuilder.create("test", editHash);

--- a/bots/submit/src/test/java/org/openjdk/skara/bots/submit/SubmitBotTests.java
+++ b/bots/submit/src/test/java/org/openjdk/skara/bots/submit/SubmitBotTests.java
@@ -46,11 +46,11 @@ class SubmitBotTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             TestBotRunner.runPeriodicItems(bot);
@@ -75,11 +75,11 @@ class SubmitBotTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             TestBotRunner.runPeriodicItems(bot);
@@ -104,11 +104,11 @@ class SubmitBotTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Create a fake check from a while back
@@ -140,11 +140,11 @@ class SubmitBotTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Create a fake check from a while back

--- a/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestBot.java
+++ b/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestBot.java
@@ -95,7 +95,7 @@ public class TestBot implements Bot {
         Predicate<HostUser> isCommitter = null;
         if (checkCommitterStatus) {
             try {
-                var censusRepo = Repository.materialize(censusDir, censusRemote.url(), Branch.defaultFor(VCS.GIT).name());
+                var censusRepo = Repository.materialize(censusDir, censusRemote.authenticatedUrl(), Branch.defaultFor(VCS.GIT).name());
                 var census = Census.parse(censusDir);
                 var namespace = census.namespace(repo.namespace());
                 var jcheckConf = repo.fileContents(".jcheck/conf", Branch.defaultFor(VCS.GIT).name())

--- a/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestWorkItem.java
+++ b/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestWorkItem.java
@@ -423,7 +423,7 @@ public class TestWorkItem implements WorkItem {
                             return new RuntimeException("Repository in " + localRepoDir + " has vanished");
                     });
                 }
-                fetchHead = localRepo.fetch(repository.url(), pr.headHash().hex(), false);
+                fetchHead = localRepo.fetch(repository.authenticatedUrl(), pr.headHash().hex(), false);
                 localRepo.checkout(fetchHead, true);
                 job = ci.submit(localRepoDir, jobs, jobId);
             } catch (IOException e) {

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
@@ -236,7 +236,7 @@ class InMemoryHostedRepository implements HostedRepository {
 
     @Override
     public URI url() {
-        return null;
+        return url;
     }
 
     @Override

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
@@ -235,6 +235,11 @@ class InMemoryHostedRepository implements HostedRepository {
     }
 
     @Override
+    public URI remoteUrl() {
+        return null;
+    }
+
+    @Override
     public void addCollaborator(HostUser user, boolean canPush) {
     }
 

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
@@ -94,7 +94,7 @@ class InMemoryHostedRepository implements HostedRepository {
     }
 
     @Override
-    public URI url() {
+    public URI authenticatedUrl() {
         return url;
     }
 
@@ -235,7 +235,7 @@ class InMemoryHostedRepository implements HostedRepository {
     }
 
     @Override
-    public URI remoteUrl() {
+    public URI url() {
         return null;
     }
 

--- a/bots/testinfo/src/test/java/org/openjdk/skara/bots/testinfo/TestInfoTests.java
+++ b/bots/testinfo/src/test/java/org/openjdk/skara/bots/testinfo/TestInfoTests.java
@@ -45,11 +45,11 @@ public class TestInfoTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(), Path.of("appendable.txt"),
                                                      Set.of("issues"), null);
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Add some checks to the repository
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "preedit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "preedit", true);
             var check1 = CheckBuilder.create("ps1", editHash).title("PS1");
             author.createCheck(check1.complete(true).build());
             var check2 = CheckBuilder.create("ps2", editHash).title("PS2");
@@ -60,7 +60,7 @@ public class TestInfoTests {
             author.createCheck(check4.details(URI.create("https://www.example.com")).build());
 
             // Now make a PR
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Check the status
@@ -94,16 +94,16 @@ public class TestInfoTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(), Path.of("appendable.txt"),
                                                      Set.of("issues"), null);
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Add a check to the repository
             var editHash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash, author.url(), "preedit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "preedit", true);
             var check1 = CheckBuilder.create("ps1", editHash).title("PS1");
             author.createCheck(check1.complete(true).build());
 
             // Now make an actual PR
-            localRepo.push(editHash, author.url(), "edit", true);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             // Check the status
@@ -115,12 +115,12 @@ public class TestInfoTests {
 
             // And a second one
             var editHash2 = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(editHash2, author.url(), "preedit");
+            localRepo.push(editHash2, author.authenticatedUrl(), "preedit");
             var check2 = CheckBuilder.create("ps2", editHash2).title("PS2");
             author.createCheck(check2.complete(false).build());
 
             // Push an update to the PR
-            localRepo.push(editHash2, author.url(), "edit", true);
+            localRepo.push(editHash2, author.authenticatedUrl(), "edit", true);
 
             // Check the status
             TestBotRunner.runPeriodicItems(checkBot);

--- a/bots/topological/src/main/java/org/openjdk/skara/bots/topological/TopologicalBot.java
+++ b/bots/topological/src/main/java/org/openjdk/skara/bots/topological/TopologicalBot.java
@@ -73,7 +73,7 @@ class TopologicalBot implements Bot, WorkItem {
             if (!Files.exists(dir)) {
                 log.info("Cloning " + hostedRepo.name());
                 Files.createDirectories(dir);
-                repo = Repository.clone(hostedRepo.url(), dir);
+                repo = Repository.clone(hostedRepo.authenticatedUrl(), dir);
             } else {
                 log.info("Found existing scratch directory for " + hostedRepo.name());
                 repo = Repository.get(dir)
@@ -166,7 +166,7 @@ class TopologicalBot implements Bot, WorkItem {
                             .collect(Collectors.joining("\n", "\n", "\n")));
             }
             try {
-                repo.push(repo.head(), hostedRepo.url(), branch.name());
+                repo.push(repo.head(), hostedRepo.authenticatedUrl(), branch.name());
             } catch (IOException e) {
                 log.severe("Pushing failed! Aborting...");
                 repo.reset(oldHead, true);

--- a/bots/topological/src/test/java/org/openjdk/skara/bots/topological/TopologicalBotTests.java
+++ b/bots/topological/src/test/java/org/openjdk/skara/bots/topological/TopologicalBotTests.java
@@ -57,7 +57,7 @@ class TopologicalBotTests {
             Files.writeString(readme, "Hello world\n");
             repo.add(readme);
             repo.commit("An initial commit", "duke", "duke@openjdk.org");
-            repo.pushAll(hostedRepo.url());
+            repo.pushAll(hostedRepo.authenticatedUrl());
 
             var aBranch = repo.branch(repo.head(), "A");
             // no deps -> depends on master
@@ -70,7 +70,7 @@ class TopologicalBotTests {
             Files.writeString(bDeps, "A");
             repo.add(bDeps);
             repo.commit("Adding deps file to B", "duke", "duke@openjdk.org");
-            repo.pushAll(hostedRepo.url());
+            repo.pushAll(hostedRepo.authenticatedUrl());
 
             var cBranch = repo.branch(repo.head(), "C");
             repo.checkout(cBranch);
@@ -78,14 +78,14 @@ class TopologicalBotTests {
             Files.writeString(cDeps, "B A");
             repo.add(cDeps);
             repo.commit("Adding deps file to C", "duke", "duke@openjdk.org");
-            repo.pushAll(hostedRepo.url());
+            repo.pushAll(hostedRepo.authenticatedUrl());
 
             repo.checkout(new Branch("master"));
             var newFile = fromDir.resolve("NewFile.txt");
             Files.writeString(newFile, "Hello world\n");
             repo.add(newFile);
             var preHash = repo.commit("An additional commit", "duke", "duke@openjdk.org");
-            repo.pushAll(hostedRepo.url());
+            repo.pushAll(hostedRepo.authenticatedUrl());
 
             var preCommits = repo.commits().asList();
             assertEquals(4, preCommits.size());
@@ -126,14 +126,14 @@ class TopologicalBotTests {
             Files.writeString(readme, "Hello world\n");
             repo.add(readme);
             repo.commit("An initial commit", "duke", "duke@openjdk.org");
-            repo.pushAll(hostedRepo.url());
+            repo.pushAll(hostedRepo.authenticatedUrl());
 
             var aBranch = repo.branch(repo.head(), "A");
             repo.checkout(aBranch);
             Files.writeString(readme, "A conflicting line\n", APPEND);
             repo.add(readme);
             var aStartHash = repo.commit("A conflicting commit", "duke", "duke@openjdk.org");
-            repo.pushAll(hostedRepo.url());
+            repo.pushAll(hostedRepo.authenticatedUrl());
 
             var depsFileName = "deps.txt";
 
@@ -143,7 +143,7 @@ class TopologicalBotTests {
             Files.writeString(bDeps, "A");
             repo.add(bDeps);
             var bDepsHash = repo.commit("Adding deps file to B", "duke", "duke@openjdk.org");
-            repo.pushAll(hostedRepo.url());
+            repo.pushAll(hostedRepo.authenticatedUrl());
 
             var cBranch = repo.branch(repo.head(), "C");
             repo.checkout(cBranch);
@@ -151,13 +151,13 @@ class TopologicalBotTests {
             Files.writeString(cDeps, "B");
             repo.add(cDeps);
             var cDepsHash = repo.commit("Adding deps file to C", "duke", "duke@openjdk.org");
-            repo.pushAll(hostedRepo.url());
+            repo.pushAll(hostedRepo.authenticatedUrl());
 
             repo.checkout(new Branch("master"));
             Files.writeString(readme, "Goodbye world!\n", APPEND);
             repo.add(readme);
             var preHash = repo.commit("An additional commit", "duke", "duke@openjdk.org");
-            repo.pushAll(hostedRepo.url());
+            repo.pushAll(hostedRepo.authenticatedUrl());
 
             var preCommits = repo.commits().asList();
             assertEquals(5, preCommits.size());

--- a/census/src/test/java/org/openjdk/skara/census/CensusTests.java
+++ b/census/src/test/java/org/openjdk/skara/census/CensusTests.java
@@ -216,7 +216,7 @@ class CensusTests {
 
             var masterHash = localRepo.commit("Add namespace and contributors", "testauthor", "ta@none.none");
 
-            localRepo.push(masterHash, censusRepo.url(), "censusref", true);
+            localRepo.push(masterHash, censusRepo.authenticatedUrl(), "censusref", true);
 
             var namespace = Census.parseNamespace(censusRepo, "censusref", "aspace");
 

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrCreate.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrCreate.java
@@ -305,7 +305,7 @@ public class GitPrCreate {
         }
 
         var mailingLists = new ArrayList<String>();
-        var parentProject = ForgeUtils.projectName(parentRepo.authenticatedUrl());
+        var parentProject = ForgeUtils.projectName(parentRepo.url());
         var isTargetingJDKRepo = parentProject.matches(".*\\/jdk[0-9]*");
         var cc = getOption("cc", "create", arguments);
         var isCCManual = cc != null && !cc.equals("auto");

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrCreate.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrCreate.java
@@ -305,7 +305,7 @@ public class GitPrCreate {
         }
 
         var mailingLists = new ArrayList<String>();
-        var parentProject = ForgeUtils.projectName(parentRepo.url());
+        var parentProject = ForgeUtils.projectName(parentRepo.authenticatedUrl());
         var isTargetingJDKRepo = parentProject.matches(".*\\/jdk[0-9]*");
         var cc = getOption("cc", "create", arguments);
         var isCCManual = cc != null && !cc.equals("auto");

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrShow.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrShow.java
@@ -80,7 +80,7 @@ public class GitPrShow {
         var pr = getPullRequest(uri, repo, host, id);
         var useTool = getSwitch("tool", "show", arguments);
 
-        var fetchHead = repo.fetch(pr.repository().remoteUrl(), pr.fetchRef());
+        var fetchHead = repo.fetch(pr.repository().url(), pr.fetchRef());
         show(pr.targetRef(), fetchHead, useTool);
     }
 }

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrShow.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrShow.java
@@ -80,7 +80,7 @@ public class GitPrShow {
         var pr = getPullRequest(uri, repo, host, id);
         var useTool = getSwitch("tool", "show", arguments);
 
-        var fetchHead = repo.fetch(pr.repository().webUrl(), pr.fetchRef());
+        var fetchHead = repo.fetch(pr.repository().remoteUrl(), pr.fetchRef());
         show(pr.targetRef(), fetchHead, useTool);
     }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
@@ -83,6 +83,9 @@ public interface HostedRepository {
     URI webUrl(String baseRef, String headRef);
     URI diffUrl(String prId);
     VCS repositoryType();
+    /**
+     * Returns a URL suitable for CLI interactions with the repository
+     */
     URI remoteUrl();
 
     /**

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
@@ -74,7 +74,7 @@ public interface HostedRepository {
      */
     String name();
     Optional<HostedRepository> parent();
-    URI url();
+    URI authenticatedUrl();
     URI webUrl();
     URI nonTransformedWebUrl();
     URI webUrl(Hash hash);
@@ -86,7 +86,7 @@ public interface HostedRepository {
     /**
      * Returns a URL suitable for CLI interactions with the repository
      */
-    URI remoteUrl();
+    URI url();
 
     /**
      * Returns contents of the file, if the file does not exist, returns Optional.empty().

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
@@ -83,6 +83,7 @@ public interface HostedRepository {
     URI webUrl(String baseRef, String headRef);
     URI diffUrl(String prId);
     VCS repositoryType();
+    URI remoteUrl();
 
     /**
      * Returns contents of the file, if the file does not exist, returns Optional.empty().

--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequestUtils.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequestUtils.java
@@ -93,7 +93,7 @@ public class PullRequestUtils {
         String ref;
         if (!source.contains(":")) {
             // Try to fetch the source as a name of a ref (branch or tag)
-            var hash = fetchRef(localRepo, pr.repository().url(), source);
+            var hash = fetchRef(localRepo, pr.repository().authenticatedUrl(), source);
             if (hash.isPresent()) {
                 return hash.get();
             }
@@ -117,7 +117,7 @@ public class PullRequestUtils {
             throw new CommitFailure("Could not find project `" + repoName + "` - check that it is correct.");
         }
 
-        var hash = fetchRef(localRepo, sourceRepo.get().url(), ref);
+        var hash = fetchRef(localRepo, sourceRepo.get().authenticatedUrl(), ref);
         if (hash.isPresent()) {
             return hash.get();
         } else {
@@ -164,7 +164,7 @@ public class PullRequestUtils {
 
     public static Repository materialize(HostedRepositoryPool hostedRepositoryPool, PullRequest pr, Path path) throws IOException {
         var localRepo = hostedRepositoryPool.checkout(pr.repository(), pr.headHash().hex(), path);
-        localRepo.fetch(pr.repository().url(), "+" + pr.targetRef() + ":prutils_targetref", false);
+        localRepo.fetch(pr.repository().authenticatedUrl(), "+" + pr.targetRef() + ":prutils_targetref", false);
         return localRepo;
     }
 

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -213,7 +213,7 @@ public class GitHubRepository implements HostedRepository {
     }
 
     @Override
-    public URI url() {
+    public URI authenticatedUrl() {
         var builder = URIBuilder.base(gitHubHost.getURI())
                                 .setPath("/" + repository + ".git");
         var token = gitHubHost.getInstallationToken();
@@ -259,7 +259,7 @@ public class GitHubRepository implements HostedRepository {
     }
 
     @Override
-    public URI remoteUrl() {
+    public URI url() {
         var endpoint = "/" + repository + ".git";
         return gitHubHost.getWebURI(endpoint);
     }

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -259,6 +259,12 @@ public class GitHubRepository implements HostedRepository {
     }
 
     @Override
+    public URI remoteUrl() {
+        var endpoint = "/" + repository + ".git";
+        return gitHubHost.getWebURI(endpoint);
+    }
+
+    @Override
     public Optional<String> fileContents(String filename, String ref) {
         // Get file contents using raw format. This allows us to get files of
         // size up to 100MB (up from 1MB if getting in object from).

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -530,7 +530,7 @@ public class GitLabMergeRequest implements PullRequest {
     }
 
     private String linkToDiff(String path, Hash hash, int line) {
-        return "[" + path + " line " + line + "](" + URIBuilder.base(repository.authenticatedUrl())
+        return "[" + path + " line " + line + "](" + URIBuilder.base(repository.url())
                          .setPath("/" + repository.name()+ "/blob/" + hash.hex() + "/" + path)
                          .setAuthentication(null)
                          .build() + "#L" + Integer.toString(line) + ")";

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -530,7 +530,7 @@ public class GitLabMergeRequest implements PullRequest {
     }
 
     private String linkToDiff(String path, Hash hash, int line) {
-        return "[" + path + " line " + line + "](" + URIBuilder.base(repository.url())
+        return "[" + path + " line " + line + "](" + URIBuilder.base(repository.authenticatedUrl())
                          .setPath("/" + repository.name()+ "/blob/" + hash.hex() + "/" + path)
                          .setAuthentication(null)
                          .build() + "#L" + Integer.toString(line) + ")";

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -235,7 +235,7 @@ public class GitLabRepository implements HostedRepository {
     }
 
     @Override
-    public URI url() {
+    public URI authenticatedUrl() {
         if (gitLabHost.useSsh()) {
             return URI.create("ssh://git@" + gitLabHost.getPat().orElseThrow().username() + "." + gitLabHost.getUri().getHost() + "/" + projectName + ".git");
         } else {
@@ -288,7 +288,7 @@ public class GitLabRepository implements HostedRepository {
     }
 
     @Override
-    public URI remoteUrl() {
+    public URI url() {
         return URIBuilder.base(gitLabHost.getUri())
                 .setPath("/" + projectName + ".git")
                 .build();

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -288,6 +288,13 @@ public class GitLabRepository implements HostedRepository {
     }
 
     @Override
+    public URI remoteUrl() {
+        return URIBuilder.base(gitLabHost.getUri())
+                .setPath("/" + projectName + ".git")
+                .build();
+    }
+
+    @Override
     public Optional<String> fileContents(String filename, String ref) {
         var encodedFileName = URLEncoder.encode(filename, StandardCharsets.UTF_8);
         var content = request.get("repository/files/" + encodedFileName)

--- a/forge/src/test/java/org/openjdk/skara/forge/HostedRepositoryPoolTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/HostedRepositoryPoolTests.java
@@ -43,11 +43,11 @@ public class HostedRepositoryPoolTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(sourceFolder.path(), source.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, source.url(), "master", true);
+            localRepo.push(masterHash, source.authenticatedUrl(), "master", true);
 
             // Push something else
             var hash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(hash, source.url(), "master");
+            localRepo.push(hash, source.authenticatedUrl(), "master");
 
             var pool = new HostedRepositoryPool(seedFolder.path());
             var clone = pool.checkout(source, hash.hex(), cloneFolder.path());
@@ -66,14 +66,14 @@ public class HostedRepositoryPoolTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(sourceFolder.path(), source.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, source.url(), "master", true);
+            localRepo.push(masterHash, source.authenticatedUrl(), "master", true);
 
             var pool = new HostedRepositoryPool(seedFolder.path());
             var bareClone = pool.materializeBare(source, cloneFolder.path());
 
             // Push something else
             var hash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(hash, source.url(), "master");
+            localRepo.push(hash, source.authenticatedUrl(), "master");
 
             // The commit should not appear from this
             bareClone = pool.materializeBare(source, cloneFolder.path());
@@ -81,7 +81,7 @@ public class HostedRepositoryPoolTests {
             assertEquals(Optional.empty(), bareCommit);
 
             // But should be possible to fetch
-            bareClone.fetchAll(source.url());
+            bareClone.fetchAll(source.authenticatedUrl());
             bareCommit = bareClone.lookup(hash);
             assertEquals(bareCommit.get().hash(), hash);
         }
@@ -98,7 +98,7 @@ public class HostedRepositoryPoolTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(sourceFolder.path(), source.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, source.url(), "master", true);
+            localRepo.push(masterHash, source.authenticatedUrl(), "master", true);
 
             var pool = new HostedRepositoryPool(seedFolder.path());
             var empty = TestableRepository.init(cloneFolder.path(), VCS.GIT);
@@ -119,7 +119,7 @@ public class HostedRepositoryPoolTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(sourceFolder.path(), source.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, source.url(), "master", true);
+            localRepo.push(masterHash, source.authenticatedUrl(), "master", true);
 
             var pool = new HostedRepositoryPool(seedFolder.path());
             var clone = pool.checkout(source, "master", cloneFolder.path());
@@ -130,7 +130,7 @@ public class HostedRepositoryPoolTests {
 
             // Push something else
             var hash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(hash, source.url(), "master");
+            localRepo.push(hash, source.authenticatedUrl(), "master");
 
             updatedClone = pool.checkout(source, "master", cloneFolder.path());
             assertTrue(CheckableRepository.hasBeenEdited(updatedClone));
@@ -148,7 +148,7 @@ public class HostedRepositoryPoolTests {
             // Populate the projects repository
             var localRepo = CheckableRepository.init(sourceFolder.path(), source.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
-            localRepo.push(masterHash, source.url(), "master", true);
+            localRepo.push(masterHash, source.authenticatedUrl(), "master", true);
 
             var pool = new HostedRepositoryPool(seedFolder.path());
             var clone = pool.checkout(source, "master", cloneFolder.path());
@@ -159,7 +159,7 @@ public class HostedRepositoryPoolTests {
 
             // Push something else
             var hash = CheckableRepository.appendAndCommit(localRepo);
-            localRepo.push(hash, source.url(), "master");
+            localRepo.push(hash, source.authenticatedUrl(), "master");
 
             updatedClone = pool.checkoutAllowStale(source, "master", cloneFolder.path());
             assertFalse(CheckableRepository.hasBeenEdited(updatedClone));

--- a/forge/src/test/java/org/openjdk/skara/forge/PullRequestUtilsTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/PullRequestUtilsTests.java
@@ -43,12 +43,12 @@ public class PullRequestUtilsTests {
             var repoFolder = tempFolder.path().resolve("repo");
             var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
             credentials.commitLock(localRepo);
-            localRepo.pushAll(repo.url());
+            localRepo.pushAll(repo.authenticatedUrl());
 
             var issueProject = credentials.getIssueProject();
             var issue = issueProject.createIssue("This is an issue", List.of("Indeed"), Map.of("issuetype", JSON.of("Enhancement")));
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", issue.id() + ": Fix that issue");
-            localRepo.push(editHash, repo.url(), "master");
+            localRepo.push(editHash, repo.authenticatedUrl(), "master");
             var pr1 = credentials.createPullRequest(repo, "master", "master", issue.id() + ": Fix that issue");
 
             {

--- a/forge/src/test/java/org/openjdk/skara/forge/gitlab/GitLabRestApiTest.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/gitlab/GitLabRestApiTest.java
@@ -207,9 +207,9 @@ public class GitLabRestApiTest {
 
         try (var tempDir = new TemporaryDirectory()) {
             var localRepoDir = tempDir.path().resolve("local");
-            var localRepo = GitRepository.clone(gitLabRepo.url(), localRepoDir, false, null);
+            var localRepo = GitRepository.clone(gitLabRepo.authenticatedUrl(), localRepoDir, false, null);
             var head = localRepo.head();
-            localRepo.push(head, gitLabRepo.url(), branchName, true);
+            localRepo.push(head, gitLabRepo.authenticatedUrl(), branchName, true);
 
             gitLabRepo.unprotectBranchPattern(branchName);
             // Don't fail on repeated invocations

--- a/storage/src/main/java/org/openjdk/skara/storage/HostedRepositoryStorage.java
+++ b/storage/src/main/java/org/openjdk/skara/storage/HostedRepositoryStorage.java
@@ -68,7 +68,7 @@ class HostedRepositoryStorage<T> implements Storage<T> {
         while (retryCount < 10) {
             try {
                 try {
-                    return Repository.materialize(localStorage, repository.url(), "+" + ref + ":storage");
+                    return Repository.materialize(localStorage, repository.authenticatedUrl(), "+" + ref + ":storage");
                 } catch (IOException e2) {
                     // The remote ref may not yet exist
                     Repository localRepository = Repository.init(localStorage, repository.repositoryType());
@@ -88,7 +88,7 @@ class HostedRepositoryStorage<T> implements Storage<T> {
                     var firstCommit = localRepository.commit(message, authorName, authorEmail);
 
                     // If the materialization failed for any other reason than the remote ref not existing, this will fail
-                    localRepository.push(firstCommit, repository.url(), ref);
+                    localRepository.push(firstCommit, repository.authenticatedUrl(), ref);
                     return localRepository;
                 }
             } catch (IOException e) {
@@ -121,7 +121,7 @@ class HostedRepositoryStorage<T> implements Storage<T> {
             // The local storage has changed, try to push it to the remote
             try {
                 var updatedHash = localRepository.head();
-                localRepository.push(updatedHash, hostedRepository.url(), ref);
+                localRepository.push(updatedHash, hostedRepository.authenticatedUrl(), ref);
                 current = updated;
                 return;
             } catch (IOException e) {
@@ -129,7 +129,7 @@ class HostedRepositoryStorage<T> implements Storage<T> {
 
                 // Check if the remote has changed
                 try {
-                    var remoteHash = localRepository.fetch(hostedRepository.url(), ref);
+                    var remoteHash = localRepository.fetch(hostedRepository.authenticatedUrl(), ref);
                     if (!remoteHash.equals(lastRemoteHash)) {
                         localRepository.checkout(remoteHash, true);
                         repositoryStorage = new RepositoryStorage<>(localRepository, fileName, authorName, authorEmail, message, serializer, deserializer);

--- a/test/src/main/java/org/openjdk/skara/test/CensusBuilder.java
+++ b/test/src/main/java/org/openjdk/skara/test/CensusBuilder.java
@@ -221,7 +221,7 @@ public class CensusBuilder {
 
             localRepository.add(folder);
             var hash = localRepository.commit("Generated census", "Census User", "cu@test.test");
-            localRepository.push(hash, repository.url(), Branch.defaultFor(VCS.GIT).name(), true);
+            localRepository.push(hash, repository.authenticatedUrl(), Branch.defaultFor(VCS.GIT).name(), true);
             return repository;
 
         } catch (IOException e) {

--- a/test/src/main/java/org/openjdk/skara/test/HostCredentials.java
+++ b/test/src/main/java/org/openjdk/skara/test/HostCredentials.java
@@ -283,7 +283,7 @@ public class HostCredentials implements AutoCloseable {
             var lockFile = repoFolder.resolve("lock.txt");
             Repository localRepo;
             try {
-                localRepo = Repository.materialize(repoFolder, repo.url(), "testlock");
+                localRepo = Repository.materialize(repoFolder, repo.authenticatedUrl(), "testlock");
             } catch (IOException e) {
                 // If the branch does not exist, we'll try to create it
                 localRepo = TestableRepository.init(repoFolder, VCS.GIT);
@@ -302,7 +302,7 @@ public class HostCredentials implements AutoCloseable {
 
             // The lock either doesn't exist or is stale, try to grab it
             var lockHash = commitLock(localRepo);
-            localRepo.push(lockHash, repo.url(), "testlock");
+            localRepo.push(lockHash, repo.authenticatedUrl(), "testlock");
             log.info("Obtained credentials lock");
 
             // If no exception occurs (such as the push fails), we have obtained the lock
@@ -315,10 +315,10 @@ public class HostCredentials implements AutoCloseable {
             var repoFolder = tempFolder.path().resolve("lock");
             var lockFile = repoFolder.resolve("lock.txt");
             Repository localRepo;
-            localRepo = Repository.materialize(repoFolder, repo.url(), "testlock");
+            localRepo = Repository.materialize(repoFolder, repo.authenticatedUrl(), "testlock");
             localRepo.remove(lockFile);
             var lockHash = localRepo.commit("Unlock", "test", "test@test.test");
-            localRepo.push(lockHash, repo.url(), "testlock");
+            localRepo.push(lockHash, repo.authenticatedUrl(), "testlock");
         }
     }
 

--- a/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
@@ -56,7 +56,7 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
         this.host = host;
         this.projectName = projectName;
         this.localRepository = localRepository;
-        pullRequestPattern = Pattern.compile(authenticatedUrl().toString() + "/pr/" + "(\\d+)");
+        pullRequestPattern = Pattern.compile(webUrl().toString() + "/pr/" + "(\\d+)");
         commitComments = new HashMap<>();
     }
 

--- a/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
@@ -56,7 +56,7 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
         this.host = host;
         this.projectName = projectName;
         this.localRepository = localRepository;
-        pullRequestPattern = Pattern.compile(url().toString() + "/pr/" + "(\\d+)");
+        pullRequestPattern = Pattern.compile(authenticatedUrl().toString() + "/pr/" + "(\\d+)");
         commitComments = new HashMap<>();
     }
 
@@ -159,7 +159,7 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
     }
 
     @Override
-    public URI url() {
+    public URI authenticatedUrl() {
         try {
             // We need a URL without a trailing slash
             var fileName = localRepository.root().getFileName().toString();
@@ -171,22 +171,22 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
 
     @Override
     public URI webUrl() {
-        return url();
+        return authenticatedUrl();
     }
 
     @Override
     public URI nonTransformedWebUrl() {
-        return url();
+        return authenticatedUrl();
     }
 
     @Override
     public URI webUrl(Hash hash) {
-        return URI.create(url().toString() + "/" + hash.hex());
+        return URI.create(authenticatedUrl().toString() + "/" + hash.hex());
     }
 
     @Override
     public URI webUrl(String baseRef, String headRef) {
-        return URI.create(url().toString() + "/" + baseRef + "..." + headRef);
+        return URI.create(authenticatedUrl().toString() + "/" + baseRef + "..." + headRef);
     }
 
     @Override
@@ -200,8 +200,8 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
     }
 
     @Override
-    public URI remoteUrl() {
-        return url();
+    public URI url() {
+        return authenticatedUrl();
     }
 
     @Override

--- a/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
@@ -200,6 +200,11 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
     }
 
     @Override
+    public URI remoteUrl() {
+        return url();
+    }
+
+    @Override
     public Optional<String> fileContents(String filename, String ref) {
         try {
             var bytes = localRepository.show(Path.of(filename), localRepository.resolve(ref).orElseThrow());

--- a/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
@@ -214,7 +214,7 @@ public class TestPullRequest extends TestIssue implements PullRequest {
     @Override
     public URI webUrl() {
         try {
-            return new URI(targetRepository.authenticatedUrl().toString() + "/pr/" + id());
+            return new URI(targetRepository.webUrl().toString() + "/pr/" + id());
         } catch (URISyntaxException e) {
             throw new RuntimeException(e);
         }

--- a/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
@@ -214,7 +214,7 @@ public class TestPullRequest extends TestIssue implements PullRequest {
     @Override
     public URI webUrl() {
         try {
-            return new URI(targetRepository.url().toString() + "/pr/" + id());
+            return new URI(targetRepository.authenticatedUrl().toString() + "/pr/" + id());
         } catch (URISyntaxException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
In this patch, `.git` is added to the URLs printed by Skara.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1813](https://bugs.openjdk.org/browse/SKARA-1813): URLs printed by Skara should have ".git" at the end of the repo name


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to [95d2c6e2](https://git.openjdk.org/skara/pull/1467/files/95d2c6e27c1f2f3c8acd7d6f3a8077b2fcda9b5b)
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer) ⚠️ Review applies to [959eb93b](https://git.openjdk.org/skara/pull/1467/files/959eb93b4f0fdf831669d81c215ce03df0658947)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1467/head:pull/1467` \
`$ git checkout pull/1467`

Update a local copy of the PR: \
`$ git checkout pull/1467` \
`$ git pull https://git.openjdk.org/skara pull/1467/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1467`

View PR using the GUI difftool: \
`$ git pr show -t 1467`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1467.diff">https://git.openjdk.org/skara/pull/1467.diff</a>

</details>
