### PR TITLE
2063: Reduce the health check times of local repo instance

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
@@ -398,7 +398,7 @@ class ArchiveWorkItem implements WorkItem {
                 archiver.addReviewComment(reviewComment);
             }
 
-            var webrevGenerator = bot.webrevStorage().generator(pr, localRepo, webrevPath);
+            var webrevGenerator = bot.webrevStorage().generator(pr, localRepo, webrevPath, hostedRepositoryPool);
             var newMails = archiver.generateNewEmails(sentMails, bot.cooldown(), localRepo, bot.issueTracker(), jbs.toUpperCase(), webrevGenerator,
                                                       (index, webrevs) -> updateWebrevComment(comments, index, webrevs),
                                                       user -> getAuthorAddress(census, user),

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
@@ -335,19 +335,15 @@ class WebrevStorage {
             Repository htmlLocalStorage = null;
 
             private void initializeLocalStorage() {
-                if (jsonLocalStorage == null && !(jsonStorage == null)) {
-                    try {
+                try {
+                    if (jsonLocalStorage == null && !(jsonStorage == null)) {
                         jsonLocalStorage = hostedRepositoryPool.checkout(jsonStorage, storageRef, scratchPath);
-                    } catch (IOException e) {
-                        throw new RuntimeException(e);
                     }
-                }
-                if (htmlLocalStorage == null && !(htmlStorage == null)) {
-                    try {
+                    if (htmlLocalStorage == null && !(htmlStorage == null)) {
                         htmlLocalStorage = hostedRepositoryPool.checkout(htmlStorage, storageRef, scratchPath);
-                    } catch (IOException e) {
-                        throw new RuntimeException(e);
                     }
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
                 }
             }
 

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/WebrevStorageTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/WebrevStorageTests.java
@@ -24,6 +24,7 @@ package org.openjdk.skara.bots.mlbridge;
 
 import org.openjdk.skara.email.EmailAddress;
 import org.openjdk.skara.forge.HostedRepository;
+import org.openjdk.skara.forge.HostedRepositoryPool;
 import org.openjdk.skara.test.*;
 import org.openjdk.skara.vcs.*;
 
@@ -70,7 +71,8 @@ class WebrevStorageTests {
             var prFolder = tempFolder.path().resolve("pr");
             var prRepo = Repository.materialize(prFolder, pr.repository().authenticatedUrl(), "edit");
             var scratchFolder = tempFolder.path().resolve("scratch");
-            var generator = storage.generator(pr, prRepo, scratchFolder);
+            var seedPath = tempFolder.path().resolve("seed");
+            var generator = storage.generator(pr, prRepo, scratchFolder, new HostedRepositoryPool(seedPath));
             generator.generate(masterHash, editHash, "00", WebrevDescription.Type.FULL);
 
             // Check that the web link has been verified now and followed the redirect
@@ -123,7 +125,8 @@ class WebrevStorageTests {
             var prFolder = tempFolder.path().resolve("pr");
             var prRepo = Repository.materialize(prFolder, pr.repository().authenticatedUrl(), "edit");
             var scratchFolder = tempFolder.path().resolve("scratch");
-            var generator = storage.generator(pr, prRepo, scratchFolder);
+            var seedPath = tempFolder.path().resolve("seed");
+            var generator = storage.generator(pr, prRepo, scratchFolder, new HostedRepositoryPool(seedPath));
             generator.generate(masterHash, editHash, "00", WebrevDescription.Type.FULL);
 
             // Update the local repository and check that the webrev has been generated
@@ -207,7 +210,8 @@ class WebrevStorageTests {
             var prRepo = Repository.materialize(prFolder, pr.repository().authenticatedUrl(), "edit");
             var scratchFolder = tempFolder.path().resolve("scratch");
             var generatorProgressMarker = scratchFolder.resolve("test/" + pr.id() + "/00/nanoduke.ico");
-            var generator = storage.generator(pr, prRepo, scratchFolder);
+            var seedPath = tempFolder.path().resolve("seed");
+            var generator = storage.generator(pr, prRepo, scratchFolder, new HostedRepositoryPool(seedPath));
 
             // Commit something during generation
             var interceptFolder = tempFolder.path().resolve("intercept");

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepositoryPool.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepositoryPool.java
@@ -45,6 +45,7 @@ public class HostedRepositoryPool {
     private class HostedRepositoryInstance {
         private final HostedRepository hostedRepository;
         private final Path seed;
+        private static Set<String> healthySet = new HashSet<>();
 
         private HostedRepositoryInstance(HostedRepository hostedRepository) {
             this.hostedRepository = hostedRepository;
@@ -147,7 +148,7 @@ public class HostedRepositoryPool {
                 return cloneSeeded(path, allowStale, bare);
             } else {
                 var localRepoInstance = localRepo.get();
-                if (!localRepoInstance.isHealthy()) {
+                if (!isHealthy(localRepoInstance, path)) {
                     removeOldClone(path, "unhealthy");
                     return cloneSeeded(path, allowStale, bare);
                 } else {
@@ -162,6 +163,18 @@ public class HostedRepositoryPool {
                         return cloneSeeded(path, allowStale, bare);
                     }
                 }
+            }
+        }
+
+        private boolean isHealthy(Repository localRepoInstance, Path path) throws IOException {
+            if (healthySet.contains(path.toString())) {
+                return true;
+            } else {
+                boolean isHealthy = localRepoInstance.isHealthy();
+                if (isHealthy) {
+                    healthySet.add(path.toString());
+                }
+                return isHealthy;
             }
         }
     }

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepositoryPool.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepositoryPool.java
@@ -122,7 +122,9 @@ public class HostedRepositoryPool {
             }
             Repository.clone(remote, tmpClonePath, bare, seed);
             Files.move(tmpClonePath, path);
-            healthySet.add(path);
+            if (Repository.get(path).isPresent()) {
+                healthySet.add(path);
+            }
             return Repository.get(path).orElseThrow();
         }
 

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepositoryPool.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepositoryPool.java
@@ -45,7 +45,7 @@ public class HostedRepositoryPool {
     private class HostedRepositoryInstance {
         private final HostedRepository hostedRepository;
         private final Path seed;
-        private static Set<String> healthySet = new HashSet<>();
+        private static Set<Path> healthySet = new HashSet<>();
 
         private HostedRepositoryInstance(HostedRepository hostedRepository) {
             this.hostedRepository = hostedRepository;
@@ -122,6 +122,7 @@ public class HostedRepositoryPool {
             }
             Repository.clone(remote, tmpClonePath, bare, seed);
             Files.move(tmpClonePath, path);
+            healthySet.add(path);
             return Repository.get(path).orElseThrow();
         }
 
@@ -167,12 +168,12 @@ public class HostedRepositoryPool {
         }
 
         private boolean isHealthy(Repository localRepoInstance, Path path) throws IOException {
-            if (healthySet.contains(path.toString())) {
+            if (healthySet.contains(path)) {
                 return true;
             } else {
                 boolean isHealthy = localRepoInstance.isHealthy();
                 if (isHealthy) {
-                    healthySet.add(path.toString());
+                    healthySet.add(path);
                 }
                 return isHealthy;
             }


### PR DESCRIPTION
In the method HostedRepositoryPool#materializeClone, when the bot is trying to reuse a local repo instance, the bot will always check whether the repo is still good by processing command "git fsck --connectivity-only".

Sometimes this command would be slow and Erik said that we should believe the bots are doing right things, so we should assume the local repos are good, so the health check is not always needed. But shutdown of the bot could make a local repo instance unhealthy, so we should at least do the health check once for each local repo instance after the bot is restarted.

To solve this issue, Erik suggested to maintain a static map for keeping track of paths of known checked/good repositories.

To leverage this patch to mlbridge bot, I also made some changes to WebrevStorage.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2063](https://bugs.openjdk.org/browse/SKARA-2063): Reduce the health check times of local repo instance (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1569/head:pull/1569` \
`$ git checkout pull/1569`

Update a local copy of the PR: \
`$ git checkout pull/1569` \
`$ git pull https://git.openjdk.org/skara.git pull/1569/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1569`

View PR using the GUI difftool: \
`$ git pr show -t 1569`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1569.diff">https://git.openjdk.org/skara/pull/1569.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1569#issuecomment-1760382020)