### PR TITLE
1859: Add "tags only" option to MirrorBot

### DIFF
--- a/bots/mirror/src/main/java/org/openjdk/skara/bots/mirror/MirrorBot.java
+++ b/bots/mirror/src/main/java/org/openjdk/skara/bots/mirror/MirrorBot.java
@@ -133,7 +133,13 @@ class MirrorBot implements Bot, WorkItem {
     @Override
     public String toString() {
         var name = "MirrorBot@" + from.name() + "->" + to.name();
-        if (!branchPatterns.isEmpty()) {
+        if (branchPatterns.isEmpty()) {
+            if (onlyTags) {
+                name += " ()";
+            } else {
+                name += " (*)";
+            }
+        } else {
             var branchPatterns = this.branchPatterns.stream().map(Pattern::toString).collect(Collectors.toList());
             name += " (" + String.join(",", branchPatterns) + ")";
         }

--- a/bots/mirror/src/main/java/org/openjdk/skara/bots/mirror/MirrorBot.java
+++ b/bots/mirror/src/main/java/org/openjdk/skara/bots/mirror/MirrorBot.java
@@ -137,6 +137,13 @@ class MirrorBot implements Bot, WorkItem {
             var branchPatterns = this.branchPatterns.stream().map(Pattern::toString).collect(Collectors.toList());
             name += " (" + String.join(",", branchPatterns) + ")";
         }
+        if (onlyTags) {
+            name += " [tags only]";
+        } else if (includeTags) {
+            name += " [tags included]";
+        } else {
+            name += " [tags excluded]";
+        }
         return name;
     }
 
@@ -166,5 +173,9 @@ class MirrorBot implements Bot, WorkItem {
 
     public boolean isIncludeTags() {
         return includeTags;
+    }
+
+    public boolean isOnlyTags() {
+        return onlyTags;
     }
 }

--- a/bots/mirror/src/main/java/org/openjdk/skara/bots/mirror/MirrorBotFactory.java
+++ b/bots/mirror/src/main/java/org/openjdk/skara/bots/mirror/MirrorBotFactory.java
@@ -96,9 +96,6 @@ public class MirrorBotFactory implements BotFactory {
             if (onlyTags && !branchPatterns.isEmpty()) {
                 throw new IllegalStateException("Branches cannot be mirrored when only tags are mirrored");
             }
-            if (includeTags && !branchPatterns.isEmpty()) {
-                throw new IllegalStateException("Cannot include tags with only selected branches (tags are *not* per branch)");
-            }
 
             log.info("Setting up mirroring from " + fromRepo.name() + "to " + toRepo.name());
             bots.add(new MirrorBot(storage, fromRepo, toRepo, branchPatterns, includeTags, onlyTags));

--- a/bots/mirror/src/main/java/org/openjdk/skara/bots/mirror/MirrorBotFactory.java
+++ b/bots/mirror/src/main/java/org/openjdk/skara/bots/mirror/MirrorBotFactory.java
@@ -83,8 +83,8 @@ public class MirrorBotFactory implements BotFactory {
             var onlyTags = false;
             if (repo.contains("tags")) {
                 var tags = repo.get("tags").asString().toLowerCase().strip();
-                if (!Set.of("include", "only", "exclude").contains(tags)) {
-                    throw new IllegalStateException("\"tags\" field can only have values \"include\", \"only\" or \"exclude\"");
+                if (!Set.of("include", "only").contains(tags)) {
+                    throw new IllegalStateException("\"tags\" field can only have value \"include\" or \"only\"");
                 }
                 onlyTags = tags.equals("only");
                 includeTags = tags.equals("include");

--- a/bots/mirror/src/test/java/org/openjdk/skara/bots/mirror/MirrorBotFactoryTest.java
+++ b/bots/mirror/src/test/java/org/openjdk/skara/bots/mirror/MirrorBotFactoryTest.java
@@ -23,6 +23,7 @@
 package org.openjdk.skara.bots.mirror;
 
 import java.util.List;
+import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.Test;
 import org.openjdk.skara.json.JWCC;
@@ -90,7 +91,7 @@ class MirrorBotFactoryTest {
             assertEquals("test", mirrorBot2.getBranchPatterns().get(2).toString());
 
             MirrorBot mirrorBot3 = (MirrorBot) bots.get(2);
-            assertEquals("MirrorBot@from3->to3 [tags included]", mirrorBot3.toString());
+            assertEquals("MirrorBot@from3->to3 (*) [tags included]", mirrorBot3.toString());
             assertTrue(mirrorBot3.isIncludeTags());
             assertFalse(mirrorBot3.isOnlyTags());
             assertEquals(0, mirrorBot3.getBranchPatterns().size());
@@ -179,34 +180,6 @@ class MirrorBotFactoryTest {
     }
 
     @Test
-    public void testPassesWithBranchesAndTagsExplicitlyExcluded() {
-        try (var tempFolder = new TemporaryDirectory()) {
-            String jsonString = """
-                    {
-                      "repositories": [
-                        {
-                          "from": "from1",
-                          "to": "to1",
-                          "branches": "master",
-                          "tags": "exclude"
-                        }
-                      ]
-                    }
-                    """;
-            var jsonConfig = JWCC.parse(jsonString).asObject();
-
-            var testBotFactory = TestBotFactory.newBuilder()
-                    .addHostedRepository("from1", new TestHostedRepository("from1"))
-                    .addHostedRepository("to1", new TestHostedRepository("to1"))
-                    .storagePath(tempFolder.path().resolve("storage"))
-                    .build();
-
-            var bots = testBotFactory.createBots(MirrorBotFactory.NAME, jsonConfig);
-            assertEquals(1, bots.size());
-        }
-    }
-
-    @Test
     public void testCreateWithTags() {
         try (var tempFolder = new TemporaryDirectory()) {
             String jsonString = """
@@ -225,12 +198,16 @@ class MirrorBotFactoryTest {
                         {
                           "from": "from3",
                           "to": "to3",
-                          "tags": "only"
                         },
                         {
                           "from": "from4",
                           "to": "to4",
-                          "tags": "exclude"
+                          "tags": "only"
+                        },
+                        {
+                          "from": "from5",
+                          "to": "to5",
+                          "branches": ["master", "dev"]
                         },
                       ]
                     }
@@ -242,37 +219,49 @@ class MirrorBotFactoryTest {
                     .addHostedRepository("from2", new TestHostedRepository("from2"))
                     .addHostedRepository("from3", new TestHostedRepository("from3"))
                     .addHostedRepository("from4", new TestHostedRepository("from4"))
+                    .addHostedRepository("from5", new TestHostedRepository("from5"))
                     .addHostedRepository("to1", new TestHostedRepository("to1"))
                     .addHostedRepository("to2", new TestHostedRepository("to2"))
                     .addHostedRepository("to3", new TestHostedRepository("to3"))
                     .addHostedRepository("to4", new TestHostedRepository("to4"))
+                    .addHostedRepository("to5", new TestHostedRepository("to5"))
                     .storagePath(tempFolder.path().resolve("storage"))
                     .build();
 
             var bots = testBotFactory.createBots(MirrorBotFactory.NAME, jsonConfig);
-            assertEquals(4, bots.size());
+            assertEquals(5, bots.size());
 
             MirrorBot mirrorBot1 = (MirrorBot) bots.get(0);
             assertEquals("MirrorBot@from1->to1 (master) [tags excluded]", mirrorBot1.toString());
             assertFalse(mirrorBot1.isIncludeTags());
-            assertEquals("master", mirrorBot1.getBranchPatterns().get(0).toString());
+            assertFalse(mirrorBot1.isOnlyTags());
+            assertEquals(List.of("master"),
+                         mirrorBot1.getBranchPatterns().stream().map(Pattern::toString).toList());
 
             MirrorBot mirrorBot2 = (MirrorBot) bots.get(1);
-            assertEquals("MirrorBot@from2->to2 [tags included]", mirrorBot2.toString());
+            assertEquals("MirrorBot@from2->to2 (*) [tags included]", mirrorBot2.toString());
             assertTrue(mirrorBot2.isIncludeTags());
+            assertFalse(mirrorBot2.isOnlyTags());
             assertEquals(List.of(), mirrorBot2.getBranchPatterns());
 
             MirrorBot mirrorBot3 = (MirrorBot) bots.get(2);
-            assertEquals("MirrorBot@from3->to3 [tags only]", mirrorBot3.toString());
+            assertEquals("MirrorBot@from3->to3 (*) [tags included]", mirrorBot3.toString());
             assertTrue(mirrorBot3.isIncludeTags());
-            assertTrue(mirrorBot3.isOnlyTags());
-            assertEquals(0, mirrorBot3.getBranchPatterns().size());
+            assertFalse(mirrorBot3.isOnlyTags());
+            assertEquals(List.of(), mirrorBot3.getBranchPatterns());
 
             MirrorBot mirrorBot4 = (MirrorBot) bots.get(3);
-            assertEquals("MirrorBot@from4->to4 [tags excluded]", mirrorBot4.toString());
-            assertFalse(mirrorBot4.isIncludeTags());
-            assertFalse(mirrorBot4.isOnlyTags());
-            assertEquals(0, mirrorBot3.getBranchPatterns().size());
+            assertEquals("MirrorBot@from4->to4 () [tags only]", mirrorBot4.toString());
+            assertTrue(mirrorBot4.isIncludeTags());
+            assertTrue(mirrorBot4.isOnlyTags());
+            assertEquals(List.of(), mirrorBot4.getBranchPatterns());
+
+            MirrorBot mirrorBot5 = (MirrorBot) bots.get(4);
+            assertEquals("MirrorBot@from5->to5 (master,dev) [tags excluded]", mirrorBot5.toString());
+            assertFalse(mirrorBot5.isIncludeTags());
+            assertFalse(mirrorBot5.isOnlyTags());
+            assertEquals(List.of("master", "dev"),
+                         mirrorBot5.getBranchPatterns().stream().map(Pattern::toString).toList());
         }
     }
 }

--- a/bots/mirror/src/test/java/org/openjdk/skara/bots/mirror/MirrorBotFactoryTest.java
+++ b/bots/mirror/src/test/java/org/openjdk/skara/bots/mirror/MirrorBotFactoryTest.java
@@ -22,6 +22,8 @@
  */
 package org.openjdk.skara.bots.mirror;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 import org.openjdk.skara.json.JWCC;
 import org.openjdk.skara.test.TemporaryDirectory;
@@ -74,20 +76,202 @@ class MirrorBotFactoryTest {
             assertEquals(3, bots.size());
 
             MirrorBot mirrorBot1 = (MirrorBot) bots.get(0);
-            assertEquals("MirrorBot@from1->to1 (master)", mirrorBot1.toString());
+            assertEquals("MirrorBot@from1->to1 (master) [tags excluded]", mirrorBot1.toString());
             assertFalse(mirrorBot1.isIncludeTags());
+            assertFalse(mirrorBot1.isOnlyTags());
             assertEquals("master", mirrorBot1.getBranchPatterns().get(0).toString());
 
             MirrorBot mirrorBot2 = (MirrorBot) bots.get(1);
-            assertEquals("MirrorBot@from2->to2 (master,dev,test)", mirrorBot2.toString());
+            assertEquals("MirrorBot@from2->to2 (master,dev,test) [tags excluded]", mirrorBot2.toString());
             assertFalse(mirrorBot2.isIncludeTags());
+            assertFalse(mirrorBot2.isOnlyTags());
             assertEquals("master", mirrorBot2.getBranchPatterns().get(0).toString());
             assertEquals("dev", mirrorBot2.getBranchPatterns().get(1).toString());
             assertEquals("test", mirrorBot2.getBranchPatterns().get(2).toString());
 
             MirrorBot mirrorBot3 = (MirrorBot) bots.get(2);
-            assertEquals("MirrorBot@from3->to3", mirrorBot3.toString());
+            assertEquals("MirrorBot@from3->to3 [tags included]", mirrorBot3.toString());
             assertTrue(mirrorBot3.isIncludeTags());
+            assertFalse(mirrorBot3.isOnlyTags());
+            assertEquals(0, mirrorBot3.getBranchPatterns().size());
+        }
+    }
+
+    @Test
+    public void testThrowsWithUnsupportedTagsValue() {
+        try (var tempFolder = new TemporaryDirectory()) {
+            String jsonString = """
+                    {
+                      "repositories": [
+                        {
+                          "from": "from1",
+                          "to": "to1",
+                          "branches": "master",
+                          "tags": "foo"
+                        }
+                      ]
+                    }
+                    """;
+            var jsonConfig = JWCC.parse(jsonString).asObject();
+
+            var testBotFactory = TestBotFactory.newBuilder()
+                    .addHostedRepository("from1", new TestHostedRepository("from1"))
+                    .addHostedRepository("to1", new TestHostedRepository("to1"))
+                    .storagePath(tempFolder.path().resolve("storage"))
+                    .build();
+
+            assertThrows(IllegalStateException.class, () -> testBotFactory.createBots(MirrorBotFactory.NAME, jsonConfig));
+        }
+    }
+
+    @Test
+    public void testThrowsWithBranchesAndTagsOnly() {
+        try (var tempFolder = new TemporaryDirectory()) {
+            String jsonString = """
+                    {
+                      "repositories": [
+                        {
+                          "from": "from1",
+                          "to": "to1",
+                          "branches": "master",
+                          "tags": "only"
+                        }
+                      ]
+                    }
+                    """;
+            var jsonConfig = JWCC.parse(jsonString).asObject();
+
+            var testBotFactory = TestBotFactory.newBuilder()
+                    .addHostedRepository("from1", new TestHostedRepository("from1"))
+                    .addHostedRepository("to1", new TestHostedRepository("to1"))
+                    .storagePath(tempFolder.path().resolve("storage"))
+                    .build();
+
+            assertThrows(IllegalStateException.class, () -> testBotFactory.createBots(MirrorBotFactory.NAME, jsonConfig));
+        }
+    }
+
+    @Test
+    public void testThrowsWithBranchesAndTagsIncluded() {
+        try (var tempFolder = new TemporaryDirectory()) {
+            String jsonString = """
+                    {
+                      "repositories": [
+                        {
+                          "from": "from1",
+                          "to": "to1",
+                          "branches": "master",
+                          "tags": "include"
+                        }
+                      ]
+                    }
+                    """;
+            var jsonConfig = JWCC.parse(jsonString).asObject();
+
+            var testBotFactory = TestBotFactory.newBuilder()
+                    .addHostedRepository("from1", new TestHostedRepository("from1"))
+                    .addHostedRepository("to1", new TestHostedRepository("to1"))
+                    .storagePath(tempFolder.path().resolve("storage"))
+                    .build();
+
+            assertThrows(IllegalStateException.class, () -> testBotFactory.createBots(MirrorBotFactory.NAME, jsonConfig));
+        }
+    }
+
+    @Test
+    public void testPassesWithBranchesAndTagsExplicitlyExcluded() {
+        try (var tempFolder = new TemporaryDirectory()) {
+            String jsonString = """
+                    {
+                      "repositories": [
+                        {
+                          "from": "from1",
+                          "to": "to1",
+                          "branches": "master",
+                          "tags": "exclude"
+                        }
+                      ]
+                    }
+                    """;
+            var jsonConfig = JWCC.parse(jsonString).asObject();
+
+            var testBotFactory = TestBotFactory.newBuilder()
+                    .addHostedRepository("from1", new TestHostedRepository("from1"))
+                    .addHostedRepository("to1", new TestHostedRepository("to1"))
+                    .storagePath(tempFolder.path().resolve("storage"))
+                    .build();
+
+            var bots = testBotFactory.createBots(MirrorBotFactory.NAME, jsonConfig);
+            assertEquals(1, bots.size());
+        }
+    }
+
+    @Test
+    public void testCreateWithTags() {
+        try (var tempFolder = new TemporaryDirectory()) {
+            String jsonString = """
+                    {
+                      "repositories": [
+                        {
+                          "from": "from1",
+                          "to": "to1",
+                          "branches": "master"
+                        },
+                        {
+                          "from": "from2",
+                          "to": "to2",
+                          "tags": "include"
+                        },
+                        {
+                          "from": "from3",
+                          "to": "to3",
+                          "tags": "only"
+                        },
+                        {
+                          "from": "from4",
+                          "to": "to4",
+                          "tags": "exclude"
+                        },
+                      ]
+                    }
+                    """;
+            var jsonConfig = JWCC.parse(jsonString).asObject();
+
+            var testBotFactory = TestBotFactory.newBuilder()
+                    .addHostedRepository("from1", new TestHostedRepository("from1"))
+                    .addHostedRepository("from2", new TestHostedRepository("from2"))
+                    .addHostedRepository("from3", new TestHostedRepository("from3"))
+                    .addHostedRepository("from4", new TestHostedRepository("from4"))
+                    .addHostedRepository("to1", new TestHostedRepository("to1"))
+                    .addHostedRepository("to2", new TestHostedRepository("to2"))
+                    .addHostedRepository("to3", new TestHostedRepository("to3"))
+                    .addHostedRepository("to4", new TestHostedRepository("to4"))
+                    .storagePath(tempFolder.path().resolve("storage"))
+                    .build();
+
+            var bots = testBotFactory.createBots(MirrorBotFactory.NAME, jsonConfig);
+            assertEquals(4, bots.size());
+
+            MirrorBot mirrorBot1 = (MirrorBot) bots.get(0);
+            assertEquals("MirrorBot@from1->to1 (master) [tags excluded]", mirrorBot1.toString());
+            assertFalse(mirrorBot1.isIncludeTags());
+            assertEquals("master", mirrorBot1.getBranchPatterns().get(0).toString());
+
+            MirrorBot mirrorBot2 = (MirrorBot) bots.get(1);
+            assertEquals("MirrorBot@from2->to2 [tags included]", mirrorBot2.toString());
+            assertTrue(mirrorBot2.isIncludeTags());
+            assertEquals(List.of(), mirrorBot2.getBranchPatterns());
+
+            MirrorBot mirrorBot3 = (MirrorBot) bots.get(2);
+            assertEquals("MirrorBot@from3->to3 [tags only]", mirrorBot3.toString());
+            assertTrue(mirrorBot3.isIncludeTags());
+            assertTrue(mirrorBot3.isOnlyTags());
+            assertEquals(0, mirrorBot3.getBranchPatterns().size());
+
+            MirrorBot mirrorBot4 = (MirrorBot) bots.get(3);
+            assertEquals("MirrorBot@from4->to4 [tags excluded]", mirrorBot4.toString());
+            assertFalse(mirrorBot4.isIncludeTags());
+            assertFalse(mirrorBot4.isOnlyTags());
             assertEquals(0, mirrorBot3.getBranchPatterns().size());
         }
     }

--- a/bots/mirror/src/test/java/org/openjdk/skara/bots/mirror/MirrorBotFactoryTest.java
+++ b/bots/mirror/src/test/java/org/openjdk/skara/bots/mirror/MirrorBotFactoryTest.java
@@ -75,13 +75,11 @@ class MirrorBotFactoryTest {
 
             MirrorBot mirrorBot1 = (MirrorBot) bots.get(0);
             assertEquals("MirrorBot@from1->to1 (master)", mirrorBot1.toString());
-            assertFalse(mirrorBot1.isShouldMirrorEverything());
             assertFalse(mirrorBot1.isIncludeTags());
             assertEquals("master", mirrorBot1.getBranchPatterns().get(0).toString());
 
             MirrorBot mirrorBot2 = (MirrorBot) bots.get(1);
             assertEquals("MirrorBot@from2->to2 (master,dev,test)", mirrorBot2.toString());
-            assertFalse(mirrorBot2.isShouldMirrorEverything());
             assertFalse(mirrorBot2.isIncludeTags());
             assertEquals("master", mirrorBot2.getBranchPatterns().get(0).toString());
             assertEquals("dev", mirrorBot2.getBranchPatterns().get(1).toString());
@@ -89,7 +87,6 @@ class MirrorBotFactoryTest {
 
             MirrorBot mirrorBot3 = (MirrorBot) bots.get(2);
             assertEquals("MirrorBot@from3->to3", mirrorBot3.toString());
-            assertTrue(mirrorBot3.isShouldMirrorEverything());
             assertTrue(mirrorBot3.isIncludeTags());
             assertEquals(0, mirrorBot3.getBranchPatterns().size());
         }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
@@ -57,7 +57,14 @@ public interface Repository extends ReadOnlyRepository {
     }
     void fetchAllRemotes(boolean includeTags) throws IOException;
     void fetchRemote(String remote) throws IOException;
-    void pushAll(URI uri) throws IOException;
+    void pushAll(URI uri, boolean force) throws IOException;
+    default void pushAll(URI uri) throws IOException {
+        pushAll(uri, false);
+    }
+    void pushTags(URI uri, boolean force) throws IOException;
+    default void pushTags(URI uri) throws IOException {
+        pushTags(uri, false);
+    }
     default void push(Hash hash, URI uri, String ref, boolean force) throws IOException {
         push(hash, uri, ref, force, false);
     }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -581,8 +581,27 @@ public class GitRepository implements Repository {
     }
 
     @Override
-    public void pushAll(URI uri) throws IOException {
-        try (var p = capture("git", "push", "--mirror", uri.toString())) {
+    public void pushAll(URI uri, boolean force) throws IOException {
+        var cmd = new ArrayList<String>();
+        cmd.addAll(List.of("git", "push", "--mirror"));
+        if (force) {
+            cmd.add("--force");
+        }
+        cmd.add(uri.toString());
+        try (var p = capture(cmd)) {
+            await(p);
+        }
+    }
+
+    @Override
+    public void pushTags(URI uri, boolean force) throws IOException {
+        var cmd = new ArrayList<String>();
+        cmd.addAll(List.of("git", "push", "--tags"));
+        if (force) {
+            cmd.add("--force");
+        }
+        cmd.add(uri.toString());
+        try (var p = capture(cmd)) {
             await(p);
         }
     }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -552,10 +552,21 @@ public class HgRepository implements Repository {
     }
 
     @Override
-    public void pushAll(URI uri) throws IOException {
-        try (var p = capture("hg", "push", "--new-branch", uri.toString())) {
+    public void pushAll(URI uri, boolean force) throws IOException {
+        var cmd = new ArrayList<String>();
+        cmd.addAll(List.of("hg", "push", "--new-branch"));
+        if (force) {
+            cmd.add("--force");
+        }
+        cmd.add(uri.toString());
+        try (var p = capture(cmd)) {
             await(p);
         }
+    }
+
+    @Override
+    public void pushTags(URI uri, boolean force) throws IOException {
+        throw new RuntimeException("Cannot push only tags with Mercurial");
     }
 
     @Override


### PR DESCRIPTION
Hi all,

please review this patch that adds an option to the `MirrorBot` to mirror only tags from one repository to another. I also added some additional logging to `MirrorBot` and cleaned up the logic a bit for selecting the "mode" (tags, mirror, selected branches) that the `MirrorBot` uses.

### Testing
- [x] Added one additional unit test

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1859](https://bugs.openjdk.org/browse/SKARA-1859): Add "tags only" option to MirrorBot


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1493/head:pull/1493` \
`$ git checkout pull/1493`

Update a local copy of the PR: \
`$ git checkout pull/1493` \
`$ git pull https://git.openjdk.org/skara.git pull/1493/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1493`

View PR using the GUI difftool: \
`$ git pr show -t 1493`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1493.diff">https://git.openjdk.org/skara/pull/1493.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1493#issuecomment-1486533385)