### PR TITLE
1199: Enforce maintainer approval in JBS before allowing to integrate backports into updates projects

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/Approval.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/Approval.java
@@ -31,14 +31,16 @@ public class Approval {
     private final String request;
     private final String approved;
     private final String rejected;
+    private final String documentLink;
     private final Map<Pattern, String> branchPrefixes;
 
-    public Approval(String prefix, String request, String approved, String rejected) {
+    public Approval(String prefix, String request, String approved, String rejected, String documentLink) {
         this.prefix = prefix;
         this.request = request;
         this.approved = approved;
         this.rejected = rejected;
         this.branchPrefixes = new HashMap<>();
+        this.documentLink = documentLink;
     }
 
     public void addBranchPrefix(Pattern branchPattern, String prefix) {
@@ -55,6 +57,10 @@ public class Approval {
 
     public String rejectedLabel(String targetRef) {
         return prefixForRef(targetRef) + rejected;
+    }
+
+    public String documentLink() {
+        return documentLink;
     }
 
     private String prefixForRef(String targetRef) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/Approval.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/Approval.java
@@ -67,4 +67,16 @@ public class Approval {
         }
         return prefix;
     }
+
+    public boolean needsApproval(String targetRef) {
+        if (branchPrefixes.isEmpty()) {
+            return true;
+        }
+        for (var branchPattern : branchPrefixes.keySet()) {
+            if (branchPattern.matcher(targetRef).matches()) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/Approval.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/Approval.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.pr;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+public class Approval {
+    private final String prefix;
+    private final String request;
+    private final String approved;
+    private final String rejected;
+    private final Map<Pattern, String> branchPrefixes;
+
+    public Approval(String prefix, String request, String approved, String rejected) {
+        this.prefix = prefix;
+        this.request = request;
+        this.approved = approved;
+        this.rejected = rejected;
+        this.branchPrefixes = new HashMap<>();
+    }
+
+    public void addBranchPrefix(Pattern branchPattern, String prefix) {
+        branchPrefixes.put(branchPattern, prefix);
+    }
+
+    public String requestedLabel(String targetRef) {
+        return prefixForRef(targetRef) + request;
+    }
+
+    public String approvedLabel(String targetRef) {
+        return prefixForRef(targetRef) + approved;
+    }
+
+    public String rejectedLabel(String targetRef) {
+        return prefixForRef(targetRef) + rejected;
+    }
+
+    private String prefixForRef(String targetRef) {
+        String prefix = this.prefix;
+        for (var entry : branchPrefixes.entrySet()) {
+            if (entry.getKey().matcher(targetRef).matches()) {
+                prefix = entry.getValue();
+                break;
+            }
+        }
+        return prefix;
+    }
+}

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -275,7 +275,7 @@ class CheckRun {
                     var issue = issueOpt.get();
                     var labelNames = issue.labelNames();
                     if (labelNames.contains(approval.approvedLabel(pr.targetRef()))) {
-                        ret.put("[" + issue.id() + "](" + issue.webUrl() + ") needs maintainer approval in JBS", true);
+                        ret.put("[" + issue.id() + "](" + issue.webUrl() + ") needs maintainer approval", true);
                     } else {
                         ret.put("[" + issue.id() + "](" + issue.webUrl() + ") needs maintainer approval in JBS", false);
                     }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -1514,7 +1514,7 @@ class CheckRun {
             return;
         }
         String message = "⚠️  @" + pr.author().username() +
-                " This change has now been reviewed and requires maintainer [approval](" + approval.documentLink() + ")." +
+                " This change is now ready for maintainer [approval](" + approval.documentLink() + ")." +
                 APPROVAL_NEEDED_MARKER;
         pr.addComment(message);
     }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -1514,7 +1514,7 @@ class CheckRun {
             return;
         }
         String message = "⚠️  @" + pr.author().username() +
-                " This change is now ready for maintainer [approval](" + approval.documentLink() + ")." +
+                " This change is now ready for you to apply for maintainer [approval](" + approval.documentLink() + ")." +
                 APPROVAL_NEEDED_MARKER;
         pr.addComment(message);
     }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -277,7 +277,7 @@ class CheckRun {
                     if (labelNames.contains(approval.approvedLabel(pr.targetRef()))) {
                         ret.put("[" + issue.id() + "](" + issue.webUrl() + ") needs maintainer approval", true);
                     } else {
-                        ret.put("[" + issue.id() + "](" + issue.webUrl() + ") needs maintainer approval in JBS", false);
+                        ret.put("[" + issue.id() + "](" + issue.webUrl() + ") needs maintainer approval", false);
                     }
                 }
             }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -269,7 +269,7 @@ class CheckRun {
                                                        IssueTrackerIssue jepIssue, JdkVersion version) {
         var ret = new HashMap<String, Boolean>();
 
-        if (approval != null) {
+        if (approval != null && approval.needsApproval(pr.targetRef())) {
             for (var issueOpt : regularIssuesMap.values()) {
                 if (issueOpt.isPresent()) {
                     var issue = issueOpt.get();
@@ -698,7 +698,7 @@ class CheckRun {
                             if (issuePriority != null) {
                                 progressBody.append(" - P").append(issuePriority.asString());
                             }
-                            if (approval != null) {
+                            if (approval != null && approval.needsApproval(pr.targetRef())) {
                                 String status = "";
                                 String targetRef = pr.targetRef();
                                 var labels = issueTrackerIssue.get().labelNames();
@@ -709,7 +709,7 @@ class CheckRun {
                                 } else if (labels.contains(approval.requestedLabel(targetRef))) {
                                     status = "Requested";
                                 }
-                                if (!status.isEmpty() && !status.isBlank()) {
+                                if (!status.isEmpty()) {
                                     progressBody.append(" - ").append(status);
                                 }
                             }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -179,7 +179,9 @@ class CheckWorkItem extends PullRequestWorkItem {
                             issueData.append(properties.get("priority").asString());
                             issueData.append(properties.get("issuetype").asString());
                         }
-                        issueData.append(String.join("", issue.labelNames()));
+                        if (bot.approval() != null && bot.approval().needsApproval(pr.targetRef())) {
+                            issueData.append(String.join("", issue.labelNames()));
+                        }
                         return issueData;
                     })
                     .collect(Collectors.joining());

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -179,6 +179,7 @@ class CheckWorkItem extends PullRequestWorkItem {
                             issueData.append(properties.get("priority").asString());
                             issueData.append(properties.get("issuetype").asString());
                         }
+                        issueData.append(String.join("", issue.labelNames()));
                         return issueData;
                     })
                     .collect(Collectors.joining());
@@ -583,7 +584,7 @@ class CheckWorkItem extends PullRequestWorkItem {
 
                 var expiresAt = CheckRun.execute(this, pr, localRepo, comments, allReviews,
                         activeReviews, labels, census, bot.ignoreStaleReviews(), bot.integrators(), bot.reviewCleanBackport(),
-                        bot.reviewMerge());
+                        bot.reviewMerge(), bot.approval());
                 if (log.isLoggable(Level.INFO)) {
                     // Log latency from the original updatedAt of the PR when this WorkItem
                     // was triggered to when it was just updated by the CheckRun.execute above.

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -77,6 +77,7 @@ class PullRequestBot implements Bot {
     private final Map<String, Boolean> initializedPRs = new ConcurrentHashMap<>();
     private final Map<String, String> jCheckConfMap = new HashMap<>();
     private final Map<String, Set<String>> targetRefPRMap = new HashMap<>();
+    private final Approval approval;
 
     private Instant lastFullUpdate;
 
@@ -91,7 +92,7 @@ class PullRequestBot implements Bot {
                    Set<String> integrators, Set<Integer> excludeCommitCommentsFrom, boolean enableCsr, boolean enableJep,
                    boolean reviewCleanBackport, String mlbridgeBotName, boolean reviewMerge, boolean processPR, boolean processCommit,
                    boolean enableMerge, Set<String> mergeSources, boolean jcheckMerge, boolean enableBackport,
-                   Map<String, List<PRRecord>> issuePRMap) {
+                   Map<String, List<PRRecord>> issuePRMap, Approval approval) {
         remoteRepo = repo;
         this.censusRepo = censusRepo;
         this.censusRef = censusRef;
@@ -126,6 +127,7 @@ class PullRequestBot implements Bot {
         this.jcheckMerge = jcheckMerge;
         this.enableBackport = enableBackport;
         this.issuePRMap = issuePRMap;
+        this.approval = approval;
 
         autoLabelled = new HashSet<>();
         poller = new PullRequestPoller(repo, true);
@@ -376,6 +378,10 @@ class PullRequestBot implements Bot {
 
     public Map<String, List<PRRecord>> issuePRMap() {
         return issuePRMap;
+    }
+
+    public Approval approval() {
+        return approval;
     }
 
     public void addIssuePRMapping(String issueId, PRRecord prRecord) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
@@ -65,6 +65,7 @@ public class PullRequestBotBuilder {
     private Set<String> mergeSources = Set.of();
     private boolean enableBackport = true;
     private Map<String, List<PRRecord>> issuePRMap;
+    private Approval approval = null;
 
     PullRequestBotBuilder() {
     }
@@ -239,14 +240,17 @@ public class PullRequestBotBuilder {
         return this;
     }
 
+    public PullRequestBotBuilder approval(Approval approval) {
+        this.approval = approval;
+        return this;
+    }
+
     public PullRequestBot build() {
-        return new PullRequestBot(repo, censusRepo, censusRef, labelConfiguration,
-                                  externalPullRequestCommands, externalCommitCommands,
-                                  blockingCheckLabels, readyLabels, twoReviewersLabels, twentyFourHoursLabels,
-                                  readyComments, issueProject, ignoreStaleReviews,
-                                  allowedTargetBranches, seedStorage, confOverrideRepo, confOverrideName,
-                                  confOverrideRef, censusLink, forks, integrators, excludeCommitCommentsFrom,
-                                  enableCsr, enableJep, reviewCleanBackport, mlbridgeBotName, reviewMerge,
-                                  processPR, processCommit, enableMerge, mergeSources, jcheckMerge, enableBackport, issuePRMap);
+        return new PullRequestBot(repo, censusRepo, censusRef, labelConfiguration, externalPullRequestCommands,
+                externalCommitCommands, blockingCheckLabels, readyLabels, twoReviewersLabels, twentyFourHoursLabels,
+                readyComments, issueProject, ignoreStaleReviews, allowedTargetBranches, seedStorage, confOverrideRepo,
+                confOverrideName, confOverrideRef, censusLink, forks, integrators, excludeCommitCommentsFrom, enableCsr,
+                enableJep, reviewCleanBackport, mlbridgeBotName, reviewMerge, processPR, processCommit, enableMerge,
+                mergeSources, jcheckMerge, enableBackport, issuePRMap, approval);
     }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
@@ -230,7 +230,8 @@ public class PullRequestBotFactory implements BotFactory {
                 String request = approvalJSON.get("request").asString();
                 String approved = approvalJSON.get("approved").asString();
                 String rejected = approvalJSON.get("rejected").asString();
-                Approval approval = new Approval(prefix, request, approved, rejected);
+                String documentLink = approvalJSON.get("documentLink").asString();
+                Approval approval = new Approval(prefix, request, approved, rejected, documentLink);
                 if (approvalJSON.contains("branches")) {
                     for (var branch : approvalJSON.get("branches").fields()) {
                         approval.addBranchPrefix(Pattern.compile(branch.name()), branch.value().get("prefix").asString());

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
@@ -224,6 +224,21 @@ public class PullRequestBotFactory implements BotFactory {
                 botBuilder.mergeSources(mergeSources);
             }
 
+            if (repo.value().contains("approval")) {
+                var approvalJSON = repo.value().get("approval");
+                String prefix = approvalJSON.contains("prefix") ? approvalJSON.get("prefix").asString() : "";
+                String request = approvalJSON.get("request").asString();
+                String approved = approvalJSON.get("approved").asString();
+                String rejected = approvalJSON.get("rejected").asString();
+                Approval approval = new Approval(prefix, request, approved, rejected);
+                if (approvalJSON.contains("branches")) {
+                    for (var branch : approvalJSON.get("branches").fields()) {
+                        approval.addBranchPrefix(Pattern.compile(branch.name()), branch.value().get("prefix").asString());
+                    }
+                }
+                botBuilder.approval(approval);
+            }
+
             var prBot = botBuilder.build();
             pullRequestBotMap.put(repository.name(), prBot);
             ret.add(prBot);

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ApprovalTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ApprovalTests.java
@@ -35,7 +35,7 @@ public class ApprovalTests {
         assertEquals("jdk17u-fix-request", approval.requestedLabel("master"));
         assertEquals("jdk17u-fix-yes", approval.approvedLabel("master"));
         assertEquals("jdk17u-fix-no", approval.rejectedLabel("master"));
-        assertEquals("https://test.opnejdk.org", approval.documentLink());
+        assertEquals("https://test.openjdk.org", approval.documentLink());
         assertTrue(approval.needsApproval("master"));
 
         approval = new Approval("jdk17u-fix-", "request", "yes", "no", "https://test.openjdk.org");

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ApprovalTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ApprovalTests.java
@@ -31,20 +31,20 @@ import static org.junit.jupiter.api.Assertions.*;
 public class ApprovalTests {
     @Test
     void simple() {
-        Approval approval = new Approval("", "jdk17u-fix-request", "jdk17u-fix-yes", "jdk17u-fix-no", "https://test.openjdk.org");
+        Approval approval = new Approval("", "jdk17u-fix-request", "jdk17u-fix-yes", "jdk17u-fix-no", "https://example.com");
         assertEquals("jdk17u-fix-request", approval.requestedLabel("master"));
         assertEquals("jdk17u-fix-yes", approval.approvedLabel("master"));
         assertEquals("jdk17u-fix-no", approval.rejectedLabel("master"));
-        assertEquals("https://test.openjdk.org", approval.documentLink());
+        assertEquals("https://example.com", approval.documentLink());
         assertTrue(approval.needsApproval("master"));
 
-        approval = new Approval("jdk17u-fix-", "request", "yes", "no", "https://test.openjdk.org");
+        approval = new Approval("jdk17u-fix-", "request", "yes", "no", "https://example.com");
         assertEquals("jdk17u-fix-request", approval.requestedLabel("master"));
         assertEquals("jdk17u-fix-yes", approval.approvedLabel("master"));
         assertEquals("jdk17u-fix-no", approval.rejectedLabel("master"));
         assertTrue(approval.needsApproval("master"));
 
-        approval = new Approval("", "-critical-request", "-critical-approved", "-critical-rejected", "https://test.openjdk.org");
+        approval = new Approval("", "-critical-request", "-critical-approved", "-critical-rejected", "https://example.com");
         approval.addBranchPrefix(Pattern.compile("jdk20.0.1"), "CPU23_04");
         approval.addBranchPrefix(Pattern.compile("jdk20.0.2"), "CPU23_05");
         assertEquals("CPU23_04-critical-request", approval.requestedLabel("jdk20.0.1"));

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ApprovalTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ApprovalTests.java
@@ -35,11 +35,13 @@ public class ApprovalTests {
         assertEquals("jdk17u-fix-request", approval.requestedLabel("master"));
         assertEquals("jdk17u-fix-yes", approval.approvedLabel("master"));
         assertEquals("jdk17u-fix-no", approval.rejectedLabel("master"));
+        assertTrue(approval.needsApproval("master"));
 
         approval = new Approval("jdk17u-fix-", "request", "yes", "no");
         assertEquals("jdk17u-fix-request", approval.requestedLabel("master"));
         assertEquals("jdk17u-fix-yes", approval.approvedLabel("master"));
         assertEquals("jdk17u-fix-no", approval.rejectedLabel("master"));
+        assertTrue(approval.needsApproval("master"));
 
         approval = new Approval("", "-critical-request", "-critical-approved", "-critical-rejected");
         approval.addBranchPrefix(Pattern.compile("jdk20.0.1"), "CPU23_04");
@@ -50,5 +52,9 @@ public class ApprovalTests {
         assertEquals("CPU23_05-critical-request", approval.requestedLabel("jdk20.0.2"));
         assertEquals("CPU23_05-critical-approved", approval.approvedLabel("jdk20.0.2"));
         assertEquals("CPU23_05-critical-rejected", approval.rejectedLabel("jdk20.0.2"));
+        assertFalse(approval.needsApproval("master"));
+        assertTrue(approval.needsApproval("jdk20.0.1"));
+        assertTrue(approval.needsApproval("jdk20.0.2"));
+        assertFalse(approval.needsApproval("jdk20.0.3"));
     }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ApprovalTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ApprovalTests.java
@@ -31,19 +31,20 @@ import static org.junit.jupiter.api.Assertions.*;
 public class ApprovalTests {
     @Test
     void simple() {
-        Approval approval = new Approval("", "jdk17u-fix-request", "jdk17u-fix-yes", "jdk17u-fix-no");
+        Approval approval = new Approval("", "jdk17u-fix-request", "jdk17u-fix-yes", "jdk17u-fix-no", "https://test.openjdk.org");
+        assertEquals("jdk17u-fix-request", approval.requestedLabel("master"));
+        assertEquals("jdk17u-fix-yes", approval.approvedLabel("master"));
+        assertEquals("jdk17u-fix-no", approval.rejectedLabel("master"));
+        assertEquals("https://test.opnejdk.org", approval.documentLink());
+        assertTrue(approval.needsApproval("master"));
+
+        approval = new Approval("jdk17u-fix-", "request", "yes", "no", "https://test.openjdk.org");
         assertEquals("jdk17u-fix-request", approval.requestedLabel("master"));
         assertEquals("jdk17u-fix-yes", approval.approvedLabel("master"));
         assertEquals("jdk17u-fix-no", approval.rejectedLabel("master"));
         assertTrue(approval.needsApproval("master"));
 
-        approval = new Approval("jdk17u-fix-", "request", "yes", "no");
-        assertEquals("jdk17u-fix-request", approval.requestedLabel("master"));
-        assertEquals("jdk17u-fix-yes", approval.approvedLabel("master"));
-        assertEquals("jdk17u-fix-no", approval.rejectedLabel("master"));
-        assertTrue(approval.needsApproval("master"));
-
-        approval = new Approval("", "-critical-request", "-critical-approved", "-critical-rejected");
+        approval = new Approval("", "-critical-request", "-critical-approved", "-critical-rejected", "https://test.openjdk.org");
         approval.addBranchPrefix(Pattern.compile("jdk20.0.1"), "CPU23_04");
         approval.addBranchPrefix(Pattern.compile("jdk20.0.2"), "CPU23_05");
         assertEquals("CPU23_04-critical-request", approval.requestedLabel("jdk20.0.1"));

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ApprovalTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ApprovalTests.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.pr;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ApprovalTests {
+    @Test
+    void simple() {
+        Approval approval = new Approval("", "jdk17u-fix-request", "jdk17u-fix-yes", "jdk17u-fix-no");
+        assertEquals("jdk17u-fix-request", approval.requestedLabel("master"));
+        assertEquals("jdk17u-fix-yes", approval.approvedLabel("master"));
+        assertEquals("jdk17u-fix-no", approval.rejectedLabel("master"));
+
+        approval = new Approval("jdk17u-fix-", "request", "yes", "no");
+        assertEquals("jdk17u-fix-request", approval.requestedLabel("master"));
+        assertEquals("jdk17u-fix-yes", approval.approvedLabel("master"));
+        assertEquals("jdk17u-fix-no", approval.rejectedLabel("master"));
+
+        approval = new Approval("", "-critical-request", "-critical-approved", "-critical-rejected");
+        approval.addBranchPrefix(Pattern.compile("jdk20.0.1"), "CPU23_04");
+        approval.addBranchPrefix(Pattern.compile("jdk20.0.2"), "CPU23_05");
+        assertEquals("CPU23_04-critical-request", approval.requestedLabel("jdk20.0.1"));
+        assertEquals("CPU23_04-critical-approved", approval.approvedLabel("jdk20.0.1"));
+        assertEquals("CPU23_04-critical-rejected", approval.rejectedLabel("jdk20.0.1"));
+        assertEquals("CPU23_05-critical-request", approval.requestedLabel("jdk20.0.2"));
+        assertEquals("CPU23_05-critical-approved", approval.approvedLabel("jdk20.0.2"));
+        assertEquals("CPU23_05-critical-rejected", approval.rejectedLabel("jdk20.0.2"));
+    }
+}

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IssueBotTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IssueBotTests.java
@@ -405,8 +405,7 @@ public class IssueBotTests {
             TestBotRunner.runPeriodicItems(prBot);
             assertFalse(pr.store().labelNames().contains("ready"));
             assertTrue(pr.store().body().contains("[TEST-1](http://localhost/project/testTEST-1) needs maintainer approval"));
-            assertEquals(pr.store().comments().get(1).body(), "⚠️  @user1 There are still some issues that have not received maintainer approval.\n" +
-                    "Please follow the instruction here to get maintainer approval: [Requesting push approval for fixes](https://openjdk.org/projects/jdk-updates/approval.html)<!-- PullRequestBot approval needed comment -->");
+            assertEquals("⚠️  @user1 This change has now been reviewed and requires maintainer [approval](https://test.openjdk.org).<!-- PullRequestBot approval needed comment -->", pr.store().comments().get(1).body());
 
             issue.addLabel("CPU23_04-critical-request");
             TestBotRunner.runPeriodicItems(issueBot);
@@ -415,7 +414,7 @@ public class IssueBotTests {
             issue.addLabel("CPU23_04-critical-approved");
             TestBotRunner.runPeriodicItems(issueBot);
             assertTrue(pr.store().body().contains("Approved"));
-            assertEquals(pr.store().comments().get(1).body(), "@user1 All the issues have already got the maintainer approval!<!-- PullRequestBot approval needed comment -->");
+            assertEquals("⚠️  @user1 This change has now been reviewed and requires maintainer [approval](https://test.openjdk.org).<!-- PullRequestBot approval needed comment -->", pr.store().comments().get(1).body());
         }
     }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IssueBotTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IssueBotTests.java
@@ -317,7 +317,7 @@ public class IssueBotTests {
                     .issueProject(issueProject)
                     .censusRepo(censusBuilder.build())
                     .issuePRMap(issuePRMap)
-                    .approval(new Approval("", "jdk17u-fix-request", "jdk17u-fix-yes", "jdk17u-fix-no"))
+                    .approval(new Approval("", "jdk17u-fix-request", "jdk17u-fix-yes", "jdk17u-fix-no", "https://test.openjdk.org"))
                     .build();
             var issueBot = new IssueBot(issueProject, List.of(author), Map.of(bot.name(), prBot), issuePRMap);
 
@@ -363,7 +363,7 @@ public class IssueBotTests {
                     .addReviewer(reviewer.forge().currentUser().id())
                     .addCommitter(author.forge().currentUser().id());
             Map<String, List<PRRecord>> issuePRMap = new HashMap<>();
-            Approval approval = new Approval("", "-critical-request", "-critical-approved", "-critical-rejected");
+            Approval approval = new Approval("", "-critical-request", "-critical-approved", "-critical-rejected", "https://test.openjdk.org");
             approval.addBranchPrefix(Pattern.compile("jdk20.0.1"), "CPU23_04");
             approval.addBranchPrefix(Pattern.compile("jdk20.0.2"), "CPU23_05");
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IssueBotTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IssueBotTests.java
@@ -405,6 +405,8 @@ public class IssueBotTests {
             TestBotRunner.runPeriodicItems(prBot);
             assertFalse(pr.store().labelNames().contains("ready"));
             assertTrue(pr.store().body().contains("[TEST-1](http://localhost/project/testTEST-1) needs maintainer approval"));
+            assertEquals(pr.store().comments().get(1).body(), "⚠️  @user1 There are still some issues that have not received maintainer approval.\n" +
+                    "Please follow the instruction here to get maintainer approval: [Requesting push approval for fixes](https://openjdk.org/projects/jdk-updates/approval.html)<!-- PullRequestBot approval needed comment -->");
 
             issue.addLabel("CPU23_04-critical-request");
             TestBotRunner.runPeriodicItems(issueBot);
@@ -413,6 +415,7 @@ public class IssueBotTests {
             issue.addLabel("CPU23_04-critical-approved");
             TestBotRunner.runPeriodicItems(issueBot);
             assertTrue(pr.store().body().contains("Approved"));
+            assertEquals(pr.store().comments().get(1).body(), "@user1 All the issues have already got the maintainer approval!<!-- PullRequestBot approval needed comment -->");
         }
     }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IssueBotTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IssueBotTests.java
@@ -317,7 +317,7 @@ public class IssueBotTests {
                     .issueProject(issueProject)
                     .censusRepo(censusBuilder.build())
                     .issuePRMap(issuePRMap)
-                    .approval(new Approval("", "jdk17u-fix-request", "jdk17u-fix-yes", "jdk17u-fix-no", "https://test.openjdk.org"))
+                    .approval(new Approval("", "jdk17u-fix-request", "jdk17u-fix-yes", "jdk17u-fix-no", "https://example.com"))
                     .build();
             var issueBot = new IssueBot(issueProject, List.of(author), Map.of(bot.name(), prBot), issuePRMap);
 
@@ -363,7 +363,7 @@ public class IssueBotTests {
                     .addReviewer(reviewer.forge().currentUser().id())
                     .addCommitter(author.forge().currentUser().id());
             Map<String, List<PRRecord>> issuePRMap = new HashMap<>();
-            Approval approval = new Approval("", "-critical-request", "-critical-approved", "-critical-rejected", "https://test.openjdk.org");
+            Approval approval = new Approval("", "-critical-request", "-critical-approved", "-critical-rejected", "https://example.com");
             approval.addBranchPrefix(Pattern.compile("jdk20.0.1"), "CPU23_04");
             approval.addBranchPrefix(Pattern.compile("jdk20.0.2"), "CPU23_05");
 
@@ -405,7 +405,7 @@ public class IssueBotTests {
             TestBotRunner.runPeriodicItems(prBot);
             assertFalse(pr.store().labelNames().contains("ready"));
             assertTrue(pr.store().body().contains("[TEST-1](http://localhost/project/testTEST-1) needs maintainer approval"));
-            assertEquals("⚠️  @user1 This change has now been reviewed and requires maintainer [approval](https://test.openjdk.org).<!-- PullRequestBot approval needed comment -->", pr.store().comments().get(1).body());
+            assertEquals("⚠️  @user1 This change is now ready for maintainer [approval](https://example.com).<!-- PullRequestBot approval needed comment -->", pr.store().comments().get(1).body());
 
             issue.addLabel("CPU23_04-critical-request");
             TestBotRunner.runPeriodicItems(issueBot);
@@ -414,7 +414,7 @@ public class IssueBotTests {
             issue.addLabel("CPU23_04-critical-approved");
             TestBotRunner.runPeriodicItems(issueBot);
             assertTrue(pr.store().body().contains("Approved"));
-            assertEquals("⚠️  @user1 This change has now been reviewed and requires maintainer [approval](https://test.openjdk.org).<!-- PullRequestBot approval needed comment -->", pr.store().comments().get(1).body());
+            assertEquals("⚠️  @user1 This change is now ready for maintainer [approval](https://example.com).<!-- PullRequestBot approval needed comment -->", pr.store().comments().get(1).body());
         }
     }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IssueBotTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IssueBotTests.java
@@ -25,6 +25,7 @@ package org.openjdk.skara.bots.pr;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.openjdk.skara.forge.CheckStatus;
+import org.openjdk.skara.forge.Review;
 import org.openjdk.skara.json.JSON;
 import org.openjdk.skara.test.CheckableRepository;
 import org.openjdk.skara.test.HostCredentials;
@@ -36,6 +37,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -295,7 +297,7 @@ public class IssueBotTests {
     }
 
     @Test
-    void maintainerApprovalInJBS(TestInfo testInfo) throws IOException {
+    void maintainerApproval(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
              var tempFolder = new TemporaryDirectory()) {
             var author = credentials.getHostedRepository();
@@ -340,6 +342,75 @@ public class IssueBotTests {
             assertTrue(pr.store().body().contains("Requested"));
 
             issue.addLabel("jdk17u-fix-yes");
+            TestBotRunner.runPeriodicItems(issueBot);
+            assertTrue(pr.store().body().contains("Approved"));
+        }
+    }
+
+    @Test
+    void maintainerApprovalWithBranchPattern(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var reviewer = credentials.getHostedRepository();
+            var bot = credentials.getHostedRepository();
+            var issueProject = credentials.getIssueProject();
+            var issue = issueProject.createIssue("This is an issue", List.of(), Map.of());
+            issue.setProperty("issuetype", JSON.of("Bug"));
+            issue.setProperty("priority", JSON.of("4"));
+
+            var censusBuilder = credentials.getCensusBuilder()
+                    .addReviewer(reviewer.forge().currentUser().id())
+                    .addCommitter(author.forge().currentUser().id());
+            Map<String, List<PRRecord>> issuePRMap = new HashMap<>();
+            Approval approval = new Approval("", "-critical-request", "-critical-approved", "-critical-rejected");
+            approval.addBranchPrefix(Pattern.compile("jdk20.0.1"), "CPU23_04");
+            approval.addBranchPrefix(Pattern.compile("jdk20.0.2"), "CPU23_05");
+
+            var prBot = PullRequestBot.newBuilder()
+                    .repo(bot)
+                    .issueProject(issueProject)
+                    .censusRepo(censusBuilder.build())
+                    .issuePRMap(issuePRMap)
+                    .approval(approval)
+                    .build();
+            var issueBot = new IssueBot(issueProject, List.of(author), Map.of(bot.name(), prBot), issuePRMap);
+
+            // Populate the projects repository
+            var localRepoFolder = tempFolder.path().resolve("localrepo");
+            var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
+            var otherHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(otherHash, author.authenticatedUrl(), "jdk20.0.1", true);
+
+            var pr = credentials.createPullRequest(author, "master", "edit", issue.id() + ": This is an issue");
+
+            TestBotRunner.runPeriodicItems(prBot);
+            assertFalse(pr.store().labelNames().contains("ready"));
+            assertTrue(pr.store().labelNames().contains("rfr"));
+            assertFalse(pr.store().body().contains("[TEST-1](http://localhost/project/testTEST-1) needs maintainer approval"));
+
+            var reviewerPr = reviewer.pullRequest(pr.id());
+            reviewerPr.addReview(Review.Verdict.APPROVED, "Looks good");
+            TestBotRunner.runPeriodicItems(prBot);
+            assertTrue(pr.store().labelNames().contains("ready"));
+
+            pr.setTargetRef("jdk20.0.1");
+            TestBotRunner.runPeriodicItems(prBot);
+            assertFalse(pr.store().labelNames().contains("ready"));
+            assertTrue(pr.store().body().contains("[TEST-1](http://localhost/project/testTEST-1) needs maintainer approval"));
+
+            issue.addLabel("CPU23_04-critical-request");
+            TestBotRunner.runPeriodicItems(issueBot);
+            assertTrue(pr.store().body().contains("Requested"));
+
+            issue.addLabel("CPU23_04-critical-approved");
             TestBotRunner.runPeriodicItems(issueBot);
             assertTrue(pr.store().body().contains("Approved"));
         }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IssueBotTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IssueBotTests.java
@@ -405,7 +405,7 @@ public class IssueBotTests {
             TestBotRunner.runPeriodicItems(prBot);
             assertFalse(pr.store().labelNames().contains("ready"));
             assertTrue(pr.store().body().contains("[TEST-1](http://localhost/project/testTEST-1) needs maintainer approval"));
-            assertEquals("⚠️  @user1 This change is now ready for maintainer [approval](https://example.com).<!-- PullRequestBot approval needed comment -->", pr.store().comments().get(1).body());
+            assertEquals("⚠️  @user1 This change is now ready for you to apply for maintainer [approval](https://example.com).<!-- PullRequestBot approval needed comment -->", pr.store().comments().get(1).body());
 
             issue.addLabel("CPU23_04-critical-request");
             TestBotRunner.runPeriodicItems(issueBot);
@@ -414,7 +414,7 @@ public class IssueBotTests {
             issue.addLabel("CPU23_04-critical-approved");
             TestBotRunner.runPeriodicItems(issueBot);
             assertTrue(pr.store().body().contains("Approved"));
-            assertEquals("⚠️  @user1 This change is now ready for maintainer [approval](https://example.com).<!-- PullRequestBot approval needed comment -->", pr.store().comments().get(1).body());
+            assertEquals("⚠️  @user1 This change is now ready for you to apply for maintainer [approval](https://example.com).<!-- PullRequestBot approval needed comment -->", pr.store().comments().get(1).body());
         }
     }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestBotFactoryTest.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestBotFactoryTest.java
@@ -144,6 +144,15 @@ class PullRequestBotFactoryTest {
                           "reviewMerge": true,
                           "processPR": false,
                           "jcheckMerge": false
+                          "approval": {
+                            "request": "-critical-request",
+                            "approved": "-critical-approved",
+                            "rejected": "-critical-rejected",
+                            "branches": {
+                              "jdk20.0.1": { "prefix": "CPU23_04" },
+                              "jdk20.0.2": { "prefix": "CPU23_05" },
+                              }
+                          }
                         }
                       },
                       "forks": {

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestBotFactoryTest.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestBotFactoryTest.java
@@ -148,7 +148,7 @@ class PullRequestBotFactoryTest {
                             "request": "-critical-request",
                             "approved": "-critical-approved",
                             "rejected": "-critical-rejected",
-                            "documentLink": "https://test.openjdk.org",
+                            "documentLink": "https://example.com",
                             "branches": {
                               "jdk20.0.1": { "prefix": "CPU23_04" },
                               "jdk20.0.2": { "prefix": "CPU23_05" },
@@ -236,7 +236,7 @@ class PullRequestBotFactoryTest {
                     .findFirst().orElseThrow();
             assertEquals("PullRequestBot@repo7", pullRequestBot7.toString());
             assertFalse(pullRequestBot7.jcheckMerge());
-            assertEquals("https://test.openjdk.org", pullRequestBot7.approval().documentLink());
+            assertEquals("https://example.com", pullRequestBot7.approval().documentLink());
 
             var csrIssueBot1 = (CSRIssueBot) bots.stream()
                     .filter(bot -> bot.toString().equals("CSRIssueBot@TEST"))

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestBotFactoryTest.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestBotFactoryTest.java
@@ -148,6 +148,7 @@ class PullRequestBotFactoryTest {
                             "request": "-critical-request",
                             "approved": "-critical-approved",
                             "rejected": "-critical-rejected",
+                            "documentLink": "https://test.openjdk.org",
                             "branches": {
                               "jdk20.0.1": { "prefix": "CPU23_04" },
                               "jdk20.0.2": { "prefix": "CPU23_05" },
@@ -235,6 +236,7 @@ class PullRequestBotFactoryTest {
                     .findFirst().orElseThrow();
             assertEquals("PullRequestBot@repo7", pullRequestBot7.toString());
             assertFalse(pullRequestBot7.jcheckMerge());
+            assertEquals("https://test.openjdk.org", pullRequestBot7.approval().documentLink());
 
             var csrIssueBot1 = (CSRIssueBot) bots.stream()
                     .filter(bot -> bot.toString().equals("CSRIssueBot@TEST"))


### PR DESCRIPTION
As Erik said in the description of this issue, currently, this issue only cares about tracking approval labels in the related bugs.

If a repository is set up with the "approval" configuration, pull requests in that repository will require the maintainer's approval in JBS. Otherwise, the pull request will not be considered ready. 

Erik has also provided a design outlining how to configure the "approval" for a repository.

```
The simple case, where the labels are the same for every branch in a repository: 

"approval": { 
  "request": "jdk17u-fix-request", 
  "approved": "jdk17u-fix-yes", 
  "rejected": "jdk17u-fix-no", 
} 

To reduce the need for changing multiple strings when copying a configuration for a new repository, there is an optional "prefix" field: 

"approval": { 
  "prefix": "jdk17u-fix-", 
  "request": "request", 
  "approved": "yes", 
  "rejected": "no", 
} 

When there are multiple branches with different labels, having the prefix set per branch can help reduce the size of the configuration significantly: 

"approval": { 
  "request": "-critical-request", 
  "approved": "-critical-approved", 
  "rejected": "-critical-rejected", 
  "branches": [ 
    "jdk20\\.0\\.1": { "prefix": "CPU23_04" } 
  ] 
} 
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1199](https://bugs.openjdk.org/browse/SKARA-1199): Enforce maintainer approval in JBS before allowing to integrate backports into updates projects (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1537/head:pull/1537` \
`$ git checkout pull/1537`

Update a local copy of the PR: \
`$ git checkout pull/1537` \
`$ git pull https://git.openjdk.org/skara.git pull/1537/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1537`

View PR using the GUI difftool: \
`$ git pr show -t 1537`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1537.diff">https://git.openjdk.org/skara/pull/1537.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1537#issuecomment-1610305331)