### PR TITLE
1824: /reviewers N should remove ready status for clean backports

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -31,7 +31,6 @@ import org.openjdk.skara.host.HostUser;
 import org.openjdk.skara.issuetracker.*;
 import org.openjdk.skara.jbs.Backports;
 import org.openjdk.skara.jbs.JdkVersion;
-import org.openjdk.skara.jcheck.ReviewersCheck;
 import org.openjdk.skara.vcs.*;
 import org.openjdk.skara.vcs.openjdk.Issue;
 
@@ -1181,10 +1180,6 @@ class CheckRun {
             integrationBlockers.addAll(secondJCheckMessage);
 
             var reviewersCommandIssued = ReviewersTracker.additionalRequiredReviewers(pr.repository().forge().currentUser(), comments).isPresent();
-            if (isCleanBackport && reviewersCommandIssued) {
-                pr.addComment("Warning: The /Reviewers command is used in a clean backport, it will enable Reviewers check for this pr. " +
-                        "If the Reviewers check requirements in the jcheck conf are stricter than the user's requirements, the bot will enforce the stricter requirements.");
-            }
             var reviewNeeded = !isCleanBackport || reviewCleanBackport || reviewersCommandIssued;
 
             // Calculate and update the status message if needed

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -31,6 +31,7 @@ import org.openjdk.skara.host.HostUser;
 import org.openjdk.skara.issuetracker.*;
 import org.openjdk.skara.jbs.Backports;
 import org.openjdk.skara.jbs.JdkVersion;
+import org.openjdk.skara.jcheck.ReviewersCheck;
 import org.openjdk.skara.vcs.*;
 import org.openjdk.skara.vcs.openjdk.Issue;
 
@@ -1179,7 +1180,12 @@ class CheckRun {
             var integrationBlockers = botSpecificIntegrationBlockers(issues);
             integrationBlockers.addAll(secondJCheckMessage);
 
-            var reviewNeeded = !isCleanBackport || reviewCleanBackport;
+            var reviewersCommandIssued = ReviewersTracker.additionalRequiredReviewers(pr.repository().forge().currentUser(), comments).isPresent();
+            if (isCleanBackport && reviewersCommandIssued) {
+                pr.addComment("Warning: The /Reviewers command is used in a clean backport, it will enable Reviewers check for this pr. " +
+                        "If the Reviewers check requirements in the jcheck conf are stricter than the user's requirements, the bot will enforce the stricter requirements.");
+            }
+            var reviewNeeded = !isCleanBackport || reviewCleanBackport || reviewersCommandIssued;
 
             // Calculate and update the status message if needed
             var statusMessage = getStatusMessage(visitor, additionalErrors, additionalProgresses, integrationBlockers, reviewNeeded, issuesWithCSRAndJEP(issues, csrIssueTrackerIssues));

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewersCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewersCommand.java
@@ -142,8 +142,7 @@ public class ReviewersCommand implements CommandHandler {
         reply.println(ReviewersTracker.setReviewersMarker(numReviewers, role));
         var totalRequired = formatLimits.values().stream().mapToInt(Integer::intValue).sum();
         if (pr.labelNames().contains("clean") && pr.labelNames().contains("backport")) {
-            reply.println("Warning: The /reviewers command is used in a clean backport, it will enable reviewers check for this pr. " +
-                    "If the reviewers check requirements in the jcheck conf are stricter than your requirements, the bot will enforce the stricter requirements.");
+            reply.println("Warning: By issuing the /reviewers command in this clean backport pull request, the reviewers check has now been enabled.");
         }
         reply.print("The total number of required reviews for this PR (including the jcheck configuration " +
                     "and the last /reviewers command) is now set to " + totalRequired);

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewersCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewersCommand.java
@@ -141,6 +141,10 @@ public class ReviewersCommand implements CommandHandler {
 
         reply.println(ReviewersTracker.setReviewersMarker(numReviewers, role));
         var totalRequired = formatLimits.values().stream().mapToInt(Integer::intValue).sum();
+        if (pr.labelNames().contains("clean") && pr.labelNames().contains("backport")) {
+            reply.println("Warning: The /reviewers command is used in a clean backport, it will enable reviewers check for this pr. " +
+                    "If the reviewers check requirements in the jcheck conf are stricter than your requirements, the bot will enforce the stricter requirements.");
+        }
         reply.print("The total number of required reviews for this PR (including the jcheck configuration " +
                     "and the last /reviewers command) is now set to " + totalRequired);
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportTests.java
@@ -1880,7 +1880,7 @@ class BackportTests {
             pr.addComment("/reviewers 1");
             TestBotRunner.runPeriodicItems(bot);
             assertTrue(pr.store().comments().get(1).body().contains("This change is no longer ready for integration - check the PR body for details."));
-            assertTrue(pr.store().body().contains("Change must be properly reviewed"));
+            assertTrue(pr.store().body().contains("Change must be properly reviewed (2 reviews required"));
             assertFalse(pr.store().labelNames().contains("ready"));
 
             var reviewPr = reviewer.pullRequest(pr.id());
@@ -1891,6 +1891,12 @@ class BackportTests {
             TestBotRunner.runPeriodicItems(bot);
             assertTrue(pr.store().comments().get(1).body().contains("This change now passes all *automated* pre-integration checks."));
             assertTrue(pr.store().labelNames().contains("ready"));
+
+            pr.addComment("/reviewers 3");
+            TestBotRunner.runPeriodicItems(bot);
+            assertTrue(pr.store().comments().get(1).body().contains("This change is no longer ready for integration - check the PR body for details."));
+            assertTrue(pr.store().body().contains("Change must be properly reviewed (3 reviews required"));
+            assertFalse(pr.store().labelNames().contains("ready"));
         }
     }
 }


### PR DESCRIPTION
Currently, If a user issues /reviewers command in a clean backport, the reviewers requirement will not be displayed in the pr body and it won't be an integration blocker.

In this patch, after user issued /reviewers command, the reviewrs check for clean backport will be enabled. And if the Reviewers check requirements in the jcheck conf are stricter than the user's requirements, the bot will enforce the stricter requirements

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1824](https://bugs.openjdk.org/browse/SKARA-1824): /reviewers N should remove ready status for clean backports


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to [aac73813](https://git.openjdk.org/skara/pull/1482/files/aac7381365bde0e861b3e3412668bc0d07e5222c)
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer) ⚠️ Review applies to [aac73813](https://git.openjdk.org/skara/pull/1482/files/aac7381365bde0e861b3e3412668bc0d07e5222c)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1482/head:pull/1482` \
`$ git checkout pull/1482`

Update a local copy of the PR: \
`$ git checkout pull/1482` \
`$ git pull https://git.openjdk.org/skara pull/1482/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1482`

View PR using the GUI difftool: \
`$ git pr show -t 1482`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1482.diff">https://git.openjdk.org/skara/pull/1482.diff</a>

</details>
