### PR TITLE
2131: Make second jcheck run work on merge-style PR

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1233,16 +1233,17 @@ class CheckRun {
                     localRepo.lookup(pr.headHash()).ifPresent(this::updateMergeClean);
                 }
 
+                var commits = localRepo.commitMetadata(localRepo.mergeBase(targetHash, pr.headHash()), pr.headHash(), true);
+                isJCheckConfUpdatedInMergePR = commits.stream().anyMatch(c -> {
+                    try {
+                        return isFileUpdated(Path.of(".jcheck", "conf"), c.hash());
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                });
+
                 // JCheck all commits in "Merge PR"
                 if (workItem.bot.jcheckMerge()) {
-                    var commits = localRepo.commitMetadata(localRepo.mergeBase(targetHash, pr.headHash()), pr.headHash(), true);
-                    isJCheckConfUpdatedInMergePR = commits.stream().anyMatch(c -> {
-                        try {
-                            return isFileUpdated(Path.of(".jcheck", "conf"), c.hash());
-                        } catch (IOException e) {
-                            throw new UncheckedIOException(e);
-                        }
-                    });
                     for (var commit : commits) {
                         var hash = commit.hash();
                         jcheckType = "merge jcheck with target conf in commit " + hash.hex();


### PR DESCRIPTION
When testing [SKARA-2115](https://bugs.openjdk.org/browse/SKARA-2115), I find that if we change the jcheck conf in the source branch of a merge style PR. The pr will NOT run jcheck against the localJCheckConf(merged conf of source and target JCheckConf).
After investigation, I realized that this bug exists since the first time we introduced the second jcheck run feature. This bug was partly fixed by introducing IsJCheckConfUpdatedInMergePR.
However, IsJCheckConfUpdatedInMergePR will only be set correctly when workItem.bot.jcheckMerge() is true.
To fix it, we should set isJCheckConfUpdatedInMergePR correctly when the PR is a merge-style PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2131](https://bugs.openjdk.org/browse/SKARA-2131): Make second jcheck run work on merge-style PR (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1595/head:pull/1595` \
`$ git checkout pull/1595`

Update a local copy of the PR: \
`$ git checkout pull/1595` \
`$ git pull https://git.openjdk.org/skara.git pull/1595/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1595`

View PR using the GUI difftool: \
`$ git pr show -t 1595`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1595.diff">https://git.openjdk.org/skara/pull/1595.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1595#issuecomment-1874632550)