### PR TITLE
2077: GitLabRepository.recentCommitComments may miss commits on non default branch

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -634,6 +634,7 @@ public class GitLabRepository implements HostedRepository {
         // Fetch eventual new commits
         var commits = request.get("repository/commits")
                 .param("since", lastCommitTime.format(DateTimeFormatter.ISO_DATE_TIME))
+                .param("all", "true")
                 .execute()
                 .asArray();
         for (var commit : commits) {


### PR DESCRIPTION
The recentCommitComments method on GitLabRepository is a big hack to overcome shortcomings in the GitLab APIs that has caused trouble for us at several occasions. I have now discovered another flaw in the implementation.

The sub method `getCommitTitleToCommitsMap` is used to build a map of commit messages to a list of commits. On first call, it builds the bulk of the map from a local repository. This is then kept up to date by calling the rest endpoint `GET /projects/:id/repository/commits` using the `since` argument to get all commits created after the newest commit already present in the map. The problem is that this API point will only return commits on the default branch. This means that after a bot restart, any new commits on other branches will not be found when looking for commit commands.

To fix this, I found the parameter `all=true` for this [endpoint](https://docs.gitlab.com/ee/api/commits.html). According to my testing, this will include commits not on the default branch while still letting us filter using `since`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2077](https://bugs.openjdk.org/browse/SKARA-2077): GitLabRepository.recentCommitComments may miss commits on non default branch (**Bug** - P4)


### Reviewers
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1576/head:pull/1576` \
`$ git checkout pull/1576`

Update a local copy of the PR: \
`$ git checkout pull/1576` \
`$ git pull https://git.openjdk.org/skara.git pull/1576/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1576`

View PR using the GUI difftool: \
`$ git pr show -t 1576`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1576.diff">https://git.openjdk.org/skara/pull/1576.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1576#issuecomment-1780136162)