### PR TITLE
2003: Timing out lock in RestRequestCache stops the bot

### DIFF
--- a/network/src/main/java/org/openjdk/skara/network/RestRequestCache.java
+++ b/network/src/main/java/org/openjdk/skara/network/RestRequestCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -101,8 +101,7 @@ enum RestRequestCache {
                 try {
                     var locked = lock.tryLock(10, TimeUnit.MINUTES);
                     if (!locked) {
-                        System.out.println("Unable to grab lock in 10 minutes - exiting...");
-                        System.exit(1);
+                        throw new RuntimeException("Unable to grab lock in 10 minutes");
                     }
                     return;
                 } catch (InterruptedException ignored) {


### PR DESCRIPTION
As Erik said in the issue description, it's better to throw an exception here.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2003](https://bugs.openjdk.org/browse/SKARA-2003): Timing out lock in RestRequestCache stops the bot (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1555/head:pull/1555` \
`$ git checkout pull/1555`

Update a local copy of the PR: \
`$ git checkout pull/1555` \
`$ git pull https://git.openjdk.org/skara.git pull/1555/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1555`

View PR using the GUI difftool: \
`$ git pr show -t 1555`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1555.diff">https://git.openjdk.org/skara/pull/1555.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1555#issuecomment-1709141668)