### PR TITLE
1821: The 'timeline` API in GitHub doesn't point out the sorting order

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -769,11 +769,7 @@ public class GitHubPullRequest implements PullRequest {
                       .map(JSONValue::asObject)
                       .filter(obj -> obj.contains("event"))
                       .filter(obj -> obj.get("event").asString().equals("closed"))
-                      .max((first, second) -> {
-                          var firstTime = ZonedDateTime.parse(first.get("created_at").asString());
-                          var secondTime = ZonedDateTime.parse(second.get("created_at").asString());
-                          return firstTime.compareTo(secondTime);
-                      })
+                      .max(Comparator.comparing(o -> ZonedDateTime.parse(o.get("created_at").asString())))
                       .map(e -> host.parseUserObject(e.get("actor")));
     }
 
@@ -794,7 +790,7 @@ public class GitHubPullRequest implements PullRequest {
                 .filter(obj -> obj.get("event").asString().equals("head_ref_force_pushed"))
                 .filter(obj -> ZonedDateTime.parse(obj.get("created_at").asString()).isAfter(lastMarkedAsReadyTime(timelineJSON)))
                 .map(obj -> ZonedDateTime.parse(obj.get("created_at").asString()))
-                .max(ZonedDateTime::compareTo);
+                .max(Comparator.naturalOrder());
     }
 
     @Override

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -769,7 +769,11 @@ public class GitHubPullRequest implements PullRequest {
                       .map(JSONValue::asObject)
                       .filter(obj -> obj.contains("event"))
                       .filter(obj -> obj.get("event").asString().equals("closed"))
-                      .reduce((a, b) -> b)
+                      .max((first, second) -> {
+                          var firstTime = ZonedDateTime.parse(first.get("created_at").asString());
+                          var secondTime = ZonedDateTime.parse(second.get("created_at").asString());
+                          return firstTime.compareTo(secondTime);
+                      })
                       .map(e -> host.parseUserObject(e.get("actor")));
     }
 
@@ -789,8 +793,8 @@ public class GitHubPullRequest implements PullRequest {
                 .filter(obj -> obj.contains("event"))
                 .filter(obj -> obj.get("event").asString().equals("head_ref_force_pushed"))
                 .filter(obj -> ZonedDateTime.parse(obj.get("created_at").asString()).isAfter(lastMarkedAsReadyTime(timelineJSON)))
-                .reduce((a, b) -> b)
-                .map(obj -> ZonedDateTime.parse(obj.get("created_at").asString()));
+                .map(obj -> ZonedDateTime.parse(obj.get("created_at").asString()))
+                .max(ZonedDateTime::compareTo);
     }
 
     @Override
@@ -820,8 +824,8 @@ public class GitHubPullRequest implements PullRequest {
                 .map(JSONValue::asObject)
                 .filter(obj -> obj.contains("event"))
                 .filter(obj -> obj.get("event").asString().equals("ready_for_review"))
-                .reduce((a, b) -> b)
                 .map(obj -> ZonedDateTime.parse(obj.get("created_at").asString()))
+                .max(ZonedDateTime::compareTo)
                 .orElseGet(this::createdAt);
     }
 }

--- a/forge/src/test/java/org/openjdk/skara/forge/github/GitHubRestApiTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/github/GitHubRestApiTests.java
@@ -221,4 +221,14 @@ public class GitHubRestApiTests {
         var lastMarkedAsDraftTime = pr.lastMarkedAsDraftTime();
         assertEquals("2023-02-11T11:51:12Z", lastMarkedAsDraftTime.get().toString());
     }
+
+    @Test
+    void testClosedBy() {
+        var githubRepoOpt = githubHost.repository("openjdk/playground");
+        assumeTrue(githubRepoOpt.isPresent());
+        var githubRepo = githubRepoOpt.get();
+        var pr = githubRepo.pullRequest("96");
+        var user = pr.closedBy();
+        assertEquals("lgxbslgx", user.get().username());
+    }
 }


### PR DESCRIPTION
Hi all,

This patch adjusts the code to avoid GitHub changing the sorting order of the `timeline` API in the future.
I worry that the time complexity may change from O(N) to O(N*N), but not sure.

Thanks for the review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1821](https://bugs.openjdk.org/browse/SKARA-1821): The 'timeline` API in GitHub doesn't point out the sorting order


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1473/head:pull/1473` \
`$ git checkout pull/1473`

Update a local copy of the PR: \
`$ git checkout pull/1473` \
`$ git pull https://git.openjdk.org/skara pull/1473/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1473`

View PR using the GUI difftool: \
`$ git pr show -t 1473`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1473.diff">https://git.openjdk.org/skara/pull/1473.diff</a>

</details>
