### PR TITLE
1858: Make it possible to configure to require reviewers for "Merge" PRs

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -426,7 +426,8 @@ class CheckWorkItem extends PullRequestWorkItem {
                 Repository localRepo = materializeLocalRepo(scratchPath, hostedRepositoryPool);
 
                 var expiresAt = CheckRun.execute(this, pr, localRepo, comments, allReviews,
-                        activeReviews, labels, census, bot.ignoreStaleReviews(), bot.integrators(), bot.reviewCleanBackport());
+                        activeReviews, labels, census, bot.ignoreStaleReviews(), bot.integrators(), bot.reviewCleanBackport(),
+                        bot.reviewMerge());
                 if (log.isLoggable(Level.INFO)) {
                     // Log latency from the original updatedAt of the PR when this WorkItem
                     // was triggered to when it was just updated by the CheckRun.execute above.

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
@@ -221,8 +221,7 @@ public class IntegrateCommand implements CommandHandler {
             }
             var localHash = checkablePr.commit(rebasedHash.get(), censusInstance.namespace(),
                     censusInstance.configuration().census().domain(), committerId, original);
-
-            if (runJcheck(pr, censusInstance, allComments, reply, localRepo, checkablePr, localHash)) {
+            if (runJcheck(pr, censusInstance, allComments, reply, localRepo, checkablePr, localHash, bot.reviewMerge())) {
                 return;
             }
 
@@ -259,9 +258,9 @@ public class IntegrateCommand implements CommandHandler {
      * Runs the checks adding to the reply message and returns true if any of them failed
      */
     static boolean runJcheck(PullRequest pr, CensusInstance censusInstance, List<Comment> allComments, PrintWriter reply,
-                      Repository localRepo, CheckablePullRequest checkablePr, Hash localHash) throws IOException {
+                      Repository localRepo, CheckablePullRequest checkablePr, Hash localHash, boolean reviewMerge) throws IOException {
         var issues = checkablePr.createVisitor();
-        var additionalConfiguration = AdditionalConfiguration.get(localRepo, localHash, pr.repository().forge().currentUser(), allComments);
+        var additionalConfiguration = AdditionalConfiguration.get(localRepo, localHash, pr.repository().forge().currentUser(), allComments, reviewMerge);
         checkablePr.executeChecks(localHash, censusInstance, issues, additionalConfiguration, checkablePr.targetHash());
         if (!issues.messages().isEmpty()) {
             reply.print("Your integration request cannot be fulfilled at this time, as ");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -65,6 +65,7 @@ class PullRequestBot implements Bot {
     private final PullRequestPoller poller;
     private final boolean reviewCleanBackport;
     private final String mlbridgeBotName;
+    private final boolean reviewMerge;
 
     private Instant lastFullUpdate;
 
@@ -77,7 +78,7 @@ class PullRequestBot implements Bot {
                    Path seedStorage, HostedRepository confOverrideRepo, String confOverrideName,
                    String confOverrideRef, String censusLink, Map<String, HostedRepository> forks,
                    Set<String> integrators, Set<Integer> excludeCommitCommentsFrom, boolean enableCsr, boolean enableJep,
-                   boolean reviewCleanBackport, String mlbridgeBotName) {
+                   boolean reviewCleanBackport, String mlbridgeBotName, boolean reviewMerge) {
         remoteRepo = repo;
         this.censusRepo = censusRepo;
         this.censusRef = censusRef;
@@ -104,6 +105,7 @@ class PullRequestBot implements Bot {
         this.enableJep = enableJep;
         this.reviewCleanBackport = reviewCleanBackport;
         this.mlbridgeBotName = mlbridgeBotName;
+        this.reviewMerge = reviewMerge;
 
         autoLabelled = new HashSet<>();
         poller = new PullRequestPoller(repo, true);
@@ -272,6 +274,10 @@ class PullRequestBot implements Bot {
 
     public String mlbridgeBotName() {
         return mlbridgeBotName;
+    }
+
+    public boolean reviewMerge(){
+        return reviewMerge;
     }
 
     public Set<String> integrators() {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,8 +56,8 @@ public class PullRequestBotBuilder {
     private Set<String> integrators = Set.of();
     private Set<Integer> excludeCommitCommentsFrom = Set.of();
     private boolean reviewCleanBackport = false;
-
     private String mlbridgeBotName;
+    private boolean reviewMerge = false;
 
     PullRequestBotBuilder() {
     }
@@ -192,6 +192,11 @@ public class PullRequestBotBuilder {
         return this;
     }
 
+    public PullRequestBotBuilder reviewMerge(boolean reviewMerge) {
+        this.reviewMerge = reviewMerge;
+        return this;
+    }
+
     public PullRequestBot build() {
         return new PullRequestBot(repo, censusRepo, censusRef, labelConfiguration,
                                   externalPullRequestCommands, externalCommitCommands,
@@ -199,6 +204,6 @@ public class PullRequestBotBuilder {
                                   readyComments, issueProject, ignoreStaleReviews,
                                   allowedTargetBranches, seedStorage, confOverrideRepo, confOverrideName,
                                   confOverrideRef, censusLink, forks, integrators, excludeCommitCommentsFrom,
-                                  enableCsr, enableJep, reviewCleanBackport, mlbridgeBotName);
+                                  enableCsr, enableJep, reviewCleanBackport, mlbridgeBotName, reviewMerge);
     }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
@@ -116,7 +116,7 @@ public class PullRequestBotFactory implements BotFactory {
             var censusRef = configuration.repositoryRef(repo.value().get("census").asString());
             var repository = configuration.repository(repo.name());
             var botBuilder = PullRequestBot.newBuilder()
-                                           .repo(repository)
+                                           .repo(configuration.repository(repo.name()))
                                            .censusRepo(censusRepo)
                                            .censusRef(censusRef)
                                            .blockingCheckLabels(blockers)
@@ -195,6 +195,10 @@ public class PullRequestBotFactory implements BotFactory {
             if (repo.value().contains("reviewCleanBackport")) {
                 botBuilder.reviewCleanBackport(repo.value().get("reviewCleanBackport").asBoolean());
             }
+            if (repo.value().contains("reviewMerge")) {
+                botBuilder.reviewMerge(repo.value().get("reviewMerge").asBoolean());
+            }
+
             var prBot = botBuilder.build();
             pullRequestBotMap.put(repository.name(), prBot);
             ret.add(prBot);

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
@@ -116,7 +116,7 @@ public class PullRequestBotFactory implements BotFactory {
             var censusRef = configuration.repositoryRef(repo.value().get("census").asString());
             var repository = configuration.repository(repo.name());
             var botBuilder = PullRequestBot.newBuilder()
-                                           .repo(configuration.repository(repo.name()))
+                                           .repo(repository)
                                            .censusRepo(censusRepo)
                                            .censusRef(censusRef)
                                            .blockingCheckLabels(blockers)

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -123,7 +123,7 @@ public class SponsorCommand implements CommandHandler {
             var localHash = checkablePr.commit(rebasedHash.get(), censusInstance.namespace(), censusInstance.configuration().census().domain(),
                     command.user().id(), original);
 
-            if (IntegrateCommand.runJcheck(pr, censusInstance, allComments, reply, localRepo, checkablePr, localHash)) {
+            if (IntegrateCommand.runJcheck(pr, censusInstance, allComments, reply, localRepo, checkablePr, localHash, bot.reviewMerge())) {
                 return;
             }
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
@@ -83,10 +83,6 @@ class MergeTests {
             localRepo.push(mergeHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "Merge " + author.name() + ":other_/-1.2");
 
-            // Approve it as another user
-            var approvalPr = integrator.pullRequest(pr.id());
-            approvalPr.addReview(Review.Verdict.APPROVED, "Approved");
-
             // Let the bot check the status
             TestBotRunner.runPeriodicItems(mergeBot);
 
@@ -98,6 +94,100 @@ class MergeTests {
             var pushed = pr.comments().stream()
                            .filter(comment -> comment.body().contains("Pushed as commit"))
                            .count();
+            assertEquals(1, pushed);
+
+            // The change should now be present on the master branch
+            var pushedRepoFolder = tempFolder.path().resolve("pushedrepo");
+            var pushedRepo = Repository.materialize(pushedRepoFolder, author.authenticatedUrl(), "master");
+            assertTrue(CheckableRepository.hasBeenEdited(pushedRepo));
+
+            // The commits from the "other" branch should be preserved and not squashed (but not the merge commit)
+            var headHash = pushedRepo.resolve("HEAD").orElseThrow();
+            Set<Hash> commits;
+            try (var tempCommits = pushedRepo.commits(masterHash.hex() + ".." + headHash.hex())) {
+                commits = tempCommits.stream()
+                        .map(Commit::hash)
+                        .collect(Collectors.toSet());
+            }
+            assertTrue(commits.contains(otherHash1));
+            assertTrue(commits.contains(otherHash2));
+            assertFalse(commits.contains(mergeHash));
+
+            // Author and committer should updated in the merge commit
+            var headCommit = pushedRepo.commits(headHash.hex() + "^.." + headHash.hex()).asList().get(0);
+            assertEquals("Merge " + author.name() + ":other_/-1.2", headCommit.message().get(0));
+            assertEquals("Generated Committer 1", headCommit.author().name());
+            assertEquals("integrationcommitter1@openjdk.org", headCommit.author().email());
+            assertEquals("Generated Committer 1", headCommit.committer().name());
+            assertEquals("integrationcommitter1@openjdk.org", headCommit.committer().email());
+        }
+    }
+
+    @Test
+    void branchMergeWithReviewMergeRequest(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+
+            var author = credentials.getHostedRepository();
+            var integrator = credentials.getHostedRepository();
+            var censusBuilder = credentials.getCensusBuilder()
+                    .addCommitter(author.forge().currentUser().id())
+                    .addReviewer(integrator.forge().currentUser().id());
+            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build())
+                    .reviewMerge(true).build();
+
+            // Populate the projects repository
+            var localRepoFolder = tempFolder.path().resolve("localrepo");
+            var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+
+            // Make more changes in another branch
+            var otherHash1 = CheckableRepository.appendAndCommit(localRepo, "First change in other_/-1.2",
+                    "First other_/-1.2\n\nReviewed-by: integrationreviewer2");
+            localRepo.push(otherHash1, author.authenticatedUrl(), "other_/-1.2", true);
+            var otherHash2 = CheckableRepository.appendAndCommit(localRepo, "Second change in other_/-1.2",
+                    "Second other_/-1.2\n\nReviewed-by: integrationreviewer2");
+            localRepo.push(otherHash2, author.authenticatedUrl(), "other_/-1.2");
+
+            // Go back to the original master
+            localRepo.checkout(masterHash, true);
+
+            // Make a change with a corresponding PR
+            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated", StandardCharsets.UTF_8);
+            localRepo.add(unrelated);
+            var updatedMaster = localRepo.commit("Unrelated", "some", "some@one");
+            localRepo.merge(otherHash2);
+            localRepo.push(updatedMaster, author.authenticatedUrl(), "master");
+
+            var mergeHash = localRepo.commit("Merge commit", "some", "some@one");
+            localRepo.push(mergeHash, author.authenticatedUrl(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "Merge " + author.name() + ":other_/-1.2");
+
+            // Let the bot check the status
+            TestBotRunner.runPeriodicItems(mergeBot);
+
+            // pr should not be ready, because review needed for merge pull requests
+            assertFalse(pr.store().labelNames().contains("ready"));
+            assertTrue(pr.store().body().contains("- [ ] Change must be properly reviewed"));
+
+            // Approve it as another user
+            var approvalPr = integrator.pullRequest(pr.id());
+            approvalPr.addReview(Review.Verdict.APPROVED, "Approved");
+            TestBotRunner.runPeriodicItems(mergeBot);
+
+            assertTrue(pr.store().labelNames().contains("ready"));
+            assertTrue(pr.store().body().contains("- [x] Change must be properly reviewed"));
+
+            // Push it
+            pr.addComment("/integrate");
+            TestBotRunner.runPeriodicItems(mergeBot);
+
+            // The bot should reply with an ok message
+            var pushed = pr.comments().stream()
+                    .filter(comment -> comment.body().contains("Pushed as commit"))
+                    .count();
             assertEquals(1, pushed);
 
             // The change should now be present on the master branch

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
@@ -214,6 +214,9 @@ class MergeTests {
             assertEquals("integrationcommitter1@openjdk.org", headCommit.author().email());
             assertEquals("Generated Committer 1", headCommit.committer().name());
             assertEquals("integrationcommitter1@openjdk.org", headCommit.committer().email());
+            assertTrue(String.join("", headCommit.message())
+                            .matches(".*Reviewed-by: integrationreviewer2$"),
+                    String.join("", headCommit.message()));
         }
     }
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestBotFactoryTest.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestBotFactoryTest.java
@@ -112,7 +112,8 @@ class PullRequestBotFactoryTest {
                             "integrator1",
                             "integrator2"
                           ],
-                          "reviewCleanBackport": true
+                          "reviewCleanBackport": true,
+                          "reviewMerge": true,
                         }
                       },
                       "forks": {
@@ -160,6 +161,7 @@ class PullRequestBotFactoryTest {
             assertTrue(integrators.contains("integrator1"));
             assertTrue(integrators.contains("integrator2"));
             assertTrue(pullRequestBot1.reviewCleanBackport());
+            assertTrue(pullRequestBot1.reviewMerge());
             assertEquals("mlbridge[bot]", pullRequestBot1.mlbridgeBotName());
 
             var csrIssueBot1 = (CSRIssueBot) bots.get(3);

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/ReviewersCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/ReviewersCheck.java
@@ -67,7 +67,7 @@ public class ReviewersCheck extends CommitCheck {
 
     @Override
     Iterator<Issue> check(Commit commit, CommitMessage message, JCheckConfiguration conf, Census census) {
-        if (commit.isMerge() || utils.addsHgTag(commit)) {
+        if ((commit.isMerge() && !conf.checks().reviewers().shouldCheckMerge()) || utils.addsHgTag(commit)) {
             return iterator();
         }
 

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/ReviewersConfiguration.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/ReviewersConfiguration.java
@@ -29,7 +29,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 
 public class ReviewersConfiguration {
-    static final ReviewersConfiguration DEFAULT = new ReviewersConfiguration(0, 1, 0, 0, 0, List.of("duke"), false);
+    static final ReviewersConfiguration DEFAULT = new ReviewersConfiguration(0, 1, 0, 0, 0, List.of("duke"), false, false);
     public static final String BYLAWS_URL = "https://openjdk.org/bylaws";
 
     private final int lead;
@@ -40,8 +40,10 @@ public class ReviewersConfiguration {
     private final List<String> ignore;
     private final boolean shouldCheckBackports;
     private String reviewRequirements;
+    private boolean shouldCheckMerge;
 
-    ReviewersConfiguration(int lead, int reviewers, int committers, int authors, int contributors, List<String> ignore, boolean shouldCheckBackports) {
+    ReviewersConfiguration(int lead, int reviewers, int committers, int authors, int contributors, List<String> ignore,
+                           boolean shouldCheckBackports, boolean shouldCheckMerge) {
         this.lead = lead;
         this.reviewers = reviewers;
         this.committers = committers;
@@ -49,6 +51,7 @@ public class ReviewersConfiguration {
         this.contributors = contributors;
         this.ignore = ignore;
         this.shouldCheckBackports = shouldCheckBackports;
+        this.shouldCheckMerge = shouldCheckMerge;
     }
 
     public int lead() {
@@ -77,6 +80,10 @@ public class ReviewersConfiguration {
 
     public boolean shouldCheckBackports() {
         return shouldCheckBackports;
+    }
+
+    public boolean shouldCheckMerge(){
+        return shouldCheckMerge;
     }
 
     public String getReviewRequirements() {
@@ -153,7 +160,8 @@ public class ReviewersConfiguration {
 
         var ignore = s.get("ignore", DEFAULT.ignore());
         var shouldCheckBackports = s.get("backports", "ignore").equals("check");
+        var shouldCheckMerge = s.get("merge", "ignore").equals("check");
 
-        return new ReviewersConfiguration(lead, reviewers, committers, authors, contributors, ignore, shouldCheckBackports);
+        return new ReviewersConfiguration(lead, reviewers, committers, authors, contributors, ignore, shouldCheckBackports, shouldCheckMerge);
     }
 }


### PR DESCRIPTION
In this patch, PR bot has been added with the capability to control the requirement of reviews for merge pull requests.

By default, review is not necessary for merge pull requests.

However, if it is desired to enable the requirement of reviews for merge requests in a repo, the configuration can be added to the PR bot configuration as follows:
```
{
  "pr": {
      "repositories": {
          "repo1": {
               "reviewMerge": true
          }
       }
  }
}
```

Currently, jcheck would run in two places in skara bot. One is in checkRun and one is in IntegrateCommand. For the merge pull requests that not require review, the Reviewers check would be skipped.

The other way to run jcheck in using SKARA CLI. This patch is also compatible with it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1858](https://bugs.openjdk.org/browse/SKARA-1858): Make it possible to configure to require reviewers for "Merge" PRs


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1495/head:pull/1495` \
`$ git checkout pull/1495`

Update a local copy of the PR: \
`$ git checkout pull/1495` \
`$ git pull https://git.openjdk.org/skara.git pull/1495/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1495`

View PR using the GUI difftool: \
`$ git pr show -t 1495`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1495.diff">https://git.openjdk.org/skara/pull/1495.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1495#issuecomment-1492457986)