### PR TITLE
2152: Use full name for tags if possible

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/TagCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/TagCommand.java
@@ -116,7 +116,8 @@ public class TagCommand implements CommandHandler {
             var contributor = censusInstance.contributor(command.user()).orElseThrow();
             var email = contributor.username() + "@" + domain;
             var message = "Added tag " + tagName + " for changeset " + commit.hash().abbreviate();
-            var tag = localRepo.tag(commit.hash(), tagName, message, contributor.username(), email);
+            var name = contributor.fullName().isPresent() ? contributor.fullName().get() : contributor.username();
+            var tag = localRepo.tag(commit.hash(), tagName, message, name, email);
             localRepo.push(tag, bot.repo().authenticatedUrl(), false);
             reply.println("The tag [" + tag.name() + "](" + bot.repo().webUrl(tag) + ") was successfully created.");
         } catch (IOException e) {


### PR DESCRIPTION
Hi all,

please review this patch that makes the `/tag` commit command use the user's full name (if possible) for the author and committer name field for the Git tag it creates. This is the same convention we use for the author/committer name and e-mail metadata in the commits (it was just a mistake on my part that `contributor.username()` was used in the original code for the `/tag` commit command).

### Testing
- [x] Added a new unit tests that fails without this patch but passes with it

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2152](https://bugs.openjdk.org/browse/SKARA-2152): Use full name for tags if possible (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1603/head:pull/1603` \
`$ git checkout pull/1603`

Update a local copy of the PR: \
`$ git checkout pull/1603` \
`$ git pull https://git.openjdk.org/skara.git pull/1603/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1603`

View PR using the GUI difftool: \
`$ git pr show -t 1603`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1603.diff">https://git.openjdk.org/skara/pull/1603.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1603#issuecomment-1900144080)