### PR TITLE
2122: Minor bot optimizations for GitHub API

### DIFF
--- a/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestPrunerBot.java
+++ b/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestPrunerBot.java
@@ -152,13 +152,13 @@ public class PullRequestPrunerBot implements Bot {
         }
 
         // Latest prune-delaying action (deliberately excluding pr.updatedAt, as it can be updated spuriously)
-        var latestAction = List.of(Stream.of(pr.createdAt()),
+        var latestAction = Stream.of(Stream.of(pr.createdAt()),
                                    pr.comments().stream()
                                      .map(Comment::updatedAt),
                                    pr.reviews().stream()
                                      .map(Review::createdAt),
-                                   pr.reviewComments().stream()
-                                     .map(Comment::updatedAt)).stream()
+                                   pr.reviewCommentsAsComments().stream()
+                                     .map(Comment::updatedAt))
                                .flatMap(Function.identity())
                                .max(ZonedDateTime::compareTo).orElseThrow();
 

--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
@@ -77,6 +77,15 @@ public interface PullRequest extends Issue {
     List<ReviewComment> reviewComments();
 
     /**
+     * Get all file specific comments but potentially without file location data.
+     * This may save computation and I/O time if constructing that data is expensive.
+     * @return
+     */
+    default List<? extends Comment> reviewCommentsAsComments() {
+        return reviewComments();
+    }
+
+    /**
      * Hash of the current head of the request.
      * @return
      */

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -260,7 +260,7 @@ public class GitHubPullRequest implements PullRequest {
         return parseReviewComment(parent, response.asObject(), true);
     }
 
-    public List<ReviewComment> reviewComments(boolean includeLocationData) {
+    private List<ReviewComment> reviewComments(boolean includeLocationData) {
         var ret = new ArrayList<ReviewComment>();
         var reviewComments = request.get("pulls/" + json.get("number").toString() + "/comments")
                 .param("per_page", "100").execute().stream()


### PR DESCRIPTION
I've made some minor optimizations to some GitHub interactions that I would like to integrate. They don't make a big impact on their own, but are part of a bigger effort to reduce latency in certain bots. The idea is to reduce the number of individual calls when possible, as we are limiting calls for rate limits through global locks. We spend a lot of time waiting on those locks, so reducing the number of calls can be valuable.

When listing ReviewComments on GitHub, we need to fetch commit data in order to correctly generate all the file and line data for the comment. However, in most cases we don't actually need this data. I propose implementing an alternate method on PullRequest to retrieve ReviewComments as a list of regular Comment objects, without the file and line data.

When listing comments of various kinds, we are often hitting pagination. The default page size on GitHub is usually 30 with 100 being the max. Our methods for listing comments always fetch all of them, so it would make sense to use the max page size to reduce the number of individual calls.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2122](https://bugs.openjdk.org/browse/SKARA-2122): Minor bot optimizations for GitHub API (**Enhancement** - P4)


### Reviewers
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1593/head:pull/1593` \
`$ git checkout pull/1593`

Update a local copy of the PR: \
`$ git checkout pull/1593` \
`$ git pull https://git.openjdk.org/skara.git pull/1593/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1593`

View PR using the GUI difftool: \
`$ git pr show -t 1593`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1593.diff">https://git.openjdk.org/skara/pull/1593.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1593#issuecomment-1858555207)