### PR TITLE
1907: PR should not be integrated with the temporary issue failure

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/PullRequestWorkItem.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/PullRequestWorkItem.java
@@ -232,7 +232,7 @@ public class PullRequestWorkItem implements WorkItem {
         if (!isOfInterest(pr)) {
             return List.of();
         }
-        if (pr.body().contains(TEMPORARY_ISSUE_FAILURE_MARKER)) {
+        if (pr.isOpen() && pr.body().contains(TEMPORARY_ISSUE_FAILURE_MARKER)) {
             log.warning("Found temporary issue failure, the notifiers will be stopped until the temporary issue failure resolved.");
             return List.of();
         }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -1257,12 +1257,14 @@ class CheckRun {
             var readyForIntegration = readyForReview &&
                                       visitor.messages().isEmpty() &&
                                       !additionalProgresses.containsValue(false) &&
-                                      integrationBlockers.isEmpty();
+                                      integrationBlockers.isEmpty() &&
+                                      !statusMessage.contains(TEMPORARY_ISSUE_FAILURE_MARKER);
             if (!reviewNeeded) {
                 // Reviews are not needed for clean backports unless this repo is configured with reviewCleanBackport enabled
                 readyForIntegration = readyForReview &&
                                       !additionalProgresses.containsValue(false) &&
-                                      integrationBlockers.isEmpty();
+                                      integrationBlockers.isEmpty() &&
+                                      !statusMessage.contains(TEMPORARY_ISSUE_FAILURE_MARKER);
             }
 
             updateMergeReadyComment(readyForIntegration, commitMessage, rebasePossible);


### PR DESCRIPTION
In SKARA-1899, we stopped all notifiers if the bot found temporary issue failure because we think it's just temporary issue failure and once the failure got resolved, the notifiers will be triggered again. However, it will introduce a new problem. If the pr is integrated when the temporary issue failure is happening, the notifiers will not be trigger again because the pr bot will not update integrated pr body.

Also, if the pr is integrated with the temporary issue failure, it would make the issue never get resolved.

In this patch, the conditions for stopping notifiers have been tightened. Besides, the pr bot would not mark a pr as ready is the pr body contains `TEMPORARY_ISSUE_FAILURE_MARKER`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1907](https://bugs.openjdk.org/browse/SKARA-1907): PR should not be integrated with the temporary issue failure


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1518/head:pull/1518` \
`$ git checkout pull/1518`

Update a local copy of the PR: \
`$ git checkout pull/1518` \
`$ git pull https://git.openjdk.org/skara.git pull/1518/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1518`

View PR using the GUI difftool: \
`$ git pr show -t 1518`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1518.diff">https://git.openjdk.org/skara/pull/1518.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1518#issuecomment-1542622385)