### PR TITLE
2191 Handle multiple available skara.gitconfig files

### DIFF
--- a/skara.gitconfig
+++ b/skara.gitconfig
@@ -20,7 +20,7 @@
 # questions.
 
 [alias]
-        skara = ! sh \"$(dirname $(git config --get-all include.path | grep 'skara.gitconfig' | sed 's@~@'$HOME'@'))/skara.sh\"
+        skara = ! sh \"$(dirname $(git config --get-all include.path | grep 'skara.gitconfig' | tail -1 | sed 's@~@'$HOME'@'))/skara.sh\"
         jcheck = ! git skara jcheck
         webrev = ! git skara webrev
         defpath = ! git skara defpath


### PR DESCRIPTION
This adds "tail -1" to the bootstrap mechanism, to handle the case if we find more than one skara.gitconfig file. The alternative is to execute a malformed shell invocation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2191](https://bugs.openjdk.org/browse/SKARA-2191): Handle multiple available skara.gitconfig files (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1618/head:pull/1618` \
`$ git checkout pull/1618`

Update a local copy of the PR: \
`$ git checkout pull/1618` \
`$ git pull https://git.openjdk.org/skara.git pull/1618/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1618`

View PR using the GUI difftool: \
`$ git pr show -t 1618`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1618.diff">https://git.openjdk.org/skara/pull/1618.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1618#issuecomment-1978782215)