### PR TITLE
1860: Make it possible to configure PR bot to jcheck all commits in "Merge PR"

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -1120,6 +1120,7 @@ class CheckRun {
         var checkBuilder = CheckBuilder.create(getJcheckName(pr), pr.headHash());
         var censusDomain = censusInstance.configuration().census().domain();
         Exception checkException = null;
+        String jcheckType = "jcheck";
 
         try {
             // Post check in-progress
@@ -1145,25 +1146,21 @@ class CheckRun {
 
                 // JCheck all commits in "Merge PR"
                 if (workItem.bot.jcheckMerge()) {
-                    var commits = localRepo.commitMetadata(localRepo.mergeBase(PullRequestUtils.targetHash(localRepo), pr.headHash()), commitHash);
+                    var commits = localRepo.commitMetadata(localRepo.mergeBase(
+                            PullRequestUtils.targetHash(localRepo), pr.headHash()), commitHash);
                     var commitHashes = commits.stream()
                             .map(CommitMetadata::hash)
                             .collect(Collectors.toSet());
                     commitHashes.remove(pr.headHash());
                     for (Hash hash : commitHashes) {
-                        try {
-                            PullRequestCheckIssueVisitor visitor = checkablePullRequest.createVisitor(hash);
-                            checkablePullRequest.executeChecks(hash, censusInstance, visitor, List.of(), hash);
-                            mergeJCheckMessage.addAll(visitor.messages().stream()
-                                    .map(StringBuilder::new)
-                                    .map(e -> e.append(" (in commit " + hash.hex() + ")"))
-                                    .map(StringBuilder::toString)
-                                    .toList());
-                        } catch (Exception e) {
-                            var message = e.getMessage() + " (exception thrown when running jcheck with commit " + hash.hex() + ")";
-                            log.warning(message);
-                            mergeJCheckMessage.add(message);
-                        }
+                        jcheckType = "merge jcheck in commit " + hash.hex();
+                        PullRequestCheckIssueVisitor visitor = checkablePullRequest.createVisitor(hash);
+                        checkablePullRequest.executeChecks(hash, censusInstance, visitor, List.of(), hash);
+                        mergeJCheckMessage.addAll(visitor.messages().stream()
+                                .map(StringBuilder::new)
+                                .map(e -> e.append(" (in commit " + hash.hex() + ")"))
+                                .map(StringBuilder::toString)
+                                .toList());
                     }
                 }
             }
@@ -1188,7 +1185,6 @@ class CheckRun {
             }
             PullRequestCheckIssueVisitor visitor = checkablePullRequest.createVisitor(checkablePullRequest.targetHash());
             boolean needUpdateAdditionalProgresses = false;
-            boolean sourceBranchJCheckConfValid = true;
             if (localHash.equals(baseHash)) {
                 if (additionalErrors.isEmpty()) {
                     additionalErrors = List.of("This PR contains no changes");
@@ -1197,26 +1193,21 @@ class CheckRun {
                 additionalErrors = List.of("This PR only contains changes already present in the target");
             } else {
                 // Determine current status
+                jcheckType = "jcheck";
                 var additionalConfiguration = AdditionalConfiguration.get(localRepo, localHash,
                         pr.repository().forge().currentUser(), comments, reviewMerge);
                 checkablePullRequest.executeChecks(localHash, censusInstance, visitor, additionalConfiguration, checkablePullRequest.targetHash());
                 // Don't need to run the second round if confOverride is set.
                 if (workItem.bot.confOverrideRepository().isEmpty() && isFileUpdated(".jcheck/conf", localHash)) {
-                    try {
-                        PullRequestCheckIssueVisitor visitor2 = checkablePullRequest.createVisitor(pr.headHash());
-                        log.info("Run jcheck again with the updated configuration");
-                        checkablePullRequest.executeChecks(localHash, censusInstance, visitor2, additionalConfiguration, pr.headHash());
-                        secondJCheckMessage.addAll(visitor2.messages().stream()
-                                .map(StringBuilder::new)
-                                .map(e -> e.append(" (failed with the updated jcheck configuration)"))
-                                .map(StringBuilder::toString)
-                                .toList());
-                    } catch (Exception e) {
-                        var message = e.getMessage() + " (exception thrown when running jcheck with updated jcheck configuration)";
-                        log.warning(message);
-                        secondJCheckMessage.add(message);
-                        sourceBranchJCheckConfValid = false;
-                    }
+                    jcheckType = "second jcheck";
+                    PullRequestCheckIssueVisitor visitor2 = checkablePullRequest.createVisitor(pr.headHash());
+                    log.info("Run jcheck again with the updated configuration");
+                    checkablePullRequest.executeChecks(localHash, censusInstance, visitor2, additionalConfiguration, pr.headHash());
+                    secondJCheckMessage.addAll(visitor2.messages().stream()
+                            .map(StringBuilder::new)
+                            .map(e -> e.append(" (failed with the updated jcheck configuration)"))
+                            .map(StringBuilder::toString)
+                            .toList());
                 }
                 additionalErrors = botSpecificChecks(isCleanBackport);
                 needUpdateAdditionalProgresses = true;
@@ -1224,7 +1215,7 @@ class CheckRun {
 
             var confFile = localRepo.lines(Path.of(".jcheck/conf"), localHash);
             JdkVersion version = null;
-            if (confFile.isPresent() && sourceBranchJCheckConfValid) {
+            if (confFile.isPresent()) {
                 var configuration = JCheckConfiguration.parse(confFile.get());
                 var versionString = configuration.general().version().orElse(null);
 
@@ -1317,7 +1308,7 @@ class CheckRun {
             log.throwing("CommitChecker", "checkStatus", e);
             newLabels.remove("ready");
             checkBuilder.metadata("invalid");
-            checkBuilder.title("Exception occurred during jcheck - the operation will be retried");
+            checkBuilder.title("Exception occurred during " + jcheckType + " - the operation will be retried");
             checkBuilder.summary(e.getMessage());
             checkBuilder.complete(false);
             checkException = e;

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -1156,7 +1156,7 @@ class CheckRun {
                             checkablePullRequest.executeChecks(hash, censusInstance, visitor, List.of(), hash);
                             mergeJCheckMessage.addAll(visitor.messages().stream()
                                     .map(StringBuilder::new)
-                                    .map(e -> e.append(" (failed when running jcheck with commit " + hash.hex() + ")"))
+                                    .map(e -> e.append(" (in commit " + hash.hex() + ")"))
                                     .map(StringBuilder::toString)
                                     .toList());
                         } catch (Exception e) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -196,13 +196,8 @@ public class CheckablePullRequest {
         }
     }
 
-    PullRequestCheckIssueVisitor createVisitor() throws IOException {
-        var checks = JCheck.checksFor(localRepo, targetHash());
-        return new PullRequestCheckIssueVisitor(checks);
-    }
-
-    PullRequestCheckIssueVisitor createVisitorUsingHeadHash() throws IOException {
-        var checks = JCheck.checksFor(localRepo, pr.headHash());
+    PullRequestCheckIssueVisitor createVisitor(Hash hash) throws IOException {
+        var checks = JCheck.checksFor(localRepo, hash);
         return new PullRequestCheckIssueVisitor(checks);
     }
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -259,7 +259,7 @@ public class IntegrateCommand implements CommandHandler {
      */
     static boolean runJcheck(PullRequest pr, CensusInstance censusInstance, List<Comment> allComments, PrintWriter reply,
                       Repository localRepo, CheckablePullRequest checkablePr, Hash localHash, boolean reviewMerge) throws IOException {
-        var issues = checkablePr.createVisitor();
+        var issues = checkablePr.createVisitor(checkablePr.targetHash());
         var additionalConfiguration = AdditionalConfiguration.get(localRepo, localHash, pr.repository().forge().currentUser(), allComments, reviewMerge);
         checkablePr.executeChecks(localHash, censusInstance, issues, additionalConfiguration, checkablePr.targetHash());
         if (!issues.messages().isEmpty()) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -69,6 +69,7 @@ class PullRequestBot implements Bot {
     private final boolean processPR;
     private final boolean processCommit;
     private final boolean enableMerge;
+    private final boolean jcheckMerge;
     private final Set<String> mergeSources;
 
     private Instant lastFullUpdate;
@@ -83,7 +84,7 @@ class PullRequestBot implements Bot {
                    String confOverrideRef, String censusLink, Map<String, HostedRepository> forks,
                    Set<String> integrators, Set<Integer> excludeCommitCommentsFrom, boolean enableCsr, boolean enableJep,
                    boolean reviewCleanBackport, String mlbridgeBotName, boolean reviewMerge, boolean processPR, boolean processCommit,
-                   boolean enableMerge, Set<String> mergeSources) {
+                   boolean enableMerge, Set<String> mergeSources, boolean jcheckMerge) {
         remoteRepo = repo;
         this.censusRepo = censusRepo;
         this.censusRef = censusRef;
@@ -115,6 +116,7 @@ class PullRequestBot implements Bot {
         this.processCommit = processCommit;
         this.enableMerge = enableMerge;
         this.mergeSources = mergeSources;
+        this.jcheckMerge = jcheckMerge;
 
         autoLabelled = new HashSet<>();
         poller = new PullRequestPoller(repo, true);
@@ -302,6 +304,10 @@ class PullRequestBot implements Bot {
 
     public boolean enableMerge() {
         return enableMerge;
+    }
+
+    public boolean jcheckMerge() {
+        return jcheckMerge;
     }
 
     public Set<String> mergeSources() {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
@@ -61,6 +61,7 @@ public class PullRequestBotBuilder {
     private boolean processPR = true;
     private boolean processCommit = true;
     private boolean enableMerge = true;
+    private boolean jcheckMerge = false;
     private Set<String> mergeSources = Set.of();
 
     PullRequestBotBuilder() {
@@ -221,6 +222,11 @@ public class PullRequestBotBuilder {
         return this;
     }
 
+    public PullRequestBotBuilder jcheckMerge(boolean jcheckMerge) {
+        this.jcheckMerge = jcheckMerge;
+        return this;
+    }
+
     public PullRequestBot build() {
         return new PullRequestBot(repo, censusRepo, censusRef, labelConfiguration,
                                   externalPullRequestCommands, externalCommitCommands,
@@ -229,6 +235,6 @@ public class PullRequestBotBuilder {
                                   allowedTargetBranches, seedStorage, confOverrideRepo, confOverrideName,
                                   confOverrideRef, censusLink, forks, integrators, excludeCommitCommentsFrom,
                                   enableCsr, enableJep, reviewCleanBackport, mlbridgeBotName, reviewMerge,
-                                  processPR, processCommit, enableMerge, mergeSources);
+                                  processPR, processCommit, enableMerge, mergeSources, jcheckMerge);
     }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
@@ -211,6 +211,9 @@ public class PullRequestBotFactory implements BotFactory {
             if (repo.value().contains("processCommit")) {
                 botBuilder.processCommit(repo.value().get("processCommit").asBoolean());
             }
+            if (repo.value().contains("jcheckMerge")) {
+                botBuilder.jcheckMerge(repo.value().get("jcheckMerge").asBoolean());
+            }
 
             if (repo.value().contains("mergeSources")) {
                 var mergeSources = repo.value().get("mergeSources").stream()

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -1350,7 +1350,7 @@ class CheckTests {
     }
 
     @Test
-    void useJCheckConfFromTargetBranch(TestInfo testInfo) throws IOException {
+    void invalidUpdatedJCheckConf(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
              var tempFolder = new TemporaryDirectory()) {
             var author = credentials.getHostedRepository();
@@ -1375,17 +1375,18 @@ class CheckTests {
             var pr = credentials.createPullRequest(author, "master", "edit",
                                                    "This is a pull request", true);
 
-            // Check the status - should *not* throw because valid .jcheck/conf from
-            // "master" branch should be used
-            TestBotRunner.runPeriodicItems(checkBot);
-            TestBotRunner.runPeriodicItems(checkBot);
-            TestBotRunner.runPeriodicItems(checkBot);
+            // Check the status - should throw because in edit hash, .jcheck/conf is updated and it will trigger second jcheck
+            assertThrows(RuntimeException.class, () -> TestBotRunner.runPeriodicItems(checkBot));
+            assertThrows(RuntimeException.class, () -> TestBotRunner.runPeriodicItems(checkBot));
+            assertThrows(RuntimeException.class, () -> TestBotRunner.runPeriodicItems(checkBot));
 
-            // Verify that the check succeeded
+            // Verify that the check failed
             var checks = pr.checks(editHash);
             assertEquals(1, checks.size());
             var check = checks.get("jcheck");
-            assertEquals(CheckStatus.SUCCESS, check.status());
+            assertEquals(CheckStatus.FAILURE, check.status());
+            assertEquals("line 0: entry must be of form 'key = value'", check.summary().get());
+            assertEquals("Exception occurred during second jcheck - the operation will be retried", check.title().get());
         }
     }
 
@@ -2777,10 +2778,15 @@ class CheckTests {
             var updateHash = localRepo.commit("make .jcheck/conf invalid", "testauthor", "ta@none.none");
             localRepo.push(updateHash, author.authenticatedUrl(), "edit", true);
 
-            TestBotRunner.runPeriodicItems(checkBot);
+            assertThrows(RuntimeException.class, () -> TestBotRunner.runPeriodicItems(checkBot));
 
-            // pr body should have the integrationBlocker for exception
-            assertTrue(pr.store().body().contains("(exception thrown when running jcheck with updated jcheck configuration)"));
+            // Verify that the check failed
+            checks = pr.checks(updateHash);
+            assertEquals(1, checks.size());
+            check = checks.get("jcheck");
+            assertEquals(CheckStatus.FAILURE, check.status());
+            assertEquals("line 18: entry must be of form 'key = value'", check.summary().get());
+            assertEquals("Exception occurred during second jcheck - the operation will be retried", check.title().get());
 
             // Restore .jcheck/conf and add whitespace issue check
             writeToCheckConf(checkConf);

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.skara.bots.pr;
 
+import org.openjdk.skara.forge.CheckStatus;
 import org.openjdk.skara.forge.Review;
 import org.openjdk.skara.issuetracker.Comment;
 import org.openjdk.skara.process.Process;
@@ -1781,14 +1782,72 @@ class MergeTests {
             pr.addComment("/integrate");
             TestBotRunner.runPeriodicItems(mergeBot);
 
-            // The bot should reply with an ok message
+            // The bot should not push the commit
             var pushed = pr.comments().stream()
                     .filter(comment -> comment.body().contains("Pushed as commit"))
                     .count();
             assertEquals(0, pushed);
 
-            assertTrue(pr.store().body().contains("Too few reviewers with at least role reviewer found (have 0, need at least 1) (failed when running jcheck with commit " + otherHash1.hex() + ")"));
-            assertTrue(pr.store().body().contains("Whitespace errors (failed when running jcheck with commit " + otherHash2.hex() + ")"));
+            assertTrue(pr.store().body().contains("Too few reviewers with at least role reviewer found (have 0, need at least 1) (in commit " + otherHash1.hex() + ")"));
+            assertTrue(pr.store().body().contains("Whitespace errors (in commit " + otherHash2.hex() + ")"));
+        }
+    }
+
+    @Test
+    void JCheckConfInvalidInOneOfTheCommits(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+
+            var author = credentials.getHostedRepository();
+            var integrator = credentials.getHostedRepository();
+            var censusBuilder = credentials.getCensusBuilder()
+                    .addCommitter(author.forge().currentUser().id())
+                    .addReviewer(integrator.forge().currentUser().id());
+            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).jcheckMerge(true).build();
+
+            // Populate the projects repository
+            var localRepoFolder = tempFolder.path().resolve("localrepo");
+            var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+
+            // Make more changes in another branch
+            var otherHash1 = CheckableRepository.appendAndCommit(localRepo, "First change in other_/-1.2",
+                    "First other_/-1.2");
+            localRepo.push(otherHash1, author.authenticatedUrl(), "other_/-1.2", true);
+
+            var confPath = localRepoFolder.resolve(".jcheck/conf");
+            Files.writeString(confPath, "Hello there!", StandardCharsets.UTF_8);
+            localRepo.add(confPath);
+            var otherHash2 = CheckableRepository.appendAndCommit(localRepo, "Second change in other_/-1.2\n\r",
+                    "Second other_/-1.2\n\nReviewed-by: integrationreviewer2");
+            localRepo.push(otherHash2, author.authenticatedUrl(), "other_/-1.2");
+
+            // Go back to the original master
+            localRepo.checkout(masterHash, true);
+
+            // Make a change with a corresponding PR
+            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated", StandardCharsets.UTF_8);
+            localRepo.add(unrelated);
+            var updatedMaster = localRepo.commit("Unrelated", "some", "some@one");
+            localRepo.merge(otherHash2);
+            localRepo.push(updatedMaster, author.authenticatedUrl(), "master");
+
+            var mergeHash = localRepo.commit("Merge commit", "some", "some@one");
+            localRepo.push(mergeHash, author.authenticatedUrl(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "Merge " + author.name() + ":other_/-1.2");
+
+            // Let the bot check the status
+            assertThrows(RuntimeException.class, () -> TestBotRunner.runPeriodicItems(mergeBot));
+
+            var checks = pr.checks(mergeHash);
+            assertEquals(1, checks.size());
+            var check = checks.get("jcheck");
+            assertEquals(CheckStatus.FAILURE, check.status());
+            assertEquals("line 0: entry must be of form 'key = value'", check.summary().get());
+            assertEquals("Exception occurred during merge jcheck in commit " + otherHash2.hex() + " - the operation will be retried",
+                    check.title().get());
         }
     }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestBotFactoryTest.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestBotFactoryTest.java
@@ -121,7 +121,8 @@ class PullRequestBotFactoryTest {
                           ],
                           "reviewCleanBackport": true,
                           "reviewMerge": true,
-                          "processPR": false
+                          "processPR": false,
+                          "jcheckMerge": true
                         },
                         "repo7": {
                           "census": "census:master",
@@ -139,7 +140,8 @@ class PullRequestBotFactoryTest {
                           ],
                           "reviewCleanBackport": true,
                           "reviewMerge": true,
-                          "processPR": false
+                          "processPR": false,
+                          "jcheckMerge": false
                         }
                       },
                       "forks": {
@@ -193,19 +195,23 @@ class PullRequestBotFactoryTest {
             assertTrue(pullRequestBot0.reviewMerge());
             assertEquals("mlbridge[bot]", pullRequestBot0.mlbridgeBotName());
             assertTrue(pullRequestBot0.enableMerge());
+            assertTrue(pullRequestBot0.jcheckMerge());
 
             var pullRequestBot1 = (PullRequestBot) bots.get(1);
             assertEquals("PullRequestBot@repo7", pullRequestBot1.toString());
+            assertFalse(pullRequestBot1.jcheckMerge());
 
             var pullRequestBot2 = (PullRequestBot) bots.get(2);
             assertEquals("PullRequestBot@repo5", pullRequestBot2.toString());
             assertTrue(pullRequestBot2.enableMerge());
+            assertFalse(pullRequestBot2.jcheckMerge());
 
             var pullRequestBot3 = (PullRequestBot) bots.get(3);
             assertEquals("PullRequestBot@repo2", pullRequestBot3.toString());
             assertFalse(pullRequestBot3.enableMerge());
             assertTrue(pullRequestBot3.mergeSources().contains("openjdk/skara"));
             assertTrue(pullRequestBot3.mergeSources().contains("openjdk/playground"));
+            assertFalse(pullRequestBot3.jcheckMerge());
 
             var csrIssueBot1 = (CSRIssueBot) bots.get(4);
             assertEquals(1, csrIssueBot1.repositories().size());


### PR DESCRIPTION
In this patch, PR bot has been added with the capability to control whether jcheck every commit in a merge PR.

By default, jcheckMerge is enabled.

However, if it is desired to enable jcheckMerge in a repo, the configuration can be added to the PR bot configuration as follows:
```
{
  "pr": {
      "repositories": {
          "repo1": {
               "jcheckMerge": true
          }
       }
  }
}
```
If jcheckMerge is true, then the pr bot would jcheck all the commits in the merge PR and if any jcheck doesn't pass, the error message will be treated as Integration blocker.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1860](https://bugs.openjdk.org/browse/SKARA-1860): Make it possible to configure PR bot to jcheck all commits in "Merge PR"


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1510/head:pull/1510` \
`$ git checkout pull/1510`

Update a local copy of the PR: \
`$ git checkout pull/1510` \
`$ git pull https://git.openjdk.org/skara.git pull/1510/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1510`

View PR using the GUI difftool: \
`$ git pr show -t 1510`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1510.diff">https://git.openjdk.org/skara/pull/1510.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1510#issuecomment-1524007706)