### PR TITLE
2107: Change naming of branches created by /backport command

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
@@ -258,7 +258,7 @@ public class BackportCommand implements CommandHandler {
         try {
             var hash = commit.hash();
             Hash backportHash;
-            var backportBranchName = realUser.username() + "-backport-" + hash.abbreviate();
+            var backportBranchName = "backport-" + realUser.username() + "-" + hash.abbreviate();
             var backportBranchHash = fork.branchHash(backportBranchName);
             if (backportBranchHash.isEmpty()) {
                 var localRepoDir = scratchArea.get(this)


### PR DESCRIPTION
Since in [JDK-8320358](https://bugs.openjdk.org/browse/JDK-8320358), the GitHub action would ignore the branches whose name start with 'jdk', we should change the naming of branches created by backport command.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2107](https://bugs.openjdk.org/browse/SKARA-2107): Change naming of branches created by /backport command (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1588/head:pull/1588` \
`$ git checkout pull/1588`

Update a local copy of the PR: \
`$ git checkout pull/1588` \
`$ git pull https://git.openjdk.org/skara.git pull/1588/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1588`

View PR using the GUI difftool: \
`$ git pr show -t 1588`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1588.diff">https://git.openjdk.org/skara/pull/1588.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1588#issuecomment-1823235093)