### PR TITLE
1853: Make it possible to disable merge PRs for a repository

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -254,7 +254,7 @@ class CheckWorkItem extends PullRequestWorkItem {
 
         // If merge pr is not allowed, reply warning to the user and return
         var mergeDisabledText = "<!-- merge error -->\n" +
-                ":warning: @" + pr.author().username() + " merge PR is not allowed in this repository, please close this pr." +
+                ":warning: @" + pr.author().username() + " Merge-style pull requests are not allowed in this repository." +
                 " If it was unintentional, please modify the title of this PR.";
         if (!bot.enableMerge() && PullRequestUtils.isMerge(pr)) {
             addErrorComment(mergeDisabledText, comments);

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -68,6 +68,7 @@ class PullRequestBot implements Bot {
     private final boolean reviewMerge;
     private final boolean processPR;
     private final boolean processCommit;
+    private final boolean enableMerge;
 
     private Instant lastFullUpdate;
 
@@ -80,7 +81,8 @@ class PullRequestBot implements Bot {
                    Path seedStorage, HostedRepository confOverrideRepo, String confOverrideName,
                    String confOverrideRef, String censusLink, Map<String, HostedRepository> forks,
                    Set<String> integrators, Set<Integer> excludeCommitCommentsFrom, boolean enableCsr, boolean enableJep,
-                   boolean reviewCleanBackport, String mlbridgeBotName, boolean reviewMerge, boolean processPR, boolean processCommit) {
+                   boolean reviewCleanBackport, String mlbridgeBotName, boolean reviewMerge, boolean processPR, boolean processCommit,
+                   boolean enableMerge) {
         remoteRepo = repo;
         this.censusRepo = censusRepo;
         this.censusRef = censusRef;
@@ -110,6 +112,7 @@ class PullRequestBot implements Bot {
         this.reviewMerge = reviewMerge;
         this.processPR = processPR;
         this.processCommit = processCommit;
+        this.enableMerge = enableMerge;
 
         autoLabelled = new HashSet<>();
         poller = new PullRequestPoller(repo, true);
@@ -293,6 +296,10 @@ class PullRequestBot implements Bot {
 
     public boolean reviewMerge(){
         return reviewMerge;
+    }
+
+    public boolean enableMerge() {
+        return enableMerge;
     }
 
     public Set<String> integrators() {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
@@ -60,6 +60,7 @@ public class PullRequestBotBuilder {
     private boolean reviewMerge = false;
     private boolean processPR = true;
     private boolean processCommit = true;
+    private boolean enableMerge = true;
 
     PullRequestBotBuilder() {
     }
@@ -209,6 +210,11 @@ public class PullRequestBotBuilder {
         return this;
     }
 
+    public PullRequestBotBuilder enableMerge(boolean enableMerge) {
+        this.enableMerge = enableMerge;
+        return this;
+    }
+
     public PullRequestBot build() {
         return new PullRequestBot(repo, censusRepo, censusRef, labelConfiguration,
                                   externalPullRequestCommands, externalCommitCommands,
@@ -217,6 +223,6 @@ public class PullRequestBotBuilder {
                                   allowedTargetBranches, seedStorage, confOverrideRepo, confOverrideName,
                                   confOverrideRef, censusLink, forks, integrators, excludeCommitCommentsFrom,
                                   enableCsr, enableJep, reviewCleanBackport, mlbridgeBotName, reviewMerge,
-                                  processPR, processCommit);
+                                  processPR, processCommit, enableMerge);
     }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
@@ -185,6 +185,9 @@ public class PullRequestBotFactory implements BotFactory {
             if (repo.value().contains("jep")) {
                 botBuilder.enableJep(repo.value().get("jep").asBoolean());
             }
+            if (repo.value().contains("merge")) {
+                botBuilder.enableMerge(repo.value().get("merge").asBoolean());
+            }
             if (repo.value().contains("integrators")) {
                 var integrators = repo.value().get("integrators")
                         .stream()

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -2840,4 +2840,52 @@ class CheckTests {
             assertTrue(pr.store().body().contains("Link to Webrev Comment"));
         }
     }
+
+    @Test
+    void mergeDisabled(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var reviewer = credentials.getHostedRepository();
+
+            var censusBuilder = credentials.getCensusBuilder()
+                    .addAuthor(author.forge().currentUser().id())
+                    .addReviewer(reviewer.forge().currentUser().id());
+            var seedFolder = tempFolder.path().resolve("seed");
+            var prBot = PullRequestBot.newBuilder()
+                    .repo(author)
+                    .censusRepo(censusBuilder.build())
+                    .censusLink("https://census.com/{{contributor}}-profile")
+                    .seedStorage(seedFolder)
+                    .enableMerge(false)
+                    .build();
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "Merge dev");
+
+            // Check the status
+            TestBotRunner.runPeriodicItems(prBot);
+
+            var comment = pr.store().comments().get(pr.store().comments().size() - 1);
+            assertEquals(1, pr.store().comments().size());
+            assertTrue(comment.body().contains("merge PR is not allowed in this repository"));
+
+            pr.setTitle("Merge test:dev");
+            TestBotRunner.runPeriodicItems(prBot);
+            comment = pr.store().comments().get(pr.store().comments().size() - 1);
+            assertEquals(1, pr.store().comments().size());
+            assertTrue(comment.body().contains("merge PR is not allowed in this repository"));
+
+            pr.setTitle("SKARA-123");
+            TestBotRunner.runPeriodicItems(prBot);
+            assertEquals(0, pr.store().comments().size());
+        }
+    }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -2875,17 +2875,17 @@ class CheckTests {
 
             var comment = pr.store().comments().get(pr.store().comments().size() - 1);
             assertEquals(1, pr.store().comments().size());
-            assertTrue(comment.body().contains("merge PR is not allowed in this repository"));
+            assertTrue(comment.body().contains("Merge-style pull requests are not allowed in this repository"));
 
             pr.setTitle("Merge test:dev");
             TestBotRunner.runPeriodicItems(prBot);
             comment = pr.store().comments().get(pr.store().comments().size() - 1);
             assertEquals(1, pr.store().comments().size());
-            assertTrue(comment.body().contains("merge PR is not allowed in this repository"));
+            assertTrue(comment.body().contains("Merge-style pull requests are not allowed in this repository"));
 
             pr.setTitle("SKARA-123");
             TestBotRunner.runPeriodicItems(prBot);
-            assertEquals(0, pr.store().comments().size());
+            assertEquals(1, pr.store().comments().size());
         }
     }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestBotFactoryTest.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestBotFactoryTest.java
@@ -68,6 +68,7 @@ class PullRequestBotFactoryTest {
                           "censuslink": "https://test.test.com",
                           "issues": "TEST",
                           "csr": true,
+                          "merge": false,
                           "two-reviewers": [
                             "rfr"
                           ],
@@ -85,6 +86,7 @@ class PullRequestBotFactoryTest {
                           "censuslink": "https://test.test.com",
                           "issues": "TEST2",
                           "csr": true,
+                          "merge": true,
                           "two-reviewers": [
                             "rfr"
                           ],
@@ -165,6 +167,15 @@ class PullRequestBotFactoryTest {
             assertTrue(pullRequestBot1.reviewCleanBackport());
             assertTrue(pullRequestBot1.reviewMerge());
             assertEquals("mlbridge[bot]", pullRequestBot1.mlbridgeBotName());
+            assertTrue(pullRequestBot1.enableMerge());
+
+            var pullRequestBot2 = (PullRequestBot) bots.get(1);
+            assertEquals("PullRequestBot@repo5", pullRequestBot2.toString());
+            assertTrue(pullRequestBot2.enableMerge());
+
+            var pullRequestBot3 = (PullRequestBot) bots.get(2);
+            assertEquals("PullRequestBot@repo2", pullRequestBot3.toString());
+            assertFalse(pullRequestBot3.enableMerge());
 
             var csrIssueBot1 = (CSRIssueBot) bots.get(3);
             assertEquals(2, csrIssueBot1.repositories().size());


### PR DESCRIPTION
In this patch, PR bot has been added with the capability to control whether merge-style pr is allowed in specific repositories.

By default, merge-style pr is enabled.

However, if it is desired to disable merge-style pr in a repo, the configuration can be added to the PR bot configuration as follows:
```
{
  "pr": {
      "repositories": {
          "repo1": {
               "merge": false
          }
       }
  }
}
```

If merge-style pr is disabled and the title of the pr matches the pattern of merge-style pr, the pr bot would reply a warning message to the user and prompt for the next steps.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1853](https://bugs.openjdk.org/browse/SKARA-1853): Make it possible to disable merge PRs for a repository


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1499/head:pull/1499` \
`$ git checkout pull/1499`

Update a local copy of the PR: \
`$ git checkout pull/1499` \
`$ git pull https://git.openjdk.org/skara.git pull/1499/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1499`

View PR using the GUI difftool: \
`$ git pr show -t 1499`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1499.diff">https://git.openjdk.org/skara/pull/1499.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1499#issuecomment-1502299516)