### PR TITLE
1706: Store github checks in PR unique way

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -1085,8 +1085,12 @@ class CheckRun {
         pr.addComment(message);
     }
 
+    static String getJcheckName(PullRequest pr) {
+        return pr.repository().forge().name().equals("GitHub") ? "jcheck-" + pr.repository().name() + "-" + pr.id() : "jcheck";
+    }
+
     private void checkStatus() {
-        var checkBuilder = CheckBuilder.create("jcheck", pr.headHash());
+        var checkBuilder = CheckBuilder.create(getJcheckName(pr), pr.headHash());
         var censusDomain = censusInstance.configuration().census().domain();
         Exception checkException = null;
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -120,7 +120,7 @@ class CheckWorkItem extends PullRequestWorkItem {
         var hash = pr.headHash();
         var metadata = getMetadata(censusInstance, pr.title(), pr.body(), comments, reviews, labels, pr.targetRef(), pr.isDraft(), null);
         var currentChecks = pr.checks(hash);
-        var jcheckName = pr.repository().forge().name().equals("GitHub") ? "jcheck" + pr.repository().name() + pr.id() : "jcheck";
+        var jcheckName = CheckRun.getJcheckName(pr);
 
         if (currentChecks.containsKey(jcheckName)) {
             var check = currentChecks.get(jcheckName);

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -120,9 +120,10 @@ class CheckWorkItem extends PullRequestWorkItem {
         var hash = pr.headHash();
         var metadata = getMetadata(censusInstance, pr.title(), pr.body(), comments, reviews, labels, pr.targetRef(), pr.isDraft(), null);
         var currentChecks = pr.checks(hash);
+        var jcheckName = pr.repository().forge().name().equals("GitHub") ? "jcheck" + pr.repository().name() + pr.id() : "jcheck";
 
-        if (currentChecks.containsKey("jcheck")) {
-            var check = currentChecks.get("jcheck");
+        if (currentChecks.containsKey(jcheckName)) {
+            var check = currentChecks.get(jcheckName);
             if (check.completedAt().isPresent() && check.metadata().isPresent()) {
                 var previousMetadata = check.metadata().get();
                 if (previousMetadata.contains(":")) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
@@ -61,6 +61,9 @@ public class IntegrateCommand implements CommandHandler {
         final var inProgress = "the status check `" + checkName + "` is still in progress";
         final var outdated = "the status check `" + checkName + "` has not been performed on commit %s yet";
 
+        checkName = checkName.equals("jcheck") && pr.repository().forge().name().equals("GitHub") ?
+                "jcheck" + pr.repository().name() + pr.id() : "jcheck";
+
         if (performedChecks.containsKey(checkName)) {
             var check = performedChecks.get(checkName);
             if (check.status() == CheckStatus.SUCCESS) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
@@ -61,9 +61,6 @@ public class IntegrateCommand implements CommandHandler {
         final var inProgress = "the status check `" + checkName + "` is still in progress";
         final var outdated = "the status check `" + checkName + "` has not been performed on commit %s yet";
 
-        checkName = checkName.equals("jcheck") && pr.repository().forge().name().equals("GitHub") ?
-                "jcheck" + pr.repository().name() + pr.id() : "jcheck";
-
         if (performedChecks.containsKey(checkName)) {
             var check = performedChecks.get(checkName);
             if (check.status() == CheckStatus.SUCCESS) {
@@ -170,7 +167,7 @@ public class IntegrateCommand implements CommandHandler {
             return;
         }
 
-        var problem = checkProblem(pr.checks(pr.headHash()), "jcheck", pr);
+        var problem = checkProblem(pr.checks(pr.headHash()), CheckRun.getJcheckName(pr), pr);
         if (problem.isPresent()) {
             reply.print("Your integration request cannot be fulfilled at this time, as ");
             reply.println(problem.get());

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -461,7 +461,7 @@ public class GitHubPullRequest implements PullRequest {
     @Override
     public void updateCheck(Check check) {
         var completedQuery = JSON.object();
-        completedQuery.put("name", check.name().equals("jcheck") ? check.name() + repository().name() + id() : check.name());
+        completedQuery.put("name", check.name());
         completedQuery.put("head_branch", json.get("head").get("ref"));
         completedQuery.put("head_sha", check.hash().hex());
 

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -461,7 +461,7 @@ public class GitHubPullRequest implements PullRequest {
     @Override
     public void updateCheck(Check check) {
         var completedQuery = JSON.object();
-        completedQuery.put("name", check.name());
+        completedQuery.put("name", check.name().equals("jcheck") ? check.name() + repository().name() + id() : check.name());
         completedQuery.put("head_branch", json.get("head").get("ref"));
         completedQuery.put("head_sha", check.hash().hex());
 


### PR DESCRIPTION
Currently, checks in GitHub are stored in the commit. So if multiple PRs share the same source commit, then they will compete with the check-runs and store their different checksum in there. This in turn means that all, or most of those PRs will always think the check is outdated when a CheckRun is performed next.
 
This patch adds repository name and pull request id to the name of check in Github. Therefore, even if multiple PRs share the same source commit, every PR will store a unique check in the commit and there is no competition exists.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1706](https://bugs.openjdk.org/browse/SKARA-1706): Store github checks in PR unique way


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1470/head:pull/1470` \
`$ git checkout pull/1470`

Update a local copy of the PR: \
`$ git checkout pull/1470` \
`$ git pull https://git.openjdk.org/skara pull/1470/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1470`

View PR using the GUI difftool: \
`$ git pr show -t 1470`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1470.diff">https://git.openjdk.org/skara/pull/1470.diff</a>

</details>
