### PR TITLE
1981: Skara sometimes puts two copies of "BUGID: TITLE" in commit message

### DIFF
--- a/bots/common/src/main/java/org/openjdk/skara/bots/common/SolvesTracker.java
+++ b/bots/common/src/main/java/org/openjdk/skara/bots/common/SolvesTracker.java
@@ -44,7 +44,7 @@ public class SolvesTracker {
         return String.format(SOLVES_MARKER, issue.shortId(), "");
     }
 
-    public static List<Issue> currentSolved(HostUser botUser, List<Comment> comments) {
+    public static List<Issue> currentSolved(HostUser botUser, List<Comment> comments, String title) {
         var solvesActions = comments.stream()
                 .filter(comment -> comment.author().equals(botUser))
                 .flatMap(comment -> comment.body().lines())
@@ -52,8 +52,12 @@ public class SolvesTracker {
                 .filter(Matcher::find)
                 .collect(Collectors.toList());
         var current = new LinkedHashMap<String, Issue>();
+        var titleIssue = Issue.fromStringRelaxed(title);
         for (var action : solvesActions) {
             var key = action.group(1);
+            if (titleIssue.isPresent() && key.equals(titleIssue.get().shortId())) {
+                continue;
+            }
             if (action.group(2).equals("")) {
                 current.remove(key);
             } else {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CSRCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CSRCommand.java
@@ -165,7 +165,7 @@ public class CSRCommand implements CommandHandler {
             reply.println(CSR_NEEDED_MARKER);
         } else {
             csrReply(reply);
-            var issues = SolvesTracker.currentSolved(pr.repository().forge().currentUser(), pr.comments());
+            var issues = SolvesTracker.currentSolved(pr.repository().forge().currentUser(), pr.comments(), pr.title());
             if (issues.isEmpty()) {
                 singleIssueLinkReply(pr, jbsMainIssueOpt.get(), reply);
             } else {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -132,7 +132,7 @@ class CheckRun {
         if (issue.isPresent()) {
             var issues = new ArrayList<Issue>();
             issues.add(issue.get());
-            issues.addAll(SolvesTracker.currentSolved(pr.repository().forge().currentUser(), comments));
+            issues.addAll(SolvesTracker.currentSolved(pr.repository().forge().currentUser(), comments, pr.title()));
             var map = new LinkedHashMap<Issue, Optional<IssueTrackerIssue>>();
             if (issueProject() != null) {
                 issues.forEach(i -> {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
@@ -88,8 +88,6 @@ public class CheckablePullRequest {
                                                                comments).stream()
                                                  .map(email -> Author.fromString(email.toString()))
                                                  .collect(Collectors.toList());
-
-        var additionalIssues = SolvesTracker.currentSolved(currentUser, comments);
         var summary = Summary.summary(currentUser, comments);
         CommitMessageBuilder commitMessageBuilder;
         if (PullRequestUtils.isMerge(pr)) {
@@ -116,6 +114,7 @@ public class CheckablePullRequest {
             var issue = Issue.fromStringRelaxed(pr.title());
             commitMessageBuilder = issue.map(CommitMessage::title).orElseGet(() -> CommitMessage.title(pr.title()));
             if (issue.isPresent()) {
+                var additionalIssues = SolvesTracker.currentSolved(currentUser, comments, pr.title());
                 commitMessageBuilder.issues(additionalIssues);
             }
             if (original != null) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IssueCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IssueCommand.java
@@ -285,8 +285,7 @@ public class IssueCommand implements CommandHandler {
             showHelp(reply);
             return;
         }
-
-        var currentSolved = SolvesTracker.currentSolved(pr.repository().forge().currentUser(), allComments)
+        var currentSolved = SolvesTracker.currentSolved(pr.repository().forge().currentUser(), allComments, pr.title())
                                          .stream()
                                          .map(Issue::shortId)
                                          .collect(Collectors.toSet());


### PR DESCRIPTION
As Kevin said in the issue, skara bot sometimes puts two copies of "BUGID: TITLE" in commit message.

To solve this issue, in this patch, when skara bots adding additional issues, it will ignore the title issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1981](https://bugs.openjdk.org/browse/SKARA-1981): Skara sometimes puts two copies of "BUGID: TITLE" in commit message (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1538/head:pull/1538` \
`$ git checkout pull/1538`

Update a local copy of the PR: \
`$ git checkout pull/1538` \
`$ git pull https://git.openjdk.org/skara.git pull/1538/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1538`

View PR using the GUI difftool: \
`$ git pr show -t 1538`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1538.diff">https://git.openjdk.org/skara/pull/1538.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1538#issuecomment-1670342440)