### PR TITLE
2176

### DIFF
--- a/bots/forward/src/main/java/org/openjdk/skara/bots/forward/ForwardBot.java
+++ b/bots/forward/src/main/java/org/openjdk/skara/bots/forward/ForwardBot.java
@@ -84,7 +84,7 @@ class ForwardBot implements Bot, WorkItem {
                      " to " + toBranch.name());
             var fetchHead = toLocalRepo.fetch(fromHostedRepo.authenticatedUrl(),
                                               fromBranch.name() + ":" + toBranch.name(),
-                                              false);
+                                              false).orElseThrow();
             log.info("Pushing " + toBranch.name() + " to " + toHostedRepo.name());
             toLocalRepo.push(fetchHead, toHostedRepo.authenticatedUrl(), toBranch.name(), false);
         } catch (IOException e) {

--- a/bots/hgbridge/src/test/java/org/openjdk/skara/bots/hgbridge/BridgeBotTests.java
+++ b/bots/hgbridge/src/test/java/org/openjdk/skara/bots/hgbridge/BridgeBotTests.java
@@ -166,7 +166,7 @@ class BridgeBotTests {
              var marksFolder = new TemporaryDirectory()) {
             // Export a partial version of a hg repository
             var localHgRepo = Repository.materialize(hgFolder.path(), source, "default");
-            localHgRepo.fetch(source, "testlock");
+            localHgRepo.fetch(source, "testlock").orElseThrow();
             var destinationRepo = credentials.getHostedRepository();
             var config = new TestExporterConfig(localHgRepo.root().toUri(), destinationRepo, marksFolder.path());
             var bridge = new JBridgeBot(config, storageFolder.path());
@@ -183,7 +183,7 @@ class BridgeBotTests {
             assertFalse(localGitTags.contains("jtreg4.1-b05"));
 
             // Import more revisions into the local hg repository and export again
-            localHgRepo.fetch(source, "default");
+            localHgRepo.fetch(source, "default").orElseThrow();
             TestBotRunner.runPeriodicItems(bridge);
 
             // There should now be more tags present
@@ -383,7 +383,7 @@ class BridgeBotTests {
              var marksFolder = new TemporaryDirectory()) {
             // Export a hg repository with unreachable commits
             var localHgRepo = Repository.materialize(hgFolder.path(), source, "default");
-            localHgRepo.fetch(source, "testlock");
+            localHgRepo.fetch(source, "testlock").orElseThrow();
             var destinationRepo = credentials.getHostedRepository();
             var config = new TestExporterConfig(localHgRepo.root().toUri(), destinationRepo, marksFolder.path());
             var bridge = new JBridgeBot(config, storageFolder.path());
@@ -412,7 +412,7 @@ class BridgeBotTests {
              var marksFolder = new TemporaryDirectory()) {
             // Export a hg repository
             var localHgRepo = Repository.materialize(hgFolder.path(), source, "default");
-            localHgRepo.fetch(source, "testlock");
+            localHgRepo.fetch(source, "testlock").orElseThrow();
             var destinationRepo = credentials.getHostedRepository();
             var config = new TestExporterConfig(localHgRepo.root().toUri(), destinationRepo, marksFolder.path());
             var bridge = new JBridgeBot(config, storageFolder.path());

--- a/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
+++ b/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
@@ -263,7 +263,7 @@ class MergeBot implements Bot, WorkItem {
         // Sync personal fork
         var remoteBranches = repo.remoteBranches(target.authenticatedUrl().toString());
         for (var branch : remoteBranches) {
-            var fetchHead = repo.fetch(target.authenticatedUrl(), branch.hash().hex(), false);
+            var fetchHead = repo.fetch(target.authenticatedUrl(), branch.hash().hex(), false).orElseThrow();
             repo.push(fetchHead, fork.authenticatedUrl(), branch.name());
         }
 
@@ -447,7 +447,7 @@ class MergeBot implements Bot, WorkItem {
 
                 log.info("Trying to merge " + fromRepo.name() + ":" + fromBranch.name() + " to " + toBranch.name());
                 log.info("Fetching " + fromRepo.name() + ":" + fromBranch.name());
-                var fetchHead = repo.fetch(fromRepo.authenticatedUrl(), fromBranch.name(), false);
+                var fetchHead = repo.fetch(fromRepo.authenticatedUrl(), fromBranch.name(), false).orElseThrow();
                 var head = repo.resolve(toBranch.name()).orElseThrow(() ->
                         new IOException("Could not resolve branch " + toBranch.name())
                 );

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveItem.java
@@ -177,8 +177,7 @@ class ArchiveItem {
                 return true;
             }
             if (tryFetch) {
-                localRepo.fetch(pr.repository().authenticatedUrl(), lastHead.hex(), false);
-                return true;
+                return localRepo.fetch(pr.repository().authenticatedUrl(), lastHead.hex(), false).isPresent();
             }
         } catch (IOException e) {
             return false;

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
@@ -97,7 +97,7 @@ class ArchiveWorkItem implements WorkItem {
             } catch (IOException e) {
                 log.info("Push to archive failed: " + e);
                 try {
-                    var remoteHead = localRepo.fetch(bot.archiveRepo().authenticatedUrl(), bot.archiveRef(), false);
+                    var remoteHead = localRepo.fetch(bot.archiveRepo().authenticatedUrl(), bot.archiveRef(), false).orElseThrow();
                     localRepo.rebase(remoteHead, bot.emailAddress().fullName().orElseThrow(), bot.emailAddress().address());
                     hash = localRepo.head();
                     log.info("Rebase successful -  new hash: " + hash);

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/CensusInstance.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/CensusInstance.java
@@ -88,7 +88,7 @@ class CensusInstance {
             var localRepo = Repository.get(repoFolder)
                                       .or(() -> Optional.of(initialize(censusRepo, censusRef, repoFolder)))
                                       .orElseThrow();
-            var hash = localRepo.fetch(censusRepo.authenticatedUrl(), censusRef, false);
+            var hash = localRepo.fetch(censusRepo.authenticatedUrl(), censusRef, false).orElseThrow();
             localRepo.checkout(hash, true);
         } catch (IOException e) {
             initialize(censusRepo, censusRef, repoFolder);

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
@@ -231,7 +231,7 @@ class WebrevStorage {
                         if (retryCount > 5) {
                             throw e;
                         }
-                        var updated = localStorage.fetch(remote, storageRef);
+                        var updated = localStorage.fetch(remote, storageRef).orElseThrow();
                         localStorage.rebase(updated, author.fullName().orElseThrow(), author.address());
                         hash = localStorage.head();
                     }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifier.java
@@ -50,7 +50,7 @@ public class PullRequestBranchNotifier implements Notifier, PullRequestListener 
         var hostedRepositoryPool = new HostedRepositoryPool(seedFolder);
         try {
             var seedRepo = hostedRepositoryPool.seedRepository(pr.repository(), false);
-            seedRepo.fetch(pr.repository().authenticatedUrl(), pr.headHash().hex());
+            seedRepo.fetch(pr.repository().authenticatedUrl(), pr.headHash().hex()).orElseThrow();
             String branch = PreIntegrations.preIntegrateBranch(pr);
             log.info("Creating new pull request pre-integration branch " + branch);
             seedRepo.push(pr.headHash(), pr.repository().authenticatedUrl(), branch, true);

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/comment/CommitCommentNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/comment/CommitCommentNotifierTests.java
@@ -69,7 +69,7 @@ public class CommitCommentNotifierTests {
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // Save the state
-            var historyState = localRepo.fetch(repo.authenticatedUrl(), "history");
+            var historyState = localRepo.fetch(repo.authenticatedUrl(), "history").orElseThrow();
 
             // Commit a fix
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", "Fix an issue");
@@ -138,7 +138,7 @@ public class CommitCommentNotifierTests {
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // Save the state
-            var historyState = localRepo.fetch(repo.authenticatedUrl(), "history");
+            var historyState = localRepo.fetch(repo.authenticatedUrl(), "history").orElseThrow();
 
             // Commit a fix
             localRepo.push(editHash, repo.authenticatedUrl(), "master");
@@ -207,7 +207,7 @@ public class CommitCommentNotifierTests {
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // Save the state
-            var historyState = localRepo.fetch(repo.authenticatedUrl(), "history");
+            var historyState = localRepo.fetch(repo.authenticatedUrl(), "history").orElseThrow();
 
             // Commit a fix
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", "Fix an issue");

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
@@ -127,7 +127,7 @@ public class IssueNotifierTests {
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // Save the state
-            var historyState = localRepo.fetch(repo.authenticatedUrl(), "history");
+            var historyState = localRepo.fetch(repo.authenticatedUrl(), "history").orElseThrow();
 
             // Create an issue and commit a fix
             var issue = issueProject.createIssue("This is an issue", List.of("Indeed"), Map.of("issuetype", JSON.of("Enhancement")));
@@ -764,7 +764,7 @@ public class IssueNotifierTests {
             assertEquals(List.of(issueProject.issueTracker().currentUser()), updatedIssue.assignees());
 
             // Restore the history to simulate looking at another repository
-            localRepo.fetch(repo.authenticatedUrl(), "history");
+            localRepo.fetch(repo.authenticatedUrl(), "history").orElseThrow();
             localRepo.push(blankHistory, repo.authenticatedUrl(), "history", true);
 
             // When the second notifier sees it, it should upgrade the build name
@@ -774,7 +774,7 @@ public class IssueNotifierTests {
             assertEquals("master", updatedIssue.properties().get(RESOLVED_IN_BUILD).asString());
 
             // Restore the history to simulate looking at another repository
-            localRepo.fetch(repo.authenticatedUrl(), "history");
+            localRepo.fetch(repo.authenticatedUrl(), "history").orElseThrow();
             localRepo.push(blankHistory, repo.authenticatedUrl(), "history", true);
 
             // When the third notifier sees it, it should switch to a build number
@@ -784,7 +784,7 @@ public class IssueNotifierTests {
             assertEquals("b04", updatedIssue.properties().get(RESOLVED_IN_BUILD).asString());
 
             // Restore the history to simulate looking at another repository
-            localRepo.fetch(repo.authenticatedUrl(), "history");
+            localRepo.fetch(repo.authenticatedUrl(), "history").orElseThrow();
             localRepo.push(blankHistory, repo.authenticatedUrl(), "history", true);
 
             // When the fourth notifier sees it, it should switch to a lower build number
@@ -794,7 +794,7 @@ public class IssueNotifierTests {
             assertEquals("b02", updatedIssue.properties().get(RESOLVED_IN_BUILD).asString());
 
             // Restore the history to simulate looking at another repository
-            localRepo.fetch(repo.authenticatedUrl(), "history");
+            localRepo.fetch(repo.authenticatedUrl(), "history").orElseThrow();
             localRepo.push(blankHistory, repo.authenticatedUrl(), "history", true);
 
             // When the fifth notifier sees it, it should NOT switch to a higher build number
@@ -1357,7 +1357,7 @@ public class IssueNotifierTests {
             localRepo.push(new Branch(repo.authenticatedUrl().toString()), "--tags", false);
 
             // Claim that it is already processed
-            localRepo.fetch(repo.authenticatedUrl(), "+history:history");
+            localRepo.fetch(repo.authenticatedUrl(), "+history:history").orElseThrow();
             localRepo.checkout(new Branch("history"), true);
             var historyFile = repoFolder.resolve("test.tags.txt");
             var processed = new ArrayList<>(Files.readAllLines(historyFile, StandardCharsets.UTF_8));
@@ -1598,7 +1598,7 @@ public class IssueNotifierTests {
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // Save the state
-            var historyState = localRepo.fetch(repo.authenticatedUrl(), "history");
+            var historyState = localRepo.fetch(repo.authenticatedUrl(), "history").orElseThrow();
 
             // Create an issue and commit a fix
             var issue = issueProject.createIssue("This is an issue", List.of("Indeed"), Map.of("issuetype", JSON.of("Enhancement")));
@@ -1653,7 +1653,7 @@ public class IssueNotifierTests {
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // Save the state
-            var historyState = localRepo.fetch(repo.authenticatedUrl(), "history");
+            var historyState = localRepo.fetch(repo.authenticatedUrl(), "history").orElseThrow();
 
             // Create an issue and commit a fix
             var issue = issueProject.createIssue("This is an issue", List.of("Indeed"), Map.of("issuetype", JSON.of("Enhancement")));
@@ -2203,7 +2203,7 @@ public class IssueNotifierTests {
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // Save the state
-            var historyState = localRepo.fetch(repo.authenticatedUrl(), "history");
+            var historyState = localRepo.fetch(repo.authenticatedUrl(), "history").orElseThrow();
 
             // Create an issue and commit a fix
             var issue = issueProject.createIssue("This is an issue", List.of("Indeed"), Map.of("issuetype", JSON.of("Enhancement")));

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/json/JsonNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/json/JsonNotifierTests.java
@@ -130,7 +130,7 @@ public class JsonNotifierTests {
             assertEquals(1, findJsonFiles(jsonFolder, "").size());
 
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", "23456789: More fixes");
-            localRepo.fetch(repo.authenticatedUrl(), "history:history");
+            localRepo.fetch(repo.authenticatedUrl(), "history:history").orElseThrow();
             localRepo.tag(editHash, "jdk-12+2", "Added tag 2", "Duke", "duke@openjdk.org");
             var editHash2 = CheckableRepository.appendAndCommit(localRepo, "Another line", "34567890: Even more fixes");
             localRepo.tag(editHash2, "jdk-12+4", "Added tag 3", "Duke", "duke@openjdk.org");

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/mailinglist/MailingListNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/mailinglist/MailingListNotifierTests.java
@@ -865,7 +865,7 @@ public class MailingListNotifierTests {
             listServer.processIncoming();
 
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", "23456789: More fixes");
-            localRepo.fetch(repo.authenticatedUrl(), "history:history");
+            localRepo.fetch(repo.authenticatedUrl(), "history:history").orElseThrow();
             localRepo.tag(editHash, "jdk-12+2", "Added tag 2", "Duke Tagger", "tagger@openjdk.org");
             CheckableRepository.appendAndCommit(localRepo, "Another line 1", "34567890: Even more fixes");
             CheckableRepository.appendAndCommit(localRepo, "Another line 2", "45678901: Yet even more fixes");
@@ -988,7 +988,7 @@ public class MailingListNotifierTests {
             listServer.processIncoming();
 
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", "23456789: More fixes");
-            localRepo.fetch(repo.authenticatedUrl(), "history:history");
+            localRepo.fetch(repo.authenticatedUrl(), "history:history").orElseThrow();
             localRepo.tag(editHash, "jdk-12+2", "Added tag 2", "Duke Tagger", "tagger@openjdk.org");
             CheckableRepository.appendAndCommit(localRepo, "Another line 1", "34567890: Even more fixes");
             CheckableRepository.appendAndCommit(localRepo, "Another line 2", "45678901: Yet even more fixes");
@@ -1158,7 +1158,7 @@ public class MailingListNotifierTests {
             listServer.processIncoming();
 
             // Save history state
-            var historyHash = localRepo.fetch(repo.authenticatedUrl(), "history");
+            var historyHash = localRepo.fetch(repo.authenticatedUrl(), "history").orElseThrow();
 
             var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", "23456789: More fixes");
             localRepo.push(editHash, repo.authenticatedUrl(), "master");

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifierTests.java
@@ -80,7 +80,7 @@ public class PullRequestBranchNotifierTests {
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The target repo should now contain the new branch
-            var hash = localRepo.fetch(repo.authenticatedUrl(), PreIntegrations.preIntegrateBranch(pr));
+            var hash = localRepo.fetch(repo.authenticatedUrl(), PreIntegrations.preIntegrateBranch(pr)).orElseThrow();
             assertEquals(editHash, hash);
 
             // Close the PR
@@ -88,14 +88,14 @@ public class PullRequestBranchNotifierTests {
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The target repo should no longer contain the branch
-            assertThrows(IOException.class, () -> localRepo.fetch(repo.authenticatedUrl(), PreIntegrations.preIntegrateBranch(pr)));
+            assertThrows(IOException.class, () -> localRepo.fetch(repo.authenticatedUrl(), PreIntegrations.preIntegrateBranch(pr)).orElseThrow());
 
             // Reopen the PR
             pr.setState(Issue.State.OPEN);
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The branch should have reappeared
-            hash = localRepo.fetch(repo.authenticatedUrl(), PreIntegrations.preIntegrateBranch(pr));
+            hash = localRepo.fetch(repo.authenticatedUrl(), PreIntegrations.preIntegrateBranch(pr)).orElseThrow();
             assertEquals(editHash, hash);
         }
     }
@@ -125,7 +125,7 @@ public class PullRequestBranchNotifierTests {
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The target repo should now contain the new branch
-            var hash = localRepo.fetch(repo.authenticatedUrl(), PreIntegrations.preIntegrateBranch(pr));
+            var hash = localRepo.fetch(repo.authenticatedUrl(), PreIntegrations.preIntegrateBranch(pr)).orElseThrow();
             assertEquals(editHash, hash);
 
             // remove label `rfr`
@@ -136,21 +136,21 @@ public class PullRequestBranchNotifierTests {
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The target repo should no longer contain the branch
-            assertThrows(IOException.class, () -> localRepo.fetch(repo.authenticatedUrl(), PreIntegrations.preIntegrateBranch(pr)));
+            assertThrows(IOException.class, () -> localRepo.fetch(repo.authenticatedUrl(), PreIntegrations.preIntegrateBranch(pr)).orElseThrow());
 
             // Reopen the PR
             pr.setState(Issue.State.OPEN);
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The target repo should not contain the branch, because the pr doesn't have label `rfr`.
-            assertThrows(IOException.class, () -> localRepo.fetch(repo.authenticatedUrl(), PreIntegrations.preIntegrateBranch(pr)));
+            assertThrows(IOException.class, () -> localRepo.fetch(repo.authenticatedUrl(), PreIntegrations.preIntegrateBranch(pr)).orElseThrow());
 
             // add label `rfr`
             pr.addLabel("rfr");
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The branch should have reappeared
-            hash = localRepo.fetch(repo.authenticatedUrl(), PreIntegrations.preIntegrateBranch(pr));
+            hash = localRepo.fetch(repo.authenticatedUrl(), PreIntegrations.preIntegrateBranch(pr)).orElseThrow();
             assertEquals(editHash, hash);
         }
     }
@@ -180,7 +180,7 @@ public class PullRequestBranchNotifierTests {
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The target repo should now contain the new branch
-            var hash = localRepo.fetch(repo.authenticatedUrl(), PreIntegrations.preIntegrateBranch(pr));
+            var hash = localRepo.fetch(repo.authenticatedUrl(), PreIntegrations.preIntegrateBranch(pr)).orElseThrow();
             assertEquals(editHash, hash);
 
             // Push another change
@@ -190,7 +190,7 @@ public class PullRequestBranchNotifierTests {
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The branch should have been updated
-            hash = localRepo.fetch(repo.authenticatedUrl(), PreIntegrations.preIntegrateBranch(pr));
+            hash = localRepo.fetch(repo.authenticatedUrl(), PreIntegrations.preIntegrateBranch(pr)).orElseThrow();
             assertEquals(updatedHash, hash);
         }
     }
@@ -220,7 +220,7 @@ public class PullRequestBranchNotifierTests {
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The target repo should now contain the new branch
-            var hash = localRepo.fetch(repo.authenticatedUrl(), PreIntegrations.preIntegrateBranch(pr));
+            var hash = localRepo.fetch(repo.authenticatedUrl(), PreIntegrations.preIntegrateBranch(pr)).orElseThrow();
             assertEquals(editHash, hash);
             try {
                 localRepo.prune(new Branch(PreIntegrations.preIntegrateBranch(pr)), repo.authenticatedUrl().toString());
@@ -258,7 +258,7 @@ public class PullRequestBranchNotifierTests {
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The target repo should now contain the new branch
-            var hash = localRepo.fetch(repo.authenticatedUrl(), PreIntegrations.preIntegrateBranch(pr));
+            var hash = localRepo.fetch(repo.authenticatedUrl(), PreIntegrations.preIntegrateBranch(pr)).orElseThrow();
             assertEquals(editHash, hash);
 
             // Create follow-up work
@@ -273,7 +273,7 @@ public class PullRequestBranchNotifierTests {
             TestBotRunner.runPeriodicItems(notifyBot);
 
             // The target repo should no longer contain the branch
-            assertThrows(IOException.class, () -> localRepo.fetch(repo.authenticatedUrl(), PreIntegrations.preIntegrateBranch(pr)));
+            assertThrows(IOException.class, () -> localRepo.fetch(repo.authenticatedUrl(), PreIntegrations.preIntegrateBranch(pr)).orElseThrow());
 
             // The follow-up PR should have been retargeted
             assertEquals("master", followUpPr.store().targetRef());
@@ -298,7 +298,7 @@ public class PullRequestBranchNotifierTests {
 
             // The target repo should no longer contain the branch
             var targetBranch = PreIntegrations.preIntegrateBranch(followUpPr);
-            assertThrows(IOException.class, () -> localRepo.fetch(repo.authenticatedUrl(), targetBranch));
+            assertThrows(IOException.class, () -> localRepo.fetch(repo.authenticatedUrl(), targetBranch).orElseThrow());
 
             // The another follow-up PR should have been retargeted
             assertEquals("master", anotherFollowUpPr.store().targetRef());

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
@@ -301,8 +301,8 @@ public class BackportCommand implements CommandHandler {
                 var localRepo = bot.hostedRepositoryPool()
                                    .orElseThrow(() -> new IllegalStateException("Missing repository pool for PR bot"))
                                    .materialize(targetRepo, localRepoDir);
-                var fetchHead = localRepo.fetch(bot.repo().authenticatedUrl(), hash.hex(), false);
-                var head = localRepo.fetch(targetRepo.authenticatedUrl(), targetBranchName, false);
+                var fetchHead = localRepo.fetch(bot.repo().authenticatedUrl(), hash.hex(), false).orElseThrow();
+                var head = localRepo.fetch(targetRepo.authenticatedUrl(), targetBranchName, false).orElseThrow();
                 var backportBranch = localRepo.branch(head, backportBranchName);
                 localRepo.checkout(backportBranch);
                 var didApply = localRepo.cherryPick(fetchHead);

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BranchCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BranchCommand.java
@@ -98,7 +98,7 @@ public class BranchCommand implements CommandHandler {
             var localRepo = bot.hostedRepositoryPool()
                                .orElseThrow(() -> new IllegalStateException("Missing repository pool for PR bot"))
                                .materialize(bot.repo(), localRepoDir);
-            localRepo.fetch(bot.repo().authenticatedUrl(), commit.hash().toString(), true);
+            localRepo.fetch(bot.repo().authenticatedUrl(), commit.hash().toString(), true).orElseThrow();
 
             var remoteBranches = bot.repo().branches();
             var remoteBranchNames = remoteBranches.stream()

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/TagCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/TagCommand.java
@@ -94,7 +94,7 @@ public class TagCommand implements CommandHandler {
             var localRepo = bot.hostedRepositoryPool()
                                .orElseThrow(() -> new IllegalStateException("Missing repository pool for PR bot"))
                                .materialize(bot.repo(), localRepoDir);
-            localRepo.fetch(bot.repo().authenticatedUrl(), commit.hash().toString(), true);
+            localRepo.fetch(bot.repo().authenticatedUrl(), commit.hash().toString(), true).orElseThrow();
 
             var existingTagNames = localRepo.tags().stream().map(Tag::name).collect(Collectors.toSet());
             if (existingTagNames.contains(tagName)) {

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrateTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrateTests.java
@@ -1286,7 +1286,7 @@ class IntegrateTests {
 
             // Add a new commit to master branch
             localRepo.checkout(new Branch("master"));
-            localRepo.fetch(author.authenticatedUrl(), "master");
+            localRepo.fetch(author.authenticatedUrl(), "master").orElseThrow();
             localRepo.merge(new Branch("FETCH_HEAD"));
             var integratedHash = localRepo.resolve("master");
             var newMasterHash = CheckableRepository.appendAndCommit(localRepo, "Another line",

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
@@ -1442,7 +1442,7 @@ class MergeTests {
             var otherHash = CheckableRepository.appendAndCommit(unrelatedRepo, "Change in other",
                                                                 "Other\n\nReviewed-by: integrationreviewer2");
             unrelatedRepo.push(otherHash, author.authenticatedUrl(), "other", true);
-            localRepo.fetch(author.authenticatedUrl(), "other");
+            localRepo.fetch(author.authenticatedUrl(), "other").orElseThrow();
 
             // Go back to the original master
             localRepo.checkout(masterHash, true);

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PreIntegrateTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PreIntegrateTests.java
@@ -117,7 +117,7 @@ public class PreIntegrateTests {
             assertTrue(followUpPr.store().labelNames().contains("ready"));
 
             // Push something else unrelated to the target
-            var currentMaster = localRepo.fetch(author.authenticatedUrl(), "master");
+            var currentMaster = localRepo.fetch(author.authenticatedUrl(), "master").orElseThrow();
             localRepo.checkout(currentMaster, true);
             var unrelatedFile2 = localRepo.root().resolve("unrelated2.txt");
             Files.writeString(unrelatedFile2, "Some other things happens in master");
@@ -135,7 +135,7 @@ public class PreIntegrateTests {
             assertLastCommentContains(followUpPr, "Pushed as commit");
 
             // Check that everything is present
-            var finalMaster = localRepo.fetch(author.authenticatedUrl(), "master");
+            var finalMaster = localRepo.fetch(author.authenticatedUrl(), "master").orElseThrow();
             localRepo.checkout(finalMaster, true);
             assertEquals("Other things happens in master", Files.readString(localRepo.root().resolve("unrelated.txt")));
             assertEquals("Some other things happens in master", Files.readString(localRepo.root().resolve("unrelated2.txt")));

--- a/bots/submit/src/main/java/org/openjdk/skara/bots/submit/SubmitBotWorkItem.java
+++ b/bots/submit/src/main/java/org/openjdk/skara/bots/submit/SubmitBotWorkItem.java
@@ -84,7 +84,7 @@ public class SubmitBotWorkItem implements WorkItem {
         try {
             var localRepo = Repository.materialize(prFolder, pr.repository().authenticatedUrl(),
                                                    "+" + pr.targetRef() + ":submit_" + pr.repository().name());
-            var headHash = localRepo.fetch(pr.repository().authenticatedUrl(), pr.headHash().hex(), false);
+            var headHash = localRepo.fetch(pr.repository().authenticatedUrl(), pr.headHash().hex(), false).orElseThrow();
 
             var checkBuilder = CheckBuilder.create(executor.checkName(), headHash);
             pr.createCheck(checkBuilder.build());

--- a/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestWorkItem.java
+++ b/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestWorkItem.java
@@ -423,7 +423,7 @@ public class TestWorkItem implements WorkItem {
                             return new RuntimeException("Repository in " + localRepoDir + " has vanished");
                     });
                 }
-                fetchHead = localRepo.fetch(repository.authenticatedUrl(), pr.headHash().hex(), false);
+                fetchHead = localRepo.fetch(repository.authenticatedUrl(), pr.headHash().hex(), false).orElseThrow();
                 localRepo.checkout(fetchHead, true);
                 job = ci.submit(localRepoDir, jobs, jobId);
             } catch (IOException e) {

--- a/cli/src/main/java/org/openjdk/skara/cli/GitBackport.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitBackport.java
@@ -173,7 +173,7 @@ public class GitBackport {
 
         System.out.println("Fetching ...");
         System.out.flush();
-        var fetchHead = repo.fetch(fromURI, commit, false);
+        var fetchHead = repo.fetch(fromURI, commit, false).orElseThrow();
 
         System.out.println("Cherry picking ...");
         System.out.flush();

--- a/cli/src/main/java/org/openjdk/skara/cli/GitSync.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitSync.java
@@ -87,7 +87,7 @@ public class GitSync {
         Hash fetchHead = null;
         logVerbose("Fetching branch " + name + " from  " + sourceURI);
         if (!isDryRun) {
-            fetchHead = repo.fetch(sourceURI, name);
+            fetchHead = repo.fetch(sourceURI, name).orElseThrow();
         }
         logVerbose("Pushing to " + targetURI);
         if (!isDryRun) {

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrApply.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrApply.java
@@ -76,7 +76,7 @@ public class GitPrApply {
         var id = pullRequestIdArgument(repo, arguments);
         var pr = getPullRequest(uri, repo, host, id);
 
-        var fetchHead = repo.fetch(pr.repository().webUrl(), pr.fetchRef());
+        var fetchHead = repo.fetch(pr.repository().webUrl(), pr.fetchRef()).orElseThrow();
         var patch = diff(pr.targetRef(), fetchHead);
         apply(patch);
         Files.deleteIfExists(patch);

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrCheckout.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrCheckout.java
@@ -80,7 +80,7 @@ public class GitPrCheckout {
         var id = pullRequestIdArgument(repo, arguments);
         var pr = getPullRequest(uri, repo, host, id);
 
-        var fetchHead = repo.fetch(pr.repository().webUrl(), pr.fetchRef());
+        var fetchHead = repo.fetch(pr.repository().webUrl(), pr.fetchRef()).orElseThrow();
         var branchName = getOption("branch", "checkout", arguments);
         if (branchName != null) {
             var branch = repo.branch(fetchHead, branchName);

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrFetch.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrFetch.java
@@ -75,7 +75,7 @@ public class GitPrFetch {
         var id = pullRequestIdArgument(repo, arguments);
         var pr = getPullRequest(uri, repo, host, id);
 
-        var fetchHead = repo.fetch(pr.repository().webUrl(), pr.fetchRef());
+        var fetchHead = repo.fetch(pr.repository().webUrl(), pr.fetchRef()).orElseThrow();
         System.out.println(fetchHead.hex());
     }
 }

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrInfo.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrInfo.java
@@ -312,8 +312,8 @@ public class GitPrInfo {
 
         if (showAll || showCommits) {
             var url = pr.repository().webUrl();
-            var target = repo.fetch(url, pr.targetRef());
-            var head = repo.fetch(url, pr.fetchRef());
+            var target = repo.fetch(url, pr.targetRef()).orElseThrow();
+            var head = repo.fetch(url, pr.fetchRef()).orElseThrow();
             var mergeBase = repo.mergeBase(head, target);
             var commits = repo.commitMetadata(mergeBase, head);
             if (showDecoration) {

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrIntegrate.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrIntegrate.java
@@ -106,7 +106,7 @@ public class GitPrIntegrate {
             if (!targetHash.isPresent()) {
                 exit("error: cannot resolve target branch " + pr.targetRef());
             }
-            var sourceHash = repo.fetch(pr.repository().webUrl(), pr.fetchRef());
+            var sourceHash = repo.fetch(pr.repository().webUrl(), pr.fetchRef()).orElseThrow();
             var mergeBase = repo.mergeBase(sourceHash, targetHash.get());
             message += " " + mergeBase.hex();
         } else if (isAuto) {

--- a/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrShow.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/pr/GitPrShow.java
@@ -80,7 +80,7 @@ public class GitPrShow {
         var pr = getPullRequest(uri, repo, host, id);
         var useTool = getSwitch("tool", "show", arguments);
 
-        var fetchHead = repo.fetch(pr.repository().url(), pr.fetchRef());
+        var fetchHead = repo.fetch(pr.repository().url(), pr.fetchRef()).orElseThrow();
         show(pr.targetRef(), fetchHead, useTool);
     }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepositoryPool.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepositoryPool.java
@@ -197,7 +197,7 @@ public class HostedRepositoryPool {
         var localClone = hostedRepositoryInstance.materializeClone(path, true, false);
         var remote = allowStale ? hostedRepositoryInstance.seedUri() : hostedRepository.authenticatedUrl();
         log.info("Updating local repository from: " + remote);
-        var refHash = localClone.fetch(remote, "+" + ref + ":hostedrepositorypool", true, true);
+        var refHash = localClone.fetch(remote, "+" + ref + ":hostedrepositorypool", true, true).orElseThrow();
         try {
             localClone.checkout(refHash, true);
         } catch (IOException e) {

--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequestUtils.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequestUtils.java
@@ -51,16 +51,14 @@ public class PullRequestUtils {
     private static Optional<Hash> fetchRef(Repository localRepo, URI uri, String ref) {
         // Just a plain name - is this a branch?
         try {
-            var hash = localRepo.fetch(uri, "+" + ref + ":refs/heads/merge_source", false);
-            return Optional.of(hash);
+            return localRepo.fetch(uri, "+" + ref + ":refs/heads/merge_source", false);
         } catch (IOException e) {
             // Ignored
         }
 
         // Perhaps it is an actual tag object - it cannot be fetched to a branch ref
         try {
-            var hash = localRepo.fetch(uri, "+" + ref + ":refs/tags/merge_source_tag", false);
-            return Optional.of(hash);
+            return localRepo.fetch(uri, "+" + ref + ":refs/tags/merge_source_tag", false);
         } catch (IOException e) {
             // Ignored
         }
@@ -164,7 +162,7 @@ public class PullRequestUtils {
 
     public static Repository materialize(HostedRepositoryPool hostedRepositoryPool, PullRequest pr, Path path) throws IOException {
         var localRepo = hostedRepositoryPool.checkout(pr.repository(), pr.headHash().hex(), path);
-        localRepo.fetch(pr.repository().authenticatedUrl(), "+" + pr.targetRef() + ":prutils_targetref", false);
+        localRepo.fetch(pr.repository().authenticatedUrl(), "+" + pr.targetRef() + ":prutils_targetref", false).orElseThrow();
         return localRepo;
     }
 

--- a/storage/src/main/java/org/openjdk/skara/storage/HostedRepositoryStorage.java
+++ b/storage/src/main/java/org/openjdk/skara/storage/HostedRepositoryStorage.java
@@ -129,7 +129,7 @@ class HostedRepositoryStorage<T> implements Storage<T> {
 
                 // Check if the remote has changed
                 try {
-                    var remoteHash = localRepository.fetch(hostedRepository.authenticatedUrl(), ref);
+                    var remoteHash = localRepository.fetch(hostedRepository.authenticatedUrl(), ref).orElseThrow();
                     if (!remoteHash.equals(lastRemoteHash)) {
                         localRepository.checkout(remoteHash, true);
                         repositoryStorage = new RepositoryStorage<>(localRepository, fileName, authorName, authorEmail, message, serializer, deserializer);

--- a/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
@@ -275,7 +275,7 @@ public class TestPullRequest extends TestIssue implements PullRequest {
             if (!targetLocalRepository.root().equals(sourceLocalRepository.root())) {
                 // The target and source repo are not same, fetch the source branch
                 var sourceUri = URI.create("file://" + sourceLocalRepository.root().toString());
-                sourceHash = targetLocalRepository.fetch(sourceUri, sourceRef);
+                sourceHash = targetLocalRepository.fetch(sourceUri, sourceRef).orElseThrow();
             }
             // Find the base hash of the source and target branches.
             var baseHash = targetLocalRepository.mergeBase(sourceHash, targetRepository.branchHash(targetRef()).orElseThrow());

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
@@ -41,13 +41,13 @@ public interface Repository extends ReadOnlyRepository {
     default void checkout(Branch b) throws IOException {
         checkout(b, false);
     }
-    default Hash fetch(URI uri, String refspec) throws IOException {
+    default Optional<Hash> fetch(URI uri, String refspec) throws IOException {
         return fetch(uri, refspec, true);
     }
-    default Hash fetch(URI uri, String refspec, boolean includeTags) throws IOException {
+    default Optional<Hash> fetch(URI uri, String refspec, boolean includeTags) throws IOException {
         return fetch(uri, refspec, includeTags, false);
     }
-    Hash fetch(URI uri, String refspec, boolean includeTags, boolean forceUpdateTags) throws IOException;
+    Optional<Hash> fetch(URI uri, String refspec, boolean includeTags, boolean forceUpdateTags) throws IOException;
     default void fetchAll(URI uri) throws IOException {
         fetchAll(uri, true);
     }
@@ -282,14 +282,14 @@ public interface Repository extends ReadOnlyRepository {
             }
         }
 
-        var baseHash = localRepo.fetch(remote, ref);
+        var baseHash = localRepo.fetch(remote, ref).orElseThrow();
 
         if (checkout) {
             try {
                 localRepo.checkout(baseHash, true);
             } catch (IOException e) {
                 localRepo.reinitialize();
-                baseHash = localRepo.fetch(remote, ref);
+                baseHash = localRepo.fetch(remote, ref).orElseThrow();
                 localRepo.checkout(baseHash, true);
             }
         }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -487,7 +487,7 @@ public class GitRepository implements Repository {
     }
 
     @Override
-    public Hash fetch(URI uri, String refspec, boolean includeTags, boolean forceUpdateTags) throws IOException {
+    public Optional<Hash> fetch(URI uri, String refspec, boolean includeTags, boolean forceUpdateTags) throws IOException {
         var cmd = new ArrayList<String>();
         cmd.addAll(List.of("git", "fetch", "--recurse-submodules=on-demand"));
         if (includeTags) {
@@ -502,7 +502,7 @@ public class GitRepository implements Repository {
         cmd.add(refspec);
         try (var p = capture(cmd)) {
             await(p);
-            return resolve("FETCH_HEAD").orElseThrow();
+            return resolve("FETCH_HEAD");
         }
     }
 

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -462,7 +462,7 @@ public class HgRepository implements Repository {
     }
 
     @Override
-    public Hash fetch(URI uri, String refspec, boolean includeTags, boolean forceUpdateTags) throws IOException {
+    public Optional<Hash> fetch(URI uri, String refspec, boolean includeTags, boolean forceUpdateTags) throws IOException {
         // Ignore includeTags and forceUpdateTags, Mercurial always fetches tags
         return fetch(uri != null ? uri.toString() : null, refspec);
     }
@@ -479,7 +479,7 @@ public class HgRepository implements Repository {
         }
     }
 
-    private Hash fetch(String from, String refspec) throws IOException {
+    private Optional<Hash> fetch(String from, String refspec) throws IOException {
         var oldHeads = new HashSet<>(heads());
 
         var cmd = new ArrayList<String>();
@@ -503,9 +503,9 @@ public class HgRepository implements Repository {
             throw new IllegalStateException("fetching multiple heads is not supported");
         } else if (newHeads.size() == 0) {
             // no new head was fetched, return current head
-            return head();
+            return Optional.of(head());
         }
-        return newHeads.iterator().next();
+        return Optional.of(newHeads.iterator().next());
     }
 
     @Override

--- a/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
@@ -731,7 +731,7 @@ public class RepositoryTests {
             r1.tag(hash, "tag", "tagging", "duke", "duke@openjdk.org");
 
             var r2 = TestableRepository.init(dir2.path(), vcs);
-            r2.fetch(r1.root().toUri(), r1.defaultBranch().name());
+            r2.fetch(r1.root().toUri(), r1.defaultBranch().name()).orElseThrow();
 
             assertTrue(r2.isHealthy());
         }
@@ -814,7 +814,7 @@ public class RepositoryTests {
                  // note: forcing unix path separators for URI
                 var upstreamURI = URI.create("file:///" + dir.toString().replace('\\', '/'));
 
-                var fetchHead = downstream.fetch(upstreamURI, downstream.defaultBranch().name());
+                var fetchHead = downstream.fetch(upstreamURI, downstream.defaultBranch().name()).orElseThrow();
                 downstream.checkout(fetchHead, false);
 
                 var downstreamReadme = dir2.path().resolve("README");
@@ -859,7 +859,7 @@ public class RepositoryTests {
                 // note: forcing unix path separators for URI
                 var upstreamURI = URI.create("file:///" + dir.toString().replace('\\', '/'));
 
-                downstream.fetch(upstreamURI, downstream.defaultBranch().name());
+                downstream.fetch(upstreamURI, downstream.defaultBranch().name()).orElseThrow();
                 var tagHash = downstream.resolve(firstTag).orElseThrow();
                 downstream.checkout(tagHash, false);
 
@@ -869,7 +869,7 @@ public class RepositoryTests {
                 var secondTag = upstream.tag(secondHash, "my-tag", "Second tag message","duke",
                         "duke@openjdk.org", null, true);
 
-                downstream.fetch(upstreamURI, downstream.defaultBranch().name(), true, true);
+                downstream.fetch(upstreamURI, downstream.defaultBranch().name(), true, true).orElseThrow();
                 tagHash = downstream.resolve(secondTag).orElseThrow();
                 downstream.checkout(tagHash, false);
                 assertEquals(secondHash, tagHash, "Tag not updated to second hash");
@@ -2970,7 +2970,7 @@ public class RepositoryTests {
                  // note: forcing unix path separators for URI
                 var upstreamURI = URI.create("file:///" + dir.toString().replace('\\', '/'));
 
-                var fetchHead = downstream.fetch(upstreamURI, downstream.defaultBranch().name());
+                var fetchHead = downstream.fetch(upstreamURI, downstream.defaultBranch().name()).orElseThrow();
                 downstream.checkout(fetchHead, false);
 
                 var downstreamReadme = dir2.path().resolve("README");


### PR DESCRIPTION
Hi all,

please review this patch that makes `Repository.fetch` return an `Optional<Hash>` instead of just a `Hash` (since a `fetch` operation might now always fetch a commit, for example if code is trying to fetch a ref that does not exist in the remote repo). A fairly large diff, but I just moved the `.orElseThrow` one frame up in the call chain, so now the caller decides whether it should do `.orElseThrow` (instread of the callee, in this case `fetch`).

Thanks,
Erik