### PR TITLE
2138: Backport instructions should include suggested PR comment

### DIFF
--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportCommitCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportCommitCommandTests.java
@@ -252,6 +252,7 @@ public class BackportCommitCommandTests {
             assertTrue(botReply.body().contains("Please fetch the appropriate branch/commit and manually resolve these conflicts"));
             assertTrue(botReply.body().contains("master:master"));
             assertTrue(botReply.body().contains("$ git checkout master"));
+            assertTrue(botReply.body().contains("Below you can find a suggestion for the pull request body:"));
             assertEquals(List.of(), author.openPullRequests());
         }
     }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportPRCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportPRCommandTests.java
@@ -120,6 +120,7 @@ public class BackportPRCommandTests {
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(pr, "@user2");
             assertLastCommentContains(pr, "Could **not** automatically backport");
+            assertLastCommentContains(pr, "Below you can find a suggestion for the pull request body:");
 
             // Resolve conflict
             localRepo.push(masterHash, targetRepo.authenticatedUrl(), "master", true);


### PR DESCRIPTION
In this patch, if user use the backport command to create a backport, regardless the backport can be created automatically or not, the user will get a suggestion for the pull request body.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2138](https://bugs.openjdk.org/browse/SKARA-2138): Backport instructions should include suggested PR comment (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1597/head:pull/1597` \
`$ git checkout pull/1597`

Update a local copy of the PR: \
`$ git checkout pull/1597` \
`$ git pull https://git.openjdk.org/skara.git pull/1597/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1597`

View PR using the GUI difftool: \
`$ git pr show -t 1597`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1597.diff">https://git.openjdk.org/skara/pull/1597.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1597#issuecomment-1885871772)