### PR TITLE
1271: Webrev generation should be optional

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
@@ -315,7 +315,7 @@ class ArchiveMessages {
                 "Commit messages:\n" +
                 formatCommitMessagesBrief(commits, commitsLink).orElse("") + "\n\n" +
                 "Changes: " + pr.changeUrl() + "\n" +
-                (webrev.uri() == null ? "" : " Webrev: " + webrev.uri().toString()) + "\n" +
+                (webrev.uri() == null ? "" : " Webrev: " + webrev.uri().toString() + "\n") +
                 issueString +
                 "  Stats: " + stats(localRepo, base, head) + "\n" +
                 "  Patch: " + pr.diffUrl().toString() + "\n" +
@@ -329,7 +329,7 @@ class ArchiveMessages {
         String webrevLinks;
         if (webrevs.size() > 0) {
             if (webrevs.stream().noneMatch(w -> w.uri() != null)) {
-                webrevLinks = "Webrev is disabled\n\n";
+                webrevLinks = "";
             } else {
                 var containsConflicts = webrevs.stream().anyMatch(w -> w.type().equals(WebrevDescription.Type.MERGE_CONFLICT));
                 var containsMergeDiffs = webrevs.stream().anyMatch(w -> w.type().equals(WebrevDescription.Type.MERGE_TARGET) ||

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
@@ -153,6 +153,9 @@ class ArchiveWorkItem implements WorkItem {
     private static final String webrevListMarker = "<!-- mlbridge webrev list -->";
 
     private void updateWebrevComment(List<Comment> comments, int index, List<WebrevDescription> webrevs) {
+        if (webrevs.stream().noneMatch(w -> w.uri() != null)) {
+            return;
+        }
         var existing = comments.stream()
                                .filter(comment -> comment.author().equals(pr.repository().forge().currentUser()))
                                .filter(comment -> comment.body().contains(webrevCommentMarker))

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
@@ -286,6 +286,9 @@ class WebrevStorage {
 
     private URI createAndArchive(PullRequest pr, Repository localRepository, Path scratchPath, Diff diff, Hash base, Hash head, String identifier) {
         try {
+            if (!generateHTML && !generateJSON) {
+                return null;
+            }
             var relativeFolder = baseFolder.resolve(String.format("%s/%s", pr.id(), identifier));
             var outputFolder = scratchPath.resolve(relativeFolder);
             var placeholder = generatePlaceholder(pr, base, head);

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -3810,7 +3810,6 @@ class MailingListBridgeBotTests {
             assertFalse(archiveContains(archiveFolder.path(), "The webrevs contain the adjustments done while merging with regards to each parent branch:"));
             assertFalse(archiveContains(archiveFolder.path(), pr.id() + "/00.0"));
             assertTrue(archiveContains(archiveFolder.path(), "3 lines in 2 files changed: 1 ins; 1 del; 1 mod"));
-            assertTrue(archiveContains(archiveFolder.path(), "Webrev is disabled"));
 
             // The PR should not contain a webrev comment
             assertEquals(0, pr.comments().size());


### PR DESCRIPTION
Currently, webrevs are generated automatically when a user pushes a new commit, and it's mandatory to choose either JSON or HTML when configuring the mlbridge bot. If both of them are disabled in the configuration, the bot will throw errors.

In this patch, generating a webrev will be optional. If both JSON and HTML are disabled, no webrev will be generated.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1271](https://bugs.openjdk.org/browse/SKARA-1271): Webrev generation should be optional


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1475/head:pull/1475` \
`$ git checkout pull/1475`

Update a local copy of the PR: \
`$ git checkout pull/1475` \
`$ git pull https://git.openjdk.org/skara pull/1475/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1475`

View PR using the GUI difftool: \
`$ git pr show -t 1475`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1475.diff">https://git.openjdk.org/skara/pull/1475.diff</a>

</details>
