### PR TITLE
2016: CSRIssueBot shouldn't force CheckWorkItem to run

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CSRIssueWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CSRIssueWorkItem.java
@@ -106,7 +106,9 @@ class CSRIssueWorkItem implements WorkItem {
                 .filter(pr -> bot.getPRBot(pr.repository().name()).enableCsr())
                 // This will mix time stamps from the IssueTracker and the Forge hosting PRs, but it's the
                 // best we can do.
-                .map(pr -> CheckWorkItem.fromCSRIssue(bot.getPRBot(pr.repository().name()), pr.id(), errorHandler, csrIssue.updatedAt()))
+                .map(pr -> CheckWorkItem.fromCSRIssue(bot.getPRBot(pr.repository().name()), pr.id(), errorHandler, csrIssue.updatedAt(),
+                        !bot.issuePRMap().containsKey(csrIssue.id()) ||
+                                bot.issuePRMap().get(csrIssue.id()).stream().noneMatch(prRecord -> prRecord.prId().equals(pr.id()))))
                 .forEach(ret::add);
         return ret;
     }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -776,6 +776,7 @@ class CheckRun {
                 progressBody.append("\n");
             }
             for (var csrIssue : csrIssues) {
+                currentIssues.add(csrIssue.id());
                 progressBody.append(" * ");
                 formatIssue(progressBody, csrIssue);
                 progressBody.append(" (**CSR**)");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -93,8 +93,8 @@ class CheckWorkItem extends PullRequestWorkItem {
     /**
      * Create CheckWorkItem spawned from CSRIssueWorkItem
      */
-    public static CheckWorkItem fromCSRIssue(PullRequestBot bot, String prId, Consumer<RuntimeException> errorHandler, ZonedDateTime triggerUpdatedAt) {
-        return new CheckWorkItem(bot, prId, errorHandler, triggerUpdatedAt, true, true, false, false);
+    public static CheckWorkItem fromCSRIssue(PullRequestBot bot, String prId, Consumer<RuntimeException> errorHandler, ZonedDateTime triggerUpdatedAt, boolean forceUpdate) {
+        return new CheckWorkItem(bot, prId, errorHandler, triggerUpdatedAt, true, forceUpdate, true, false);
     }
 
     /**
@@ -392,8 +392,8 @@ class CheckWorkItem extends PullRequestWorkItem {
 
     private void initializeIssuePRMap() {
         // When bot restarts, the issuePRMap needs to get updated with this pr
-        var prRecord = new PRRecord(pr.repository().name(), prId);
         if (!bot.initializedPRs().containsKey(prId)) {
+            var prRecord = new PRRecord(pr.repository().name(), prId);
             var issueIds = BotUtils.parseAllIssues(pr.body());
             for (String issueId : issueIds) {
                 bot.addIssuePRMapping(issueId, prRecord);


### PR DESCRIPTION
Currently, all the CheckWorkItems triggered by CSRIssueBot are having some privilege, these checkWorkItems could bypass the checksum check and force the update of the PR. Even when a user add a comment to the CSR issue, it will force the bot re-evaluate the  associated PR. This is bad and we don't have choice when implementing this.

Now we have introduced issuePRMap in SKARA-1912, so we could fix the above issue.  When creating the checkWorkItem in the CSRIssueWorkItem, we could look in the IssuePRmap. If the CSR issue is not associated with the pr, then we should force the update, otherwise we don't need to force the update.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2016](https://bugs.openjdk.org/browse/SKARA-2016): CSRIssueBot shouldn't force CheckWorkItem to run (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1586/head:pull/1586` \
`$ git checkout pull/1586`

Update a local copy of the PR: \
`$ git checkout pull/1586` \
`$ git pull https://git.openjdk.org/skara.git pull/1586/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1586`

View PR using the GUI difftool: \
`$ git pr show -t 1586`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1586.diff">https://git.openjdk.org/skara/pull/1586.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1586#issuecomment-1813137337)