### PR TITLE
2040: Temporary workaround of SKARA-2025

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/TagCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/TagCommand.java
@@ -94,6 +94,7 @@ public class TagCommand implements CommandHandler {
             var localRepo = bot.hostedRepositoryPool()
                                .orElseThrow(() -> new IllegalStateException("Missing repository pool for PR bot"))
                                .materialize(bot.repo(), localRepoDir);
+            localRepo.fetchAll(bot.repo().authenticatedUrl());
 
             var existingTagNames = localRepo.tags().stream().map(Tag::name).collect(Collectors.toSet());
             if (existingTagNames.contains(tagName)) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/TagCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/TagCommand.java
@@ -94,7 +94,7 @@ public class TagCommand implements CommandHandler {
             var localRepo = bot.hostedRepositoryPool()
                                .orElseThrow(() -> new IllegalStateException("Missing repository pool for PR bot"))
                                .materialize(bot.repo(), localRepoDir);
-            localRepo.fetchAll(bot.repo().authenticatedUrl());
+            localRepo.fetch(bot.repo().authenticatedUrl(), commit.hash().toString(), true);
 
             var existingTagNames = localRepo.tags().stream().map(Tag::name).collect(Collectors.toSet());
             if (existingTagNames.contains(tagName)) {


### PR DESCRIPTION
The final solution for [SKARA-2025](https://bugs.openjdk.org/browse/SKARA-2025) should be for us to optimize the HostedRepositoryPool#materializeClone method, but this will take some time. 

And some users would use /tag command every week, to make their experiences better, we should fix it with the temporary workaround as soon as possible. 

As Erik said in [SKARA-2025](https://bugs.openjdk.org/browse/SKARA-2025), we only need to fetch from the remote repo into local repo and the problem could be solved.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2040](https://bugs.openjdk.org/browse/SKARA-2040): Temporary workaround of SKARA-2025 (**Sub-task** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1561/head:pull/1561` \
`$ git checkout pull/1561`

Update a local copy of the PR: \
`$ git checkout pull/1561` \
`$ git pull https://git.openjdk.org/skara.git pull/1561/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1561`

View PR using the GUI difftool: \
`$ git pr show -t 1561`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1561.diff">https://git.openjdk.org/skara/pull/1561.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1561#issuecomment-1736393337)