### PR TITLE
1984: SKARA bot couldn't handle jep command if the jep doesn't have JEP Number

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -301,10 +301,10 @@ class CheckRun {
             ret.put("Change requires a JEP request to be targeted", jepHasTargeted);
             if (jepHasTargeted && newLabels.contains("jep")) {
                 log.info("JEP issue " + jepIssue.id() + " found in state " + jepIssueStatus + ", removing JEP label from " + describe(pr));
-                newLabels.remove("jep");
+                newLabels.remove(JEP_LABEL);
             } else if (!jepHasTargeted && !newLabels.contains("jep")) {
                 log.info("JEP issue " + jepIssue.id() + " found in state " + jepIssueStatus + ", adding JEP label to " + describe(pr));
-                newLabels.add("jep");
+                newLabels.add(JEP_LABEL);
             }
         }
         return ret;

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/JEPCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/JEPCommand.java
@@ -144,7 +144,7 @@ public class JEPCommand implements CommandHandler {
         } else {
             // The current issue status may be "Draft", "Submitted", "Candidate", "Proposed to Target", "Proposed to Drop" or "Closed without Delivered"
             if (jepNumber.equals("NotAllocated")) {
-                reply.println("This pull request will not be integrated until the [" + jbsIssue.id()
+                reply.println("This pull request will not be integrated until the [JEP " + jbsIssue.id()
                         + "](" + jbsIssue.webUrl() + ")" + " has been targeted.");
             } else {
                 reply.println("This pull request will not be integrated until the [JEP-" + jepNumber

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/JEPCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/JEPCommand.java
@@ -133,18 +133,23 @@ public class JEPCommand implements CommandHandler {
         var resolution = jbsIssue.resolution();
 
         // Set the marker and output the result
-        var jepNumber = jbsIssue.properties().get(JEP_NUMBER).asString();
+        var jepNumber = jbsIssue.properties().containsKey(JEP_NUMBER) ? jbsIssue.properties().get(JEP_NUMBER).asString() : "NotAllocated";
         reply.println(String.format(JEP_MARKER, jepNumber, jbsIssue.id(), jbsIssue.title()));
         if ("Targeted".equals(issueStatus) || "Integrated".equals(issueStatus) ||
-            "Completed".equals(issueStatus) || ("Closed".equals(issueStatus) && resolution.isPresent() && "Delivered".equals(resolution.get()))) {
+                "Completed".equals(issueStatus) || ("Closed".equals(issueStatus) && resolution.isPresent() && "Delivered".equals(resolution.get()))) {
             reply.println("The JEP for this pull request, [JEP-" + jepNumber + "](" + jbsIssue.webUrl() + "), has already been targeted.");
             if (labelNames.contains(JEP_LABEL)) {
                 labelsToRemove.add(JEP_LABEL);
             }
         } else {
             // The current issue status may be "Draft", "Submitted", "Candidate", "Proposed to Target", "Proposed to Drop" or "Closed without Delivered"
-            reply.println("This pull request will not be integrated until the [JEP-" + jepNumber
-                    + "](" + jbsIssue.webUrl() + ")" + " has been targeted.");
+            if (jepNumber.equals("NotAllocated")) {
+                reply.println("This pull request will not be integrated until the [" + jbsIssue.id()
+                        + "](" + jbsIssue.webUrl() + ")" + " has been targeted.");
+            } else {
+                reply.println("This pull request will not be integrated until the [JEP-" + jepNumber
+                        + "](" + jbsIssue.webUrl() + ")" + " has been targeted.");
+            }
             if (!labelNames.contains(JEP_LABEL)) {
                 labelsToAdd.add(JEP_LABEL);
             }


### PR DESCRIPTION
A user issued command /jep JDK-8310626 in https://github.com/openjdk/jdk/pull/15103 and skara bot kept throwing exceptions because the JEP doesn't have a JEP number. 

@kevinrushforth suggested that it makes more sense to make skara bot be able to associate a PR with a JEP before it is a Candidate.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1984](https://bugs.openjdk.org/browse/SKARA-1984): SKARA bot couldn't handle jep command if the jep doesn't have JEP Number (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**) ⚠️ Review applies to [d9e1ccbd](https://git.openjdk.org/skara/pull/1541/files/d9e1ccbd827b1ba85acc8300b159d6206a8cc729)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1541/head:pull/1541` \
`$ git checkout pull/1541`

Update a local copy of the PR: \
`$ git checkout pull/1541` \
`$ git pull https://git.openjdk.org/skara.git pull/1541/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1541`

View PR using the GUI difftool: \
`$ git pr show -t 1541`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1541.diff">https://git.openjdk.org/skara/pull/1541.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1541#issuecomment-1663027948)