### PR TITLE
2083: Add option for omitting messages about /approval command

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/Approval.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/Approval.java
@@ -33,14 +33,18 @@ public class Approval {
     private final String rejected;
     private final String documentLink;
     private final Map<Pattern, String> branchPrefixes;
+    private final boolean approvalComment;
+    private final String approvalTerm;
 
-    public Approval(String prefix, String request, String approved, String rejected, String documentLink) {
+    public Approval(String prefix, String request, String approved, String rejected, String documentLink, boolean approvalComment, String approvalTerm) {
         this.prefix = prefix;
         this.request = request;
         this.approved = approved;
         this.rejected = rejected;
         this.branchPrefixes = new HashMap<>();
         this.documentLink = documentLink;
+        this.approvalComment = approvalComment;
+        this.approvalTerm = approvalTerm;
     }
 
     public void addBranchPrefix(Pattern branchPattern, String prefix) {
@@ -84,5 +88,13 @@ public class Approval {
             }
         }
         return false;
+    }
+
+    public boolean approvalComment() {
+        return approvalComment;
+    }
+
+    public String approvalTerm() {
+        return approvalTerm;
     }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -279,9 +279,9 @@ class CheckRun {
                     var issue = issueOpt.get();
                     var labelNames = issue.labelNames();
                     if (labelNames.contains(approval.approvedLabel(pr.targetRef()))) {
-                        ret.put("[" + issue.id() + "](" + issue.webUrl() + ") needs maintainer approval", true);
+                        ret.put("[" + issue.id() + "](" + issue.webUrl() + ") needs " + approval.approvalTerm(), true);
                     } else {
-                        ret.put("[" + issue.id() + "](" + issue.webUrl() + ") needs maintainer approval", false);
+                        ret.put("[" + issue.id() + "](" + issue.webUrl() + ") needs " + approval.approvalTerm(), false);
                     }
                 }
             }
@@ -1335,9 +1335,9 @@ class CheckRun {
             var readyForIntegration = readyToPostApprovalNeededComment &&
                     !additionalProgresses.containsValue(false);
 
-            if (approvalNeeded() && readyToPostApprovalNeededComment) {
+            if (approvalNeeded() && approval.approvalComment() && readyToPostApprovalNeededComment) {
                 for (var entry : additionalProgresses.entrySet()) {
-                    if (!entry.getKey().endsWith("needs maintainer approval") && !entry.getValue()) {
+                    if (!entry.getKey().endsWith("needs " + approval.approvalTerm()) && !entry.getValue()) {
                         readyToPostApprovalNeededComment = false;
                         break;
                     }
@@ -1534,7 +1534,7 @@ class CheckRun {
             return;
         }
         String message = "⚠️  @" + pr.author().username() +
-                " This change is now ready for you to apply for maintainer [approval](" + approval.documentLink() + "). " +
+                " This change is now ready for you to apply for [" + approval.approvalTerm() + "](" + approval.documentLink() + "). " +
                 "This can be done directly in each associated issue or by using the " +
                 "[/approval](https://wiki.openjdk.org/display/SKARA/Pull+Request+Commands#PullRequestCommands-/approval) " +
                 "command." +

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
@@ -231,7 +231,11 @@ public class PullRequestBotFactory implements BotFactory {
                 String approved = approvalJSON.get("approved").asString();
                 String rejected = approvalJSON.get("rejected").asString();
                 String documentLink = approvalJSON.get("documentLink").asString();
-                Approval approval = new Approval(prefix, request, approved, rejected, documentLink);
+                // default value is true
+                boolean approvalComment = !approvalJSON.contains("approvalComment") || approvalJSON.get("approvalComment").asBoolean();
+                //default value is maintainer approval
+                String approvalTerm = approvalJSON.contains("approvalTerm") ? approvalJSON.get("approvalTerm").asString() : "maintainer approval";
+                Approval approval = new Approval(prefix, request, approved, rejected, documentLink, approvalComment, approvalTerm);
                 if (approvalJSON.contains("branches")) {
                     for (var branch : approvalJSON.get("branches").fields()) {
                         approval.addBranchPrefix(Pattern.compile(branch.name()), branch.value().get("prefix").asString());

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ApprovalAndApproveCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ApprovalAndApproveCommandTests.java
@@ -132,7 +132,7 @@ public class ApprovalAndApproveCommandTests {
             reviewerPr.addReview(Review.Verdict.APPROVED, "LGTM");
             TestBotRunner.runPeriodicItems(prBot);
             assertFalse(pr.store().labelNames().contains("ready"));
-            assertLastCommentContains(pr, " This change is now ready for you to apply for maintainer");
+            assertLastCommentContains(pr, " This change is now ready for you to apply for [maintainer approval]");
 
             reviewerPr.addComment("/approve yes");
             TestBotRunner.runPeriodicItems(prBot);

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ApprovalAndApproveCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ApprovalAndApproveCommandTests.java
@@ -60,7 +60,7 @@ public class ApprovalAndApproveCommandTests {
                     .addCommitter(author.forge().currentUser().id());
             Map<String, List<PRRecord>> issuePRMap = new HashMap<>();
             Approval approval = new Approval("", "-critical-request", "-critical-approved",
-                    "-critical-rejected", "https://example.com");
+                    "-critical-rejected", "https://example.com", true, "maintainer approval");
             approval.addBranchPrefix(Pattern.compile("jdk20.0.1"), "CPU23_04");
             approval.addBranchPrefix(Pattern.compile("jdk20.0.2"), "CPU23_05");
 
@@ -174,7 +174,7 @@ public class ApprovalAndApproveCommandTests {
                     .addCommitter(author.forge().currentUser().id());
             Map<String, List<PRRecord>> issuePRMap = new HashMap<>();
             Approval approval = new Approval("", "-critical-request", "-critical-approved",
-                    "-critical-rejected", "https://example.com");
+                    "-critical-rejected", "https://example.com", true, "maintainer approval");
             approval.addBranchPrefix(Pattern.compile("jdk20.0.1"), "CPU23_04");
             approval.addBranchPrefix(Pattern.compile("jdk20.0.2"), "CPU23_05");
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ApprovalTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ApprovalTests.java
@@ -32,22 +32,26 @@ public class ApprovalTests {
     @Test
     void simple() {
         Approval approval = new Approval("", "jdk17u-fix-request", "jdk17u-fix-yes",
-                "jdk17u-fix-no", "https://example.com");
+                "jdk17u-fix-no", "https://example.com", true, "maintainer approval");
         assertEquals("jdk17u-fix-request", approval.requestedLabel("master"));
         assertEquals("jdk17u-fix-yes", approval.approvedLabel("master"));
         assertEquals("jdk17u-fix-no", approval.rejectedLabel("master"));
         assertEquals("https://example.com", approval.documentLink());
+        assertTrue(approval.approvalComment());
+        assertEquals("maintainer approval", approval.approvalTerm());
         assertTrue(approval.needsApproval("master"));
 
         approval = new Approval("jdk17u-fix-", "request", "yes", "no",
-                "https://example.com");
+                "https://example.com", false, "maintainer approval");
         assertEquals("jdk17u-fix-request", approval.requestedLabel("master"));
         assertEquals("jdk17u-fix-yes", approval.approvedLabel("master"));
         assertEquals("jdk17u-fix-no", approval.rejectedLabel("master"));
+        assertFalse(approval.approvalComment());
+        assertEquals("maintainer approval", approval.approvalTerm());
         assertTrue(approval.needsApproval("master"));
 
         approval = new Approval("", "-critical-request", "-critical-approved",
-                "-critical-rejected", "https://example.com");
+                "-critical-rejected", "https://example.com", false, "critical request");
         approval.addBranchPrefix(Pattern.compile("jdk20.0.1"), "CPU23_04");
         approval.addBranchPrefix(Pattern.compile("jdk20.0.2"), "CPU23_05");
         assertEquals("CPU23_04-critical-request", approval.requestedLabel("jdk20.0.1"));
@@ -60,5 +64,7 @@ public class ApprovalTests {
         assertTrue(approval.needsApproval("jdk20.0.1"));
         assertTrue(approval.needsApproval("jdk20.0.2"));
         assertFalse(approval.needsApproval("jdk20.0.3"));
+        assertFalse(approval.approvalComment());
+        assertEquals("critical request", approval.approvalTerm());
     }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -3078,7 +3078,7 @@ class CheckTests {
                     .addCommitter(author.forge().currentUser().id());
             Map<String, List<PRRecord>> issuePRMap = new HashMap<>();
             Approval approval = new Approval("", "-critical-request", "-critical-approved",
-                    "-critical-rejected", "https://example.com");
+                    "-critical-rejected", "https://example.com", true, "maintainer approval");
             approval.addBranchPrefix(Pattern.compile("jdk20.0.1"), "CPU23_04");
             approval.addBranchPrefix(Pattern.compile("jdk20.0.2"), "CPU23_05");
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IssueBotTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IssueBotTests.java
@@ -318,7 +318,7 @@ public class IssueBotTests {
                     .censusRepo(censusBuilder.build())
                     .issuePRMap(issuePRMap)
                     .approval(new Approval("", "jdk17u-fix-request", "jdk17u-fix-yes",
-                            "jdk17u-fix-no", "https://example.com"))
+                            "jdk17u-fix-no", "https://example.com", true, "maintainer approval"))
                     .build();
             var issueBot = new IssueBot(issueProject, List.of(author), Map.of(bot.name(), prBot), issuePRMap);
 
@@ -365,7 +365,7 @@ public class IssueBotTests {
                     .addCommitter(author.forge().currentUser().id());
             Map<String, List<PRRecord>> issuePRMap = new HashMap<>();
             Approval approval = new Approval("", "-critical-request", "-critical-approved",
-                    "-critical-rejected", "https://example.com");
+                    "-critical-rejected", "https://example.com", true, "critical request");
             approval.addBranchPrefix(Pattern.compile("jdk20.0.1"), "CPU23_04");
             approval.addBranchPrefix(Pattern.compile("jdk20.0.2"), "CPU23_05");
 
@@ -396,7 +396,7 @@ public class IssueBotTests {
             TestBotRunner.runPeriodicItems(prBot);
             assertFalse(pr.store().labelNames().contains("ready"));
             assertTrue(pr.store().labelNames().contains("rfr"));
-            assertFalse(pr.store().body().contains("[TEST-1](http://localhost/project/testTEST-1) needs maintainer approval"));
+            assertFalse(pr.store().body().contains("[TEST-1](http://localhost/project/testTEST-1) needs critical request"));
 
             var reviewerPr = reviewer.pullRequest(pr.id());
             reviewerPr.addReview(Review.Verdict.APPROVED, "Looks good");
@@ -407,8 +407,8 @@ public class IssueBotTests {
             reviewerPr.addReview(Review.Verdict.APPROVED, "Looks good");
             TestBotRunner.runPeriodicItems(prBot);
             assertFalse(pr.store().labelNames().contains("ready"));
-            assertTrue(pr.store().body().contains("[TEST-1](http://localhost/project/testTEST-1) needs maintainer approval"));
-            assertEquals("⚠️  @user1 This change is now ready for you to apply for maintainer [approval](https://example.com). " +
+            assertTrue(pr.store().body().contains("[TEST-1](http://localhost/project/testTEST-1) needs critical request"));
+            assertEquals("⚠️  @user1 This change is now ready for you to apply for [critical request](https://example.com). " +
                             "This can be done directly in each associated issue or by using the " +
                             "[/approval](https://wiki.openjdk.org/display/SKARA/Pull+Request+Commands#PullRequestCommands-/approval) command." +
                             "<!-- PullRequestBot approval needed comment -->"
@@ -421,8 +421,8 @@ public class IssueBotTests {
             issue.addLabel("CPU23_04-critical-approved");
             TestBotRunner.runPeriodicItems(issueBot);
             assertTrue(pr.store().body().contains("Approved"));
-            assertTrue(pr.store().body().contains("[TEST-1](http://localhost/project/testTEST-1) needs maintainer approval"));
-            assertEquals("⚠️  @user1 This change is now ready for you to apply for maintainer [approval](https://example.com). " +
+            assertTrue(pr.store().body().contains("[TEST-1](http://localhost/project/testTEST-1) needs critical request"));
+            assertEquals("⚠️  @user1 This change is now ready for you to apply for [critical request](https://example.com). " +
                             "This can be done directly in each associated issue or by using the " +
                             "[/approval](https://wiki.openjdk.org/display/SKARA/Pull+Request+Commands#PullRequestCommands-/approval) command." +
                             "<!-- PullRequestBot approval needed comment -->"


### PR DESCRIPTION
We don't need to notify users about the /approval command in all cases. So we should make it optional.

Also the term "maintainer approval" may confuse users in some cases and we also need to make it configurable.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2083](https://bugs.openjdk.org/browse/SKARA-2083): Add option for omitting messages about /approval command (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1580/head:pull/1580` \
`$ git checkout pull/1580`

Update a local copy of the PR: \
`$ git checkout pull/1580` \
`$ git pull https://git.openjdk.org/skara.git pull/1580/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1580`

View PR using the GUI difftool: \
`$ git pr show -t 1580`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1580.diff">https://git.openjdk.org/skara/pull/1580.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1580#issuecomment-1789330111)