### PR TITLE
2051: Use real target ref to determine whether this pr needs maintainer approval in CheckWorkItem

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -213,7 +213,7 @@ class CheckWorkItem extends PullRequestWorkItem {
                             issueData.append(properties.get("priority").asString());
                             issueData.append(properties.get("issuetype").asString());
                         }
-                        if (bot.approval() != null && bot.approval().needsApproval(pr.targetRef())) {
+                        if (bot.approval() != null && bot.approval().needsApproval(PreIntegrations.realTargetRef(pr))) {
                             // Add a static sting to the metadata if the PR needs approval to force
                             // update if this configuration has changed for the target branch.
                             issueData.append("approval");


### PR DESCRIPTION
After deployed [SKARA-2045](https://bugs.openjdk.org/browse/SKARA-2045) to production, I found that some dependent pull requests are still not updated. Then I realized that in CheckWorkItem, we also need to use real target ref to determine whether this pr needs maintainer approval.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2051](https://bugs.openjdk.org/browse/SKARA-2051): Use real target ref to determine whether this pr needs maintainer approval in CheckWorkItem (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1566/head:pull/1566` \
`$ git checkout pull/1566`

Update a local copy of the PR: \
`$ git checkout pull/1566` \
`$ git pull https://git.openjdk.org/skara.git pull/1566/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1566`

View PR using the GUI difftool: \
`$ git pr show -t 1566`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1566.diff">https://git.openjdk.org/skara/pull/1566.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1566#issuecomment-1743505846)