### PR TITLE
1886: Only configure CSRIssueBot for issuetrackers where we have CSR configured

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
@@ -150,18 +150,10 @@ public class PullRequestBotFactory implements BotFactory {
                                          .collect(Collectors.toSet());
                 botBuilder.twentyFourHoursLabels(labels);
             }
+            var issueString = "";
             if (repo.value().contains("issues")) {
-                var issueString = repo.value().get("issues").asString();
+                issueString = repo.value().get("issues").asString();
                 botBuilder.issueProject(configuration.issueProject(issueString));
-                var issueProject = issueProjects.get(issueString);
-                if (issueProject == null) {
-                    issueProject = configuration.issueProject(issueString);
-                    issueProjects.put(issueString, issueProject);
-                }
-                if (!repositories.containsKey(issueProject)) {
-                    repositories.put(issueProject, new ArrayList<>());
-                }
-                repositories.get(issueProject).add(repository);
             }
             if (repo.value().contains("ignorestale")) {
                 botBuilder.ignoreStaleReviews(repo.value().get("ignorestale").asBoolean());
@@ -180,7 +172,19 @@ public class PullRequestBotFactory implements BotFactory {
                 botBuilder.censusLink(repo.value().get("censuslink").asString());
             }
             if (repo.value().contains("csr")) {
-                botBuilder.enableCsr(repo.value().get("csr").asBoolean());
+                var enableCsr = repo.value().get("csr").asBoolean();
+                botBuilder.enableCsr(enableCsr);
+                if (enableCsr && !issueString.equals("")) {
+                    var issueProject = issueProjects.get(issueString);
+                    if (issueProject == null) {
+                        issueProject = configuration.issueProject(issueString);
+                        issueProjects.put(issueString, issueProject);
+                    }
+                    if (!repositories.containsKey(issueProject)) {
+                        repositories.put(issueProject, new ArrayList<>());
+                    }
+                    repositories.get(issueProject).add(repository);
+                }
             }
             if (repo.value().contains("jep")) {
                 botBuilder.enableJep(repo.value().get("jep").asBoolean());


### PR DESCRIPTION
As Erik said in the issue, now the PullRequestBotFactory creates a CSRIssueBot for every IssueTracker configured. It is unnecessary and would trigger some errors.

In this patch, PullRequestBotFactory only creates a CSRIssueBot for the IssueTracker which is associated with any CSR enabled repository.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1886](https://bugs.openjdk.org/browse/SKARA-1886): Only configure CSRIssueBot for issuetrackers where we have CSR configured


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1506/head:pull/1506` \
`$ git checkout pull/1506`

Update a local copy of the PR: \
`$ git checkout pull/1506` \
`$ git pull https://git.openjdk.org/skara.git pull/1506/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1506`

View PR using the GUI difftool: \
`$ git pr show -t 1506`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1506.diff">https://git.openjdk.org/skara/pull/1506.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1506#issuecomment-1516920858)