### PR TITLE
SKARA-1854

### DIFF
--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
@@ -86,6 +86,9 @@ class MergeTests {
             // Let the bot check the status
             TestBotRunner.runPeriodicItems(mergeBot);
 
+            // There is a merge commit at HEAD, but the merge commit is empty
+            assertTrue(pr.store().labelNames().contains("clean"));
+
             // Push it
             pr.addComment("/integrate");
             TestBotRunner.runPeriodicItems(mergeBot);
@@ -1559,6 +1562,139 @@ class MergeTests {
 
             // There should be a warning
             assertLastCommentContains(pr, "This pull request contains merges that bring in commits not present");
+        }
+    }
+
+    @Test
+    void noMergeCommitAtHead(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+
+            var author = credentials.getHostedRepository();
+            var integrator = credentials.getHostedRepository();
+            var censusBuilder = credentials.getCensusBuilder()
+                    .addCommitter(author.forge().currentUser().id())
+                    .addReviewer(integrator.forge().currentUser().id());
+            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
+
+            // Populate the projects repository
+            var localRepoFolder = tempFolder.path().resolve("localrepo");
+            var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+
+            // Make more changes in another branch
+            var otherHash1 = CheckableRepository.appendAndCommit(localRepo, "First change in other_/-1.2",
+                    "First other_/-1.2\n\nReviewed-by: integrationreviewer2");
+            localRepo.push(otherHash1, author.authenticatedUrl(), "other_/-1.2", true);
+            var otherHash2 = CheckableRepository.appendAndCommit(localRepo, "Second change in other_/-1.2",
+                    "Second other_/-1.2\n\nReviewed-by: integrationreviewer2");
+            localRepo.push(otherHash2, author.authenticatedUrl(), "other_/-1.2");
+
+            // Go back to the original master
+            localRepo.checkout(masterHash, true);
+
+            // Make a change with a corresponding PR
+            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated", StandardCharsets.UTF_8);
+            localRepo.add(unrelated);
+            var updatedMaster = localRepo.commit("Unrelated", "some", "some@one");
+            localRepo.push(updatedMaster, author.authenticatedUrl(), "master");
+
+            var pr = credentials.createPullRequest(author, "master", "other_/-1.2", "Merge " + author.name() + ":other_/-1.2");
+
+            // Let the bot check the status
+            TestBotRunner.runPeriodicItems(mergeBot);
+
+            assertTrue(pr.store().labelNames().contains("clean"));
+        }
+    }
+
+    @Test
+    void MergeCommitWithResolutionAtHead(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+
+            var author = credentials.getHostedRepository();
+            var integrator = credentials.getHostedRepository();
+            var censusBuilder = credentials.getCensusBuilder()
+                    .addCommitter(author.forge().currentUser().id())
+                    .addReviewer(integrator.forge().currentUser().id());
+            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
+
+            // Populate the projects repository
+            var localRepoFolder = tempFolder.path().resolve("localrepo");
+            var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+
+            // Make more changes in another branch
+            var otherHash1 = CheckableRepository.appendAndCommit(localRepo, "First change in other_/-1.2",
+                    "First other_/-1.2\n\nReviewed-by: integrationreviewer2");
+            localRepo.push(otherHash1, author.authenticatedUrl(), "other_/-1.2", true);
+            var otherHash2 = CheckableRepository.appendAndCommit(localRepo, "Second change in other_/-1.2",
+                    "Second other_/-1.2\n\nReviewed-by: integrationreviewer2");
+            localRepo.push(otherHash2, author.authenticatedUrl(), "other_/-1.2");
+
+            // Go back to the original master
+            localRepo.checkout(masterHash, true);
+
+            // update
+            var defaultAppendable = Files.readString(localRepo.root().resolve("appendable.txt"), StandardCharsets.UTF_8);
+            var newAppendable = "11111\n" + defaultAppendable;
+            Files.writeString(localRepo.root().resolve("appendable.txt"), newAppendable, StandardCharsets.UTF_8);
+            localRepo.add(localRepo.root().resolve("appendable.txt"));
+            localRepo.commit("xxx", "xxx", "xxx@gmail.com");
+
+            localRepo.merge(otherHash2);
+            var mergeHash = localRepo.commit("Merge commit", "some", "some@one");
+
+            localRepo.push(mergeHash, author.authenticatedUrl(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "Merge " + author.name() + ":other_/-1.2");
+
+            // Let the bot check the status
+            TestBotRunner.runPeriodicItems(mergeBot);
+
+            // There is a merge commit at HEAD and the merge commit is not empty
+            assertFalse(pr.store().labelNames().contains("clean"));
+        }
+    }
+
+    @Test
+    void EmptyMergeCommitAtHead(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+
+            var author = credentials.getHostedRepository();
+            var integrator = credentials.getHostedRepository();
+            var censusBuilder = credentials.getCensusBuilder()
+                    .addCommitter(author.forge().currentUser().id())
+                    .addReviewer(integrator.forge().currentUser().id());
+            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
+
+            // Populate the projects repository
+            var localRepoFolder = tempFolder.path().resolve("localrepo");
+            var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+
+            var feature = localRepo.branch(masterHash, "feature");
+            localRepo.checkout(feature);
+            var featureHash = CheckableRepository.appendAndCommit(localRepo);
+
+            localRepo.checkout(masterHash);
+            localRepo.merge(featureHash, Repository.FastForward.DISABLE);
+            var mergeHash = localRepo.commit("merged", "xxx", "xxx@gmail.com");
+            localRepo.push(mergeHash, author.authenticatedUrl(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "Merge " + author.name() + ":other_/-1.2");
+
+            // Let the bot check the status
+            TestBotRunner.runPeriodicItems(mergeBot);
+
+            // There is a merge commit at HEAD and the merge commit is not empty
+            assertTrue(pr.store().labelNames().contains("clean"));
         }
     }
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -182,6 +182,8 @@ public interface Repository extends ReadOnlyRepository {
     default void updateSubmodule(Submodule s) throws IOException {
         updateSubmodule(s.path());
     }
+
+    Optional<String> commitMessageBody(Hash hash);
 
     default void push(Hash hash, URI uri, String ref) throws IOException {
         push(hash, uri, ref, false);

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1725,6 +1725,14 @@ public class GitRepository implements Repository {
         } catch (Throwable t) {
             stop(p);
             throw t;
+        }
+    }
+
+    @Override
+    public Optional<String> commitMessageBody(Hash hash) {
+        try (var p = capture("git", "show", "--pretty=format:%b", hash.hex())) {
+            var res = p.await();
+            return res.status() == 0 ? Optional.of(String.join("", res.stdout())) : Optional.empty();
         }
     }
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1521,6 +1521,11 @@ public class HgRepository implements Repository {
 
     @Override
     public Commit workingTree() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<String> commitMessageBody(Hash hash) {
         throw new UnsupportedOperationException();
     }
 }


### PR DESCRIPTION
In this patch, PR bot would add clean label to Merge-style PRs if one of the following conditions is met.

1. There isn't a merge commit at HEAD. 
To verify this condition, we can simply check the number of parents that the HEAD commit has. If the HEAD commit has one parent, it is not a merge commit. However, if it has two parents, then it is considered a merge commit.

2. The merge commit at HEAD is empty(has no merge resolutions)
To verify this condition, we should be able to tell the difference between an empty merge commit and a non-empty merge commit.

Using `git show <Hash>` would help us differentiate between this two types of commits.

(1) git show output for empty merge commit
```
commit 9752b806edafbdc210db00f3099404cd8bd11edf
Merge: 982b5ad5d8b 99f8d05da93
Author: Zhao Song <zhao.song@oracle.com>
Date:   Tue Apr 11 14:26:18 2023 -0700

    Merge branch 'feature'

```

(2) git show output for non-empty merge commit
```
commit 242a0c07cf3204c662a2f1d55a2ca3e494f955fd (HEAD -> master)
Merge: af35791d093 0ebf3bd5fe1
Author: Zhao Song <zhao.song@oracle.com>
Date:   Tue Apr 11 14:38:05 2023 -0700

    Merge branch 'feature2'

diff --cc test.java
index 7c736ab8f08,09647d12eda..a3c5725e39d
--- a/test.java
+++ b/test.java
@@@ -3,4 -3,4 +3,5 @@@
  aaaaa
  +++++
  11111
 +33333
+ 22222

```

We could find that the difference between the two is whether the commit message body is empty or not.

Since we only care about commit message body, we can use the `git show --pretty=format:%b <Hash>` command to extract solely the commit message body.

