### PR TITLE
1870: Make pr processing optional

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
@@ -58,6 +58,8 @@ public class PullRequestBotBuilder {
     private boolean reviewCleanBackport = false;
     private String mlbridgeBotName;
     private boolean reviewMerge = false;
+    private boolean processPR = true;
+    private boolean processCommit = true;
 
     PullRequestBotBuilder() {
     }
@@ -197,6 +199,16 @@ public class PullRequestBotBuilder {
         return this;
     }
 
+    public PullRequestBotBuilder processPR(boolean processPR) {
+        this.processPR = processPR;
+        return this;
+    }
+
+    public PullRequestBotBuilder processCommit(boolean processCommit) {
+        this.processCommit = processCommit;
+        return this;
+    }
+
     public PullRequestBot build() {
         return new PullRequestBot(repo, censusRepo, censusRef, labelConfiguration,
                                   externalPullRequestCommands, externalCommitCommands,
@@ -204,6 +216,7 @@ public class PullRequestBotBuilder {
                                   readyComments, issueProject, ignoreStaleReviews,
                                   allowedTargetBranches, seedStorage, confOverrideRepo, confOverrideName,
                                   confOverrideRef, censusLink, forks, integrators, excludeCommitCommentsFrom,
-                                  enableCsr, enableJep, reviewCleanBackport, mlbridgeBotName, reviewMerge);
+                                  enableCsr, enableJep, reviewCleanBackport, mlbridgeBotName, reviewMerge,
+                                  processPR, processCommit);
     }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
@@ -198,6 +198,12 @@ public class PullRequestBotFactory implements BotFactory {
             if (repo.value().contains("reviewMerge")) {
                 botBuilder.reviewMerge(repo.value().get("reviewMerge").asBoolean());
             }
+            if (repo.value().contains("processPR")) {
+                botBuilder.processPR(repo.value().get("processPR").asBoolean());
+            }
+            if (repo.value().contains("processCommit")) {
+                botBuilder.processCommit(repo.value().get("processCommit").asBoolean());
+            }
 
             var prBot = botBuilder.build();
             pullRequestBotMap.put(repository.name(), prBot);

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestBotFactoryTest.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestBotFactoryTest.java
@@ -95,7 +95,8 @@ class PullRequestBotFactoryTest {
                             "integrator1",
                             "integrator2"
                           ],
-                          "reviewCleanBackport": true
+                          "reviewCleanBackport": true,
+                          "processCommit": false
                         },
                         "repo6": {
                           "census": "census:master",
@@ -114,6 +115,7 @@ class PullRequestBotFactoryTest {
                           ],
                           "reviewCleanBackport": true,
                           "reviewMerge": true,
+                          "processPR": false
                         }
                       },
                       "forks": {


### PR DESCRIPTION
In this patch, PR bot has been added with the capability to disable PR processing and Commit processing.

By default, PR processing and Commit processing are both enabled.

However, if it is desired to disable PR processing or Commit processing in a repo, the configuration can be added to the PR bot configuration as follows:
```
{
  "pr": {
      "repositories": {
          "repo1": {
               "processPR": false,
               "processCommit": false
          }
       }
  }
}
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1870](https://bugs.openjdk.org/browse/SKARA-1870): Make pr processing optional


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1498/head:pull/1498` \
`$ git checkout pull/1498`

Update a local copy of the PR: \
`$ git checkout pull/1498` \
`$ git pull https://git.openjdk.org/skara.git pull/1498/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1498`

View PR using the GUI difftool: \
`$ git pr show -t 1498`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1498.diff">https://git.openjdk.org/skara/pull/1498.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1498#issuecomment-1499633463)