### PR TITLE
1943: Update .github/workflows/ci.yml to fix GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
 
   mac:
     name: macOS x64
-    runs-on: "macos-10.15"
+    runs-on: "macos-latest"
     needs: prerequisites
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
 
   mac:
     name: macOS x64
-    runs-on: "macos-latest"
+    runs-on: "macos-12"
     needs: prerequisites
 
     steps:


### PR DESCRIPTION
Since last month, the GitHub Action for running tests on macOS has been failing consistently, and the test job always failed due to time out. It seems like that GitHub no longer supports tests on macOS-10.15, so we need to update the configuration.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1943](https://bugs.openjdk.org/browse/SKARA-1943): Update .github/workflows/ci.yml to fix GHA (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1530/head:pull/1530` \
`$ git checkout pull/1530`

Update a local copy of the PR: \
`$ git checkout pull/1530` \
`$ git pull https://git.openjdk.org/skara.git pull/1530/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1530`

View PR using the GUI difftool: \
`$ git pr show -t 1530`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1530.diff">https://git.openjdk.org/skara/pull/1530.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1530#issuecomment-1588090745)