### PR TITLE
2089: Warn when bug fixVersion doesn't match .jcheck/conf version in PR

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -727,7 +727,7 @@ class CheckRun {
                             }
                             progressBody.append(")");
                         }
-                        if (!workItem.bot.fixVersionOverride() && issueTrackerIssue.get().isOpen()
+                        if (workItem.bot.versionMismatchWarning() && issueTrackerIssue.get().isOpen()
                                 && version != null && issueType != null && PRIMARY_TYPES.contains(issueType.asString())) {
                             var existing = Backports.findIssue(issueTrackerIssue.get(), version);
                             if (existing.isEmpty()) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -727,8 +727,8 @@ class CheckRun {
                             }
                             progressBody.append(")");
                         }
-                        if (issueTrackerIssue.get().isOpen() && version != null && issueType != null
-                                && PRIMARY_TYPES.contains(issueType.asString())) {
+                        if (!workItem.bot.fixVersionOverride() && issueTrackerIssue.get().isOpen()
+                                && version != null && issueType != null && PRIMARY_TYPES.contains(issueType.asString())) {
                             var existing = Backports.findIssue(issueTrackerIssue.get(), version);
                             if (existing.isEmpty()) {
                                 var fixVersions = Backports.fixVersions(issueTrackerIssue.get());

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -650,7 +650,7 @@ class CheckRun {
             List<String> additionalErrors, Map<String, Boolean> additionalProgresses,
             List<String> integrationBlockers, boolean reviewNeeded,
             Map<Issue, Optional<IssueTrackerIssue>> regularIssuesMap,
-            IssueTrackerIssue jepIssue, Collection<IssueTrackerIssue> csrIssues) {
+            IssueTrackerIssue jepIssue, Collection<IssueTrackerIssue> csrIssues, JdkVersion version) {
         var progressBody = new StringBuilder();
         progressBody.append("---------\n");
         progressBody.append("### Progress\n");
@@ -726,6 +726,12 @@ class CheckRun {
                                 }
                             }
                             progressBody.append(")");
+                        }
+                        if (issueTrackerIssue.get().isOpen() && version != null) {
+                            var existing = Backports.findIssue(issueTrackerIssue.get(), version);
+                            if (existing.isEmpty()) {
+                                progressBody.append("(⚠️ The fixVersion in the main issue is different from the fixVersion in .jcheck/conf.)");
+                            }
                         }
                         if (!relaxedEquals(issueTrackerIssue.get().title(), issue.description())) {
                             progressBody.append(" ⚠️ Title mismatch between PR and JBS.");
@@ -1319,7 +1325,7 @@ class CheckRun {
 
             // Calculate and update the status message if needed
             var statusMessage = getStatusMessage(visitor, additionalErrors, additionalProgresses, integrationBlockers,
-                    reviewNeeded, regularIssuesMap, jepIssue, issueToCsrMap.values());
+                    reviewNeeded, regularIssuesMap, jepIssue, issueToCsrMap.values(), version);
             var updatedBody = updateStatusMessage(statusMessage);
             var title = pr.title();
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -727,10 +727,14 @@ class CheckRun {
                             }
                             progressBody.append(")");
                         }
-                        if (issueTrackerIssue.get().isOpen() && version != null) {
+                        if (issueTrackerIssue.get().isOpen() && version != null && issueType != null
+                                && PRIMARY_TYPES.contains(issueType.asString())) {
                             var existing = Backports.findIssue(issueTrackerIssue.get(), version);
                             if (existing.isEmpty()) {
-                                progressBody.append("(⚠️ The fixVersion in the main issue is different from the fixVersion in .jcheck/conf.)");
+                                var fixVersions = Backports.fixVersions(issueTrackerIssue.get());
+                                progressBody.append("(⚠️ The fixVersion in this issue is " + fixVersions +
+                                        " but the fixVersion in .jcheck/conf is " + version.raw() + ", " +
+                                        "a new backport will be created when this pr is integrated.)");
                             }
                         }
                         if (!relaxedEquals(issueTrackerIssue.get().title(), issue.description())) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -31,6 +31,7 @@ import org.openjdk.skara.forge.*;
 import org.openjdk.skara.host.HostUser;
 import org.openjdk.skara.issuetracker.Comment;
 import org.openjdk.skara.issuetracker.IssueTrackerIssue;
+import org.openjdk.skara.json.JSONValue;
 import org.openjdk.skara.vcs.Hash;
 import org.openjdk.skara.vcs.Repository;
 import org.openjdk.skara.vcs.openjdk.CommitMessageParsers;
@@ -214,6 +215,10 @@ class CheckWorkItem extends PullRequestWorkItem {
                         if (properties != null) {
                             issueData.append(properties.get("priority").asString());
                             issueData.append(properties.get("issuetype").asString());
+                            issueData.append(properties.get("fixVersions").stream()
+                                    .map(JSONValue::asString)
+                                    .sorted()
+                                    .toList());
                         }
                         if (bot.approval() != null && bot.approval().needsApproval(PreIntegrations.realTargetRef(pr))) {
                             // Add a static sting to the metadata if the PR needs approval to force

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -215,10 +215,12 @@ class CheckWorkItem extends PullRequestWorkItem {
                         if (properties != null) {
                             issueData.append(properties.get("priority").asString());
                             issueData.append(properties.get("issuetype").asString());
-                            issueData.append(properties.get("fixVersions").stream()
-                                    .map(JSONValue::asString)
-                                    .sorted()
-                                    .toList());
+                            if (properties.get("fixVersions") != null) {
+                                issueData.append(properties.get("fixVersions").stream()
+                                        .map(JSONValue::asString)
+                                        .sorted()
+                                        .toList());
+                            }
                         }
                         if (bot.approval() != null && bot.approval().needsApproval(PreIntegrations.realTargetRef(pr))) {
                             // Add a static sting to the metadata if the PR needs approval to force

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -79,7 +79,7 @@ class PullRequestBot implements Bot {
     private final Map<String, Set<String>> targetRefPRMap = new HashMap<>();
     private final Approval approval;
     private boolean initialRun = true;
-    private final boolean fixVersionOverride;
+    private final boolean versionMismatchWarning;
 
     private Instant lastFullUpdate;
 
@@ -94,7 +94,7 @@ class PullRequestBot implements Bot {
                    Set<String> integrators, Set<Integer> excludeCommitCommentsFrom, boolean enableCsr, boolean enableJep,
                    boolean reviewCleanBackport, String mlbridgeBotName, boolean reviewMerge, boolean processPR, boolean processCommit,
                    boolean enableMerge, Set<String> mergeSources, boolean jcheckMerge, boolean enableBackport,
-                   Map<String, List<PRRecord>> issuePRMap, Approval approval, boolean fixVersionOverride) {
+                   Map<String, List<PRRecord>> issuePRMap, Approval approval, boolean versionMismatchWarning) {
         remoteRepo = repo;
         this.censusRepo = censusRepo;
         this.censusRef = censusRef;
@@ -130,7 +130,7 @@ class PullRequestBot implements Bot {
         this.enableBackport = enableBackport;
         this.issuePRMap = issuePRMap;
         this.approval = approval;
-        this.fixVersionOverride = fixVersionOverride;
+        this.versionMismatchWarning = versionMismatchWarning;
 
         autoLabelled = new HashSet<>();
         poller = new PullRequestPoller(repo, true);
@@ -399,8 +399,8 @@ class PullRequestBot implements Bot {
         return approval;
     }
 
-    public boolean fixVersionOverride() {
-        return fixVersionOverride;
+    public boolean versionMismatchWarning() {
+        return versionMismatchWarning;
     }
 
     public void addIssuePRMapping(String issueId, PRRecord prRecord) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -79,6 +79,7 @@ class PullRequestBot implements Bot {
     private final Map<String, Set<String>> targetRefPRMap = new HashMap<>();
     private final Approval approval;
     private boolean initialRun = true;
+    private final boolean fixVersionOverride;
 
     private Instant lastFullUpdate;
 
@@ -93,7 +94,7 @@ class PullRequestBot implements Bot {
                    Set<String> integrators, Set<Integer> excludeCommitCommentsFrom, boolean enableCsr, boolean enableJep,
                    boolean reviewCleanBackport, String mlbridgeBotName, boolean reviewMerge, boolean processPR, boolean processCommit,
                    boolean enableMerge, Set<String> mergeSources, boolean jcheckMerge, boolean enableBackport,
-                   Map<String, List<PRRecord>> issuePRMap, Approval approval) {
+                   Map<String, List<PRRecord>> issuePRMap, Approval approval, boolean fixVersionOverride) {
         remoteRepo = repo;
         this.censusRepo = censusRepo;
         this.censusRef = censusRef;
@@ -129,6 +130,7 @@ class PullRequestBot implements Bot {
         this.enableBackport = enableBackport;
         this.issuePRMap = issuePRMap;
         this.approval = approval;
+        this.fixVersionOverride = fixVersionOverride;
 
         autoLabelled = new HashSet<>();
         poller = new PullRequestPoller(repo, true);
@@ -395,6 +397,10 @@ class PullRequestBot implements Bot {
 
     public Approval approval() {
         return approval;
+    }
+
+    public boolean fixVersionOverride() {
+        return fixVersionOverride;
     }
 
     public void addIssuePRMapping(String issueId, PRRecord prRecord) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
@@ -66,7 +66,7 @@ public class PullRequestBotBuilder {
     private boolean enableBackport = true;
     private Map<String, List<PRRecord>> issuePRMap;
     private Approval approval = null;
-    private boolean fixVersionOverride = false;
+    private boolean versionMismatchWarning = false;
 
     PullRequestBotBuilder() {
     }
@@ -246,8 +246,8 @@ public class PullRequestBotBuilder {
         return this;
     }
 
-    public PullRequestBotBuilder fixVersionOverride(boolean fixVersionOverride) {
-        this.fixVersionOverride = fixVersionOverride;
+    public PullRequestBotBuilder versionMismatchWarning(boolean versionMismatchWarning) {
+        this.versionMismatchWarning = versionMismatchWarning;
         return this;
     }
 
@@ -257,6 +257,6 @@ public class PullRequestBotBuilder {
                 readyComments, issueProject, ignoreStaleReviews, allowedTargetBranches, seedStorage, confOverrideRepo,
                 confOverrideName, confOverrideRef, censusLink, forks, integrators, excludeCommitCommentsFrom, enableCsr,
                 enableJep, reviewCleanBackport, mlbridgeBotName, reviewMerge, processPR, processCommit, enableMerge,
-                mergeSources, jcheckMerge, enableBackport, issuePRMap, approval, fixVersionOverride);
+                mergeSources, jcheckMerge, enableBackport, issuePRMap, approval, versionMismatchWarning);
     }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
@@ -66,6 +66,7 @@ public class PullRequestBotBuilder {
     private boolean enableBackport = true;
     private Map<String, List<PRRecord>> issuePRMap;
     private Approval approval = null;
+    private boolean fixVersionOverride = false;
 
     PullRequestBotBuilder() {
     }
@@ -245,12 +246,17 @@ public class PullRequestBotBuilder {
         return this;
     }
 
+    public PullRequestBotBuilder fixVersionOverride(boolean fixVersionOverride) {
+        this.fixVersionOverride = fixVersionOverride;
+        return this;
+    }
+
     public PullRequestBot build() {
         return new PullRequestBot(repo, censusRepo, censusRef, labelConfiguration, externalPullRequestCommands,
                 externalCommitCommands, blockingCheckLabels, readyLabels, twoReviewersLabels, twentyFourHoursLabels,
                 readyComments, issueProject, ignoreStaleReviews, allowedTargetBranches, seedStorage, confOverrideRepo,
                 confOverrideName, confOverrideRef, censusLink, forks, integrators, excludeCommitCommentsFrom, enableCsr,
                 enableJep, reviewCleanBackport, mlbridgeBotName, reviewMerge, processPR, processCommit, enableMerge,
-                mergeSources, jcheckMerge, enableBackport, issuePRMap, approval);
+                mergeSources, jcheckMerge, enableBackport, issuePRMap, approval, fixVersionOverride);
     }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
@@ -244,8 +244,8 @@ public class PullRequestBotFactory implements BotFactory {
                 botBuilder.approval(approval);
             }
 
-            if (repo.value().contains("fixVersionOverride")) {
-                botBuilder.fixVersionOverride(repo.value().get("fixVersionOverride").asBoolean());
+            if (repo.value().contains("versionMismatchWarning")) {
+                botBuilder.versionMismatchWarning(repo.value().get("versionMismatchWarning").asBoolean());
             }
 
             var prBot = botBuilder.build();

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
@@ -244,6 +244,10 @@ public class PullRequestBotFactory implements BotFactory {
                 botBuilder.approval(approval);
             }
 
+            if (repo.value().contains("fixVersionOverride")) {
+                botBuilder.fixVersionOverride(repo.value().get("fixVersionOverride").asBoolean());
+            }
+
             var prBot = botBuilder.build();
             pullRequestBotMap.put(repository.name(), prBot);
             ret.add(prBot);

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -3162,7 +3162,7 @@ class CheckTests {
             issue.setProperty("fixVersions", JSON.array().add("0.1"));
             pr.store().setBody("update");
             TestBotRunner.runPeriodicItems(prBot);
-            assertFalse(pr.store().body().contains("(⚠️ The fixVersion in this issue is [0] but the fixVersion in .jcheck/conf is 0.1, a new backport will be created when this pr is integrated.)"));
+            assertFalse(pr.store().body().contains("(⚠️ The fixVersion"));
 
             issue.setProperty("fixVersions", JSON.array().add("0.1").add("0.2"));
             pr.store().setBody("update");
@@ -3173,7 +3173,51 @@ class CheckTests {
             issue.setProperty("fixVersions", JSON.array().add("tbd"));
             pr.store().setBody("update");
             TestBotRunner.runPeriodicItems(prBot);
-            assertFalse(pr.store().body().contains("(⚠️ The fixVersion in this issue is [tbd] but the fixVersion in .jcheck/conf is 0.1, a new backport will be created when this pr is integrated.)"));
+            assertFalse(pr.store().body().contains("(⚠️ The fixVersion"));
+        }
+    }
+
+    @Test
+    void fixVersionOverride(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var reviewer = credentials.getHostedRepository();
+            var bot = credentials.getHostedRepository();
+            var issueProject = credentials.getIssueProject();
+            var issue = issueProject.createIssue("This is an issue", List.of(), Map.of());
+            issue.setProperty("issuetype", JSON.of("Bug"));
+            issue.setProperty("priority", JSON.of("4"));
+            issue.setState(Issue.State.OPEN);
+            issue.setProperty("fixVersions", JSON.array().add("18"));
+
+            var censusBuilder = credentials.getCensusBuilder()
+                    .addReviewer(reviewer.forge().currentUser().id())
+                    .addCommitter(author.forge().currentUser().id());
+            Map<String, List<PRRecord>> issuePRMap = new HashMap<>();
+
+            var prBot = PullRequestBot.newBuilder()
+                    .repo(bot)
+                    .issueProject(issueProject)
+                    .censusRepo(censusBuilder.build())
+                    .issuePRMap(issuePRMap)
+                    .fixVersionOverride(true)
+                    .build();
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "1");
+
+
+            // Populate the projects repository
+            TestBotRunner.runPeriodicItems(prBot);
+            assertFalse(pr.store().body().contains("(⚠️ The fixVersion"));
         }
     }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -3117,4 +3117,63 @@ class CheckTests {
             assertTrue(followUpPr.store().body().contains("needs maintainer approval"));
         }
     }
+
+    @Test
+    void fixVersionNotMatch(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var reviewer = credentials.getHostedRepository();
+            var bot = credentials.getHostedRepository();
+            var issueProject = credentials.getIssueProject();
+            var issue = issueProject.createIssue("This is an issue", List.of(), Map.of());
+            issue.setProperty("issuetype", JSON.of("Bug"));
+            issue.setProperty("priority", JSON.of("4"));
+            issue.setState(Issue.State.OPEN);
+            issue.setProperty("fixVersions", JSON.array().add("18"));
+
+            var censusBuilder = credentials.getCensusBuilder()
+                    .addReviewer(reviewer.forge().currentUser().id())
+                    .addCommitter(author.forge().currentUser().id());
+            Map<String, List<PRRecord>> issuePRMap = new HashMap<>();
+
+            var prBot = PullRequestBot.newBuilder()
+                    .repo(bot)
+                    .issueProject(issueProject)
+                    .censusRepo(censusBuilder.build())
+                    .issuePRMap(issuePRMap)
+                    .build();
+
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "1");
+
+
+            // Populate the projects repository
+            TestBotRunner.runPeriodicItems(prBot);
+            assertTrue(pr.store().body().contains("(⚠️ The fixVersion in this issue is [18] but the fixVersion in .jcheck/conf is 0.1, a new backport will be created when this pr is integrated.)"));
+
+            issue.setProperty("fixVersions", JSON.array().add("0.1"));
+            pr.store().setBody("update");
+            TestBotRunner.runPeriodicItems(prBot);
+            assertFalse(pr.store().body().contains("(⚠️ The fixVersion in this issue is [0] but the fixVersion in .jcheck/conf is 0.1, a new backport will be created when this pr is integrated.)"));
+
+            issue.setProperty("fixVersions", JSON.array().add("0.1").add("0.2"));
+            pr.store().setBody("update");
+            TestBotRunner.runPeriodicItems(prBot);
+            assertTrue(pr.store().body().contains("(⚠️ The fixVersion in this issue is [0.1, 0.2] but the fixVersion in .jcheck/conf is 0.1, a new backport will be created when this pr is integrated.)"));
+
+
+            issue.setProperty("fixVersions", JSON.array().add("tbd"));
+            pr.store().setBody("update");
+            TestBotRunner.runPeriodicItems(prBot);
+            assertFalse(pr.store().body().contains("(⚠️ The fixVersion in this issue is [tbd] but the fixVersion in .jcheck/conf is 0.1, a new backport will be created when this pr is integrated.)"));
+        }
+    }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -2035,7 +2035,7 @@ class CheckTests {
             TestBotRunner.runPeriodicItems(csrIssueBot);
 
             var issue = issueProject.createIssue("This is the primary issue", List.of(), Map.of());
-            issue.setState(Issue.State.OPEN);
+            issue.setState(Issue.State.CLOSED);
             issue.setProperty("issuetype", JSON.of("Bug"));
             issue.setProperty("fixVersions", JSON.array().add("18"));
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -3142,6 +3142,7 @@ class CheckTests {
                     .issueProject(issueProject)
                     .censusRepo(censusBuilder.build())
                     .issuePRMap(issuePRMap)
+                    .versionMismatchWarning(true)
                     .build();
 
             // Populate the projects repository
@@ -3178,7 +3179,7 @@ class CheckTests {
     }
 
     @Test
-    void fixVersionOverride(TestInfo testInfo) throws IOException {
+    void versionMismatchWarningOffByDefault(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
              var tempFolder = new TemporaryDirectory()) {
             var author = credentials.getHostedRepository();
@@ -3201,7 +3202,6 @@ class CheckTests {
                     .issueProject(issueProject)
                     .censusRepo(censusBuilder.build())
                     .issuePRMap(issuePRMap)
-                    .fixVersionOverride(true)
                     .build();
 
             // Populate the projects repository

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestBotFactoryTest.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestBotFactoryTest.java
@@ -124,7 +124,8 @@ class PullRequestBotFactoryTest {
                           "reviewCleanBackport": true,
                           "reviewMerge": true,
                           "processPR": false,
-                          "jcheckMerge": true
+                          "jcheckMerge": true,
+                          "versionMismatchWarning": false,
                         },
                         "repo7": {
                           "census": "census:master",
@@ -153,7 +154,8 @@ class PullRequestBotFactoryTest {
                               "jdk20.0.1": { "prefix": "CPU23_04" },
                               "jdk20.0.2": { "prefix": "CPU23_05" },
                               }
-                          }
+                          },
+                          "versionMismatchWarning": true,
                         }
                       },
                       "forks": {
@@ -205,6 +207,7 @@ class PullRequestBotFactoryTest {
             assertTrue(pullRequestBot5.enableMerge());
             assertFalse(pullRequestBot5.jcheckMerge());
             assertTrue(pullRequestBot5.enableBackport());
+            assertFalse(pullRequestBot5.versionMismatchWarning());
 
             var pullRequestBot6 = (PullRequestBot) bots.stream()
                     .filter(bot -> bot.toString().equals("PullRequestBot@repo6"))
@@ -230,6 +233,7 @@ class PullRequestBotFactoryTest {
             assertTrue(pullRequestBot6.enableMerge());
             assertTrue(pullRequestBot6.jcheckMerge());
             assertTrue(pullRequestBot6.enableBackport());
+            assertFalse(pullRequestBot6.versionMismatchWarning());
 
             var pullRequestBot7 = (PullRequestBot) bots.stream()
                     .filter(bot -> bot.toString().equals("PullRequestBot@repo7"))
@@ -237,6 +241,7 @@ class PullRequestBotFactoryTest {
             assertEquals("PullRequestBot@repo7", pullRequestBot7.toString());
             assertFalse(pullRequestBot7.jcheckMerge());
             assertEquals("https://example.com", pullRequestBot7.approval().documentLink());
+            assertTrue(pullRequestBot7.versionMismatchWarning());
 
             var csrIssueBot1 = (CSRIssueBot) bots.stream()
                     .filter(bot -> bot.toString().equals("CSRIssueBot@TEST"))


### PR DESCRIPTION
This patch tries to alert the user when the fixVersion in the issue differs from the fixVersion in .jcheck/conf, thereby preventing the creation of unwanted backports.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2089](https://bugs.openjdk.org/browse/SKARA-2089): Warn when bug fixVersion doesn't match .jcheck/conf version in PR (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1585/head:pull/1585` \
`$ git checkout pull/1585`

Update a local copy of the PR: \
`$ git checkout pull/1585` \
`$ git pull https://git.openjdk.org/skara.git pull/1585/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1585`

View PR using the GUI difftool: \
`$ git pr show -t 1585`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1585.diff">https://git.openjdk.org/skara/pull/1585.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1585#issuecomment-1802886998)