### PR TITLE
2144: Bot image is only built for Linux x64

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -212,13 +212,10 @@ task bots(type: Copy) {
 
     dependsOn ':bots:cli:images'
 
-    def os = getOS()
-    def cpu = getCPU()
-
     from zipTree(file(project.rootDir.toString() +
                       '/bots/cli/build/distributions/cli' +
-                      '-' + project.version + '-' +
-                      os + '-' + cpu + '.zip'))
+                      '-' + project.version +
+                      '-linux-x64.zip'))
     into project.rootDir.toString() + '/bots/bin'
 }
 


### PR DESCRIPTION
Hi all,

please review this small patch that fixes the `bots` target in `build.gradle`. The problem is that the `bots` target in `build.gradle` tries to unpack a `.zip` file named after the local operating system and architecture, but we only ever build the bot jimage for Linux x64. The `bots` target should therefore only try to extract a `linux-x64` image.

### Testing
- [x] Tested locally on macOS aarch64

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2144](https://bugs.openjdk.org/browse/SKARA-2144): Bot image is only built for Linux x64 (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1599/head:pull/1599` \
`$ git checkout pull/1599`

Update a local copy of the PR: \
`$ git checkout pull/1599` \
`$ git pull https://git.openjdk.org/skara.git pull/1599/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1599`

View PR using the GUI difftool: \
`$ git pr show -t 1599`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1599.diff">https://git.openjdk.org/skara/pull/1599.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1599#issuecomment-1889288301)