### PR TITLE
2164: Add git notes notifier

### DIFF
--- a/bots/notify/build.gradle
+++ b/bots/notify/build.gradle
@@ -32,6 +32,7 @@ module {
         opens 'org.openjdk.skara.bots.notify.issue' to 'org.junit.platform.commons'
         opens 'org.openjdk.skara.bots.notify.comment' to 'org.junit.platform.commons'
         opens 'org.openjdk.skara.bots.notify.prbranch' to 'org.junit.platform.commons'
+        opens 'org.openjdk.skara.bots.notify.notes' to 'org.junit.platform.commons'
     }
 }
 

--- a/bots/notify/src/main/java/module-info.java
+++ b/bots/notify/src/main/java/module-info.java
@@ -44,5 +44,6 @@ module org.openjdk.skara.bots.notify {
             org.openjdk.skara.bots.notify.mailinglist.MailingListNotifierFactory,
             org.openjdk.skara.bots.notify.slack.SlackNotifierFactory,
             org.openjdk.skara.bots.notify.comment.CommitCommentNotifierFactory,
-            org.openjdk.skara.bots.notify.prbranch.PullRequestBranchNotifierFactory;
+            org.openjdk.skara.bots.notify.prbranch.PullRequestBranchNotifierFactory,
+            org.openjdk.skara.bots.notify.notes.CommitNoteNotifierFactory;
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/notes/CommitNoteNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/notes/CommitNoteNotifier.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.notify.notes;
+
+import org.openjdk.skara.bots.notify.*;
+import org.openjdk.skara.forge.*;
+import org.openjdk.skara.issuetracker.*;
+import org.openjdk.skara.vcs.*;
+import org.openjdk.skara.vcs.openjdk.CommitMessageParsers;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+class CommitNoteNotifier implements Notifier, PullRequestListener {
+    private final Logger log = Logger.getLogger("org.openjdk.skara.bots.notify");
+
+    private final IssueProject issueProject;
+
+    CommitNoteNotifier(IssueProject issueProject) {
+        this.issueProject = issueProject;
+    }
+
+    private List<IssueTrackerIssue> issues(Commit commit) {
+        var commitMessage = CommitMessageParsers.v1.parse(commit.metadata());
+        return commitMessage.issues()
+                            .stream()
+                            .map(i -> issueProject.issue(i.shortId()))
+                            .filter(Optional::isPresent)
+                            .map(Optional::get)
+                            .collect(Collectors.toList());
+    }
+
+    @Override
+    public void attachTo(Emitter e) {
+        e.registerPullRequestListener(this);
+    }
+
+    @Override
+    public void onIntegratedPullRequest(PullRequest pr, Path scratchPath, Hash hash)  {
+        try {
+            var pool = new HostedRepositoryPool(scratchPath.resolve("pool"));
+            var localRepoDir = scratchPath.resolve(pr.repository().name());
+            var localRepo = pool.materialize(pr.repository(), localRepoDir);
+            localRepo.fetch(pr.repository().authenticatedUrl(), hash.hex(), true);
+
+            var commit = pr.repository().commit(hash).orElseThrow(() ->
+                    new IllegalStateException("Integrated commit " + hash +
+                                            " not present in repository " + pr.repository().webUrl())
+            );
+            var issues = issues(commit);
+
+            var note = new ArrayList<String>();
+            note.add("Commit: " + commit.webUrl());
+            note.add("Review: " + pr.webUrl());
+            if (!issues.isEmpty()) {
+                note.add("Issues:");
+                for (var issue : issues) {
+                    note.add("- " + issue.webUrl());
+                }
+            }
+
+            localRepo.fetch(pr.repository().authenticatedUrl(), "refs/notes/*:refs/notes/*");
+            var existingNotes = localRepo.notes(hash);
+            if (existingNotes.isEmpty()) {
+                localRepo.addNote(hash, note, "Duke", "duke@openjdk.org");
+                localRepo.pushNotes(pr.repository().authenticatedUrl());
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public String name() {
+        return "notes";
+    }
+}

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/notes/CommitNoteNotifierFactory.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/notes/CommitNoteNotifierFactory.java
@@ -20,53 +20,23 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package org.openjdk.skara.forge;
+package org.openjdk.skara.bots.notify.notes;
 
-import org.openjdk.skara.vcs.*;
+import org.openjdk.skara.bot.BotConfiguration;
+import org.openjdk.skara.bots.notify.*;
+import org.openjdk.skara.json.JSONObject;
 
 import java.net.URI;
-import java.util.*;
-import java.time.*;
-import java.time.format.*;
 
-public class HostedCommit extends Commit {
-    private final URI url;
-    private final URI webUrl;
-
-    public HostedCommit(CommitMetadata metadata, List<Diff> parentDiffs, URI url) {
-        this(metadata, parentDiffs, url, url);
-    }
-    public HostedCommit(CommitMetadata metadata, List<Diff> parentDiffs, URI url, URI webUrl) {
-        super(metadata, parentDiffs);
-        this.url = url;
-        this.webUrl = webUrl;
-    }
-
-    public URI url() {
-        return url;
-    }
-
-    public URI webUrl() {
-        return webUrl;
+public class CommitNoteNotifierFactory implements NotifierFactory {
+    @Override
+    public String name() {
+        return "notes";
     }
 
     @Override
-    public String toString() {
-        return url.toString();
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(url);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (!(o instanceof HostedCommit)) {
-            return false;
-        }
-
-        var other = (HostedCommit) o;
-        return Objects.equals(url, other.url);
+    public Notifier create(BotConfiguration botConfiguration, JSONObject notifierConfiguration) {
+        var issueProject = botConfiguration.issueProject(notifierConfiguration.get("project").asString());
+        return new CommitNoteNotifier(issueProject);
     }
 }

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/NotifyBotFactoryTest.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/NotifyBotFactoryTest.java
@@ -94,6 +94,9 @@ class NotifyBotFactoryTest {
                             "project": "test_bugs/TEST"
                           },
                           "prbranch": {
+                          },
+                          "notes": {
+                            "project": "test_bugs/TEST"
                           }
                         },
                         "repo2": {
@@ -119,6 +122,9 @@ class NotifyBotFactoryTest {
                             "project": "test_bugs/TEST"
                           },
                           "prbranch": {
+                          },
+                          "notes": {
+                            "project": "test_bugs/TEST"
                           }
                         }
                       }

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/notes/CommitNoteNotiferTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/notes/CommitNoteNotiferTests.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.notify.notes;
+
+import org.junit.jupiter.api.*;
+import org.openjdk.skara.bots.notify.NotifyBot;
+import org.openjdk.skara.json.JSON;
+import org.openjdk.skara.test.*;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.openjdk.skara.bots.notify.TestUtils.*;
+
+public class CommitNoteNotiferTests {
+    @Test
+    void testCommitNote(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var repo = credentials.getHostedRepository();
+            var repoFolder = tempFolder.path().resolve("repo");
+            var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
+            credentials.commitLock(localRepo);
+            localRepo.pushAll(repo.authenticatedUrl());
+
+            var tagStorage = createTagStorage(repo);
+            var branchStorage = createBranchStorage(repo);
+            var prStateStorage = createPullRequestStateStorage(repo);
+            var storageFolder = tempFolder.path().resolve("storage");
+
+            var issueProject = credentials.getIssueProject();
+            var notifyBot = NotifyBot.newBuilder()
+                                     .repository(repo)
+                                     .storagePath(storageFolder)
+                                     .branches(Pattern.compile("master"))
+                                     .tagStorageBuilder(tagStorage)
+                                     .branchStorageBuilder(branchStorage)
+                                     .prStateStorageBuilder(prStateStorage)
+                                     .integratorId(repo.forge().currentUser().id())
+                                     .build();
+            // Register a RepositoryListener to make history initialize on the first run
+            notifyBot.registerRepositoryListener(new NullRepositoryListener());
+            var notifier = new CommitNoteNotifier(issueProject);
+            notifier.attachTo(notifyBot);
+
+            // Initialize history
+            TestBotRunner.runPeriodicItems(notifyBot);
+
+            // Save the state
+            var historyState = localRepo.fetch(repo.authenticatedUrl(), "history");
+
+            // "Fake" an integrated pull request
+            var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", "Fix an issue");
+            localRepo.push(editHash, repo.authenticatedUrl(), "master");
+            var pr = credentials.createPullRequest(repo, "master", "master", "Fix an issue");
+            pr.setBody("I made a fix");
+            pr.addLabel("integrated");
+            pr.addComment("More text!\n\n@user Pushed as commit " + editHash.hex() + ". Even more text.\n\nAnd some additional text.");
+            TestBotRunner.runPeriodicItems(notifyBot);
+
+            // Check commit note
+            var remoteCommit = repo.commit(editHash).orElseThrow();
+            localRepo.fetch(repo.authenticatedUrl(), "refs/notes/*:refs/notes/*");
+            var note = localRepo.notes(editHash);
+            assertEquals(List.of("Commit: " + remoteCommit.webUrl(),
+                                 "Review: " + pr.webUrl()),
+                         note);
+        }
+    }
+
+    @Test
+    void testCommitNoteWithIssues(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var repo = credentials.getHostedRepository();
+            var repoFolder = tempFolder.path().resolve("repo");
+            var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType());
+            credentials.commitLock(localRepo);
+            localRepo.pushAll(repo.authenticatedUrl());
+
+            var tagStorage = createTagStorage(repo);
+            var branchStorage = createBranchStorage(repo);
+            var prStateStorage = createPullRequestStateStorage(repo);
+            var storageFolder = tempFolder.path().resolve("storage");
+
+            var issueProject = credentials.getIssueProject();
+            var issue = issueProject.createIssue("A title",
+                                                 List.of("A description"),
+                                                 Map.of("issuetype", JSON.of("Enhancement")));
+            var commitMessageTitle = issue.id() + ": A title";
+            var editHash = CheckableRepository.appendAndCommit(localRepo, "Change", commitMessageTitle);
+
+            var notifyBot = NotifyBot.newBuilder()
+                                     .repository(repo)
+                                     .storagePath(storageFolder)
+                                     .branches(Pattern.compile("master"))
+                                     .tagStorageBuilder(tagStorage)
+                                     .branchStorageBuilder(branchStorage)
+                                     .prStateStorageBuilder(prStateStorage)
+                                     .integratorId(repo.forge().currentUser().id())
+                                     .build();
+            // Register a RepositoryListener to make history initialize on the first run
+            notifyBot.registerRepositoryListener(new NullRepositoryListener());
+            var notifier = new CommitNoteNotifier(issueProject);
+            notifier.attachTo(notifyBot);
+
+            // Initialize history
+            TestBotRunner.runPeriodicItems(notifyBot);
+
+            // Save the state
+            var historyState = localRepo.fetch(repo.authenticatedUrl(), "history");
+
+            // "Fake" a fix
+            localRepo.push(editHash, repo.authenticatedUrl(), "master");
+            var pr = credentials.createPullRequest(repo, "master", "master", commitMessageTitle);
+            pr.setBody("\n\n### Issue\n * [" + issue.id() + "](https://openjdk.org): The issue");
+            pr.addLabel("integrated");
+            pr.addComment("Pushed as commit " + editHash.hex() + ".");
+            TestBotRunner.runPeriodicItems(notifyBot);
+
+            // Check commit note
+            var remoteCommit = repo.commit(editHash).orElseThrow();
+            localRepo.fetch(repo.authenticatedUrl(), "refs/notes/*:refs/notes/*");
+            var note = localRepo.notes(editHash);
+            assertEquals(List.of("Commit: " + remoteCommit.webUrl(),
+                                 "Review: " + pr.webUrl(),
+                                 "Issues:",
+                                 "- " + issue.webUrl()),
+                         note);
+        }
+    }
+}

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -582,7 +582,9 @@ public class GitHubRepository implements HostedRepository {
         } else {
             diffs = List.of();
         }
-        return Optional.of(new HostedCommit(metadata, diffs, URI.create(o.get("html_url").asString())));
+        var url = URI.create(o.get("html_url").asString());
+        var webUrl = gitHubHost.getWebURI(url.getPath());
+        return Optional.of(new HostedCommit(metadata, diffs, url, webUrl));
     }
 
     @Override


### PR DESCRIPTION
Hi all,

please review this patch that adds a new notifier that records the link to a commit, the link to the review and ev. links to issues in a [git note](https://git-scm.com/docs/git-notes). This will make it possible to view this information using e.g. `git log` or `git show` _without_ having these URLs in the commit message itself. Git notes are also modifiable (they are just blobs referred to by a ref), so they can be updated if ever change the scheme or domain for these links.

I also added two unit tests for testing the new notifier.

Thanks,
Erik

/depends 1607

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2164](https://bugs.openjdk.org/browse/SKARA-2164): Add git notes notifier (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1608/head:pull/1608` \
`$ git checkout pull/1608`

Update a local copy of the PR: \
`$ git checkout pull/1608` \
`$ git pull https://git.openjdk.org/skara.git pull/1608/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1608`

View PR using the GUI difftool: \
`$ git pr show -t 1608`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1608.diff">https://git.openjdk.org/skara/pull/1608.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1608#issuecomment-1914829371)