### PR TITLE
2043: Skara mistakenly tagged the wrong commit when processing a /tag command

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -465,28 +465,55 @@ public class GitLabRepository implements HostedRepository {
                 .execute();
     }
 
+    // Handles results from both comments and discussions API
     private CommitComment toCommitComment(Hash hash, JSONValue o) {
-       var line = o.get("line").isNull()? -1 : o.get("line").asInt();
-       var path = o.get("path").isNull()? null : Path.of(o.get("path").asString());
-       // GitLab does not offer updated_at for commit comments
-       var createdAt = ZonedDateTime.parse(o.get("created_at").asString());
-       // GitLab does not offer an id for commit comments
-       var body = o.get("note").asString();
-       var user = gitLabHost.parseAuthorField(o);
-       var id = Integer.toString((hash.hex() + createdAt.toString() + user.id()).hashCode());
-       return new CommitComment(hash,
-                                path,
-                                line,
-                                id,
-                                body,
-                                gitLabHost.parseAuthorField(o),
-                                createdAt,
-                                createdAt);
+        if (o.contains("note")) {
+            var line = o.get("line").isNull() ? -1 : o.get("line").asInt();
+            var path = o.get("path").isNull() ? null : Path.of(o.get("path").asString());
+            // GitLab does not offer updated_at for commit comments
+            var createdAt = ZonedDateTime.parse(o.get("created_at").asString());
+            var body = o.get("note").asString();
+            return new CommitComment(hash,
+                    path,
+                    line,
+                    null, // The comments API does not return an ID
+                    body,
+                    gitLabHost.parseAuthorField(o),
+                    createdAt,
+                    createdAt);
+
+        } else if (o.contains("notes")) {
+            var note = o.get("notes").asArray().get(0);
+            var line = -1;
+            Path path = null;
+            if (note.contains("position")) {
+                var position = note.get("position");
+                if (!position.get("new_line").isNull()) {
+                    line = position.get("new_line").asInt();
+                    path = Path.of(position.get("new_path").asString());
+                } else if (!position.get("old_line").isNull()) {
+                    line = position.get("old_line").asInt();
+                    path = Path.of(position.get("old_path").asString());
+                }
+            }
+            return new CommitComment(hash,
+                    path,
+                    line,
+                    String.valueOf(note.get("id").asInt()),
+                    note.get("body").asString(),
+                    gitLabHost.parseAuthorField(note),
+                    ZonedDateTime.parse(note.get("created_at").asString()),
+                    ZonedDateTime.parse(note.get("updated_at").asString()));
+
+        } else {
+            throw new RuntimeException("Object contains neither 'note' or 'notes', cannot parse commit comment");
+        }
     }
 
     @Override
     public List<CommitComment> commitComments(Hash hash) {
-        return request.get("repository/commits/" + hash.hex() + "/comments")
+        // Using the discussions API gives us more information, most notably the ID field
+        return request.get("repository/commits/" + hash.hex() + "/discussions")
                       .execute()
                       .stream()
                       .map(o -> toCommitComment(hash, o))
@@ -512,26 +539,22 @@ public class GitLabRepository implements HostedRepository {
         return Set.of();
     }
 
-    private Hash commitWithComment(String commitTitle,
-                                   ZonedDateTime commentCreatedAt,
-                                   HostUser author,
-                                   Map<String, Set<Hash>> commitTitleToCommits) {
+    private Optional<CommitComment> findComment(String commitTitle,
+            String commentId,
+            Map<String, Set<Hash>> commitTitleToCommits) {
         var candidates = commitsWithTitle(commitTitle, commitTitleToCommits);
-        if (candidates.size() == 1) {
-            return candidates.iterator().next();
+        // Even if there is only one candidate, we need to make sure the comment
+        // exists on that commit before we try to process it. If this fails it's
+        // most likely due to inconsistent data from GitLab, which should
+        // eventually clear up on subsequent tries.
+        Optional<CommitComment> found = candidates.stream()
+                .flatMap(candidate -> commitComments(candidate).stream())
+                .filter(comment -> comment.id().equals(commentId))
+                .findFirst();
+        if (found.isEmpty()) {
+            log.warning("Did not find commit with title " + commitTitle + " for repository " + projectName);
         }
-
-        for (var candidate : candidates) {
-            var comments = commitComments(candidate);
-            for (var comment : comments) {
-                if (comment.createdAt().equals(commentCreatedAt) &&
-                    comment.author().equals(author)) {
-                    return candidate;
-                }
-            }
-        }
-
-        throw new RuntimeException("Did not find commit with title " + commitTitle + " for repository " + projectName);
+        return found;
     }
 
     /**
@@ -548,19 +571,19 @@ public class GitLabRepository implements HostedRepository {
 
         var formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
         var notes = request.get("events")
-                      .param("after", updatedAfter.format(formatter))
-                      .execute()
-                      .stream()
-                      .filter(o -> o.contains("note") &&
-                                   o.get("note").contains("noteable_type") &&
-                                   o.get("note").get("noteable_type").asString().equals("Commit"))
-                      .filter(o -> o.contains("target_type") &&
-                                   !o.get("target_type").isNull() &&
-                                   o.get("target_type").asString().equals("Note"))
-                      .filter(o -> o.contains("author") &&
-                                   o.get("author").contains("id") &&
-                                   !excludeAuthors.contains(o.get("author").get("id").asInt()))
-                      .toList();
+                .param("after", updatedAfter.format(formatter))
+                .execute()
+                .stream()
+                .filter(o -> o.contains("note") &&
+                        o.get("note").contains("noteable_type") &&
+                        o.get("note").get("noteable_type").asString().equals("Commit"))
+                .filter(o -> o.contains("target_type") &&
+                        !o.get("target_type").isNull() &&
+                        o.get("target_type").asString().equals("Note"))
+                .filter(o -> o.contains("author") &&
+                        o.get("author").contains("id") &&
+                        !excludeAuthors.contains(o.get("author").get("id").asInt()))
+                .toList();
 
         if (notes.isEmpty()) {
             return List.of();
@@ -569,18 +592,10 @@ public class GitLabRepository implements HostedRepository {
         var commitTitleToCommits = getCommitTitleToCommitsMap(localRepo, branches);
 
         return notes.stream()
-                    .map(o -> {
-                        var createdAt = ZonedDateTime.parse(o.get("note").get("created_at").asString());
-                        var body = o.get("note").get("body").asString();
-                        var user = gitLabHost.parseAuthorField(o);
-                        var id = o.get("note").get("id").asInt();
-                        var hash = commitWithComment(o.get("target_title").asString(),
-                                                     createdAt,
-                                                     user,
-                                                     commitTitleToCommits);
-                        return new CommitComment(hash, null, -1, String.valueOf(id), body, user, createdAt, createdAt);
-                    })
-                    .toList();
+                .map(o -> findComment(o.get("target_title").asString(),
+                        String.valueOf(o.get("note").get("id").asInt()), commitTitleToCommits))
+                .flatMap(Optional::stream)
+                .toList();
     }
 
     /**
@@ -623,6 +638,10 @@ public class GitLabRepository implements HostedRepository {
         return commitTitleToCommits;
     }
 
+    /**
+     * The CommitComment returned from this method will not have an ID field,
+     * this is due to a limitation in the GitLab API.
+     */
     @Override
     public CommitComment addCommitComment(Hash hash, String body) {
         var query = JSON.object().put("note", body);


### PR DESCRIPTION
The method `GitLabRepository::recentCommitComments` may sometimes return a comment associated with the wrong commit. We have seen it happen, which caused a tag to be set on the wrong commit. My theory is that this was caused by a race, which was probably made more potent due to GitLab sometimes being slow in returning up to date data. See bug for more details.

The main fix is to always verify that an event note about a recent commit comment actually matches a comment found on the commit in question. The current implementation has a quick return when only one potential commit is found.

In addition to that, I'm also reworking the implementation to be a bit more robust. @zhaosongzs found that there is an alternate API for retrieving commit comments called "discussions" and that gives us more data, notably the same ID field as an event has. This makes it possible to match an event note with a commit comment note by ID instead of by the combination of author and created_at. From this further simplifications naturally fell out.

A CommitComment returned from `GitLabRepository::addCommitComment` no longer contains a value for ID. I think this is more correct than making up a value. I verified that no code seems to be using the returned object currently, so this shouldn't impact anything.

The two new tests were run and inspected manually.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2043](https://bugs.openjdk.org/browse/SKARA-2043): Skara mistakenly tagged the wrong commit when processing a /tag command (**Bug** - P2)


### Reviewers
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1564/head:pull/1564` \
`$ git checkout pull/1564`

Update a local copy of the PR: \
`$ git checkout pull/1564` \
`$ git pull https://git.openjdk.org/skara.git pull/1564/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1564`

View PR using the GUI difftool: \
`$ git pr show -t 1564`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1564.diff">https://git.openjdk.org/skara/pull/1564.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1564#issuecomment-1739807289)