### PR TITLE
2059: Improve error message when cli encounters 401

### DIFF
--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,6 +50,7 @@ dependencies {
     implementation project(':version')
     implementation project(':process')
     implementation project(':jbs')
+    implementation project(':network')
 
     testImplementation project(':test')
 }

--- a/cli/src/main/java/module-info.java
+++ b/cli/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,6 +33,7 @@ module org.openjdk.skara.cli {
     requires org.openjdk.skara.version;
     requires org.openjdk.skara.process;
     requires org.openjdk.skara.jbs;
+    requires org.openjdk.skara.network;
 
     requires java.net.http;
     requires java.logging;

--- a/cli/src/main/java/org/openjdk/skara/cli/GitSkara.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitSkara.java
@@ -233,7 +233,9 @@ public class GitSkara {
                 commands.get(command).main(commandArgs);
             } catch (UncheckedRestException e) {
                 if (e.getStatusCode() == 401) {
-                    System.err.println("Unauthorized: You do not have access to this resource.");
+                    System.err.println("Unauthorized: You do not have access to " + e.getRequest().uri().toString());
+                    System.err.println("Please see the page below to correctly configure your personal access token.");
+                    System.err.println("https://wiki.openjdk.org/display/SKARA/CLI+Tools#CLITools-PersonalAccessToken");
                 } else {
                     throw e;
                 }

--- a/cli/src/main/java/org/openjdk/skara/cli/GitSkara.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitSkara.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 package org.openjdk.skara.cli;
 
 import org.openjdk.skara.args.Main;
+import org.openjdk.skara.network.UncheckedRestException;
 import org.openjdk.skara.vcs.Repository;
 import org.openjdk.skara.vcs.git.GitVersion;
 import org.openjdk.skara.vcs.openjdk.CommitMessageParsers;
@@ -228,7 +229,15 @@ public class GitSkara {
         var command = isEmpty ? "help" : args[0];
         var commandArgs = isEmpty ? new String[0] : Arrays.copyOfRange(args, 1, args.length);
         if (commands.containsKey(command)) {
-            commands.get(command).main(commandArgs);
+            try {
+                commands.get(command).main(commandArgs);
+            } catch (UncheckedRestException e) {
+                if (e.getStatusCode() == 401) {
+                    System.err.println("Unauthorized: You do not have access to this resource.");
+                } else {
+                    throw e;
+                }
+            }
         } else {
             System.err.println("error: unknown command: " + command);
             help(new String[0]);

--- a/network/src/main/java/org/openjdk/skara/network/RestRequest.java
+++ b/network/src/main/java/org/openjdk/skara/network/RestRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -373,7 +373,7 @@ public class RestRequest {
         try {
             return JSON.parse(response.body());
         } catch (RuntimeException e) {
-            throw new UncheckedRestException("Failed to parse response", e, response.statusCode());
+            throw new UncheckedRestException("Failed to parse response", e, response.statusCode(), response.request());
         }
     }
 
@@ -388,7 +388,7 @@ public class RestRequest {
             log.warning("Request returned bad status: " + response.statusCode());
             log.info(queryBuilder.toString());
             log.info(response.body());
-            throw new UncheckedRestException(response.statusCode());
+            throw new UncheckedRestException(response.statusCode(), response.request());
         } else {
             return Optional.empty();
         }
@@ -531,7 +531,7 @@ public class RestRequest {
         var response = sendRequest(request, queryBuilder.skipLimiter);
         responseCounter.labels(Integer.toString(response.statusCode()), Boolean.toString(false)).inc();
         if (response.statusCode() >= 400) {
-            throw new UncheckedRestException(response.statusCode());
+            throw new UncheckedRestException(response.statusCode(), response.request());
         }
         return response.body();
     }

--- a/network/src/main/java/org/openjdk/skara/network/UncheckedRestException.java
+++ b/network/src/main/java/org/openjdk/skara/network/UncheckedRestException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,8 @@
  */
 package org.openjdk.skara.network;
 
+import java.net.http.HttpRequest;
+
 /**
  * Specialized RuntimeException thrown when a REST call receives a response code
  * >=400 that isn't handled. When catching this, details about the failed call
@@ -30,16 +32,23 @@ package org.openjdk.skara.network;
 public class UncheckedRestException extends RuntimeException {
     int statusCode;
 
-    public UncheckedRestException(int statusCode) {
-        this("Request returned bad status", null, statusCode);
+    HttpRequest request;
+
+    public UncheckedRestException(int statusCode, HttpRequest request) {
+        this("Request returned bad status", null, statusCode, request);
     }
 
-    public UncheckedRestException(String message, Throwable cause, int statusCode) {
-        super("[" +statusCode + "] " + message, cause);
+    public UncheckedRestException(String message, Throwable cause, int statusCode, HttpRequest request) {
+        super("[" + statusCode + "] " + message, cause);
         this.statusCode = statusCode;
+        this.request = request;
     }
 
     public int getStatusCode() {
         return statusCode;
+    }
+
+    public HttpRequest getRequest() {
+        return request;
     }
 }


### PR DESCRIPTION
As Erik said in the issue "A user tried to run `git pr checkout` and got UncheckedRestException with 401. The repository in question had remotes pointing to a gitlab instance while the user was trying to get a PR from github. Not sure if that is relevant here. We should not fail with a stacktrace but should rather explain that we authorization failed and print which URL we tried to connect to."

To not fail with a stack trace, in this patch, `UncheckedRestException` will be caught in the `GitSkara#main` and status code will be checked, if the status code is 401, the cli tool should print suitable error message to the user.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2059](https://bugs.openjdk.org/browse/SKARA-2059): Improve error message when cli encounters 401 (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1571/head:pull/1571` \
`$ git checkout pull/1571`

Update a local copy of the PR: \
`$ git checkout pull/1571` \
`$ git pull https://git.openjdk.org/skara.git pull/1571/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1571`

View PR using the GUI difftool: \
`$ git pr show -t 1571`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1571.diff">https://git.openjdk.org/skara/pull/1571.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1571#issuecomment-1769374456)