### PR TITLE
1588: Bridge messages should not be sent for PRs in draft state

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
@@ -117,7 +117,7 @@ class ArchiveWorkItem implements WorkItem {
         }
     }
 
-    private boolean ignoreComment(HostUser author, String body, ZonedDateTime createdTime) {
+    private boolean ignoreComment(HostUser author, String body, ZonedDateTime createdTime, ZonedDateTime lastDraftTime) {
         if (pr.repository().forge().currentUser().equals(author)) {
             return true;
         }
@@ -141,8 +141,7 @@ class ArchiveWorkItem implements WorkItem {
         // If the pull request was converted to draft, the comments
         // after the last converted time should be ignored.
         if (pr.isDraft()) {
-            var lastDraftTime = pr.lastMarkedAsDraftTime();
-            if (lastDraftTime.isPresent() && lastDraftTime.get().isBefore(createdTime)) {
+            if (lastDraftTime != null && lastDraftTime.isBefore(createdTime)) {
                 return true;
             }
         }
@@ -343,10 +342,11 @@ class ArchiveWorkItem implements WorkItem {
             var webrevPath = scratchPath.resolve("mlbridge-webrevs");
             var listServer = MailingListServerFactory.createMailmanServer(bot.listArchive(), bot.smtpServer(), bot.sendInterval());
             var archiver = new ReviewArchive(pr, bot.emailAddress());
+            var lastDraftTime = pr.lastMarkedAsDraftTime().orElse(null);
 
             // Regular comments
             for (var comment : comments) {
-                if (ignoreComment(comment.author(), comment.body(), comment.createdAt())) {
+                if (ignoreComment(comment.author(), comment.body(), comment.createdAt(), lastDraftTime)) {
                     archiver.addIgnored(comment);
                 } else {
                     archiver.addComment(comment);
@@ -356,7 +356,7 @@ class ArchiveWorkItem implements WorkItem {
             // Review comments
             var reviews = pr.reviews();
             for (var review : reviews) {
-                if (ignoreComment(review.reviewer(), review.body().orElse(""), review.createdAt())) {
+                if (ignoreComment(review.reviewer(), review.body().orElse(""), review.createdAt(), lastDraftTime)) {
                     continue;
                 }
                 archiver.addReview(review);
@@ -368,7 +368,7 @@ class ArchiveWorkItem implements WorkItem {
                                    .sorted(Comparator.comparing(ReviewComment::path))
                                    .collect(Collectors.toList());
             for (var reviewComment : reviewComments) {
-                if (ignoreComment(reviewComment.author(), reviewComment.body(), reviewComment.createdAt())) {
+                if (ignoreComment(reviewComment.author(), reviewComment.body(), reviewComment.createdAt(), lastDraftTime)) {
                     continue;
                 }
                 archiver.addReviewComment(reviewComment);

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBot.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -203,7 +203,6 @@ public class MailingListBridgeBot implements Bot {
 
         List<PullRequest> prs = poller.updatedPullRequests();
         prs.stream()
-                .filter(pr -> !pr.isDraft())
                 .map(pr -> new ArchiveWorkItem(pr, this,
                         e -> poller.retryPullRequest(pr),
                         r -> poller.quarantinePullRequest(pr, r)))

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBot.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -203,6 +203,7 @@ public class MailingListBridgeBot implements Bot {
 
         List<PullRequest> prs = poller.updatedPullRequests();
         prs.stream()
+                .filter(pr -> !pr.isDraft())
                 .map(pr -> new ArchiveWorkItem(pr, this,
                         e -> poller.retryPullRequest(pr),
                         r -> poller.quarantinePullRequest(pr, r)))

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -3551,6 +3551,36 @@ class MailingListBridgeBotTests {
             assertEquals(3, archiveContainsCount(archiveFolder.path(), "RFR: 1234: This is a pull request"));
             assertEquals(1, archiveContainsCount(archiveFolder.path(), "This is a comment"));
             assertEquals(1, archiveContainsCount(archiveFolder.path(), "This is a new comment"));
+
+            // Add a new comment before making it as draft.
+            pr.addComment("This is a comment before making");
+
+            // Make it as draft again.
+            pr.makeDraft();
+
+            // Add a new comment after making it as draft.
+            pr.addComment("This is a comment after making");
+
+            // Run another archive pass.
+            TestBotRunner.runPeriodicItems(mlBot);
+
+            // The archive should only contain the comments before making it as draft.
+            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            assertEquals(4, archiveContainsCount(archiveFolder.path(), "RFR: 1234: This is a pull request"));
+            assertEquals(1, archiveContainsCount(archiveFolder.path(), "This is a comment before making"));
+            assertFalse(archiveContains(archiveFolder.path(), "This is a comment after making"));
+
+            // Make it as not draft again.
+            pr.makeNotDraft();
+
+            // Run another archive pass.
+            TestBotRunner.runPeriodicItems(mlBot);
+
+            // The archive should now contain all the comments.
+            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            assertEquals(5, archiveContainsCount(archiveFolder.path(), "RFR: 1234: This is a pull request"));
+            assertEquals(1, archiveContainsCount(archiveFolder.path(), "This is a comment before making"));
+            assertEquals(1, archiveContainsCount(archiveFolder.path(), "This is a comment after making"));
         }
     }
 }

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -3435,6 +3435,122 @@ class MailingListBridgeBotTests {
 
             // There should have been a reply directed towards the bridged mail id
             assertEquals(1, archiveContainsCount(archiveFolder.path(), Pattern.quote("In-Reply-To: <bridgedemailid@bridge.bridge>")));
+        }
+    }
+
+    @Test
+    void notArchiveDraftPR(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory();
+             var archiveFolder = new TemporaryDirectory();
+             var listServer = new TestMailmanServer();
+             var webrevServer = new TestWebrevServer()) {
+            var author = credentials.getHostedRepository();
+            var archive = credentials.getHostedRepository();
+            var ignored = credentials.getHostedRepository();
+            var listAddress = EmailAddress.parse(listServer.createList("test"));
+            var censusBuilder = credentials.getCensusBuilder()
+                    .addAuthor(author.forge().currentUser().id());
+            var from = EmailAddress.from("test", "test@test.mail");
+            var mlBot = MailingListBridgeBot.newBuilder()
+                    .from(from)
+                    .repo(author)
+                    .archive(archive)
+                    .censusRepo(censusBuilder.build())
+                    .lists(List.of(new MailingListConfiguration(listAddress, Set.of())))
+                    .ignoredUsers(Set.of(ignored.forge().currentUser().username()))
+                    .ignoredComments(Set.of())
+                    .listArchive(listServer.getArchive())
+                    .smtpServer(listServer.getSMTP())
+                    .webrevStorageHTMLRepository(archive)
+                    .webrevStorageRef("webrev")
+                    .webrevStorageBase(Path.of("test"))
+                    .webrevStorageBaseUri(webrevServer.uri())
+                    .readyLabels(Set.of("rfr"))
+                    .readyComments(Map.of(ignored.forge().currentUser().username(), Pattern.compile("ready")))
+                    .issueTracker(URIBuilder.base("http://issues.test/browse/").build())
+                    .headers(Map.of("Extra1", "val1", "Extra2", "val2"))
+                    .sendInterval(Duration.ZERO)
+                    .build();
+
+            // Populate the repository.
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            localRepo.push(masterHash, author.url(), "master", true);
+            localRepo.push(masterHash, archive.url(), "webrev", true);
+
+            // Make a change with a corresponding PR.
+            var editHash = CheckableRepository.appendAndCommit(localRepo, "A simple change",
+                    "Change msg\n\nWith several lines");
+            localRepo.push(editHash, author.url(), "edit", true);
+            var pr = credentials.createPullRequest(archive, "master", "edit", "1234: This is a pull request");
+            pr.setBody("This is not ready now");
+
+            // Make it as draft, now the PR is not ready.
+            pr.makeDraft();
+
+            // Run an archive pass.
+            TestBotRunner.runPeriodicItems(mlBot);
+
+            // A draft PR should not be archived.
+            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            assertFalse(archiveContains(archiveFolder.path(), "This is a pull request"));
+
+            // Make it as not draft.
+            pr.makeNotDraft();
+
+            // Flag it as ready for review.
+            pr.setBody("This should be ready now");
+            pr.addLabel("rfr");
+
+            // Post a ready comment.
+            var ignoredPr = ignored.pullRequest(pr.id());
+            ignoredPr.addComment("ready");
+
+            // Run another archive pass.
+            TestBotRunner.runPeriodicItems(mlBot);
+
+            // The archive should now contain an entry.
+            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            assertEquals(1, archiveContainsCount(archiveFolder.path(), "RFR: 1234: This is a pull request"));
+
+            // Add a comment.
+            pr.addComment("This is a comment");
+
+            // Run another archive pass.
+            TestBotRunner.runPeriodicItems(mlBot);
+
+            // The archive should now contain the comment.
+            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            assertEquals(2, archiveContainsCount(archiveFolder.path(), "RFR: 1234: This is a pull request"));
+            assertEquals(1, archiveContainsCount(archiveFolder.path(), "This is a comment"));
+
+            // Make it as draft again.
+            pr.makeDraft();
+
+            // Add a new comment.
+            pr.addComment("This is a new comment");
+
+            // Run another archive pass.
+            TestBotRunner.runPeriodicItems(mlBot);
+
+            // The archive should not now contain the new comment.
+            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            assertEquals(2, archiveContainsCount(archiveFolder.path(), "RFR: 1234: This is a pull request"));
+            assertEquals(1, archiveContainsCount(archiveFolder.path(), "This is a comment"));
+            assertFalse(archiveContains(archiveFolder.path(), "This is a new comment"));
+
+            // Make it as not draft again.
+            pr.makeNotDraft();
+
+            // Run another archive pass.
+            TestBotRunner.runPeriodicItems(mlBot);
+
+            // The archive should now contain the new comment.
+            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            assertEquals(3, archiveContainsCount(archiveFolder.path(), "RFR: 1234: This is a pull request"));
+            assertEquals(1, archiveContainsCount(archiveFolder.path(), "This is a comment"));
+            assertEquals(1, archiveContainsCount(archiveFolder.path(), "This is a new comment"));
         }
     }
 }

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -291,6 +291,11 @@ class InMemoryPullRequest implements PullRequest {
     @Override
     public void makeNotDraft() {
 
+    }
+
+    @Override
+    public Optional<ZonedDateTime> lastMarkedAsDraftTime() {
+        return Optional.empty();
     }
 
     @Override

--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -162,6 +162,16 @@ public interface PullRequest extends Issue {
      */
     boolean isDraft();
     void makeNotDraft();
+
+    /**
+     * Return the last time the pull request was converted to draft.
+     * If the pull request was created as draft, return the created time of the pull request.
+     * If the pull request was always ready for review and never converted to draft, return empty.
+     * If the restful api doesn't support draft pull request, return empty.
+     * Note: if the pull request was created as draft, but later converted to ready
+     *  and didn't convert to draft again, this method will return empty.
+     */
+    Optional<ZonedDateTime> lastMarkedAsDraftTime();
 
     Optional<ZonedDateTime> labelAddedAt(String label);
 

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -709,8 +709,8 @@ public class GitHubPullRequest implements PullRequest {
                 .map(JSONValue::asObject)
                 .filter(obj -> obj.contains("event"))
                 .filter(obj -> obj.get("event").asString().equals("convert_to_draft"))
-                .reduce((a, b) -> b)
-                .map(obj -> ZonedDateTime.parse(obj.get("created_at").asString()));
+                .map(obj -> ZonedDateTime.parse(obj.get("created_at").asString()))
+                .reduce((a, b) -> a.isBefore(b) ? b : a);
         if (lastMarkedAsDraftTime.isEmpty() && isDraft()) {
             return Optional.of(createdAt());
         }

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -710,7 +710,7 @@ public class GitHubPullRequest implements PullRequest {
                 .filter(obj -> obj.contains("event"))
                 .filter(obj -> obj.get("event").asString().equals("convert_to_draft"))
                 .map(obj -> ZonedDateTime.parse(obj.get("created_at").asString()))
-                .reduce((a, b) -> a.isBefore(b) ? b : a);
+                .max(ZonedDateTime::compareTo);
         if (lastMarkedAsDraftTime.isEmpty() && isDraft()) {
             return Optional.of(createdAt());
         }

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -701,6 +701,20 @@ public class GitHubPullRequest implements PullRequest {
             .post()
             .body(JSON.object().put("query", mutation))
             .execute();
+    }
+
+    @Override
+    public Optional<ZonedDateTime> lastMarkedAsDraftTime() {
+        var lastMarkedAsDraftTime = request.get("issues/" + json.get("number").toString() + "/timeline")                .execute().stream()
+                .map(JSONValue::asObject)
+                .filter(obj -> obj.contains("event"))
+                .filter(obj -> obj.get("event").asString().equals("convert_to_draft"))
+                .reduce((a, b) -> b)
+                .map(obj -> ZonedDateTime.parse(obj.get("created_at").asString()));
+        if (lastMarkedAsDraftTime.isEmpty() && isDraft()) {
+            return Optional.of(createdAt());
+        }
+        return lastMarkedAsDraftTime;
     }
 
     @Override

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -789,8 +789,8 @@ public class GitLabMergeRequest implements PullRequest {
                 .map(JSONValue::asObject)
                 .filter(obj -> obj.get("system").asBoolean())
                 .filter(obj -> draftMessage.equals(obj.get("body").asString()))
-                .reduce((a, b) -> a)
-                .map(obj -> ZonedDateTime.parse(obj.get("created_at").asString()));
+                .map(obj -> ZonedDateTime.parse(obj.get("created_at").asString()))
+                .reduce((a, b) -> a.isBefore(b) ? b : a);
         if (lastMarkedAsDraftTime.isEmpty() && isDraft()) {
             return Optional.of(createdAt());
         }

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -790,7 +790,7 @@ public class GitLabMergeRequest implements PullRequest {
                 .filter(obj -> obj.get("system").asBoolean())
                 .filter(obj -> draftMessage.equals(obj.get("body").asString()))
                 .map(obj -> ZonedDateTime.parse(obj.get("created_at").asString()))
-                .reduce((a, b) -> a.isBefore(b) ? b : a);
+                .max(ZonedDateTime::compareTo);
         if (lastMarkedAsDraftTime.isEmpty() && isDraft()) {
             return Optional.of(createdAt());
         }

--- a/forge/src/test/java/org/openjdk/skara/forge/github/GitHubRestApiTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/github/GitHubRestApiTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -210,5 +210,15 @@ public class GitHubRestApiTests {
                     "Diff for huge file contents, printing first 50 chars of each '"
                     + fileContent.substring(0, 50) + "' '" + returnedContents.get().substring(0, 50) + "'");
         }
+    }
+
+    @Test
+    void testLastMarkedAsDraftTime() {
+        var githubRepoOpt = githubHost.repository("openjdk/playground");
+        assumeTrue(githubRepoOpt.isPresent());
+        var githubRepo = githubRepoOpt.get();
+        var pr = githubRepo.pullRequest("129");
+        var lastMarkedAsDraftTime = pr.lastMarkedAsDraftTime();
+        assertEquals("2023-02-11T11:51:12Z", lastMarkedAsDraftTime.get().toString());
     }
 }

--- a/forge/src/test/java/org/openjdk/skara/forge/gitlab/GitLabRestApiTest.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/gitlab/GitLabRestApiTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -217,5 +217,20 @@ public class GitLabRestApiTest {
 
             gitLabRepo.deleteBranch(branchName);
         }
+    }
+
+    @Test
+    void testLastMarkedAsDraftTime() throws IOException {
+        var settings = ManualTestSettings.loadManualTestSettings();
+        var username = settings.getProperty("gitlab.user");
+        var token = settings.getProperty("gitlab.pat");
+        var credential = new Credential(username, token);
+        var uri = URIBuilder.base(settings.getProperty("gitlab.uri")).build();
+        var gitLabHost = new GitLabHost("gitlab", uri, false, credential, Set.of());
+        var gitLabRepo = gitLabHost.repository(settings.getProperty("gitlab.repository")).orElseThrow();
+        var gitLabMergeRequest = gitLabRepo.pullRequest(settings.getProperty("gitlab.merge.request.id"));
+
+        var lastMarkedAsDraftTime = gitLabMergeRequest.lastMarkedAsDraftTime();
+        assertEquals("2023-02-11T08:43:52.408Z", lastMarkedAsDraftTime.get().toString());
     }
 }

--- a/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -223,6 +223,10 @@ public class TestPullRequest extends TestIssue implements PullRequest {
     @Override
     public void makeNotDraft() {
         store().setDraft(false);
+    }
+
+    public void makeDraft() {
+        store().setDraft(true);
     }
 
     @Override

--- a/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
@@ -230,6 +230,11 @@ public class TestPullRequest extends TestIssue implements PullRequest {
     }
 
     @Override
+    public Optional<ZonedDateTime> lastMarkedAsDraftTime() {
+        return Optional.ofNullable(store().lastMarkedAsDraftTime());
+    }
+
+    @Override
     public URI diffUrl() {
         return URI.create(webUrl().toString() + ".diff");
     }

--- a/test/src/main/java/org/openjdk/skara/test/TestPullRequestStore.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestPullRequestStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,6 +48,7 @@ public class TestPullRequestStore extends TestIssueStore {
     private final List<ReferenceChange> targetReferenceChanges = new ArrayList<>();
 
     private ZonedDateTime lastMarkedAsReadyTime;
+    private ZonedDateTime lastMarkedAsDraftTime;
 
     public TestPullRequestStore(String id, HostUser author, String title, List<String> body,
             TestHostedRepository sourceRepository, String targetRef, String sourceRef, boolean draft) {
@@ -56,7 +57,9 @@ public class TestPullRequestStore extends TestIssueStore {
         this.targetRef = targetRef;
         this.sourceRef = sourceRef;
         this.draft = draft;
-        if (!draft) {
+        if (draft) {
+            lastMarkedAsDraftTime = ZonedDateTime.now();
+        } else {
             lastMarkedAsReadyTime = ZonedDateTime.now();
         }
     }
@@ -129,7 +132,9 @@ public class TestPullRequestStore extends TestIssueStore {
 
     public void setDraft(boolean draft) {
         this.draft = draft;
-        if (!draft) {
+        if (draft) {
+            lastMarkedAsDraftTime = ZonedDateTime.now();
+        } else {
             lastMarkedAsReadyTime = ZonedDateTime.now();
         }
     }
@@ -140,5 +145,9 @@ public class TestPullRequestStore extends TestIssueStore {
 
     public ZonedDateTime lastMarkedAsReadyTime() {
         return lastMarkedAsReadyTime;
+    }
+
+    public ZonedDateTime lastMarkedAsDraftTime() {
+        return lastMarkedAsDraftTime;
     }
 }


### PR DESCRIPTION
Hi all,

This patch prevents the `mailling bridge bot` from sending emails when a PR is draft.
And the related test case is added.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1588](https://bugs.openjdk.org/browse/SKARA-1588): Bridge messages should not be sent for PRs in draft state


### Reviewers
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - Committer) ⚠️ Review applies to [cdcfe380](https://git.openjdk.org/skara/pull/1469/files/cdcfe38057166bd94d6b834cf3e7dd13b5d86f33)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to [4d50eaad](https://git.openjdk.org/skara/pull/1469/files/4d50eaade87cfec1218e7341d563ed7eb853f85b)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1469/head:pull/1469` \
`$ git checkout pull/1469`

Update a local copy of the PR: \
`$ git checkout pull/1469` \
`$ git pull https://git.openjdk.org/skara pull/1469/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1469`

View PR using the GUI difftool: \
`$ git pr show -t 1469`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1469.diff">https://git.openjdk.org/skara/pull/1469.diff</a>

</details>
