### PR TITLE
2151: Remove hardcoded reference to bugs.openjdk.org from mlbridge bot

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBot.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -93,7 +93,7 @@ public class MailingListBridgeBot implements Bot {
 
         webrevStorage = new WebrevStorage(webrevStorageHTMLRepository, webrevStorageJSONRepository, webrevStorageRef,
                                           webrevStorageBase, webrevStorageBaseUri, from,
-                                          webrevGenerateHTML, webrevGenerateJSON);
+                                          webrevGenerateHTML, webrevGenerateJSON, issueTracker);
         poller = new PullRequestPoller(codeRepo, true);
     }
 

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
@@ -103,12 +103,15 @@ class WebrevStorage {
                             .pullRequest(pr.webUrl().toString())
                             .username(fullName);
 
-        var conf = JCheckConfiguration.from(localRepository, head);
-        if (conf.isPresent()) {
-            var project = conf.get().general().jbs() != null ? conf.get().general().jbs() : conf.get().general().project();
-            builder.issueLinker(id -> issueTracker + project + "-" + id);
+        var issue = Issue.fromStringRelaxed(pr.title());
+        if (issue.isPresent()) {
+            builder.issue(issue.get().shortId());
+            var conf = JCheckConfiguration.from(localRepository, head);
+            if (conf.isPresent()) {
+                var project = conf.get().general().jbs() != null ? conf.get().general().jbs() : conf.get().general().project();
+                builder.issueLinker(id -> issueTracker + project + "-" + id);
+            }
         }
-        Issue.fromStringRelaxed(pr.title()).ifPresent(value -> builder.issue(value.shortId()));
 
         if (diff != null) {
             builder.generate(diff);

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -246,6 +246,8 @@ class MailingListBridgeBotTests {
             // And there should be a webrev
             Repository.materialize(webrevFolder.path(), archive.authenticatedUrl(), "webrev");
             assertTrue(webrevContains(webrevFolder.path(), "1 lines changed"));
+            assertTrue(webrevContains(webrevFolder.path(), "<a href=\"http://issues.test/browse/tstprj-1234\">tstprj-1234</a>"));
+
             var comments = pr.comments();
             var webrevComments = comments.stream()
                                          .filter(comment -> comment.author().equals(author.forge().currentUser()))

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/WebrevStorageTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/WebrevStorageTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@ import org.openjdk.skara.vcs.*;
 import org.junit.jupiter.api.*;
 
 import java.io.*;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.util.UUID;
@@ -66,7 +67,7 @@ class WebrevStorageTests {
 
             var from = EmailAddress.from("test", "test@test.mail");
             var storage = new WebrevStorage(archive, "webrev", Path.of("test"),
-                                            webrevServer.uri(), from);
+                    webrevServer.uri(), from, URI.create("http://issues.test/browse/"));
 
             var prFolder = tempFolder.path().resolve("pr");
             var prRepo = Repository.materialize(prFolder, pr.repository().authenticatedUrl(), "edit");
@@ -121,7 +122,7 @@ class WebrevStorageTests {
 
             var from = EmailAddress.from("test", "test@test.mail");
             var storage = new WebrevStorage(archive, "webrev", Path.of("test"),
-                                            webrevServer.uri(), from);
+                    webrevServer.uri(), from, URI.create("http://issues.test/browse/"));
 
             var prFolder = tempFolder.path().resolve("pr");
             var prRepo = Repository.materialize(prFolder, pr.repository().authenticatedUrl(), "edit");
@@ -206,7 +207,7 @@ class WebrevStorageTests {
 
             var from = EmailAddress.from("test", "test@test.mail");
             var storage = new WebrevStorage(archive, "webrev", Path.of("test"),
-                                            webrevServer.uri(), from);
+                    webrevServer.uri(), from, URI.create("http://issues.test/browse/"));
 
             var prFolder = tempFolder.path().resolve("pr");
             var prRepo = Repository.materialize(prFolder, pr.repository().authenticatedUrl(), "edit");


### PR DESCRIPTION
As Erik said in the issue description, previously, in WebrevStorage, there is hardcoded reference to "bugs.openjdk.org" to look up issues. However, we could get the issueTracker url from mlbridge bot and use it to generate the issue link without sending requests.

Also, previously, in WebrevStorage, `issueLinker` of `Webrev.builder` is never set, so all the code related with generating the issue link are useless in production. The webrev build would never set an issue link in index.html without `issueLinker`. This patch also fixes  this problem.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2151](https://bugs.openjdk.org/browse/SKARA-2151): Remove hardcoded reference to bugs.openjdk.org from mlbridge bot (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1604/head:pull/1604` \
`$ git checkout pull/1604`

Update a local copy of the PR: \
`$ git checkout pull/1604` \
`$ git pull https://git.openjdk.org/skara.git pull/1604/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1604`

View PR using the GUI difftool: \
`$ git pr show -t 1604`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1604.diff">https://git.openjdk.org/skara/pull/1604.diff</a>

</details>
