### PR TITLE
2049: After enabled maintainer approval in a repo, some pull requests are not updated

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -214,6 +214,7 @@ class CheckWorkItem extends PullRequestWorkItem {
                             issueData.append(properties.get("issuetype").asString());
                         }
                         if (bot.approval() != null && bot.approval().needsApproval(pr.targetRef())) {
+                            issueData.append("approval");
                             issueData.append(String.join("", issue.labelNames()));
                         }
                         return issueData;

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -214,6 +214,8 @@ class CheckWorkItem extends PullRequestWorkItem {
                             issueData.append(properties.get("issuetype").asString());
                         }
                         if (bot.approval() != null && bot.approval().needsApproval(pr.targetRef())) {
+                            // Add a static sting to the metadata if the PR needs approval to force
+                            // update if this configuration has changed for the target branch.
                             issueData.append("approval");
                             issueData.append(String.join("", issue.labelNames()));
                         }


### PR DESCRIPTION
Today, I enabled maintainer approval feature in openjdk/jdk8u-dev. 

After I enabled this feature, I expect to see the progress like "JDK-XXXXXXX needs maintainer approval" in the body of all open prs. 

However, this pr(https://github.com/openjdk/jdk8u-dev/pull/368) is not updated. 

The reason is that although after we enabled the maintainer approval feature, the issue labels will be calculated in the issueMetaData, there still exists some issues that doesn't contain any label. 

To solve this, I think we could add a string "approval" to issueMetaData after we enabled the maintainer approval.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2049](https://bugs.openjdk.org/browse/SKARA-2049): After enabled maintainer approval in a repo, some pull requests are not updated (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1563/head:pull/1563` \
`$ git checkout pull/1563`

Update a local copy of the PR: \
`$ git checkout pull/1563` \
`$ git pull https://git.openjdk.org/skara.git pull/1563/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1563`

View PR using the GUI difftool: \
`$ git pr show -t 1563`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1563.diff">https://git.openjdk.org/skara/pull/1563.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1563#issuecomment-1739789466)