### PR TITLE
1825: BotTaskAggregationHandler causes OOME

### DIFF
--- a/bot/src/test/java/org/openjdk/skara/bot/BotTaskAggregationHandlerTests.java
+++ b/bot/src/test/java/org/openjdk/skara/bot/BotTaskAggregationHandlerTests.java
@@ -38,6 +38,7 @@ class TestBotTaskAggregationHandler extends BotTaskAggregationHandler {
     private final Collection<List<LogRecord>> taskRecords;
 
     TestBotTaskAggregationHandler() {
+        super(false);
         nonTaskRecords = new ConcurrentLinkedQueue<>();
         taskRecords = new ConcurrentLinkedQueue<>();
     }

--- a/bots/cli/src/main/java/org/openjdk/skara/bots/cli/BotSlackHandler.java
+++ b/bots/cli/src/main/java/org/openjdk/skara/bots/cli/BotSlackHandler.java
@@ -46,6 +46,7 @@ class BotSlackHandler extends BotTaskAggregationHandler {
     private int dropCount;
 
     BotSlackHandler(URI webhookUrl, String username, String prefix, Duration minimumSeparation, Map<String, String> links) {
+        super(true);
         webhook = new RestRequest(webhookUrl);
         this.username = username;
         this.prefix = prefix;
@@ -108,28 +109,16 @@ class BotSlackHandler extends BotTaskAggregationHandler {
 
     @Override
     public void publishAggregated(List<LogRecord> task) {
-        var maxLevel = task.stream()
-                           .map(record -> record.getLevel().intValue())
-                           .max(Integer::compareTo)
-                           .orElseThrow();
-
-        if (maxLevel < getLevel().intValue()) {
-            return;
-        }
-
-        var important = task.stream()
-                            .filter(record -> record.getLevel().intValue() >= getLevel().intValue())
+        var message = task.stream()
                             .map(this::formatMessage)
                             .collect(Collectors.joining("\n"));
-        publishToSlack(important);
+        if (!message.isEmpty()) {
+            publishToSlack(message);
+        }
     }
 
     @Override
     public void publishSingle(LogRecord record) {
-        if (record.getLevel().intValue() < getLevel().intValue()) {
-            return;
-        }
-
         publishToSlack(formatMessage(record));
     }
 


### PR DESCRIPTION
The BotTaskAggregationHandler saves all log records in a list per thread and publishes them when a specific marker is detected in a record. This marker signals the end of a WorkItem run. If a large amount of log messages are generated by a single WorkItem, this can result in a very large amount of log messages being saved. We currently have a case where 18 million+ have been observed when processing the webrevs for https://github.com/openjdk/mobile/pull/16 in MailingListBridgeBot.

The irony here is that the only subclass of this abstract handler, the BotSlackHandler, throws away all log records that are lower level than what it's supposed to log, so we are saving all of these, only to log those of level SEVERE in the end. In the past, this class was also used for logging to logstash, and in that case, when we had one SEVERE log record, we actually wanted to log everything that lead up to it.

This fix makes it an option for the BotTaskAggregationHandler if it should save everything or just above the configured level, so a subclass can choose which behavior it expects. I also removed the filtering in BotSlackHandler as its no longer needed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1825](https://bugs.openjdk.org/browse/SKARA-1825): BotTaskAggregationHandler causes OOME


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1477/head:pull/1477` \
`$ git checkout pull/1477`

Update a local copy of the PR: \
`$ git checkout pull/1477` \
`$ git pull https://git.openjdk.org/skara pull/1477/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1477`

View PR using the GUI difftool: \
`$ git pr show -t 1477`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1477.diff">https://git.openjdk.org/skara/pull/1477.diff</a>

</details>
