### PR TITLE
1903: Verify User's repository access when processing backport command

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
@@ -397,7 +397,7 @@ public class BackportCommand implements CommandHandler {
             hasGroupMembership = targetRepo.canPush(user);
         }
         if (!hasGroupMembership) {
-            reply.println("The backport can not be created because you don't have group membership in the target repository!");
+            reply.println("The backport can not be created because you don't have access to the target repository.");
         }
         return hasGroupMembership;
     }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
@@ -69,7 +69,7 @@ public class BackportCommand implements CommandHandler {
             + " ([how to associate your GitHub account with your OpenJDK username]"
             + "(https://wiki.openjdk.org/display/skara#Skara-AssociatingyourGitHubaccountandyourOpenJDKusername)).";
 
-    private static final String REPO_ACCESS_WARNING = "The backport can not be created because you don't have access to the target repository.";
+    private static final String INSUFFICIENT_ACCESS_WARNING = "The backport can not be created because you don't have access to the target repository.";
 
     @Override
     public void handle(PullRequestBot bot, PullRequest pr, CensusInstance censusInstance, ScratchArea scratchArea, CommandInvocation command,
@@ -123,8 +123,8 @@ public class BackportCommand implements CommandHandler {
             }
             var targetBranchName = targetBranch.name();
 
-            if (!targetRepo.hasRepoAccess(command.user())) {
-                reply.println(REPO_ACCESS_WARNING);
+            if (!targetRepo.canCreatePullRequest(command.user())) {
+                reply.println(INSUFFICIENT_ACCESS_WARNING);
                 return;
             }
 
@@ -240,8 +240,8 @@ public class BackportCommand implements CommandHandler {
             }
         }
 
-        if (!targetRepo.hasRepoAccess(realUser)) {
-            reply.println(REPO_ACCESS_WARNING);
+        if (!targetRepo.canCreatePullRequest(realUser)) {
+            reply.println(INSUFFICIENT_ACCESS_WARNING);
             return;
         }
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
@@ -121,6 +121,10 @@ public class BackportCommand implements CommandHandler {
             }
             var targetBranchName = targetBranch.name();
 
+            if (!verifyGroupMembership(targetRepo, command.user(), reply)) {
+                return;
+            }
+
             // Add label
             var backportLabel = generateBackportLabel(targetRepoName, targetBranchName);
             if (pr.labelNames().contains(backportLabel)) {
@@ -231,6 +235,10 @@ public class BackportCommand implements CommandHandler {
                     return;
                 }
             }
+        }
+
+        if (!verifyGroupMembership(targetRepo, realUser, reply)) {
+            return;
         }
 
         try {
@@ -380,5 +388,17 @@ public class BackportCommand implements CommandHandler {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+    }
+
+    private boolean verifyGroupMembership(HostedRepository targetRepo, HostUser user, PrintWriter reply) {
+        // Only check in GitLab
+        boolean hasGroupMembership = true;
+        if (!targetRepo.forge().name().equals("GitHub") && !targetRepo.forge().name().equals("Test")) {
+            hasGroupMembership = targetRepo.canPush(user);
+        }
+        if (!hasGroupMembership) {
+            reply.println("The backport can not be created because you don't have group membership in the target repository!");
+        }
+        return hasGroupMembership;
     }
 }

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
@@ -274,4 +274,9 @@ class InMemoryHostedRepository implements HostedRepository {
     public int deleteDeployKeys(Duration age) {
         return 0;
     }
+
+    @Override
+    public boolean hasRepoAccess(HostUser user) {
+        return false;
+    }
 }

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
@@ -276,7 +276,7 @@ class InMemoryHostedRepository implements HostedRepository {
     }
 
     @Override
-    public boolean hasRepoAccess(HostUser user) {
+    public boolean canCreatePullRequest(HostUser user) {
         return false;
     }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
@@ -216,7 +216,7 @@ public interface HostedRepository {
     int deleteDeployKeys(Duration age);
 
     /**
-     * Check whether the user has access to this repository
+     * Check whether the user is allowed to create pull request in this repository
      */
-    boolean hasRepoAccess(HostUser user);
+    boolean canCreatePullRequest(HostUser user);
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
@@ -214,4 +214,9 @@ public interface HostedRepository {
      * The return value is the count of deleted keys
      */
     int deleteDeployKeys(Duration age);
+
+    /**
+     * Check whether the user has access to this repository
+     */
+    boolean hasRepoAccess(HostUser user);
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -743,7 +743,7 @@ public class GitHubRepository implements HostedRepository {
     }
 
     @Override
-    public boolean hasRepoAccess(HostUser user) {
+    public boolean canCreatePullRequest(HostUser user) {
         return true;
     }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -741,4 +741,9 @@ public class GitHubRepository implements HostedRepository {
         }
         return expired.size();
     }
+
+    @Override
+    public boolean hasRepoAccess(HostUser user) {
+        return true;
+    }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -845,7 +845,7 @@ public class GitLabRepository implements HostedRepository {
     }
 
     @Override
-    public boolean hasRepoAccess(HostUser user) {
+    public boolean canCreatePullRequest(HostUser user) {
         return canPush(user);
     }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -843,4 +843,9 @@ public class GitLabRepository implements HostedRepository {
         }
         return expiredKeys.size();
     }
+
+    @Override
+    public boolean hasRepoAccess(HostUser user) {
+        return canPush(user);
+    }
 }

--- a/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
@@ -453,4 +453,9 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
     public Map<Integer, ZonedDateTime> deployKeys() {
         return deployKeys;
     }
+
+    @Override
+    public boolean hasRepoAccess(HostUser user) {
+        return true;
+    }
 }

--- a/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
@@ -455,7 +455,7 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
     }
 
     @Override
-    public boolean hasRepoAccess(HostUser user) {
+    public boolean canCreatePullRequest(HostUser user) {
         return true;
     }
 }


### PR DESCRIPTION
In GitLab, every project is under a group. If a user doesn't have access to the group, then the user will not be able to see any project under the group. 

However, when processing backport command, the bot will not verify user's group membership, so that it's possible for the bot to create a pull request that is invisible to the user. 

For example, if a user has access to "groupA" but not "groupB", then he can issue the "/backport groupB/repo2" command on one of the commits in "groupA/repo1". In this case, Skara bot would create a PR that is invisible to the user.

To fix this issue, we need to verify user's membership after we get the targetRepo. `GitLabRepository#canPush` is very helpful.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1903](https://bugs.openjdk.org/browse/SKARA-1903): Verify User's repository access when processing backport command


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1516/head:pull/1516` \
`$ git checkout pull/1516`

Update a local copy of the PR: \
`$ git checkout pull/1516` \
`$ git pull https://git.openjdk.org/skara.git pull/1516/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1516`

View PR using the GUI difftool: \
`$ git pr show -t 1516`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1516.diff">https://git.openjdk.org/skara/pull/1516.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1516#issuecomment-1540911440)