### PR TITLE
1669: Limit the amount of description copied into subsequent comment emails

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ReviewArchive.java
@@ -82,6 +82,8 @@ class ReviewArchive {
 
     public static final Pattern PUSHED_PATTERN = Pattern.compile("Pushed as commit ([a-f0-9]{40})\\.");
 
+    private static final int QUOTE_BODY_MAX_LENGTH = 2500;
+
     private Optional<Hash> findIntegratedHash() {
         return ignoredComments.stream()
                               .map(Comment::body)
@@ -233,6 +235,9 @@ class ReviewArchive {
     }
 
     private String quoteBody(String body) {
+        if (body.length() > QUOTE_BODY_MAX_LENGTH) {
+            body = body.substring(0, QUOTE_BODY_MAX_LENGTH) + "...";
+        }
         return Arrays.stream(body.strip().split("\\R"))
                      .map(line -> line.length() > 0 ? line.charAt(0) == '>' ? ">" + line : "> " + line : "> ")
                      .collect(Collectors.joining("\n"));

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -3889,4 +3889,98 @@ class MailingListBridgeBotTests {
             assertEquals(0, pr.comments().size());
         }
     }
+
+    @Test
+    void archiveLongBody(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory();
+             var archiveFolder = new TemporaryDirectory();
+             var webrevFolder = new TemporaryDirectory();
+             var listServer = new TestMailmanServer();
+             var webrevServer = new TestWebrevServer()) {
+            var author = credentials.getHostedRepository();
+            var archive = credentials.getHostedRepository();
+            var ignored = credentials.getHostedRepository();
+            var listAddress = EmailAddress.parse(listServer.createList("test"));
+            var censusBuilder = credentials.getCensusBuilder()
+                    .addAuthor(author.forge().currentUser().id());
+            var from = EmailAddress.from("test", "test@test.mail");
+            var mlBot = MailingListBridgeBot.newBuilder()
+                    .from(from)
+                    .repo(author)
+                    .archive(archive)
+                    .censusRepo(censusBuilder.build())
+                    .lists(List.of(new MailingListConfiguration(listAddress, Set.of())))
+                    .ignoredUsers(Set.of(ignored.forge().currentUser().username()))
+                    .ignoredComments(Set.of())
+                    .listArchive(listServer.getArchive())
+                    .smtpServer(listServer.getSMTP())
+                    .webrevStorageHTMLRepository(archive)
+                    .webrevStorageRef("webrev")
+                    .webrevStorageBase(Path.of("test"))
+                    .webrevStorageBaseUri(webrevServer.uri())
+                    .readyLabels(Set.of("rfr"))
+                    .readyComments(Map.of(ignored.forge().currentUser().username(), Pattern.compile("ready")))
+                    .issueTracker(URIBuilder.base("http://issues.test/browse/").build())
+                    .headers(Map.of("Extra1", "val1", "Extra2", "val2"))
+                    .sendInterval(Duration.ZERO)
+                    .build();
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+            localRepo.push(masterHash, archive.authenticatedUrl(), "webrev", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo, "A simple change",
+                    "Change msg\n\nWith several lines");
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
+            var pr = credentials.createPullRequest(archive, "master", "edit", "1234: This is a pull request");
+
+            // Flag it as ready for review
+            pr.setBody("This should now be ready" + "0".repeat(10000));
+            pr.addLabel("rfr");
+
+            var ignoredPr = ignored.pullRequest(pr.id());
+
+            // Now post a ready comment
+            ignoredPr.addComment("ready");
+
+            //skara command prefixed with non-white space - should be archived
+            pr.addComment("do not ignore me /help");
+
+            //valid skara command - should not be archived
+            pr.addComment("/help");
+
+            //Invalid skara command but starting with '/' - should be archived
+            pr.addComment("/some-text & more text");
+
+            //Not a valid skara command with upper case letter - should be archived
+            pr.addComment("/Help");
+
+            // Run another archive pass
+            TestBotRunner.runPeriodicItems(mlBot);
+
+            Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
+            // Should contain truncated pr body
+            assertTrue(archiveContains(archiveFolder.path(), pr.store().body().substring(0, 2500) + "..."));
+
+            // The mailing list as well
+            listServer.processIncoming();
+            var mailmanServer = MailingListServerFactory.createMailmanServer(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
+            var mailmanList = mailmanServer.getListReader(listAddress.address());
+            var conversations = mailmanList.conversations(Duration.ofDays(1));
+            assertEquals(1, conversations.size());
+            var mail = conversations.get(0).first();
+            assertEquals("RFR: 1234: This is a pull request", mail.subject());
+            assertEquals(pr.author().fullName(), mail.author().fullName().orElseThrow());
+            assertEquals(from.address(), mail.author().address());
+            assertEquals(listAddress, mail.sender());
+            assertEquals("val1", mail.headerValue("Extra1"));
+            assertEquals("val2", mail.headerValue("Extra2"));
+            // The first mail should contain full pr body
+            assertTrue(mail.body().contains(pr.store().body()));
+        }
+    }
 }


### PR DESCRIPTION
A user complains about that sometimes the pr body can be very long and this very long pr body will be included in every email about this pr. The user will need to scroll down many times to the bottom of the email to find the useful information.

In this patch, the length of **quoted** pr body or comment is limited to 2500.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1669](https://bugs.openjdk.org/browse/SKARA-1669): Limit the amount of description copied into subsequent comment emails


### Reviewers
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1511/head:pull/1511` \
`$ git checkout pull/1511`

Update a local copy of the PR: \
`$ git checkout pull/1511` \
`$ git pull https://git.openjdk.org/skara.git pull/1511/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1511`

View PR using the GUI difftool: \
`$ git pr show -t 1511`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1511.diff">https://git.openjdk.org/skara/pull/1511.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1511#issuecomment-1536497401)