### PR TITLE
2189: Mark command as handled when JCheckConfiguration is missing or invalid in PullRequestCommandWorkItem

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
@@ -224,7 +224,7 @@ public class PullRequestCommandWorkItem extends PullRequestWorkItem {
                 log.severe(bot.confOverrideName() + " on " + bot.confOverrideRef() +
                         " is missing or invalid in repo " + bot.confOverrideRepository().get().name());
                 printer.println("The JCheck configuration has been overridden, " +
-                        "but it's missing or invalid. Skara admin has been noticed and will fix it as soon as possible.");
+                        "but is missing or invalid. Skara admins have been notified.");
             }
             printer.print("Please issue this command again once the problem has been resolved.");
             pr.addComment(writer.toString());

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
@@ -206,6 +206,13 @@ public class PullRequestCommandWorkItem extends PullRequestWorkItem {
             census = CensusInstance.createCensusInstance(hostedRepositoryPool, bot.censusRepo(), bot.censusRef(), scratchArea.getCensus(), pr,
                     bot.confOverrideRepository().orElse(null), bot.confOverrideName(), bot.confOverrideRef());
         } catch (InvalidJCheckConfException | MissingJCheckConfException e) {
+            String errorMessage;
+            if (e instanceof InvalidJCheckConfException) {
+                errorMessage = "invalid";
+            } else {
+                errorMessage = "missing";
+            }
+
             var writer = new StringWriter();
             var printer = new PrintWriter(writer);
 
@@ -216,17 +223,17 @@ public class PullRequestCommandWorkItem extends PullRequestWorkItem {
             if (bot.confOverrideRepository().isEmpty()) {
                 var branchNames = pr.repository().branches().stream().map(HostedBranch::name).toList();
                 if (branchNames.contains(pr.targetRef())) {
-                    printer.println("JCheck configuration is missing or invalid in the target branch of this pull request.");
+                    printer.print("JCheck configuration is " + errorMessage + " in the target branch of this pull request.");
                 } else {
-                    printer.println("The target branch of this pull request no longer exists. Please retarget this pull request.");
+                    printer.print("The target branch of this pull request no longer exists. Please retarget this pull request.");
                 }
             } else {
                 log.severe(bot.confOverrideName() + " on " + bot.confOverrideRef() +
-                        " is missing or invalid in repo " + bot.confOverrideRepository().get().name());
-                printer.println("The JCheck configuration has been overridden, " +
-                        "but is missing or invalid. Skara admins have been notified.");
+                        " is " + errorMessage + " in repo " + bot.confOverrideRepository().get().name());
+                printer.print("The JCheck configuration has been overridden, " +
+                        "but is " + errorMessage + ". Skara admins have been notified.");
             }
-            printer.print("Please issue this command again once the problem has been resolved.");
+            printer.print(" Please issue this command again once the problem has been resolved.");
             pr.addComment(writer.toString());
             return List.of();
         }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -2377,6 +2377,25 @@ class CheckTests {
             TestBotRunner.runPeriodicItems(checkBot);
             assertEquals(1, pr.store().comments().size());
 
+            var reviewerPr = reviewer.pullRequest(pr.id());
+            // Close the pr so we can skip CheckWorkItem
+            pr.setState(Issue.State.CLOSED);
+            reviewerPr.addComment("/reviewers 2");
+            TestBotRunner.runPeriodicItems(checkBot);
+            assertEquals("<!-- Jmerge command reply message (1) -->\n" +
+                    "@user2 JCheck configuration is missing or invalid in the target branch of this pull request.\n" +
+                    "Please issue this command again once the problem has been resolved.", pr.store().comments().get(2).body());
+
+            pr.setTargetRef("notExist");
+            reviewerPr.addComment("/reviewers 2");
+            TestBotRunner.runPeriodicItems(checkBot);
+            assertEquals("<!-- Jmerge command reply message (3) -->\n" +
+                    "@user2 The target branch of this pull request no longer exists. Please retarget this pull request.\n" +
+                    "Please issue this command again once the problem has been resolved.", pr.store().comments().get(4).body());
+
+            pr.setTargetRef("master");
+            pr.setState(Issue.State.OPEN);
+
             // Restore .jcheck/conf
             localRepo.checkout(masterHash);
             Files.createDirectories(tempFolder.path().resolve(".jcheck"));
@@ -2404,10 +2423,13 @@ class CheckTests {
         try (var credentials = new HostCredentials(testInfo);
              var tempFolder = new TemporaryDirectory()) {
             var author = credentials.getHostedRepository();
+            var reviewer = credentials.getHostedRepository();
             var conf = credentials.getHostedRepository();
 
             var censusBuilder = credentials.getCensusBuilder()
-                    .addAuthor(author.forge().currentUser().id());
+                    .addAuthor(author.forge().currentUser().id())
+                    .addReviewer(reviewer.forge().currentUser().id());
+
             var checkBot = PullRequestBot.newBuilder()
                     .repo(author)
                     .censusRepo(censusBuilder.build())
@@ -2442,6 +2464,16 @@ class CheckTests {
             TestBotRunner.runPeriodicItems(checkBot);
             TestBotRunner.runPeriodicItems(checkBot);
             assertEquals(1, pr.store().comments().size());
+
+            var reviewerPr = reviewer.pullRequest(pr.id());
+            // Close the pr so we can skip CheckWorkItem
+            pr.setState(Issue.State.CLOSED);
+            reviewerPr.addComment("/reviewers 2");
+            TestBotRunner.runPeriodicItems(checkBot);
+            assertEquals("<!-- Jmerge command reply message (1) -->\n" +
+                    "@user2 The JCheck configuration has been overridden, but it's missing or invalid. Skara admin has been noticed and will fix it as soon as possible.\n" +
+                    "Please issue this command again once the problem has been resolved.", pr.store().comments().get(2).body());
+            pr.setState(Issue.State.OPEN);
 
             // Upload .jcheck/conf to jcheck-branch
             var jCheckBranch = localRepo.branch(masterHash, "jcheck-branch");

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -2383,14 +2383,15 @@ class CheckTests {
             reviewerPr.addComment("/reviewers 2");
             TestBotRunner.runPeriodicItems(checkBot);
             assertEquals("<!-- Jmerge command reply message (1) -->\n" +
-                    "@user2 JCheck configuration is missing or invalid in the target branch of this pull request.\n" +
+                    "@user2 JCheck configuration is invalid in the target branch of this pull request. " +
                     "Please issue this command again once the problem has been resolved.", pr.store().comments().get(2).body());
 
             pr.setTargetRef("notExist");
             reviewerPr.addComment("/reviewers 2");
             TestBotRunner.runPeriodicItems(checkBot);
             assertEquals("<!-- Jmerge command reply message (3) -->\n" +
-                    "@user2 The target branch of this pull request no longer exists. Please retarget this pull request.\n" +
+                    "@user2 The target branch of this pull request no longer exists. " +
+                    "Please retarget this pull request. " +
                     "Please issue this command again once the problem has been resolved.", pr.store().comments().get(4).body());
 
             pr.setTargetRef("master");
@@ -2471,7 +2472,7 @@ class CheckTests {
             reviewerPr.addComment("/reviewers 2");
             TestBotRunner.runPeriodicItems(checkBot);
             assertEquals("<!-- Jmerge command reply message (1) -->\n" +
-                    "@user2 The JCheck configuration has been overridden, but it's missing or invalid. Skara admin has been noticed and will fix it as soon as possible.\n" +
+                    "@user2 The JCheck configuration has been overridden, but is missing. Skara admins have been notified. " +
                     "Please issue this command again once the problem has been resolved.", pr.store().comments().get(2).body());
             pr.setState(Issue.State.OPEN);
 


### PR DESCRIPTION
Recently, we found that the skara bot keeps trying to process /open command in this pr https://github.com/openjdk/jdk8u-dev/pull/393

After investigation, we found that this pr is a dependent pr and this pr was closed before the parent pr(https://github.com/openjdk/jdk8u-dev/pull/392) got integrated, so this dependent pr didn't get retargeted.

Skara bot was trying to process the command but the bot couldn't find jcheck configuration in the target branch because the target is already deleted. And when the jcheck configuration is invalid or missing in PullRequestCommandWorkItem, RuntimeException would be thrown, causing the bot to repeatedly process the command. This behavior is wrong because when jcheck configuration is missing or invalid, it wouldn't recover automatically. In this case, the bot should just notice the user what problem it found and mark the command as handled to prevent the bot from being stuck in a loop.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2189](https://bugs.openjdk.org/browse/SKARA-2189): Mark command as handled when JCheckConfiguration is missing or invalid in PullRequestCommandWorkItem (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1616/head:pull/1616` \
`$ git checkout pull/1616`

Update a local copy of the PR: \
`$ git checkout pull/1616` \
`$ git pull https://git.openjdk.org/skara.git pull/1616/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1616`

View PR using the GUI difftool: \
`$ git pr show -t 1616`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1616.diff">https://git.openjdk.org/skara/pull/1616.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1616#issuecomment-1974074771)