### PR TITLE
1817: 'WIP merge requests' renamed to 'draft merge requests' in GitLab

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -634,7 +634,7 @@ public class GitLabMergeRequest implements PullRequest {
 
     @Override
     public boolean isDraft() {
-        return json.get("work_in_progress").asBoolean();
+        return json.get("draft").asBoolean();
     }
 
 
@@ -775,7 +775,7 @@ public class GitLabMergeRequest implements PullRequest {
     @Override
     public void makeNotDraft() {
         var title = title();
-        var draftPrefix = "WIP:";
+        var draftPrefix = "Draft:";
         if (title.startsWith(draftPrefix)) {
             setTitle(title.substring(draftPrefix.length()).stripLeading());
         }

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -114,7 +114,7 @@ public class GitLabRepository implements HostedRepository {
         var pr = request.post("merge_requests")
                         .body("source_branch", sourceRef)
                         .body("target_branch", targetRef)
-                        .body("title", draft ? "WIP: " : "" + title)
+                        .body("title", (draft ? "Draft: " : "") + title)
                         .body("description", String.join("\n", body))
                         .body("target_project_id", Long.toString(target.id()))
                         .execute();

--- a/forge/src/test/java/org/openjdk/skara/forge/gitlab/GitLabRestApiTest.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/gitlab/GitLabRestApiTest.java
@@ -33,11 +33,11 @@ import org.openjdk.skara.vcs.Branch;
 import org.openjdk.skara.vcs.Hash;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Set;
 import org.openjdk.skara.vcs.git.GitRepository;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * To be able to run the tests, you need to remove or comment out the @Disabled annotation first.
@@ -217,5 +217,26 @@ public class GitLabRestApiTest {
 
             gitLabRepo.deleteBranch(branchName);
         }
+    }
+
+    @Test
+    void testDraftMR() throws IOException {
+        var settings = ManualTestSettings.loadManualTestSettings();
+        var username = settings.getProperty("gitlab.user");
+        var token = settings.getProperty("gitlab.pat");
+        var credential = new Credential(username, token);
+        var uri = URIBuilder.base(settings.getProperty("gitlab.uri")).build();
+        var gitLabHost = new GitLabHost("gitlab", uri, false, credential, Set.of());
+        var gitLabRepo = gitLabHost.repository(settings.getProperty("gitlab.repository")).orElseThrow();
+
+        var gitLabMergeRequest = gitLabRepo.createPullRequest(gitLabRepo, settings.getProperty("gitlab.targetRef"),
+                settings.getProperty("gitlab.sourceRef"), "Test", List.of("test"), true);
+        assertTrue(gitLabMergeRequest.isDraft());
+        assertEquals("Draft: Test", gitLabMergeRequest.title());
+
+        gitLabMergeRequest.makeNotDraft();
+        gitLabMergeRequest = gitLabRepo.pullRequest(gitLabMergeRequest.id());
+        assertFalse(gitLabMergeRequest.isDraft());
+        assertEquals("Test", gitLabMergeRequest.title());
     }
 }

--- a/json/src/test/java/org/openjdk/skara/json/JSONParserTests.java
+++ b/json/src/test/java/org/openjdk/skara/json/JSONParserTests.java
@@ -439,7 +439,7 @@ public class JSONParserTests {
                 "\"source_project_id\":55," +
                 "\"target_project_id\":55," +
                 "\"labels\":[]," +
-                "\"work_in_progress\":false," +
+                "\"draft\":false," +
                 "\"milestone\":null," +
                 "\"merge_when_pipeline_succeeds\":false," +
                 "\"merge_status\":\"can_be_merged\"," +


### PR DESCRIPTION
Since 'WIP' is deprecated in GitLab, we need to update methods related with 'WIP'.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1817](https://bugs.openjdk.org/browse/SKARA-1817): 'WIP merge requests' renamed to 'draft merge requests' in GitLab


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1472/head:pull/1472` \
`$ git checkout pull/1472`

Update a local copy of the PR: \
`$ git checkout pull/1472` \
`$ git pull https://git.openjdk.org/skara pull/1472/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1472`

View PR using the GUI difftool: \
`$ git pr show -t 1472`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1472.diff">https://git.openjdk.org/skara/pull/1472.diff</a>

</details>
