### PR TITLE
1979: MailingListNotifier will not send an email notification when the first branch of some repos is created

### DIFF
--- a/issuetracker/src/test/java/org/openjdk/skara/issuetracker/jira/JiraProjectTests.java
+++ b/issuetracker/src/test/java/org/openjdk/skara/issuetracker/jira/JiraProjectTests.java
@@ -40,7 +40,7 @@ import static org.openjdk.skara.issuetracker.jira.JiraProject.JEP_NUMBER;
  * To be able to run the tests, you need to remove or comment out the @Disabled
  * annotation first.
  */
-@Disabled("Manual")
+//@Disabled("Manual")
 public class JiraProjectTests {
 
     @Test

--- a/issuetracker/src/test/java/org/openjdk/skara/issuetracker/jira/JiraProjectTests.java
+++ b/issuetracker/src/test/java/org/openjdk/skara/issuetracker/jira/JiraProjectTests.java
@@ -40,7 +40,7 @@ import static org.openjdk.skara.issuetracker.jira.JiraProject.JEP_NUMBER;
  * To be able to run the tests, you need to remove or comment out the @Disabled
  * annotation first.
  */
-//@Disabled("Manual")
+@Disabled("Manual")
 public class JiraProjectTests {
 
     @Test


### PR DESCRIPTION
A Leyden committer created a new branch (pregenerate-lambdas) and pushed to it, but skara bot didn't sent email notification to [leyden-dev@openjdk.org](mailto:leyden-dev@openjdk.org). 

After investigating, I found the reason is that in the configuration of NotifyBot, we configured branches as '!master'. Due to this configuration, 'master' branch would be ignored in knownRefs. Therefore, in method RepositoryWorkItem#handleNewRef, The NotifyBot would not be able to find a candidate and it will return immediately.

In this patch, defaultBranch would always be included in the candidate refs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1979](https://bugs.openjdk.org/browse/SKARA-1979): MailingListNotifier will not send an email notification when the first branch of some repos is created (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1539/head:pull/1539` \
`$ git checkout pull/1539`

Update a local copy of the PR: \
`$ git checkout pull/1539` \
`$ git pull https://git.openjdk.org/skara.git pull/1539/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1539`

View PR using the GUI difftool: \
`$ git pr show -t 1539`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1539.diff">https://git.openjdk.org/skara/pull/1539.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1539#issuecomment-1671834651)