### PR TITLE
1914: IssuePoller always returns the most recently updated issue even if it has already been handled

### DIFF
--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraHost.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraHost.java
@@ -55,7 +55,7 @@ public class JiraHost implements IssueTracker {
     /**
      * This constructor is only used by the manual test code.
      */
-    JiraHost(URI uri, String cookie) {
+    JiraHost(URI uri, String header, String value) {
         this.uri = uri;
         this.visibilityRole = null;
         this.securityLevel = null;
@@ -63,7 +63,7 @@ public class JiraHost implements IssueTracker {
         var baseApi = URIBuilder.base(uri)
                                 .appendPath("/rest/api/2/")
                                 .build();
-        request = new RestRequest(baseApi, "test", (r) -> Arrays.asList("Cookie", cookie));
+        request = new RestRequest(baseApi, "test", (r) -> Arrays.asList(header, value));
     }
 
     JiraHost(URI uri, JiraVault jiraVault) {

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraIssueTrackerFactory.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraIssueTrackerFactory.java
@@ -59,6 +59,10 @@ public class JiraIssueTrackerFactory implements IssueTrackerFactory {
      * This method is only used by the manual test code.
      */
     public IssueTracker create(URI uri, String cookie) {
-        return new JiraHost(uri, cookie);
+        return new JiraHost(uri, "Cookie", cookie);
+    }
+
+    public IssueTracker createWithPat(URI uri, String pat) {
+        return new JiraHost(uri, "Bearer", pat);
     }
 }

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraIssueTrackerFactory.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraIssueTrackerFactory.java
@@ -62,7 +62,11 @@ public class JiraIssueTrackerFactory implements IssueTrackerFactory {
         return new JiraHost(uri, "Cookie", cookie);
     }
 
+    /**
+     * Get the issue tracker according to personal access token
+     * This method is only used by the manual test code.
+     */
     public IssueTracker createWithPat(URI uri, String pat) {
-        return new JiraHost(uri, "Bearer", pat);
+        return new JiraHost(uri, "Authorization", pat);
     }
 }

--- a/issuetracker/src/test/java/org/openjdk/skara/issuetracker/jira/JiraProjectTests.java
+++ b/issuetracker/src/test/java/org/openjdk/skara/issuetracker/jira/JiraProjectTests.java
@@ -39,7 +39,7 @@ import static org.openjdk.skara.issuetracker.jira.JiraProject.JEP_NUMBER;
  * To be able to run the tests, you need to remove or comment out the @Disabled
  * annotation first.
  */
-@Disabled("Manual")
+//@Disabled("Manual")
 public class JiraProjectTests {
 
     @Test
@@ -82,5 +82,19 @@ public class JiraProjectTests {
         jiraIssue.setState(Issue.State.CLOSED);
         var jiraIssueOpt2 = jiraProject.issue(issueId);
         assertEquals(Issue.State.CLOSED, jiraIssueOpt2.get().state());
+    }
+
+    @Test
+    void testEquals() throws IOException {
+        var settings = ManualTestSettings.loadManualTestSettings();
+        var uri = URIBuilder.base("https://bugs.openjdk.org").build();
+        var pat = settings.getProperty("jira.pat");
+        var jiraHost = new JiraIssueTrackerFactory().createWithPat(uri, pat);
+        var jiraProject = jiraHost.project("SKARA");
+
+        var issue = jiraProject.issue("1914").orElseThrow();
+        var issue2 = jiraProject.issue("1914").orElseThrow();
+
+        assertEquals(issue, issue2);
     }
 }

--- a/issuetracker/src/test/java/org/openjdk/skara/issuetracker/jira/JiraProjectTests.java
+++ b/issuetracker/src/test/java/org/openjdk/skara/issuetracker/jira/JiraProjectTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openjdk.skara.issuetracker.Issue;
 import org.openjdk.skara.network.URIBuilder;
+import org.openjdk.skara.proxy.HttpProxy;
 import org.openjdk.skara.test.ManualTestSettings;
 
 import java.io.IOException;
@@ -39,7 +40,7 @@ import static org.openjdk.skara.issuetracker.jira.JiraProject.JEP_NUMBER;
  * To be able to run the tests, you need to remove or comment out the @Disabled
  * annotation first.
  */
-//@Disabled("Manual")
+@Disabled("Manual")
 public class JiraProjectTests {
 
     @Test
@@ -86,14 +87,17 @@ public class JiraProjectTests {
 
     @Test
     void testEquals() throws IOException {
-        var settings = ManualTestSettings.loadManualTestSettings();
+        HttpProxy.setup();
         var uri = URIBuilder.base("https://bugs.openjdk.org").build();
+        var settings = ManualTestSettings.loadManualTestSettings();
         var pat = settings.getProperty("jira.pat");
-        var jiraHost = new JiraIssueTrackerFactory().createWithPat(uri, pat);
-        var jiraProject = jiraHost.project("SKARA");
+        var project = settings.getProperty("jira.project");
+        var issueId = settings.getProperty("jira.issue");
+        var jiraHost = new JiraIssueTrackerFactory().createWithPat(uri, "Bearer " + pat);
+        var jiraProject = jiraHost.project(project);
 
-        var issue = jiraProject.issue("1914").orElseThrow();
-        var issue2 = jiraProject.issue("1914").orElseThrow();
+        var issue = jiraProject.issue(issueId).orElseThrow();
+        var issue2 = jiraProject.issue(issueId).orElseThrow();
 
         assertEquals(issue, issue2);
     }

--- a/json/src/main/java/org/openjdk/skara/json/JSONObject.java
+++ b/json/src/main/java/org/openjdk/skara/json/JSONObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -106,6 +106,11 @@ public class JSONObject implements JSONValue {
 
     public JSONObject putNull(String k) {
         value.put(k, JSON.of());
+        return this;
+    }
+
+    public JSONObject remove(String k) {
+        value.remove(k);
         return this;
     }
 


### PR DESCRIPTION
When I was testing with [SKARA-1912](https://bugs.openjdk.org/browse/SKARA-1912), I observed an issue in the IssuePoller. Although some updated csr issues has been handled in the previous round, the most recently updated csr issue would be returned again in the next round. Therefore, this would trigger the CSRIssueWorkItem and CheckWorkItem to update the PR very frequently. 

Erik investigated it and found the root cause. 

In the IssuePoller#updatedIssues, the poller first queries for updated issues (which may include some handled issues due to the imprecise timestamp, measured in minutes). Subsequently, the poller checks whether the issues have been really updated by comparing them with their copies using JiraIssue#equals. In this method, we compare the json of the issue with our own copy. If the issues are really updated, the poller returns them. 

Originally, the JiraIssue#equals method worked well. However, now, when the poller uses the REST API to retrieve the JSON of the issue, it includes a field called "customfield_11700," which represents the "Development" field used by Jira to display data quickly and easily in the issues. Within this field, there are various objects, such as "[SummaryItemBean@5e105688](mailto:SummaryItemBean@5e105688)." These objects change each time the poller makes a query. Therefore, even if the issue has not actually been updated, the JiraIssue#equals method will return false.

In this patch, some fields will be filtered out before comparing the jsons.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1914](https://bugs.openjdk.org/browse/SKARA-1914): IssuePoller always returns the most recently updated issue even if it has already been handled


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1522/head:pull/1522` \
`$ git checkout pull/1522`

Update a local copy of the PR: \
`$ git checkout pull/1522` \
`$ git pull https://git.openjdk.org/skara.git pull/1522/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1522`

View PR using the GUI difftool: \
`$ git pr show -t 1522`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1522.diff">https://git.openjdk.org/skara/pull/1522.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1522#issuecomment-1555064783)