### PR TITLE
2045: Make maintainer approval feature compatible with dependent pr feature.

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ApprovalCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ApprovalCommand.java
@@ -48,6 +48,8 @@ public class ApprovalCommand implements CommandHandler {
 
     private static final Pattern APPROVAL_ARG_PATTERN = Pattern.compile("(([A-Za-z]+-)?[0-9]+)? ?(request|cancel)(.*?)?", Pattern.MULTILINE | Pattern.DOTALL);
 
+    private static final Pattern PRE_INTEGRATE_BRANCH_PATTERN = Pattern.compile("pr/(\\d+)");
+
     @Override
     public void handle(PullRequestBot bot, PullRequest pr, CensusInstance censusInstance, ScratchArea scratchArea, CommandInvocation command, List<Comment> allComments, PrintWriter reply) {
         if (!command.user().equals(pr.author())) {
@@ -55,13 +57,13 @@ public class ApprovalCommand implements CommandHandler {
             return;
         }
         var approval = bot.approval();
-        var targetRef = pr.targetRef();
+        var targetRef = realTargetRef(pr);
         if (approval == null) {
             reply.println("Changes in this repository do not require maintainer approval.");
             return;
         }
         if (!approval.needsApproval(targetRef)) {
-            reply.println("Changes to branch " + pr.targetRef() + " do not require maintainer approval");
+            reply.println("Changes to branch " + targetRef + " do not require maintainer approval");
             return;
         }
         var argMatcher = APPROVAL_ARG_PATTERN.matcher(command.args());
@@ -169,5 +171,16 @@ public class ApprovalCommand implements CommandHandler {
 
     private void showHelp(PrintWriter reply) {
         reply.println("usage: `/approval [<id>] (request|cancel) [<text>]`");
+    }
+
+    public static String realTargetRef(PullRequest pr) {
+        var targetRef = pr.targetRef();
+        var matcher = PRE_INTEGRATE_BRANCH_PATTERN.matcher(targetRef);
+        if (!matcher.matches()) {
+            return targetRef;
+        }
+        String id = matcher.group(1);
+        var dependentPR = pr.repository().pullRequest(id);
+        return realTargetRef(dependentPR);
     }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ApproveCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ApproveCommand.java
@@ -65,7 +65,7 @@ public class ApproveCommand implements CommandHandler {
             return;
         }
         if (!approval.needsApproval(targetRef)) {
-            reply.println("Changes to branch " + pr.targetRef() + " do not require maintainer approval");
+            reply.println("Changes to branch " + targetRef + " do not require maintainer approval");
             return;
         }
         var argMatcher = APPROVE_ARG_PATTERN.matcher(command.args());

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ApproveCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ApproveCommand.java
@@ -23,6 +23,7 @@
 package org.openjdk.skara.bots.pr;
 
 import org.openjdk.skara.bots.common.SolvesTracker;
+import org.openjdk.skara.forge.PreIntegrations;
 import org.openjdk.skara.forge.PullRequest;
 import org.openjdk.skara.issuetracker.Comment;
 import org.openjdk.skara.vcs.openjdk.Issue;
@@ -30,7 +31,6 @@ import org.openjdk.skara.vcs.openjdk.Issue;
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.regex.Pattern;
 
 public class ApproveCommand implements CommandHandler {
@@ -59,7 +59,7 @@ public class ApproveCommand implements CommandHandler {
         }
 
         var approval = bot.approval();
-        var targetRef = ApprovalCommand.realTargetRef(pr);
+        var targetRef = PreIntegrations.realTargetRef(pr);
         if (approval == null) {
             reply.println("Changes in this repository do not require maintainer approval.");
             return;

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ApproveCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ApproveCommand.java
@@ -59,7 +59,7 @@ public class ApproveCommand implements CommandHandler {
         }
 
         var approval = bot.approval();
-        var targetRef = pr.targetRef();
+        var targetRef = ApprovalCommand.realTargetRef(pr);
         if (approval == null) {
             reply.println("Changes in this repository do not require maintainer approval.");
             return;

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -76,6 +76,7 @@ class CheckRun {
     private final boolean reviewCleanBackport;
     private final boolean reviewMerge;
     private final Approval approval;
+    private final String realTargetRef;
 
     private Duration expiresIn;
 
@@ -104,6 +105,7 @@ class CheckRun {
                 workItem.bot.confOverrideName(),
                 workItem.bot.confOverrideRef(),
                 comments);
+        realTargetRef = ApprovalCommand.realTargetRef(pr);
     }
 
     static Optional<Instant> execute(CheckWorkItem workItem, PullRequest pr, Repository localRepo, List<Comment> comments,
@@ -710,13 +712,12 @@ class CheckRun {
                             }
                             if (approvalNeeded()) {
                                 String status = "";
-                                String targetRef = pr.targetRef();
                                 var labels = issueTrackerIssue.get().labelNames();
-                                if (labels.contains(approval.rejectedLabel(targetRef))) {
+                                if (labels.contains(approval.rejectedLabel(realTargetRef))) {
                                     status = "Rejected";
-                                } else if (labels.contains(approval.approvedLabel(targetRef))) {
+                                } else if (labels.contains(approval.approvedLabel(realTargetRef))) {
                                     status = "Approved";
-                                } else if (labels.contains(approval.requestedLabel(targetRef))) {
+                                } else if (labels.contains(approval.requestedLabel(realTargetRef))) {
                                     status = "Requested";
                                     requestPresent = true;
                                 }
@@ -1518,7 +1519,7 @@ class CheckRun {
     }
 
     private boolean approvalNeeded() {
-        return approval != null && approval.needsApproval(pr.targetRef());
+        return approval != null && approval.needsApproval(realTargetRef);
     }
 
     private void postApprovalNeededComment() {

--- a/forge/src/main/java/org/openjdk/skara/forge/PreIntegrations.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PreIntegrations.java
@@ -65,8 +65,6 @@ public class PreIntegrations {
         if (idOpt.isEmpty()) {
             return pr.targetRef();
         }
-        String id = idOpt.get();
-        var dependentPR = pr.repository().pullRequest(id);
-        return realTargetRef(dependentPR);
+        return realTargetRef(pr.repository().pullRequest(idOpt.get()));
     }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/PreIntegrations.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PreIntegrations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,5 +58,15 @@ public class PreIntegrations {
 
     public static boolean isPreintegrationBranch(String name) {
         return name.startsWith("pr/");
+    }
+
+    public static String realTargetRef(PullRequest pr) {
+        Optional<String> idOpt = dependentPullRequestId(pr);
+        if (idOpt.isEmpty()) {
+            return pr.targetRef();
+        }
+        String id = idOpt.get();
+        var dependentPR = pr.repository().pullRequest(id);
+        return realTargetRef(dependentPR);
     }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/PreIntegrations.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PreIntegrations.java
@@ -62,9 +62,6 @@ public class PreIntegrations {
 
     public static String realTargetRef(PullRequest pr) {
         Optional<String> idOpt = dependentPullRequestId(pr);
-        if (idOpt.isEmpty()) {
-            return pr.targetRef();
-        }
-        return realTargetRef(pr.repository().pullRequest(idOpt.get()));
+        return idOpt.isEmpty() ? pr.targetRef() : realTargetRef(pr.repository().pullRequest(idOpt.get()));
     }
 }


### PR DESCRIPTION
A user reported that a dependent pr in a repo which configured with maintainer approval feature is not marked for approval. 

After investigation, I realized that the skara bot would determine whether this pr needs maintainer approval by checking whether merging into the target branch needs maintainer approval. 
  
In this case, we only configured that merging into master branch of jdk21u needs maintainer approval, however, for dependent pull requests, the target branch is pr/XXX. 

To fix this issue, we should let the skara bot be able to find the real target ref.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2045](https://bugs.openjdk.org/browse/SKARA-2045): Make maintainer approval feature compatible with dependent pr feature. (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1562/head:pull/1562` \
`$ git checkout pull/1562`

Update a local copy of the PR: \
`$ git checkout pull/1562` \
`$ git pull https://git.openjdk.org/skara.git pull/1562/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1562`

View PR using the GUI difftool: \
`$ git pr show -t 1562`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1562.diff">https://git.openjdk.org/skara/pull/1562.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1562#issuecomment-1738068895)