### PR TITLE
1994: Reply from /reviewer credit can be clearer

### DIFF
--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ReviewerTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ReviewerTests.java
@@ -526,6 +526,20 @@ class ReviewerTests {
             assertLastCommentContains(pr, "Reviewer `integrationreviewer1` successfully removed");
             assertLastCommentContains(pr, "Reviewer `integrationcommitter3` successfully removed");
 
+            pr.addComment("/reviewer credit integrationreviewer2");
+            TestBotRunner.runPeriodicItems(prBot);
+            assertLastCommentContains(pr,
+                    "Reviewer `integrationreviewer2` has already made an authenticated review of this PR, " +
+                            "and does not need to be credited manually.");
+
+            var reviewPr = integrator.pullRequest(pr.id());
+            reviewPr.addReview(Review.Verdict.NONE, "My comments");
+            pr.addComment("/reviewer credit integrationreviewer1");
+            TestBotRunner.runPeriodicItems(prBot);
+            assertLastCommentContains(pr,
+                    "Reviewer `integrationreviewer1` has already made an authenticated review of this PR, " +
+                            "but did not approve it. Manually crediting them is not allowed.");
+
             // Check the PR body
             assertFalse(pr.store().body().contains(" * Generated Reviewer 1 - **Reviewer**"));
             assertFalse(pr.store().body().contains(" * Generated Committer 3 - Committer"));


### PR DESCRIPTION
This patch improved the bot's reply in some cases when the pr author issues '/reviewer <user>' command.

When the pr author is trying to credit an user with '/reviewer <user>' command,

If the user already approved this pr, Skara bot should reply "Reviewer <user> has already made an authenticated review of this PR, and does not need to be credited manually." 

If the user already reviewed this pr(but not approved), Skara bot should reply "Reviewer <user> has already made an authenticated review of this PR, but did not approve it. Manually crediting them is not allowed."

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1994](https://bugs.openjdk.org/browse/SKARA-1994): Reply from /reviewer credit can be clearer (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1547/head:pull/1547` \
`$ git checkout pull/1547`

Update a local copy of the PR: \
`$ git checkout pull/1547` \
`$ git pull https://git.openjdk.org/skara.git pull/1547/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1547`

View PR using the GUI difftool: \
`$ git pr show -t 1547`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1547.diff">https://git.openjdk.org/skara/pull/1547.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1547#issuecomment-1688654516)