### PR TITLE
SKARA-2000

### DIFF
--- a/bots/common/src/main/java/org/openjdk/skara/bots/common/BotUtils.java
+++ b/bots/common/src/main/java/org/openjdk/skara/bots/common/BotUtils.java
@@ -38,7 +38,8 @@ public class BotUtils {
     private static final Pattern issuePattern = Pattern.compile("^(?: \\* )?\\[(\\S+)]\\(.*\\): (.*$)", Pattern.MULTILINE);
 
     public static String escape(String s) {
-        return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
+        return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+                .replace("@", "@<!---->");
     }
 
     /**


### PR DESCRIPTION
In this patch, the bot would escape `@` in the issue title in pr body.

I tried to escape `@` with `&#64;`, but failed, the text would still mention the link.

So according to this [page](https://github.com/github/markup/issues/1168#issuecomment-494946168), I escape `@` with `@<!---->`.

