### PR TITLE
827: Copyright year differences can be regarded as a clean backport

### DIFF
--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportTests.java
@@ -1954,7 +1954,6 @@ class BackportTests {
                      * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
                      * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
                      */
-                     
                      Line1
                      Line2
                      """);
@@ -1971,7 +1970,6 @@ class BackportTests {
                      * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
                      * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
                      */
-                     
                      Line1
                      Line2
                      """);
@@ -1986,7 +1984,6 @@ class BackportTests {
                      * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
                      * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
                      */
-                     
                      Line1
                      Line2
                      Line3
@@ -2011,7 +2008,6 @@ class BackportTests {
                      * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
                      * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
                      */
-                     
                      Line1
                      Line2
                      Line3

--- a/forge/src/test/java/org/openjdk/skara/forge/github/GitHubRestApiTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/github/GitHubRestApiTests.java
@@ -286,4 +286,17 @@ public class GitHubRestApiTests {
         assertTrue(expiredDeployKeys.contains("Test1"));
         assertTrue(expiredDeployKeys.contains("Test2"));
     }
+
+
+    @Test
+    void testBackportCleanIgnoreCopyRight() {
+        var gitHubRepo = githubHost.repository(settings.getProperty("github.repository")).orElseThrow();
+
+        var pr = gitHubRepo.pullRequest(settings.getProperty("github.prId"));
+        var commit = pr.repository().forge().search(new Hash(settings.getProperty("github.commitHash")), true);
+        var backportDiff = commit.get().parentDiffs().get(0);
+        var prDiff = pr.diff();
+        var isClean = DiffComparator.areFuzzyEqual(backportDiff, prDiff);
+        assertTrue(isClean);
+    }
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/DiffComparator.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/DiffComparator.java
@@ -64,18 +64,18 @@ public class DiffComparator {
     }
 
     private static boolean areFuzzyEqual(Patch a, Patch b) {
-        Pattern copyRightPattern = Pattern.compile("""
+        Pattern copyrightPattern = Pattern.compile("""
                 -(.)*Copyright \\(c\\) (?:\\d|\\s|,)* Oracle and/or its affiliates\\. All rights reserved\\.
                 \\+(.)*Copyright \\(c\\) (?:\\d|\\s|,)* Oracle and/or its affiliates\\. All rights reserved\\.
                 """);
 
         var aHunks = a.asTextualPatch().hunks()
                 .stream()
-                .filter(hunk -> !copyRightPattern.matcher(hunk.toString()).find())
+                .filter(hunk -> !copyrightPattern.matcher(hunk.toString()).find())
                 .toList();
         var bHunks = b.asTextualPatch().hunks()
                 .stream()
-                .filter(hunk -> !copyRightPattern.matcher(hunk.toString()).find())
+                .filter(hunk -> !copyrightPattern.matcher(hunk.toString()).find())
                 .toList();
 
         if (aHunks.size() != bHunks.size()) {

--- a/vcs/src/main/java/org/openjdk/skara/vcs/DiffComparator.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/DiffComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,12 +22,16 @@
  */
 package org.openjdk.skara.vcs;
 
-import java.io.*;
-import java.nio.file.*;
 import java.util.*;
 import java.util.regex.Pattern;
 
 public class DiffComparator {
+
+    private static final Pattern COPYRIGHT_PATTERN = Pattern.compile("""
+            -(.)*Copyright \\(c\\) (?:\\d|\\s|,)* Oracle and/or its affiliates\\. All rights reserved\\.
+            \\+(.)*Copyright \\(c\\) (?:\\d|\\s|,)* Oracle and/or its affiliates\\. All rights reserved\\.
+            """);
+
     public static boolean areFuzzyEqual(Diff a, Diff b) {
         var aPatches = new HashMap<String, Patch>();
         for (var patch : a.patches()) {
@@ -64,18 +68,13 @@ public class DiffComparator {
     }
 
     private static boolean areFuzzyEqual(Patch a, Patch b) {
-        Pattern copyrightPattern = Pattern.compile("""
-                -(.)*Copyright \\(c\\) (?:\\d|\\s|,)* Oracle and/or its affiliates\\. All rights reserved\\.
-                \\+(.)*Copyright \\(c\\) (?:\\d|\\s|,)* Oracle and/or its affiliates\\. All rights reserved\\.
-                """);
-
         var aHunks = a.asTextualPatch().hunks()
                 .stream()
-                .filter(hunk -> !copyrightPattern.matcher(hunk.toString()).find())
+                .filter(hunk -> !COPYRIGHT_PATTERN.matcher(hunk.toString()).find())
                 .toList();
         var bHunks = b.asTextualPatch().hunks()
                 .stream()
-                .filter(hunk -> !copyrightPattern.matcher(hunk.toString()).find())
+                .filter(hunk -> !COPYRIGHT_PATTERN.matcher(hunk.toString()).find())
                 .toList();
 
         if (aHunks.size() != bHunks.size()) {


### PR DESCRIPTION
As many users requested, when determining whether a backport is clean, our bot should ignore copyright year difference.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-827](https://bugs.openjdk.org/browse/SKARA-827): Copyright year differences can be regarded as a clean backport (**Enhancement** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1556/head:pull/1556` \
`$ git checkout pull/1556`

Update a local copy of the PR: \
`$ git checkout pull/1556` \
`$ git pull https://git.openjdk.org/skara.git pull/1556/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1556`

View PR using the GUI difftool: \
`$ git pr show -t 1556`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1556.diff">https://git.openjdk.org/skara/pull/1556.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1556#issuecomment-1710785729)