### PR TITLE
2163: Add API to Repository for working "git notes"

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
@@ -192,13 +192,13 @@ public interface Repository extends ReadOnlyRepository {
     }
 
     void addNote(Hash hash,
-                 List<String> note,
+                 List<String> lines,
                  String authorName,
                  String authorEmail,
                  String committerName,
                  String committerEmail) throws IOException;
-    default void addNote(Hash hash, List<String> note, String authorName, String authorEmail) throws IOException {
-        addNote(hash, note, authorName, authorEmail, authorName, authorEmail);
+    default void addNote(Hash hash, List<String> lines, String authorName, String authorEmail) throws IOException {
+        addNote(hash, lines, authorName, authorEmail, authorName, authorEmail);
     }
     List<String> notes(Hash hash) throws IOException;
     void pushNotes(URI uri) throws IOException;

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
@@ -191,6 +191,18 @@ public interface Repository extends ReadOnlyRepository {
         updateSubmodule(s.path());
     }
 
+    void addNote(Hash hash,
+                 List<String> note,
+                 String authorName,
+                 String authorEmail,
+                 String committerName,
+                 String committerEmail) throws IOException;
+    default void addNote(Hash hash, List<String> note, String authorName, String authorEmail) throws IOException {
+        addNote(hash, note, authorName, authorEmail, authorName, authorEmail);
+    }
+    List<String> notes(Hash hash) throws IOException;
+    void pushNotes(URI uri) throws IOException;
+
     /**
      * Check whether this commit is empty.
      * For a merge commit, it will be considered as empty if it has no merge resolutions.

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -1773,7 +1773,7 @@ public class GitRepository implements Repository {
 
     @Override
     public void addNote(Hash hash,
-                        List<String> note,
+                        List<String> lines,
                         String authorName,
                         String authorEmail,
                         String committerName,
@@ -1783,7 +1783,7 @@ public class GitRepository implements Repository {
             throw new IllegalStateException("A note already exists for " + hash.hex());
         }
 
-        var cmd = Process.capture("git", "notes", "add", "-m", String.join("\n", note), hash.hex())
+        var cmd = Process.capture("git", "notes", "add", "-m", String.join("\n", lines), hash.hex())
                          .workdir(dir)
                          .environ(currentEnv)
                          .environ("GIT_AUTHOR_NAME", authorName)

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -1770,4 +1770,44 @@ public class GitRepository implements Repository {
             return true;
         }
     }
+
+    @Override
+    public void addNote(Hash hash,
+                        List<String> note,
+                        String authorName,
+                        String authorEmail,
+                        String committerName,
+                        String committerEmail) throws IOException {
+        var existing = notes(hash);
+        if (!existing.isEmpty()) {
+            throw new IllegalStateException("A note already exists for " + hash.hex());
+        }
+
+        var cmd = Process.capture("git", "notes", "add", "-m", String.join("\n", note), hash.hex())
+                         .workdir(dir)
+                         .environ(currentEnv)
+                         .environ("GIT_AUTHOR_NAME", authorName)
+                         .environ("GIT_AUTHOR_EMAIL", authorEmail)
+                         .environ("GIT_COMMITTER_NAME", committerName)
+                         .environ("GIT_COMMITTER_EMAIL", committerEmail);
+        try (var p = cmd.execute()) {
+            await(p);
+        }
+    }
+
+    @Override
+    public List<String> notes(Hash hash) throws IOException {
+        try (var p = capture("git", "notes", "show", hash.hex())) {
+            var res = p.await();
+            if (res.status() != 0) {
+                return List.of();
+            }
+            return res.stdout();
+        }
+    }
+
+    @Override
+    public void pushNotes(URI uri) throws IOException {
+        push("refs/notes/*:refs/notes/*", uri);
+    }
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -1558,7 +1558,7 @@ public class HgRepository implements Repository {
 
     @Override
     public void addNote(Hash hash,
-                        List<String> note,
+                        List<String> lines,
                         String authorName,
                         String authorEmail,
                         String committerName,

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -1555,4 +1555,24 @@ public class HgRepository implements Repository {
     public boolean isEmptyCommit(Hash hash) {
         throw new UnsupportedOperationException();
     }
+
+    @Override
+    public void addNote(Hash hash,
+                        List<String> note,
+                        String authorName,
+                        String authorEmail,
+                        String committerName,
+                        String committerEmail) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<String> notes(Hash hash) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void pushNotes(URI uri) throws IOException {
+        throw new UnsupportedOperationException();
+    }
 }


### PR DESCRIPTION
Hi all,

please review this patch that adds the methods `addNote`. `notes` and `pushNotes` to `Repository.java` to allow Skara code to work with [git notes](https://git-scm.com/docs/git-notes). This will be used in another patch to implement a "git note"-notifier (see https://bugs.openjdk.org/browse/SKARA-2164). 

I opted for a fairly minimal API here even though the `git notes` command exposes many more features. I also decided to add the `pushNotes` method although callers could use the `push(String refspec, URI uri)` variant because I don't like the notes refspec to "leak" out into other parts of the code.

Also added a couple of unit tests.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2163](https://bugs.openjdk.org/browse/SKARA-2163): Add API to Repository for working "git notes" (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to [b6aabbda](https://git.openjdk.org/skara/pull/1607/files/b6aabbda38033960fe37a6c2421bd74cdd36e863)
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1607/head:pull/1607` \
`$ git checkout pull/1607`

Update a local copy of the PR: \
`$ git checkout pull/1607` \
`$ git pull https://git.openjdk.org/skara.git pull/1607/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1607`

View PR using the GUI difftool: \
`$ git pr show -t 1607`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1607.diff">https://git.openjdk.org/skara/pull/1607.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1607#issuecomment-1914812453)