### PR TITLE
1823: Mailing list bot should include link to comment on the Git forge

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveItem.java
@@ -246,7 +246,7 @@ class ArchiveItem {
                                () -> ArchiveMessages.composeReplySubject(parent.subject()),
                                () -> ArchiveMessages.composeReplyHeader(parent.createdAt(), hostUserToEmailAuthor.author(parent.author)),
                                () -> ArchiveMessages.composeComment(comment),
-                               () -> ArchiveMessages.composeReplyFooter(pr, comment, null, null));
+                               () -> ArchiveMessages.composeCommentReplyFooter(pr, comment));
     }
 
     static ArchiveItem from(PullRequest pr, Review review, HostUserToEmailAuthor hostUserToEmailAuthor, HostUserToUsername hostUserToUsername, HostUserToRole hostUserToRole, ArchiveItem parent) {
@@ -262,7 +262,7 @@ class ArchiveItem {
                                () -> ArchiveMessages.composeReplySubject(parent.subject()),
                                () -> ArchiveMessages.composeReplyHeader(parent.createdAt(), hostUserToEmailAuthor.author(parent.author())),
                                () -> ArchiveMessages.composeReviewComment(pr, reviewComment),
-                               () -> ArchiveMessages.composeReplyFooter(pr, null, reviewComment, null));
+                               () -> ArchiveMessages.composeReviewCommentReplyFooter(pr, reviewComment));
     }
 
     static ArchiveItem closedNotice(PullRequest pr, HostUserToEmailAuthor hostUserToEmailAuthor, ArchiveItem parent, String subjectPrefix) {

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveItem.java
@@ -246,7 +246,7 @@ class ArchiveItem {
                                () -> ArchiveMessages.composeReplySubject(parent.subject()),
                                () -> ArchiveMessages.composeReplyHeader(parent.createdAt(), hostUserToEmailAuthor.author(parent.author)),
                                () -> ArchiveMessages.composeComment(comment),
-                               () -> ArchiveMessages.composeReplyFooter(pr));
+                               () -> ArchiveMessages.composeReplyFooter(pr, comment, null, null));
     }
 
     static ArchiveItem from(PullRequest pr, Review review, HostUserToEmailAuthor hostUserToEmailAuthor, HostUserToUsername hostUserToUsername, HostUserToRole hostUserToRole, ArchiveItem parent) {
@@ -262,7 +262,7 @@ class ArchiveItem {
                                () -> ArchiveMessages.composeReplySubject(parent.subject()),
                                () -> ArchiveMessages.composeReplyHeader(parent.createdAt(), hostUserToEmailAuthor.author(parent.author())),
                                () -> ArchiveMessages.composeReviewComment(pr, reviewComment),
-                               () -> ArchiveMessages.composeReplyFooter(pr));
+                               () -> ArchiveMessages.composeReplyFooter(pr, null, reviewComment, null));
     }
 
     static ArchiveItem closedNotice(PullRequest pr, HostUserToEmailAuthor hostUserToEmailAuthor, ArchiveItem parent, String subjectPrefix) {

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
@@ -305,6 +305,20 @@ class ArchiveMessages {
         return "PR: " + pr.webUrl();
     }
 
+    static String composeReplyFooter(PullRequest pr, Comment comment, ReviewComment reviewComment, Review review) {
+        var footer = new StringBuilder();
+        if (comment != null) {
+            footer.append("Comment: " + pr.commentUrl(comment).toString());
+        }
+        if (reviewComment != null) {
+            footer.append("ReviewComment: " + pr.reviewCommentUrl(reviewComment).toString());
+        }
+        if (review != null) {
+            footer.append("Review: " + pr.reviewUrl(review).toString());
+        }
+        return footer.toString();
+    }
+
     // When changing this, ensure that the PR pattern in the notifier still matches
     static String composeConversationFooter(PullRequest pr, URI issueProject, String projectPrefix, Repository localRepo, WebrevDescription webrev, Hash base, Hash head) {
         var commits = commits(localRepo, base, head);
@@ -442,7 +456,7 @@ class ArchiveMessages {
                 result.append("\n\n");
             }
         }
-        result.append(composeReplyFooter(pr));
+        result.append(composeReplyFooter(pr, null, null, review));
         return result.toString();
     }
 

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
@@ -308,7 +308,7 @@ class ArchiveMessages {
     static String composeReplyFooter(PullRequest pr, Comment comment, ReviewComment reviewComment, Review review) {
         var footer = new StringBuilder();
         if (comment != null) {
-            footer.append("Comment: " + pr.commentUrl(comment).toString());
+            footer.append("PR Comment: " + pr.commentUrl(comment).toString());
         }
         if (reviewComment != null) {
             footer.append("ReviewComment: " + pr.reviewCommentUrl(reviewComment).toString());

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
@@ -305,18 +305,16 @@ class ArchiveMessages {
         return "PR: " + pr.webUrl();
     }
 
-    static String composeReplyFooter(PullRequest pr, Comment comment, ReviewComment reviewComment, Review review) {
-        var footer = new StringBuilder();
-        if (comment != null) {
-            footer.append("PR Comment: " + pr.commentUrl(comment).toString());
-        }
-        if (reviewComment != null) {
-            footer.append("PR Review Comment: " + pr.reviewCommentUrl(reviewComment).toString());
-        }
-        if (review != null) {
-            footer.append("PR Review: " + pr.reviewUrl(review).toString());
-        }
-        return footer.toString();
+    static String composeCommentReplyFooter(PullRequest pr, Comment comment) {
+        return "PR Comment: " + pr.commentUrl(comment).toString();
+    }
+
+    static String composeReviewCommentReplyFooter(PullRequest pr, ReviewComment reviewComment) {
+        return "PR Review Comment: " + pr.reviewCommentUrl(reviewComment).toString();
+    }
+
+    static String composeReviewReplyFooter(PullRequest pr, Review review) {
+        return "PR Review: " + pr.reviewUrl(review).toString();
     }
 
     // When changing this, ensure that the PR pattern in the notifier still matches
@@ -456,7 +454,7 @@ class ArchiveMessages {
                 result.append("\n\n");
             }
         }
-        result.append(composeReplyFooter(pr, null, null, review));
+        result.append(composeReviewReplyFooter(pr, review));
         return result.toString();
     }
 

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
@@ -314,7 +314,7 @@ class ArchiveMessages {
             footer.append("ReviewComment: " + pr.reviewCommentUrl(reviewComment).toString());
         }
         if (review != null) {
-            footer.append("Review: " + pr.reviewUrl(review).toString());
+            footer.append("PR Review: " + pr.reviewUrl(review).toString());
         }
         return footer.toString();
     }

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
@@ -311,7 +311,7 @@ class ArchiveMessages {
             footer.append("PR Comment: " + pr.commentUrl(comment).toString());
         }
         if (reviewComment != null) {
-            footer.append("ReviewComment: " + pr.reviewCommentUrl(reviewComment).toString());
+            footer.append("PR Review Comment: " + pr.reviewCommentUrl(reviewComment).toString());
         }
         if (review != null) {
             footer.append("PR Review: " + pr.reviewUrl(review).toString());

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
@@ -354,10 +354,10 @@ class ReviewArchive {
                 var newFooterFragments = Stream.of(item.footer().split("\n\n"))
                                                .filter(line -> !includedFooterFragments.contains(line))
                                                .collect(Collectors.toList());
-                footer.append(String.join("\n\n", newFooterFragments));
-                if (!newFooterFragments.isEmpty()) {
+                if(!footer.isEmpty() && !newFooterFragments.isEmpty()){
                     footer.append("\n");
                 }
+                footer.append(String.join("\n\n", newFooterFragments));
                 includedFooterFragments.addAll(newFooterFragments);
             }
 

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
@@ -355,6 +355,9 @@ class ReviewArchive {
                                                .filter(line -> !includedFooterFragments.contains(line))
                                                .collect(Collectors.toList());
                 footer.append(String.join("\n\n", newFooterFragments));
+                if (!newFooterFragments.isEmpty()) {
+                    footer.append("\n");
+                }
                 includedFooterFragments.addAll(newFooterFragments);
             }
 

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
@@ -354,7 +354,7 @@ class ReviewArchive {
                 var newFooterFragments = Stream.of(item.footer().split("\n\n"))
                                                .filter(line -> !includedFooterFragments.contains(line))
                                                .collect(Collectors.toList());
-                if(!footer.isEmpty() && !newFooterFragments.isEmpty()){
+                if (!footer.isEmpty() && !newFooterFragments.isEmpty()) {
                     footer.append("\n");
                 }
                 footer.append(String.join("\n\n", newFooterFragments));

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -243,12 +243,14 @@ class MailingListBridgeBotTests {
             Repository.materialize(archiveFolder.path(), archive.url(), "master");
             assertTrue(archiveContains(archiveFolder.path(), "This is a comment"));
             assertTrue(archiveContains(archiveFolder.path(), "> This should now be ready"));
+            assertTrue(archiveContains(archiveFolder.path(), "hosted.git/pr/1/comment/3"));
             assertFalse(archiveContains(archiveFolder.path(), "Don't mind me"));
 
             listServer.processIncoming();
             conversations = mailmanList.conversations(Duration.ofDays(1));
             assertEquals(1, conversations.size());
             assertEquals(2, conversations.get(0).allMessages().size());
+            assertTrue(conversations.get(0).allMessages().get(1).body().contains("hosted.git/pr/1/comment/3"));
 
             // Remove the rfr flag and post another comment
             pr.addLabel("rfr");
@@ -270,7 +272,8 @@ class MailingListBridgeBotTests {
                 assertEquals(from.address(), newMail.author().address());
                 assertEquals(listAddress, newMail.sender());
             }
-            assertTrue(conversations.get(0).allMessages().get(2).body().contains("This is a comment 😄"));
+            assertTrue(conversations.get(0).allMessages().get(2).body().contains("This is another comment"));
+            assertTrue(conversations.get(0).allMessages().get(2).body().contains("hosted.git/pr/1/comment/5"));
         }
     }
 
@@ -819,6 +822,9 @@ class MailingListBridgeBotTests {
             conversations = mailmanList.conversations(Duration.ofDays(1));
             assertEquals(1, conversations.size());
             assertEquals(3, conversations.get(0).allMessages().size());
+            assertTrue(conversations.get(0).allMessages().get(1).body().contains("hosted.git/pr/1/reviewComment/0"));
+            assertTrue(conversations.get(0).allMessages().get(2).body().contains("hosted.git/pr/1/reviewComment/2"));
+
             for (var newMail : conversations.get(0).allMessages()) {
                 assertEquals(from.address(), newMail.author().address());
                 assertEquals(listAddress, newMail.sender());
@@ -913,6 +919,10 @@ class MailingListBridgeBotTests {
             assertEquals("RFR: This is a pull request", reviewReply.subject());
             assertTrue(reviewReply.body().contains("Review comment\n\n"), reviewReply.body());
             assertTrue(reviewReply.body().contains("Another review comment"), reviewReply.body());
+            assertTrue(reviewReply.body().contains("hosted.git/pr/1/reviewComment/0"), reviewReply.body());
+            assertTrue(reviewReply.body().contains("hosted.git/pr/1/reviewComment/1"), reviewReply.body());
+            assertTrue(reviewReply.body().contains("hosted.git/pr/1/reviewComment/2"), reviewReply.body());
+            assertTrue(reviewReply.body().contains("hosted.git/pr/1/reviewComment/3"), reviewReply.body());
 
             // Now reply to the first and second (collapsed) comment
             pr.addReviewCommentReply(first, "I agree");
@@ -2293,6 +2303,15 @@ class MailingListBridgeBotTests {
             assertEquals(1, archiveContainsCount(archiveFolder.path(), "Marked as reviewed by "));
             assertEquals(1, archiveContainsCount(archiveFolder.path(), "Reason 2"));
             assertEquals(2, archiveContainsCount(archiveFolder.path(), "Re: RFR:"));
+
+            listServer.processIncoming();
+            listServer.processIncoming();
+            listServer.processIncoming();
+            var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
+            var mailmanList = mailmanServer.getListReader(listAddress.address());
+            var conversations = mailmanList.conversations(Duration.ofDays(1));
+            assertTrue(conversations.get(0).allMessages().get(1).body().contains("hosted.git/pr/1/review/0"));
+            assertTrue(conversations.get(0).allMessages().get(2).body().contains("hosted.git/pr/1/review/1"));
 
             // Yet another change
             reviewedPr.addReview(Review.Verdict.DISAPPROVED, "Reason 3");

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
@@ -207,6 +207,21 @@ class InMemoryPullRequest implements PullRequest {
     }
 
     @Override
+    public URI commentUrl(Comment comment) {
+        return null;
+    }
+
+    @Override
+    public URI reviewCommentUrl(ReviewComment reviewComment) {
+        return null;
+    }
+
+    @Override
+    public URI reviewUrl(Review review) {
+        return null;
+    }
+
+    @Override
     public boolean isDraft() {
         return false;
     }

--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
@@ -156,6 +156,12 @@ public interface PullRequest extends Issue {
      */
     URI changeUrl(Hash base);
 
+    URI commentUrl(Comment comment);
+
+    URI reviewCommentUrl(ReviewComment reviewComment);
+
+    URI reviewUrl(Review review);
+
     /**
      * Returns true if the request is in draft mode.
      * @return

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -525,6 +525,21 @@ public class GitHubPullRequest implements PullRequest {
     }
 
     @Override
+    public URI commentUrl(Comment comment) {
+        return URIBuilder.base(webUrl()).appendPath("#issuecomment-" + comment.id()).build();
+    }
+
+    @Override
+    public URI reviewCommentUrl(ReviewComment reviewComment) {
+        return URIBuilder.base(webUrl()).appendPath("#discussion_r" + reviewComment.id()).build();
+    }
+
+    @Override
+    public URI reviewUrl(Review review) {
+        return URIBuilder.base(webUrl()).appendPath("#pullrequestreview-" + review.id()).build();
+    }
+
+    @Override
     public boolean isDraft() {
         return json.get("draft").asBoolean();
     }

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -627,6 +627,21 @@ public class GitLabMergeRequest implements PullRequest {
     }
 
     @Override
+    public URI commentUrl(Comment comment) {
+        return URIBuilder.base(webUrl()).appendPath("#note_" + comment.id()).build();
+    }
+
+    @Override
+    public URI reviewCommentUrl(ReviewComment reviewComment) {
+        return URIBuilder.base(webUrl()).appendPath("#note_" + reviewComment.id()).build();
+    }
+
+    @Override
+    public URI reviewUrl(Review review) {
+        return URIBuilder.base(webUrl()).appendPath("#note_" + review.id()).build();
+    }
+
+    @Override
     public boolean isDraft() {
         return json.get("draft").asBoolean();
     }

--- a/forge/src/test/java/org/openjdk/skara/forge/github/GitHubRestApiTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/github/GitHubRestApiTests.java
@@ -28,6 +28,7 @@ import org.openjdk.skara.forge.Forge;
 import org.openjdk.skara.forge.HostedRepository;
 import org.openjdk.skara.host.Credential;
 import org.openjdk.skara.issuetracker.Comment;
+import org.openjdk.skara.json.JSON;
 import org.openjdk.skara.network.URIBuilder;
 import org.openjdk.skara.proxy.HttpProxy;
 import org.openjdk.skara.test.ManualTestSettings;
@@ -230,5 +231,32 @@ public class GitHubRestApiTests {
         var pr = githubRepo.pullRequest("96");
         var user = pr.closedBy();
         assertEquals("lgxbslgx", user.get().username());
+    }
+
+    @Test
+    void test() {
+        var username = settings.getProperty("github.user");
+        var token = settings.getProperty("github.pat");
+        var credential = new Credential(username, token);
+        var uri = URIBuilder.base(GITHUB_REST_URI).build();
+        var configuration = JSON.object().put("weburl", JSON.object().put("pattern", "^https://github.com/openjdk/(.*)$").put("replacement", "https://git.openjdk.org/$1"));
+        var githubHost = new GitHubForgeFactory().create(uri, credential, configuration);
+
+        var githubRepoOpt = githubHost.repository("openjdk/playground");
+        assumeTrue(githubRepoOpt.isPresent());
+        var githubRepo = githubRepoOpt.get();
+        var pr = githubRepo.pullRequest("129");
+
+        var labelComment = pr.comments().stream()
+                .filter(comment -> comment.body().contains("The following label will be automatically applied to this pull request:"))
+                .findFirst()
+                .get();
+        assertEquals("https://git.openjdk.org/playground/pull/129#issuecomment-1426703897", pr.commentUrl(labelComment).toString());
+
+        var reviewComment = pr.reviewComments().get(0);
+        assertEquals("https://git.openjdk.org/playground/pull/129#discussion_r1108931186", pr.reviewCommentUrl(reviewComment).toString());
+
+        var review = pr.reviews().get(0);
+        assertEquals("https://git.openjdk.org/playground/pull/129#pullrequestreview-1302142525", pr.reviewUrl(review).toString());
     }
 }

--- a/forge/src/test/java/org/openjdk/skara/forge/gitlab/GitLabRestApiTest.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/gitlab/GitLabRestApiTest.java
@@ -254,4 +254,26 @@ public class GitLabRestApiTest {
         assertFalse(gitLabMergeRequest.isDraft());
         assertEquals("Test", gitLabMergeRequest.title());
     }
+
+    @Test
+    void testHtmlUrl() throws IOException {
+        var settings = ManualTestSettings.loadManualTestSettings();
+        var username = settings.getProperty("gitlab.user");
+        var token = settings.getProperty("gitlab.pat");
+        var credential = new Credential(username, token);
+        var uri = URIBuilder.base(settings.getProperty("gitlab.uri")).build();
+        var gitLabHost = new GitLabHost("gitlab", uri, false, credential, Set.of());
+        var gitLabRepo = gitLabHost.repository(settings.getProperty("gitlab.repository")).orElseThrow();
+        var gitLabMergeRequest = gitLabRepo.pullRequest(settings.getProperty("gitlab.merge.request.id"));
+
+        System.out.println(gitLabMergeRequest.webUrl());
+        var comment = gitLabMergeRequest.comments().get(0);
+        assertEquals(settings.getProperty("comment_html_url"), gitLabMergeRequest.commentUrl(comment).toString());
+
+        var reviewComment = gitLabMergeRequest.reviewComments().get(0);
+        assertEquals(settings.getProperty("reviewComment_html_url"), gitLabMergeRequest.reviewCommentUrl(reviewComment).toString());
+
+        var review = gitLabMergeRequest.reviews().get(0);
+        assertEquals(settings.getProperty("review_html_url"), gitLabMergeRequest.reviewUrl(review).toString());
+    }
 }

--- a/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
@@ -23,6 +23,7 @@
 package org.openjdk.skara.test;
 
 import org.openjdk.skara.forge.*;
+import org.openjdk.skara.issuetracker.Comment;
 import org.openjdk.skara.issuetracker.Label;
 import org.openjdk.skara.network.URIBuilder;
 import org.openjdk.skara.vcs.Diff;
@@ -204,6 +205,21 @@ public class TestPullRequest extends TestIssue implements PullRequest {
     @Override
     public URI changeUrl(Hash base) {
         return URIBuilder.base(webUrl()).appendPath("/files/" + base.abbreviate()).build();
+    }
+
+    @Override
+    public URI commentUrl(Comment comment) {
+        return URIBuilder.base(webUrl()).appendPath("/comment/" + comment.id()).build();
+    }
+
+    @Override
+    public URI reviewCommentUrl(ReviewComment reviewComment) {
+        return URIBuilder.base(webUrl()).appendPath("/reviewComment/" + reviewComment.id()).build();
+    }
+
+    @Override
+    public URI reviewUrl(Review review) {
+        return URIBuilder.base(webUrl()).appendPath("/review/" + review.id()).build();
     }
 
     @Override


### PR DESCRIPTION
This patch will add the ability to attach comment/reviewComment/review link to the email generated by mlbridge bot

The implementation for GitHub is straightforward, we can extract the URL for a specific comment or review from the JSON response using the `html_url` field and include it in the email. 

For GitLab, we will need to generate the URL using the `id` field in `note,` since GitLab does not provide an field like `html_url` in its JSON responses.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1823](https://bugs.openjdk.org/browse/SKARA-1823): Mailing list bot should include link to comment on the Git forge


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1478/head:pull/1478` \
`$ git checkout pull/1478`

Update a local copy of the PR: \
`$ git checkout pull/1478` \
`$ git pull https://git.openjdk.org/skara pull/1478/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1478`

View PR using the GUI difftool: \
`$ git pr show -t 1478`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1478.diff">https://git.openjdk.org/skara/pull/1478.diff</a>

</details>
