### PR TITLE
1910: Basic support for Bitbucket as a Forge

### DIFF
--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunnerConfiguration.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunnerConfiguration.java
@@ -87,8 +87,8 @@ public class BotRunnerConfiguration {
                     try {
                         var keyContents = Files.readString(keyFile, StandardCharsets.UTF_8);
                         var pat = new Credential(github.get("app").get("id").asString() + ";" +
-                                                         github.get("app").get("installation").asString(),
-                                                 keyContents);
+                                github.get("app").get("installation").asString(),
+                                keyContents);
                         ret.put(entry.name(), Forge.from("github", uri, pat, github.asObject()));
                     } catch (IOException e) {
                         throw new ConfigurationError("Cannot find key file: " + keyFile);
@@ -99,6 +99,11 @@ public class BotRunnerConfiguration {
                 } else {
                     ret.put(entry.name(), Forge.from("github", uri, github.asObject()));
                 }
+            } else if (entry.value().contains("bitbucket")) {
+                var bitbucket = entry.value().get("bitbucket");
+                var uri = URIBuilder.base(bitbucket.get("url").asString()).build();
+                var credential = new Credential(bitbucket.get("username").asString(), bitbucket.get("pat").asString());
+                ret.put(entry.name(), Forge.from("bitbucket", uri, credential, bitbucket.asObject()));
             } else {
                 throw new ConfigurationError("Host " + entry.name());
             }

--- a/bots/mirror/src/main/java/org/openjdk/skara/bots/mirror/MirrorBotFactory.java
+++ b/bots/mirror/src/main/java/org/openjdk/skara/bots/mirror/MirrorBotFactory.java
@@ -97,7 +97,7 @@ public class MirrorBotFactory implements BotFactory {
                 throw new IllegalStateException("Branches cannot be mirrored when only tags are mirrored");
             }
 
-            log.info("Setting up mirroring from " + fromRepo.name() + "to " + toRepo.name());
+            log.info("Setting up mirroring from " + fromRepo.name() + " to " + toRepo.name());
             bots.add(new MirrorBot(storage, fromRepo, toRepo, branchPatterns, includeTags, onlyTags));
         }
         return bots;

--- a/forge/src/main/java/module-info.java
+++ b/forge/src/main/java/module-info.java
@@ -36,5 +36,8 @@ module org.openjdk.skara.forge {
 
     uses org.openjdk.skara.forge.ForgeFactory;
 
-    provides org.openjdk.skara.forge.ForgeFactory with org.openjdk.skara.forge.github.GitHubForgeFactory, org.openjdk.skara.forge.gitlab.GitLabForgeFactory;
+    provides org.openjdk.skara.forge.ForgeFactory with
+            org.openjdk.skara.forge.github.GitHubForgeFactory,
+            org.openjdk.skara.forge.gitlab.GitLabForgeFactory,
+            org.openjdk.skara.forge.bitbucket.BitbucketForgeFactory;
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/ForgeUtils.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/ForgeUtils.java
@@ -1,0 +1,51 @@
+package org.openjdk.skara.forge;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.regex.Pattern;
+
+public class ForgeUtils {
+
+    /**
+     * Adds a special ssh key configuration in the user's ssh config file.
+     * The config will only apply to the fake host userName.hostName so should
+     * not interfere with other user configurations. The caller of this method
+     * needs to use userName.hostName as host name when calling ssh.
+     */
+    public static void configureSshKey(String userName, String hostName, String sshKeyFile) {
+        var cfgPath = Path.of(System.getProperty("user.home"), ".ssh");
+        if (!Files.isDirectory(cfgPath)) {
+            try {
+                Files.createDirectories(cfgPath);
+            } catch (IOException ignored) {
+            }
+        }
+
+        var cfgFile = cfgPath.resolve("config");
+        var existing = "";
+        try {
+            existing = Files.readString(cfgFile, StandardCharsets.UTF_8);
+        } catch (IOException ignored) {
+        }
+
+        var userHost = userName + "." + hostName;
+        var existingBlock = Pattern.compile("^Match host " + Pattern.quote(userHost) + "(?:\\R[ \\t]+.*)+", Pattern.MULTILINE);
+        var existingMatcher = existingBlock.matcher(existing);
+        var filtered = existingMatcher.replaceAll("");
+        var result = "Match host " + userHost + "\n" +
+                "  Hostname " + hostName + "\n" +
+                "  PreferredAuthentications publickey\n" +
+                "  StrictHostKeyChecking no\n" +
+                "  IdentityFile " + sshKeyFile + "\n" +
+                "\n";
+
+        try {
+            Files.writeString(cfgFile, result + filtered.strip() + "\n", StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/forge/src/main/java/org/openjdk/skara/forge/bitbucket/BitbucketForgeFactory.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/bitbucket/BitbucketForgeFactory.java
@@ -31,6 +31,7 @@ import org.openjdk.skara.host.Credential;
 import org.openjdk.skara.json.JSONObject;
 
 public class BitbucketForgeFactory implements ForgeFactory {
+
     @Override
     public String name() {
         return "bitbucket";
@@ -48,18 +49,17 @@ public class BitbucketForgeFactory implements ForgeFactory {
             name = configuration.get("name").asString();
         }
         var useSsh = false;
-        if (configuration != null && configuration.contains("sshkey") && credential != null) {
+        if (configuration != null && configuration.contains("sshkey")) {
+            if (credential == null) {
+                throw new RuntimeException("Cannot use SSH without credentials");
+            }
             ForgeUtils.configureSshKey(credential.username(), uri.getHost(), configuration.get("sshkey").asString());
             useSsh = true;
         }
-        int sshport = 22;
+        int sshport = BitbucketHost.DEFAULT_SSH_PORT;
         if (configuration != null && configuration.contains("sshport")) {
             sshport = configuration.get("sshport").asInt();
         }
-        if (credential != null) {
-            return new BitbucketHost(name, uri, useSsh, sshport, credential);
-        } else {
-            return new BitbucketHost(name, uri, useSsh, sshport);
-        }
+        return new BitbucketHost(name, uri, useSsh, sshport, credential);
     }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/bitbucket/BitbucketForgeFactory.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/bitbucket/BitbucketForgeFactory.java
@@ -1,0 +1,43 @@
+package org.openjdk.skara.forge.bitbucket;
+
+import java.net.URI;
+import java.util.Set;
+import org.openjdk.skara.forge.Forge;
+import org.openjdk.skara.forge.ForgeFactory;
+import org.openjdk.skara.forge.ForgeUtils;
+import org.openjdk.skara.host.Credential;
+import org.openjdk.skara.json.JSONObject;
+
+public class BitbucketForgeFactory implements ForgeFactory {
+    @Override
+    public String name() {
+        return "bitbucket";
+    }
+
+    @Override
+    public Set<String> knownHosts() {
+        return Set.of();
+    }
+
+    @Override
+    public Forge create(URI uri, Credential credential, JSONObject configuration) {
+        var name = "Bitbucket";
+        if (configuration != null && configuration.contains("name")) {
+            name = configuration.get("name").asString();
+        }
+        var useSsh = false;
+        if (configuration != null && configuration.contains("sshkey") && credential != null) {
+            ForgeUtils.configureSshKey(credential.username(), uri.getHost(), configuration.get("sshkey").asString());
+            useSsh = true;
+        }
+        int sshport = 22;
+        if (configuration != null && configuration.contains("sshport")) {
+            sshport = configuration.get("sshport").asInt();
+        }
+        if (credential != null) {
+            return new BitbucketHost(name, uri, useSsh, sshport, credential);
+        } else {
+            return new BitbucketHost(name, uri, useSsh, sshport);
+        }
+    }
+}

--- a/forge/src/main/java/org/openjdk/skara/forge/bitbucket/BitbucketForgeFactory.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/bitbucket/BitbucketForgeFactory.java
@@ -1,10 +1,32 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
 package org.openjdk.skara.forge.bitbucket;
 
 import java.net.URI;
 import java.util.Set;
 import org.openjdk.skara.forge.Forge;
 import org.openjdk.skara.forge.ForgeFactory;
-import org.openjdk.skara.forge.ForgeUtils;
+import org.openjdk.skara.forge.internal.ForgeUtils;
 import org.openjdk.skara.host.Credential;
 import org.openjdk.skara.json.JSONObject;
 

--- a/forge/src/main/java/org/openjdk/skara/forge/bitbucket/BitbucketHost.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/bitbucket/BitbucketHost.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
 package org.openjdk.skara.forge.bitbucket;
 
 import java.net.URI;

--- a/forge/src/main/java/org/openjdk/skara/forge/bitbucket/BitbucketHost.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/bitbucket/BitbucketHost.java
@@ -32,6 +32,7 @@ import org.openjdk.skara.host.HostUser;
 import org.openjdk.skara.vcs.Hash;
 
 public class BitbucketHost implements Forge {
+    public static final int DEFAULT_SSH_PORT = 22;
     private final String name;
     private final URI uri;
     private final boolean useSsh;
@@ -44,14 +45,6 @@ public class BitbucketHost implements Forge {
         this.useSsh = useSsh;
         this.sshPort = sshPort;
         this.credential = credential;
-    }
-
-    public BitbucketHost(String name, URI uri, boolean useSsh, int sshPort) {
-        this.name = name;
-        this.uri = uri;
-        this.useSsh = useSsh;
-        this.sshPort = sshPort;
-        this.credential = null;
     }
 
     @Override
@@ -67,7 +60,7 @@ public class BitbucketHost implements Forge {
         if (credential == null) {
             throw new IllegalStateException("Cannot use ssh without user name");
         }
-        return credential.username() + "." + uri.getHost() + ((sshPort != 22) ? ":" + sshPort : "");
+        return credential.username() + "." + uri.getHost() + ((sshPort != DEFAULT_SSH_PORT) ? ":" + sshPort : "");
     }
 
     boolean useSsh() {

--- a/forge/src/main/java/org/openjdk/skara/forge/bitbucket/BitbucketHost.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/bitbucket/BitbucketHost.java
@@ -1,0 +1,93 @@
+package org.openjdk.skara.forge.bitbucket;
+
+import java.net.URI;
+import java.util.Optional;
+import org.openjdk.skara.forge.Forge;
+import org.openjdk.skara.forge.HostedCommit;
+import org.openjdk.skara.forge.HostedRepository;
+import org.openjdk.skara.host.Credential;
+import org.openjdk.skara.host.HostUser;
+import org.openjdk.skara.vcs.Hash;
+
+public class BitbucketHost implements Forge {
+    private final String name;
+    private final URI uri;
+    private final boolean useSsh;
+    private final int sshPort;
+    private final Credential credential;
+
+    public BitbucketHost(String name, URI uri, boolean useSsh, int sshPort, Credential credential) {
+        this.name = name;
+        this.uri = uri;
+        this.useSsh = useSsh;
+        this.sshPort = sshPort;
+        this.credential = credential;
+    }
+
+    public BitbucketHost(String name, URI uri, boolean useSsh, int sshPort) {
+        this.name = name;
+        this.uri = uri;
+        this.useSsh = useSsh;
+        this.sshPort = sshPort;
+        this.credential = null;
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    public URI getUri() {
+        return uri;
+    }
+
+    public String sshHostString() {
+        if (credential == null) {
+            throw new IllegalStateException("Cannot use ssh without user name");
+        }
+        return credential.username() + "." + uri.getHost() + ((sshPort != 22) ? ":" + sshPort : "");
+    }
+
+    boolean useSsh() {
+        return useSsh;
+    }
+
+    Optional<Credential> getCredential() {
+        return Optional.ofNullable(credential);
+    }
+
+    @Override
+    public Optional<HostedRepository> repository(String name) {
+        return Optional.of(new BitbucketRepository(this, name));
+    }
+
+    @Override
+    public Optional<HostedCommit> search(Hash hash, boolean includeDiffs) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isValid() {
+        return true;
+    }
+
+    @Override
+    public Optional<HostUser> user(String username) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public HostUser currentUser() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isMemberOf(String groupId, HostUser user) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String hostname() {
+        return uri.getHost();
+    }
+}

--- a/forge/src/main/java/org/openjdk/skara/forge/bitbucket/BitbucketRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/bitbucket/BitbucketRepository.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
 package org.openjdk.skara.forge.bitbucket;
 
 import java.net.URI;

--- a/forge/src/main/java/org/openjdk/skara/forge/bitbucket/BitbucketRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/bitbucket/BitbucketRepository.java
@@ -48,17 +48,17 @@ import org.openjdk.skara.vcs.Tag;
 import org.openjdk.skara.vcs.VCS;
 
 public class BitbucketRepository implements HostedRepository {
-    private final BitbucketHost bitbucketHost;
-    private final String repositoryName;
+    private final BitbucketHost host;
+    private final String name;
 
-    public BitbucketRepository(BitbucketHost bitbucketHost, String repositoryName) {
-        this.bitbucketHost = bitbucketHost;
-        this.repositoryName = repositoryName;
+    public BitbucketRepository(BitbucketHost host, String name) {
+        this.host = host;
+        this.name = name;
     }
 
     @Override
     public Forge forge() {
-        return bitbucketHost;
+        return host;
     }
 
     @Override
@@ -103,7 +103,7 @@ public class BitbucketRepository implements HostedRepository {
 
     @Override
     public String name() {
-        return repositoryName;
+        return name;
     }
 
     @Override
@@ -113,13 +113,13 @@ public class BitbucketRepository implements HostedRepository {
 
     @Override
     public URI authenticatedUrl() {
-        if (bitbucketHost.useSsh()) {
-            return URI.create("ssh://git@" + bitbucketHost.sshHostString() + "/" + repositoryName + ".git");
+        if (host.useSsh()) {
+            return URI.create("ssh://git@" + host.sshHostString() + "/" + name + ".git");
         } else {
             var builder = URIBuilder
-                    .base(bitbucketHost.getUri())
-                    .setPath("/" + repositoryName + ".git");
-            bitbucketHost.getCredential().ifPresent(cred -> builder.setAuthentication(cred.username() + ":" + cred.password()));
+                    .base(host.getUri())
+                    .setPath("/" + name + ".git");
+            host.getCredential().ifPresent(cred -> builder.setAuthentication(cred.username() + ":" + cred.password()));
             return builder.build();
         }
     }
@@ -181,7 +181,7 @@ public class BitbucketRepository implements HostedRepository {
 
     @Override
     public String namespace() {
-        return URIBuilder.base(bitbucketHost.getUri()).build().getHost();
+        return URIBuilder.base(host.getUri()).build().getHost();
     }
 
     @Override

--- a/forge/src/main/java/org/openjdk/skara/forge/bitbucket/BitbucketRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/bitbucket/BitbucketRepository.java
@@ -1,0 +1,284 @@
+package org.openjdk.skara.forge.bitbucket;
+
+import java.net.URI;
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.openjdk.skara.forge.Check;
+import org.openjdk.skara.forge.CommitComment;
+import org.openjdk.skara.forge.Forge;
+import org.openjdk.skara.forge.HostedBranch;
+import org.openjdk.skara.forge.HostedCommit;
+import org.openjdk.skara.forge.HostedRepository;
+import org.openjdk.skara.forge.PullRequest;
+import org.openjdk.skara.forge.WebHook;
+import org.openjdk.skara.forge.WorkflowStatus;
+import org.openjdk.skara.host.HostUser;
+import org.openjdk.skara.issuetracker.Label;
+import org.openjdk.skara.json.JSONValue;
+import org.openjdk.skara.network.URIBuilder;
+import org.openjdk.skara.vcs.Branch;
+import org.openjdk.skara.vcs.Hash;
+import org.openjdk.skara.vcs.ReadOnlyRepository;
+import org.openjdk.skara.vcs.Tag;
+import org.openjdk.skara.vcs.VCS;
+
+public class BitbucketRepository implements HostedRepository {
+    private final BitbucketHost bitbucketHost;
+    private final String repositoryName;
+
+    public BitbucketRepository(BitbucketHost bitbucketHost, String repositoryName) {
+        this.bitbucketHost = bitbucketHost;
+        this.repositoryName = repositoryName;
+    }
+
+    @Override
+    public Forge forge() {
+        return bitbucketHost;
+    }
+
+    @Override
+    public PullRequest createPullRequest(HostedRepository target, String targetRef, String sourceRef, String title, List<String> body, boolean draft) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public PullRequest pullRequest(String id) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<PullRequest> pullRequests() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<PullRequest> openPullRequests() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<PullRequest> pullRequestsAfter(ZonedDateTime updatedAfter) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<PullRequest> openPullRequestsAfter(ZonedDateTime updatedAfter) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<PullRequest> findPullRequestsWithComment(String author, String body) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<PullRequest> parsePullRequestUrl(String url) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String name() {
+        return repositoryName;
+    }
+
+    @Override
+    public Optional<HostedRepository> parent() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public URI authenticatedUrl() {
+        if (bitbucketHost.useSsh()) {
+            return URI.create("ssh://git@" + bitbucketHost.sshHostString() + "/" + repositoryName + ".git");
+        } else {
+            var builder = URIBuilder
+                    .base(bitbucketHost.getUri())
+                    .setPath("/" + repositoryName + ".git");
+            bitbucketHost.getCredential().ifPresent(cred -> builder.setAuthentication(cred.username() + ":" + cred.password()));
+            return builder.build();
+        }
+    }
+
+    @Override
+    public URI webUrl() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public URI nonTransformedWebUrl() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public URI webUrl(Hash hash) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public URI webUrl(Branch branch) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public URI webUrl(Tag tag) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public URI webUrl(String baseRef, String headRef) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public URI diffUrl(String prId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public VCS repositoryType() {
+        return VCS.GIT;
+    }
+
+    @Override
+    public URI url() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<String> fileContents(String filename, String ref) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void writeFileContents(String filename, String content, Branch branch, String message, String authorName, String authorEmail) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String namespace() {
+        return URIBuilder.base(bitbucketHost.getUri()).build().getHost();
+    }
+
+    @Override
+    public Optional<WebHook> parseWebHook(JSONValue body) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public HostedRepository fork() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long id() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<Hash> branchHash(String ref) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<HostedBranch> branches() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void protectBranchPattern(String pattern) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void unprotectBranchPattern(String pattern) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void deleteBranch(String ref) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<CommitComment> commitComments(Hash hash) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<CommitComment> recentCommitComments(ReadOnlyRepository localRepo, Set<Integer> excludeAuthors, List<Branch> Branches, ZonedDateTime updatedAfter) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CommitComment addCommitComment(Hash hash, String body) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateCommitComment(String id, String body) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<HostedCommit> commit(Hash hash, boolean includeDiffs) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<Check> allChecks(Hash hash) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public WorkflowStatus workflowStatus() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public URI createPullRequestUrl(HostedRepository target, String targetRef, String sourceRef) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void addCollaborator(HostUser user, boolean canPush) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean canPush(HostUser user) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void restrictPushAccess(Branch branch, HostUser users) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<Label> labels() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void addLabel(Label label) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateLabel(Label label) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void deleteLabel(Label label) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int deleteDeployKeys(Duration age) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabForgeFactory.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabForgeFactory.java
@@ -28,7 +28,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.openjdk.skara.forge.Forge;
 import org.openjdk.skara.forge.ForgeFactory;
-import org.openjdk.skara.forge.ForgeUtils;
+import org.openjdk.skara.forge.internal.ForgeUtils;
 import org.openjdk.skara.host.Credential;
 import org.openjdk.skara.json.JSONObject;
 import org.openjdk.skara.json.JSONValue;

--- a/forge/src/main/java/org/openjdk/skara/forge/internal/ForgeUtils.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/internal/ForgeUtils.java
@@ -1,4 +1,26 @@
-package org.openjdk.skara.forge;
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.forge.internal;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;


### PR DESCRIPTION
This patch adds very basic support for Bitbucket as a Forge, just enough to be able to use a Bitbucket repo as the source for mirroring.

In order to support ssh for bitbucket, I moved the `configureSshKey` method from `GitLabForgeFactory` to a new utility class, so that it could be shared more easily.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1910](https://bugs.openjdk.org/browse/SKARA-1910): Basic support for Bitbucket as a Forge


### Reviewers
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - Committer) ⚠️ Review applies to [0a81c6f6](https://git.openjdk.org/skara/pull/1521/files/0a81c6f6537e60707c38e9663393341836170433)
 * [Erik Helin](https://openjdk.org/census#ehelin) (@edvbld - **Reviewer**) ⚠️ Review applies to [0a81c6f6](https://git.openjdk.org/skara/pull/1521/files/0a81c6f6537e60707c38e9663393341836170433)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1521/head:pull/1521` \
`$ git checkout pull/1521`

Update a local copy of the PR: \
`$ git checkout pull/1521` \
`$ git pull https://git.openjdk.org/skara.git pull/1521/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1521`

View PR using the GUI difftool: \
`$ git pr show -t 1521`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1521.diff">https://git.openjdk.org/skara/pull/1521.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1521#issuecomment-1546242996)