### PR TITLE
SKARA-1937

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -1335,7 +1335,7 @@ class CheckRun {
 
             // Calculate current metadata to avoid unnecessary future checks
             var metadata = workItem.getMetadata(workItem.getPRMetadata(censusInstance, title, updatedBody, pr.comments(), activeReviews,
-                                                newLabels, pr.targetRef(), pr.isDraft()), workItem.getIssueMetadata(updatedBody), expiresIn);
+                    newLabels, pr.targetRef(), pr.isDraft(), pr.targetRefJCheckConf()), workItem.getIssueMetadata(updatedBody), expiresIn);
             checkBuilder.metadata(metadata);
         } catch (Exception e) {
             log.throwing("CommitChecker", "checkStatus", e);

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -135,8 +135,8 @@ class CheckWorkItem extends PullRequestWorkItem {
             digest.update(commentString.getBytes(StandardCharsets.UTF_8));
             digest.update(labelString.getBytes(StandardCharsets.UTF_8));
             digest.update(targetRef.getBytes(StandardCharsets.UTF_8));
-            digest.update(isDraft ? (byte)0 : (byte)1);
             digest.update(jcheckConfInTargetRef.getBytes(StandardCharsets.UTF_8));
+            digest.update(isDraft ? (byte)0 : (byte)1);
 
             return Base64.getUrlEncoder().encodeToString(digest.digest());
         } catch (NoSuchAlgorithmException e) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -105,7 +105,7 @@ class CheckWorkItem extends PullRequestWorkItem {
     }
 
     String getPRMetadata(CensusInstance censusInstance, String title, String body, List<Comment> comments,
-                       List<Review> reviews, Set<String> labels, String targetRef, boolean isDraft) {
+                       List<Review> reviews, Set<String> labels, String targetRef, boolean isDraft, String jcheckConfInTargetRef) {
         try {
             var approverString = reviews.stream()
                                         .filter(review -> review.verdict() == Review.Verdict.APPROVED)
@@ -136,6 +136,7 @@ class CheckWorkItem extends PullRequestWorkItem {
             digest.update(labelString.getBytes(StandardCharsets.UTF_8));
             digest.update(targetRef.getBytes(StandardCharsets.UTF_8));
             digest.update(isDraft ? (byte)0 : (byte)1);
+            digest.update(jcheckConfInTargetRef.getBytes(StandardCharsets.UTF_8));
 
             return Base64.getUrlEncoder().encodeToString(digest.digest());
         } catch (NoSuchAlgorithmException e) {
@@ -223,7 +224,8 @@ class CheckWorkItem extends PullRequestWorkItem {
                     }
                     // triggered by pr updates
                 } else {
-                    var currPRMetadata = getPRMetadata(censusInstance, pr.title(), pr.body(), comments, reviews, labels, pr.targetRef(), pr.isDraft());
+                    var currPRMetadata = getPRMetadata(censusInstance, pr.title(), pr.body(), comments, reviews,
+                            labels, pr.targetRef(), pr.isDraft(), pr.targetRefJCheckConf());
                     if (expiresAt != null) {
                         if (previousPRMetadata.equals(currPRMetadata) && expiresAt.isAfter(Instant.now())) {
                             log.finer("[PR]Metadata with expiration time is still valid, not checking again");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -168,33 +168,31 @@ class PullRequestBot implements Bot {
             List<PullRequest> prs = poller.updatedPullRequests();
             workItems.addAll(getPullRequestWorkItems(prs));
 
-            var jCheckConfUpdateRelatedPRs = getJCheckConfUpdateRelatedPRs(prs);
-            workItems.addAll(getPullRequestWorkItems(jCheckConfUpdateRelatedPRs));
+            var jCheckConfUpdateRelatedPRs = getJCheckConfUpdateRelatedPRs();
+            // Filter out duplicate prs
+            var filteredPrs = jCheckConfUpdateRelatedPRs.stream()
+                    .filter(pullRequest -> prs.stream()
+                            .noneMatch(pr -> pr.isSame(pullRequest)))
+                    .toList();
+            workItems.addAll(getPullRequestWorkItems(filteredPrs));
             poller.lastBatchHandled();
         }
         return workItems;
     }
 
-    private List<PullRequest> getJCheckConfUpdateRelatedPRs(List<PullRequest> prs) {
+    private List<PullRequest> getJCheckConfUpdateRelatedPRs() {
         var ret = new ArrayList<PullRequest>();
-        // Get all open prs and filter out duplicate prs
-        var openPrs = remoteRepo.openPullRequests().stream()
-                .filter(pullRequest -> prs.stream()
-                        .noneMatch(pullRequest1 -> pullRequest1.isSame(pullRequest)))
+        // Get all branches except 'pr' branch
+        var allTargetRefs = remoteRepo.branches().stream()
+                .map(HostedBranch::name)
+                .filter(name -> !name.startsWith("pr/"))
                 .toList();
-        // Get all target refs except 'pr' refs
-        // If a pr's targetRef is pr ref, it means it's a dependent pr
-        // For dependent PRs, we don't need to update them at this time
-        var allTargetRefs = openPrs.stream()
-                .map(PullRequest::targetRef)
-                .filter(ref -> !ref.startsWith("pr/"))
-                .collect(Collectors.toSet());
         // Check if .jcheck/conf updated in each target ref
         for (var targetRef : allTargetRefs) {
             var currConf = remoteRepo.fileContents(".jcheck/conf", targetRef)
                     .orElseThrow(() -> new RuntimeException("Could not find .jcheck/conf on ref " + targetRef + " in repo " + remoteRepo.name()));
             if (!jCheckConfMap.containsKey(targetRef) || !jCheckConfMap.get(targetRef).equals(currConf)) {
-                ret.addAll(openPrs.stream()
+                ret.addAll(remoteRepo.openPullRequests().stream()
                         .filter(pullRequest -> pullRequest.targetRef().equals(targetRef))
                         .toList());
                 jCheckConfMap.put(targetRef, currConf);

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -189,8 +189,11 @@ class PullRequestBot implements Bot {
                 .toList();
         // Check if .jcheck/conf updated in each target ref
         for (var targetRef : allTargetRefs) {
-            var currConf = remoteRepo.fileContents(".jcheck/conf", targetRef)
-                    .orElseThrow(() -> new RuntimeException("Could not find .jcheck/conf on ref " + targetRef + " in repo " + remoteRepo.name()));
+            var currConfOpt = remoteRepo.fileContents(".jcheck/conf", targetRef);
+            if (currConfOpt.isEmpty()) {
+                continue;
+            }
+            var currConf = currConfOpt.get();
             if (!jCheckConfMap.containsKey(targetRef) || !jCheckConfMap.get(targetRef).equals(currConf)) {
                 ret.addAll(remoteRepo.openPullRequests().stream()
                         .filter(pullRequest -> pullRequest.targetRef().equals(targetRef))

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
@@ -367,4 +367,9 @@ class InMemoryPullRequest implements PullRequest {
     public List<ReferenceChange> targetRefChanges() {
         return List.of();
     }
+
+    @Override
+    public String targetRefJCheckConf() {
+        return null;
+    }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
@@ -265,4 +265,10 @@ public interface PullRequest extends Issue {
                 })
                 .toList();
     }
+
+    /**
+     * Returns .jcheck/conf in the target ref of this pull request
+     * @return
+     */
+    String targetRefJCheckConf();
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -844,8 +844,7 @@ public class GitHubPullRequest implements PullRequest {
     @Override
     public String targetRefJCheckConf() {
         if (targetRefJCheckConf == null) {
-            targetRefJCheckConf = repository.fileContents(".jcheck/conf", targetRef())
-                    .orElseThrow(() -> new RuntimeException("Could not find .jcheck/conf on ref " + targetRef() + " in repo " + repository.name()));
+            targetRefJCheckConf = repository.fileContents(".jcheck/conf", targetRef()).orElse("");
         }
         return targetRefJCheckConf;
     }

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -45,6 +45,7 @@ public class GitHubPullRequest implements PullRequest {
     private final Logger log = Logger.getLogger("org.openjdk.skara.host");
 
     private List<Label> labels = null;
+    private String targetRefJCheckConf;
 
     private static final int GITHUB_PR_COMMENT_BODY_MAX_SIZE = 64_000;
 
@@ -838,5 +839,14 @@ public class GitHubPullRequest implements PullRequest {
                 .map(obj -> ZonedDateTime.parse(obj.get("created_at").asString()))
                 .max(ZonedDateTime::compareTo)
                 .orElseGet(this::createdAt);
+    }
+
+    @Override
+    public String targetRefJCheckConf() {
+        if (targetRefJCheckConf == null) {
+            targetRefJCheckConf = repository.fileContents(".jcheck/conf", targetRef())
+                    .orElseThrow(() -> new RuntimeException("Could not find .jcheck/conf on ref " + targetRef() + " in repo " + repository.name()));
+        }
+        return targetRefJCheckConf;
     }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -952,8 +952,7 @@ public class GitLabMergeRequest implements PullRequest {
     @Override
     public String targetRefJCheckConf() {
         if (targetRefJCheckConf == null) {
-            targetRefJCheckConf = repository.fileContents(".jcheck/conf", targetRef())
-                    .orElseThrow(() -> new RuntimeException("Could not find .jcheck/conf on ref " + targetRef() + " in repo " + repository.name()));
+            targetRefJCheckConf = repository.fileContents(".jcheck/conf", targetRef()).orElse("");
         }
         return targetRefJCheckConf;
     }

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -50,6 +50,7 @@ public class GitLabMergeRequest implements PullRequest {
 
     // Lazy cache for comparisonSnapshot
     private Object comparisonSnapshot;
+    private String targetRefJCheckConf;
 
     private static final int GITLAB_MR_COMMENT_BODY_MAX_SIZE = 64_000;
 
@@ -925,5 +926,14 @@ public class GitLabMergeRequest implements PullRequest {
                     + "...";
         }
         return body;
+    }
+
+    @Override
+    public String targetRefJCheckConf() {
+        if (targetRefJCheckConf == null) {
+            targetRefJCheckConf = repository.fileContents(".jcheck/conf", targetRef())
+                    .orElseThrow(() -> new RuntimeException("Could not find .jcheck/conf on ref " + targetRef() + " in repo " + repository.name()));
+        }
+        return targetRefJCheckConf;
     }
 }

--- a/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
@@ -269,6 +269,9 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
         try {
             var result = new ArrayList<HostedBranch>();
             for (var b : localRepository.branches()) {
+                if (b.name().equals("testhostcontent") || b.name().equals("testlock")) {
+                    continue;
+                }
                 result.add(new HostedBranch(b.name(), localRepository.resolve(b).orElseThrow()));
             }
             return result;

--- a/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
@@ -52,6 +52,7 @@ public class TestPullRequest extends TestIssue implements PullRequest {
     protected final String targetRef;
     protected final boolean draft;
     private List<Label> labels;
+    private String targetRefJCheckConf;
 
     public TestPullRequest(TestPullRequestStore store, TestHostedRepository targetRepository) {
         super(store, targetRepository.forge().currentUser());
@@ -354,5 +355,14 @@ public class TestPullRequest extends TestIssue implements PullRequest {
     @Override
     public int hashCode() {
         return Objects.hash(super.hashCode(), headHash, sourceRef, targetRef, draft);
+    }
+
+    @Override
+    public String targetRefJCheckConf() {
+        if (targetRefJCheckConf == null) {
+            targetRefJCheckConf = targetRepository.fileContents(".jcheck/conf", targetRef())
+                    .orElseThrow(() -> new RuntimeException("Could not find .jcheck/conf on ref " + targetRef() + " in repo " + targetRepository.name()));
+        }
+        return targetRefJCheckConf;
     }
 }

--- a/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
@@ -360,8 +360,7 @@ public class TestPullRequest extends TestIssue implements PullRequest {
     @Override
     public String targetRefJCheckConf() {
         if (targetRefJCheckConf == null) {
-            targetRefJCheckConf = targetRepository.fileContents(".jcheck/conf", targetRef())
-                    .orElseThrow(() -> new RuntimeException("Could not find .jcheck/conf on ref " + targetRef() + " in repo " + targetRepository.name()));
+            targetRefJCheckConf = targetRepository.fileContents(".jcheck/conf", targetRef()).orElse("");
         }
         return targetRefJCheckConf;
     }


### PR DESCRIPTION
As Erik said in the issue: "When we bump the version in .jcheck/conf from N to N+1 in the jdk master branch, PRs with CSRs are often not updated to reflect this."

This root cause of this is that changing of .jcheck/conf in target ref of the pr will not be able to trigger checkWorkItem for this pr.

In this patch,
1. The prBot will monitor the changes to the .jcheck/conf file in any branch(except for PR branches).
2. If the prBot detects an update to the .jcheck/conf file in a branch, it will trigger a checkWorkItem for all open PRs whose target ref is the branch where the .jcheck/conf file was updated.
3. To solve the problem related with bot restarting, the contents of the .jcheck/conf file in the target branch of a PR will be included in the metadata hash.