### PR TITLE
2004: Field 'groups' in Class GitLabHost should be 'List'

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabForgeFactory.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabForgeFactory.java
@@ -50,7 +50,7 @@ public class GitLabForgeFactory implements ForgeFactory {
         if (configuration != null && configuration.contains("name")) {
             name = configuration.get("name").asString();
         }
-        List<String> groups = new ArrayList<>();
+        List<String> groups = List.of();
         if (configuration != null && configuration.contains("groups")) {
             groups = configuration.get("groups")
                                   .stream()

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabForgeFactory.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabForgeFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,9 +23,9 @@
 package org.openjdk.skara.forge.gitlab;
 
 import java.net.URI;
-import java.util.HashSet;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.openjdk.skara.forge.Forge;
 import org.openjdk.skara.forge.ForgeFactory;
 import org.openjdk.skara.forge.internal.ForgeUtils;
@@ -50,12 +50,12 @@ public class GitLabForgeFactory implements ForgeFactory {
         if (configuration != null && configuration.contains("name")) {
             name = configuration.get("name").asString();
         }
-        Set<String> groups = new HashSet<>();
+        List<String> groups = new ArrayList<>();
         if (configuration != null && configuration.contains("groups")) {
             groups = configuration.get("groups")
                                   .stream()
                                   .map(JSONValue::asString)
-                                  .collect(Collectors.toSet());
+                                  .toList();
         }
         var useSsh = false;
         if (configuration != null && configuration.contains("sshkey") && credential != null) {

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabHost.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabHost.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,11 +43,11 @@ public class GitLabHost implements Forge {
     private final Credential pat;
     private final RestRequest request;
     private final Logger log = Logger.getLogger("org.openjdk.skara.forge.gitlab");
-    private final Set<String> groups;
+    private final List<String> groups;
 
     private HostUser cachedCurrentUser = null;
 
-    public GitLabHost(String name, URI uri, boolean useSsh, Credential pat, Set<String> groups) {
+    public GitLabHost(String name, URI uri, boolean useSsh, Credential pat, List<String> groups) {
         this.name = name;
         this.uri = uri;
         this.useSsh = useSsh;
@@ -60,7 +60,7 @@ public class GitLabHost implements Forge {
         request = new RestRequest(baseApi, pat.username(), (r) -> Arrays.asList("Private-Token", pat.password()));
     }
 
-    GitLabHost(String name, URI uri, boolean useSsh, Set<String> groups) {
+    GitLabHost(String name, URI uri, boolean useSsh, List<String> groups) {
         this.name = name;
         this.uri = uri;
         this.useSsh = useSsh;

--- a/forge/src/test/java/org/openjdk/skara/forge/ManualForgeTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/ManualForgeTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -80,7 +81,7 @@ public class ManualForgeTests {
         var pat = settings.getProperty("gitlab.pat");
         var credential = new Credential(user, pat);
 
-        var gitLabHost = new GitLabHost("gitlab", uri, false, credential, Set.of());
+        var gitLabHost = new GitLabHost("gitlab", uri, false, credential, List.of());
 
         var repo = gitLabHost.repository(settings.getProperty("gitlab.repository")).orElseThrow();
 

--- a/forge/src/test/java/org/openjdk/skara/forge/gitlab/GitLabRestApiTest.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/gitlab/GitLabRestApiTest.java
@@ -53,7 +53,7 @@ public class GitLabRestApiTest {
         var token = settings.getProperty("gitlab.pat");
         var credential = new Credential(username, token);
         var uri = URIBuilder.base(settings.getProperty("gitlab.uri")).build();
-        var gitLabHost = new GitLabHost("gitlab", uri, false, credential, Set.of());
+        var gitLabHost = new GitLabHost("gitlab", uri, false, credential, List.of());
         var gitLabRepo = gitLabHost.repository(settings.getProperty("gitlab.repository")).orElseThrow();
         var gitLabMergeRequest = gitLabRepo.pullRequest(settings.getProperty("gitlab.merge.request.id"));
 
@@ -69,7 +69,7 @@ public class GitLabRestApiTest {
         var token = settings.getProperty("gitlab.pat");
         var credential = new Credential(username, token);
         var uri = URIBuilder.base(settings.getProperty("gitlab.uri")).build();
-        var gitLabHost = new GitLabHost("gitlab", uri, false, credential, Set.of());
+        var gitLabHost = new GitLabHost("gitlab", uri, false, credential, List.of());
         var gitLabRepo = gitLabHost.repository(settings.getProperty("gitlab.repository")).orElseThrow();
         var gitLabMergeRequest = gitLabRepo.pullRequest(settings.getProperty("gitlab.merge.request.id"));
 
@@ -89,7 +89,7 @@ public class GitLabRestApiTest {
         var token = settings.getProperty("gitlab.pat");
         var credential = new Credential(username, token);
         var uri = URIBuilder.base(settings.getProperty("gitlab.uri")).build();
-        var gitLabHost = new GitLabHost("gitlab", uri, false, credential, Set.of());
+        var gitLabHost = new GitLabHost("gitlab", uri, false, credential, List.of());
         var gitLabRepo = gitLabHost.repository(settings.getProperty("gitlab.repository")).orElseThrow();
         var gitLabMergeRequest = gitLabRepo.pullRequest(settings.getProperty("gitlab.merge.request.id"));
 
@@ -119,7 +119,7 @@ public class GitLabRestApiTest {
         var token = settings.getProperty("gitlab.pat");
         var credential = new Credential(username, token);
         var uri = URIBuilder.base(settings.getProperty("gitlab.uri")).build();
-        var gitLabHost = new GitLabHost("gitlab", uri, false, credential, Set.of());
+        var gitLabHost = new GitLabHost("gitlab", uri, false, credential, List.of());
         var gitLabRepo = gitLabHost.repository(settings.getProperty("gitlab.repository")).orElseThrow();
         var gitLabMergeRequest = gitLabRepo.pullRequest(settings.getProperty("gitlab.merge.request.id"));
 
@@ -141,7 +141,7 @@ public class GitLabRestApiTest {
         var token = settings.getProperty("gitlab.pat");
         var credential = new Credential(username, token);
         var uri = URIBuilder.base(settings.getProperty("gitlab.uri")).build();
-        var gitLabHost = new GitLabHost("gitlab", uri, false, credential, Set.of());
+        var gitLabHost = new GitLabHost("gitlab", uri, false, credential, List.of());
         var gitLabRepo = gitLabHost.repository(settings.getProperty("gitlab.repository")).orElseThrow();
         var branch = new Branch(settings.getProperty("gitlab.repository.branch"));
 
@@ -157,7 +157,7 @@ public class GitLabRestApiTest {
         var token = settings.getProperty("gitlab.pat");
         var credential = new Credential(username, token);
         var uri = URIBuilder.base(settings.getProperty("gitlab.uri")).build();
-        var gitLabHost = new GitLabHost("gitlab", uri, false, credential, Set.of());
+        var gitLabHost = new GitLabHost("gitlab", uri, false, credential, List.of());
         var gitLabRepo = gitLabHost.repository(settings.getProperty("gitlab.repository")).orElseThrow();
         var branch = new Branch(settings.getProperty("gitlab.repository.branch"));
 
@@ -198,7 +198,7 @@ public class GitLabRestApiTest {
         var token = settings.getProperty("gitlab.pat");
         var credential = new Credential(username, token);
         var uri = URIBuilder.base(settings.getProperty("gitlab.uri")).build();
-        var gitLabHost = new GitLabHost("gitlab", uri, false, credential, Set.of());
+        var gitLabHost = new GitLabHost("gitlab", uri, false, credential, List.of());
         var gitLabRepo = gitLabHost.repository(settings.getProperty("gitlab.repository")).orElseThrow();
         var branchName = "pr/4711";
 
@@ -227,7 +227,7 @@ public class GitLabRestApiTest {
         var token = settings.getProperty("gitlab.pat");
         var credential = new Credential(username, token);
         var uri = URIBuilder.base(settings.getProperty("gitlab.uri")).build();
-        var gitLabHost = new GitLabHost("gitlab", uri, false, credential, Set.of());
+        var gitLabHost = new GitLabHost("gitlab", uri, false, credential, List.of());
         var gitLabRepo = gitLabHost.repository(settings.getProperty("gitlab.repository")).orElseThrow();
         var gitLabMergeRequest = gitLabRepo.pullRequest(settings.getProperty("gitlab.merge.request.id"));
 
@@ -242,7 +242,7 @@ public class GitLabRestApiTest {
         var token = settings.getProperty("gitlab.pat");
         var credential = new Credential(username, token);
         var uri = URIBuilder.base(settings.getProperty("gitlab.uri")).build();
-        var gitLabHost = new GitLabHost("gitlab", uri, false, credential, Set.of());
+        var gitLabHost = new GitLabHost("gitlab", uri, false, credential, List.of());
         var gitLabRepo = gitLabHost.repository(settings.getProperty("gitlab.repository")).orElseThrow();
 
         var gitLabMergeRequest = gitLabRepo.createPullRequest(gitLabRepo, settings.getProperty("gitlab.targetRef"),
@@ -263,7 +263,7 @@ public class GitLabRestApiTest {
         var token = settings.getProperty("gitlab.pat");
         var credential = new Credential(username, token);
         var uri = URIBuilder.base(settings.getProperty("gitlab.uri")).build();
-        var gitLabHost = new GitLabHost("gitlab", uri, false, credential, Set.of());
+        var gitLabHost = new GitLabHost("gitlab", uri, false, credential, List.of());
         var gitLabRepo = gitLabHost.repository(settings.getProperty("gitlab.repository")).orElseThrow();
         var gitLabMergeRequest = gitLabRepo.pullRequest(settings.getProperty("gitlab.merge.request.id"));
 
@@ -285,7 +285,7 @@ public class GitLabRestApiTest {
         var token = settings.getProperty("gitlab.pat");
         var credential = new Credential(username, token);
         var uri = URIBuilder.base(settings.getProperty("gitlab.uri")).build();
-        var gitLabHost = new GitLabHost("gitlab", uri, false, credential, Set.of());
+        var gitLabHost = new GitLabHost("gitlab", uri, false, credential, List.of());
         var gitLabRepo = gitLabHost.repository(settings.getProperty("gitlab.repository")).orElseThrow();
 
         gitLabRepo.deleteDeployKeys(Duration.ofHours(24));
@@ -298,7 +298,7 @@ public class GitLabRestApiTest {
         var token = settings.getProperty("gitlab.pat");
         var credential = new Credential(username, token);
         var uri = URIBuilder.base(settings.getProperty("gitlab.uri")).build();
-        var gitLabHost = new GitLabHost("gitlab", uri, false, credential, Set.of());
+        var gitLabHost = new GitLabHost("gitlab", uri, false, credential, List.of());
         var gitLabRepo = gitLabHost.repository(settings.getProperty("gitlab.repository")).orElseThrow();
 
         var expiredDeployKeys = gitLabRepo.deployKeyTitles(Duration.ofMinutes(5));


### PR DESCRIPTION
Currently, the type of field 'groups' in GitLabHost is a set. However, we would like the bot has some preference for some groups, so this field should be able to keep the order. 

The solution is to change the type this field to List.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2004](https://bugs.openjdk.org/browse/SKARA-2004): Field 'groups' in Class GitLabHost should be 'List' (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1550/head:pull/1550` \
`$ git checkout pull/1550`

Update a local copy of the PR: \
`$ git checkout pull/1550` \
`$ git pull https://git.openjdk.org/skara.git pull/1550/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1550`

View PR using the GUI difftool: \
`$ git pr show -t 1550`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1550.diff">https://git.openjdk.org/skara/pull/1550.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1550#issuecomment-1692021401)