### PR TITLE
1932: Override abstract method canCreatePullRequest in BitbucketRepository

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/bitbucket/BitbucketRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/bitbucket/BitbucketRepository.java
@@ -303,4 +303,9 @@ public class BitbucketRepository implements HostedRepository {
     public int deleteDeployKeys(Duration age) {
         throw new UnsupportedOperationException();
     }
+
+    @Override
+    public boolean canCreatePullRequest(HostUser user) {
+        throw new UnsupportedOperationException();
+    }
 }


### PR DESCRIPTION
After integrated [SKARA-1903](https://bugs.openjdk.org/browse/SKARA-1903), the build of SKARA failed. The reason is that BitbucketRepository implements interface HostedRepository and in [SKARA-1903](https://bugs.openjdk.org/browse/SKARA-1903), a new method canCreatePullRequest was introduced in HostedRepository, so we need to override this method in BitbucketRepository.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1932](https://bugs.openjdk.org/browse/SKARA-1932): Override abstract method canCreatePullRequest in BitbucketRepository


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1525/head:pull/1525` \
`$ git checkout pull/1525`

Update a local copy of the PR: \
`$ git checkout pull/1525` \
`$ git pull https://git.openjdk.org/skara.git pull/1525/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1525`

View PR using the GUI difftool: \
`$ git pr show -t 1525`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1525.diff">https://git.openjdk.org/skara/pull/1525.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1525#issuecomment-1577177345)