### PR TITLE
2037: Change the order of bots in PullRequestBotFactory

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -69,6 +69,17 @@ class CheckWorkItem extends PullRequestWorkItem {
     private final boolean initialRun;
     private final Map<String, Optional<IssueTrackerIssue>> issues = new HashMap<>();
 
+    @Override
+    public boolean replaces(WorkItem other) {
+        if (!other.getClass().equals(this.getClass())) {
+            return false;
+        }
+        var otherCheckWorkItem = (CheckWorkItem) other;
+        return !concurrentWith(other) && this.forceUpdate == otherCheckWorkItem.forceUpdate
+                && this.initialRun == otherCheckWorkItem.initialRun
+                && this.spawnedFromIssueBot == otherCheckWorkItem.spawnedFromIssueBot;
+    }
+
     private CheckWorkItem(PullRequestBot bot, String prId, Consumer<RuntimeException> errorHandler, ZonedDateTime triggerUpdatedAt,
                           boolean needsReadyCheck, boolean forceUpdate, boolean spawnedFromIssueBot, boolean initialRun) {
         super(bot, prId, errorHandler, triggerUpdatedAt, needsReadyCheck);

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
@@ -247,18 +247,15 @@ public class PullRequestBotFactory implements BotFactory {
 
         // Create a CSRIssueBot for each issueProject which associated with at least one csr enabled repository
         for (var issueProject : repositoriesForCSR.keySet()) {
-            ret.add(new CSRIssueBot(issueProject, repositoriesForCSR.get(issueProject), pullRequestBotMap,
+            ret.add(0, new CSRIssueBot(issueProject, repositoriesForCSR.get(issueProject), pullRequestBotMap,
                     issueProjectToIssuePRMapMap.get(issueProject)));
         }
 
         // Create an IssueBot for each issueProject
         for (var issueProject : issueProjectToIssuePRMapMap.keySet()) {
-            ret.add(new IssueBot(issueProject, repositories.get(issueProject), pullRequestBotMap,
+            ret.add(0, new IssueBot(issueProject, repositories.get(issueProject), pullRequestBotMap,
                     issueProjectToIssuePRMapMap.get(issueProject)));
         }
-
-        // Reverse the list to make sure IssueBots would be run first
-        Collections.reverse(ret);
 
         return ret;
     }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
@@ -257,6 +257,9 @@ public class PullRequestBotFactory implements BotFactory {
                     issueProjectToIssuePRMapMap.get(issueProject)));
         }
 
+        // Reverse the list to make sure IssueBots would be run first
+        Collections.reverse(ret);
+
         return ret;
     }
 }


### PR DESCRIPTION
Today, when restarting the bot, I found that the IssueBot was down for a long time(about 30 minutes), and then I realized that in PullRequestBotFactory, we created all pullRequestBots first, then CSRIssueBots, and IssueBots last. 

After the bot is restarted, the botRunner would run all pullRequestBots first and we have a lot of pullRequestBots, so it will take a lot of time. And if users make changes to issues in JBS during this interval, the IssueBot may not be able to get all updated issues. It's really bad. 

To solve this problem, we could to reverse the order of bots in PullRequestBotFactory, therefore we could make sure IssueBot will be run firstly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2037](https://bugs.openjdk.org/browse/SKARA-2037): Change the order of bots in PullRequestBotFactory (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1558/head:pull/1558` \
`$ git checkout pull/1558`

Update a local copy of the PR: \
`$ git checkout pull/1558` \
`$ git pull https://git.openjdk.org/skara.git pull/1558/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1558`

View PR using the GUI difftool: \
`$ git pr show -t 1558`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1558.diff">https://git.openjdk.org/skara/pull/1558.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1558#issuecomment-1730577757)