### PR TITLE
1828: RFR emails still be sent when PR is in draft state

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
@@ -137,7 +137,7 @@ class ReviewArchive {
 
         // Check if we're at a revision not previously reported
         var baseHash = PullRequestUtils.baseHash(pr, localRepo);
-        if (!baseHash.equals(lastBase) || !pr.headHash().equals(lastHead)) {
+        if (!pr.isDraft() && (!baseHash.equals(lastBase) || !pr.headHash().equals(lastHead))) {
             if (generated.isEmpty()) {
                 var first = ArchiveItem.from(pr, localRepo, hostUserToEmailAuthor, issueTracker, issuePrefix, webrevGenerator, webrevNotification, pr.createdAt(), pr.updatedAt(), baseHash, pr.headHash(), subjectPrefix, threadPrefix);
                 generated.add(first);

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -3624,6 +3624,36 @@ class MailingListBridgeBotTests {
             assertEquals(5, archiveContainsCount(archiveFolder.path(), "RFR: 1234: This is a pull request"));
             assertEquals(1, archiveContainsCount(archiveFolder.path(), "This is a comment before making"));
             assertEquals(1, archiveContainsCount(archiveFolder.path(), "This is a comment after making"));
+
+            // Push a new commit before making it as draft.
+            var secondHash = CheckableRepository.appendAndCommit(localRepo, "Second change", "Change msg");
+            localRepo.push(secondHash, author.url(), "edit", true);
+
+            // Make it as draft again.
+            pr.makeDraft();
+
+            // Push a new commit after making it as draft.
+            var thirdHash = CheckableRepository.appendAndCommit(localRepo, "Third change", "Change msg");
+            localRepo.push(thirdHash, author.url(), "edit", true);
+
+            // Run another archive pass.
+            TestBotRunner.runPeriodicItems(mlBot);
+
+            // The archive shouldn't contain any new commit.
+            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            assertEquals(5, archiveContainsCount(archiveFolder.path(), "RFR: 1234: This is a pull request"));
+            assertFalse(archiveContains(archiveFolder.path(), "RFR: 1234: This is a pull request \\[v2\\]"));
+
+            // Make it as not draft again.
+            pr.makeNotDraft();
+
+            // Run another archive pass.
+            TestBotRunner.runPeriodicItems(mlBot);
+
+            // The archive should now contain all the comments.
+            Repository.materialize(archiveFolder.path(), archive.url(), "master");
+            assertEquals(6, archiveContainsCount(archiveFolder.path(), "RFR: 1234: This is a pull request"));
+            assertEquals(1, archiveContainsCount(archiveFolder.path(), "RFR: 1234: This is a pull request \\[v2\\]"));
         }
     }
 


### PR DESCRIPTION
Hi all,

This patch blocks the RFR email when new commits are pushed to a draft PR. And the test case is added. too.

But it doesn't solve the synchronization problem that Erik mentioned in [PR-1469](https://github.com/openjdk/skara/pull/1469#issuecomment-1425916242). Because the bot only generates one email one time regradless of the number of the commits.

Thanks for the review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1828](https://bugs.openjdk.org/browse/SKARA-1828): RFR emails still be sent when PR is in draft state


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to [d223a7d2](https://git.openjdk.org/skara/pull/1484/files/d223a7d2c753956aa039adc84c2631e7180caa0e)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara pull/1484/head:pull/1484` \
`$ git checkout pull/1484`

Update a local copy of the PR: \
`$ git checkout pull/1484` \
`$ git pull https://git.openjdk.org/skara pull/1484/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1484`

View PR using the GUI difftool: \
`$ git pr show -t 1484`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1484.diff">https://git.openjdk.org/skara/pull/1484.diff</a>

</details>
