### PR TITLE
1995: The logic for getting repository name and branch name in the backport pr command is inconsistent

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
@@ -39,7 +39,6 @@ import java.util.stream.Collectors;
 import java.time.format.DateTimeFormatter;
 
 import static org.openjdk.skara.bots.common.CommandNameEnum.backport;
-import static org.openjdk.skara.bots.common.CommandNameEnum.commandNamesSepByDelim;
 
 public class BackportCommand implements CommandHandler {
     private void showHelp(PrintWriter reply) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
@@ -39,6 +39,7 @@ import java.util.stream.Collectors;
 import java.time.format.DateTimeFormatter;
 
 import static org.openjdk.skara.bots.common.CommandNameEnum.backport;
+import static org.openjdk.skara.bots.common.CommandNameEnum.commandNamesSepByDelim;
 
 public class BackportCommand implements CommandHandler {
     private void showHelp(PrintWriter reply) {
@@ -105,7 +106,7 @@ public class BackportCommand implements CommandHandler {
             }
             var targetRepoName = targetRepo.name();
 
-            var targetBranch = getTargetBranch(parts.length == 3 ? parts[2] : "master", targetRepo, reply);
+            var targetBranch = getTargetBranch(parts, 2, targetRepo, reply);
             if (targetBranch == null) {
                 return;
             }
@@ -127,7 +128,7 @@ public class BackportCommand implements CommandHandler {
             var targetRepoName = targetRepo.name();
 
             // Get target branch
-            var targetBranch = getTargetBranch(parts.length == 2 ? parts[1] : "master", targetRepo, reply);
+            var targetBranch = getTargetBranch(parts, 1, targetRepo, reply);
             if (targetBranch == null) {
                 return;
             }
@@ -182,7 +183,8 @@ public class BackportCommand implements CommandHandler {
         return potentialTargetRepo.get();
     }
 
-    private Branch getTargetBranch(String targetBranchName, HostedRepository targetRepo, PrintWriter reply) {
+    private Branch getTargetBranch(String[] parts, int index, HostedRepository targetRepo, PrintWriter reply) {
+        var targetBranchName = parts.length == index + 1 ? parts[index] : "master";
         var targetBranches = targetRepo.branches();
         if (targetBranches.stream().noneMatch(b -> b.name().equals(targetBranchName))) {
             reply.println("The target branch `" + targetBranchName + "` does not exist");
@@ -220,7 +222,7 @@ public class BackportCommand implements CommandHandler {
         var fork = bot.forks().get(targetRepo.name());
 
         // Get target branch
-        var targetBranch = getTargetBranch(parts.length == 2 ? parts[1] : "master", targetRepo, reply);
+        var targetBranch = getTargetBranch(parts, 1, targetRepo, reply);
         if (targetBranch == null) {
             return;
         }


### PR DESCRIPTION
In the backport pull request command, the process of getting the repository name and branch name differs between cancelling a backport request and creating a backport request. 

In this patch, I made the logic consistent.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1995](https://bugs.openjdk.org/browse/SKARA-1995): The logic for getting repository name and branch name in the backport pr command is inconsistent (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1545/head:pull/1545` \
`$ git checkout pull/1545`

Update a local copy of the PR: \
`$ git checkout pull/1545` \
`$ git pull https://git.openjdk.org/skara.git pull/1545/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1545`

View PR using the GUI difftool: \
`$ git pr show -t 1545`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1545.diff">https://git.openjdk.org/skara/pull/1545.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1545#issuecomment-1681273450)