### PR TITLE
2056: Improve logging of external commands

### DIFF
--- a/process/src/main/java/org/openjdk/skara/process/Execution.java
+++ b/process/src/main/java/org/openjdk/skara/process/Execution.java
@@ -131,7 +131,7 @@ public class Execution implements AutoCloseable {
 
     private void startProcess() throws IOException {
         cmd = String.join(" ", processBuilder.command());
-        log.finer("Executing '" + cmd + "'");
+        log.finer("Executing '" + cmd + "' in " + processBuilder.directory());
 
         prepareRedirects();
 
@@ -142,7 +142,8 @@ public class Execution implements AutoCloseable {
     private void waitForProcess() throws IOException, InterruptedException {
         var terminated = this.process.waitFor(timeout.toMillis(), TimeUnit.MILLISECONDS);
         var duration = Duration.between(startTime, Instant.now());
-        log.log(Level.FINE, "Executing '" + String.join(" ", processBuilder.command()) + " took " + duration, duration);
+        log.log(Level.FINE, "Executing '" + String.join(" ", processBuilder.command())
+                + "' in " + processBuilder.directory() + " took " + duration, duration);
         if (!terminated) {
             log.warning("Command '" + cmd + "' didn't finish in " + timeout + ", attempting to terminate...");
             this.process.destroyForcibly().waitFor();


### PR DESCRIPTION
In order to make it easier to analyze bot behavior, I would like to add the working directory to log messages when running external commands. Most external commands are git performing operations on a local repository and by including the directory in the log message, we can easily see which repository the git command is operating on.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2056](https://bugs.openjdk.org/browse/SKARA-2056): Improve logging of external commands (**Enhancement** - P4)


### Reviewers
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1567/head:pull/1567` \
`$ git checkout pull/1567`

Update a local copy of the PR: \
`$ git checkout pull/1567` \
`$ git pull https://git.openjdk.org/skara.git pull/1567/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1567`

View PR using the GUI difftool: \
`$ git pr show -t 1567`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1567.diff">https://git.openjdk.org/skara/pull/1567.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1567#issuecomment-1756055605)