### PR TITLE
SKARA-1838

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitJCheck.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitJCheck.java
@@ -349,6 +349,9 @@ public class GitJCheck {
                 }
             } catch (Exception e) {
                 System.err.println(String.format("error: exception thrown during jcheck: %s", e.getMessage()));
+                if (e.getMessage().equals("java.net.ConnectException")) {
+                    System.err.println("If you are connected to Oracle's VPN, please set the https_proxy environment variable and try again");
+                }
                 return 1;
             }
         }


### PR DESCRIPTION
Sometimes, users may want to run jcheck locally before creating PRs. However, Oracle employees who are connected to the Oracle VPN and have not set the https_proxy environment variable may encounter a "connect exception" error. 
In this patch, we will provide users with more information in the case of a "connect exception" error while running jcheck.