### PR TITLE
2086: Use short Ids to get cached issue data in CheckWorkItem#getIssueMetadata

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -183,7 +183,7 @@ class CheckRun {
     private Optional<IssueTrackerIssue> jepIssue() {
         if (issueProject() != null) {
             var comment = findJepComment();
-            return comment.flatMap(c -> workItem.issueTrackerIssue(c.group(2)));
+            return comment.flatMap(c -> workItem.issueTrackerIssue(new Issue(c.group(2), "").shortId()));
         }
         return Optional.empty();
     }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -142,14 +142,14 @@ class CheckWorkItem extends PullRequestWorkItem {
 
     /**
      * Provides cached fetching of issues from the IssueTracker.
-     * @param id ID of issue to fetch
+     * @param shortId Short id of issue to fetch, e.g. the id of an issue is TEST-123, then the short id of the issue is 123
      * @return The issue if found, otherwise empty.
      */
-    Optional<IssueTrackerIssue> issueTrackerIssue(String id) {
-        if (!issues.containsKey(id)) {
-            issues.put(id, bot.issueProject().issue(id));
+    Optional<IssueTrackerIssue> issueTrackerIssue(String shortId) {
+        if (!issues.containsKey(shortId)) {
+            issues.put(shortId, bot.issueProject().issue(shortId));
         }
-        return issues.get(id);
+        return issues.get(shortId);
     }
 
     String getPRMetadata(CensusInstance censusInstance, String title, String body, List<Comment> comments,

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -34,6 +34,7 @@ import org.openjdk.skara.issuetracker.IssueTrackerIssue;
 import org.openjdk.skara.vcs.Hash;
 import org.openjdk.skara.vcs.Repository;
 import org.openjdk.skara.vcs.openjdk.CommitMessageParsers;
+import org.openjdk.skara.vcs.openjdk.Issue;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
@@ -199,6 +200,7 @@ class CheckWorkItem extends PullRequestWorkItem {
             }
             var issueIds = BotUtils.parseAllIssues(prBody);
             var issuesData = issueIds.stream()
+                    .map(i -> new Issue(i, "").shortId())
                     .sorted()
                     .map(this::issueTrackerIssue)
                     .filter(Optional::isPresent)
@@ -528,7 +530,7 @@ class CheckWorkItem extends PullRequestWorkItem {
                         return List.of();
                     }
 
-                    var id = issues.get(0).id();
+                    var id = issues.get(0).shortId();
                     var issue = issueTrackerIssue(id);
                     if (!issue.isPresent()) {
                         var text = "<!-- backport error -->\n" +


### PR DESCRIPTION
A user reported that in a repo which is configured with maintainer approval feature, he added the approved label to the issue but skara bot didn't update the related PR.

From the log, I found skara bot said "[Issue]No activity since last check, not checking again."

When investigating, I guess the scenario likes this. When the bot is evaluating a PR. The bot fetches the issue and the issue only contains label “XXX-fix-request”. Then, the user add "XXX-fix-yes" to issue. So in the end of evaluation, the bot fetches the issue again and calculates the metadata again (at that time, the issue contains label “XXX-fix-request, XXX-fix-yes”). So in the next round, the bot would think that new label “XXX-fix-yes” is already handled, so it will not evaluate the PR again.

But as Erik introduced a cache for IssueTrackerIssue in CheckWorkItem in [SKARA-1963](https://bugs.openjdk.org/browse/SKARA-1963). I think the bot shouldn't fetch the issue from JBS again in the end of checkRun. But the bot really did. Then I found that the key of the map(cache) are supposed to be short id of the JBS issue, But in CheckWorkItem#getIssueMetadata, the bot is trying to use the whole id of JBS issue to get the cached data, which will always miss and trigger the remote call.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2086](https://bugs.openjdk.org/browse/SKARA-2086): Use short Ids to get cached issue data in CheckWorkItem#getIssueMetadata (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1579/head:pull/1579` \
`$ git checkout pull/1579`

Update a local copy of the PR: \
`$ git checkout pull/1579` \
`$ git pull https://git.openjdk.org/skara.git pull/1579/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1579`

View PR using the GUI difftool: \
`$ git pr show -t 1579`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1579.diff">https://git.openjdk.org/skara/pull/1579.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1579#issuecomment-1786111151)