### PR TITLE
1950: Don't run the second jcheck if there is no .jcheck/conf in source branch

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -1370,7 +1370,7 @@ class CheckRun {
     }
 
     private boolean isFileUpdated(String filename, Hash hash) throws IOException {
-        return localRepo.show(Path.of(filename), hash).isPresent() &&
+        return !localRepo.files(hash, Path.of(filename)).isEmpty() &&
                 localRepo.commits(hash.hex(), 1).stream()
                         .anyMatch(commit -> commit.parentDiffs().stream()
                                 .anyMatch(diff -> diff.patches().stream()

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -1370,11 +1370,12 @@ class CheckRun {
     }
 
     private boolean isFileUpdated(String filename, Hash hash) throws IOException {
-        return localRepo.commits(hash.hex(), 1).stream()
-                .anyMatch(commit -> commit.parentDiffs().stream()
-                        .anyMatch(diff -> diff.patches().stream()
-                                .anyMatch(patch -> (patch.source().path().isPresent() && patch.source().path().get().toString().equals(filename))
-                                        || ((patch.target().path().isPresent() && patch.target().path().get().toString().equals(filename))))));
+        return localRepo.show(Path.of(filename), hash).isPresent() &&
+                localRepo.commits(hash.hex(), 1).stream()
+                        .anyMatch(commit -> commit.parentDiffs().stream()
+                                .anyMatch(diff -> diff.patches().stream()
+                                        .anyMatch(patch -> (patch.source().path().isPresent() && patch.source().path().get().toString().equals(filename))
+                                                || ((patch.target().path().isPresent() && patch.target().path().get().toString().equals(filename))))));
     }
 
     private void updateCSRLabel(List<Issue> issues, JdkVersion version, Map<Issue, org.openjdk.skara.issuetracker.Issue> csrIssueTrackerIssueMap) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
@@ -210,7 +210,7 @@ public class CheckablePullRequest {
             conf = JCheck.parseConfiguration(localRepo, hash, additionalConfiguration);
         }
         if (conf.isEmpty()) {
-            throw new RuntimeException("Failed to parse jcheck configuration at: " + targetHash() + " with extra: " + additionalConfiguration);
+            throw new RuntimeException("Failed to parse jcheck configuration at: " + hash + " with extra: " + additionalConfiguration);
         }
         visitor.setConfiguration(conf.get());
         try (var issues = JCheck.check(localRepo, censusInstance.census(), CommitMessageParsers.v1, localHash,


### PR DESCRIPTION
[SKARA-1937](https://bugs.openjdk.org/browse/SKARA-1937) triggered CheckWorkItem for many “ancient” prs and if the pr’s source branch doesn’t contain .jcheck/conf , it would trigger the second run of jcheck and then throw some exceptions.

In this patch, before the bot runs the second round of jcheck, it will check if .jcheck/conf exists in the "merge" branch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1950](https://bugs.openjdk.org/browse/SKARA-1950): Don't run the second jcheck if there is no .jcheck/conf in source branch (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1533/head:pull/1533` \
`$ git checkout pull/1533`

Update a local copy of the PR: \
`$ git checkout pull/1533` \
`$ git pull https://git.openjdk.org/skara.git pull/1533/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1533`

View PR using the GUI difftool: \
`$ git pr show -t 1533`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1533.diff">https://git.openjdk.org/skara/pull/1533.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1533#issuecomment-1593790065)