### PR TITLE
2080: ini: allow values to be updated

### DIFF
--- a/ini/src/test/java/org/openjdk/skara/ini/INITests.java
+++ b/ini/src/test/java/org/openjdk/skara/ini/INITests.java
@@ -193,4 +193,43 @@ public class INITests {
         assertTrue(ini.contains("project"));
         assertFalse(ini.contains("bugs"));
     }
+
+    @Test
+    void testUpdatingValueInGlobalSection() {
+        var lines = List.of(
+            "foo=bar",
+            "foo=baz"
+        );
+        var ini = INI.parse(lines);
+        assertEquals("baz", ini.get("foo").asString());
+    }
+
+    @Test
+    void testUpdatingValueInSection() {
+        var lines = List.of(
+            "[checks]",
+            "    commits = reviews",
+            "",
+            "[checks]",
+            "    commits = none"
+        );
+        var ini = INI.parse(lines);
+        assertEquals("none", ini.section("checks").get("commits").asString());
+    }
+
+    @Test
+    void testUpdatingValueInSubsection() {
+        var lines = List.of(
+            "[checks]",
+            "    commits = reviews",
+            "",
+            "[checks \"reviews\"]",
+            "    merge = ignore",
+            "",
+            "[checks \"reviews\"]",
+            "    merge = check"
+        );
+        var ini = INI.parse(lines);
+        assertEquals("check", ini.section("checks").subsection("reviews").get("merge").asString());
+    }
 }


### PR DESCRIPTION
Hi all,

please review this patch that makes the `INI` parser allow values to be updated _if_ they are set multiple times in a file. The below example would result in the key `name` having the value `jane`:

```
name=john
name=jane
```

Values in sections and sub-sections can now also be updated, the below example would result in the key `age` in the subsection `[person "john"]` having the value `47`:

```
[person]
age=0

[person "john"]
age=1

[person "john"]
age=47
```

This is in line with how Git's INI parser is working, see the following example:

```
$ printf '[test]\nfoo=bar\n' >> .git/config
$ printf '[test]\nfoo=baz\n' >> .git/config
$ cat .git/config
[test]
foo=bar
[test]
foo=baz
$ git config test.foo
baz
```

Enabling keys to be updated makes modifying just a single key in a `.jcheck/conf` easier. Appending the following to any `.jcheck/conf` would make merge commits requiring reviews:

```
[checks "reviewer"]
merge=check
```

This property will be used to simplify [AdditionalConfiguration](https://github.com/openjdk/skara/blob/master/bots/pr/src/main/java/org/openjdk/skara/bots/pr/AdditionalConfiguration.java) in an upcoming PR.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2080](https://bugs.openjdk.org/browse/SKARA-2080): ini: allow values to be updated (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1577/head:pull/1577` \
`$ git checkout pull/1577`

Update a local copy of the PR: \
`$ git checkout pull/1577` \
`$ git pull https://git.openjdk.org/skara.git pull/1577/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1577`

View PR using the GUI difftool: \
`$ git pr show -t 1577`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1577.diff">https://git.openjdk.org/skara/pull/1577.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1577#issuecomment-1782495883)