### PR TITLE
1899: Stop notifiers when the PR bot fails to retrieve issue temporarily

### DIFF
--- a/bots/common/src/main/java/org/openjdk/skara/bots/common/PullRequestConstants.java
+++ b/bots/common/src/main/java/org/openjdk/skara/bots/common/PullRequestConstants.java
@@ -32,6 +32,7 @@ public class PullRequestConstants {
     public static final String CSR_UNNEEDED_MARKER = "<!-- csr: 'unneeded' -->";
     public static final String JEP_MARKER = "<!-- jep: '%s' '%s' '%s' -->"; // <!-- jep: 'JEP-ID' 'ISSUE-ID' 'ISSUE-TITLE' -->
     public static final String WEBREV_COMMENT_MARKER = "<!-- mlbridge webrev comment -->";
+    public static final String TEMPORARY_ISSUE_FAILURE_MARKER = "<!-- temporary issue failure -->";
 
     // LABELS
     public static final String CSR_LABEL = "csr";

--- a/bots/notify/build.gradle
+++ b/bots/notify/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,6 +51,7 @@ dependencies {
     implementation project(':mailinglist')
     implementation project(':jbs')
     implementation project(':metrics')
+    implementation project(':bots:common')
 
     testImplementation project(':test')
 }

--- a/bots/notify/src/main/java/module-info.java
+++ b/bots/notify/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ module org.openjdk.skara.bots.notify {
     requires org.openjdk.skara.mailinglist;
     requires org.openjdk.skara.network;
     requires org.openjdk.skara.jbs;
+    requires org.openjdk.skara.bots.common;
     requires java.logging;
     requires java.net.http;
 

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/PullRequestWorkItem.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/PullRequestWorkItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.openjdk.skara.bot.WorkItem;
 import org.openjdk.skara.bots.notify.prbranch.PullRequestBranchNotifier;
-import org.openjdk.skara.forge.HostedBranch;
 import org.openjdk.skara.forge.PreIntegrations;
 import org.openjdk.skara.forge.PullRequest;
 import org.openjdk.skara.json.*;
@@ -41,6 +40,8 @@ import java.util.*;
 import java.util.function.Consumer;
 import java.util.regex.*;
 import java.util.stream.*;
+
+import static org.openjdk.skara.bots.common.PullRequestConstants.*;
 
 public class PullRequestWorkItem implements WorkItem {
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots.notify");
@@ -229,6 +230,10 @@ public class PullRequestWorkItem implements WorkItem {
     @Override
     public Collection<WorkItem> run(Path scratchPath) {
         if (!isOfInterest(pr)) {
+            return List.of();
+        }
+        if (pr.body().contains(TEMPORARY_ISSUE_FAILURE_MARKER)) {
+            log.warning("Found temporary issue failure, the notifiers will be stopped until the temporary issue failure resolved.");
             return List.of();
         }
         var historyPath = scratchPath.resolve("notify").resolve("history");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -717,6 +717,7 @@ class CheckRun {
                         progressBody.append("⚠️ Temporary failure when trying to retrieve information on issue `");
                         progressBody.append(currentIssue.id());
                         progressBody.append("`.");
+                        progressBody.append(TEMPORARY_ISSUE_FAILURE_MARKER);
                         setExpiration(Duration.ofMinutes(30));
                     }
                 }


### PR DESCRIPTION
A user reported that skara bot was editing the links in [JDK-8306027](https://bugs.openjdk.org/browse/JDK-8306027) and generated many mail spam.

As Erik said, [JDK-8306781](https://bugs.openjdk.org/browse/JDK-8306781) is the CSR of JDK-8306027. JDK-8306781 was updated few hours ago and it triggered CSRIssueWorkItem to update the pull request(https://github.com/openjdk/jdk/pull/13661). However, when updating the pr, the bot failed to retrieve JDK-8306027 and printed "⚠️ Temporary failure when trying to retrieve information on issue 8306027" in the pr body. This update of PR body triggered PullRequestWorkItem in NotifyBot and make issueNotifier to update links to PR issues.

To resolve this issue, I think we could stop the notifiers when the bot finds temporary issue failure.

Once the temporary issue failure has been resolved, the pr body will be updated again and it will trigger the notifiers to work.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1899](https://bugs.openjdk.org/browse/SKARA-1899): Stop notifiers when the PR bot fails to retrieve issue temporarily


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1512/head:pull/1512` \
`$ git checkout pull/1512`

Update a local copy of the PR: \
`$ git checkout pull/1512` \
`$ git pull https://git.openjdk.org/skara.git pull/1512/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1512`

View PR using the GUI difftool: \
`$ git pr show -t 1512`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1512.diff">https://git.openjdk.org/skara/pull/1512.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1512#issuecomment-1535311566)