### PR TITLE
1340: Correct email domain not always used when adding a contributor to a PR

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ContributorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ContributorCommand.java
@@ -87,7 +87,7 @@ public class ContributorCommand implements CommandHandler {
         }
 
         if (contributor.fullName().isPresent()) {
-            return Optional.of(EmailAddress.from(contributor.fullName().get(), contributor.username() + "@" + censusInstance.configuration.census().domain()));
+            return Optional.of(EmailAddress.from(contributor.fullName().get(), contributor.username() + "@" + censusInstance.configuration().census().domain()));
         } else {
             reply.println("`" + user + "` does not have a full name recorded in the census.");
             return Optional.empty();

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ContributorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ContributorCommand.java
@@ -87,7 +87,8 @@ public class ContributorCommand implements CommandHandler {
         }
 
         if (contributor.fullName().isPresent()) {
-            return Optional.of(EmailAddress.from(contributor.fullName().get(), contributor.username() + "@" + censusInstance.configuration().census().domain()));
+            return Optional.of(EmailAddress.from(contributor.fullName().get(), contributor.username() + "@" +
+                    censusInstance.configuration().census().domain()));
         } else {
             reply.println("`" + user + "` does not have a full name recorded in the census.");
             return Optional.empty();

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ContributorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ContributorCommand.java
@@ -87,7 +87,7 @@ public class ContributorCommand implements CommandHandler {
         }
 
         if (contributor.fullName().isPresent()) {
-            return Optional.of(EmailAddress.from(contributor.fullName().get(), contributor.username() + "@openjdk.org"));
+            return Optional.of(EmailAddress.from(contributor.fullName().get(), contributor.username() + "@" + censusInstance.configuration.census().domain()));
         } else {
             reply.println("`" + user + "` does not have a full name recorded in the census.");
             return Optional.empty();


### PR DESCRIPTION
Now, the email domain for additional contributors is always the default "openjdk.org" domain because we hardcoded it.

To resolve this issue, we should use the domain in jcheck configuration file.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1340](https://bugs.openjdk.org/browse/SKARA-1340): Correct email domain not always used when adding a contributor to a PR


### Reviewers
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer) ⚠️ Review applies to [b2bc9c37](https://git.openjdk.org/skara/pull/1513/files/b2bc9c375fe7f27dba51255bd48919397cdf9717)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to [bf623cfa](https://git.openjdk.org/skara/pull/1513/files/bf623cfa0201ecf74fa9d2e3cf42335269518a3d)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1513/head:pull/1513` \
`$ git checkout pull/1513`

Update a local copy of the PR: \
`$ git checkout pull/1513` \
`$ git pull https://git.openjdk.org/skara.git pull/1513/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1513`

View PR using the GUI difftool: \
`$ git pr show -t 1513`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1513.diff">https://git.openjdk.org/skara/pull/1513.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1513#issuecomment-1536591219)