### PR TITLE
1935: Show issue priority as Pn rather than "n"

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -697,7 +697,7 @@ class CheckRun {
                                     if (issuePriority == null) {
                                         progressBody.append(")");
                                     } else {
-                                        progressBody.append(" - `" + issuePriority + "`)");
+                                        progressBody.append(" - P" + issuePriority.asString() + ")");
                                     }
                                     currentIssues.add(iss.get().id());
                                 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IssueBotTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IssueBotTests.java
@@ -113,7 +113,7 @@ public class IssueBotTests {
             // PR body has been updated, so the metadata for pr is also changed
             assertNotEquals(prMetadata1, prMetadata2);
             assertNotEquals(issueMetadata1, issueMetadata2);
-            assertTrue(pr.store().body().contains("(**Bug** - `\"4\"`)"));
+            assertTrue(pr.store().body().contains("(**Bug** - P4)"));
 
             // Update the PR and run issueBot first
             // There should be no update in the check
@@ -280,17 +280,17 @@ public class IssueBotTests {
             assertNotEquals(prMetadata1, prMetadata2);
             assertNotEquals(issueMetadata1, issueMetadata2);
             assertTrue(pr.store().body().contains("This is an issue (**Bug**)"));
-            assertTrue(pr.store().body().contains("This is an issue2 (**Bug** - `\"4\"`)"));
+            assertTrue(pr.store().body().contains("This is an issue2 (**Bug** - P4)"));
 
             // Update issue
             issue.setProperty("priority", JSON.of("1"));
             // Run prBot first
             TestBotRunner.runPeriodicItems(prBot);
-            assertFalse(pr.store().body().contains("This is an issue (**Bug** - `\"1\"`)"));
+            assertFalse(pr.store().body().contains("This is an issue (**Bug** - P1)"));
             // Run issueBot
             TestBotRunner.runPeriodicItems(issueBot);
-            assertTrue(pr.store().body().contains("This is an issue (**Bug** - `\"1\"`)"));
-            assertTrue(pr.store().body().contains("This is an issue2 (**Bug** - `\"4\"`)"));
+            assertTrue(pr.store().body().contains("This is an issue (**Bug** - P1)"));
+            assertTrue(pr.store().body().contains("This is an issue2 (**Bug** - P4)"));
         }
     }
 }


### PR DESCRIPTION
Show issue priority as Pn rather than "n"

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1935](https://bugs.openjdk.org/browse/SKARA-1935): Show issue priority as Pn rather than "n" (**Bug** - `"4"`)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1527/head:pull/1527` \
`$ git checkout pull/1527`

Update a local copy of the PR: \
`$ git checkout pull/1527` \
`$ git pull https://git.openjdk.org/skara.git pull/1527/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1527`

View PR using the GUI difftool: \
`$ git pr show -t 1527`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1527.diff">https://git.openjdk.org/skara/pull/1527.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1527#issuecomment-1581166805)