### PR TITLE
2159: CheckRun repeats search for backport commit on each evaluation

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -477,7 +477,15 @@ class CheckRun {
         if (hash == null) {
             return Optional.empty();
         }
-        var commit = pr.repository().forge().search(hash, true);
+        var repoName = checkablePullRequest.findOriginalBackportRepo();
+        if (repoName == null) {
+            return Optional.empty();
+        }
+        var repo = pr.repository().forge().repository(repoName);
+        if (repo.isEmpty()) {
+            throw new IllegalStateException("Backport comment for PR " + pr.id() + " contains bad repo name: " + repoName);
+        }
+        var commit = repo.get().commit(hash, true);
         if (commit.isEmpty()) {
             throw new IllegalStateException("Backport comment for PR " + pr.id() + " contains bad hash: " + hash.hex());
         }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -479,7 +479,7 @@ class CheckRun {
         }
         var repoName = checkablePullRequest.findOriginalBackportRepo();
         if (repoName == null) {
-            return Optional.empty();
+            repoName = pr.repository().forge().search(hash).orElseThrow();
         }
         var repo = pr.repository().forge().repository(repoName);
         if (repo.isEmpty()) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -527,8 +527,8 @@ class CheckWorkItem extends PullRequestWorkItem {
                 var forge = pr.repository().forge();
                 var repoName = forge.search(hash);
                 if (repoName.isPresent()) {
-                    var metadata = forge.repository(repoName.get()).flatMap(repository -> repository.commit(hash));
-                    var message = CommitMessageParsers.v1.parse(metadata.orElseThrow().message());
+                    var commit = forge.repository(repoName.get()).flatMap(repository -> repository.commit(hash));
+                    var message = CommitMessageParsers.v1.parse(commit.orElseThrow().message());
                     var issues = message.issues();
                     var comment = new ArrayList<String>();
                     if (issues.isEmpty()) {
@@ -568,7 +568,7 @@ class CheckWorkItem extends PullRequestWorkItem {
                     if (!summary.isEmpty()) {
                         text += " and summary";
                     }
-                    text += " from the original [commit](" + metadata.get().url() + ").";
+                    text += " from the original [commit](" + commit.get().url() + ").";
                     comment.add(text);
                     pr.addComment(String.join("\n", comment));
                     pr.addLabel("backport");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -524,10 +524,11 @@ class CheckWorkItem extends PullRequestWorkItem {
                 } catch (IOException e) {
                     throw new UncheckedIOException(e);
                 }
-                var repoName = pr.repository().forge().search(hash);
+                var forge = pr.repository().forge();
+                var repoName = forge.search(hash);
                 if (repoName.isPresent()) {
-                    var metadata = pr.repository().forge().repository(repoName.get()).flatMap(repository -> repository.commit(hash));
-                    var message = CommitMessageParsers.v1.parse(metadata.get().message());
+                    var metadata = forge.repository(repoName.get()).flatMap(repository -> repository.commit(hash));
+                    var message = CommitMessageParsers.v1.parse(metadata.orElseThrow().message());
                     var issues = message.issues();
                     var comment = new ArrayList<String>();
                     if (issues.isEmpty()) {
@@ -573,7 +574,6 @@ class CheckWorkItem extends PullRequestWorkItem {
                     pr.addLabel("backport");
                     return List.of(CheckWorkItem.fromWorkItem(bot, prId, errorHandler, triggerUpdatedAt));
                 } else {
-                    var botUser = pr.repository().forge().currentUser();
                     var text = "<!-- backport error -->\n" +
                             ":warning: @" + pr.author().username() + " could not find any commit with hash `" +
                             hash.hex() + "`. Please update the title with the hash for an existing commit.";

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -524,8 +524,9 @@ class CheckWorkItem extends PullRequestWorkItem {
                 } catch (IOException e) {
                     throw new UncheckedIOException(e);
                 }
-                var metadata = pr.repository().forge().search(hash);
-                if (metadata.isPresent()) {
+                var repoName = pr.repository().forge().search(hash);
+                if (repoName.isPresent()) {
+                    var metadata = pr.repository().forge().repository(repoName.get()).flatMap(repository -> repository.commit(hash));
                     var message = CommitMessageParsers.v1.parse(metadata.get().message());
                     var issues = message.issues();
                     var comment = new ArrayList<String>();
@@ -550,6 +551,7 @@ class CheckWorkItem extends PullRequestWorkItem {
                     }
                     pr.setTitle(id + ": " + issue.get().title());
                     comment.add("<!-- backport " + hash.hex() + " -->\n");
+                    comment.add("<!-- repo " + repoName.get() + " -->\n");
                     for (var additionalIssue : issues.subList(1, issues.size())) {
                         comment.add(SolvesTracker.setSolvesMarker(additionalIssue));
                     }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHost.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryHost.java
@@ -73,7 +73,7 @@ class InMemoryHost implements Forge {
     }
 
     @Override
-    public Optional<HostedCommit> search(Hash hash, boolean includeDiffs) {
+    public Optional<String> search(Hash hash, boolean includeDiffs) {
         return Optional.empty();
     }
 

--- a/forge/src/main/java/org/openjdk/skara/forge/Forge.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/Forge.java
@@ -49,8 +49,8 @@ public interface Forge extends Host {
      * @param includeDiffs Set to true to include parent diffs in Commit, default false
      * @return Commit instance if found, otherwise empty
      */
-    Optional<HostedCommit> search(Hash hash, boolean includeDiffs);
-    default Optional<HostedCommit> search(Hash hash) {
+    Optional<String> search(Hash hash, boolean includeDiffs);
+    default Optional<String> search(Hash hash) {
         return search(hash, false);
     }
 

--- a/forge/src/main/java/org/openjdk/skara/forge/Forge.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/Forge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,7 @@ public interface Forge extends Host {
      * Search the whole host for a commit by hash.
      * @param hash Hash to search for
      * @param includeDiffs Set to true to include parent diffs in Commit, default false
-     * @return Commit instance if found, otherwise empty
+     * @return Repository name if found, otherwise empty
      */
     Optional<String> search(Hash hash, boolean includeDiffs);
     default Optional<String> search(Hash hash) {

--- a/forge/src/main/java/org/openjdk/skara/forge/bitbucket/BitbucketHost.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/bitbucket/BitbucketHost.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/forge/src/main/java/org/openjdk/skara/forge/bitbucket/BitbucketHost.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/bitbucket/BitbucketHost.java
@@ -79,7 +79,7 @@ public class BitbucketHost implements Forge {
     }
 
     @Override
-    public Optional<HostedCommit> search(Hash hash, boolean includeDiffs) {
+    public Optional<String> search(Hash hash, boolean includeDiffs) {
         throw new UnsupportedOperationException();
     }
 

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubHost.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubHost.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -457,10 +457,8 @@ public class GitHubHost implements Forge {
         // There is no good way of knowing for sure which repository we would rather
         // get the commit from, but a reasonable default is to go by the shortest
         // name as that is most likely the main repository of the project.
-        var shortestName = items.stream()
+        return items.stream()
                 .map(o -> o.get("repository").get("full_name").asString())
                 .min(Comparator.comparing(String::length));
-        return shortestName;
-//        return shortestName.flatMap(this::repository).flatMap(r -> r.commit(hash, includeDiffs));
     }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubHost.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubHost.java
@@ -443,7 +443,7 @@ public class GitHubHost implements Forge {
     }
 
     @Override
-    public Optional<HostedCommit> search(Hash hash, boolean includeDiffs) {
+    public Optional<String> search(Hash hash, boolean includeDiffs) {
         var orgsToSearch = orgs.stream().map(o -> "org:" + o).collect(Collectors.joining(" "));
         if (!orgsToSearch.isEmpty()) {
             orgsToSearch = " " + orgsToSearch;
@@ -460,6 +460,7 @@ public class GitHubHost implements Forge {
         var shortestName = items.stream()
                 .map(o -> o.get("repository").get("full_name").asString())
                 .min(Comparator.comparing(String::length));
-        return shortestName.flatMap(this::repository).flatMap(r -> r.commit(hash, includeDiffs));
+        return shortestName;
+//        return shortestName.flatMap(this::repository).flatMap(r -> r.commit(hash, includeDiffs));
     }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabHost.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabHost.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,6 @@ import java.net.*;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 
 public class GitLabHost implements Forge {
     private final String name;
@@ -236,7 +235,6 @@ public class GitLabHost implements Forge {
 
     @Override
     public Optional<String> search(Hash hash, boolean includeDiffs) {
-        var hex = hash.hex();
         for (var group : groups) {
             var ids = request.get("groups/" + group + "/projects")
                                   .execute()
@@ -247,7 +245,7 @@ public class GitLabHost implements Forge {
                                   // path name as that is most likely the main repository of the project.
                                   .sorted(Comparator.comparing(o -> o.get("path").asString().length()))
                                   .map(o -> o.get("id").asInt())
-                                  .collect(Collectors.toList());
+                                  .toList();
             for (var id : ids) {
                 var project = new GitLabRepository(this, id);
                 var commit = project.commit(hash, includeDiffs);

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabHost.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabHost.java
@@ -235,7 +235,7 @@ public class GitLabHost implements Forge {
     }
 
     @Override
-    public Optional<HostedCommit> search(Hash hash, boolean includeDiffs) {
+    public Optional<String> search(Hash hash, boolean includeDiffs) {
         var hex = hash.hex();
         for (var group : groups) {
             var ids = request.get("groups/" + group + "/projects")
@@ -252,7 +252,7 @@ public class GitLabHost implements Forge {
                 var project = new GitLabRepository(this, id);
                 var commit = project.commit(hash, includeDiffs);
                 if (commit.isPresent()) {
-                    return commit;
+                    return Optional.of(project.name());
                 }
             }
         }

--- a/forge/src/test/java/org/openjdk/skara/forge/github/GitHubRestApiTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/github/GitHubRestApiTests.java
@@ -293,7 +293,9 @@ public class GitHubRestApiTests {
         var gitHubRepo = githubHost.repository(settings.getProperty("github.repository")).orElseThrow();
 
         var pr = gitHubRepo.pullRequest(settings.getProperty("github.prId"));
-        var commit = pr.repository().forge().search(new Hash(settings.getProperty("github.commitHash")), true);
+        var hash = new Hash(settings.getProperty("github.commitHash"));
+        var repoName = pr.repository().forge().search(hash, true);
+        var commit = pr.repository().forge().repository(repoName.get()).get().commit(hash, true);
         var backportDiff = commit.get().parentDiffs().get(0);
         var prDiff = pr.diff();
         var isClean = DiffComparator.areFuzzyEqual(backportDiff, prDiff);

--- a/forge/src/test/java/org/openjdk/skara/forge/github/GitHubRestApiTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/github/GitHubRestApiTests.java
@@ -235,7 +235,7 @@ public class GitHubRestApiTests {
     }
 
     @Test
-    void test() {
+    void testGeneratingUrl() {
         var username = settings.getProperty("github.user");
         var token = settings.getProperty("github.pat");
         var credential = new Credential(username, token);
@@ -295,8 +295,11 @@ public class GitHubRestApiTests {
         var pr = gitHubRepo.pullRequest(settings.getProperty("github.prId"));
         var hash = new Hash(settings.getProperty("github.commitHash"));
         var repoName = pr.repository().forge().search(hash, true);
-        var commit = pr.repository().forge().repository(repoName.get()).get().commit(hash, true);
-        var backportDiff = commit.get().parentDiffs().get(0);
+        assertTrue(repoName.isPresent());
+        var repository = pr.repository().forge().repository(repoName.get());
+        assertTrue(repository.isPresent());
+        var commit = repository.get().commit(hash, true);
+        var backportDiff = commit.orElseThrow().parentDiffs().get(0);
         var prDiff = pr.diff();
         var isClean = DiffComparator.areFuzzyEqual(backportDiff, prDiff);
         assertTrue(isClean);

--- a/forge/src/test/java/org/openjdk/skara/forge/gitlab/GitLabRestApiTest.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/gitlab/GitLabRestApiTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -256,7 +256,10 @@ public class GitLabRestApiTest {
         var pr = gitLabRepo.pullRequest(settings.getProperty("gitlab.prId"));
         var hash = new Hash(settings.getProperty("gitlab.commitHash"));
         var repoName = pr.repository().forge().search(hash, true);
-        var commit = pr.repository().forge().repository(repoName.get()).get().commit(hash, true);
+        assertTrue(repoName.isPresent());
+        var repository = pr.repository().forge().repository(repoName.get());
+        assertTrue(repository.isPresent());
+        var commit = repository.get().commit(hash, true);
         var backportDiff = commit.orElseThrow().parentDiffs().get(0);
         var prDiff = pr.diff();
         var isClean = DiffComparator.areFuzzyEqual(backportDiff, prDiff);

--- a/test/src/main/java/org/openjdk/skara/test/TestHost.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHost.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/src/main/java/org/openjdk/skara/test/TestHost.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHost.java
@@ -184,12 +184,12 @@ public class TestHost implements Forge, IssueTracker {
     }
 
     @Override
-    public Optional<HostedCommit> search(Hash hash, boolean includeDiffs) {
+    public Optional<String> search(Hash hash, boolean includeDiffs) {
         for (var key : data.repositories.keySet()) {
             var repo = repository(key).orElseThrow();
             var commit = repo.commit(hash, includeDiffs);
             if (commit.isPresent()) {
-                return commit;
+                return Optional.of(repo.name());
             }
         }
         return Optional.empty();


### PR DESCRIPTION
As Erik said in the issue description, when skara bot is searching for the original commit for a backport port, it's very inefficient for GitLab because GitLab doesn't provide the good rest api as GitHub for the bot to search for a commit by hash. So Skara have no choice but go through all the repositories and it's very slow right now.

To fix it, we could store the repository name together with the commit hash in the comment, therefore the bot will only need to run the search once.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2159](https://bugs.openjdk.org/browse/SKARA-2159): CheckRun repeats search for backport commit on each evaluation (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1605/head:pull/1605` \
`$ git checkout pull/1605`

Update a local copy of the PR: \
`$ git checkout pull/1605` \
`$ git pull https://git.openjdk.org/skara.git pull/1605/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1605`

View PR using the GUI difftool: \
`$ git pr show -t 1605`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1605.diff">https://git.openjdk.org/skara/pull/1605.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1605#issuecomment-1912577170)