### PR TITLE
2109: Fix failing test BranchCommitCommandTests.nonConformingBranch

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BranchCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BranchCommand.java
@@ -121,7 +121,7 @@ public class BranchCommand implements CommandHandler {
             var jcheckConf = JCheckConfiguration.from(localRepo, commit.hash());
             var branchPattern = jcheckConf.map(c -> c.repository().branches());
             if (branchPattern.isPresent() && !branchName.matches(branchPattern.get())) {
-                reply.println("The given branch name `" + branchName + "` is not of the form `" + branchPattern + "`.");
+                reply.println("The given branch name `" + branchName + "` is not of the form `" + branchPattern.get() + "`.");
                 return;
             }
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BranchCommitCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BranchCommitCommandTests.java
@@ -74,7 +74,6 @@ public class BranchCommitCommandTests {
             assertTrue(botReply.body().contains("was successfully created"));
 
             var localAuthorRepoDir = tempFolder.path().resolve("author");
-            System.err.println("author.authenticatedUrl(): " + author.authenticatedUrl());
             var localAuthorRepo = Repository.clone(author.authenticatedUrl(), localAuthorRepoDir);
             var next = new Branch("next");
             localAuthorRepo.checkout(next);
@@ -295,7 +294,6 @@ public class BranchCommitCommandTests {
             var recentCommitComments = author.recentCommitComments();
             assertEquals(2, recentCommitComments.size());
             var botReply = recentCommitComments.get(0);
-            System.out.println(botReply);
             assertTrue(botReply.body().contains("The given branch name `bar` is not of the form `foo`"));
 
             var localAuthorRepoDir = tempFolder.path().resolve("author");


### PR DESCRIPTION
Hi all,

please review this small patch that adds a missing `.get()` in a message by the `BranchCommand`. The failing unit tests is now passing (I also removed some spurious logging from unit tests).

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2109](https://bugs.openjdk.org/browse/SKARA-2109): Fix failing test BranchCommitCommandTests.nonConformingBranch (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1589/head:pull/1589` \
`$ git checkout pull/1589`

Update a local copy of the PR: \
`$ git checkout pull/1589` \
`$ git pull https://git.openjdk.org/skara.git pull/1589/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1589`

View PR using the GUI difftool: \
`$ git pr show -t 1589`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1589.diff">https://git.openjdk.org/skara/pull/1589.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1589#issuecomment-1829872820)