### PR TITLE
1818: Get rid of extra REST request in GitLabMergeRequest#author

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -82,13 +82,7 @@ public class GitLabMergeRequest implements PullRequest {
 
     @Override
     public HostUser author() {
-        var username = json.get("author").get("username").asString();
-        var author = repository.forge().user(username);
-        if (author.isPresent()) {
-            return author.get();
-        } else {
-            throw new RuntimeException("Author of GitLab merge request unknown: " + username + "(maybe the user is inactive)");
-        }
+        return host.parseAuthorField(json);
     }
 
     @Override


### PR DESCRIPTION
Currently, in GitLabMergeRequest#author, the bot makes an unnecessary REST request to retrieve the HostUser object. 
However, with recent advancements in GitLab, it's possible to parse the HostUser directly from the pull request JSON. 
Getting rid of this redundant REST request would also solve the 'user is inactive' issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1818](https://bugs.openjdk.org/browse/SKARA-1818): Get rid of extra REST request in GitLabMergeRequest#author


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1471/head:pull/1471` \
`$ git checkout pull/1471`

Update a local copy of the PR: \
`$ git checkout pull/1471` \
`$ git pull https://git.openjdk.org/skara pull/1471/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1471`

View PR using the GUI difftool: \
`$ git pr show -t 1471`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1471.diff">https://git.openjdk.org/skara/pull/1471.diff</a>

</details>
