### PR TITLE
Draft: SKARA-2172: Deduplicate code in BackportTests

### DIFF
--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportTests.java
@@ -1031,7 +1031,7 @@ class BackportTests {
     void whitespaceAtEnd(TestInfo testInfo) throws IOException {
         try(var credentials = new HostCredentials(testInfo)) {
             String testString = "Backport %s ";
-            setupAndTest(testString, credentials);        
+            setupAndTest(testString, credentials);  
         }
     }
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportTests.java
@@ -1031,7 +1031,7 @@ class BackportTests {
     void whitespaceAtEnd(TestInfo testInfo) throws IOException {
         try(var credentials = new HostCredentials(testInfo)) {
             String testString = "Backport %s ";
-            setupAndTest(testString, credentials);  
+            setupAndTest(testString, credentials);
         }
     }
 


### PR DESCRIPTION
Refactored tests in BackportTests.java by moving repeated code in to a function that gets called by the tests. All the modified test work the same way they did before.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1612/head:pull/1612` \
`$ git checkout pull/1612`

Update a local copy of the PR: \
`$ git checkout pull/1612` \
`$ git pull https://git.openjdk.org/skara.git pull/1612/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1612`

View PR using the GUI difftool: \
`$ git pr show -t 1612`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1612.diff">https://git.openjdk.org/skara/pull/1612.diff</a>

</details>
