### PR TITLE
2137: Add integrity check to integrate and sponsor commands

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrityVerifier.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrityVerifier.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.pr;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.*;
+import java.util.List;
+import java.util.stream.*;
+import java.util.logging.Logger;
+
+import org.openjdk.skara.forge.PullRequest;
+import org.openjdk.skara.vcs.*;
+
+class IntegrityVerifier {
+    private final Repository repo;
+    private final URI remote;
+    private static final Logger log = Logger.getLogger("org.openjdk.skara.bots.pr");
+
+    IntegrityVerifier(Repository repo, URI remote) {
+        this.repo = repo;
+        this.remote = remote;
+    }
+
+    void verifyPullRequestTarget(PullRequest pr) throws IOException {
+        var targetHeadHash = pr.repository().branchHash(pr.targetRef()).orElseThrow();
+        var targetHeadCommit = pr.repository().commit(targetHeadHash).orElseThrow();
+        verifyBranch(pr.repository().name(), pr.targetRef(), targetHeadCommit);
+    }
+
+    void verifyBranch(String repositoryName, String branchName, Commit current) throws IOException {
+        var integrityBranch = repositoryName + "-" + branchName;
+
+        var branches = repo.remoteBranches(remote).stream().map(Reference::name).collect(Collectors.toSet());
+        if (!branches.contains(integrityBranch)) {
+            var masterHead = repo.fetch(remote, "master", false);
+            repo.checkout(masterHead);
+            var heads = repo.root().resolve("heads.txt");
+            var content = List.of(current.hash().hex(), current.parents().get(0).hex());
+            Files.write(heads, content, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+            repo.add(heads);
+            var head = repo.commit("Initialize heads.txt with '" + current.hash().hex() + "' for " + repositoryName + ":" + branchName,
+                                   "duke",
+                                   "duke@openjdk.org");
+            repo.push(head, remote, integrityBranch);
+            return;
+        }
+
+        var latest = repo.fetch(remote, integrityBranch, false);
+        repo.checkout(latest);
+        var heads = repo.root().resolve("heads.txt");
+        var lines = Files.readAllLines(heads);
+        if (lines.size() != 2) {
+            throw new IllegalStateException("Corrupt heads.txt file for branch " + integrityBranch);
+        }
+        var expected = new Hash(lines.get(0));
+        if (!expected.equals(current.hash())) {
+            var firstParent = new Hash(lines.get(1));
+            if (firstParent.equals(current.hash())) {
+                // The bot must have crashed between pushing to the integrity repo and to the target repo,
+                // recover integrity repository
+                log.info("Resetting heads.txt from '" + expected + "' to '" + current.hash() + "'");
+                var content = List.of(current.hash().hex(), current.parents().get(0).hex());
+                Files.write(heads, content, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+                repo.add(heads);
+                var head = repo.commit("Resetting heads.txt from '" + expected + "' to '" + current.hash() + "'",
+                                       "duke",
+                                       "duke@openjdk.org");
+                repo.push(head, remote, integrityBranch.toString());
+            } else {
+                var msg = "Expected HEAD in branch " + branchName + " in repo " + repositoryName +
+                          " to be '" + expected.hex() + "', but it was '"  + current.hash().hex() + "'";
+                log.severe(msg);
+                throw new IllegalArgumentException(msg);
+            }
+        }
+    }
+
+    void updateBranch(String repositoryName, String branchName, Commit next) throws IOException {
+        var integrityBranch = repositoryName + "-" + branchName;
+        var latest = repo.fetch(remote, integrityBranch);
+        repo.checkout(latest);
+        var heads = repo.root().resolve("heads.txt");
+        var lines = Files.readAllLines(heads);
+        if (lines.size() != 2) {
+            throw new IllegalStateException("Corrupt " + heads + " file for branch " + integrityBranch);
+        }
+        var current = new Hash(lines.get(0));
+
+        var content = List.of(next.hash().hex(), next.parents().get(0).hex());
+        Files.write(heads, content, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+        repo.add(heads);
+        var head = repo.commit("Updating from '" + current + "' to '" + next  + "'",
+                               "duke",
+                               "duke@openjdk.org");
+        repo.push(head, remote, integrityBranch);
+    }
+
+    void updatePullRequestTarget(PullRequest pr, Commit next) throws IOException {
+        updateBranch(pr.repository().name(), pr.targetRef(), next);
+    }
+}

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -80,6 +80,7 @@ class PullRequestBot implements Bot {
     private final Approval approval;
     private boolean initialRun = true;
     private final boolean versionMismatchWarning;
+    private final HostedRepository integrityRepo;
 
     private Instant lastFullUpdate;
 
@@ -94,7 +95,7 @@ class PullRequestBot implements Bot {
                    Set<String> integrators, Set<Integer> excludeCommitCommentsFrom, boolean enableCsr, boolean enableJep,
                    boolean reviewCleanBackport, String mlbridgeBotName, MergePullRequestReviewConfiguration reviewMerge, boolean processPR, boolean processCommit,
                    boolean enableMerge, Set<String> mergeSources, boolean jcheckMerge, boolean enableBackport,
-                   Map<String, List<PRRecord>> issuePRMap, Approval approval, boolean versionMismatchWarning) {
+                   Map<String, List<PRRecord>> issuePRMap, Approval approval, boolean versionMismatchWarning, HostedRepository integrityRepo) {
         remoteRepo = repo;
         this.censusRepo = censusRepo;
         this.censusRef = censusRef;
@@ -131,6 +132,7 @@ class PullRequestBot implements Bot {
         this.issuePRMap = issuePRMap;
         this.approval = approval;
         this.versionMismatchWarning = versionMismatchWarning;
+        this.integrityRepo = integrityRepo;
 
         autoLabelled = new HashSet<>();
         poller = new PullRequestPoller(repo, true);
@@ -401,6 +403,14 @@ class PullRequestBot implements Bot {
 
     public boolean versionMismatchWarning() {
         return versionMismatchWarning;
+    }
+
+    public Optional<HostedRepository> integrityRepo() {
+        return Optional.ofNullable(integrityRepo);
+    }
+
+    public boolean shouldVerifyIntegrity() {
+        return integrityRepo != null;
     }
 
     public void addIssuePRMapping(String issueId, PRRecord prRecord) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
@@ -53,6 +53,7 @@ public class PullRequestBotBuilder {
     private boolean enableCsr = false;
     private boolean enableJep = false;
     private Map<String, HostedRepository> forks = Map.of();
+    private HostedRepository integrityRepo = null;
     private Set<String> integrators = Set.of();
     private Set<Integer> excludeCommitCommentsFrom = Set.of();
     private boolean reviewCleanBackport = false;
@@ -181,6 +182,11 @@ public class PullRequestBotBuilder {
         return this;
     }
 
+    public PullRequestBotBuilder integrityRepo(HostedRepository integrityRepo) {
+        this.integrityRepo = integrityRepo;
+        return this;
+    }
+
     public PullRequestBotBuilder integrators(Set<String> integrators) {
         this.integrators = new HashSet<>(integrators);
         return this;
@@ -257,6 +263,6 @@ public class PullRequestBotBuilder {
                 readyComments, issueProject, ignoreStaleReviews, allowedTargetBranches, seedStorage, confOverrideRepo,
                 confOverrideName, confOverrideRef, censusLink, forks, integrators, excludeCommitCommentsFrom, enableCsr,
                 enableJep, reviewCleanBackport, mlbridgeBotName, reviewMerge, processPR, processCommit, enableMerge,
-                mergeSources, jcheckMerge, enableBackport, issuePRMap, approval, versionMismatchWarning);
+                mergeSources, jcheckMerge, enableBackport, issuePRMap, approval, versionMismatchWarning, integrityRepo);
     }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
@@ -91,6 +91,11 @@ public class PullRequestBotFactory implements BotFactory {
                     .forEach(id -> excludeCommitCommentsFrom.add(id));
         }
 
+        HostedRepository integrityRepo = null;
+        if (specific.contains("integrity")) {
+            integrityRepo = configuration.repository(specific.get("integrity").get("repo").asString());
+        }
+
         var readyLabels = specific.get("ready").get("labels").stream()
                                   .map(JSONValue::asString)
                                   .collect(Collectors.toSet());
@@ -129,6 +134,7 @@ public class PullRequestBotFactory implements BotFactory {
                                            .seedStorage(configuration.storageFolder().resolve("seeds"))
                                            .excludeCommitCommentsFrom(excludeCommitCommentsFrom)
                                            .forks(forks)
+                                           .integrityRepo(integrityRepo)
                                            .mlbridgeBotName(mlbridgeBotName);
 
             if (repo.value().contains("labels")) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ScratchArea.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ScratchArea.java
@@ -57,4 +57,7 @@ public class ScratchArea {
         return root.resolve("census");
     }
 
+    public Path getIntegrity() {
+        return root.resolve(botName).resolve("integrity");
+    }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
@@ -133,6 +133,14 @@ public class SponsorCommand implements CommandHandler {
             if (!localHash.equals(checkablePr.targetHash())) {
                 var amendedHash = checkablePr.amendManualReviewers(localHash, censusInstance.namespace(), original);
                 IntegrateCommand.addPrePushComment(pr, amendedHash, rebaseMessage.toString());
+
+                if (bot.shouldVerifyIntegrity()) {
+                    var verifier = IntegrateCommand.materializeIntegrityVerifier(bot, pr, scratchArea);
+                    verifier.verifyPullRequestTarget(pr);
+                    var amendedCommit = localRepo.lookup(amendedHash).orElseThrow();
+                    verifier.updatePullRequestTarget(pr, amendedCommit);
+                }
+
                 localRepo.push(amendedHash, pr.repository().authenticatedUrl(), pr.targetRef());
                 markIntegratedAndClosed(pr, amendedHash, reply, allComments);
             } else {

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrityTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrityTests.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.pr;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.*;
+import static java.nio.file.StandardOpenOption.*;
+import java.util.List;
+import java.util.logging.Logger;
+
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.openjdk.skara.vcs.*;
+import org.openjdk.skara.test.TemporaryDirectory;
+
+class IntegrityTests {
+    @BeforeEach
+    void disableConfig() {
+        Repository.ignoreConfiguration();
+    }
+
+    private static Repository createRepo(TemporaryDirectory tmp) throws IOException {
+        var dir = tmp.path().resolve("repo");
+        return Repository.init(dir, VCS.GIT);
+    }
+
+    private static Commit createCommit(Repository repo) throws IOException {
+        var f = repo.root().resolve("README.txt");
+        Files.write(f, "This is just to create a commit\n".getBytes(), WRITE, APPEND, CREATE);
+        repo.add(f);
+        var hash = repo.commit("A commit", "duke", "duke@openjdk.org");
+        return repo.lookup(hash).orElseThrow();
+    }
+
+    private static Repository createRemoteIntegrityRepo(TemporaryDirectory tmp) throws IOException {
+        var dir = tmp.path().resolve("remote");
+        var repo = Repository.init(dir, VCS.GIT);
+        Files.write(dir.resolve(".git").resolve("config"),
+                    List.of("[receive]", "denyCurrentBranch=ignore"),
+                    WRITE, APPEND);
+        createCommit(repo);
+        return repo;
+    }
+
+    private static Repository createLocalIntegrityRepo(TemporaryDirectory tmp) throws IOException {
+        var dir = tmp.path().resolve("local");
+        var repo = Repository.init(dir, VCS.GIT);
+        return repo;
+    }
+
+    @Test
+    void missingIntegrityBranch() throws Exception {
+        try (var dir = new TemporaryDirectory(false)) {
+            var local = createLocalIntegrityRepo(dir);
+            var remote = createRemoteIntegrityRepo(dir);
+
+            var repo = createRepo(dir);
+            var current = createCommit(repo);
+
+            var verifier = new IntegrityVerifier(local, remote.root().toUri());
+            verifier.verifyBranch("repo", "branch", current);
+
+            var integrityBranch = new Branch("repo-branch");
+            assertTrue(remote.branches().contains(integrityBranch));
+
+            var head = local.fetch(remote.root().toUri(), integrityBranch.name());
+            local.checkout(head);
+            var heads = Files.readAllLines(local.root().resolve("heads.txt"));
+            assertEquals(List.of(current.hash().hex(), current.parents().get(0).hex()), heads);
+        }
+    }
+
+    @Test
+    void verifyingIsIdempotent() throws Exception {
+        try (var dir = new TemporaryDirectory()) {
+            var local = createLocalIntegrityRepo(dir);
+            var remote = createRemoteIntegrityRepo(dir);
+
+            var repo = createRepo(dir);
+            var current = createCommit(repo);
+
+            var verifier = new IntegrityVerifier(local, remote.root().toUri());
+            verifier.verifyBranch("repo", "branch", current);
+            verifier.verifyBranch("repo", "branch", current);
+
+            var integrityBranch = new Branch("repo-branch");
+            assertTrue(remote.branches().contains(integrityBranch));
+
+            var head = local.fetch(remote.root().toUri(), integrityBranch.name());
+            local.checkout(head);
+            var heads = Files.readAllLines(local.root().resolve("heads.txt"));
+            assertEquals(List.of(current.hash().hex(), current.parents().get(0).hex()), heads);
+        }
+    }
+
+    @Test
+    void updateIntegrityBranch() throws Exception {
+        try (var dir = new TemporaryDirectory()) {
+            var local = createLocalIntegrityRepo(dir);
+            var remote = createRemoteIntegrityRepo(dir);
+
+            var repo = createRepo(dir);
+            var current = createCommit(repo);
+            var next = createCommit(repo);
+
+            var verifier = new IntegrityVerifier(local, remote.root().toUri());
+
+            verifier.verifyBranch("repo", "branch", current);
+            verifier.updateBranch("repo", "branch", next);
+
+            // Next should now be "current", so should be able to verify
+            verifier.verifyBranch("repo", "branch", next);
+
+            var integrityBranch = new Branch("repo-branch");
+            assertTrue(remote.branches().contains(integrityBranch));
+
+            var head = local.fetch(remote.root().toUri(), integrityBranch.name());
+            local.checkout(head);
+            var heads = Files.readAllLines(local.root().resolve("heads.txt"));
+            assertEquals(List.of(next.hash().hex(), current.hash().hex()), heads);
+        }
+    }
+
+    @Test
+    void recoverAbortedPush() throws Exception {
+        try (var dir = new TemporaryDirectory()) {
+            var local = createLocalIntegrityRepo(dir);
+            var remote = createRemoteIntegrityRepo(dir);
+
+            var repo = createRepo(dir);
+            var current = createCommit(repo);
+            var next = createCommit(repo);
+
+            var verifier = new IntegrityVerifier(local, remote.root().toUri());
+
+            verifier.verifyBranch("repo", "branch", current);
+            verifier.updateBranch("repo", "branch", next);
+
+            // Simulate a integration being aborted after updateBranch has been
+            // called but before "git push" has been executed
+            var unpushed = createCommit(repo);
+            verifier.verifyBranch("repo", "branch", next);
+            verifier.updateBranch("repo", "branch", unpushed);
+
+            // The verifier should now *not* throw when verifying next
+            // (since next is the parent of unpushed)
+            verifier.verifyBranch("repo", "branch", next);
+
+            var integrityBranch = new Branch("repo-branch");
+            assertTrue(remote.branches().contains(integrityBranch));
+
+            var head = local.fetch(remote.root().toUri(), integrityBranch.name());
+            local.checkout(head);
+            var heads = Files.readAllLines(local.root().resolve("heads.txt"));
+            assertEquals(List.of(next.hash().hex(), current.hash().hex()), heads);
+        }
+    }
+
+    @Test
+    void unexpectedTargetHeadThrows() throws Exception {
+        try (var dir = new TemporaryDirectory()) {
+            var local = createLocalIntegrityRepo(dir);
+            var remote = createRemoteIntegrityRepo(dir);
+
+            var repo = createRepo(dir);
+            var current = createCommit(repo);
+            var next = createCommit(repo);
+
+            var verifier = new IntegrityVerifier(local, remote.root().toUri());
+
+            verifier.verifyBranch("repo", "branch", current);
+            verifier.updateBranch("repo", "branch", next);
+
+            var unexpected = createCommit(repo);
+            assertThrows(IllegalArgumentException.class,
+                         () -> { verifier.verifyBranch("repo", "branch", unexpected); });
+        }
+    }
+}

--- a/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
@@ -23,6 +23,7 @@
 package org.openjdk.skara.vcs;
 
 import java.io.IOException;
+import java.net.URI;
 import java.nio.file.Path;
 import java.nio.charset.StandardCharsets;
 import java.util.stream.Collectors;
@@ -148,6 +149,9 @@ public interface ReadOnlyRepository {
     boolean isValidRevisionRange(String expression) throws IOException;
     Optional<String> upstreamFor(Branch branch) throws IOException;
     List<Reference> remoteBranches(String remote) throws IOException;
+    default List<Reference> remoteBranches(URI uri) throws IOException {
+        return remoteBranches(uri.toString());
+    }
     List<String> remotes() throws IOException;
     List<Submodule> submodules() throws IOException;
     Tree tree(Hash h) throws IOException;


### PR DESCRIPTION
Hi all,

please review this patch that adds that makes it possible to enable an "integrity check" for the `/integrate` and `/sponsor` commands. The integrity check will be run before a commit is pushed and ensures that the most recent commit on the target branch was integrated by the bots.

The integrity check is implemented by utilizing an additional repository that for each repository and branch combination for a forge stores the two most recent commits pushed by the bots. This is information is stored in a text file called `heads.txt`, the first list line being the full hash of the most recent commit and the second line being the full hash of the next to most recent commit. The hashes of the two most recent commits are needed for the scenario when a bot throws an exception _after_ the file `heads.txt` in the integrity repo has been updated but _before_ the actual commit has been pushed to the target branch of the pull request. The `IntegrityVerifier` will recognize this case the next time a commit is verified (via a call to `verifyBranch`) and automatically correct the data in the integrity repository.

I also added a couple of new unit tests as well as two larger unit tests for the `/integrate` and `/sponsor` commands.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2137](https://bugs.openjdk.org/browse/SKARA-2137): Add integrity check to integrate and sponsor commands (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1596/head:pull/1596` \
`$ git checkout pull/1596`

Update a local copy of the PR: \
`$ git checkout pull/1596` \
`$ git pull https://git.openjdk.org/skara.git pull/1596/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1596`

View PR using the GUI difftool: \
`$ git pr show -t 1596`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1596.diff">https://git.openjdk.org/skara/pull/1596.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1596#issuecomment-1884463873)