### PR TITLE
1936: IssueCommand would change pr title in GitLab

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IssueCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IssueCommand.java
@@ -162,7 +162,7 @@ public class IssueCommand implements CommandHandler {
             return;
         }
 
-        var titleIssue = Issue.fromStringRelaxed(pr.title());
+        var titleIssue = Issue.fromStringRelaxed(removeDraftPrefix(pr.title()));
         for (var issue : validatedIssues) {
             if (titleIssue.isEmpty()) {
                 reply.print("The primary solved issue for a PR is set through the PR title. Since the current title does ");
@@ -183,6 +183,11 @@ public class IssueCommand implements CommandHandler {
                 reply.println("Adding additional issue to " + name + " list: `" + issue.toShortString() + "`.");
             }
         }
+    }
+
+    private String removeDraftPrefix(String title) {
+        String pattern = "(?i)^draft:?\\s*";
+        return title.replaceAll(pattern, "");
     }
 
     private void removeIssue(PullRequestBot bot, String args, Set<String> currentSolved, PrintWriter reply) throws InvalidIssue {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IssueCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IssueCommand.java
@@ -162,7 +162,7 @@ public class IssueCommand implements CommandHandler {
             return;
         }
 
-        var titleIssue = Issue.fromStringRelaxed(removeDraftPrefix(pr.title()));
+        var titleIssue = Issue.fromStringRelaxed(pr.title());
         for (var issue : validatedIssues) {
             if (titleIssue.isEmpty()) {
                 reply.print("The primary solved issue for a PR is set through the PR title. Since the current title does ");
@@ -183,11 +183,6 @@ public class IssueCommand implements CommandHandler {
                 reply.println("Adding additional issue to " + name + " list: `" + issue.toShortString() + "`.");
             }
         }
-    }
-
-    private String removeDraftPrefix(String title) {
-        String pattern = "(?i)^draft:?\\s*";
-        return title.replaceAll(pattern, "");
     }
 
     private void removeIssue(PullRequestBot bot, String args, Set<String> currentSolved, PrintWriter reply) throws InvalidIssue {

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -343,8 +343,7 @@ public class GitLabMergeRequest implements PullRequest {
     }
 
     /**
-     * In GitLab, if the pull request is in draft mode, the title will include the draft prefix,
-     * @return
+     * In GitLab, if the pull request is in draft mode, the title will include the draft prefix
      */
     @Override
     public String title() {

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -52,6 +52,7 @@ public class GitLabMergeRequest implements PullRequest {
     private Object comparisonSnapshot;
 
     private static final int GITLAB_MR_COMMENT_BODY_MAX_SIZE = 64_000;
+    private static final String DRAFT_PREFIX = "Draft:";
 
     GitLabMergeRequest(GitLabRepository repository, GitLabHost host, JSONValue jsonValue, RestRequest request) {
         this.repository = repository;
@@ -341,13 +342,36 @@ public class GitLabMergeRequest implements PullRequest {
         return targetRef;
     }
 
+    /**
+     * In GitLab, if the pull request is in draft mode, the title will include the draft prefix,
+     * @return
+     */
     @Override
     public String title() {
-        return json.get("title").asString().strip();
+        var title = json.get("title").asString().strip();
+        String pattern = "(?i)^draft:?\\s*";
+        return title.replaceAll(pattern, "").strip();
     }
 
+    /**
+     * In GitLab, when the bot attempts to update the pull request title,
+     * it should check if the pull request is in draft mode.
+     * If it is, the bot should add the draft prefix.
+     */
     @Override
     public void setTitle(String title) {
+        if (isDraft()) {
+            title = DRAFT_PREFIX + " " + title;
+        }
+        request.put("")
+               .body("title", title)
+               .execute();
+    }
+
+    /**
+     * This method sets the title without checking if the pull request is in draft mode.
+     */
+    private void setTitleWithoutDraftPrefix(String title) {
         request.put("")
                .body("title", title)
                .execute();
@@ -783,10 +807,8 @@ public class GitLabMergeRequest implements PullRequest {
 
     @Override
     public void makeNotDraft() {
-        var title = title();
-        var draftPrefix = "Draft:";
-        if (title.startsWith(draftPrefix)) {
-            setTitle(title.substring(draftPrefix.length()).stripLeading());
+        if (isDraft()) {
+            setTitleWithoutDraftPrefix(title());
         }
     }
 


### PR DESCRIPTION
In GitLab, when a user wants to create a PR in draft mode, they need to include the prefix "Draft: " before the title(Checked the GitLab Document, "WIP" is already deprecated and removed). However, if the user wants to use the "/issue" command to add another issue to this PR, the pr bot will not be able to parse the issue within the PR title. Therefore, the bot will modify the PR title to match the new issue the user wants to add, resulting in the removal of the draft state of the PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1936](https://bugs.openjdk.org/browse/SKARA-1936): IssueCommand would change pr title in GitLab (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1528/head:pull/1528` \
`$ git checkout pull/1528`

Update a local copy of the PR: \
`$ git checkout pull/1528` \
`$ git pull https://git.openjdk.org/skara.git pull/1528/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1528`

View PR using the GUI difftool: \
`$ git pr show -t 1528`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1528.diff">https://git.openjdk.org/skara/pull/1528.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1528#issuecomment-1581627685)