### PR TITLE
1885: Add method deleteDeployKeys to HostedRepository

### DIFF
--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -267,5 +267,10 @@ class InMemoryHostedRepository implements HostedRepository {
 
     @Override
     public void deleteLabel(Label label) {
+    }
+
+    @Override
+    public int deleteDeployKeys(int age) {
+        return 0;
     }
 }

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
@@ -271,7 +271,7 @@ class InMemoryHostedRepository implements HostedRepository {
     }
 
     @Override
-    public int deleteDeployKeys(Duration duration) {
+    public int deleteDeployKeys(Duration age) {
         return 0;
     }
 }

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
@@ -29,6 +29,7 @@ import org.openjdk.skara.json.JSONValue;
 import org.openjdk.skara.vcs.*;
 
 import java.net.URI;
+import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.*;
 
@@ -270,7 +271,7 @@ class InMemoryHostedRepository implements HostedRepository {
     }
 
     @Override
-    public int deleteDeployKeys(int age) {
+    public int deleteDeployKeys(Duration duration) {
         return 0;
     }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
@@ -211,8 +211,7 @@ public interface HostedRepository {
 
     /**
      * Delete deploy keys which are older than 'age' in this repository
-     * The unit of age is hour
      * The return value is the count of deleted keys
      */
-    int deleteDeployKeys(int age);
+    int deleteDeployKeys(Duration duration);
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
@@ -213,5 +213,5 @@ public interface HostedRepository {
      * Delete deploy keys which are older than 'age' in this repository
      * The return value is the count of deleted keys
      */
-    int deleteDeployKeys(Duration duration);
+    int deleteDeployKeys(Duration age);
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -208,4 +208,11 @@ public interface HostedRepository {
     default boolean isSame(HostedRepository other) {
         return name().equals(other.name()) && forge().name().equals(other.forge().name());
     }
+
+    /**
+     * Delete deploy keys which are older than 'age' in this repository
+     * The unit of age is hour
+     * The return value is the count of deleted keys
+     */
+    int deleteDeployKeys(int age);
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -730,11 +730,11 @@ public class GitHubRepository implements HostedRepository {
     }
 
     @Override
-    public int deleteDeployKeys(Duration duration) {
+    public int deleteDeployKeys(Duration age) {
         var expired = request.get("keys").execute()
                 .stream()
                 .filter(key -> ZonedDateTime.parse(key.get("created_at").asString())
-                        .isBefore(ZonedDateTime.now().minusSeconds(duration.toSeconds())))
+                        .isBefore(ZonedDateTime.now().minus(age)))
                 .toList();
         for (var key : expired) {
             request.delete("keys/" + key.get("id")).execute();

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -726,5 +726,17 @@ public class GitHubRepository implements HostedRepository {
     public void deleteLabel(Label label) {
         request.delete("labels/" + label.name())
                 .execute();
+    }
+
+    @Override
+    public int deleteDeployKeys(int age) {
+        var expired = request.get("keys").execute()
+                .stream()
+                .filter(key -> ZonedDateTime.parse(key.get("created_at").asString()).isBefore(ZonedDateTime.now().minusHours(age)))
+                .toList();
+        for (var key : expired) {
+            request.delete("keys/" + key.get("id")).execute();
+        }
+        return expired.size();
     }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -24,6 +24,7 @@ package org.openjdk.skara.forge.github;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.time.Duration;
 import java.util.regex.Matcher;
 import org.openjdk.skara.forge.*;
 import org.openjdk.skara.host.HostUser;
@@ -729,10 +730,11 @@ public class GitHubRepository implements HostedRepository {
     }
 
     @Override
-    public int deleteDeployKeys(int age) {
+    public int deleteDeployKeys(Duration duration) {
         var expired = request.get("keys").execute()
                 .stream()
-                .filter(key -> ZonedDateTime.parse(key.get("created_at").asString()).isBefore(ZonedDateTime.now().minusHours(age)))
+                .filter(key -> ZonedDateTime.parse(key.get("created_at").asString())
+                        .isBefore(ZonedDateTime.now().minusSeconds(duration.toSeconds())))
                 .toList();
         for (var key : expired) {
             request.delete("keys/" + key.get("id")).execute();

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -830,10 +830,11 @@ public class GitLabRepository implements HostedRepository {
     }
 
     @Override
-    public int deleteDeployKeys(int age) {
+    public int deleteDeployKeys(Duration duration) {
         var expiredKeys = request.get("deploy_keys").execute()
                 .stream()
-                .filter(key -> ZonedDateTime.parse(key.get("created_at").asString()).isBefore(ZonedDateTime.now().minusHours(age)))
+                .filter(key -> ZonedDateTime.parse(key.get("created_at").asString())
+                        .isBefore(ZonedDateTime.now().minusSeconds(duration.toSeconds())))
                 .toList();
         for (var key : expiredKeys) {
             request.delete("deploy_keys/" + key.get("id"))

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -830,11 +830,11 @@ public class GitLabRepository implements HostedRepository {
     }
 
     @Override
-    public int deleteDeployKeys(Duration duration) {
+    public int deleteDeployKeys(Duration age) {
         var expiredKeys = request.get("deploy_keys").execute()
                 .stream()
                 .filter(key -> ZonedDateTime.parse(key.get("created_at").asString())
-                        .isBefore(ZonedDateTime.now().minusSeconds(duration.toSeconds())))
+                        .isBefore(ZonedDateTime.now().minus(age)))
                 .toList();
         for (var key : expiredKeys) {
             request.delete("deploy_keys/" + key.get("id"))

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -827,5 +827,19 @@ public class GitLabRepository implements HostedRepository {
     public void deleteLabel(Label label) {
         request.delete("labels/" + label.name())
                 .execute();
+    }
+
+    @Override
+    public int deleteDeployKeys(int age) {
+        var expiredKeys = request.get("deploy_keys").execute()
+                .stream()
+                .filter(key -> ZonedDateTime.parse(key.get("created_at").asString()).isBefore(ZonedDateTime.now().minusHours(age)))
+                .toList();
+        for (var key : expiredKeys) {
+            request.delete("deploy_keys/" + key.get("id"))
+                    .header("Content-Type", "application/json")
+                    .execute();
+        }
+        return expiredKeys.size();
     }
 }

--- a/forge/src/test/java/org/openjdk/skara/forge/github/GitHubRestApiTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/github/GitHubRestApiTests.java
@@ -259,4 +259,12 @@ public class GitHubRestApiTests {
         var review = pr.reviews().get(0);
         assertEquals("https://git.openjdk.org/playground/pull/129#pullrequestreview-1302142525", pr.reviewUrl(review).toString());
     }
+
+    @Test
+    void testDeleteDeployKey() {
+        var githubRepoOpt = githubHost.repository("zhaosongzs/Test");
+        assumeTrue(githubRepoOpt.isPresent());
+        var githubRepo = githubRepoOpt.get();
+        githubRepo.deleteDeployKeys(24);
+    }
 }

--- a/forge/src/test/java/org/openjdk/skara/forge/github/GitHubRestApiTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/github/GitHubRestApiTests.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.skara.forge.github;
 
+import java.time.Duration;
 import java.util.Properties;
 import org.junit.jupiter.api.*;
 import org.openjdk.skara.forge.Forge;
@@ -265,6 +266,6 @@ public class GitHubRestApiTests {
         var githubRepoOpt = githubHost.repository("zhaosongzs/Test");
         assumeTrue(githubRepoOpt.isPresent());
         var githubRepo = githubRepoOpt.get();
-        githubRepo.deleteDeployKeys(24);
+        githubRepo.deleteDeployKeys(Duration.ofHours(24));
     }
 }

--- a/forge/src/test/java/org/openjdk/skara/forge/gitlab/GitLabRestApiTest.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/gitlab/GitLabRestApiTest.java
@@ -33,6 +33,7 @@ import org.openjdk.skara.vcs.Branch;
 import org.openjdk.skara.vcs.Hash;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.List;
 import java.util.Set;
 import org.openjdk.skara.vcs.git.GitRepository;
@@ -287,6 +288,6 @@ public class GitLabRestApiTest {
         var gitLabHost = new GitLabHost("gitlab", uri, false, credential, Set.of());
         var gitLabRepo = gitLabHost.repository(settings.getProperty("gitlab.repository")).orElseThrow();
 
-        gitLabRepo.deleteDeployKeys(24);
+        gitLabRepo.deleteDeployKeys(Duration.ofHours(24));
     }
 }

--- a/forge/src/test/java/org/openjdk/skara/forge/gitlab/GitLabRestApiTest.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/gitlab/GitLabRestApiTest.java
@@ -38,7 +38,6 @@ import java.util.Set;
 import org.openjdk.skara.vcs.git.GitRepository;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * To be able to run the tests, you need to remove or comment out the @Disabled annotation first.

--- a/forge/src/test/java/org/openjdk/skara/forge/gitlab/GitLabRestApiTest.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/gitlab/GitLabRestApiTest.java
@@ -38,6 +38,7 @@ import java.util.Set;
 import org.openjdk.skara.vcs.git.GitRepository;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * To be able to run the tests, you need to remove or comment out the @Disabled annotation first.
@@ -275,5 +276,18 @@ public class GitLabRestApiTest {
 
         var review = gitLabMergeRequest.reviews().get(0);
         assertEquals(settings.getProperty("review_html_url"), gitLabMergeRequest.reviewUrl(review).toString());
+    }
+
+    @Test
+    void testDeleteDeployKey() throws IOException {
+        var settings = ManualTestSettings.loadManualTestSettings();
+        var username = settings.getProperty("gitlab.user");
+        var token = settings.getProperty("gitlab.pat");
+        var credential = new Credential(username, token);
+        var uri = URIBuilder.base(settings.getProperty("gitlab.uri")).build();
+        var gitLabHost = new GitLabHost("gitlab", uri, false, credential, Set.of());
+        var gitLabRepo = gitLabHost.repository(settings.getProperty("gitlab.repository")).orElseThrow();
+
+        gitLabRepo.deleteDeployKeys(24);
     }
 }

--- a/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
@@ -435,10 +435,10 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
     }
 
     @Override
-    public int deleteDeployKeys(Duration duration) {
+    public int deleteDeployKeys(Duration age) {
         var expiredKeys = deployKeys.entrySet()
                 .stream()
-                .filter(entry -> entry.getValue().isBefore(ZonedDateTime.now().minusSeconds(duration.toSeconds())))
+                .filter(entry -> entry.getValue().isBefore(ZonedDateTime.now().minus(age)))
                 .toList();
         for (var key : expiredKeys) {
             deployKeys.remove(key.getKey());

--- a/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
@@ -35,6 +35,7 @@ import org.openjdk.skara.vcs.*;
 import java.io.*;
 import java.net.*;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.regex.Pattern;
@@ -434,10 +435,10 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
     }
 
     @Override
-    public int deleteDeployKeys(int age) {
+    public int deleteDeployKeys(Duration duration) {
         var expiredKeys = deployKeys.entrySet()
                 .stream()
-                .filter(entry -> entry.getValue().isBefore(ZonedDateTime.now().minusHours(age)))
+                .filter(entry -> entry.getValue().isBefore(ZonedDateTime.now().minusSeconds(duration.toSeconds())))
                 .toList();
         for (var key : expiredKeys) {
             deployKeys.remove(key.getKey());

--- a/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,6 +50,7 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
     private List<Label> labels = new ArrayList<>();
     private final Set<Check> checks = new HashSet<>();
     private final Set<String> protectedBranchPatterns = new HashSet<>();
+    private Map<Integer, ZonedDateTime> deployKeys = new HashMap<>();
 
     public TestHostedRepository(TestHost host, String projectName, Repository localRepository) {
         super(host, projectName);
@@ -430,5 +431,25 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
     public void deleteLabel(Label label) {
         var existingLabel = labels.stream().filter(l -> l.name().equals(label.name())).findAny();
         existingLabel.ifPresent(value -> labels.remove(value));
+    }
+
+    @Override
+    public int deleteDeployKeys(int age) {
+        var expiredKeys = deployKeys.entrySet()
+                .stream()
+                .filter(entry -> entry.getValue().isBefore(ZonedDateTime.now().minusHours(age)))
+                .toList();
+        for (var key : expiredKeys) {
+            deployKeys.remove(key.getKey());
+        }
+        return expiredKeys.size();
+    }
+
+    public void addDeployKeys(int id, ZonedDateTime createTime) {
+        deployKeys.put(id, createTime);
+    }
+
+    public Map<Integer, ZonedDateTime> deployKeys() {
+        return deployKeys;
     }
 }


### PR DESCRIPTION
The method deleteDeployKeys is designed to delete deploy keys from this repository.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1885](https://bugs.openjdk.org/browse/SKARA-1885): Add method deleteDeployKeys to HostedRepository


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1505/head:pull/1505` \
`$ git checkout pull/1505`

Update a local copy of the PR: \
`$ git checkout pull/1505` \
`$ git pull https://git.openjdk.org/skara.git pull/1505/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1505`

View PR using the GUI difftool: \
`$ git pr show -t 1505`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1505.diff">https://git.openjdk.org/skara/pull/1505.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1505#issuecomment-1515337398)