### PR TITLE
1892: Handle jfx cpu versions

### DIFF
--- a/jbs/src/main/java/org/openjdk/skara/jbs/Backports.java
+++ b/jbs/src/main/java/org/openjdk/skara/jbs/Backports.java
@@ -128,7 +128,8 @@ public class Backports {
      * the fixVersionList has an <N>-pool-<opt> entry.
      */
     private static boolean matchOptPoolVersion(Issue issue, JdkVersion fixVersion) {
-        var majorVersion = fixVersion.feature();
+        // Remove any trailing 'u' from the feature version as that isn't used in *-pool versions
+        var majorVersion = fixVersion.feature().replaceFirst("u$", "");
         if (fixVersion.opt().isPresent()) {
             var poolSuffix = "-pool-" + fixVersion.opt().get();
             var poolVersion = JdkVersion.parse(majorVersion + poolSuffix);
@@ -149,7 +150,8 @@ public class Backports {
      * <N>-pool entry.
      */
     private static boolean matchPoolVersion(Issue issue, JdkVersion fixVersion) {
-        var majorVersion = fixVersion.feature();
+        // Remove any trailing 'u' from the feature version as that isn't used in *-pool versions
+        var majorVersion = fixVersion.feature().replaceFirst("u$", "");
         var poolVersion = JdkVersion.parse(majorVersion + "-pool");
         // fixVersion may be something that doesn't parse into a valid pool version
         if (poolVersion.isPresent()) {

--- a/jbs/src/main/java/org/openjdk/skara/jbs/JdkVersion.java
+++ b/jbs/src/main/java/org/openjdk/skara/jbs/JdkVersion.java
@@ -39,7 +39,7 @@ public class JdkVersion implements Comparable<JdkVersion> {
     private final static Pattern prefixVersionPattern = Pattern.compile("([a-z]+[1-9][0-9]?)(u([0-9]{1,3}))?$");
 
     // Match a version string symbolizing some future, but yet undefined, update of a major version
-    private final static Pattern futureUpdatePattern = Pattern.compile("((openjdk)?[1-9][0-9]*u)(-([a-z0-9]+))?$");
+    private final static Pattern futureUpdatePattern = Pattern.compile("((openjdk|jfx)?[1-9][0-9]*u)(-([a-z0-9]+))?$");
 
     private final static Pattern prefixPattern = Pattern.compile("([a-z]+)([0-9.]+)$");
 
@@ -88,9 +88,9 @@ public class JdkVersion implements Comparable<JdkVersion> {
                 raw = raw.substring(0, optionalStart);
             }
             String prefix = null;
-            if ("jdk".equals(raw) && "cpu".equals(optional)) {
-                // Special case of jdk-cpu. This symbolic version has no set numbers
-                finalComponents.add("jdk");
+            if ("cpu".equals(optional)) {
+                // Special case of *-cpu. This symbolic version has no set numbers
+                finalComponents.add(raw);
             } else {
                 var prefixMatcher = prefixPattern.matcher(raw);
                 if (prefixMatcher.matches()) {

--- a/jbs/src/main/java/org/openjdk/skara/jbs/JdkVersion.java
+++ b/jbs/src/main/java/org/openjdk/skara/jbs/JdkVersion.java
@@ -88,7 +88,7 @@ public class JdkVersion implements Comparable<JdkVersion> {
                 raw = raw.substring(0, optionalStart);
             }
             String prefix = null;
-            if ("cpu".equals(optional)) {
+            if ("cpu".equals(optional) && raw.matches("[a-z]+")) {
                 // Special case of *-cpu. This symbolic version has no set numbers
                 finalComponents.add(raw);
             } else {

--- a/jbs/src/main/java/org/openjdk/skara/jbs/JdkVersion.java
+++ b/jbs/src/main/java/org/openjdk/skara/jbs/JdkVersion.java
@@ -39,7 +39,7 @@ public class JdkVersion implements Comparable<JdkVersion> {
     private final static Pattern prefixVersionPattern = Pattern.compile("([a-z]+[1-9][0-9]?)(u([0-9]{1,3}))?$");
 
     // Match a version string symbolizing some future, but yet undefined, update of a major version
-    private final static Pattern futureUpdatePattern = Pattern.compile("((openjdk|jfx)?[1-9][0-9]*u)(-([a-z0-9]+))?$");
+    private final static Pattern futureUpdatePattern = Pattern.compile("(([a-z])*[1-9][0-9]*u)(-([a-z0-9]+))?$");
 
     private final static Pattern prefixPattern = Pattern.compile("([a-z]+)([0-9.]+)$");
 

--- a/jbs/src/test/java/org/openjdk/skara/jbs/BackportsTests.java
+++ b/jbs/src/test/java/org/openjdk/skara/jbs/BackportsTests.java
@@ -175,6 +175,17 @@ public class BackportsTests {
             backport.setProperty("fixVersions", JSON.array().add("openjfx17-pool"));
             assertEquals(backport.id(), Backports.findIssue(issue, JdkVersion.parse("openjfx17.0.1").orElseThrow()).orElseThrow().id());
 
+            // This may not be desired behavior, but this tests illustrates the current behavior
+            // to avoid confusion.
+            backport.setProperty("fixVersions", JSON.array().add("17-pool"));
+            assertEquals(backport.id(), Backports.findIssue(issue, JdkVersion.parse("openjfx17.0.1").orElseThrow()).orElseThrow().id());
+
+            backport.setProperty("fixVersions", JSON.array().add("20-pool"));
+            assertEquals(backport.id(), Backports.findIssue(issue, JdkVersion.parse("20u-cpu").orElseThrow()).orElseThrow().id());
+
+            backport.setProperty("fixVersions", JSON.array().add("jfx20-pool"));
+            assertEquals(backport.id(), Backports.findIssue(issue, JdkVersion.parse("jfx20u-cpu").orElseThrow()).orElseThrow().id());
+
             backportFoo.setProperty("fixVersions", JSON.array().add("8-pool-foo"));
             assertEquals(backportFoo.id(), Backports.findIssue(issue, JdkVersion.parse("8u333-foo").orElseThrow()).orElseThrow().id());
 

--- a/jbs/src/test/java/org/openjdk/skara/jbs/JdkVersionTests.java
+++ b/jbs/src/test/java/org/openjdk/skara/jbs/JdkVersionTests.java
@@ -85,6 +85,9 @@ public class JdkVersionTests {
         assertEquals(List.of("16u"), jdk16uCpu.components());
         assertEquals("cpu", jdk16uCpu.opt().orElseThrow());
         assertEquals(List.of("openjdk7u"), from("openjdk7u").components());
+        var jfx20uCpu = from("jfx20u-cpu");
+        assertEquals(List.of("jfx20u"), jfx20uCpu.components());
+        assertEquals("cpu", jfx20uCpu.opt().orElseThrow());
     }
 
     @Test
@@ -92,6 +95,13 @@ public class JdkVersionTests {
         var jdkCpu = from("jdk-cpu");
         assertEquals(List.of("jdk"), jdkCpu.components());
         assertEquals("cpu", jdkCpu.opt().orElseThrow());
+    }
+
+    @Test
+    void jfxCpu() {
+        var jfxCpu = from("jfx-cpu");
+        assertEquals(List.of("jfx"), jfxCpu.components());
+        assertEquals("cpu", jfxCpu.opt().orElseThrow());
     }
 
     @Test

--- a/jbs/src/test/java/org/openjdk/skara/jbs/JdkVersionTests.java
+++ b/jbs/src/test/java/org/openjdk/skara/jbs/JdkVersionTests.java
@@ -143,7 +143,6 @@ public class JdkVersionTests {
     void nonConforming() {
         assertEquals(Optional.empty(), JdkVersion.parse("bla"));
         assertEquals(Optional.empty(), JdkVersion.parse(""));
-        assertEquals(Optional.empty(), JdkVersion.parse("foobar7u"));
     }
 
     @Test


### PR DESCRIPTION
The JdkVersion parser needs to handle versions on the form "jfx-cpu" and "jfxXXu-cpu". I chose to just accept any prefix string consisting of lower case letters.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1892](https://bugs.openjdk.org/browse/SKARA-1892): Handle jfx cpu versions


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**) ⚠️ Review applies to [bc43df18](https://git.openjdk.org/skara/pull/1509/files/bc43df18b0a8200770c9a0b37f3b5d41eaab21ae)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1509/head:pull/1509` \
`$ git checkout pull/1509`

Update a local copy of the PR: \
`$ git checkout pull/1509` \
`$ git pull https://git.openjdk.org/skara.git pull/1509/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1509`

View PR using the GUI difftool: \
`$ git pr show -t 1509`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1509.diff">https://git.openjdk.org/skara/pull/1509.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1509#issuecomment-1522336663)