### PR TITLE
1837: Skara bot continuously keeps updating the PR title

### DIFF
--- a/bots/csr/src/main/java/org/openjdk/skara/bots/csr/PullRequestWorkItem.java
+++ b/bots/csr/src/main/java/org/openjdk/skara/bots/csr/PullRequestWorkItem.java
@@ -109,13 +109,13 @@ class PullRequestWorkItem implements WorkItem {
     private boolean hasCsrIssue(String statusMessage, Issue csr) {
         return statusMessage.contains(csr.id()) &&
                 statusMessage.contains(csr.webUrl().toString()) &&
-                statusMessage.contains(csr.title() + " (**CSR**)");
+                statusMessage.contains(BotUtils.escape(csr.title()) + " (**CSR**)");
     }
 
     private boolean hasWithdrawnCsrIssue(String statusMessage, Issue csr) {
         return statusMessage.contains(csr.id()) &&
                 statusMessage.contains(csr.webUrl().toString()) &&
-                statusMessage.contains(csr.title() + " (**CSR**) (Withdrawn)");
+                statusMessage.contains(BotUtils.escape(csr.title()) + " (**CSR**) (Withdrawn)");
     }
 
     private String getStatusMessage(PullRequest pr) {

--- a/bots/csr/src/test/java/org/openjdk/skara/bots/csr/CSRBotTests.java
+++ b/bots/csr/src/test/java/org/openjdk/skara/bots/csr/CSRBotTests.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.skara.bots.csr;
 
+import org.openjdk.skara.bots.common.BotUtils;
 import org.openjdk.skara.bots.common.SolvesTracker;
 import org.openjdk.skara.forge.PullRequestUtils;
 import org.openjdk.skara.issuetracker.Link;
@@ -455,7 +456,7 @@ class CSRBotTests {
             assertFalse(pr.store().body().contains(CSR_UPDATE_MARKER));
 
             // Add the csr issue.
-            var csr = issueProject.createIssue("This is an CSR", List.of(), Map.of());
+            var csr = issueProject.createIssue("This is an CSR <1>", List.of(), Map.of());
             csr.setProperty("issuetype", JSON.of("CSR"));
             csr.setState(Issue.State.OPEN);
             issue.addLink(Link.create(csr, "csr for").build());
@@ -469,7 +470,7 @@ class CSRBotTests {
             assertFalse(pr.store().body().contains(CSR_UPDATE_MARKER));
 
             // Add csr issue and progress to the PR body
-            pr.setBody("PR body\n" + PROGRESS_MARKER + csr.id() + csr.webUrl().toString() + csr.title() + " (**CSR**)"
+            pr.setBody("PR body\n" + PROGRESS_MARKER + csr.id() + csr.webUrl().toString() + BotUtils.escape(csr.title()) + " (**CSR**)"
                     + "- [ ] " + generateCSRProgressMessage(csr));
             // Run bot
             TestBotRunner.runPeriodicItems(csrPullRequestBot);
@@ -485,7 +486,7 @@ class CSRBotTests {
             assertTrue(pr.store().body().contains(CSR_UPDATE_MARKER));
 
             // Add csr issue and selected progress to the PR body
-            pr.setBody("PR body\n" + PROGRESS_MARKER + csr.id() + csr.webUrl().toString() + csr.title() + " (**CSR**)"
+            pr.setBody("PR body\n" + PROGRESS_MARKER + csr.id() + csr.webUrl().toString() + BotUtils.escape(csr.title()) + " (**CSR**)"
                     + "- [x] " + generateCSRProgressMessage(csr));
             // Run bot
             TestBotRunner.runPeriodicItems(csrPullRequestBot);
@@ -493,7 +494,7 @@ class CSRBotTests {
             assertFalse(pr.store().body().contains(CSR_UPDATE_MARKER));
 
             // Add csr update marker to the pull request body manually.
-            pr.setBody("PR body\n" + PROGRESS_MARKER + csr.id() + csr.webUrl().toString() + csr.title() + " (**CSR**)"
+            pr.setBody("PR body\n" + PROGRESS_MARKER + csr.id() + csr.webUrl().toString() + BotUtils.escape(csr.title()) + " (**CSR**)"
                     + "- [ ] " + generateCSRProgressMessage(csr));
             // Run bot
             TestBotRunner.runPeriodicItems(csrPullRequestBot);


### PR DESCRIPTION
A user reported that he found the bot is continuously updating the [pr](https://github.com/openjdk/jdk/pull/12797) body. After investigating, I found that this bug is a side effect of [SKARA-1807](https://bugs.openjdk.org/browse/SKARA-1807). In SKARA-1807, we escaped the issue title in PR body and the title of JDK-8303474 includes ‘>’. So the csr issue title in the pr body is `(fc) FileChannel::transferFrom should support position &gt; size()`. In some logic, the csr bot is looking for the title of the csr issue(not escaped), so the bot is looking for `(fc) FileChannel::transferFrom should support position > size()` and if the bot couldn’t find the csr issue title, the bot would assume this pr body is outdated and will update it. Therefore, the bot is stuck in an infinite loop.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1837](https://bugs.openjdk.org/browse/SKARA-1837): Skara bot continuously keeps updating the PR title


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1480/head:pull/1480` \
`$ git checkout pull/1480`

Update a local copy of the PR: \
`$ git checkout pull/1480` \
`$ git pull https://git.openjdk.org/skara pull/1480/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1480`

View PR using the GUI difftool: \
`$ git pr show -t 1480`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1480.diff">https://git.openjdk.org/skara/pull/1480.diff</a>

</details>
