### PR TITLE
1814: Add logic to allow bot run Backport Command

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
@@ -172,7 +172,7 @@ public class BackportCommand implements CommandHandler {
     @Override
     public void handle(PullRequestBot bot, HostedCommit commit, LimitedCensusInstance censusInstance,
             Path scratchPath, CommandInvocation command, List<Comment> allComments, PrintWriter reply) {
-        if (censusInstance.contributor(command.user()).isEmpty()) {
+        if (censusInstance.contributor(command.user()).isEmpty() && !command.user().equals(bot.repo().forge().currentUser())) {
             reply.println(USER_INVALID_WARNING);
             return;
         }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
@@ -334,7 +334,7 @@ public class IntegrateCommand implements CommandHandler {
                 var repoName = matcher.group(1);
                 var branchName = matcher.group(2);
                 var text = "Creating backport for repo " + repoName + " on branch " + branchName
-                        + "\n/backport " + repoName + " " + branchName + "\n"
+                        + "\n\n/backport " + repoName + " " + branchName + "\n"
                         + PullRequestCommandWorkItem.VALID_BOT_COMMAND_MARKER;
                 if (allComments.stream()
                         .filter(c -> c.author().equals(botUser))

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportPRCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportPRCommandTests.java
@@ -49,7 +49,6 @@ public class BackportPRCommandTests {
 
             var censusBuilder = credentials.getCensusBuilder()
                     .addReviewer(integrator.forge().currentUser().id())
-                    .addReviewer(bot.forge().currentUser().id())
                     .addCommitter(author.forge().currentUser().id());
             var prBot = PullRequestBot.newBuilder()
                     .repo(bot)


### PR DESCRIPTION
In [SKARA-1797](https://bugs.openjdk.org/browse/SKARA-1797), the bot might issue /backport command when the pr is integrated. 

However, in the very first of Backport Command, the bot would check whether the command user is in the census. The bot itself is not in the census, so the command issued by the bot would fail.

In this patch, I added the logic to explicitly allow bot run `/backport` command in closed pr or commits.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1814](https://bugs.openjdk.org/browse/SKARA-1814): Add logic to allow bot run Backport Command


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1468/head:pull/1468` \
`$ git checkout pull/1468`

Update a local copy of the PR: \
`$ git checkout pull/1468` \
`$ git pull https://git.openjdk.org/skara pull/1468/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1468`

View PR using the GUI difftool: \
`$ git pr show -t 1468`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1468.diff">https://git.openjdk.org/skara/pull/1468.diff</a>

</details>
