### PR TITLE
1939: Make work item scheduling more resilient against failures

### DIFF
--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
@@ -457,24 +457,25 @@ public class BotRunner {
             log.log(Level.FINE, "Start of checking for periodic items", TaskPhases.BEGIN);
             try {
                 for (var bot : bots) {
+                    Instant botStart = Instant.now();
                     try (var ___ = new LogContext("bot", bot.toString())) {
-                        Instant botStart = Instant.now();
                         log.fine("Start of checking for periodic items for " + bot);
                         var items = bot.getPeriodicItems();
                         for (var item : items) {
                             submitOrSchedule(item);
                         }
+                    } catch (UncheckedRestException e) {
+                        // Log as WARNING to avoid triggering alarms. Failed REST calls are tracked
+                        // using metrics.
+                        log.log(Level.WARNING, "RestException during periodic items checking", e);
+                    } catch (RuntimeException e) {
+                        log.log(Level.SEVERE, "Exception during periodic items checking: " + e.getMessage(), e);
+                    } finally {
                         var duration = Duration.between(botStart, Instant.now());
                         log.log(Level.FINE, "Checking for periodic items for " + bot + " took " + duration, duration);
                         PERIODIC_CHECK_TIME.labels(bot.name()).inc(duration.toMillis() / 1_000.0);
                     }
                 }
-            } catch (UncheckedRestException e) {
-                // Log as WARNING to avoid triggering alarms. Failed REST calls are tracked
-                // using metrics.
-                log.log(Level.WARNING, "RestException during periodic items checking", e);
-            } catch (RuntimeException e) {
-                log.log(Level.SEVERE, "Exception during periodic items checking: " + e.getMessage(), e);
             } finally {
                 var duration = Duration.between(start, Instant.now());
                 log.log(Level.FINE, "Checking periodic items took " + duration,


### PR DESCRIPTION
When the BotRunner calls getPeriodicItems, any failure will terminate the whole loop. This means that one misconfigured repository, or problem with the forge, can prevent all other repos from being processed. I think it would be a good idea to keep trying each bot instance in the list even if some of them fail.

This patch moves the catch clauses inside the loop. I'm also moving some logging and metrics gathering into a finally block.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1939](https://bugs.openjdk.org/browse/SKARA-1939): Make work item scheduling more resilient against failures (**Enhancement** - P4)


### Reviewers
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1529/head:pull/1529` \
`$ git checkout pull/1529`

Update a local copy of the PR: \
`$ git checkout pull/1529` \
`$ git pull https://git.openjdk.org/skara.git pull/1529/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1529`

View PR using the GUI difftool: \
`$ git pr show -t 1529`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1529.diff">https://git.openjdk.org/skara/pull/1529.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1529#issuecomment-1585231002)