### PR TITLE
2182: Throw UncheckedRestException on empty GET responses

### DIFF
--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
@@ -227,7 +227,8 @@ public class BotRunner {
                     if (e.getCause() instanceof UncheckedRestException) {
                         // Log as WARNING to avoid triggering alarms. Failed REST calls are tracked
                         // using metrics.
-                        log.log(Level.WARNING, "RestException during item execution (" + item + ")", e.getCause());
+                        log.log(Level.WARNING, "RestException during item execution (" + item + ")"
+                                + e.getCause().getMessage(), e.getCause());
                     } else {
                         log.log(Level.SEVERE, "Exception during item execution (" + item + "): " + e.getMessage(), e);
                     }
@@ -472,7 +473,7 @@ public class BotRunner {
                     } catch (UncheckedRestException e) {
                         // Log as WARNING to avoid triggering alarms. Failed REST calls are tracked
                         // using metrics.
-                        log.log(Level.WARNING, "RestException during periodic items checking", e);
+                        log.log(Level.WARNING, "RestException during periodic items checking: " + e.getMessage(), e);
                     } catch (RuntimeException e) {
                         log.log(Level.SEVERE, "Exception during periodic items checking: " + e.getMessage(), e);
                     } finally {

--- a/network/src/main/java/org/openjdk/skara/network/RestRequest.java
+++ b/network/src/main/java/org/openjdk/skara/network/RestRequest.java
@@ -502,7 +502,9 @@ public class RestRequest {
         }
 
         if (queryBuilder.failOnEmptyResponse && response.body().isBlank()) {
-            throw new UncheckedRestException("Empty response body", response.statusCode(), request.build());
+            throw new UncheckedRestException("Empty response body, Location: "
+                    + response.headers().firstValue("Location").orElse(""),
+                    response.statusCode(), request.build());
         }
 
         var nextRequest = nextLinkExtractor.getNextLinkRequest(response);

--- a/network/src/main/java/org/openjdk/skara/network/RestRequest.java
+++ b/network/src/main/java/org/openjdk/skara/network/RestRequest.java
@@ -502,8 +502,8 @@ public class RestRequest {
         }
 
         if (queryBuilder.failOnEmptyResponse && response.body().isBlank()) {
-            throw new UncheckedRestException("Empty response body, Location: "
-                    + response.headers().firstValue("Location").orElse(""),
+            throw new UncheckedRestException("Empty response body"
+                    + response.headers().firstValue("Location").map(s -> ", redirect: " + s).orElse(""),
                     response.statusCode(), request.build());
         }
 

--- a/network/src/main/java/org/openjdk/skara/network/UncheckedRestException.java
+++ b/network/src/main/java/org/openjdk/skara/network/UncheckedRestException.java
@@ -38,6 +38,10 @@ public class UncheckedRestException extends RuntimeException {
         this("Request returned bad status", null, statusCode, request);
     }
 
+    public UncheckedRestException(String message, int statusCode, HttpRequest request) {
+        this(message, null, statusCode, request);
+    }
+
     public UncheckedRestException(String message, Throwable cause, int statusCode, HttpRequest request) {
         super("[" + statusCode + "] " + message, cause);
         this.statusCode = statusCode;


### PR DESCRIPTION
A very common type of SEVERE logging message, which we get notifications for as admins, is this:

Exception during periodic items checking: Cannot invoke "org.openjdk.skara.json.JSONArray.stream()" because the return value of "org.openjdk.skara.json.JSONValue.asArray()" is null

There are some other kinds of instances where the NPE isn't providing any information, but that are likely caused by the same thing. From what I can tell, what's happening is that a REST GET call (typically to GitHub) returns an empty string in the response body. Our JSON parser translates this to a JSONNull and we subsequently try to treat it as a JSONArray and get the NPE when trying to call `stream()` on it. This typically happens a few times per day across all the bots. Ultimately I think this is a bug with GitHub, but we need to deal with it in a better way.

My proposed solution is to add an option to RestRequest, `failOnEmptyResponse`, that defaults to true for GET requests but otherwise false. If set and the response body is empty, an UncheckedRestException is thrown. This exception is already handled as just a warning and we are collecting metrics for it to sound alarms if we get a lot of them.

Investigation and experimentation with this patch in our staging environment showed that these are (at least primarily) a mix of 302 and 304 responses. The 302 from JBS with a redirect to a maintenance page and 304 from GitHub for an unknown reason. We could have tried to handle every response code, or made >=300 errors, but for now I think the current approach is more straightforward and more likely to catch the problems we are specifically seeing. We are still logging the response codes so if we see other patterns in the future, we can adapt.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2182](https://bugs.openjdk.org/browse/SKARA-2182): Throw UncheckedRestException on empty GET responses (**Bug** - P3)


### Reviewers
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1614/head:pull/1614` \
`$ git checkout pull/1614`

Update a local copy of the PR: \
`$ git checkout pull/1614` \
`$ git pull https://git.openjdk.org/skara.git pull/1614/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1614`

View PR using the GUI difftool: \
`$ git pr show -t 1614`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1614.diff">https://git.openjdk.org/skara/pull/1614.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1614#issuecomment-1962048482)