### PR TITLE
1827: Better handling of Error

### DIFF
--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
@@ -233,7 +233,7 @@ public class BotRunner {
                     item.handleRuntimeException(e);
                 } catch (Error e) {
                     EXCEPTIONS_COUNTER.labels(item.botName(), item.workItemName(), e.getClass().getName()).inc();
-                    log.log(Level.SEVERE, "Error thrown during item execution: " + e.getMessage(), e);
+                    log.log(Level.SEVERE, "Error thrown during item execution: (" + item + "): " + e.getMessage(), e);
                     throw e;
                 } finally {
                     var duration = Duration.between(start, Instant.now());

--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
@@ -231,19 +231,24 @@ public class BotRunner {
                         log.log(Level.SEVERE, "Exception during item execution (" + item + "): " + e.getMessage(), e);
                     }
                     item.handleRuntimeException(e);
+                } catch (Error e) {
+                    EXCEPTIONS_COUNTER.labels(item.botName(), item.workItemName(), e.getClass().getName()).inc();
+                    log.log(Level.SEVERE, "Error thrown during item execution: " + e.getMessage(), e);
+                    throw e;
                 } finally {
                     var duration = Duration.between(start, Instant.now());
                     log.log(Level.FINE, "Item " + item + " is now done after " + duration,
                             new Object[]{TaskPhases.END, duration});
+                    synchronized (executor) {
+                        scratchPaths.addLast(scratchPath);
+                        done(item);
+                    }
                 }
                 if (followUpItems != null) {
                     followUpItems.forEach(BotRunner.this::submitOrSchedule);
                 }
 
                 synchronized (executor) {
-                    scratchPaths.addLast(scratchPath);
-                    done(item);
-
                     // Some of the pending items may now be eligible for execution
                     var candidateItems = pending.entrySet().stream()
                             .filter(e -> e.getValue().isEmpty() || !active.containsKey(e.getValue().get()))


### PR DESCRIPTION
After some deliberation, I think this is how we should handle an `Error` being thrown when running a `WorkItem`. 

We need to attempt to log it and register it in the counters, otherwise it will be very hard to discover the problem. 

We also need to attempt to return the scratch path to the BotRunner, as well as removing the item from the active set, otherwise the BotRunner will enter a broken state. The drawback of this is that it will allow new instances of the same WorkItem to run, which will likely repeat the Error. I still think that's the better option compared to what we experienced in SKARA-1825.

I think it's fine to skip scheduling of pending items. When an Error has been thrown in a thread, we should try to minimize any additional work in that thread to only what's necessary. Unless every WorkItem throws an Error, pending items will get scheduled eventually anyway, by some other successful WorkItem. If every WorkItem is throwing an Error, then not scheduling pending items is the least of our problems. By re-throwing the `Error` we make sure the Runnable exits as quickly as possible.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1827](https://bugs.openjdk.org/browse/SKARA-1827): Better handling of Error


### Reviewers
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - **Reviewer**) ⚠️ Review applies to [63f8a7a9](https://git.openjdk.org/skara/pull/1490/files/63f8a7a9028edf79de0826326d1c667bd79b3dae)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1490/head:pull/1490` \
`$ git checkout pull/1490`

Update a local copy of the PR: \
`$ git checkout pull/1490` \
`$ git pull https://git.openjdk.org/skara.git pull/1490/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1490`

View PR using the GUI difftool: \
`$ git pr show -t 1490`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1490.diff">https://git.openjdk.org/skara/pull/1490.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1490#issuecomment-1480198057)