### PR TITLE
2149: Allow multiple query parameters with the same key

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
@@ -255,7 +255,7 @@ class WebrevStorage {
         var uriBuilder = URIBuilder.base(uri);
 
         while (Instant.now().isBefore(end)) {
-            var uncachedUri = uriBuilder.setQuery(Map.of("nocache", UUID.randomUUID().toString())).build();
+            var uncachedUri = uriBuilder.setQuery(Map.of("nocache", List.of(UUID.randomUUID().toString()))).build();
             log.fine("Validating webrev URL: " + uncachedUri);
             var request = HttpRequest.newBuilder(uncachedUri)
                                      .timeout(Duration.ofSeconds(30))

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -645,7 +645,7 @@ public class GitLabMergeRequest implements PullRequest {
     @Override
     public URI changeUrl(Hash base) {
         return URIBuilder.base(webUrl()).appendPath("/diffs")
-                         .setQuery(Map.of("start_sha", base.hex()))
+                         .setQuery(Map.of("start_sha", List.of(base.hex())))
                          .build();
     }
 

--- a/network/src/main/java/org/openjdk/skara/network/URIBuilder.java
+++ b/network/src/main/java/org/openjdk/skara/network/URIBuilder.java
@@ -22,9 +22,9 @@
  */
 package org.openjdk.skara.network;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.net.*;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -142,14 +142,13 @@ public class URIBuilder {
         return this;
     }
 
-    public URIBuilder setQuery(Map<String, String> parameters) {
+    public URIBuilder setQuery(Map<String, List<String>> parameters) {
         var query = parameters.entrySet().stream()
-                .map(p -> {
-                    try {
-                        return URLEncoder.encode(p.getKey(), "UTF-8") + "=" + URLEncoder.encode(p.getValue(), "UTF-8");
-                    } catch (UnsupportedEncodingException e) {
-                        throw new RuntimeException("Cannot find UTF-8");
-                    }
+                .flatMap(p -> {
+                    var key = URLEncoder.encode(p.getKey(), StandardCharsets.UTF_8);
+                    return p.getValue()
+                            .stream()
+                            .map(v -> key + "=" + URLEncoder.encode(v, StandardCharsets.UTF_8));
                 })
                 .collect(Collectors.joining("&"));
 

--- a/network/src/test/java/org/openjdk/skara/network/RestRequestTests.java
+++ b/network/src/test/java/org/openjdk/skara/network/RestRequestTests.java
@@ -377,4 +377,36 @@ class RestRequestTests {
             assertEquals(List.of(), receiver.getRawRequests());
         }
     }
+
+    @Test
+    void multipleParamsWithSameKey() throws IOException {
+        try (var receiver = new RestReceiver()) {
+            var restRequest = new RestRequest(receiver.getEndpoint());
+            var httpRequest = restRequest.get("/test").param("k", "v1").param("k", "v2").build();
+            assertEquals("k=v1&k=v2", httpRequest.uri().getQuery());
+        }
+    }
+
+    @Test
+    void multipleParamsWithMultipleKeys() throws IOException {
+        try (var receiver = new RestReceiver()) {
+            var restRequest = new RestRequest(receiver.getEndpoint());
+            var httpRequest = restRequest.get("/test").param("k1", "v1").param("k2", "v2").build();
+            assertEquals("k1=v1&k2=v2", httpRequest.uri().getQuery());
+        }
+    }
+
+    @Test
+    void multipleParamsWithMultipleKeysWithMultipleValues() throws IOException {
+        try (var receiver = new RestReceiver()) {
+            var restRequest = new RestRequest(receiver.getEndpoint());
+            var httpRequest = restRequest.get("/test")
+                                         .param("k1", "v1")
+                                         .param("k1", "v2")
+                                         .param("k2", "v3")
+                                         .param("k2", "v4")
+                                         .build();
+            assertEquals("k1=v1&k1=v2&k2=v3&k2=v4", httpRequest.uri().getQuery());
+        }
+    }
 }

--- a/network/src/test/java/org/openjdk/skara/network/URIBuilderTests.java
+++ b/network/src/test/java/org/openjdk/skara/network/URIBuilderTests.java
@@ -22,6 +22,8 @@
  */
 package org.openjdk.skara.network;
 
+import java.util.*;
+
 import org.openjdk.skara.network.*;
 
 import org.junit.jupiter.api.Test;
@@ -74,5 +76,30 @@ class URIBuilderTests {
     void noHost() {
         var a = URIBuilder.base("file:///a/b/c").build();
         assertEquals("/a/b/c", a.getPath());
+    }
+
+    @Test
+    void multipleParamsWithSameKey() {
+        var params = Map.of("key", List.of("v1", "v2"));
+        var uri = URIBuilder.base(validHost).setQuery(params).build();
+        assertEquals("key=v1&key=v2", uri.getQuery());
+    }
+
+    @Test
+    void multipleParamsWithDifferentKeys() {
+        var params = new LinkedHashMap<String, List<String>>();
+        params.put("k1", List.of("v1", "v2"));
+        params.put("k2", List.of("v3", "v4"));
+        var uri = URIBuilder.base(validHost).setQuery(params).build();
+        assertEquals("k1=v1&k1=v2&k2=v3&k2=v4", uri.getQuery());
+    }
+
+    @Test
+    void singleKeyAndValue() {
+        var params = Map.of(
+            "k1", List.of("v1")
+        );
+        var uri = URIBuilder.base(validHost).setQuery(params).build();
+        assertEquals("k1=v1", uri.getQuery());
     }
 }


### PR DESCRIPTION
Hi all.

please review this patch that makes `RestRequest` support multiple query parameters with the same key. This idiom is sometimes used in REST APIs (for example GitLab's REST API). The query parameters should always be kept in program order, since some REST APIs (e.g. GitLab) care about the order of the query parameters.

I also added a new `build` method on `RestRequest` to ease unit testing.

### Testing
- [x] Added a bunch of unit tests

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2149](https://bugs.openjdk.org/browse/SKARA-2149): Allow multiple query parameters with the same key (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1601/head:pull/1601` \
`$ git checkout pull/1601`

Update a local copy of the PR: \
`$ git checkout pull/1601` \
`$ git pull https://git.openjdk.org/skara.git pull/1601/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1601`

View PR using the GUI difftool: \
`$ git pr show -t 1601`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1601.diff">https://git.openjdk.org/skara/pull/1601.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1601#issuecomment-1898098697)