### PR TITLE
1843: mlbridge bot bridges emails generated by itself

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBot.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBot.java
@@ -114,8 +114,7 @@ public class MailingListArchiveReaderBot implements Bot {
             pr = foundPr.get();
             resolvedPullRequests.put(first.id(), pr);
         }
-        var bridgeIdStr = "^[^.]+\\.[^.]+@(?:" + pr.repository().url().getHost() + "|" + pr.repository().authenticatedUrl().getHost() + ")$";
-        var bridgeIdPattern = Pattern.compile(bridgeIdStr);
+        var bridgeIdPattern = Pattern.compile("^[^.]+\\.[^.]+@" + pr.repository().authenticatedUrl().getHost() + "$");
 
         // Filter out already bridged comments
         var bridgeCandidates = newMessages.stream()

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBot.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBot.java
@@ -114,7 +114,8 @@ public class MailingListArchiveReaderBot implements Bot {
             pr = foundPr.get();
             resolvedPullRequests.put(first.id(), pr);
         }
-        var bridgeIdPattern = Pattern.compile("^[^.]+\\.[^.]+@" + pr.repository().url().getHost() + "$");
+        var bridgeIdStr = "^[^.]+\\.[^.]+@(?:" + pr.repository().url().getHost() + "|" + pr.repository().authenticatedUrl().getHost() + ")$";
+        var bridgeIdPattern = Pattern.compile(bridgeIdStr);
 
         // Filter out already bridged comments
         var bridgeCandidates = newMessages.stream()

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
@@ -296,7 +296,7 @@ class ReviewArchive {
             digest.update(identifier.getBytes(StandardCharsets.UTF_8));
             var encodedCommon = Base64.getUrlEncoder().encodeToString(digest.digest());
 
-            return EmailAddress.from(encodedCommon + "." + UUID.randomUUID() + "@" + pr.repository().url().getHost());
+            return EmailAddress.from(encodedCommon + "." + UUID.randomUUID() + "@" + pr.repository().authenticatedUrl().getHost());
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException("Cannot find SHA-256");
         }


### PR DESCRIPTION
Hi all,

This patch filters both `github.com` (by `authenticatedUrl()`) and `git.openjdk.com` (by `url()`) in `MailingListArchiveReaderBot::inspect` to avoid the bot posting the unnecessary comments to the PRs. Please see SKARA-1843 [1] for more information.

But I can't write a test case for it now, because the current URLs of the repositories in test code are fake and their host are empty, which means both `pr.repository().url().getHost()` and `pr.repository().authenticatedUrl().getHost()` always return `null`.

Thanks for the review.

Best Regards,
-- Guoxiong

[1] https://bugs.openjdk.org/browse/SKARA-1843

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1843](https://bugs.openjdk.org/browse/SKARA-1843): mlbridge bot bridges emails generated by itself


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1485/head:pull/1485` \
`$ git checkout pull/1485`

Update a local copy of the PR: \
`$ git checkout pull/1485` \
`$ git pull https://git.openjdk.org/skara.git pull/1485/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1485`

View PR using the GUI difftool: \
`$ git pr show -t 1485`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1485.diff">https://git.openjdk.org/skara/pull/1485.diff</a>

</details>
