### PR TITLE
2160: Update GHA versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: Determine target project name (fork source)
         id: upstream_repo
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           result-encoding: string
           script: "return (await github.rest.repos.get( {owner: context.repo.owner, repo: context.repo.repo })).data.source.name"


### PR DESCRIPTION
This patch is trying to update the GHA versions, only `actions/checkout` and `actions/github-script` are used in GitHub Actions for skara. As `actions/checkout` is already the latest version, I only bumped the version of `actions/github-script`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2160](https://bugs.openjdk.org/browse/SKARA-2160): Update GHA versions (**Enhancement** - P4)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1609/head:pull/1609` \
`$ git checkout pull/1609`

Update a local copy of the PR: \
`$ git checkout pull/1609` \
`$ git pull https://git.openjdk.org/skara.git pull/1609/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1609`

View PR using the GUI difftool: \
`$ git pr show -t 1609`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1609.diff">https://git.openjdk.org/skara/pull/1609.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1609#issuecomment-1915802516)