### PR TITLE
1332: Skara sometimes fails to detect that a backport was clean

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -838,7 +838,7 @@ public class GitLabMergeRequest implements PullRequest {
 
     @Override
     public Diff diff() {
-        var changes = request.get("changes").execute();
+        var changes = request.get("changes").param("access_raw_diffs", "true").execute();
         var targetHash = repository.branchHash(targetRef()).orElseThrow();
         return repository.toDiff(targetHash, headHash(), changes.get("changes"));
     }


### PR DESCRIPTION
The pr bot sometimes fails to detect a backport is clean.

This issue for GitHub part was resolved by Guoxiong Li in [SKARA-1406](https://bugs.openjdk.org/browse/SKARA-1406).

This issue for GitLab part will be resolved in this patch.

Investigated some GitLab MR examples, I found that although the GitLab UI shows there are diffs in some files, when the bot queries changes of the pr, GitLab would tell the bot there are no diffs in some files. 

After reading the GitLab Api document, I found that we should set `access_raw_diffs` to `true` to get all the diffs.

https://docs.gitlab.com/ee/api/merge_requests.html#get-single-merge-request-changes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1332](https://bugs.openjdk.org/browse/SKARA-1332): Skara sometimes fails to detect that a backport was clean


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1515/head:pull/1515` \
`$ git checkout pull/1515`

Update a local copy of the PR: \
`$ git checkout pull/1515` \
`$ git pull https://git.openjdk.org/skara.git pull/1515/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1515`

View PR using the GUI difftool: \
`$ git pr show -t 1515`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1515.diff">https://git.openjdk.org/skara/pull/1515.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1515#issuecomment-1538963719)