### PR TITLE
SKARA-1925

### DIFF
--- a/bots/common/src/main/java/org/openjdk/skara/bots/common/CommandNameEnum.java
+++ b/bots/common/src/main/java/org/openjdk/skara/bots/common/CommandNameEnum.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
 package org.openjdk.skara.bots.common;
 
 import java.util.stream.Collectors;
@@ -11,7 +33,7 @@ public enum CommandNameEnum {
     integrate,
     sponsor,
     contributor,
-    summary,
+    summary(true),
     issue,
     solves,
     reviewers,
@@ -24,6 +46,19 @@ public enum CommandNameEnum {
     open,
     backport,
     tag;
+
+    private boolean isMultiLine = false;
+
+    CommandNameEnum() {
+    }
+
+    CommandNameEnum(boolean isMultiLine) {
+        this.isMultiLine = isMultiLine;
+    }
+
+    public boolean isMultiLine() {
+        return isMultiLine;
+    }
 
     /* Utility method for returning command names separated by provided deliminator */
     public static String commandNamesSepByDelim(String deliminator) {

--- a/bots/common/src/main/java/org/openjdk/skara/bots/common/PatternEnum.java
+++ b/bots/common/src/main/java/org/openjdk/skara/bots/common/PatternEnum.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
 package org.openjdk.skara.bots.common;
 
 import java.util.regex.Pattern;
@@ -12,7 +34,6 @@ import static java.util.regex.Pattern.compile;
 public enum PatternEnum {
 
     EXECUTION_COMMAND_PATTERN(compile("^\\s*/([a-z]+)(?:\\s+|$)(.*)?")),
-    ARCHIVAL_COMMAND_PATTERN(compile(EXECUTION_COMMAND_PATTERN.pattern.pattern(), Pattern.MULTILINE | Pattern.DOTALL)),
     COMMENT_PATTERN(compile("<!--.*?-->", DOTALL | MULTILINE));
 
     private final Pattern pattern;

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
@@ -36,7 +36,6 @@ import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static org.openjdk.skara.bots.common.PatternEnum.ARCHIVAL_COMMAND_PATTERN;
 import static org.openjdk.skara.bots.common.PatternEnum.COMMENT_PATTERN;
 
 class ArchiveMessages {
@@ -48,8 +47,7 @@ class ArchiveMessages {
         var commentMatcher = COMMENT_PATTERN.getPattern().matcher(body);
         body = commentMatcher.replaceAll("");
 
-        var commandLineMatcher = ARCHIVAL_COMMAND_PATTERN.getPattern().matcher(body);
-        body = commandLineMatcher.replaceAll("");
+        body = ArchiveWorkItem.filterOutCommands(body);
 
         body = MarkdownToText.removeFormatting(body);
         return body.strip();

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -1540,7 +1540,8 @@ class MailingListBridgeBotTests {
             pr.addComment("/integrate stuff");
             pr.addComment("the command is /hello there");
             pr.addComment("but this will be parsed\n/newline command");
-            pr.addComment("/multiline\nwill be dropped");
+            pr.addComment("/summary\nwill be dropped");
+            pr.addComment("/csr needed\nThis should not be dropped");
             TestBotRunner.runPeriodicItems(mlBot);
 
             // Run an archive pass
@@ -1563,13 +1564,14 @@ class MailingListBridgeBotTests {
             assertFalse(archiveContains(archiveFolder.path(), "/newline"));
             assertFalse(archiveContains(archiveFolder.path(), "/multiline"));
             assertFalse(archiveContains(archiveFolder.path(), "will be dropped"));
+            assertTrue(archiveContains(archiveFolder.path(), "This should not be dropped"));
 
             // There should not be consecutive empty lines due to a filtered multiline message
             var lines = archiveContents(archiveFolder.path(), "").orElseThrow();
             assertFalse(lines.contains("\n\n\n"), lines);
 
             // And a stand-alone multiline comment should not cause another mail to be sent
-            pr.addComment("/another\nmultiline\nwill not cause another mail");
+            pr.addComment("/summary\nmultiline\nwill not cause another mail");
             TestBotRunner.runPeriodicItems(mlBot);
             Repository.materialize(archiveFolder.path(), archive.authenticatedUrl(), "master");
             lines = archiveContents(archiveFolder.path(), "").orElseThrow();


### PR DESCRIPTION
A user reported that there is no email generated for this comment. 
https://github.com/openjdk/jdk/pull/14114#issuecomment-1562126987 

It is caused by the initial `/csr needed` command. 

The logic about filtering out commands from a comment differs between `ArchiveWorkItem#ignoreComment` and `CommandExtractor#extractCommands`.

In this patch, I make the logic consistent in this two methods.

1. Any line starts with '/' followed by lowercase characters will be recognized as a command line. The command line will be stripped. 
2. Check whether this command is a multiline command. If so, the following lines will be considered as arguments of the command and the argument lines will be stripped until the bot found another command line.