### PR TITLE
2061: Checking for .jcheck/conf fails when pr/X branches are removed

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -182,7 +182,7 @@ class PullRequestBot implements Bot {
                 var targetRef = pr.targetRef();
                 var prId = pr.id();
                 if (pr.isOpen()) {
-                    targetRefPRMap.keySet().forEach(key -> targetRefPRMap.get(key).remove(prId));
+                    targetRefPRMap.values().forEach(s -> s.remove(prId));
                     targetRefPRMap.computeIfAbsent(targetRef, key -> new HashSet<>()).add(prId);
                 } else {
                     if (targetRefPRMap.containsKey(targetRef)) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -182,6 +182,7 @@ class PullRequestBot implements Bot {
                 var targetRef = pr.targetRef();
                 var prId = pr.id();
                 if (pr.isOpen()) {
+                    targetRefPRMap.keySet().forEach(key -> targetRefPRMap.get(key).remove(prId));
                     targetRefPRMap.computeIfAbsent(targetRef, key -> new HashSet<>()).add(prId);
                 } else {
                     if (targetRefPRMap.containsKey(targetRef)) {
@@ -189,6 +190,11 @@ class PullRequestBot implements Bot {
                     }
                 }
             }
+
+            var keysToRemove = targetRefPRMap.keySet().stream()
+                    .filter(key -> targetRefPRMap.get(key).isEmpty())
+                    .toList();
+            keysToRemove.forEach(targetRefPRMap::remove);
 
             var jCheckConfUpdateRelatedPRs = getJCheckConfUpdateRelatedPRs();
             // Filter out duplicate prs


### PR DESCRIPTION
As Erik described in the issue, "The targetRefPRMap introduced in [SKARA-1937](https://bugs.openjdk.org/browse/SKARA-1937) isn't working well with the dependent PR feature. When a pr/X branch is removed, the map may still contains that branch which will cause getPeriodicItems to fail with exception when trying to get .jcheck/conf from the non existing branch.". 

To solve this issue, I think that every pr would only have one targetRef, so before the bot is trying to create an entry for the pr, the bot should delete any existing entry associated with that pr.

Since the operations are all about HashMap, I believe they wouldn't significantly impact the bot's performance.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2061](https://bugs.openjdk.org/browse/SKARA-2061): Checking for .jcheck/conf fails when pr/X branches are removed (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1568/head:pull/1568` \
`$ git checkout pull/1568`

Update a local copy of the PR: \
`$ git checkout pull/1568` \
`$ git pull https://git.openjdk.org/skara.git pull/1568/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1568`

View PR using the GUI difftool: \
`$ git pr show -t 1568`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1568.diff">https://git.openjdk.org/skara/pull/1568.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1568#issuecomment-1759754673)