### PR TITLE
2042: Allow bulk requests with /approval request command

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ApprovalCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ApprovalCommand.java
@@ -86,7 +86,7 @@ public class ApprovalCommand implements CommandHandler {
 
             var issueTrackerIssueOpt = issueProject.issue(issue.shortId());
             if (issueTrackerIssueOpt.isEmpty()) {
-                reply.println("Can not find " + issue.id() + " in the " + issueProject.name() + " project.");
+                reply.println("Can not be found in the " + issueProject.name() + " project.");
                 continue;
             }
             var issueTrackerIssue = issueTrackerIssueOpt.get();

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ApprovalCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ApprovalCommand.java
@@ -22,18 +22,15 @@
  */
 package org.openjdk.skara.bots.pr;
 
-import org.openjdk.skara.bots.common.SolvesTracker;
 import org.openjdk.skara.forge.PullRequest;
 import org.openjdk.skara.issuetracker.Comment;
-import org.openjdk.skara.vcs.openjdk.Issue;
 
 import java.io.PrintWriter;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.regex.Pattern;
 
 import static org.openjdk.skara.bots.common.CommandNameEnum.approval;
+import static org.openjdk.skara.bots.pr.ApproveCommand.getIssues;
 
 public class ApprovalCommand implements CommandHandler {
     @Override
@@ -75,91 +72,65 @@ public class ApprovalCommand implements CommandHandler {
         String option = argMatcher.group(3);
         String message = argMatcher.group(4);
 
-        var issueOpt = getIssue(issueId, pr, allComments, reply);
-        if (issueOpt.isEmpty()) {
+        var issues = getIssues(issueId, pr, allComments, reply);
+        if (issues.isEmpty()) {
             return;
         }
-        var issue = issueOpt.get();
-
-        if (issue.project().isPresent() && !issue.project().get().equalsIgnoreCase(issueProject.name())) {
-            reply.println("Approval can only be requested for issues in the " + issueProject.name() + " project.");
-            return;
-        }
-
-        var issueTrackerIssueOpt = issueProject.issue(issue.shortId());
-        if (issueTrackerIssueOpt.isEmpty()) {
-            reply.println("Can not find " + issue.id() + " in the " + issueProject.name() + " project.");
-            return;
-        }
-        var issueTrackerIssue = issueTrackerIssueOpt.get();
-        var requestLabel = approval.requestedLabel(targetRef);
-        var approvedLabel = approval.approvedLabel(targetRef);
-        var rejectedLabel = approval.rejectedLabel(targetRef);
-        var prefix = "[" + requestLabel + "]";
-        var comments = issueTrackerIssue.comments();
-        var existingComment = comments.stream()
-                .filter(comment -> comment.author().equals(issueProject.issueTracker().currentUser()))
-                .filter(comment -> comment.body().startsWith(prefix))
-                .findFirst();
-
-        var labels = issueTrackerIssue.labelNames();
-        if (option.equals("cancel")) {
-            if (labels.contains(approvedLabel) || labels.contains(rejectedLabel)) {
-                reply.println("The request has already been handled by a maintainer and can no longer be canceled.");
-            } else {
-                issueTrackerIssue.removeLabel(requestLabel);
-                existingComment.ifPresent(issueTrackerIssue::removeComment);
-                reply.println("The approval request has been cancelled successfully.");
+        reply.println();
+        for (var issue : issues) {
+            reply.print(issue.id() + ": ");
+            if (issue.project().isPresent() && !issue.project().get().equalsIgnoreCase(issueProject.name())) {
+                reply.println("Approval can only be requested for issues in the " + issueProject.name() + " project.");
+                continue;
             }
-        } else if (option.equals("request")) {
-            if (labels.contains(approvedLabel)) {
-                reply.println("Approval has already been requested and approved.");
-            } else if (labels.contains(rejectedLabel)) {
-                reply.println("Approval has already been requested and rejected.");
-            } else {
-                var messageToPost = prefix + " Approval Request from " + command.user().fullName() + "\n" + message.trim();
-                if (existingComment.isPresent()) {
-                    if (!existingComment.get().body().equals(messageToPost)) {
-                        Comment comment = issueTrackerIssue.updateComment(existingComment.get().id(), messageToPost);
-                        reply.println("The approval [request](" + issueTrackerIssue.commentUrl(comment) + ") has been updated successfully.");
-                    } else {
-                        reply.println("The approval [request](" + issueTrackerIssue.commentUrl(existingComment.get()) + ") was already up to date.");
-                    }
+
+            var issueTrackerIssueOpt = issueProject.issue(issue.shortId());
+            if (issueTrackerIssueOpt.isEmpty()) {
+                reply.println("Can not find " + issue.id() + " in the " + issueProject.name() + " project.");
+                continue;
+            }
+            var issueTrackerIssue = issueTrackerIssueOpt.get();
+            var requestLabel = approval.requestedLabel(targetRef);
+            var approvedLabel = approval.approvedLabel(targetRef);
+            var rejectedLabel = approval.rejectedLabel(targetRef);
+            var prefix = "[" + requestLabel + "]";
+            var comments = issueTrackerIssue.comments();
+            var existingComment = comments.stream()
+                    .filter(comment -> comment.author().equals(issueProject.issueTracker().currentUser()))
+                    .filter(comment -> comment.body().startsWith(prefix))
+                    .findFirst();
+
+            var labels = issueTrackerIssue.labelNames();
+            if (option.equals("cancel")) {
+                if (labels.contains(approvedLabel) || labels.contains(rejectedLabel)) {
+                    reply.println("The request has already been handled by a maintainer and can no longer be canceled.");
                 } else {
-                    Comment comment = issueTrackerIssue.addComment(messageToPost);
-                    reply.println("The approval [request](" + issueTrackerIssue.commentUrl(comment) + ") has been created successfully.");
+                    issueTrackerIssue.removeLabel(requestLabel);
+                    existingComment.ifPresent(issueTrackerIssue::removeComment);
+                    reply.println("The approval request has been cancelled successfully.");
                 }
-                issueTrackerIssue.addLabel(requestLabel);
+            } else if (option.equals("request")) {
+                if (labels.contains(approvedLabel)) {
+                    reply.println("Approval has already been requested and approved.");
+                } else if (labels.contains(rejectedLabel)) {
+                    reply.println("Approval has already been requested and rejected.");
+                } else {
+                    var messageToPost = prefix + " Approval Request from " + command.user().fullName() + "\n" + message.trim();
+                    if (existingComment.isPresent()) {
+                        if (!existingComment.get().body().equals(messageToPost)) {
+                            Comment comment = issueTrackerIssue.updateComment(existingComment.get().id(), messageToPost);
+                            reply.println("The approval [request](" + issueTrackerIssue.commentUrl(comment) + ") has been updated successfully.");
+                        } else {
+                            reply.println("The approval [request](" + issueTrackerIssue.commentUrl(existingComment.get()) + ") was already up to date.");
+                        }
+                    } else {
+                        Comment comment = issueTrackerIssue.addComment(messageToPost);
+                        reply.println("The approval [request](" + issueTrackerIssue.commentUrl(comment) + ") has been created successfully.");
+                    }
+                    issueTrackerIssue.addLabel(requestLabel);
+                }
             }
         }
-    }
-
-    private Optional<Issue> getIssue(String issueId, PullRequest pr, List<Comment> allComments, PrintWriter reply) {
-        var titleIssue = Issue.fromStringRelaxed(pr.title());
-        var issues = new ArrayList<String>();
-        titleIssue.ifPresent(value -> issues.add(value.shortId()));
-        issues.addAll(SolvesTracker.currentSolved(pr.repository().forge().currentUser(), allComments, pr.title())
-                .stream()
-                .map(Issue::shortId)
-                .toList());
-        // If there is only one issue associated with the pr, then the user don't need to specify the issueID in command
-        if (issueId == null) {
-            if (issues.size() == 1) {
-                issueId = issues.get(0);
-            } else if (issues.size() == 0) {
-                reply.println("There is no issue associated with this pull request.");
-                return Optional.empty();
-            } else {
-                reply.println("There are multiple issues associated with this pull request, you need to request approval for each one individually.");
-                return Optional.empty();
-            }
-        }
-        Issue issue = new Issue(issueId, null);
-        if (!issues.contains(issue.shortId())) {
-            reply.println("Approval can only be requested for issues that this pull request solves.");
-            return Optional.empty();
-        }
-        return Optional.of(issue);
     }
 
     @Override

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ApproveCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ApproveCommand.java
@@ -117,7 +117,7 @@ public class ApproveCommand implements CommandHandler {
         }
     }
 
-    public static List<Issue> getIssues(String issueId, PullRequest pr, List<Comment> allComments, PrintWriter reply) {
+    static List<Issue> getIssues(String issueId, PullRequest pr, List<Comment> allComments, PrintWriter reply) {
         var titleIssue = Issue.fromStringRelaxed(pr.title());
         var issueIds = new ArrayList<String>();
         titleIssue.ifPresent(value -> issueIds.add(value.shortId()));
@@ -132,7 +132,7 @@ public class ApproveCommand implements CommandHandler {
             if (issueIds.contains(issue.shortId())) {
                 ret.add(issue);
             } else {
-                reply.println(issueId + " is not associated with this pull request.");
+                reply.println("This issue is not associated with this pull request.");
             }
             // If issueId is not specified, then handle all the issues associated with this pull request
         } else {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ApproveCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ApproveCommand.java
@@ -30,7 +30,6 @@ import org.openjdk.skara.vcs.openjdk.Issue;
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.regex.Pattern;
 
 public class ApproveCommand implements CommandHandler {
@@ -118,7 +117,7 @@ public class ApproveCommand implements CommandHandler {
         }
     }
 
-    private List<Issue> getIssues(String issueId, PullRequest pr, List<Comment> allComments, PrintWriter reply) {
+    public static List<Issue> getIssues(String issueId, PullRequest pr, List<Comment> allComments, PrintWriter reply) {
         var titleIssue = Issue.fromStringRelaxed(pr.title());
         var issueIds = new ArrayList<String>();
         titleIssue.ifPresent(value -> issueIds.add(value.shortId()));
@@ -133,7 +132,7 @@ public class ApproveCommand implements CommandHandler {
             if (issueIds.contains(issue.shortId())) {
                 ret.add(issue);
             } else {
-                reply.println("You can only handle approval requests for issues that this pull request solves.");
+                reply.println(issueId + " is not associated with this pull request.");
             }
             // If issueId is not specified, then handle all the issues associated with this pull request
         } else {

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ApprovalAndApproveCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ApprovalAndApproveCommandTests.java
@@ -219,11 +219,28 @@ public class ApprovalAndApproveCommandTests {
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(pr, "JDK-1: Can only approve issues in the TEST project.");
 
-            pr.addComment("/approval 1 request my reason");
-            pr.addComment("/approval 2 request my reason");
+            pr.addComment("/approval request my reason");
             TestBotRunner.runPeriodicItems(prBot);
             TestBotRunner.runPeriodicItems(issueBot);
-            assertLastCommentContains(pr, "The approval [request](http://localhost/project/testTEST-2?focusedCommentId=0) has been created successfully.");
+            assertLastCommentContains(pr, "1: The approval [request](http://localhost/project/testTEST-1?focusedCommentId=0) has been created successfully.");
+            assertLastCommentContains(pr, "2: The approval [request](http://localhost/project/testTEST-2?focusedCommentId=0) has been created successfully.");
+
+            pr.addComment("/approval cancel");
+            TestBotRunner.runPeriodicItems(prBot);
+            TestBotRunner.runPeriodicItems(issueBot);
+            assertLastCommentContains(pr, "1: The approval request has been cancelled successfully.");
+            assertLastCommentContains(pr, "2: The approval request has been cancelled successfully.");
+
+            pr.addComment("/approval 1 request my reason for 1");
+            TestBotRunner.runPeriodicItems(prBot);
+            TestBotRunner.runPeriodicItems(issueBot);
+            assertLastCommentContains(pr, "1: The approval [request](http://localhost/project/testTEST-1?focusedCommentId=0) has been created successfully.");
+
+            pr.addComment("/approval request my reason");
+            TestBotRunner.runPeriodicItems(prBot);
+            TestBotRunner.runPeriodicItems(issueBot);
+            assertLastCommentContains(pr, "1: The approval [request](http://localhost/project/testTEST-1?focusedCommentId=0) has been updated successfully.");
+            assertLastCommentContains(pr, "2: The approval [request](http://localhost/project/testTEST-2?focusedCommentId=0) has been created successfully.");
 
             reviewerPr.addComment("/approve 1 no");
             TestBotRunner.runPeriodicItems(prBot);


### PR DESCRIPTION
As some users requested, we will allow bulk requests with `/approval` request command.

If an id is not specified in the `/approval` command, the bot will generate a maintainer approval request for all associated bugs.

This also applies to the `/approval cancel` command, which will cancel the maintainer approval request for all associated bugs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2042](https://bugs.openjdk.org/browse/SKARA-2042): Allow bulk requests with /approval request command (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1565/head:pull/1565` \
`$ git checkout pull/1565`

Update a local copy of the PR: \
`$ git checkout pull/1565` \
`$ git pull https://git.openjdk.org/skara.git pull/1565/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1565`

View PR using the GUI difftool: \
`$ git pr show -t 1565`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1565.diff">https://git.openjdk.org/skara/pull/1565.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1565#issuecomment-1740149634)