### PR TITLE
1905: Notify graal mailing list for JVMCI related PRs

### DIFF
--- a/config/mailinglist/rules/jdk.json
+++ b/config/mailinglist/rules/jdk.json
@@ -223,6 +223,12 @@
             "test/micro/org/openjdk/bench/jdk",
             "test/micro/org/openjdk/bench/vm/lang/"
         ],
+        "graal": [
+            "src/hotspot/share/jvmci/",
+            "src/jdk.internal.vm.ci/",
+            "src/jdk.internal.vm.compiler/",
+            "src/jdk.internal.vm.compiler.management/"
+        ],
         "hotspot": [
             "doc/hotspot-.*",
             "src/hotspot/share/prims/",


### PR DESCRIPTION
Add the new `graal` label to the auto label configuration for jvmci related paths. This will include the graal-dev mailinglist in PRs touching files in those paths.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1905](https://bugs.openjdk.org/browse/SKARA-1905): Notify graal mailing list for JVMCI related PRs


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1520/head:pull/1520` \
`$ git checkout pull/1520`

Update a local copy of the PR: \
`$ git checkout pull/1520` \
`$ git pull https://git.openjdk.org/skara.git pull/1520/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1520`

View PR using the GUI difftool: \
`$ git pr show -t 1520`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1520.diff">https://git.openjdk.org/skara/pull/1520.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1520#issuecomment-1544684175)