### PR TITLE
2111: Normalize usernames before comparing

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -37,6 +37,7 @@ import org.openjdk.skara.vcs.openjdk.Issue;
 
 import java.io.*;
 import java.nio.file.Path;
+import java.text.Normalizer;
 import java.time.*;
 import java.util.*;
 import java.util.logging.Logger;
@@ -1075,8 +1076,11 @@ class CheckRun {
         var head = pr.repository().commit(pr.headHash()).orElseThrow(
             () -> new IllegalStateException("Cannot lookup HEAD hash for PR " + pr.id())
         );
-        if (!pr.author().fullName().equals(pr.author().username()) &&
-            !pr.author().fullName().equals(head.author().name())) {
+        // Normalize the strings before comparison to ensure unicode characters are encoded in the same way
+        var prAuthorFullName = Normalizer.normalize(pr.author().fullName(), Normalizer.Form.NFC);
+        var prAuthorUserName = Normalizer.normalize(pr.author().username(), Normalizer.Form.NFC);
+        var headAuthorName = Normalizer.normalize(head.author().name(), Normalizer.Form.NFC);
+        if (!prAuthorFullName.equals(prAuthorUserName) && !prAuthorFullName.equals(headAuthorName)) {
             var headUrl = pr.headUrl().toString();
             var message = ":warning: @" + pr.author().username() + " the full name on your profile does not match " +
                 "the author name in this pull requests' [HEAD](" + headUrl + ") commit. " +


### PR DESCRIPTION
In https://github.com/openjdk/jdk/pull/16788#issuecomment-1827984539, although the user's full name and the head commit author's name seems exactly same in the GitHub. The bot was thinking they are different, Erik pointed out the root cause "The problem was that a unicode character was encoded differently, one as a composition and one as a single character. "

To avoid this kind of problems in the future, we should normalize the strings before comparison to ensure unicode characters are encoded in the same way.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2111](https://bugs.openjdk.org/browse/SKARA-2111): Normalize usernames before comparing (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1591/head:pull/1591` \
`$ git checkout pull/1591`

Update a local copy of the PR: \
`$ git checkout pull/1591` \
`$ git pull https://git.openjdk.org/skara.git pull/1591/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1591`

View PR using the GUI difftool: \
`$ git pr show -t 1591`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1591.diff">https://git.openjdk.org/skara/pull/1591.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1591#issuecomment-1841292716)