### PR TITLE
1990: Fix MailingListNotifierTests#testMailingListBranch

### DIFF
--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/mailinglist/MailingListNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/mailinglist/MailingListNotifierTests.java
@@ -1041,6 +1041,7 @@ public class MailingListNotifierTests {
             var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             credentials.commitLock(localRepo);
+            CheckableRepository.appendAndCommit(localRepo, "update master branch");
             localRepo.pushAll(repo.authenticatedUrl());
 
             var listAddress = EmailAddress.parse(listServer.createList("test"));
@@ -1086,9 +1087,7 @@ public class MailingListNotifierTests {
             assertEquals(listAddress, email.sender());
             assertEquals(EmailAddress.from("testauthor", "ta@none.none"), email.author());
             assertEquals(email.recipients(), List.of(listAddress));
-            assertTrue(email.subject().contains("git: test: created branch newbranch1 based on the branch"));
-            assertTrue(email.subject().contains("master") || email.subject().contains("testlock"));
-            assertTrue(email.subject().contains("containing 2 unique commits"));
+            assertTrue(email.subject().contains("git: test: created branch newbranch1 based on the branch master containing 2 unique commits"));
             assertTrue(email.body().contains("12345678: Some fixes"));
             assertTrue(email.hasHeader("extra1"));
             assertEquals("value1", email.headerValue("extra1"));

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/mailinglist/MailingListNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/mailinglist/MailingListNotifierTests.java
@@ -1086,7 +1086,9 @@ public class MailingListNotifierTests {
             assertEquals(listAddress, email.sender());
             assertEquals(EmailAddress.from("testauthor", "ta@none.none"), email.author());
             assertEquals(email.recipients(), List.of(listAddress));
-            assertEquals("git: test: created branch newbranch1 based on the branch master containing 2 unique commits", email.subject());
+            assertTrue(email.subject().contains("git: test: created branch newbranch1 based on the branch"));
+            assertTrue(email.subject().contains("master") || email.subject().contains("testlock"));
+            assertTrue(email.subject().contains("containing 2 unique commits"));
             assertTrue(email.body().contains("12345678: Some fixes"));
             assertTrue(email.hasHeader("extra1"));
             assertEquals("value1", email.headerValue("extra1"));

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/mailinglist/MailingListNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/mailinglist/MailingListNotifierTests.java
@@ -1087,7 +1087,7 @@ public class MailingListNotifierTests {
             assertEquals(listAddress, email.sender());
             assertEquals(EmailAddress.from("testauthor", "ta@none.none"), email.author());
             assertEquals(email.recipients(), List.of(listAddress));
-            assertTrue(email.subject().contains("git: test: created branch newbranch1 based on the branch master containing 2 unique commits"));
+            assertEquals("git: test: created branch newbranch1 based on the branch master containing 2 unique commits", email.subject());
             assertTrue(email.body().contains("12345678: Some fixes"));
             assertTrue(email.hasHeader("extra1"));
             assertEquals("value1", email.headerValue("extra1"));


### PR DESCRIPTION
Due to [SKARA-1979](https://bugs.openjdk.org/browse/SKARA-1979), when generating a notification email for the first branch of a repository, all refs except pr/X branches are regarded as potential candidates. 

Therefore, this test sometimes fails because the master branch and testlock branch are identical, and it's uncertain which one will be selected as the base for the new branch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1990](https://bugs.openjdk.org/browse/SKARA-1990): Fix MailingListNotifierTests#testMailingListBranch (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1543/head:pull/1543` \
`$ git checkout pull/1543`

Update a local copy of the PR: \
`$ git checkout pull/1543` \
`$ git pull https://git.openjdk.org/skara.git pull/1543/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1543`

View PR using the GUI difftool: \
`$ git pr show -t 1543`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1543.diff">https://git.openjdk.org/skara/pull/1543.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1543#issuecomment-1675199206)