### PR TITLE
SKARA-1909

### DIFF
--- a/network/src/main/java/org/openjdk/skara/network/RestRequest.java
+++ b/network/src/main/java/org/openjdk/skara/network/RestRequest.java
@@ -109,6 +109,10 @@ public class RestRequest {
                 return rawBody;
             }
 
+            if (body == null && queryType == RequestType.GET && bodyParams.isEmpty()) {
+                return null;
+            }
+
             var finalBody = body == null ? JSON.object() : body.asObject();
             for (var param : bodyParams) {
                 finalBody.put(param.key, param.value);


### PR DESCRIPTION
Over the last week, we have had issues with JBS returning weird errors seemingly randomly, which has caused a lot of problems with the bots. It turns out our hosting provider has become more stringent with handling http/2 requests and no longer likes GET requests with a request body. Skara currently always fills in the body of a request, regardless of type, with an empty JSON document '{}' when the body is empty. This seems to be faulty behavior and we should let empty GET calls be empty instead.

I have been running staging with this patch over night and there were no errors.