### PR TITLE
2015: Initial run of PR IssueBot misses issue updates

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CSRIssueWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CSRIssueWorkItem.java
@@ -106,7 +106,7 @@ class CSRIssueWorkItem implements WorkItem {
                 .filter(pr -> bot.getPRBot(pr.repository().name()).enableCsr())
                 // This will mix time stamps from the IssueTracker and the Forge hosting PRs, but it's the
                 // best we can do.
-                .map(pr -> new CheckWorkItem(bot.getPRBot(pr.repository().name()), pr.id(), errorHandler, csrIssue.updatedAt(), true, true))
+                .map(pr -> new CheckWorkItem(bot.getPRBot(pr.repository().name()), pr.id(), errorHandler, csrIssue.updatedAt(), true, true, false, false))
                 .forEach(ret::add);
         return ret;
     }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CSRIssueWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CSRIssueWorkItem.java
@@ -106,7 +106,7 @@ class CSRIssueWorkItem implements WorkItem {
                 .filter(pr -> bot.getPRBot(pr.repository().name()).enableCsr())
                 // This will mix time stamps from the IssueTracker and the Forge hosting PRs, but it's the
                 // best we can do.
-                .map(pr -> new CheckWorkItem(bot.getPRBot(pr.repository().name()), pr.id(), errorHandler, csrIssue.updatedAt(), true, true, false, false))
+                .map(pr -> CheckWorkItem.fromCSRIssue(bot.getPRBot(pr.repository().name()), pr.id(), errorHandler, csrIssue.updatedAt()))
                 .forEach(ret::add);
         return ret;
     }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -108,7 +108,7 @@ class CheckWorkItem extends PullRequestWorkItem {
     /**
      * Create Normal CheckWorkItem
      */
-    public static CheckWorkItem normal(PullRequestBot bot, String prId, Consumer<RuntimeException> errorHandler, ZonedDateTime triggerUpdatedAt) {
+    public static CheckWorkItem fromWorkItem(PullRequestBot bot, String prId, Consumer<RuntimeException> errorHandler, ZonedDateTime triggerUpdatedAt) {
         return new CheckWorkItem(bot, prId, errorHandler, triggerUpdatedAt, false, false, false, false);
     }
 
@@ -545,7 +545,7 @@ class CheckWorkItem extends PullRequestWorkItem {
                     comment.add(text);
                     pr.addComment(String.join("\n", comment));
                     pr.addLabel("backport");
-                    return List.of(CheckWorkItem.normal(bot, prId, errorHandler, triggerUpdatedAt));
+                    return List.of(CheckWorkItem.fromWorkItem(bot, prId, errorHandler, triggerUpdatedAt));
                 } else {
                     var botUser = pr.repository().forge().currentUser();
                     var text = "<!-- backport error -->\n" +
@@ -584,14 +584,14 @@ class CheckWorkItem extends PullRequestWorkItem {
                 var comment = pr.addComment(text);
                 pr.addLabel("backport");
                 logLatency("Time from PR updated to backport comment posted ", comment.createdAt(), log);
-                return List.of(CheckWorkItem.normal(bot, prId, errorHandler, triggerUpdatedAt));
+                return List.of(CheckWorkItem.fromWorkItem(bot, prId, errorHandler, triggerUpdatedAt));
             }
 
             // If the title needs updating, we run the check again
             if (updateTitle()) {
                 var updatedPr = bot.repo().pullRequest(prId);
                 logLatency("Time from PR updated to title corrected ", updatedPr.updatedAt(), log);
-                return List.of(CheckWorkItem.normal(bot, prId, errorHandler, triggerUpdatedAt));
+                return List.of(CheckWorkItem.fromWorkItem(bot, prId, errorHandler, triggerUpdatedAt));
             }
 
             // Check force push

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IssueBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IssueBot.java
@@ -95,8 +95,8 @@ class IssueBot implements Bot {
                     .filter(Issue::isOpen)
                     // This will mix time stamps from the IssueTracker and the Forge hosting PRs, but it's the
                     // best we can do.
-                    .map(pr -> new CheckWorkItem(pullRequestBotMap.get(pr.repository().name()), pr.id(),
-                            e -> poller.retryIssue(issue), issue.updatedAt(), true, false, true, false))
+                    .map(pr -> CheckWorkItem.fromIssueBot(pullRequestBotMap.get(pr.repository().name()), pr.id(),
+                            e -> poller.retryIssue(issue), issue.updatedAt()))
                     .forEach(items::add);
         }
         poller.lastBatchHandled();

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IssueBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IssueBot.java
@@ -96,7 +96,7 @@ class IssueBot implements Bot {
                     // This will mix time stamps from the IssueTracker and the Forge hosting PRs, but it's the
                     // best we can do.
                     .map(pr -> new CheckWorkItem(pullRequestBotMap.get(pr.repository().name()), pr.id(),
-                            e -> poller.retryIssue(issue), issue.updatedAt(), true, false, true))
+                            e -> poller.retryIssue(issue), issue.updatedAt(), true, false, true, false))
                     .forEach(items::add);
         }
         poller.lastBatchHandled();

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -78,6 +78,7 @@ class PullRequestBot implements Bot {
     private final Map<String, String> jCheckConfMap = new HashMap<>();
     private final Map<String, Set<String>> targetRefPRMap = new HashMap<>();
     private final Approval approval;
+    private boolean initialRun = true;
 
     private Instant lastFullUpdate;
 
@@ -150,12 +151,14 @@ class PullRequestBot implements Bot {
 
         for (var pr : pullRequests) {
             if (pr.state() == Issue.State.OPEN) {
-                ret.add(new CheckWorkItem(this, pr.id(), e -> poller.retryPullRequest(pr), pr.updatedAt(), true));
+                ret.add(new CheckWorkItem(this, pr.id(), e -> poller.retryPullRequest(pr), pr.updatedAt(), true, false, false, initialRun));
             } else {
                 // Closed PR's do not need to be checked
                 ret.add(new PullRequestCommandWorkItem(this, pr.id(), e -> poller.retryPullRequest(pr), pr.updatedAt(), true));
             }
         }
+
+        initialRun = false;
 
         return ret;
     }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -151,7 +151,11 @@ class PullRequestBot implements Bot {
 
         for (var pr : pullRequests) {
             if (pr.state() == Issue.State.OPEN) {
-                ret.add(new CheckWorkItem(this, pr.id(), e -> poller.retryPullRequest(pr), pr.updatedAt(), true, false, false, initialRun));
+                if (initialRun) {
+                    ret.add(CheckWorkItem.fromInitialRunOfPRBot(this, pr.id(), e -> poller.retryPullRequest(pr), pr.updatedAt()));
+                } else {
+                    ret.add(CheckWorkItem.fromPRBot(this, pr.id(), e -> poller.retryPullRequest(pr), pr.updatedAt()));
+                }
             } else {
                 // Closed PR's do not need to be checked
                 ret.add(new PullRequestCommandWorkItem(this, pr.id(), e -> poller.retryPullRequest(pr), pr.updatedAt(), true));

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
@@ -215,7 +215,7 @@ public class PullRequestCommandWorkItem extends PullRequestWorkItem {
         if (!pr.labelNames().contains("integrated") || pr.findIntegratedCommitHash().isEmpty()) {
             processCommand(pr, census, scratchArea, command, comments, false);
             // Run another check to reflect potential changes from commands
-            return List.of(new CheckWorkItem(bot, prId, errorHandler, triggerUpdatedAt, false, false, false, false));
+            return List.of(CheckWorkItem.normal(bot, prId, errorHandler, triggerUpdatedAt));
         } else {
             processCommand(pr, census, scratchArea, command, comments, true);
             return List.of();

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
@@ -215,7 +215,7 @@ public class PullRequestCommandWorkItem extends PullRequestWorkItem {
         if (!pr.labelNames().contains("integrated") || pr.findIntegratedCommitHash().isEmpty()) {
             processCommand(pr, census, scratchArea, command, comments, false);
             // Run another check to reflect potential changes from commands
-            return List.of(CheckWorkItem.normal(bot, prId, errorHandler, triggerUpdatedAt));
+            return List.of(CheckWorkItem.fromWorkItem(bot, prId, errorHandler, triggerUpdatedAt));
         } else {
             processCommand(pr, census, scratchArea, command, comments, true);
             return List.of();

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
@@ -215,7 +215,7 @@ public class PullRequestCommandWorkItem extends PullRequestWorkItem {
         if (!pr.labelNames().contains("integrated") || pr.findIntegratedCommitHash().isEmpty()) {
             processCommand(pr, census, scratchArea, command, comments, false);
             // Run another check to reflect potential changes from commands
-            return List.of(new CheckWorkItem(bot, prId, errorHandler, triggerUpdatedAt, false));
+            return List.of(new CheckWorkItem(bot, prId, errorHandler, triggerUpdatedAt, false, false, false, false));
         } else {
             processCommand(pr, census, scratchArea, command, comments, true);
             return List.of();


### PR DESCRIPTION
Currently, if pullRequestBot is down for more than 10 minutes and during that time, if users make changes to some issues, than the update activities would not trigger CheckWorkItem after the bot restarts.

To solve this problem, In this patch, after the bot restarts, in the initial run, pullRequestBot would make CheckWorkItem compare both prMetaData and issueMetaData.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2015](https://bugs.openjdk.org/browse/SKARA-2015): Initial run of PR IssueBot misses issue updates (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1554/head:pull/1554` \
`$ git checkout pull/1554`

Update a local copy of the PR: \
`$ git checkout pull/1554` \
`$ git pull https://git.openjdk.org/skara.git pull/1554/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1554`

View PR using the GUI difftool: \
`$ git pr show -t 1554`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1554.diff">https://git.openjdk.org/skara/pull/1554.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1554#issuecomment-1708882636)