### PR TITLE
2039: Only post ApprovalNeededComment when the user hasn't applied for maintainer approval for all the issues

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -80,6 +80,7 @@ class CheckRun {
     private Duration expiresIn;
     // Only set if approval is configured for the repo
     private String realTargetRef;
+    private boolean missingApproval = false;
 
     private CheckRun(CheckWorkItem workItem, PullRequest pr, Repository localRepo, List<Comment> comments,
                      List<Review> allReviews, List<Review> activeReviews, Set<String> labels,
@@ -720,6 +721,8 @@ class CheckRun {
                                 } else if (labels.contains(approval.requestedLabel(realTargetRef))) {
                                     status = "Requested";
                                     requestPresent = true;
+                                } else {
+                                    missingApproval = true;
                                 }
                                 if (!status.isEmpty()) {
                                     progressBody.append(" - ").append(status);
@@ -1390,7 +1393,7 @@ class CheckRun {
                 newLabels.remove("merge-conflict");
             }
 
-            if (!PullRequestUtils.isMerge(pr) && !newLabels.contains("ready") && !newLabels.contains(APPROVAL_LABEL)
+            if (!PullRequestUtils.isMerge(pr) && !newLabels.contains("ready") && missingApproval
                     && approvalNeeded() && approval.approvalComment() && readyToPostApprovalNeededComment) {
                 for (var entry : additionalProgresses.entrySet()) {
                     if (!entry.getKey().endsWith("needs " + approval.approvalTerm()) && !entry.getValue()) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -1375,18 +1375,6 @@ class CheckRun {
             var readyForIntegration = readyToPostApprovalNeededComment &&
                     !additionalProgresses.containsValue(false);
 
-            if (approvalNeeded() && approval.approvalComment() && readyToPostApprovalNeededComment) {
-                for (var entry : additionalProgresses.entrySet()) {
-                    if (!entry.getKey().endsWith("needs " + approval.approvalTerm()) && !entry.getValue()) {
-                        readyToPostApprovalNeededComment = false;
-                        break;
-                    }
-                }
-                if (readyToPostApprovalNeededComment) {
-                    postApprovalNeededComment();
-                }
-            }
-
             updateMergeReadyComment(readyForIntegration, commitMessage, rebasePossible);
             if (readyForIntegration && rebasePossible) {
                 newLabels.add("ready");
@@ -1400,6 +1388,19 @@ class CheckRun {
                 newLabels.add("merge-conflict");
             } else {
                 newLabels.remove("merge-conflict");
+            }
+
+            if (!PullRequestUtils.isMerge(pr) && !newLabels.contains("ready") && !newLabels.contains(APPROVAL_LABEL)
+                    && approvalNeeded() && approval.approvalComment() && readyToPostApprovalNeededComment) {
+                for (var entry : additionalProgresses.entrySet()) {
+                    if (!entry.getKey().endsWith("needs maintainer approval") && !entry.getValue()) {
+                        readyToPostApprovalNeededComment = false;
+                        break;
+                    }
+                }
+                if (readyToPostApprovalNeededComment) {
+                    postApprovalNeededComment();
+                }
             }
 
             if (pr.sourceRepository().isPresent()) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -80,7 +80,7 @@ class CheckRun {
     private Duration expiresIn;
     // Only set if approval is configured for the repo
     private String realTargetRef;
-    private boolean missingApproval = false;
+    private boolean missingApprovalRequest = false;
 
     private CheckRun(CheckWorkItem workItem, PullRequest pr, Repository localRepo, List<Comment> comments,
                      List<Review> allReviews, List<Review> activeReviews, Set<String> labels,
@@ -722,7 +722,7 @@ class CheckRun {
                                     status = "Requested";
                                     requestPresent = true;
                                 } else {
-                                    missingApproval = true;
+                                    missingApprovalRequest = true;
                                 }
                                 if (!status.isEmpty()) {
                                     progressBody.append(" - ").append(status);
@@ -1393,7 +1393,7 @@ class CheckRun {
                 newLabels.remove("merge-conflict");
             }
 
-            if (!PullRequestUtils.isMerge(pr) && !newLabels.contains("ready") && missingApproval
+            if (!PullRequestUtils.isMerge(pr) && !newLabels.contains("ready") && missingApprovalRequest
                     && approvalNeeded() && approval.approvalComment() && readyToPostApprovalNeededComment) {
                 for (var entry : additionalProgresses.entrySet()) {
                     if (!entry.getKey().endsWith("needs " + approval.approvalTerm()) && !entry.getValue()) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -1393,7 +1393,7 @@ class CheckRun {
             if (!PullRequestUtils.isMerge(pr) && !newLabels.contains("ready") && !newLabels.contains(APPROVAL_LABEL)
                     && approvalNeeded() && approval.approvalComment() && readyToPostApprovalNeededComment) {
                 for (var entry : additionalProgresses.entrySet()) {
-                    if (!entry.getKey().endsWith("needs maintainer approval") && !entry.getValue()) {
+                    if (!entry.getKey().endsWith("needs " + approval.approvalTerm()) && !entry.getValue()) {
                         readyToPostApprovalNeededComment = false;
                         break;
                     }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ApprovalAndApproveCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ApprovalAndApproveCommandTests.java
@@ -132,7 +132,6 @@ public class ApprovalAndApproveCommandTests {
             reviewerPr.addReview(Review.Verdict.APPROVED, "LGTM");
             TestBotRunner.runPeriodicItems(prBot);
             assertFalse(pr.store().labelNames().contains("ready"));
-            assertLastCommentContains(pr, " This change is now ready for you to apply for [maintainer approval]");
 
             reviewerPr.addComment("/approve yes");
             TestBotRunner.runPeriodicItems(prBot);

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ApprovalAndApproveCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ApprovalAndApproveCommandTests.java
@@ -164,9 +164,11 @@ public class ApprovalAndApproveCommandTests {
             var issue1 = issueProject.createIssue("This is an issue", List.of(), Map.of());
             issue1.setProperty("issuetype", JSON.of("Bug"));
             issue1.setProperty("priority", JSON.of("4"));
+            issue1.addLabel("CPU23_04-critical-request");
             var issue2 = issueProject.createIssue("This is an issue 2", List.of(), Map.of());
-            issue1.setProperty("issuetype", JSON.of("Bug"));
-            issue1.setProperty("priority", JSON.of("2"));
+            issue2.setProperty("issuetype", JSON.of("Bug"));
+            issue2.setProperty("priority", JSON.of("2"));
+            issue2.addLabel("CPU23_04-critical-request");
 
             var censusBuilder = credentials.getCensusBuilder()
                     .addReviewer(reviewer.forge().currentUser().id())
@@ -209,6 +211,16 @@ public class ApprovalAndApproveCommandTests {
 
             var reviewerPr = reviewer.pullRequest(pr.id());
             reviewerPr.addReview(Review.Verdict.APPROVED, "LGTM");
+            TestBotRunner.runPeriodicItems(prBot);
+
+            pr.addComment("/approval 1 cancel");
+            TestBotRunner.runPeriodicItems(prBot);
+            TestBotRunner.runPeriodicItems(issueBot);
+            assertLastCommentContains(pr, "This change is now ready for you to apply for [maintainer approval](https://example.com).");
+            pr.addComment("/approval 2 cancel");
+            TestBotRunner.runPeriodicItems(prBot);
+            TestBotRunner.runPeriodicItems(issueBot);
+
             reviewerPr.addComment("/approve yes");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(pr, "1: There is no maintainer approval request for this issue.");

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IssueBotTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IssueBotTests.java
@@ -412,7 +412,7 @@ public class IssueBotTests {
                             "This can be done directly in each associated issue or by using the " +
                             "[/approval](https://wiki.openjdk.org/display/SKARA/Pull+Request+Commands#PullRequestCommands-/approval) command." +
                             "<!-- PullRequestBot approval needed comment -->"
-                    , pr.store().comments().get(1).body());
+                    , pr.store().comments().get(2).body());
 
             issue.addLabel("CPU23_04-critical-request");
             TestBotRunner.runPeriodicItems(issueBot);
@@ -426,7 +426,7 @@ public class IssueBotTests {
                             "This can be done directly in each associated issue or by using the " +
                             "[/approval](https://wiki.openjdk.org/display/SKARA/Pull+Request+Commands#PullRequestCommands-/approval) command." +
                             "<!-- PullRequestBot approval needed comment -->"
-                    , pr.store().comments().get(1).body());
+                    , pr.store().comments().get(2).body());
         }
     }
 }


### PR DESCRIPTION
In [SKARA-1949](https://bugs.openjdk.org/browse/SKARA-1949), we introduced /approval command and at the same time, we let the bot post ApprovalNeededComment when the pull request is reviewed.

As Kevin Rushforth suggested, the bot shouldn't post ApprovalNeededComment if the user already applied for all the issues.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2039](https://bugs.openjdk.org/browse/SKARA-2039): Only post ApprovalNeededComment when the user hasn't applied for maintainer approval for all the issues (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1606/head:pull/1606` \
`$ git checkout pull/1606`

Update a local copy of the PR: \
`$ git checkout pull/1606` \
`$ git pull https://git.openjdk.org/skara.git pull/1606/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1606`

View PR using the GUI difftool: \
`$ git pr show -t 1606`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1606.diff">https://git.openjdk.org/skara/pull/1606.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1606#issuecomment-1912757257)