### PR TITLE
2190: Setting maximum size limit for PR diff in generating Webrev

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
@@ -40,6 +40,7 @@ import static org.openjdk.skara.bots.common.PatternEnum.COMMENT_PATTERN;
 
 class ArchiveMessages {
 
+    private static final String WEBREV_UNAVAILABLE_COMMENT = "Webrev is not available because diff is too large";
     private static String filterCommentsAndCommands(String body) {
         var parsedBody = PullRequestBody.parse(body);
         body = parsedBody.bodyText();
@@ -326,7 +327,7 @@ class ArchiveMessages {
                 formatCommitMessagesBrief(commits, commitsLink).orElse("") + "\n\n" +
                 "Changes: " + pr.changeUrl() + "\n" +
                 (webrev.diffTooLarge() ?
-                        "  Webrev: Webrev is not available because diff is too large\n" :
+                        "  Webrev: " + WEBREV_UNAVAILABLE_COMMENT + "\n" :
                         (webrev.uri() == null ? "" : "  Webrev: " + webrev.uri().toString() + "\n")) +
                 issueString +
                 "  Stats: " + stats(localRepo, base, head) + "\n" +
@@ -354,7 +355,7 @@ class ArchiveMessages {
                         + ":\n" +
                         webrevs.stream()
                                 .map(d -> d.diffTooLarge() ?
-                                        String.format(" - %s: %s", d.shortLabel(), "Webrev is not available because diff is too large") :
+                                        String.format(" - %s: %s", d.shortLabel(), WEBREV_UNAVAILABLE_COMMENT) :
                                         String.format(" - %s: %s", d.shortLabel(), d.uri()))
                                 .collect(Collectors.joining("\n")) + "\n\n";
             }
@@ -374,7 +375,7 @@ class ArchiveMessages {
     static String composeRebasedFooter(PullRequest pr, Repository localRepo, WebrevDescription fullWebrev, Hash base, Hash head) {
         return "Changes: " + pr.changeUrl() + "\n" +
                 (fullWebrev.diffTooLarge() ?
-                        "  Webrev: Webrev is not available because diff is too large\n" :
+                        "  Webrev: " + WEBREV_UNAVAILABLE_COMMENT + "\n" :
                         (fullWebrev.uri() == null ? "" : "  Webrev: " + fullWebrev.uri().toString() + "\n")) +
                 "  Stats: " + stats(localRepo, base, head) + "\n" +
                 "  Patch: " + pr.diffUrl().toString() + "\n" +
@@ -387,9 +388,9 @@ class ArchiveMessages {
                 "  - all: " + pr.changeUrl() + "\n" +
                 "  - new: " + pr.changeUrl(lastHead) + "\n\n" +
                 (fullWebrev.diffTooLarge() ? "Webrevs:\n" : fullWebrev.uri() == null ? "" : "Webrevs:\n") +
-                (fullWebrev.diffTooLarge() ? " - full: Webrev is not available because diff is too large\n" :
+                (fullWebrev.diffTooLarge() ? " - full: " + WEBREV_UNAVAILABLE_COMMENT + "\n" :
                         fullWebrev.uri() == null ? "" : " - full: " + fullWebrev.uri().toString() + "\n") +
-                (incrementalWebrev.diffTooLarge() ? " - incr: Webrev is not available because diff is too large\n\n" :
+                (incrementalWebrev.diffTooLarge() ? " - incr: " + WEBREV_UNAVAILABLE_COMMENT + "\n\n" :
                         incrementalWebrev.uri() == null ? "" : " - incr: " + incrementalWebrev.uri().toString() + "\n\n") +
                 "  Stats: " + stats(localRepo, lastHead, head) + "\n" +
                 "  Patch: " + pr.diffUrl().toString() + "\n" +

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -176,7 +176,7 @@ class ArchiveWorkItem implements WorkItem {
     private static final String webrevListMarker = "<!-- mlbridge webrev list -->";
 
     private void updateWebrevComment(List<Comment> comments, int index, List<WebrevDescription> webrevs) {
-        if (webrevs.stream().noneMatch(w -> w.uri() != null)) {
+        if (webrevs.stream().noneMatch(w -> (w.uri() != null || w.diffTooLarge()))) {
             return;
         }
         var existing = comments.stream()
@@ -184,8 +184,10 @@ class ArchiveWorkItem implements WorkItem {
                                .filter(comment -> comment.body().contains(WEBREV_COMMENT_MARKER))
                                .findAny();
         var webrevDescriptions = webrevs.stream()
-                                        .map(d -> String.format("[%s](%s)", d.label(), d.uri()))
-                                        .collect(Collectors.joining(" - "));
+                .map(d -> d.diffTooLarge() ?
+                        String.format("[%s](%s)", d.label(), "Webrev is not available because diff is too large") :
+                        String.format("[%s](%s)", d.label(), d.uri()))
+                .collect(Collectors.joining(" - "));
         var comment = WEBREV_COMMENT_MARKER + "\n";
         comment += webrevHeaderMarker + "\n";
         comment += "### Webrevs" + "\n";

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevDescription.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,17 +36,20 @@ public class WebrevDescription {
     private final URI uri;
     private final Type type;
     private final String description;
+    private final boolean diffTooLarge;
 
-    public WebrevDescription(URI uri, Type type, String description) {
+    public WebrevDescription(URI uri, Type type, String description, boolean diffTooLarge) {
         this.uri = uri;
         this.type = type;
         this.description = description;
+        this.diffTooLarge = diffTooLarge;
     }
 
-    public WebrevDescription(URI uri, Type type) {
+    public WebrevDescription(URI uri, Type type, boolean diffTooLarge) {
         this.uri = uri;
         this.type = type;
         this.description = null;
+        this.diffTooLarge = diffTooLarge;
     }
 
     public Type type() {
@@ -57,6 +60,9 @@ public class WebrevDescription {
         return uri;
     }
 
+    public boolean diffTooLarge() {
+        return diffTooLarge;
+    }
     public String label() {
         switch (type) {
             case FULL:

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -4028,7 +4028,7 @@ class MailingListBridgeBotTests {
             localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
             localRepo.push(masterHash, archive.authenticatedUrl(), "webrev", true);
 
-            // Make a change with a corresponding PR
+            // Make a very big change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo, "A simple change\n".repeat(300001),
                     "Change msg\n\nWith several lines");
             localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
@@ -4043,7 +4043,7 @@ class MailingListBridgeBotTests {
             var ignoredPr = ignored.pullRequest(pr.id());
             ignoredPr.addComment("ready");
 
-            // Run another archive pass
+            // Run an archive pass
             TestBotRunner.runPeriodicItems(mlBot);
 
             // The archive should now contain an entry

--- a/cli/src/main/java/org/openjdk/skara/cli/GitWebrev.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitWebrev.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -448,26 +448,34 @@ public class GitWebrev {
             }
             var upstreamName = upstreamPullPath.getPath().substring(1);
             var originName = originPullPath.getPath().substring(1);
-            Webrev.repository(repo)
-                  .output(output)
-                  .upstream(upstreamPullPath, upstreamName)
-                  .fork(originPullPath, originName)
-                  .similarity(similarity)
-                  .generateJSON(base, head);
+            try {
+                Webrev.repository(repo)
+                      .output(output)
+                      .upstream(upstreamPullPath, upstreamName)
+                      .fork(originPullPath, originName)
+                      .similarity(similarity)
+                      .generateJSON(base, head);
+            } catch (DiffTooLargeException e) {
+                System.out.println("Webrev is not available because diff is too large.");
+            }
         } else {
-            Webrev.repository(repo)
-                  .output(output)
-                  .title(title)
-                  .upstream(upstream)
-                  .username(author.name())
-                  .commitLinker(hash -> upstreamURL == null ? null : upstreamURL + "/commit/" + hash)
-                  .issueLinker(id -> jbs + (isDigit(id.charAt(0)) ? jbsProject + "-" : "") + id)
-                  .issue(issue)
-                  .version(version)
-                  .files(files)
-                  .similarity(similarity)
-                  .comments(comments)
-                  .generate(base, head);
+            try {
+                Webrev.repository(repo)
+                      .output(output)
+                      .title(title)
+                      .upstream(upstream)
+                      .username(author.name())
+                      .commitLinker(hash -> upstreamURL == null ? null : upstreamURL + "/commit/" + hash)
+                      .issueLinker(id -> jbs + (isDigit(id.charAt(0)) ? jbsProject + "-" : "") + id)
+                      .issue(issue)
+                      .version(version)
+                      .files(files)
+                      .similarity(similarity)
+                      .comments(comments)
+                      .generate(base, head);
+            } catch (DiffTooLargeException e) {
+                System.out.println("Webrev is not available because diff is too large.");
+            }
         }
         if (!quiet) {
             System.out.println("Webrev executed successfully, details are in the link below:");

--- a/webrev/src/main/java/org/openjdk/skara/webrev/DiffTooLargeException.java
+++ b/webrev/src/main/java/org/openjdk/skara/webrev/DiffTooLargeException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.webrev;
+
+public class DiffTooLargeException extends Exception {
+    public DiffTooLargeException() {
+    }
+}

--- a/webrev/src/main/java/org/openjdk/skara/webrev/Webrev.java
+++ b/webrev/src/main/java/org/openjdk/skara/webrev/Webrev.java
@@ -51,6 +51,8 @@ public class Webrev {
 
     private static final Logger log = Logger.getLogger("org.openjdk.skara.webrev");
 
+    private static final int TOTAL_CHANGES_THRESHOLD = 300000;
+
     public static final Set<String> STATIC_FILES =
         Set.of(ANCNAV_HTML, ANCNAV_JS, ICON, CSS, INDEX);
 
@@ -207,7 +209,7 @@ public class Webrev {
                     .flatMap(textualPatch -> textualPatch.hunks().stream())
                     .mapToInt(Hunk::changes)
                     .sum();
-            return totalChanges > 300000;
+            return totalChanges > TOTAL_CHANGES_THRESHOLD;
         }
 
         private void generateJSON(Diff diff, Hash tailEnd, Hash head) throws IOException, DiffTooLargeException {

--- a/webrev/src/main/java/org/openjdk/skara/webrev/Webrev.java
+++ b/webrev/src/main/java/org/openjdk/skara/webrev/Webrev.java
@@ -202,6 +202,7 @@ public class Webrev {
 
         private boolean isDiffTooLarge(Diff diff) {
             var totalChanges = diff.patches().stream()
+                    .filter(Patch::isTextual)
                     .map(Patch::asTextualPatch)
                     .flatMap(textualPatch -> textualPatch.hunks().stream())
                     .mapToInt(Hunk::changes)

--- a/webrev/src/main/java/org/openjdk/skara/webrev/Webrev.java
+++ b/webrev/src/main/java/org/openjdk/skara/webrev/Webrev.java
@@ -207,7 +207,7 @@ public class Webrev {
                     .flatMap(textualPatch -> textualPatch.hunks().stream())
                     .mapToInt(Hunk::changes)
                     .sum();
-            if (totalChanges > 100000) {
+            if (totalChanges > 300000) {
                 return;
             }
 

--- a/webrev/src/main/java/org/openjdk/skara/webrev/Webrev.java
+++ b/webrev/src/main/java/org/openjdk/skara/webrev/Webrev.java
@@ -200,20 +200,17 @@ public class Webrev {
             return commits.stream().anyMatch(CommitMetadata::isMerge);
         }
 
-        private boolean isDiffTooLarge(Diff diff) {
+        private void generateJSON(Diff diff, Hash tailEnd, Hash head) throws IOException {
             var totalChanges = diff.patches().stream()
                     .filter(Patch::isTextual)
                     .map(Patch::asTextualPatch)
                     .flatMap(textualPatch -> textualPatch.hunks().stream())
                     .mapToInt(Hunk::changes)
                     .sum();
-            return totalChanges > 100000;
-        }
-
-        private void generateJSON(Diff diff, Hash tailEnd, Hash head) throws IOException {
-            if (isDiffTooLarge(diff)) {
+            if (totalChanges > 100000) {
                 return;
             }
+
             if (head == null) {
                 throw new IllegalArgumentException("Must supply a head hash");
             }
@@ -335,9 +332,6 @@ public class Webrev {
         }
 
         private void generate(Diff diff, Hash tailEnd, Hash head) throws IOException {
-            if (isDiffTooLarge(diff)) {
-                return;
-            }
             Files.createDirectories(output);
 
             copyResource(ANCNAV_HTML);

--- a/webrev/src/test/java/org/openjdk/skara/webrev/WebrevTests.java
+++ b/webrev/src/test/java/org/openjdk/skara/webrev/WebrevTests.java
@@ -43,7 +43,7 @@ class WebrevTests {
 
     @ParameterizedTest
     @EnumSource(VCS.class)
-    void simple(VCS vcs) throws IOException {
+    void simple(VCS vcs) throws IOException, DiffTooLargeException {
         try (var repoFolder = new TemporaryDirectory();
              var webrevFolder = new TemporaryDirectory()) {
             var repo = TestableRepository.init(repoFolder.path(), vcs);
@@ -63,7 +63,7 @@ class WebrevTests {
 
     @ParameterizedTest
     @EnumSource(VCS.class)
-    void middle(VCS vcs) throws IOException {
+    void middle(VCS vcs) throws IOException, DiffTooLargeException {
         try (var repoFolder = new TemporaryDirectory();
              var webrevFolder = new TemporaryDirectory()) {
             var repo = TestableRepository.init(repoFolder.path(), vcs);
@@ -82,7 +82,7 @@ class WebrevTests {
 
     @ParameterizedTest
     @EnumSource(VCS.class)
-    void emptySourceHunk(VCS vcs) throws IOException {
+    void emptySourceHunk(VCS vcs) throws IOException, DiffTooLargeException {
         try (var repoFolder = new TemporaryDirectory();
         var webrevFolder = new TemporaryDirectory()) {
             var repo = TestableRepository.init(repoFolder.path(), vcs);
@@ -101,7 +101,7 @@ class WebrevTests {
 
     @ParameterizedTest
     @EnumSource(VCS.class)
-    void removedHeader(VCS vcs) throws IOException {
+    void removedHeader(VCS vcs) throws IOException, DiffTooLargeException {
         try (var repoFolder = new TemporaryDirectory();
              var webrevFolder = new TemporaryDirectory()) {
             var repo = TestableRepository.init(repoFolder.path(), vcs);
@@ -120,7 +120,7 @@ class WebrevTests {
 
     @ParameterizedTest
     @EnumSource(VCS.class)
-    void removeBinaryFile(VCS vcs) throws IOException {
+    void removeBinaryFile(VCS vcs) throws IOException, DiffTooLargeException {
         try (var tmp = new TemporaryDirectory()) {
             var repo = TestableRepository.init(tmp.path().resolve("repo"), vcs);
             var binaryFile = repo.root().resolve("x.jpg");
@@ -137,7 +137,7 @@ class WebrevTests {
 
     @ParameterizedTest
     @EnumSource(VCS.class)
-    void addBinaryFile(VCS vcs) throws IOException {
+    void addBinaryFile(VCS vcs) throws IOException, DiffTooLargeException {
         try (var tmp = new TemporaryDirectory()) {
             var repo = TestableRepository.init(tmp.path().resolve("repo"), vcs);
             var readme = repo.root().resolve("README");
@@ -157,7 +157,7 @@ class WebrevTests {
 
     @ParameterizedTest
     @EnumSource(VCS.class)
-    void modifyBinaryFile(VCS vcs) throws IOException {
+    void modifyBinaryFile(VCS vcs) throws IOException, DiffTooLargeException {
         try (var tmp = new TemporaryDirectory()) {
             var repo = TestableRepository.init(tmp.path().resolve("repo"), vcs);
             var readme = repo.root().resolve("README");
@@ -178,7 +178,7 @@ class WebrevTests {
 
     @ParameterizedTest
     @EnumSource(VCS.class)
-    void reservedName(VCS vcs) throws IOException {
+    void reservedName(VCS vcs) throws IOException, DiffTooLargeException {
         try (var repoFolder = new TemporaryDirectory();
              var webrevFolder = new TemporaryDirectory()) {
             var repo = TestableRepository.init(repoFolder.path(), vcs);


### PR DESCRIPTION
https://github.com/openjdk/tsan/pull/17, there are more than 5000 commits in this pr and mlbridge bot was trying to generate the webrev. The generation of webrev was successful but the webrev file was too big and exceeded GitHub's file size limit.

So as ErikJ suggested, if the diff of the pr is too large, we shouldn't generate webrev for it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2190](https://bugs.openjdk.org/browse/SKARA-2190): Setting maximum size limit for PR diff in generating Webrev (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1617/head:pull/1617` \
`$ git checkout pull/1617`

Update a local copy of the PR: \
`$ git checkout pull/1617` \
`$ git pull https://git.openjdk.org/skara.git pull/1617/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1617`

View PR using the GUI difftool: \
`$ git pr show -t 1617`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1617.diff">https://git.openjdk.org/skara/pull/1617.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1617#issuecomment-1982142763)