### PR TITLE
1879: Make GitRepository#isEmptyCommit be compatible with old versions of Git

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -1749,7 +1749,7 @@ public class GitRepository implements Repository {
 
     @Override
     public boolean isEmptyCommit(Hash hash) {
-        try (var p = capture("git", "show", "--diff-merges=dense-combined", "--pretty=format:%b", hash.hex())) {
+        try (var p = capture("git", "show", "--cc", "--pretty=format:%b", hash.hex())) {
             var res = p.await();
             if (res.status() != 0) {
                 return false;


### PR DESCRIPTION
In SKARA-1854, we introduced a method GitRepository#isEmptyCommit. In addition, the git show command includes the option '--diff-merges=dense-combined' in git 2.30.0. However, this option is not available in old versions of git. To ensure compatibility with old versions of Git, we should replace '--diff-merges=dense-combined' with the '--cc' option.

References:
[1]https://git-scm.com/docs/git-show/2.29.0
[2]https://git-scm.com/docs/git-show/2.30.0

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1879](https://bugs.openjdk.org/browse/SKARA-1879): Make GitRepository#isEmptyCommit be compatible with old versions of Git


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1501/head:pull/1501` \
`$ git checkout pull/1501`

Update a local copy of the PR: \
`$ git checkout pull/1501` \
`$ git pull https://git.openjdk.org/skara.git pull/1501/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1501`

View PR using the GUI difftool: \
`$ git pr show -t 1501`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1501.diff">https://git.openjdk.org/skara/pull/1501.diff</a>

</details>
