### PR TITLE
1948: User not getting push access to backport branch

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
@@ -322,8 +322,15 @@ public class BackportCommand implements CommandHandler {
 
             if (!fork.canPush(realUser)) {
                 fork.addCollaborator(realUser, true);
+            } else {
+                // It's not possible to add branch level push protection unless the user
+                // already has push permissions in the repository. If we try to restrict
+                // it anyway, nobody can push to the branch. At least this way, if the
+                // user already has push permissions, the branch will be protected,
+                // otherwise anyone with push permissions in the repository will be able
+                // to push to the branch.
+                fork.restrictPushAccess(new Branch(backportBranchName), realUser);
             }
-            fork.restrictPushAccess(new Branch(backportBranchName), realUser);
 
             var message = CommitMessageParsers.v1.parse(commit);
             var formatter = DateTimeFormatter.ofPattern("d MMM uuuu");

--- a/forge/src/test/java/org/openjdk/skara/forge/github/GitHubRestApiTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/github/GitHubRestApiTests.java
@@ -268,4 +268,12 @@ public class GitHubRestApiTests {
         var githubRepo = githubRepoOpt.get();
         githubRepo.deleteDeployKeys(Duration.ofHours(24));
     }
+
+    @Test
+    void restrictPushAccess() {
+        var gitHubRepo = githubHost.repository(settings.getProperty("github.repository")).orElseThrow();
+        var branch = new Branch(settings.getProperty("github.repository.branch"));
+        var user = githubHost.user(settings.getProperty("github.user2")).orElseThrow();
+        gitHubRepo.restrictPushAccess(branch, user);
+    }
 }


### PR DESCRIPTION
When a user creates a backport PR using the /backport command, they are supposed to get push access to the branch in the fork repository. On GitHub, this has stopped working (assuming it ever worked). Experimentation shows that for a user to be eligible for listing in a branch protection rule, that user must first have push access in the repository. Just having a pending invite is not enough. When a user issues the /backport command, an invite is automatically sent to become a collaborator with push access in the repository, but the user has to accept it before it comes into effect.

Given this, I don't see a way to consistently provide branch level push access restrictions for the fork repositories. But instead of removing the feature completely, we can apply it when possible. The first /backport by a user will not get exclusive push access, but if the user accepts the invite before the next time, then from then on, any new backport branches will be protected. Not sure if this is worth it, but since we have the functionality, we may as well apply it when possible.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1948](https://bugs.openjdk.org/browse/SKARA-1948): User not getting push access to backport branch (**Bug** - P3)


### Reviewers
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1532/head:pull/1532` \
`$ git checkout pull/1532`

Update a local copy of the PR: \
`$ git checkout pull/1532` \
`$ git pull https://git.openjdk.org/skara.git pull/1532/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1532`

View PR using the GUI difftool: \
`$ git pr show -t 1532`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1532.diff">https://git.openjdk.org/skara/pull/1532.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1532#issuecomment-1591972633)