### PR TITLE
2091: CheckRun fails with NPE if github fullName is null

### DIFF
--- a/host/src/main/java/org/openjdk/skara/host/HostUser.java
+++ b/host/src/main/java/org/openjdk/skara/host/HostUser.java
@@ -158,6 +158,10 @@ public class HostUser {
         if (fullName == null) {
             update();
         }
+        // If the user doesn't set full name, then use username instead
+        if (fullName == null) {
+            return username();
+        }
         return fullName;
     }
 


### PR DESCRIPTION
If a user doesn't set name in the GitHub profile, when the bot is trying to get the full name of the user, the bot would get `null` and in some cases, it will trigger NPE.

To solve this problem, I think if the user doesn't set name, then the bot should use his username instead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2091](https://bugs.openjdk.org/browse/SKARA-2091): CheckRun fails with NPE if github fullName is null (**Bug** - P2)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1582/head:pull/1582` \
`$ git checkout pull/1582`

Update a local copy of the PR: \
`$ git checkout pull/1582` \
`$ git pull https://git.openjdk.org/skara.git pull/1582/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1582`

View PR using the GUI difftool: \
`$ git pr show -t 1582`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1582.diff">https://git.openjdk.org/skara/pull/1582.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1582#issuecomment-1791431651)