### PR TITLE
1902: Log response code when response body cannot be parsed

### DIFF
--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
@@ -219,7 +219,8 @@ public class BotRunner {
                     EXCEPTIONS_COUNTER.labels(item.botName(), item.workItemName(), e.getClass().getName()).inc();
                     // Log as WARNING to avoid triggering alarms. Failed REST calls are tracked
                     // using metrics.
-                    log.log(Level.WARNING, "RestException during item execution (" + item + ")", e);
+                    log.log(Level.WARNING, "RestException during item execution (" + item + ") status code: "
+                            + e.getStatusCode(), e);
                     item.handleRuntimeException(e);
                 } catch (RuntimeException e) {
                     EXCEPTIONS_COUNTER.labels(item.botName(), item.workItemName(), e.getClass().getName()).inc();

--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
@@ -219,8 +219,8 @@ public class BotRunner {
                     EXCEPTIONS_COUNTER.labels(item.botName(), item.workItemName(), e.getClass().getName()).inc();
                     // Log as WARNING to avoid triggering alarms. Failed REST calls are tracked
                     // using metrics.
-                    log.log(Level.WARNING, "RestException during item execution (" + item + ") status code: "
-                            + e.getStatusCode(), e);
+                    log.log(Level.WARNING, "RestException during item execution (" + item + "): "
+                            + e.getMessage(), e);
                     item.handleRuntimeException(e);
                 } catch (RuntimeException e) {
                     EXCEPTIONS_COUNTER.labels(item.botName(), item.workItemName(), e.getClass().getName()).inc();

--- a/network/src/main/java/org/openjdk/skara/network/RestRequest.java
+++ b/network/src/main/java/org/openjdk/skara/network/RestRequest.java
@@ -366,7 +366,11 @@ public class RestRequest {
         if (response.body().isEmpty()) {
             return JSON.of();
         }
-        return JSON.parse(response.body());
+        try {
+            return JSON.parse(response.body());
+        } catch (RuntimeException e) {
+            throw new UncheckedRestException("Failed to parse response", e, response.statusCode());
+        }
     }
 
     private Optional<JSONValue> transformBadResponse(HttpResponse<String> response, QueryBuilder queryBuilder) {
@@ -380,7 +384,7 @@ public class RestRequest {
             log.warning("Request returned bad status: " + response.statusCode());
             log.info(queryBuilder.toString());
             log.info(response.body());
-            throw new UncheckedRestException("Request returned bad status: " + response.statusCode(), response.statusCode());
+            throw new UncheckedRestException(response.statusCode());
         } else {
             return Optional.empty();
         }
@@ -523,7 +527,7 @@ public class RestRequest {
         var response = sendRequest(request, queryBuilder.skipLimiter);
         responseCounter.labels(Integer.toString(response.statusCode()), Boolean.toString(false)).inc();
         if (response.statusCode() >= 400) {
-            throw new UncheckedRestException("Bad response: " + response.statusCode(), response.statusCode());
+            throw new UncheckedRestException(response.statusCode());
         }
         return response.body();
     }

--- a/network/src/main/java/org/openjdk/skara/network/UncheckedRestException.java
+++ b/network/src/main/java/org/openjdk/skara/network/UncheckedRestException.java
@@ -30,8 +30,12 @@ package org.openjdk.skara.network;
 public class UncheckedRestException extends RuntimeException {
     int statusCode;
 
-    public UncheckedRestException(String message, int statusCode) {
-        super(message);
+    public UncheckedRestException(int statusCode) {
+        this("Request returned bad status", null, statusCode);
+    }
+
+    public UncheckedRestException(String message, Throwable cause, int statusCode) {
+        super("[" +statusCode + "] " + message, cause);
         this.statusCode = statusCode;
     }
 


### PR DESCRIPTION
This patch adds better logging of response status codes when things fail.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1902](https://bugs.openjdk.org/browse/SKARA-1902): Log response code when response body cannot be parsed


### Reviewers
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - Committer) ⚠️ Review applies to [7a480353](https://git.openjdk.org/skara/pull/1514/files/7a480353061048bcb378a6071d23360f62ada768)
 * [Erik Helin](https://openjdk.org/census#ehelin) (@edvbld - **Reviewer**) ⚠️ Review applies to [7a480353](https://git.openjdk.org/skara/pull/1514/files/7a480353061048bcb378a6071d23360f62ada768)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1514/head:pull/1514` \
`$ git checkout pull/1514`

Update a local copy of the PR: \
`$ git checkout pull/1514` \
`$ git pull https://git.openjdk.org/skara.git pull/1514/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1514`

View PR using the GUI difftool: \
`$ git pr show -t 1514`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1514.diff">https://git.openjdk.org/skara/pull/1514.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1514#issuecomment-1536818287)