### PR TITLE
1849: Exception when creating a new PR from CLI

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrCreate.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrCreate.java
@@ -253,6 +253,9 @@ public class GitPrCreate {
             var remoteBranches = repo.branches(remote);
             var candidates = new ArrayList<Branch>();
             for (var b : remoteBranches) {
+                if (b.name().length() <= remote.length()) {
+                    continue;
+                }
                 var withoutRemotePrefix = b.name().substring(remote.length() + 1);
                 if (upstreamBranchNames.contains(withoutRemotePrefix)) {
                     candidates.add(b);


### PR DESCRIPTION
Since `git-for-each-ref` is updated in git 2.40.0, the output of this command is changed and would invoke some errors when using `git pr create`.

In this patch, we would filter out invalid output when trying to find candidate target refs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1849](https://bugs.openjdk.org/browse/SKARA-1849): Exception when creating a new PR from CLI


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1488/head:pull/1488` \
`$ git checkout pull/1488`

Update a local copy of the PR: \
`$ git checkout pull/1488` \
`$ git pull https://git.openjdk.org/skara.git pull/1488/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1488`

View PR using the GUI difftool: \
`$ git pr show -t 1488`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1488.diff">https://git.openjdk.org/skara/pull/1488.diff</a>

</details>
