### PR TITLE
SKARA-1873

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryWorkItem.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryWorkItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -358,10 +358,6 @@ public class RepositoryWorkItem implements WorkItem {
             var history = UpdateHistory.create(tagStorageBuilder, historyPath.resolve("tags"), branchStorageBuilder, historyPath.resolve("branches"));
             var errors = new ArrayList<Throwable>();
 
-            for (var listener : listeners) {
-                errors.addAll(handleTags(localRepo, history, listener, notifierScratchPath.resolve(listener.name())));
-            }
-
             boolean hasBranchHistory = !history.isEmpty();
             for (var ref : knownRefs) {
                 if (!hasBranchHistory) {
@@ -384,6 +380,11 @@ public class RepositoryWorkItem implements WorkItem {
                 }
                 errors.addAll(handleRef(localRepo, history, ref, knownRefs, scratchPath));
             }
+
+            for (var listener : listeners) {
+                errors.addAll(handleTags(localRepo, history, listener, notifierScratchPath.resolve(listener.name())));
+            }
+
             if (!errors.isEmpty()) {
                 errors.forEach(error -> log.log(Level.WARNING, error.getMessage(), error));
                 throw new RuntimeException("Errors detected when processing repository notifications", errors.get(0));


### PR DESCRIPTION
As Erik said in the issue description, "If a new commit is integrated into a repository branch and quickly tagged, the notifier may miss updating the "Resolved In Build" field in the issue associated with that commit. This happens if the same RepositoryWorkItem instance handles both the tag and the commit, because it will handle the tag first, before a suitable backport has been created".

To solve this issue, we need to rearrange the order of handles of the tags and commits. 

I checked the logic inside the two methods and I couldn't find any problem would be introduced due to this change. But I could not guarantee that no problem would be found later.