### PR TITLE
2038: Don't post error message of invalid jcheck configuration when encountering UncheckedIOException

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LimitedCensusInstance.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LimitedCensusInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -106,7 +106,7 @@ class LimitedCensusInstance {
                         confOverrideRef);
             }
             return configuration;
-        } catch (UncheckedRestException e) {
+        } catch (UncheckedRestException | UncheckedIOException e) {
             throw e;
         } catch (RuntimeException e) {
             throw new InvalidJCheckConfException(e);


### PR DESCRIPTION
In CheckWorkItem, the bot would check whether this pull request has a valid jcheck configuration and if not, the bot would post an error message of invalid jcheck configuration in the pull request. 

Today, a user reported that he saw this error message in his pull request and he couldn't determine whether the pull request is good. After reading the log, I found that it's just a temporary glitch. The bot was trying to read jcheck configuration in GitHub but got HttpTimeoutException, so the bot posted the error message. But it recovers in the next try. 
https://github.com/openjdk/panama-foreign/pull/893 

To sum, in the cases of some temporary glitches, we shouldn't post error message to pull request to confuse users.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2038](https://bugs.openjdk.org/browse/SKARA-2038): Don't post error message of invalid jcheck configuration when encountering UncheckedIOException (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1559/head:pull/1559` \
`$ git checkout pull/1559`

Update a local copy of the PR: \
`$ git checkout pull/1559` \
`$ git pull https://git.openjdk.org/skara.git pull/1559/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1559`

View PR using the GUI difftool: \
`$ git pr show -t 1559`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1559.diff">https://git.openjdk.org/skara/pull/1559.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1559#issuecomment-1731972954)