### PR TITLE
2150: Allow pull requests to have the title "Merge"

### DIFF
--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
@@ -1966,7 +1966,7 @@ class MergeTests {
             localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make more changes in another branch
-            var otherHash1 = CheckableRepository.appendAndCommit(localRepo, "First change in other", 
+            var otherHash1 = CheckableRepository.appendAndCommit(localRepo, "First change in other",
                     "First other\n\nReviewed-by: integrationreviewer2");
             var otherHash2 = CheckableRepository.appendAndCommit(localRepo, "Second change in other",
                     "Second other\n\nReviewed-by: integrationreviewer2");


### PR DESCRIPTION
Hi all,

please review this patch that allow "merge style" pull requests to have just the title "Merge". If the title is just "Merge" then the bots will rewrite the title to `Merge <HEAD>` where `<HEAD>` is the HEAD of the pull request source branch. This is useful if the integrator knows that they want the HEAD of the pull request source branch as the second parent for the resulting merge commit (this removes the need to manually specify the HEAD hash in the PR title).

### Testing
- [x] Added a new unit test

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2150](https://bugs.openjdk.org/browse/SKARA-2150): Allow pull requests to have the title "Merge" (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1602/head:pull/1602` \
`$ git checkout pull/1602`

Update a local copy of the PR: \
`$ git checkout pull/1602` \
`$ git pull https://git.openjdk.org/skara.git pull/1602/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1602`

View PR using the GUI difftool: \
`$ git pr show -t 1602`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1602.diff">https://git.openjdk.org/skara/pull/1602.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1602#issuecomment-1898470847)