### PR TITLE
1035: Race when creating backports for bug spanning multiple repos

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
@@ -31,6 +31,7 @@ import org.openjdk.skara.issuetracker.*;
 import org.openjdk.skara.jbs.*;
 import org.openjdk.skara.jcheck.JCheckConfiguration;
 import org.openjdk.skara.json.JSON;
+import org.openjdk.skara.network.UncheckedRestException;
 import org.openjdk.skara.vcs.*;
 import org.openjdk.skara.vcs.openjdk.*;
 
@@ -307,14 +308,14 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
                                 log.info("Creating new backport for " + issue.id() + " with fixVersion " + requestedVersion);
                                 try {
                                     issue = jbsBackport.createBackport(issue, requestedVersion, username.orElse(null), defaultSecurity(branch));
-                                } catch (Exception exp) {
+                                } catch (UncheckedRestException e) {
                                     existing = Backports.findIssue(issue, fixVersion);
                                     if (existing.isPresent()) {
-                                        log.info("Race condition occurred while creating the back port. So returning an existing backport for " + issue.id() + " and requested fixVersion "
+                                        log.info("Race condition occurred while creating backport issue, returning the existing backport for " + issue.id() + " and requested fixVersion "
                                                 + requestedVersion + " " + existing.get().id());
                                         issue = existing.get();
                                     } else {
-                                        throw exp;
+                                        throw e;
                                     }
                                 }
                             } else {


### PR DESCRIPTION
SKARA-1035: Race when creating backports for bug spanning multiple repos

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1035](https://bugs.openjdk.org/browse/SKARA-1035): Race when creating backports for bug spanning multiple repos


### Reviewers
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - Committer)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1476/head:pull/1476` \
`$ git checkout pull/1476`

Update a local copy of the PR: \
`$ git checkout pull/1476` \
`$ git pull https://git.openjdk.org/skara pull/1476/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1476`

View PR using the GUI difftool: \
`$ git pr show -t 1476`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1476.diff">https://git.openjdk.org/skara/pull/1476.diff</a>

</details>
