### PR TITLE
2115: More flexible merge PR review configuration

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/AdditionalConfiguration.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/AdditionalConfiguration.java
@@ -31,10 +31,10 @@ import java.io.IOException;
 import java.util.*;
 
 public class AdditionalConfiguration {
-    static List<String> get(JCheckConfiguration original, HostUser botUser, List<Comment> comments, boolean reviewMerge) throws IOException {
+    static List<String> get(JCheckConfiguration original, HostUser botUser, List<Comment> comments, MergePullRequestReviewConfiguration reviewMerge) throws IOException {
         var ret = new ArrayList<String>();
         var additionalReviewers = ReviewersTracker.additionalRequiredReviewers(botUser, comments);
-        if (additionalReviewers.isEmpty() && !reviewMerge) {
+        if (additionalReviewers.isEmpty() && reviewMerge == MergePullRequestReviewConfiguration.JCHECK) {
             return ret;
         }
 
@@ -45,8 +45,10 @@ public class AdditionalConfiguration {
         ret.add("[checks \"reviewers\"]");
         updatedLimits.forEach((role, count) -> ret.add(role + "=" + count));
         ret.add("minimum=disable");
-        if (reviewMerge) {
+        if (reviewMerge == MergePullRequestReviewConfiguration.ALWAYS) {
             ret.add("merge=check");
+        } else if (reviewMerge == MergePullRequestReviewConfiguration.NEVER) {
+            ret.add("merge=ignore");
         }
         return ret;
     }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -83,7 +83,7 @@ class CheckRun {
     private CheckRun(CheckWorkItem workItem, PullRequest pr, Repository localRepo, List<Comment> comments,
                      List<Review> allReviews, List<Review> activeReviews, Set<String> labels,
                      CensusInstance censusInstance, boolean ignoreStaleReviews, Set<String> integrators, boolean reviewCleanBackport,
-                     boolean reviewMerge, Approval approval) throws IOException {
+                     MergePullRequestReviewConfiguration reviewMerge, Approval approval) throws IOException {
         this.workItem = workItem;
         this.pr = pr;
         this.localRepo = localRepo;
@@ -109,7 +109,7 @@ class CheckRun {
 
     static Optional<Instant> execute(CheckWorkItem workItem, PullRequest pr, Repository localRepo, List<Comment> comments,
                                      List<Review> allReviews, List<Review> activeReviews, Set<String> labels, CensusInstance censusInstance,
-                                     boolean ignoreStaleReviews, Set<String> integrators, boolean reviewCleanBackport, boolean reviewMerge,
+                                     boolean ignoreStaleReviews, Set<String> integrators, boolean reviewCleanBackport, MergePullRequestReviewConfiguration reviewMerge,
                                      Approval approval) throws IOException {
         var run = new CheckRun(workItem, pr, localRepo, comments, allReviews, activeReviews, labels, censusInstance,
                 ignoreStaleReviews, integrators, reviewCleanBackport, reviewMerge, approval);

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
@@ -47,10 +47,10 @@ public class CheckablePullRequest {
     private final boolean ignoreStaleReviews;
     private final List<String> confOverride;
     private final List<Comment> comments;
-    private final boolean reviewMerge;
+    private final MergePullRequestReviewConfiguration reviewMerge;
 
     CheckablePullRequest(PullRequest pr, Repository localRepo, boolean ignoreStaleReviews,
-            HostedRepository jcheckRepo, String jcheckName, String jcheckRef, List<Comment> comments, boolean reviewMerge) {
+            HostedRepository jcheckRepo, String jcheckName, String jcheckRef, List<Comment> comments, MergePullRequestReviewConfiguration reviewMerge) {
         this.pr = pr;
         this.localRepo = localRepo;
         this.ignoreStaleReviews = ignoreStaleReviews;

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/MergePullRequestReviewConfiguration.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/MergePullRequestReviewConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/MergePullRequestReviewConfiguration.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/MergePullRequestReviewConfiguration.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.pr;
+
+enum MergePullRequestReviewConfiguration {
+    ALWAYS,
+    NEVER,
+    JCHECK
+}

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -367,7 +367,7 @@ class PullRequestBot implements Bot {
         return mlbridgeBotName;
     }
 
-    public MergePullRequestReviewConfiguration reviewMerge(){
+    public MergePullRequestReviewConfiguration reviewMerge() {
         return reviewMerge;
     }
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -66,7 +66,7 @@ class PullRequestBot implements Bot {
     private final PullRequestPoller poller;
     private final boolean reviewCleanBackport;
     private final String mlbridgeBotName;
-    private final boolean reviewMerge;
+    private final MergePullRequestReviewConfiguration reviewMerge;
     private final boolean processPR;
     private final boolean processCommit;
     private final boolean enableMerge;
@@ -92,7 +92,7 @@ class PullRequestBot implements Bot {
                    Path seedStorage, HostedRepository confOverrideRepo, String confOverrideName,
                    String confOverrideRef, String censusLink, Map<String, HostedRepository> forks,
                    Set<String> integrators, Set<Integer> excludeCommitCommentsFrom, boolean enableCsr, boolean enableJep,
-                   boolean reviewCleanBackport, String mlbridgeBotName, boolean reviewMerge, boolean processPR, boolean processCommit,
+                   boolean reviewCleanBackport, String mlbridgeBotName, MergePullRequestReviewConfiguration reviewMerge, boolean processPR, boolean processCommit,
                    boolean enableMerge, Set<String> mergeSources, boolean jcheckMerge, boolean enableBackport,
                    Map<String, List<PRRecord>> issuePRMap, Approval approval, boolean versionMismatchWarning) {
         remoteRepo = repo;
@@ -367,7 +367,7 @@ class PullRequestBot implements Bot {
         return mlbridgeBotName;
     }
 
-    public boolean reviewMerge(){
+    public MergePullRequestReviewConfiguration reviewMerge(){
         return reviewMerge;
     }
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
@@ -57,7 +57,7 @@ public class PullRequestBotBuilder {
     private Set<Integer> excludeCommitCommentsFrom = Set.of();
     private boolean reviewCleanBackport = false;
     private String mlbridgeBotName;
-    private boolean reviewMerge = false;
+    private MergePullRequestReviewConfiguration reviewMerge = MergePullRequestReviewConfiguration.JCHECK;
     private boolean processPR = true;
     private boolean processCommit = true;
     private boolean enableMerge = true;
@@ -201,7 +201,7 @@ public class PullRequestBotBuilder {
         return this;
     }
 
-    public PullRequestBotBuilder reviewMerge(boolean reviewMerge) {
+    public PullRequestBotBuilder reviewMerge(MergePullRequestReviewConfiguration reviewMerge) {
         this.reviewMerge = reviewMerge;
         return this;
     }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
@@ -205,13 +205,19 @@ public class PullRequestBotFactory implements BotFactory {
                 botBuilder.reviewCleanBackport(repo.value().get("reviewCleanBackport").asBoolean());
             }
             if (repo.value().contains("reviewMerge")) {
-                MergePullRequestReviewConfiguration result = MergePullRequestReviewConfiguration.JCHECK;
+                MergePullRequestReviewConfiguration result = null;
 
                 var val = repo.value().get("reviewMerge").asString().toLowerCase().trim();
                 if (val.equals("always")) {
                     result = MergePullRequestReviewConfiguration.ALWAYS;
                 } else if (val.equals("never")) {
                     result = MergePullRequestReviewConfiguration.NEVER;
+                } else if (val.equals("jcheck")) {
+                    result = MergePullRequestReviewConfiguration.JCHECK;
+                } else {
+                    throw new RuntimeException("Unexpected value for key \"reviewMerge\": '" +
+                                               repo.value().get("reviewMerge") + "', " +
+                                               "expected one of \"always\", \"never\" or \"jcheck\"");
                 }
 
                 botBuilder.reviewMerge(result);

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
@@ -205,7 +205,16 @@ public class PullRequestBotFactory implements BotFactory {
                 botBuilder.reviewCleanBackport(repo.value().get("reviewCleanBackport").asBoolean());
             }
             if (repo.value().contains("reviewMerge")) {
-                botBuilder.reviewMerge(repo.value().get("reviewMerge").asBoolean());
+                MergePullRequestReviewConfiguration result = MergePullRequestReviewConfiguration.JCHECK;
+
+                var val = repo.value().get("reviewMerge").asString().toLowerCase().trim();
+                if (val.equals("always")) {
+                    result = MergePullRequestReviewConfiguration.ALWAYS;
+                } else if (val.equals("never")) {
+                    result = MergePullRequestReviewConfiguration.NEVER;
+                }
+
+                botBuilder.reviewMerge(result);
             }
             if (repo.value().contains("processPR")) {
                 botBuilder.processPR(repo.value().get("processPR").asBoolean());

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/AdditionalConfigurationTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/AdditionalConfigurationTests.java
@@ -66,7 +66,7 @@ class AdditionalConfigurationTests {
             var jcheckConf = JCheck.parseConfiguration(localRepo, masterHash, List.of());
             assertTrue(jcheckConf.isPresent());
             var additional = AdditionalConfiguration.get(jcheckConf.get(), bot.forge().currentUser(),
-                                                         pr.comments(), false);
+                                                         pr.comments(), MergePullRequestReviewConfiguration.ALWAYS);
             var expected = List.of(
                 "[checks \"reviewers\"]",
                 "lead=0",
@@ -74,7 +74,8 @@ class AdditionalConfigurationTests {
                 "committers=0",
                 "authors=1",
                 "contributors=0",
-                "minimum=disable"
+                "minimum=disable",
+                "merge=check"
             );
             assertEquals(expected, additional);
         }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -3134,7 +3134,7 @@ class CheckTests {
                                          .confOverrideRepo(conf)
                                          .confOverrideName("jcheck.conf")
                                          .confOverrideRef("jcheck-branch")
-                                         .reviewMerge(true)
+                                         .reviewMerge(MergePullRequestReviewConfiguration.ALWAYS)
                                          .build();
 
             // Populate the projects repository

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
@@ -138,7 +138,7 @@ class MergeTests {
                     .addCommitter(author.forge().currentUser().id())
                     .addReviewer(integrator.forge().currentUser().id());
             var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build())
-                    .reviewMerge(true).build();
+                    .reviewMerge(MergePullRequestReviewConfiguration.ALWAYS).build();
 
             // Populate the projects repository
             var localRepoFolder = tempFolder.path().resolve("localrepo");

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestBotFactoryTest.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestBotFactoryTest.java
@@ -122,7 +122,7 @@ class PullRequestBotFactoryTest {
                             "integrator2"
                           ],
                           "reviewCleanBackport": true,
-                          "reviewMerge": true,
+                          "reviewMerge": "always",
                           "processPR": false,
                           "jcheckMerge": true,
                           "versionMismatchWarning": false,
@@ -142,7 +142,7 @@ class PullRequestBotFactoryTest {
                             "integrator2"
                           ],
                           "reviewCleanBackport": true,
-                          "reviewMerge": true,
+                          "reviewMerge": "always",
                           "processPR": false,
                           "jcheckMerge": false
                           "approval": {
@@ -228,7 +228,7 @@ class PullRequestBotFactoryTest {
             assertTrue(integrators.contains("integrator1"));
             assertTrue(integrators.contains("integrator2"));
             assertTrue(pullRequestBot6.reviewCleanBackport());
-            assertTrue(pullRequestBot6.reviewMerge());
+            assertEquals(MergePullRequestReviewConfiguration.ALWAYS, pullRequestBot6.reviewMerge());
             assertEquals("mlbridge[bot]", pullRequestBot6.mlbridgeBotName());
             assertTrue(pullRequestBot6.enableMerge());
             assertTrue(pullRequestBot6.jcheckMerge());


### PR DESCRIPTION
Hi all,

please review this patch that enables a bit more flexible configuration for checking merge pull requests. Today we can configure that a merge pull requests always should be checked and if that isn't configured then the `.jcheck/conf` from the repository is used. If we ever want to set `merge=check` in the `.jcheck/conf` file in repos then we will need a way to _disable_ running jcheck on merge pull requests (for example for projects using merge pull requests to sync in commits).

This patch makes it possible to configure that merge pull requests should either always be checked, never be checked or checked according to `.jcheck/conf` in the repo.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2115](https://bugs.openjdk.org/browse/SKARA-2115): More flexible merge PR review configuration (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1592/head:pull/1592` \
`$ git checkout pull/1592`

Update a local copy of the PR: \
`$ git checkout pull/1592` \
`$ git pull https://git.openjdk.org/skara.git pull/1592/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1592`

View PR using the GUI difftool: \
`$ git pr show -t 1592`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1592.diff">https://git.openjdk.org/skara/pull/1592.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1592#issuecomment-1842614457)