### PR TITLE
2168: Don't preserve invalid local clone

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepositoryPool.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepositoryPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@ import java.net.URI;
 import java.nio.file.*;
 import java.time.*;
 import java.util.*;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class HostedRepositoryPool {
@@ -130,17 +129,8 @@ public class HostedRepositoryPool {
 
         private void removeOldClone(Path path, String reason) {
             if (Files.exists(path)) {
-                var preserved = path.resolveSibling(path.getFileName().toString() + "-" + reason + "-" + UUID.randomUUID());
-                log.severe("Invalid local repository detected (" + reason + ") - preserved in: " + preserved);
-                try {
-                    Files.move(path, preserved);
-                } catch (IOException e) {
-                    log.log(Level.SEVERE, "Failed to preserve old clone at " + path, e);
-                } finally {
-                    if (Files.exists(path)) {
-                        clearDirectory(path);
-                    }
-                }
+                log.severe("Invalid local repository " + path + " detected (" + reason + ")");
+                clearDirectory(path);
             }
         }
 


### PR DESCRIPTION
When skara bot is running, it frequently clones a lot of repos to the local machine and sometimes, the clone would be invalid due to various reasons.

Currently, if the skara bot found an invalid local clone, it will preserve the invalid clone by renaming it. ErikJ said the original authors might want to do some investigations on the invalid clones, so they chose to preserve the invalid clone.

But now, we rarely investigate the clones. And as time goes by, the local machine running skara will have more and more invalid clones and the disk usage will be very high. And skara admin will need to clean the invalid repos periodically.

To fix this issue, we should just clear the invalid repo in HostedRepositoryPool#removeOldClone.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2168](https://bugs.openjdk.org/browse/SKARA-2168): Don't preserve invalid local clone (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1615/head:pull/1615` \
`$ git checkout pull/1615`

Update a local copy of the PR: \
`$ git checkout pull/1615` \
`$ git pull https://git.openjdk.org/skara.git pull/1615/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1615`

View PR using the GUI difftool: \
`$ git pr show -t 1615`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1615.diff">https://git.openjdk.org/skara/pull/1615.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1615#issuecomment-1965509140)