### PR TITLE
2143: Support selective tags mirroring

### DIFF
--- a/bots/mirror/src/main/java/org/openjdk/skara/bots/mirror/MirrorBot.java
+++ b/bots/mirror/src/main/java/org/openjdk/skara/bots/mirror/MirrorBot.java
@@ -128,7 +128,7 @@ class MirrorBot implements Bot, WorkItem {
             } else if (!refspecs.isEmpty()) {
                 for (var refspec : refspecs) {
                     log.info("Pushing using refspec " + refspec + " to " + to.name());
-                    repo.push(refspec, to.authenticatedUrl(), true);
+                    repo.push(refspec, to.authenticatedUrl());
                 }
             }
         } catch (IOException e) {

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
@@ -71,6 +71,7 @@ public interface Repository extends ReadOnlyRepository {
     void push(Hash hash, URI uri, String ref, boolean force, boolean includeTags) throws IOException;
     void push(Branch branch, String remote, boolean setUpstream) throws IOException;
     void push(Tag tag, URI uri, boolean force) throws IOException;
+    void push(String refspec, URI uri, boolean force) throws IOException;
     void clean() throws IOException;
     void reset(Hash target, boolean hard) throws IOException;
     void revert(Hash parent) throws IOException;

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
@@ -71,7 +71,7 @@ public interface Repository extends ReadOnlyRepository {
     void push(Hash hash, URI uri, String ref, boolean force, boolean includeTags) throws IOException;
     void push(Branch branch, String remote, boolean setUpstream) throws IOException;
     void push(Tag tag, URI uri, boolean force) throws IOException;
-    void push(String refspec, URI uri, boolean force) throws IOException;
+    void push(String refspec, URI uri) throws IOException;
     void clean() throws IOException;
     void reset(Hash target, boolean hard) throws IOException;
     void revert(Hash parent) throws IOException;

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -650,6 +650,16 @@ public class GitRepository implements Repository {
     }
 
     @Override
+    public void push(String refspec, URI uri, boolean force) throws IOException {
+        if (force && !refspec.equals("+")) {
+            refspec = "+" + refspec;
+        }
+        try (var p = capture("git", "push", uri.toString(), refspec)) {
+            await(p);
+        }
+    }
+
+    @Override
     public void push(Branch branch, String remote, boolean setUpstream) throws IOException {
         var cmd = new ArrayList<String>();
         cmd.addAll(List.of("git", "push", remote, branch.name()));

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -650,10 +650,7 @@ public class GitRepository implements Repository {
     }
 
     @Override
-    public void push(String refspec, URI uri, boolean force) throws IOException {
-        if (force && !refspec.equals("+")) {
-            refspec = "+" + refspec;
-        }
+    public void push(String refspec, URI uri) throws IOException {
         try (var p = capture("git", "push", uri.toString(), refspec)) {
             await(p);
         }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -604,6 +604,11 @@ public class HgRepository implements Repository {
     }
 
     @Override
+    public void push(String refspec, URI uri, boolean force) throws IOException {
+        throw new RuntimeException("Refspec not supported with Mercurial");
+    }
+
+    @Override
     public boolean isClean() throws IOException {
         try (var p = capture("hg", "status")) {
             var output = await(p);

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -604,7 +604,7 @@ public class HgRepository implements Repository {
     }
 
     @Override
-    public void push(String refspec, URI uri, boolean force) throws IOException {
+    public void push(String refspec, URI uri) throws IOException {
         throw new RuntimeException("Refspec not supported with Mercurial");
     }
 


### PR DESCRIPTION
We need a way to mirror tags selectively. Here is how I think I want to solve this. We currently have

"branches": Is either a string of one branch pattern or an array of multiple branch patterns
"tags": Takes either "include" or "only", if value is "only", "branches" cannot also be set

Instead of trying to somehow bend the "tags" parameter into taking some kind of patterns, I want to introduce a new parameter "refspecs". The value is an array (or a single string for convenience). Each string constitutes a single refspec that will be given unmodified to a "git push" command (with a + for force if not already present). The configuration becomes a bit more verbose by using this format, but it's also much more powerful. It makes it possible to express more complex mappings using the mirror bot, which may very well be needed when we start using branches more actively.

When setting "refspecs", we do not accept either "branches" or "tags" in the same configuration.

We still pull everything to the local repository in the bot. The refspec is only applied to the push command. Keeping the local repo the same as the source repo reduced the risk of bot configs interfering with each other through conflicting configurations.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2143](https://bugs.openjdk.org/browse/SKARA-2143): Support selective tags mirroring (**Enhancement** - P4)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1600/head:pull/1600` \
`$ git checkout pull/1600`

Update a local copy of the PR: \
`$ git checkout pull/1600` \
`$ git pull https://git.openjdk.org/skara.git pull/1600/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1600`

View PR using the GUI difftool: \
`$ git pr show -t 1600`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1600.diff">https://git.openjdk.org/skara/pull/1600.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1600#issuecomment-1894693601)