### PR TITLE
2033: Require all bugs to be accessible before marking PR 'rfr'

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -76,6 +76,7 @@ class CheckRun {
     private final boolean reviewCleanBackport;
     private final boolean reviewMerge;
     private final Approval approval;
+    private boolean allIssuesAccessible = true;
 
     private Duration expiresIn;
 
@@ -144,6 +145,7 @@ class CheckRun {
                     var issueTrackerIssue = workItem.issueTrackerIssue(i.shortId());
                     if (issueTrackerIssue.isEmpty()) {
                         log.info("Failed to retrieve issue " + i.id());
+                        allIssuesAccessible = false;
                         setExpiration(Duration.ofMinutes(10));
                     }
                     map.put(i, issueTrackerIssue);
@@ -409,6 +411,11 @@ class CheckRun {
     }
 
     private boolean updateReadyForReview(PullRequestCheckIssueVisitor visitor, List<String> additionalErrors) {
+        // All the issues must be accessible
+        if (!allIssuesAccessible) {
+            return false;
+        }
+
         // Additional errors are not allowed
         if (!additionalErrors.isEmpty()) {
             newLabels.remove("rfr");


### PR DESCRIPTION
If one or more issues associated with the pull request is not accessible, then the pull request should be considered as invalid. Also, no 'rft' label will be added to this pull request and this could help prevent emails from being sent out while the pull request is associated with invalid issues.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2033](https://bugs.openjdk.org/browse/SKARA-2033): Require all bugs to be accessible before marking PR 'rfr' (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1560/head:pull/1560` \
`$ git checkout pull/1560`

Update a local copy of the PR: \
`$ git checkout pull/1560` \
`$ git pull https://git.openjdk.org/skara.git pull/1560/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1560`

View PR using the GUI difftool: \
`$ git pr show -t 1560`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1560.diff">https://git.openjdk.org/skara/pull/1560.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1560#issuecomment-1734151322)