### PR TITLE
1997: Allow the creator of a PR to set the commit author

### DIFF
--- a/bots/common/src/main/java/org/openjdk/skara/bots/common/CommandNameEnum.java
+++ b/bots/common/src/main/java/org/openjdk/skara/bots/common/CommandNameEnum.java
@@ -47,7 +47,8 @@ public enum CommandNameEnum {
     backport,
     tag,
     approval(true),
-    approve;
+    approve,
+    author;
 
     private boolean isMultiLine = false;
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/AuthorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/AuthorCommand.java
@@ -52,7 +52,7 @@ public class AuthorCommand implements CommandHandler {
     @Override
     public void handle(PullRequestBot bot, PullRequest pr, CensusInstance censusInstance, ScratchArea scratchArea, CommandInvocation command, List<Comment> allComments, PrintWriter reply) {
         if (!command.user().equals(pr.author())) {
-            reply.println("Only the author (@" + pr.author().username() + ") is allowed to issue the `author` command.");
+            reply.println("Only the pull request author (@" + pr.author().username() + ") is allowed to issue the `author` command.");
             return;
         }
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/AuthorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/AuthorCommand.java
@@ -105,7 +105,7 @@ public class AuthorCommand implements CommandHandler {
                     }
                 }
                 if (currAuthor.isEmpty()) {
-                    reply.println("There is no overriding author set in this pull request.");
+                    reply.println("There is no overriding author set for this pull request.");
                 } else {
                     if (currAuthor.get().equals(author.get())) {
                         reply.println(OverridingAuthor.removeAuthorMarker(author.get()));

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/AuthorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/AuthorCommand.java
@@ -88,7 +88,7 @@ public class AuthorCommand implements CommandHandler {
                     return;
                 }
                 reply.println(Authors.setAuthorMarker(author.get()));
-                reply.println("Author of this pull request has been set to `" + author.get() + "` successfully.");
+                reply.println("Setting overriding author to `" + author.get() + "`. When this pull request is integrated, the overriding author will be used in the commit.");
                 break;
             }
             case "remove": {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/AuthorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/AuthorCommand.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.pr;
+
+import org.openjdk.skara.forge.PullRequest;
+import org.openjdk.skara.issuetracker.Comment;
+
+import java.io.PrintWriter;
+import java.util.*;
+import java.util.regex.Pattern;
+
+import static org.openjdk.skara.bots.common.CommandNameEnum.author;
+
+public class AuthorCommand implements CommandHandler {
+    private static final Pattern COMMAND_PATTERN = Pattern.compile("^(set|remove)\\s+(.+)$");
+
+    private void showHelp(PrintWriter reply) {
+        reply.println("Syntax: `/author (set|remove) [@user | openjdk-user | Full Name <email@address>]`. For example:");
+        reply.println();
+        reply.println(" * `/author set @openjdk-bot`");
+        reply.println(" * `/author set duke`");
+        reply.println(" * `/author set J. Duke <duke@openjdk.org>`");
+        reply.println();
+        reply.println("User names can only be used for users in the census associated with this repository. " +
+                "For other authors you need to supply the full name and email address.");
+    }
+
+    @Override
+    public void handle(PullRequestBot bot, PullRequest pr, CensusInstance censusInstance, ScratchArea scratchArea, CommandInvocation command, List<Comment> allComments, PrintWriter reply) {
+        if (!command.user().equals(pr.author())) {
+            reply.println("Only the author (@" + pr.author().username() + ") is allowed to issue the `author` command.");
+            return;
+        }
+
+        if (censusInstance.isCommitter(pr.author())) {
+            reply.println("Only committers in this [project](https://openjdk.org/census#" + censusInstance.project().name() + ") are allowed to issue the `author` command.");
+            return;
+        }
+
+        var matcher = COMMAND_PATTERN.matcher(command.args());
+        if (!matcher.matches()) {
+            showHelp(reply);
+            return;
+        }
+
+        var author = ContributorCommand.parseUser(matcher.group(2), pr, censusInstance, reply);
+        if (author.isEmpty()) {
+            reply.println();
+            showHelp(reply);
+            return;
+        }
+
+        switch (matcher.group(1)) {
+            case "set": {
+                reply.println(Authors.setAuthorMarker(author.get()));
+                reply.println("Author of this pull request has been set to `" + author.get() + "` successfully.");
+                break;
+            }
+            case "remove": {
+                var currAuthor = Authors.author(pr.repository().forge().currentUser(), allComments);
+                if (currAuthor.isEmpty()) {
+                    reply.println("There is no author set in this pull request.");
+                } else {
+                    if (currAuthor.get().equals(author.get())) {
+                        reply.println(Authors.removeAuthorMarker(author.get()));
+                        reply.println("Author `" + author.get() + "` successfully removed.");
+                    } else {
+                        reply.println("`" + author.get() + "` was not set to this pull request's author.");
+                        reply.println("Current author of this pull request is set to: `" + currAuthor.get() + "`");
+                    }
+                }
+                break;
+            }
+        }
+    }
+
+    @Override
+    public String description() {
+        return "sets or removes author for a PR";
+    }
+
+    @Override
+    public String name() {
+        return author.name();
+    }
+
+    @Override
+    public boolean allowedInBody() {
+        return true;
+    }
+}

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/AuthorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/AuthorCommand.java
@@ -121,7 +121,7 @@ public class AuthorCommand implements CommandHandler {
 
     @Override
     public String description() {
-        return "sets an overriding author used in the final commit when the PR is integrated";
+        return "sets an overriding author to be used in the commit when the PR is integrated";
     }
 
     @Override

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/AuthorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/AuthorCommand.java
@@ -57,7 +57,7 @@ public class AuthorCommand implements CommandHandler {
         }
 
         if (!censusInstance.isCommitter(pr.author())) {
-            reply.println("Only committers in this [project](https://openjdk.org/census#" + censusInstance.project().name() + ") are allowed to issue the `author` command.");
+            reply.println("Only [Committers](https://openjdk.org/bylaws#committer) are allowed to issue the `author` command.");
             return;
         }
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/AuthorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/AuthorCommand.java
@@ -87,12 +87,12 @@ public class AuthorCommand implements CommandHandler {
                     showHelp(reply);
                     return;
                 }
-                reply.println(Authors.setAuthorMarker(author.get()));
+                reply.println(OverridingAuthor.setAuthorMarker(author.get()));
                 reply.println("Setting overriding author to `" + author.get() + "`. When this pull request is integrated, the overriding author will be used in the commit.");
                 break;
             }
             case "remove": {
-                var currAuthor = Authors.author(pr.repository().forge().currentUser(), allComments);
+                var currAuthor = OverridingAuthor.author(pr.repository().forge().currentUser(), allComments);
                 Optional<EmailAddress> author;
                 if (authorArg == null) {
                     author = currAuthor;
@@ -105,10 +105,10 @@ public class AuthorCommand implements CommandHandler {
                     }
                 }
                 if (currAuthor.isEmpty()) {
-                    reply.println("There is no author set in this pull request.");
+                    reply.println("There is no overriding author set in this pull request.");
                 } else {
                     if (currAuthor.get().equals(author.get())) {
-                        reply.println(Authors.removeAuthorMarker(author.get()));
+                        reply.println(OverridingAuthor.removeAuthorMarker(author.get()));
                         reply.println("Overriding author `" + author.get() + "` was successfully removed. When this pull request is integrated, the pull request author will be the author of the commit.");
                     } else {
                         reply.println("Cannot remove `" + author.get() + "`, the overriding author is currently set to: `" + currAuthor.get() + "`");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/AuthorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/AuthorCommand.java
@@ -111,8 +111,7 @@ public class AuthorCommand implements CommandHandler {
                         reply.println(Authors.removeAuthorMarker(author.get()));
                         reply.println("Overriding author `" + author.get() + "` was successfully removed. When this pull request is integrated, the pull request author will be the author of the commit.");
                     } else {
-                        reply.println("`" + author.get() + "` was not set to this pull request's author.");
-                        reply.println("Current author of this pull request is set to: `" + currAuthor.get() + "`");
+                        reply.println("Cannot remove `" + author.get() + "`, the overriding author is currently set to: `" + currAuthor.get() + "`");
                     }
                 }
                 break;

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/AuthorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/AuthorCommand.java
@@ -109,7 +109,7 @@ public class AuthorCommand implements CommandHandler {
                 } else {
                     if (currAuthor.get().equals(author.get())) {
                         reply.println(Authors.removeAuthorMarker(author.get()));
-                        reply.println("Author `" + author.get() + "` successfully removed.");
+                        reply.println("Overriding author `" + author.get() + "` was successfully removed. When this pull request is integrated, the pull request author will be the author of the commit.");
                     } else {
                         reply.println("`" + author.get() + "` was not set to this pull request's author.");
                         reply.println("Current author of this pull request is set to: `" + currAuthor.get() + "`");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/AuthorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/AuthorCommand.java
@@ -56,10 +56,10 @@ public class AuthorCommand implements CommandHandler {
             return;
         }
 
-//        if (!censusInstance.isCommitter(pr.author())) {
-//            reply.println("Only committers in this [project](https://openjdk.org/census#" + censusInstance.project().name() + ") are allowed to issue the `author` command.");
-//            return;
-//        }
+        if (!censusInstance.isCommitter(pr.author())) {
+            reply.println("Only committers in this [project](https://openjdk.org/census#" + censusInstance.project().name() + ") are allowed to issue the `author` command.");
+            return;
+        }
 
         var matcher = COMMAND_PATTERN.matcher(command.args());
         if (!matcher.matches()) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/AuthorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/AuthorCommand.java
@@ -122,7 +122,7 @@ public class AuthorCommand implements CommandHandler {
 
     @Override
     public String description() {
-        return "sets or removes author for a PR";
+        return "sets an overriding author used in the final commit when the PR is integrated";
     }
 
     @Override

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/AuthorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/AuthorCommand.java
@@ -109,7 +109,7 @@ public class AuthorCommand implements CommandHandler {
                 } else {
                     if (currAuthor.get().equals(author.get())) {
                         reply.println(OverridingAuthor.removeAuthorMarker(author.get()));
-                        reply.println("Overriding author `" + author.get() + "` was successfully removed. When this pull request is integrated, the pull request author will be the author of the commit.");
+                        reply.println("Overriding author `" + author.get() + "` was successfully removed. When this pull request is integrated, the pull request author will be used as the author of the commit.");
                     } else {
                         reply.println("Cannot remove `" + author.get() + "`, the overriding author is currently set to: `" + currAuthor.get() + "`");
                     }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/Authors.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/Authors.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.pr;
+
+import org.openjdk.skara.email.EmailAddress;
+import org.openjdk.skara.host.*;
+import org.openjdk.skara.issuetracker.Comment;
+
+import java.util.*;
+import java.util.regex.*;
+
+class Authors {
+    private static final String SET_MARKER = "<!-- set author: '%s' -->";
+    private static final String REMOVE_MARKER = "<!-- remove author: '%s' -->";
+    private static final Pattern MARKER_PATTERN = Pattern.compile("<!-- (set|remove) author: '(.*?)' -->");
+
+    static String setAuthorMarker(EmailAddress author) {
+        return String.format(SET_MARKER, author.toString());
+    }
+
+    static String removeAuthorMarker(EmailAddress author) {
+        return String.format(REMOVE_MARKER, author.toString());
+    }
+
+    static Optional<EmailAddress> author(HostUser botUser, List<Comment> comments) {
+        var authorActions = comments.stream()
+                .filter(comment -> comment.author().equals(botUser))
+                .map(comment -> MARKER_PATTERN.matcher(comment.body()))
+                .filter(Matcher::find)
+                .toList();
+        Optional<EmailAddress> author = Optional.empty();
+        for (var action : authorActions) {
+            switch (action.group(1)) {
+                case "set":
+                    author = Optional.of(EmailAddress.parse(action.group(2)));
+                    break;
+                case "remove":
+                    author = Optional.empty();
+                    break;
+            }
+        }
+
+        return author;
+    }
+}
+

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -1242,7 +1242,7 @@ class CheckRun {
             try {
                 // Do not pass eventual original commit even for backports since it will cause
                 // the reviewer check to be ignored.
-                localHash = checkablePullRequest.commit(commitHash, censusInstance.namespace(), censusDomain, null, null);
+                localHash = checkablePullRequest.commit(commitHash, censusInstance.namespace(), censusDomain, null, null, comments);
             } catch (CommitFailure e) {
                 additionalErrors = List.of(e.getMessage());
                 localHash = baseHash;

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -100,9 +100,10 @@ class CheckRun {
 
         baseHash = PullRequestUtils.baseHash(pr, localRepo);
         checkablePullRequest = new CheckablePullRequest(pr, localRepo, ignoreStaleReviews,
-                                                        workItem.bot.confOverrideRepository().orElse(null),
-                                                        workItem.bot.confOverrideName(),
-                                                        workItem.bot.confOverrideRef());
+                workItem.bot.confOverrideRepository().orElse(null),
+                workItem.bot.confOverrideName(),
+                workItem.bot.confOverrideRef(),
+                comments);
     }
 
     static Optional<Instant> execute(CheckWorkItem workItem, PullRequest pr, Repository localRepo, List<Comment> comments,
@@ -465,7 +466,7 @@ class CheckRun {
     }
 
     private Optional<HostedCommit> backportedFrom() {
-        var hash = checkablePullRequest.findOriginalBackportHash(comments);
+        var hash = checkablePullRequest.findOriginalBackportHash();
         if (hash == null) {
             return Optional.empty();
         }
@@ -1242,7 +1243,7 @@ class CheckRun {
             try {
                 // Do not pass eventual original commit even for backports since it will cause
                 // the reviewer check to be ignored.
-                localHash = checkablePullRequest.commit(commitHash, censusInstance.namespace(), censusDomain, null, null, comments);
+                localHash = checkablePullRequest.commit(commitHash, censusInstance.namespace(), censusDomain, null, null);
             } catch (CommitFailure e) {
                 additionalErrors = List.of(e.getMessage());
                 localHash = baseHash;
@@ -1316,7 +1317,7 @@ class CheckRun {
             var updatedBody = updateStatusMessage(statusMessage);
             var title = pr.title();
 
-            var amendedHash = checkablePullRequest.amendManualReviewers(localHash, censusInstance.namespace(), original.map(Commit::hash).orElse(null), comments);
+            var amendedHash = checkablePullRequest.amendManualReviewers(localHash, censusInstance.namespace(), original.map(Commit::hash).orElse(null));
             var commit = localRepo.lookup(amendedHash).orElseThrow();
             var commitMessage = String.join("\n", commit.message());
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -465,7 +465,7 @@ class CheckRun {
     }
 
     private Optional<HostedCommit> backportedFrom() {
-        var hash = checkablePullRequest.findOriginalBackportHash();
+        var hash = checkablePullRequest.findOriginalBackportHash(comments);
         if (hash == null) {
             return Optional.empty();
         }
@@ -1316,7 +1316,7 @@ class CheckRun {
             var updatedBody = updateStatusMessage(statusMessage);
             var title = pr.title();
 
-            var amendedHash = checkablePullRequest.amendManualReviewers(localHash, censusInstance.namespace(), original.map(Commit::hash).orElse(null));
+            var amendedHash = checkablePullRequest.amendManualReviewers(localHash, censusInstance.namespace(), original.map(Commit::hash).orElse(null), comments);
             var commit = localRepo.lookup(amendedHash).orElseThrow();
             var commitMessage = String.join("\n", commit.message());
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
@@ -178,6 +178,11 @@ public class CheckablePullRequest {
             committer = author;
         }
 
+        var authorSet = Authors.author(pr.repository().forge().currentUser(), pr.comments());
+        if (authorSet.isPresent()) {
+            author = new Author(authorSet.get().fullName().orElse(""), authorSet.get().address());
+        }
+
         var activeReviews = filterActiveReviews(pr.reviews(), pr.targetRef());
         var commitMessage = commitMessage(finalHead, activeReviews, namespace, false, original);
         return PullRequestUtils.createCommit(pr, localRepo, finalHead, author, committer, commitMessage);

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
@@ -26,6 +26,7 @@ import org.openjdk.skara.bots.common.SolvesTracker;
 import org.openjdk.skara.census.*;
 import org.openjdk.skara.forge.*;
 import org.openjdk.skara.host.HostUser;
+import org.openjdk.skara.issuetracker.Comment;
 import org.openjdk.skara.jcheck.*;
 import org.openjdk.skara.vcs.*;
 import org.openjdk.skara.vcs.openjdk.*;
@@ -155,7 +156,7 @@ public class CheckablePullRequest {
         return List.copyOf(reviewPerUser.values());
     }
 
-    Hash commit(Hash finalHead, Namespace namespace, String censusDomain, String sponsorId, Hash original) throws IOException, CommitFailure {
+    Hash commit(Hash finalHead, Namespace namespace, String censusDomain, String sponsorId, Hash original, List<Comment> comments) throws IOException, CommitFailure {
         Author committer;
         Author author;
         var contributor = namespace.get(pr.author().id());
@@ -178,9 +179,9 @@ public class CheckablePullRequest {
             committer = author;
         }
 
-        var overridingAuthor = Authors.author(pr.repository().forge().currentUser(), pr.comments());
-        if (authorSet.isPresent()) {
-            author = new Author(authorSet.get().fullName().orElse(""), authorSet.get().address());
+        var overridingAuthor = OverridingAuthor.author(pr.repository().forge().currentUser(), comments);
+        if (overridingAuthor.isPresent()) {
+            author = new Author(overridingAuthor.get().fullName().orElse(""), overridingAuthor.get().address());
         }
 
         var activeReviews = filterActiveReviews(pr.reviews(), pr.targetRef());

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
@@ -178,7 +178,7 @@ public class CheckablePullRequest {
             committer = author;
         }
 
-        var authorSet = Authors.author(pr.repository().forge().currentUser(), pr.comments());
+        var overridingAuthor = Authors.author(pr.repository().forge().currentUser(), pr.comments());
         if (authorSet.isPresent()) {
             author = new Author(authorSet.get().fullName().orElse(""), authorSet.get().address());
         }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CleanCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CleanCommand.java
@@ -58,7 +58,7 @@ public class CleanCommand implements CommandHandler {
             return;
         }
 
-        if (!pr.labelNames().contains("backport") || CheckablePullRequest.findOriginalBackportHash(pr) == null) {
+        if (!pr.labelNames().contains("backport") || CheckablePullRequest.findOriginalBackportHash(pr, allComments) == null) {
             reply.println("Can only mark [backport pull requests]" +
                     "(https://wiki.openjdk.org/display/SKARA/Backports#Backports-BackportPullRequests)," +
                     " with an original hash, as clean");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandExtractor.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandExtractor.java
@@ -65,7 +65,8 @@ public class CommandExtractor {
             Map.entry(backport.name(), new BackportCommand()),
             Map.entry(tag.name(), new TagCommand()),
             Map.entry(approval.name(), new ApprovalCommand()),
-            Map.entry(approve.name(), new ApproveCommand())
+            Map.entry(approve.name(), new ApproveCommand()),
+            Map.entry(author.name(), new AuthorCommand())
     );
 
     static class HelpCommand implements CommandHandler {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ContributorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ContributorCommand.java
@@ -47,7 +47,7 @@ public class ContributorCommand implements CommandHandler {
                 "For other contributors you need to supply the full name and email address.");
     }
 
-    private Optional<EmailAddress> parseUser(String user, PullRequest pr, CensusInstance censusInstance, PrintWriter reply) {
+    public static Optional<EmailAddress> parseUser(String user, PullRequest pr, CensusInstance censusInstance, PrintWriter reply) {
         user = user.strip();
         if (user.isEmpty()) {
             reply.println("Username parameter is empty.");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
@@ -221,7 +221,7 @@ public class IntegrateCommand implements CommandHandler {
                 committerId = command.user().id();
             }
             var localHash = checkablePr.commit(rebasedHash.get(), censusInstance.namespace(),
-                    censusInstance.configuration().census().domain(), committerId, original);
+                    censusInstance.configuration().census().domain(), committerId, original, allComments);
             if (runJcheck(pr, censusInstance, allComments, reply, localRepo, checkablePr, localHash, bot.reviewMerge())) {
                 return;
             }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
@@ -213,7 +213,7 @@ public class IntegrateCommand implements CommandHandler {
                 return;
             }
 
-            var original = checkablePr.findOriginalBackportHash();
+            var original = checkablePr.findOriginalBackportHash(allComments);
             // If someone other than the author or the bot issued the /integrate command, then that person
             // should be set as sponsor/integrator. Otherwise pass null to use the default author.
             String committerId = null;
@@ -239,7 +239,7 @@ public class IntegrateCommand implements CommandHandler {
 
             // Rebase and push it!
             if (!localHash.equals(checkablePr.targetHash())) {
-                var amendedHash = checkablePr.amendManualReviewers(localHash, censusInstance.namespace(), original);
+                var amendedHash = checkablePr.amendManualReviewers(localHash, censusInstance.namespace(), original, allComments);
                 addPrePushComment(pr, amendedHash, rebaseMessage.toString());
                 localRepo.push(amendedHash, pr.repository().authenticatedUrl(), pr.targetRef());
                 markIntegratedAndClosed(pr, amendedHash, reply, allComments);

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/OverridingAuthor.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/OverridingAuthor.java
@@ -29,7 +29,7 @@ import org.openjdk.skara.issuetracker.Comment;
 import java.util.*;
 import java.util.regex.*;
 
-class Authors {
+class OverridingAuthor {
     private static final String SET_MARKER = "<!-- set author: '%s' -->";
     private static final String REMOVE_MARKER = "<!-- remove author: '%s' -->";
     private static final Pattern MARKER_PATTERN = Pattern.compile("<!-- (set|remove) author: '(.*?)' -->");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
@@ -97,9 +97,10 @@ public class SponsorCommand implements CommandHandler {
 
             var localRepo = IntegrateCommand.materializeLocalRepo(bot, pr, scratchArea);
             var checkablePr = new CheckablePullRequest(pr, localRepo, bot.ignoreStaleReviews(),
-                                                       bot.confOverrideRepository().orElse(null),
-                                                       bot.confOverrideName(),
-                                                       bot.confOverrideRef());
+                    bot.confOverrideRepository().orElse(null),
+                    bot.confOverrideName(),
+                    bot.confOverrideRef(),
+                    allComments);
 
             // Validate the target hash if requested
             if (!command.args().isBlank()) {
@@ -120,16 +121,16 @@ public class SponsorCommand implements CommandHandler {
                 return;
             }
 
-            var original = checkablePr.findOriginalBackportHash(allComments);
+            var original = checkablePr.findOriginalBackportHash();
             var localHash = checkablePr.commit(rebasedHash.get(), censusInstance.namespace(), censusInstance.configuration().census().domain(),
-                    command.user().id(), original, allComments);
+                    command.user().id(), original);
 
             if (IntegrateCommand.runJcheck(pr, censusInstance, allComments, reply, localRepo, checkablePr, localHash, bot.reviewMerge())) {
                 return;
             }
 
             if (!localHash.equals(checkablePr.targetHash())) {
-                var amendedHash = checkablePr.amendManualReviewers(localHash, censusInstance.namespace(), original, allComments);
+                var amendedHash = checkablePr.amendManualReviewers(localHash, censusInstance.namespace(), original);
                 IntegrateCommand.addPrePushComment(pr, amendedHash, rebaseMessage.toString());
                 localRepo.push(amendedHash, pr.repository().authenticatedUrl(), pr.targetRef());
                 markIntegratedAndClosed(pr, amendedHash, reply, allComments);

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
@@ -122,7 +122,7 @@ public class SponsorCommand implements CommandHandler {
 
             var original = checkablePr.findOriginalBackportHash();
             var localHash = checkablePr.commit(rebasedHash.get(), censusInstance.namespace(), censusInstance.configuration().census().domain(),
-                    command.user().id(), original);
+                    command.user().id(), original, allComments);
 
             if (IntegrateCommand.runJcheck(pr, censusInstance, allComments, reply, localRepo, checkablePr, localHash, bot.reviewMerge())) {
                 return;

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
@@ -120,7 +120,7 @@ public class SponsorCommand implements CommandHandler {
                 return;
             }
 
-            var original = checkablePr.findOriginalBackportHash();
+            var original = checkablePr.findOriginalBackportHash(allComments);
             var localHash = checkablePr.commit(rebasedHash.get(), censusInstance.namespace(), censusInstance.configuration().census().domain(),
                     command.user().id(), original, allComments);
 
@@ -129,7 +129,7 @@ public class SponsorCommand implements CommandHandler {
             }
 
             if (!localHash.equals(checkablePr.targetHash())) {
-                var amendedHash = checkablePr.amendManualReviewers(localHash, censusInstance.namespace(), original);
+                var amendedHash = checkablePr.amendManualReviewers(localHash, censusInstance.namespace(), original, allComments);
                 IntegrateCommand.addPrePushComment(pr, amendedHash, rebaseMessage.toString());
                 localRepo.push(amendedHash, pr.repository().authenticatedUrl(), pr.targetRef());
                 markIntegratedAndClosed(pr, amendedHash, reply, allComments);

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/AuthorCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/AuthorCommandTests.java
@@ -83,21 +83,21 @@ public class AuthorCommandTests {
 
             // The bot should reply with a success message
             assertLastCommentContains(pr, "Overriding author `Test Person <test@test.test>` was successfully removed. " +
-                    "When this pull request is integrated, the pull request author will be the author of the commit.");
+                    "When this pull request is integrated, the pull request author will be used as the author of the commit.");
 
             // Remove something that isn't there
             pr.addComment("/author remove Test Person 2 <test2@test.test>");
             TestBotRunner.runPeriodicItems(prBot);
 
             // The bot should reply with an error message
-            assertLastCommentContains(pr, "There is no overriding author set in this pull request.");
+            assertLastCommentContains(pr, "There is no overriding author set for this pull request.");
 
             // Remove something that isn't there
             pr.addComment("/author remove");
             TestBotRunner.runPeriodicItems(prBot);
 
             // The bot should reply with an error message
-            assertLastCommentContains(pr, "There is no overriding author set in this pull request.");
+            assertLastCommentContains(pr, "There is no overriding author set for this pull request.");
 
             // Now add someone back again
             pr.addComment("/author Test Person <test@test.test>");

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/AuthorCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/AuthorCommandTests.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.pr;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.openjdk.skara.forge.Review;
+import org.openjdk.skara.test.CheckableRepository;
+import org.openjdk.skara.test.HostCredentials;
+import org.openjdk.skara.test.TemporaryDirectory;
+import org.openjdk.skara.test.TestBotRunner;
+import org.openjdk.skara.vcs.Repository;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.openjdk.skara.bots.pr.PullRequestAsserts.assertLastCommentContains;
+
+public class AuthorCommandTests {
+    @Test
+    void simple(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var integrator = credentials.getHostedRepository();
+
+            var censusBuilder = credentials.getCensusBuilder()
+                    .addReviewer(integrator.forge().currentUser().id())
+                    .addCommitter(author.forge().currentUser().id());
+            var prBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
+
+            // Populate the projects repository
+            var localRepoFolder = tempFolder.path().resolve("localrepo");
+            var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
+
+            // Issue an invalid command
+            pr.addComment("/author xx");
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // The bot should reply with an error message
+            assertLastCommentContains(pr, "Syntax");
+
+            // set an author
+            pr.addComment("/author set Test Person <test@test.test>");
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // The bot should reply with a success message
+            assertLastCommentContains(pr, "Author of this pull request has been set to `Test Person <test@test.test>` successfully.");
+
+            // Remove it again
+            pr.addComment("/author remove Test Person <test@test.test>");
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // The bot should reply with a success message
+            assertLastCommentContains(pr, "Author `Test Person <test@test.test>` successfully removed.");
+
+            // Remove something that isn't there
+            pr.addComment("/author remove Test Person 2 <test2@test.test>");
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // The bot should reply with an error message
+            assertLastCommentContains(pr, "There is no author set in this pull request.");
+
+            // Now add someone back again
+            pr.addComment("/author set Test Person <test@test.test>");
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // The bot should reply with a success message
+            assertLastCommentContains(pr, "Author of this pull request has been set to `Test Person <test@test.test>` successfully.");
+
+            // Remove something that isn't there
+            pr.addComment("/author remove Test Person 2 <test2@test.test>");
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // The bot should reply with an error message
+            assertLastCommentContains(pr, "@user1 `Test Person 2 <test2@test.test>` was not set to this pull request's author.");
+            assertLastCommentContains(pr, "Current author of this pull request is set to: `Test Person <test@test.test>`");
+
+            // Approve it as another user
+            var approvalPr = integrator.pullRequest(pr.id());
+            approvalPr.addReview(Review.Verdict.APPROVED, "Approved");
+            TestBotRunner.runPeriodicItems(prBot);
+            TestBotRunner.runPeriodicItems(prBot);
+
+            var pushed = pr.comments().stream()
+                    .filter(comment -> comment.body().contains("change now passes all *automated*"))
+                    .count();
+            assertEquals(1, pushed);
+
+            // Integrate
+            pr.addComment("/integrate");
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // The bot should reply with an ok message
+            assertLastCommentContains(pr, "Pushed as commit");
+
+            // The change should now be present on the master branch
+            var pushedFolder = tempFolder.path().resolve("pushed");
+            var pushedRepo = Repository.materialize(pushedFolder, author.authenticatedUrl(), "master");
+            assertTrue(CheckableRepository.hasBeenEdited(pushedRepo));
+
+            var headHash = pushedRepo.resolve("HEAD").orElseThrow();
+            var headCommit = pushedRepo.commits(headHash.hex() + "^.." + headHash.hex()).asList().get(0);
+
+            assertEquals("Test Person", headCommit.author().name());
+            assertEquals("Generated Committer 2", headCommit.committer().name());
+        }
+    }
+}

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/AuthorCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/AuthorCommandTests.java
@@ -76,7 +76,7 @@ public class AuthorCommandTests {
             // The bot should reply with a success message
             assertLastCommentContains(pr, "Author of this pull request has been set to `Test Person <test@test.test>` successfully.");
 
-            // Remove it again
+            // Remove it
             pr.addComment("/author remove Test Person <test@test.test>");
             TestBotRunner.runPeriodicItems(prBot);
 
@@ -90,8 +90,15 @@ public class AuthorCommandTests {
             // The bot should reply with an error message
             assertLastCommentContains(pr, "There is no author set in this pull request.");
 
+            // Remove something that isn't there
+            pr.addComment("/author remove");
+            TestBotRunner.runPeriodicItems(prBot);
+
+            // The bot should reply with an error message
+            assertLastCommentContains(pr, "There is no author set in this pull request.");
+
             // Now add someone back again
-            pr.addComment("/author set Test Person <test@test.test>");
+            pr.addComment("/author Test Person <test@test.test>");
             TestBotRunner.runPeriodicItems(prBot);
 
             // The bot should reply with a success message

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/AuthorCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/AuthorCommandTests.java
@@ -74,43 +74,45 @@ public class AuthorCommandTests {
             TestBotRunner.runPeriodicItems(prBot);
 
             // The bot should reply with a success message
-            assertLastCommentContains(pr, "Author of this pull request has been set to `Test Person <test@test.test>` successfully.");
+            assertLastCommentContains(pr, "Setting overriding author to `Test Person <test@test.test>`. " +
+                    "When this pull request is integrated, the overriding author will be used in the commit.");
 
             // Remove it
             pr.addComment("/author remove Test Person <test@test.test>");
             TestBotRunner.runPeriodicItems(prBot);
 
             // The bot should reply with a success message
-            assertLastCommentContains(pr, "Author `Test Person <test@test.test>` successfully removed.");
+            assertLastCommentContains(pr, "Overriding author `Test Person <test@test.test>` was successfully removed. " +
+                    "When this pull request is integrated, the pull request author will be the author of the commit.");
 
             // Remove something that isn't there
             pr.addComment("/author remove Test Person 2 <test2@test.test>");
             TestBotRunner.runPeriodicItems(prBot);
 
             // The bot should reply with an error message
-            assertLastCommentContains(pr, "There is no author set in this pull request.");
+            assertLastCommentContains(pr, "There is no overriding author set in this pull request.");
 
             // Remove something that isn't there
             pr.addComment("/author remove");
             TestBotRunner.runPeriodicItems(prBot);
 
             // The bot should reply with an error message
-            assertLastCommentContains(pr, "There is no author set in this pull request.");
+            assertLastCommentContains(pr, "There is no overriding author set in this pull request.");
 
             // Now add someone back again
             pr.addComment("/author Test Person <test@test.test>");
             TestBotRunner.runPeriodicItems(prBot);
 
             // The bot should reply with a success message
-            assertLastCommentContains(pr, "Author of this pull request has been set to `Test Person <test@test.test>` successfully.");
+            assertLastCommentContains(pr, "Setting overriding author to `Test Person <test@test.test>`. " +
+                    "When this pull request is integrated, the overriding author will be used in the commit.");
 
             // Remove something that isn't there
             pr.addComment("/author remove Test Person 2 <test2@test.test>");
             TestBotRunner.runPeriodicItems(prBot);
 
             // The bot should reply with an error message
-            assertLastCommentContains(pr, "@user1 `Test Person 2 <test2@test.test>` was not set to this pull request's author.");
-            assertLastCommentContains(pr, "Current author of this pull request is set to: `Test Person <test@test.test>`");
+            assertLastCommentContains(pr, "Cannot remove `Test Person 2 <test2@test.test>`, the overriding author is currently set to: `Test Person <test@test.test>`");
 
             // Approve it as another user
             var approvalPr = integrator.pullRequest(pr.id());


### PR DESCRIPTION
In this pr, we will introduce a new pull request command `/author`.

If an author wants to contribute a change to a repository, but he doesn't have access, then someone with the access will be able to help him with this command.

Usage: `/author [set|remove] [@user | openjdk-user | Full Name <email@address>]`
Examples: 
`/author set @openjdk-bot`
`/author @openjdk-bot`
`/author set J. Duke <duke@openjdk.org>`
`/author remove @openjdk-bot`
`/author remove`

Note: only Committers of the repository would be allowed to issue /author command.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1997](https://bugs.openjdk.org/browse/SKARA-1997): Allow the creator of a PR to set the commit author (**Enhancement** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1553/head:pull/1553` \
`$ git checkout pull/1553`

Update a local copy of the PR: \
`$ git checkout pull/1553` \
`$ git pull https://git.openjdk.org/skara.git pull/1553/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1553`

View PR using the GUI difftool: \
`$ git pr show -t 1553`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1553.diff">https://git.openjdk.org/skara/pull/1553.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1553#issuecomment-1701881537)