### PR TITLE
2068: Backport command should use default branch of repo as default

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
@@ -183,7 +183,7 @@ public class BackportCommand implements CommandHandler {
     }
 
     private Branch getTargetBranch(String[] parts, int index, HostedRepository targetRepo, PrintWriter reply) {
-        var targetBranchName = parts.length == index + 1 ? parts[index] : "master";
+        var targetBranchName = parts.length == index + 1 ? parts[index] : targetRepo.defaultBranchName();
         var targetBranches = targetRepo.branches();
         if (targetBranches.stream().noneMatch(b -> b.name().equals(targetBranchName))) {
             reply.println("The target branch `" + targetBranchName + "` does not exist");

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHostedRepository.java
@@ -174,6 +174,11 @@ class InMemoryHostedRepository implements HostedRepository {
     }
 
     @Override
+    public String defaultBranchName() {
+        return null;
+    }
+
+    @Override
     public void protectBranchPattern(String ref) {
     }
 

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
@@ -110,6 +110,7 @@ public interface HostedRepository {
     long id();
     Optional<Hash> branchHash(String ref);
     List<HostedBranch> branches();
+    String defaultBranchName();
 
     /**
      * Adds a branch protection rule based on a branch pattern. The rule prevents

--- a/forge/src/main/java/org/openjdk/skara/forge/bitbucket/BitbucketRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/bitbucket/BitbucketRepository.java
@@ -210,6 +210,11 @@ public class BitbucketRepository implements HostedRepository {
     }
 
     @Override
+    public String defaultBranchName() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public void protectBranchPattern(String pattern) {
         throw new UnsupportedOperationException();
     }

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -354,6 +354,11 @@ public class GitHubRepository implements HostedRepository {
     }
 
     @Override
+    public String defaultBranchName() {
+        return json().get("default_branch").asString();
+    }
+
+    @Override
     public void protectBranchPattern(String pattern) {
         // This could be implemented using GraphQL, but we currently don't need it for GitHub
         throw new UnsupportedOperationException();

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -435,6 +435,11 @@ public class GitLabRepository implements HostedRepository {
     }
 
     @Override
+    public String defaultBranchName() {
+        return json.get("default_branch").asString();
+    }
+
+    @Override
     public void protectBranchPattern(String pattern) {
         var body = JSON.object()
                 .put("name", pattern)

--- a/forge/src/test/java/org/openjdk/skara/forge/github/GitHubRestApiTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/github/GitHubRestApiTests.java
@@ -299,4 +299,10 @@ public class GitHubRestApiTests {
         var isClean = DiffComparator.areFuzzyEqual(backportDiff, prDiff);
         assertTrue(isClean);
     }
+
+    @Test
+    void testDefaultBranchName() {
+        var gitHubRepo = githubHost.repository(settings.getProperty("github.repository")).orElseThrow();
+        assertEquals(settings.getProperty("github.repository.branch"), gitHubRepo.defaultBranchName());
+    }
 }

--- a/forge/src/test/java/org/openjdk/skara/forge/gitlab/GitLabRestApiTest.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/gitlab/GitLabRestApiTest.java
@@ -358,4 +358,17 @@ public class GitLabRestApiTest {
 
         assertFalse(comments.isEmpty());
     }
+
+    @Test
+    void testDefaultBranchName() throws IOException {
+        var settings = ManualTestSettings.loadManualTestSettings();
+        var username = settings.getProperty("gitlab.user");
+        var token = settings.getProperty("gitlab.pat");
+        var credential = new Credential(username, token);
+        var uri = URIBuilder.base(settings.getProperty("gitlab.uri")).build();
+        var gitLabHost = new GitLabHost("gitlab", uri, false, credential, List.of());
+        var gitLabRepo = gitLabHost.repository(settings.getProperty("gitlab.repository")).orElseThrow();
+
+        assertEquals(settings.getProperty("gitlab.repository.branch"), gitLabRepo.defaultBranchName());
+    }
 }

--- a/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHostedRepository.java
@@ -278,6 +278,11 @@ public class TestHostedRepository extends TestIssueProject implements HostedRepo
     }
 
     @Override
+    public String defaultBranchName() {
+        return "master";
+    }
+
+    @Override
     public void protectBranchPattern(String pattern) {
         protectedBranchPatterns.add(pattern);
     }


### PR DESCRIPTION
When a user is using /backport command to create a backport and the user doesn't specify a target branch, skara bot would use "master" as a default target branch. However, in some repos, like lilliput-jdk17u and lilliput-jdk21u, the default branch is not "master". Therefore, it will be better to use the repository's default branch as the default target branch of /backport command.

As Erik said, the value of default branch is already available in the repository JSON. So we just need to implement a `getDefaultBranchName` method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2068](https://bugs.openjdk.org/browse/SKARA-2068): Backport command should use default branch of repo as default (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1572/head:pull/1572` \
`$ git checkout pull/1572`

Update a local copy of the PR: \
`$ git checkout pull/1572` \
`$ git pull https://git.openjdk.org/skara.git pull/1572/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1572`

View PR using the GUI difftool: \
`$ git pr show -t 1572`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1572.diff">https://git.openjdk.org/skara/pull/1572.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1572#issuecomment-1771479647)