### PR TITLE
2101: Change confusing requirement text

### DIFF
--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/IssuesCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/IssuesCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,6 +68,6 @@ public class IssuesCheck extends CommitCheck {
 
     @Override
     public String description() {
-        return "Commit message must refer to an issue";
+        return "PR title must begin with a JBS issue number";
     }
 }


### PR DESCRIPTION
The checkbox list in "Progress" in the PRs body says:

"Commit message must refer to an issue"

but it is not really talking about the commit message, but the PR title. The "refer to an issue" is also vague; especially since the only time you will be hit by this problem is when you are a newcomer, and do not understand what is expected of you.

The text should be rephrased to be more helpful to newcomers.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [SKARA-2101](https://bugs.openjdk.org/browse/SKARA-2101): Change confusing requirement text (**Bug** - P5)


### Reviewers
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1584/head:pull/1584` \
`$ git checkout pull/1584`

Update a local copy of the PR: \
`$ git checkout pull/1584` \
`$ git pull https://git.openjdk.org/skara.git pull/1584/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1584`

View PR using the GUI difftool: \
`$ git pr show -t 1584`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1584.diff">https://git.openjdk.org/skara/pull/1584.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1584#issuecomment-1802360731)