### PR TITLE
1983 Handle multiple include paths

### DIFF
--- a/skara.gitconfig
+++ b/skara.gitconfig
@@ -20,7 +20,7 @@
 # questions.
 
 [alias]
-        skara = ! sh \"$(dirname $(git config include.path | grep 'skara.gitconfig' | sed 's@~@'$HOME'@'))/skara.sh\"
+        skara = ! sh \"$(dirname $(git config --get-all include.path | grep 'skara.gitconfig' | sed 's@~@'$HOME'@'))/skara.sh\"
         jcheck = ! git skara jcheck
         webrev = ! git skara webrev
         defpath = ! git skara defpath


### PR DESCRIPTION
Add the --get-all flag to handle the case where a user has multiple values for include.path

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1983](https://bugs.openjdk.org/browse/SKARA-1983): Handle multiple include paths (**Enhancement** - P4)


### Reviewers
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1540/head:pull/1540` \
`$ git checkout pull/1540`

Update a local copy of the PR: \
`$ git checkout pull/1540` \
`$ git pull https://git.openjdk.org/skara.git pull/1540/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1540`

View PR using the GUI difftool: \
`$ git pr show -t 1540`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1540.diff">https://git.openjdk.org/skara/pull/1540.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1540#issuecomment-1662057892)