### PR TITLE
2011: GHA: Resolve deprecation warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,10 +36,10 @@ jobs:
 
       - name: Check if submit tests should actually run
         id: check_submit
-        run: echo "::set-output name=should_run::${{ env.TARGET_PROJECT == steps.upstream_repo.outputs.result }}"
+        run: echo "should_run=${{ env.TARGET_PROJECT == steps.upstream_repo.outputs.result }}" >> $GITHUB_OUTPUT
 
       - name: Checkout the source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 1000
         if: steps.check_submit.outputs.should_run != 'false'
@@ -48,18 +48,18 @@ jobs:
         id: merge_target
         run: |
           git fetch https://github.com/openjdk/${{ steps.upstream_repo.outputs.result }} ${TARGET_BRANCH}
-          echo "::set-output name=hash::`git rev-parse FETCH_HEAD`"
-          echo "::set-output name=command::git fetch https://github.com/openjdk/${{ steps.upstream_repo.outputs.result }} ${TARGET_BRANCH}"
+          echo "hash=`git rev-parse FETCH_HEAD`" >> $GITHUB_OUTPUT
+          echo "command=git fetch https://github.com/openjdk/${{ steps.upstream_repo.outputs.result }} ${TARGET_BRANCH}" >> $GITHUB_OUTPUT
         if: steps.check_submit.outputs.should_run != 'false'
 
       - name: Determine merge strategy
         id: try_merge_target
         run: >
           (git -c user.name="presubmit" -c user.email="presubmit@github.actions" merge --no-edit ${{ steps.merge_target.outputs.hash }} &&
-            echo "::set-output name=command::git -c user.name="presubmit" -c user.email="presubmit@github.actions" merge --no-edit ${{ steps.merge_target.outputs.hash }}") ||
+            (echo "command=git -c user.name="presubmit" -c user.email="presubmit@github.actions" merge --no-edit ${{ steps.merge_target.outputs.hash }}") >> $GITHUB_OUTPUT) ||
           (git merge --abort && git -c user.name="presubmit" -c user.email="presubmit@github.actions" rebase ${{ steps.merge_target.outputs.hash }} &&
-            echo "::set-output name=command::git -c user.name="presubmit" -c user.email="presubmit@github.actions" rebase ${{ steps.merge_target.outputs.hash }}") ||
-          echo "::set-output name=command::echo There are merge conflicts with the target that will have to be resolved before integration"
+            (echo "command=git -c user.name="presubmit" -c user.email="presubmit@github.actions" rebase ${{ steps.merge_target.outputs.hash }}") >> $GITHUB_OUTPUT) ||
+          (echo "command=echo There are merge conflicts with the target that will have to be resolved before integration" >> $GITHUB_OUTPUT)
 
   linux:
     name: Linux x64
@@ -69,7 +69,7 @@ jobs:
 
     steps:
       - name: Checkout the source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 1000
 
@@ -88,7 +88,7 @@ jobs:
 
     steps:
       - name: Checkout the source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 1000
 
@@ -110,7 +110,7 @@ jobs:
 
     steps:
       - name: Checkout the source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 1000
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,10 @@ jobs:
     steps:
       - name: Determine target project name (fork source)
         id: upstream_repo
-        uses: actions/github-script@v3
+        uses: actions/github-script@v6
         with:
           result-encoding: string
-          script: "return (await github.repos.get( {owner: context.repo.owner, repo: context.repo.repo })).data.source.name"
+          script: "return (await github.rest.repos.get( {owner: context.repo.owner, repo: context.repo.repo })).data.source.name"
 
       - name: Check if submit tests should actually run
         id: check_submit


### PR DESCRIPTION
This PR resolves deprecation warnings in the GHA workflow by updating dependencies and replacing the deprecated `set-output` with `GITHUB_OUTPUT`.

v2 to v3 major in `checkout` just updated the node version.

Github Script v3->v6 also needed a small code change (`github.repos`->`github.rest.repos`), following the documentation.

GHA workflows still pass with these changes.

Note that I don't have a JBS account to be able to make an issue for this PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2011](https://bugs.openjdk.org/browse/SKARA-2011): GHA: Resolve deprecation warnings (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1552/head:pull/1552` \
`$ git checkout pull/1552`

Update a local copy of the PR: \
`$ git checkout pull/1552` \
`$ git pull https://git.openjdk.org/skara.git pull/1552/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1552`

View PR using the GUI difftool: \
`$ git pr show -t 1552`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1552.diff">https://git.openjdk.org/skara/pull/1552.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1552#issuecomment-1700856314)