### PR TITLE
1934: Update ext.py to make test compatible with Mercurial6.4

### DIFF
--- a/vcs/src/main/resources/ext.py
+++ b/vcs/src/main/resources/ext.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -339,7 +339,13 @@ def ls_tree(ui, repo, rev, **opts):
 
 @command(b'ls-remote', [], b'hg ls-remote PATH')
 def ls_remote(ui, repo, path, **opts):
-    peer = mercurial.hg.peer(ui or repo, opts, ui.expandpath(path))
+    try:
+        peer = mercurial.hg.peer(ui or repo, opts, ui.expandpath(path))
+    except:
+        from mercurial import utils
+        origsource, remote_path, branch = utils.urlutil.get_clone_path(ui, path)
+        peer = mercurial.hg.peer(repo, opts, remote_path)
+
     for branch, heads in peer.branchmap().iteritems():
         for head in heads:
             write(mercurial.node.hex(head))


### PR DESCRIPTION
Recently, I updated my mercurial  version to 6.4 and `RepositoryTests#testRemoteBranches` started to fail. 

After investigation, I found that `ui.expandpath` is deprecated and removed. To make our tests compatible with latest mercurial, we need to update method `ls_remote` in ext.py.

References:
[1]:https://www.mail-archive.com/mercurial-devel@mercurial-scm.org/msg58072.html
[2]:https://github.com/phacility/arcanist/commit/0fc22183e796fb8ac2e3a0a3f3f37aa964c6d7fa

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1934](https://bugs.openjdk.org/browse/SKARA-1934): Update ext.py to make test compatible with Mercurial6.4 (**Bug** - `"4"`)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1526/head:pull/1526` \
`$ git checkout pull/1526`

Update a local copy of the PR: \
`$ git checkout pull/1526` \
`$ git pull https://git.openjdk.org/skara.git pull/1526/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1526`

View PR using the GUI difftool: \
`$ git pr show -t 1526`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1526.diff">https://git.openjdk.org/skara/pull/1526.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1526#issuecomment-1579527916)