### PR TITLE
1890: Add method deployKeyTitles

### DIFF
--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
@@ -276,7 +276,7 @@ class InMemoryHostedRepository implements HostedRepository {
     }
 
     @Override
-    public List<String> getExpiredDeployKeys(Duration age) {
+    public List<String> deployKeyTitles(Duration age) {
         return List.of();
     }
 }

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
@@ -274,4 +274,9 @@ class InMemoryHostedRepository implements HostedRepository {
     public int deleteDeployKeys(Duration age) {
         return 0;
     }
+
+    @Override
+    public List<String> getExpiredDeployKeys(Duration age) {
+        return List.of();
+    }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
@@ -218,5 +218,5 @@ public interface HostedRepository {
     /**
      * Return the titles of expired deploy keys which are older than 'age' in this repository
      */
-    List<String> getExpiredDeployKeys(Duration age);
+    List<String> deployKeyTitles(Duration age);
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
@@ -214,4 +214,9 @@ public interface HostedRepository {
      * The return value is the count of deleted keys
      */
     int deleteDeployKeys(Duration age);
+
+    /**
+     * Return the titles of expired deploy keys which are older than 'age' in this repository
+     */
+    List<String> getExpiredDeployKeys(Duration age);
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/bitbucket/BitbucketRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/bitbucket/BitbucketRepository.java
@@ -313,4 +313,9 @@ public class BitbucketRepository implements HostedRepository {
     public List<PullRequest> openPullRequestsWithTargetRef(String targetRef) {
         throw new UnsupportedOperationException();
     }
+
+    @Override
+    public List<String> deployKeyTitles(Duration age) {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -743,7 +743,7 @@ public class GitHubRepository implements HostedRepository {
     }
 
     @Override
-    public List<String> getExpiredDeployKeys(Duration age) {
+    public List<String> deployKeyTitles(Duration age) {
         var parts = name().split("/");
         var owner = parts[0];
         var name = parts[1];

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -845,7 +845,7 @@ public class GitLabRepository implements HostedRepository {
     }
 
     @Override
-    public List<String> getExpiredDeployKeys(Duration age) {
+    public List<String> deployKeyTitles(Duration age) {
         return request.get("deploy_keys").execute()
                 .stream()
                 .filter(key -> ZonedDateTime.parse(key.get("created_at").asString())

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -843,4 +843,14 @@ public class GitLabRepository implements HostedRepository {
         }
         return expiredKeys.size();
     }
+
+    @Override
+    public List<String> getExpiredDeployKeys(Duration age) {
+        return request.get("deploy_keys").execute()
+                .stream()
+                .filter(key -> ZonedDateTime.parse(key.get("created_at").asString())
+                        .isBefore(ZonedDateTime.now().minus(age)))
+                .map(key -> key.get("title").asString())
+                .toList();
+    }
 }

--- a/forge/src/test/java/org/openjdk/skara/forge/github/GitHubRestApiTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/github/GitHubRestApiTests.java
@@ -274,7 +274,7 @@ public class GitHubRestApiTests {
         var githubRepoOpt = githubHost.repository("zhaosongzs/Test");
         assumeTrue(githubRepoOpt.isPresent());
         var githubRepo = githubRepoOpt.get();
-        var expiredDeployKeys = githubRepo.getExpiredDeployKeys(Duration.ofMinutes(5));
+        var expiredDeployKeys = githubRepo.deployKeyTitles(Duration.ofMinutes(5));
         assertTrue(expiredDeployKeys.contains("Test1"));
         assertTrue(expiredDeployKeys.contains("Test2"));
     }

--- a/forge/src/test/java/org/openjdk/skara/forge/github/GitHubRestApiTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/github/GitHubRestApiTests.java
@@ -270,7 +270,7 @@ public class GitHubRestApiTests {
     }
 
     @Test
-    void testGetExpiredDeployKeys() {
+    void testDeployKeyTitles() {
         var githubRepoOpt = githubHost.repository("zhaosongzs/Test");
         assumeTrue(githubRepoOpt.isPresent());
         var githubRepo = githubRepoOpt.get();

--- a/forge/src/test/java/org/openjdk/skara/forge/github/GitHubRestApiTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/github/GitHubRestApiTests.java
@@ -268,4 +268,14 @@ public class GitHubRestApiTests {
         var githubRepo = githubRepoOpt.get();
         githubRepo.deleteDeployKeys(Duration.ofHours(24));
     }
+
+    @Test
+    void testGetExpiredDeployKeys() {
+        var githubRepoOpt = githubHost.repository("zhaosongzs/Test");
+        assumeTrue(githubRepoOpt.isPresent());
+        var githubRepo = githubRepoOpt.get();
+        var expiredDeployKeys = githubRepo.getExpiredDeployKeys(Duration.ofMinutes(5));
+        assertTrue(expiredDeployKeys.contains("Test1"));
+        assertTrue(expiredDeployKeys.contains("Test2"));
+    }
 }

--- a/forge/src/test/java/org/openjdk/skara/forge/gitlab/GitLabRestApiTest.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/gitlab/GitLabRestApiTest.java
@@ -292,7 +292,7 @@ public class GitLabRestApiTest {
     }
 
     @Test
-    void testGetExpiredDeployKeys() throws IOException {
+    void testDeployKeyTitles() throws IOException {
         var settings = ManualTestSettings.loadManualTestSettings();
         var username = settings.getProperty("gitlab.user");
         var token = settings.getProperty("gitlab.pat");

--- a/forge/src/test/java/org/openjdk/skara/forge/gitlab/GitLabRestApiTest.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/gitlab/GitLabRestApiTest.java
@@ -301,7 +301,7 @@ public class GitLabRestApiTest {
         var gitLabHost = new GitLabHost("gitlab", uri, false, credential, Set.of());
         var gitLabRepo = gitLabHost.repository(settings.getProperty("gitlab.repository")).orElseThrow();
 
-        var expiredDeployKeys = gitLabRepo.getExpiredDeployKeys(Duration.ofMinutes(5));
+        var expiredDeployKeys = gitLabRepo.deployKeyTitles(Duration.ofMinutes(5));
         assertTrue(expiredDeployKeys.contains("test1"));
     }
 }

--- a/forge/src/test/java/org/openjdk/skara/forge/gitlab/GitLabRestApiTest.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/gitlab/GitLabRestApiTest.java
@@ -290,4 +290,18 @@ public class GitLabRestApiTest {
 
         gitLabRepo.deleteDeployKeys(Duration.ofHours(24));
     }
+
+    @Test
+    void testGetExpiredDeployKeys() throws IOException {
+        var settings = ManualTestSettings.loadManualTestSettings();
+        var username = settings.getProperty("gitlab.user");
+        var token = settings.getProperty("gitlab.pat");
+        var credential = new Credential(username, token);
+        var uri = URIBuilder.base(settings.getProperty("gitlab.uri")).build();
+        var gitLabHost = new GitLabHost("gitlab", uri, false, credential, Set.of());
+        var gitLabRepo = gitLabHost.repository(settings.getProperty("gitlab.repository")).orElseThrow();
+
+        var expiredDeployKeys = gitLabRepo.getExpiredDeployKeys(Duration.ofMinutes(5));
+        assertTrue(expiredDeployKeys.contains("test1"));
+    }
 }

--- a/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
@@ -51,7 +51,7 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
     private List<Label> labels = new ArrayList<>();
     private final Set<Check> checks = new HashSet<>();
     private final Set<String> protectedBranchPatterns = new HashSet<>();
-    private Map<Integer, ZonedDateTime> deployKeys = new HashMap<>();
+    private Map<String, ZonedDateTime> deployKeys = new HashMap<>();
 
     public TestHostedRepository(TestHost host, String projectName, Repository localRepository) {
         super(host, projectName);
@@ -446,11 +446,20 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
         return expiredKeys.size();
     }
 
-    public void addDeployKeys(int id, ZonedDateTime createTime) {
-        deployKeys.put(id, createTime);
+    @Override
+    public List<String> getExpiredDeployKeys(Duration age) {
+        return deployKeys.entrySet()
+                .stream()
+                .filter(entry -> entry.getValue().isBefore(ZonedDateTime.now().minus(age)))
+                .map(Map.Entry::getKey)
+                .toList();
     }
 
-    public Map<Integer, ZonedDateTime> deployKeys() {
+    public void addDeployKeys(String title, ZonedDateTime createTime) {
+        deployKeys.put(title, createTime);
+    }
+
+    public Map<String, ZonedDateTime> deployKeys() {
         return deployKeys;
     }
 }

--- a/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
@@ -447,7 +447,7 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
     }
 
     @Override
-    public List<String> getExpiredDeployKeys(Duration age) {
+    public List<String> deployKeyTitles(Duration age) {
         return deployKeys.entrySet()
                 .stream()
                 .filter(entry -> entry.getValue().isBefore(ZonedDateTime.now().minus(age)))


### PR DESCRIPTION
Add a new method called getExpiredDeployKeys in HostedRepository

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1890](https://bugs.openjdk.org/browse/SKARA-1890): Add method deployKeyTitles (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1508/head:pull/1508` \
`$ git checkout pull/1508`

Update a local copy of the PR: \
`$ git checkout pull/1508` \
`$ git pull https://git.openjdk.org/skara.git pull/1508/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1508`

View PR using the GUI difftool: \
`$ git pr show -t 1508`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1508.diff">https://git.openjdk.org/skara/pull/1508.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1508#issuecomment-1522404760)