### PR TITLE
1878: Improve argument check in SKARA CLI

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/ForgeUtils.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/ForgeUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -77,7 +77,7 @@ public class ForgeUtils {
 
     public static String getOption(String name, String command, String subsection, Arguments arguments) {
         if (arguments.contains(name)) {
-            return arguments.get(name).asString();
+            return getArgument(name, arguments);
         }
 
         if (subsection != null && !subsection.isEmpty()) {
@@ -88,6 +88,31 @@ public class ForgeUtils {
         }
 
         return gitConfig(command + "." + name);
+    }
+
+    // Returning null means that this option is not displayed in the command.
+    // If this option is not followed by an argument, the program will exit and report an error.
+    public static String getOption(String name, Arguments arguments) {
+        if (arguments.contains(name)) {
+            return getArgument(name, arguments);
+        }
+        return null;
+    }
+
+    public static String getOption(String name, Arguments arguments, String defaultVal) {
+        if (arguments.contains(name)) {
+            return getArgument(name, arguments);
+        }
+        return defaultVal;
+    }
+
+    private static String getArgument(String name, Arguments arguments) {
+        var arg = arguments.get(name);
+        if (!arg.isPresent()) {
+            System.err.printf("error: a non-empty value is needed for '%s'%n", name);
+            System.exit(1);
+        }
+        return arg.asString();
     }
 
     public static boolean getSwitch(String name, String command, String subsection, Arguments arguments) {

--- a/cli/src/main/java/org/openjdk/skara/cli/GitBackport.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitBackport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,8 +24,6 @@ package org.openjdk.skara.cli;
 
 import org.openjdk.skara.args.*;
 import org.openjdk.skara.vcs.*;
-import org.openjdk.skara.forge.*;
-import org.openjdk.skara.issuetracker.Comment;
 import org.openjdk.skara.host.Credential;
 import org.openjdk.skara.version.Version;
 import org.openjdk.skara.proxy.HttpProxy;
@@ -34,16 +32,14 @@ import java.io.IOException;
 import java.net.*;
 import java.nio.file.*;
 import java.util.*;
-import java.util.function.Supplier;
 import java.util.logging.Level;
-import java.util.stream.Collectors;
 
 public class GitBackport {
     private static String getOption(String name, Arguments arguments, ReadOnlyRepository repo) throws IOException {
-        if (arguments.contains(name)) {
-            return arguments.get(name).asString();
+        var arg = ForgeUtils.getOption(name, arguments);
+        if (arg != null) {
+            return arg;
         }
-
         var lines = repo.config("backport." + name);
         return lines.size() == 1 ? lines.get(0) : null;
     }

--- a/cli/src/main/java/org/openjdk/skara/cli/GitCommitComments.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitCommitComments.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,15 +23,12 @@
 package org.openjdk.skara.cli;
 
 import org.openjdk.skara.args.*;
-import org.openjdk.skara.forge.Forge;
 import org.openjdk.skara.host.*;
-import org.openjdk.skara.vcs.Repository;
 import org.openjdk.skara.proxy.HttpProxy;
 import org.openjdk.skara.version.Version;
 
 import java.io.*;
 import java.net.URI;
-import java.nio.file.*;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.function.Supplier;
@@ -60,11 +57,7 @@ public class GitCommitComments {
     }
 
     private static String getOption(String name, Arguments arguments) {
-        if (arguments.contains(name)) {
-            return arguments.get(name).asString();
-        }
-
-        return gitConfig("cc." + name);
+        return ForgeUtils.getOption(name, "cc", null, arguments);
     }
 
     private static boolean getSwitch(String name, String subsection, Arguments arguments) {

--- a/cli/src/main/java/org/openjdk/skara/cli/GitDefpath.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitDefpath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,10 +23,8 @@
 package org.openjdk.skara.cli;
 
 import org.openjdk.skara.args.*;
-import org.openjdk.skara.forge.Forge;
 import org.openjdk.skara.host.Credential;
 import org.openjdk.skara.vcs.*;
-import org.openjdk.skara.webrev.*;
 import org.openjdk.skara.proxy.HttpProxy;
 import org.openjdk.skara.version.Version;
 
@@ -218,7 +216,7 @@ public class GitDefpath {
         }
 
         var isMercurial = arguments.contains("mercurial");
-        var remote = arguments.contains("remote") ? arguments.get("remote").asString() : null;
+        var remote = ForgeUtils.getOption("remote", arguments);
         if (remote == null) {
             var lines = repo.config("defpath.remote");
             if (lines.size() == 1) {
@@ -237,7 +235,7 @@ public class GitDefpath {
             die("error: peers cannot be specified together with -d flag");
         }
 
-        var fallback = arguments.contains("secondary") ? arguments.get("secondary").asString() : null;
+        var fallback = ForgeUtils.getOption("secondary", arguments);
         if (fallback == null) {
             var lines = repo.config("defpath.secondary");
             if (lines.size() == 1) {

--- a/cli/src/main/java/org/openjdk/skara/cli/GitFork.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitFork.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,16 +71,7 @@ public class GitFork {
     }
 
     private String getOption(String name) {
-        if (arguments.contains(name)) {
-            return arguments.get(name).asString();
-        }
-
-        var subsectionSpecific = gitConfig("fork." + sourceArg + "." + name);
-        if (subsectionSpecific != null) {
-            return subsectionSpecific;
-        }
-
-        return gitConfig("fork." + name);
+        return ForgeUtils.getOption(name, "fork", sourceArg, arguments);
     }
 
     private boolean getSwitch(String name) {

--- a/cli/src/main/java/org/openjdk/skara/cli/GitJCheck.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitJCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,11 +65,7 @@ public class GitJCheck {
     }
 
     static String getOption(String name, Arguments arguments) {
-        if (arguments.contains(name)) {
-            return arguments.get(name).asString();
-        }
-
-        return gitConfig("jcheck." + name);
+        return ForgeUtils.getOption(name, "jcheck", null, arguments);
     }
 
     static boolean getSwitch(String name, Arguments arguments) {
@@ -283,11 +279,7 @@ public class GitJCheck {
         JCheckConfiguration overridingConfig = null;
         // Using jcheck configuration in a specified rev
         if (confRev) {
-            var rev = arguments.get("conf-rev").asString();
-            if (rev == null || rev.startsWith("--")) {
-                System.err.println(String.format("error: must enter rev after --conf-rev"));
-                return 1;
-            }
+            var rev = ForgeUtils.getOption("conf-rev", arguments);
             var confCommitHash = repo.resolve(rev);
             if (confCommitHash.isEmpty()) {
                 System.err.println(String.format("error: rev %s is invalid!", rev));
@@ -316,7 +308,7 @@ public class GitJCheck {
         }
         // Using pointed file as jcheck configuration or jcheck configuration in current working tree
         else if (confFile || confWorkingTree || workingTree) {
-            var fileName = confFile ? arguments.get("conf-file").asString() : ".jcheck/conf";
+            var fileName = ForgeUtils.getOption("conf-file", arguments, ".jcheck/conf");
             try {
                 var content = Files.readAllBytes(Path.of(fileName));
                 var lines = new String(content, StandardCharsets.UTF_8).lines().toList();

--- a/cli/src/main/java/org/openjdk/skara/cli/GitPublish.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitPublish.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -119,8 +119,9 @@ public class GitPublish {
     }
 
     private static String getOption(String name, Arguments arguments, ReadOnlyRepository repo) throws IOException {
-        if (arguments.contains(name)) {
-            return arguments.get(name).asString();
+        var arg = ForgeUtils.getOption(name, arguments);
+        if (arg != null) {
+            return arg;
         }
 
         var lines = repo.config("publish." + name);

--- a/cli/src/main/java/org/openjdk/skara/cli/GitSync.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitSync.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/cli/src/main/java/org/openjdk/skara/cli/GitSync.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitSync.java
@@ -75,10 +75,10 @@ public class GitSync {
     }
 
     private String getOption(String name) throws IOException {
-        if (arguments.contains(name)) {
-            return arguments.get(name).asString();
+        var arg = ForgeUtils.getOption(name, arguments);
+        if (arg != null) {
+            return arg;
         }
-
         var lines = repo.config("sync." + name);
         return lines.size() == 1 ? lines.get(0) : null;
     }
@@ -330,29 +330,18 @@ public class GitSync {
         System.out.println("Will sync changes from " + sourceURI + " to " + targetURI);
 
         var branches = new HashSet<String>();
-        if (arguments.contains("branches")) {
-            var requested = arguments.get("branches").asString().split(",");
+        var branchesArg = getOption("branches");
+        if (branchesArg != null) {
+            var requested = branchesArg.split(",");
             for (var branch : requested) {
                 branches.add(branch.trim());
-            }
-        } else {
-            var lines = repo.config("sync.branches");
-            if (lines.size() == 1) {
-                var requested = lines.get(0).split(",");
-                for (var branch : requested) {
-                    branches.add(branch.trim());
-                }
             }
         }
 
         var ignore = Pattern.compile("pr/.*");
-        if (arguments.contains("ignore")) {
-            ignore = Pattern.compile(arguments.get("ignore").asString());
-        } else {
-            var lines = repo.config("sync.ignore");
-            if (lines.size() == 1) {
-                ignore = Pattern.compile(lines.get(0));
-            }
+        var ignoreArg = getOption("ignore");
+        if (ignoreArg != null) {
+            ignore = Pattern.compile(ignoreArg);
         }
 
         var remoteBranches = repo.remoteBranches(sourceName);

--- a/cli/src/main/java/org/openjdk/skara/cli/GitWebrev.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitWebrev.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -278,7 +278,11 @@ public class GitWebrev {
             System.exit(1);
         }
 
-        var rev = arguments.contains("rev") ? resolve(repo, arguments.get("rev").asString()) : null;
+        Hash rev = null;
+        var revArg = ForgeUtils.getOption("rev", arguments);
+        if (revArg != null) {
+            rev = resolve(repo, revArg);
+        }
         if (rev == null && !(arguments.contains("base") && arguments.contains("head"))) {
             if (isMercurial) {
                 resolve(repo, noOutgoing ? "tip" : "min(outgoing())^");
@@ -332,10 +336,18 @@ public class GitWebrev {
             }
         }
 
-        var base = arguments.contains("base") ? resolve(repo, arguments.get("base").asString()) : rev;
-        var head = arguments.contains("head") ? resolve(repo, arguments.get("head").asString()) : null;
+        var base = rev;
+        var baseArg = ForgeUtils.getOption("base", arguments);
+        if (baseArg != null) {
+            base = resolve(repo, baseArg);
+        }
+        Hash head = null;
+        var headArg = ForgeUtils.getOption("head", arguments);
+        if (headArg != null) {
+            head = resolve(repo, headArg);
+        }
 
-        var issue = arguments.contains("cr") ? arguments.get("cr").asString() : null;
+        String issue = ForgeUtils.getOption("cr", arguments);
         if (issue != null) {
             if (issue.startsWith("http")) {
                 var uri = URI.create(issue);
@@ -367,8 +379,7 @@ public class GitWebrev {
         }
         var output = Path.of(out);
 
-        var title = arguments.contains("title") ?
-            arguments.get("title").asString() : null;
+        String title = ForgeUtils.getOption("title", arguments);
         if (title == null && issue != null) {
             try {
                 var uri = new URI(issue);

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrContributor.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrContributor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,8 +23,7 @@
 package org.openjdk.skara.cli.pr;
 
 import org.openjdk.skara.args.*;
-import org.openjdk.skara.issuetracker.Comment;
-import org.openjdk.skara.forge.PullRequest;
+import org.openjdk.skara.cli.ForgeUtils;
 
 import static org.openjdk.skara.cli.pr.Utils.*;
 
@@ -74,11 +73,11 @@ public class GitPrContributor {
         var pr = getPullRequest(uri, repo, host, id);
 
         if (arguments.contains("add")) {
-            var username = arguments.get("add").asString();
+            var username = ForgeUtils.getOption("add", arguments);
             var comment = pr.addComment("/contributor add" + " " + username);
             showReply(awaitReplyTo(pr, comment));
         } else if (arguments.contains("remove")) {
-            var username = arguments.get("remove").asString();
+            var username = ForgeUtils.getOption("remove", arguments);
             var comment = pr.addComment("/contributor remove" + " " + username);
             showReply(awaitReplyTo(pr, comment));
         } else {

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrIssue.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrIssue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrIssue.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrIssue.java
@@ -23,8 +23,7 @@
 package org.openjdk.skara.cli.pr;
 
 import org.openjdk.skara.args.*;
-import org.openjdk.skara.issuetracker.Comment;
-import org.openjdk.skara.forge.PullRequest;
+import org.openjdk.skara.cli.ForgeUtils;
 
 import static org.openjdk.skara.cli.pr.Utils.*;
 
@@ -88,11 +87,11 @@ public class GitPrIssue {
         var pr = getPullRequest(uri, repo, host, id);
 
         if (arguments.contains("add")) {
-            var issueId = arguments.get("add").asString();
+            var issueId = ForgeUtils.getOption("add", arguments);
             var comment = pr.addComment("/issue add" + " " + issueId);
             showReply(awaitReplyTo(pr, comment));
         } else if (arguments.contains("remove")) {
-            var issueId = arguments.get("remove").asString();
+            var issueId = ForgeUtils.getOption("remove", arguments);
             var comment = pr.addComment("/issue remove" + " " + issueId);
             showReply(awaitReplyTo(pr, comment));
         } else if (arguments.contains("create")) {
@@ -100,8 +99,8 @@ public class GitPrIssue {
                 System.err.println("error: no component specified, use --component");
                 System.exit(1);
             }
-            var component = arguments.get("component").asString();
-            var prio = arguments.get("priority").orString("4");
+            var component = ForgeUtils.getOption("component", arguments);
+            var prio = ForgeUtils.getOption("priority", arguments, "4");
             if (!List.of("1", "2", "3", "4", "5").contains(prio)) {
                 System.err.println("error: unsupported priority: " + prio);
                 System.err.println("       Supported priorities are: 1,2,3,4,5");

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrReview.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrReview.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 package org.openjdk.skara.cli.pr;
 
 import org.openjdk.skara.args.*;
+import org.openjdk.skara.cli.ForgeUtils;
 import org.openjdk.skara.forge.Review;
 
 import static org.openjdk.skara.cli.pr.Utils.*;
@@ -82,10 +83,8 @@ public class GitPrReview {
         var id = pullRequestIdArgument(repo, arguments);
         var pr = getPullRequest(uri, repo, host, id);
 
-        var message = arguments.contains("message") ?
-            arguments.get("message").asString() :
-            null;
-        var type = arguments.get("type").asString();
+        var message = ForgeUtils.getOption("message", arguments);
+        var type = ForgeUtils.getOption("type", arguments);
         checkType(type, parser);
         if ("approve".equals(type)) {
             pr.addReview(Review.Verdict.APPROVED, message);

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrReviewer.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrReviewer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 package org.openjdk.skara.cli.pr;
 
 import org.openjdk.skara.args.*;
+import org.openjdk.skara.cli.ForgeUtils;
 
 import static org.openjdk.skara.cli.pr.Utils.*;
 
@@ -72,11 +73,11 @@ public class GitPrReviewer {
         var pr = getPullRequest(uri, repo, host, id);
 
         if (arguments.contains("credit")) {
-            var username = arguments.get("credit").asString();
+            var username = ForgeUtils.getOption("credit", arguments);
             var comment = pr.addComment("/reviewer credit" + " " + username);
             showReply(awaitReplyTo(pr, comment));
         } else if (arguments.contains("remove")) {
-            var username = arguments.get("remove").asString();
+            var username = ForgeUtils.getOption("remove", arguments);
             var comment = pr.addComment("/reviewer remove" + " " + username);
             showReply(awaitReplyTo(pr, comment));
         } else {

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrTest.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 package org.openjdk.skara.cli.pr;
 
 import org.openjdk.skara.args.*;
+import org.openjdk.skara.cli.ForgeUtils;
 
 import static org.openjdk.skara.cli.pr.Utils.*;
 
@@ -91,7 +92,7 @@ public class GitPrTest {
         } else if (arguments.contains("cancel")) {
             command += " cancel";
         } else if (arguments.contains("job")) {
-            command += arguments.get("job").asString();
+            command += ForgeUtils.getOption("job", arguments);
         }
         var testComment = pr.addComment(command);
 


### PR DESCRIPTION
Currently, if a user misuses a command, in some cases, SKARA CLI crashes and throws a stack trace, which is bad and does not provide useful information to the user. 

After investigating, I found that in many places, we don't check whether an option is followed by an argument, and it would trigger some issues.

In this patch, the program would always check the presence of an argument  before attempting to retrieve it for an option.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1878](https://bugs.openjdk.org/browse/SKARA-1878): Improve argument check in SKARA CLI


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1502/head:pull/1502` \
`$ git checkout pull/1502`

Update a local copy of the PR: \
`$ git checkout pull/1502` \
`$ git pull https://git.openjdk.org/skara.git pull/1502/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1502`

View PR using the GUI difftool: \
`$ git pr show -t 1502`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1502.diff">https://git.openjdk.org/skara/pull/1502.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1502#issuecomment-1507734950)