### PR TITLE
2088: Skara /reviewers command is no longer effective

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/AdditionalConfiguration.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/AdditionalConfiguration.java
@@ -45,6 +45,7 @@ public class AdditionalConfiguration {
         var updatedLimits = ReviewersTracker.updatedRoleLimits(currentConfiguration, additionalReviewers.get().number(), additionalReviewers.get().role());
         ret.add("[checks \"reviewers\"]");
         updatedLimits.forEach((role, count) -> ret.add(role + "=" + count));
+        ret.add("minimum=disable");
         if (reviewMerge) {
             ret.add("merge=check");
         }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/AdditionalConfigurationTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/AdditionalConfigurationTests.java
@@ -22,7 +22,6 @@
  */
 package org.openjdk.skara.bots.pr;
 
-import org.openjdk.skara.forge.*;
 import org.openjdk.skara.test.*;
 
 import java.io.*;

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/AdditionalConfigurationTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/AdditionalConfigurationTests.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.pr;
+
+import org.openjdk.skara.forge.*;
+import org.openjdk.skara.test.*;
+
+import java.io.*;
+import java.util.*;
+
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class AdditionalConfigurationTests {
+    @Test
+    void minimumShouldBeDisabled(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var integrator = credentials.getHostedRepository();
+            var bot = credentials.getHostedRepository();
+
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addReviewer(integrator.forge().currentUser().id())
+                                           .addCommitter(author.forge().currentUser().id());
+            var prBot = PullRequestBot.newBuilder().repo(bot).censusRepo(censusBuilder.build()).build();
+
+            // Populate the projects repository
+            var localRepoFolder = tempFolder.path().resolve("localrepo");
+            var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "123: This is a pull request");
+
+            var reviewerPr = (TestPullRequest)integrator.pullRequest(pr.id());
+
+            // Require two reviewers
+            reviewerPr.addComment("/reviewers 2");
+            TestBotRunner.runPeriodicItems(prBot);
+
+            var additional = AdditionalConfiguration.get(localRepo, masterHash, bot.forge().currentUser(),
+                                                         pr.comments(), false);
+            var expected = List.of(
+                "[checks \"reviewers\"]",
+                "lead=0",
+                "reviewers=1",
+                "committers=0",
+                "authors=1",
+                "contributors=0",
+                "minimum=disable"
+            );
+            assertEquals(expected, additional);
+        }
+    }
+}

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/ReviewersConfiguration.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/ReviewersConfiguration.java
@@ -130,31 +130,40 @@ public class ReviewersConfiguration {
         var contributors = s.get("contributors", 0);
 
         if (s.contains("minimum")) {
-            // Reset defaults to 0
-            lead = 0;
-            reviewers = 0;
-            committers = 0;
-            authors = 0;
-            contributors = 0;
-
-            var minimum = s.get("minimum").asInt();
-            if (s.contains("role")) {
-                var role = s.get("role").asString();
-                if (role.equals("lead")) {
-                    lead = minimum;
-                } else if (role.equals("reviewer")) {
-                    reviewers = minimum;
-                } else if (role.equals("committer")) {
-                    committers = minimum;
-                } else if (role.equals("author")) {
-                    authors = minimum;
-                } else if (role.equals("contributor")) {
-                    contributors = minimum;
-                } else {
-                    throw new IllegalArgumentException("Unexpected role: " + role);
+            var isMinimumDisabled = s.get("minimum").asString().trim().toLowerCase().equals("disable");
+            if (!isMinimumDisabled) {
+                for (var role : List.of("lead", "reviewers", "committers", "authors", "contributors")) {
+                    if (s.contains(role)) {
+                        throw new IllegalStateException("Cannot combine 'minimum' with '" + role + "'");
+                    }
                 }
-            } else {
-                reviewers = minimum;
+
+                // Reset defaults to 0
+                lead = 0;
+                reviewers = 0;
+                committers = 0;
+                authors = 0;
+                contributors = 0;
+
+                var minimum = s.get("minimum").asInt();
+                if (s.contains("role")) {
+                    var role = s.get("role").asString();
+                    if (role.equals("lead")) {
+                        lead = minimum;
+                    } else if (role.equals("reviewer")) {
+                        reviewers = minimum;
+                    } else if (role.equals("committer")) {
+                        committers = minimum;
+                    } else if (role.equals("author")) {
+                        authors = minimum;
+                    } else if (role.equals("contributor")) {
+                        contributors = minimum;
+                    } else {
+                        throw new IllegalArgumentException("Unexpected role: " + role);
+                    }
+                } else {
+                    reviewers = minimum;
+                }
             }
         }
 

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/ReviewersCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/ReviewersCheckTests.java
@@ -698,4 +698,21 @@ class ReviewersCheckTests {
         return String.format(hasReview, totalNum, totalNum > 1 ? "s" : "", String.join(", ", requireList));
     }
 
+    @Test
+    void minimumCanBeDisabled() {
+        var conf = new ArrayList<>(CONFIGURATION);
+        conf.add("reviewers = 1");
+        conf.add("minimum = disable");
+        assertEquals(constructReviewRequirement(0, 1, 0, 0, 0),
+                JCheckConfiguration.parse(conf).checks().reviewers().getReviewRequirements());
+    }
+
+    @Test
+    void minimumWithAnotherRoleTrows() {
+        var conf = new ArrayList<>(CONFIGURATION);
+        conf.add("reviewers = 1");
+        conf.add("minimum = 1");
+        assertThrows(IllegalStateException.class, () -> JCheckConfiguration.parse(conf));
+    }
+
 }


### PR DESCRIPTION
Hi all,

please review this fix for [SKARA-2088](https://bugs.openjdk.org/browse/SKARA-2088). The fix consists of adding a special value (`disable`) to the key `minimum` in the `[checks "reviewers"]` subsection. This way the functionality enabled by the `minimum` key can be disabled by `AdditionalConfiguration.java` (since INI doesn't feature a way for keys to be unset).

I also made the `ReviewersCheckConfiguration` a bit more strict - the `minimum` key should never be combined with the keys `lead`, `reviewers`, `committers`, `authors` or `contributors`.

Finally I added tests for the above three scenarios.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2088](https://bugs.openjdk.org/browse/SKARA-2088): Skara /reviewers command is no longer effective (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to [f7e49b61](https://git.openjdk.org/skara/pull/1581/files/f7e49b6145224bc5403d2294ad647e58233d6e67)
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - **Reviewer**) ⚠️ Review applies to [f7e49b61](https://git.openjdk.org/skara/pull/1581/files/f7e49b6145224bc5403d2294ad647e58233d6e67)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1581/head:pull/1581` \
`$ git checkout pull/1581`

Update a local copy of the PR: \
`$ git checkout pull/1581` \
`$ git pull https://git.openjdk.org/skara.git pull/1581/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1581`

View PR using the GUI difftool: \
`$ git pr show -t 1581`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1581.diff">https://git.openjdk.org/skara/pull/1581.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1581#issuecomment-1790819439)