### PR TITLE
2141: Inform user about accepting fork repo invite in /backport command reply

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -366,8 +366,14 @@ public class BackportCommand implements CommandHandler {
                 backportHash = backportBranchHash.get();
             }
 
+            var invitationReminder = "";
             if (!fork.canPush(realUser)) {
                 fork.addCollaborator(realUser, true);
+                if (bot.repo().forge().name().equals("GitHub")) {
+                    invitationReminder = "\n\n⚠️ @" + realUser.username() + " " +
+                            "You are not yet a collaborator in my fork [" + fork.name() + "](" + fork.url() + "). " +
+                            "An invite will be sent out and you need to accept it before you can proceed.";
+                }
             } else {
                 // It's not possible to add branch level push protection unless the user
                 // already has push permissions in the repository. If we try to restrict
@@ -408,15 +414,8 @@ public class BackportCommand implements CommandHandler {
                           "$ git add paths/to/changed/files\n" +
                           "$ git commit --message 'Describe additional changes made'\n" +
                           "$ git push " + fork.url() + " " + backportBranchName + "\n" +
-                          "```");
-            if (bot.repo().forge().name().equals("GitHub")) {
-                reply.println();
-                reply.print("@");
-                reply.print(realUser.username());
-                reply.print(" ");
-                reply.print("If this is the first time you are using the /backport command for this particular target repository, " +
-                        "a `collaborator` invite will be sent out for my fork [" + fork.name() + "](" + fork.url() + "). You will need to accept this invite before you can proceed.\n");
-            }
+                          "```" +
+                          invitationReminder);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
@@ -409,6 +409,14 @@ public class BackportCommand implements CommandHandler {
                           "$ git commit --message 'Describe additional changes made'\n" +
                           "$ git push " + fork.url() + " " + backportBranchName + "\n" +
                           "```");
+            if (bot.repo().forge().name().equals("GitHub")) {
+                reply.println();
+                reply.print("@");
+                reply.print(realUser.username());
+                reply.print(" ");
+                reply.print("If this is the first time you are using the /backport command for this particular target repository, " +
+                        "a `collaborator` invite will be sent out for my fork [" + fork.name() + "](" + fork.url() + "). You will need to accept this invite before you can proceed.\n");
+            }
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
@@ -370,9 +370,9 @@ public class BackportCommand implements CommandHandler {
             if (!fork.canPush(realUser)) {
                 fork.addCollaborator(realUser, true);
                 if (bot.repo().forge().name().equals("GitHub")) {
-                    invitationReminder = "\n\n⚠️ @" + realUser.username() + " " +
-                            "You are not yet a collaborator in my fork [" + fork.name() + "](" + fork.url() + "). " +
-                            "An invite will be sent out and you need to accept it before you can proceed.";
+                    invitationReminder = "\n\n⚠️ @" + realUser.username() +
+                            " You are not yet a collaborator in my fork [" + fork.name() + "](" + fork.url() + ")." +
+                            " An invite will be sent out and you need to accept it before you can proceed.";
                 }
             } else {
                 // It's not possible to add branch level push protection unless the user


### PR DESCRIPTION
After users issued /backport command to create backport PRs in GitHub, skara bot will invite the users to be collaborators of the bot's fork. Sometimes, the users will ignore the invitation and later when they are trying to update the backport branch, they will find they don't have the access. This patch is trying to add a comment to remind the user to accept the invitation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2141](https://bugs.openjdk.org/browse/SKARA-2141): Inform user about accepting fork repo invite in /backport command reply (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1598/head:pull/1598` \
`$ git checkout pull/1598`

Update a local copy of the PR: \
`$ git checkout pull/1598` \
`$ git pull https://git.openjdk.org/skara.git pull/1598/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1598`

View PR using the GUI difftool: \
`$ git pr show -t 1598`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1598.diff">https://git.openjdk.org/skara/pull/1598.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1598#issuecomment-1887984476)