### PR TITLE
2070: Get a placeholder message spot for integration message

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -64,7 +64,8 @@ class CheckRun {
     private final CheckablePullRequest checkablePullRequest;
 
     private static final Logger log = Logger.getLogger("org.openjdk.skara.bots.pr");
-    private static final String MERGE_READY_MARKER = "<!-- PullRequestBot merge is ready comment -->";
+    protected static final String MERGE_READY_MARKER = "<!-- PullRequestBot merge is ready comment -->";
+    protected static final String PLACEHOLDER_MARKER = "<!-- PullRequestBot placeholder -->";
     private static final String OUTDATED_HELP_MARKER = "<!-- PullRequestBot outdated help comment -->";
     private static final String SOURCE_BRANCH_WARNING_MARKER = "<!-- PullRequestBot source branch warning comment -->";
     private static final String MERGE_COMMIT_WARNING_MARKER = "<!-- PullRequestBot merge commit warning comment -->";
@@ -1124,7 +1125,7 @@ class CheckRun {
                     log.info("Merge ready comment already exists, no need to update");
                 }
             }
-        } else if (existing.isPresent()) {
+        } else if (existing.isPresent() && !existing.get().body().contains(PLACEHOLDER_MARKER)) {
             var message = getMergeNoLongerReadyComment();
             if (!existing.get().body().equals(message)) {
                 log.info("Updating no longer ready comment");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -417,7 +417,7 @@ class CheckWorkItem extends PullRequestWorkItem {
         var hostedRepositoryPool = new HostedRepositoryPool(seedPath);
         CensusInstance census;
         var comments = prComments();
-        comments = postPlaceholderMessageForReadyComment(comments);
+        comments = postPlaceholderForReadyComment(comments);
 
         try {
             census = CensusInstance.createCensusInstance(hostedRepositoryPool, bot.censusRepo(), bot.censusRef(), scratchArea.getCensus(), pr,
@@ -733,9 +733,9 @@ class CheckWorkItem extends PullRequestWorkItem {
         if (existing.isPresent()) {
             return comments;
         }
+        log.info("Posting placeholder comment");
         String message = "❗ This change is not yet ready to be integrated.\n" +
                 "See the **Progress** checklist in the description for automated requirements.\n" +
-                "This project also has non-automated pre-integration requirements. Please see the file CONTRIBUTING.md for details.\n" +
                 MERGE_READY_MARKER + "\n" + PLACEHOLDER_MARKER;
         // If the bot posted a placeholder comment, we should update comments otherwise the bot will not be able to find
         // comment with MERGE_READY_MARKER later and post merge ready comment again

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -48,8 +48,11 @@ import java.util.function.Consumer;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.openjdk.skara.bots.common.PullRequestConstants.WEBREV_COMMENT_MARKER;
+import static org.openjdk.skara.bots.pr.CheckRun.MERGE_READY_MARKER;
+import static org.openjdk.skara.bots.pr.CheckRun.PLACEHOLDER_MARKER;
 import static org.openjdk.skara.forge.PullRequestUtils.mergeSourcePattern;
 
 class CheckWorkItem extends PullRequestWorkItem {
@@ -414,6 +417,7 @@ class CheckWorkItem extends PullRequestWorkItem {
         var hostedRepositoryPool = new HostedRepositoryPool(seedPath);
         CensusInstance census;
         var comments = prComments();
+        comments = postPlaceholderMessageForReadyComment(comments);
 
         try {
             census = CensusInstance.createCensusInstance(hostedRepositoryPool, bot.censusRepo(), bot.censusRef(), scratchArea.getCensus(), pr,
@@ -719,6 +723,23 @@ class CheckWorkItem extends PullRequestWorkItem {
         return allCommands.stream()
                 .filter(ci -> ci.name().equals("integrate"))
                 .anyMatch(ci -> !handled.contains(ci.id()));
+    }
+
+    private List<Comment> postPlaceholderMessageForReadyComment(List<Comment> comments) {
+        var existing = comments.stream()
+                .filter(comment -> comment.author().equals(pr.repository().forge().currentUser()))
+                .filter(comment -> comment.body().contains(MERGE_READY_MARKER))
+                .findAny();
+        if (existing.isPresent()) {
+            return comments;
+        }
+        String message = "❗ This change is not yet ready to be integrated.\n" +
+                "See the **Progress** checklist in the description for automated requirements.\n" +
+                "This project also has non-automated pre-integration requirements. Please see the file CONTRIBUTING.md for details.\n" +
+                MERGE_READY_MARKER + "\n" + PLACEHOLDER_MARKER;
+        // If the bot posted a placeholder comment, we should update comments otherwise the bot will not be able to find
+        // comment with MERGE_READY_MARKER later and post merge ready comment again
+        return Stream.concat(comments.stream(), Stream.of(pr.addComment(message))).toList();
     }
 
     @Override

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -725,7 +725,7 @@ class CheckWorkItem extends PullRequestWorkItem {
                 .anyMatch(ci -> !handled.contains(ci.id()));
     }
 
-    private List<Comment> postPlaceholderMessageForReadyComment(List<Comment> comments) {
+    private List<Comment> postPlaceholderForReadyComment(List<Comment> comments) {
         var existing = comments.stream()
                 .filter(comment -> comment.author().equals(pr.repository().forge().currentUser()))
                 .filter(comment -> comment.body().contains(MERGE_READY_MARKER))

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportPRCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportPRCommandTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -162,6 +162,8 @@ public class BackportPRCommandTests {
             var editHash = CheckableRepository.appendAndCommit(localRepo);
             localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "123: This is a pull request");
+
+            TestBotRunner.runPeriodicItems(prBot);
 
             //close the pr
             pr.store().setState(Issue.State.CLOSED);

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,7 @@ import java.util.*;
 import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.openjdk.skara.bots.pr.PullRequestAsserts.assertFirstCommentContains;
 import static org.openjdk.skara.bots.pr.PullRequestAsserts.assertLastCommentContains;
 
 class BackportTests {
@@ -90,7 +91,7 @@ class BackportTests {
 
             // The bot should reply with a backport message
             TestBotRunner.runPeriodicItems(bot);
-            var backportComment = pr.comments().get(0).body();
+            var backportComment = pr.comments().get(1).body();
             assertTrue(backportComment.contains("This backport pull request has now been updated with issue"));
             assertTrue(backportComment.contains("<!-- backport " + releaseHash.hex() + " -->"));
             assertEquals(issue1Number + ": An issue", pr.store().title());
@@ -100,7 +101,7 @@ class BackportTests {
             var prAsReviewer = reviewer.pullRequest(pr.id());
             prAsReviewer.addReview(Review.Verdict.APPROVED, "Looks good");
             TestBotRunner.runPeriodicItems(bot);
-            assertLastCommentContains(pr, "This change now passes all *automated* pre-integration checks");
+            assertFirstCommentContains(pr, "This change now passes all *automated* pre-integration checks");
 
             // Integrate
             author.pullRequest(pr.id());
@@ -192,7 +193,7 @@ class BackportTests {
             // The bot should reply with a backport message
             TestBotRunner.runPeriodicItems(bot);
             var comments = pr.comments();
-            var backportComment = comments.get(0).body();
+            var backportComment = comments.get(1).body();
             assertTrue(backportComment.contains("This backport pull request has now been updated with issue"));
             assertTrue(backportComment.contains("<!-- backport " + releaseHash.hex() + " -->"));
             assertEquals(issue1Number + ": An issue", pr.store().title());
@@ -202,7 +203,7 @@ class BackportTests {
             var prAsReviewer = reviewer.pullRequest(pr.id());
             prAsReviewer.addReview(Review.Verdict.APPROVED, "Looks good");
             TestBotRunner.runPeriodicItems(bot);
-            assertLastCommentContains(pr, "This change now passes all *automated* pre-integration checks");
+            assertFirstCommentContains(pr, "This change now passes all *automated* pre-integration checks");
 
             // Integrate
             author.pullRequest(pr.id());
@@ -296,7 +297,7 @@ class BackportTests {
 
             // The bot should reply with a backport message
             TestBotRunner.runPeriodicItems(bot);
-            var backportComment = pr.comments().get(0).body();
+            var backportComment = pr.comments().get(1).body();
             assertTrue(backportComment.contains("This backport pull request has now been updated with issue"));
             assertTrue(backportComment.contains("<!-- backport " + releaseHash.hex() + " -->"));
             assertEquals(issue1Number + ": An issue", pr.store().title());
@@ -306,7 +307,7 @@ class BackportTests {
             var prAsReviewer = reviewer.pullRequest(pr.id());
             prAsReviewer.addReview(Review.Verdict.APPROVED, "Looks good");
             TestBotRunner.runPeriodicItems(bot);
-            assertLastCommentContains(pr, "This change now passes all *automated* pre-integration checks");
+            assertFirstCommentContains(pr, "This change now passes all *automated* pre-integration checks");
 
             // Integrate
             author.pullRequest(pr.id());
@@ -385,7 +386,7 @@ class BackportTests {
 
             // Re-running the bot should not cause any more error comments
             TestBotRunner.runPeriodicItems(bot);
-            assertEquals(1, pr.comments().size());
+            assertEquals(2, pr.comments().size());
         }
     }
 
@@ -454,7 +455,7 @@ class BackportTests {
 
             // Re-running the bot should not cause any more error comments
             TestBotRunner.runPeriodicItems(bot);
-            assertEquals(1, pr.comments().size());
+            assertEquals(2, pr.comments().size());
         }
     }
 
@@ -526,7 +527,7 @@ class BackportTests {
 
             // Re-running the bot should not cause any more error comments
             TestBotRunner.runPeriodicItems(bot);
-            assertEquals(1, pr.comments().size());
+            assertEquals(2, pr.comments().size());
         }
     }
 
@@ -582,7 +583,7 @@ class BackportTests {
             // The bot should reply with a backport message
             TestBotRunner.runPeriodicItems(bot);
             var comments = pr.comments();
-            var backportComment = comments.get(0).body();
+            var backportComment = comments.get(1).body();
             assertTrue(backportComment.contains("This backport pull request has now been updated with issue"));
             assertTrue(backportComment.contains("<!-- backport " + releaseHash.hex() + " -->"));
             assertEquals(issue1Number + ": An issue", pr.store().title());
@@ -655,7 +656,7 @@ class BackportTests {
             // The bot should reply with a backport message
             TestBotRunner.runPeriodicItems(bot);
             var comments = pr.comments();
-            var backportComment = comments.get(0).body();
+            var backportComment = comments.get(1).body();
             assertTrue(backportComment.contains("This backport pull request has now been updated with issue"));
             assertTrue(backportComment.contains("<!-- backport " + upstreamHash.hex() + " -->"));
             assertEquals(issue2Number + ": Another issue", pr.store().title());
@@ -726,7 +727,7 @@ class BackportTests {
             // The bot should reply with a backport message
             TestBotRunner.runPeriodicItems(bot);
             var comments = pr.comments();
-            var backportComment = comments.get(0).body();
+            var backportComment = comments.get(1).body();
             assertTrue(backportComment.contains("This backport pull request has now been updated with issue"));
             assertTrue(backportComment.contains("<!-- backport " + upstreamHash.hex() + " -->"));
             assertEquals(issue2Number + ": Another issue", pr.store().title());
@@ -801,7 +802,7 @@ class BackportTests {
             // The bot should reply with a backport message
             TestBotRunner.runPeriodicItems(bot);
             var comments = pr.comments();
-            var backportComment = comments.get(0).body();
+            var backportComment = comments.get(1).body();
             assertTrue(backportComment.contains("This backport pull request has now been updated with issue"));
             assertTrue(backportComment.contains("<!-- backport " + upstreamHash.hex() + " -->"));
             assertEquals(issue2Number + ": Another issue", pr.store().title());
@@ -863,11 +864,11 @@ class BackportTests {
 
             // The bot should reply with a backport message and that the PR is ready
             TestBotRunner.runPeriodicItems(bot);
-            var backportComment = pr.comments().get(0).body();
+            var backportComment = pr.comments().get(1).body();
             assertTrue(backportComment.contains("This backport pull request has now been updated with issue"));
             assertTrue(backportComment.contains("<!-- backport " + releaseHash.hex() + " -->"));
             assertEquals(issue1Number + ": An issue", pr.store().title());
-            assertLastCommentContains(pr, "This change now passes all *automated* pre-integration checks");
+            assertFirstCommentContains(pr, "This change now passes all *automated* pre-integration checks");
             assertTrue(pr.store().labelNames().contains("ready"));
             assertTrue(pr.store().labelNames().contains("rfr"));
             assertTrue(pr.store().labelNames().contains("clean"));
@@ -960,11 +961,11 @@ class BackportTests {
 
             // The bot should reply with a backport message and that the PR is ready
             TestBotRunner.runPeriodicItems(bot);
-            var backportComment = pr.comments().get(0).body();
+            var backportComment = pr.comments().get(1).body();
             assertTrue(backportComment.contains("This backport pull request has now been updated with issue"));
             assertTrue(backportComment.contains("<!-- backport " + releaseHash.hex() + " -->"));
             assertEquals(issue1Number + ": An issue", pr.store().title());
-            assertLastCommentContains(pr, "This change now passes all *automated* pre-integration checks");
+            assertFirstCommentContains(pr, "This change now passes all *automated* pre-integration checks");
             assertTrue(pr.store().labelNames().contains("ready"));
             assertTrue(pr.store().labelNames().contains("rfr"));
             assertTrue(pr.store().labelNames().contains("clean"));
@@ -1070,7 +1071,7 @@ class BackportTests {
 
             // The bot should reply with a backport message
             TestBotRunner.runPeriodicItems(bot);
-            var backportComment = pr.comments().get(0).body();
+            var backportComment = pr.comments().get(1).body();
             assertTrue(backportComment.contains("This backport pull request has now been updated with issue"));
             assertTrue(backportComment.contains("<!-- backport " + releaseHash.hex() + " -->"));
             assertEquals(issue1Number + ": An issue", pr.store().title());
@@ -1129,7 +1130,7 @@ class BackportTests {
 
             // The bot should reply with a backport message
             TestBotRunner.runPeriodicItems(bot);
-            var backportComment = pr.comments().get(0).body();
+            var backportComment = pr.comments().get(1).body();
             assertTrue(backportComment.contains("This backport pull request has now been updated with issue"));
             assertTrue(backportComment.contains("<!-- backport " + releaseHash.hex() + " -->"));
             assertEquals(issue1Number + ": An issue", pr.store().title());
@@ -1188,7 +1189,7 @@ class BackportTests {
 
             // The bot should reply with a backport message
             TestBotRunner.runPeriodicItems(bot);
-            var backportComment = pr.comments().get(0).body();
+            var backportComment = pr.comments().get(1).body();
             assertTrue(backportComment.contains("This backport pull request has now been updated with issue"));
             assertTrue(backportComment.contains("<!-- backport " + releaseHash.hex() + " -->"));
             assertEquals(issue1Number + ": An issue", pr.store().title());
@@ -1247,7 +1248,7 @@ class BackportTests {
 
             // The bot should reply with a backport message
             TestBotRunner.runPeriodicItems(bot);
-            var backportComment = pr.comments().get(0).body();
+            var backportComment = pr.comments().get(1).body();
             assertTrue(backportComment.contains("This backport pull request has now been updated with issue"));
             assertTrue(backportComment.contains("<!-- backport " + releaseHash.hex() + " -->"));
             assertEquals(issue1Number + ": An issue", pr.store().title());
@@ -1306,7 +1307,7 @@ class BackportTests {
 
             // The bot should reply with a backport message
             TestBotRunner.runPeriodicItems(bot);
-            var backportComment = pr.comments().get(0).body();
+            var backportComment = pr.comments().get(1).body();
             assertTrue(backportComment.contains("This backport pull request has now been updated with issue"));
             assertTrue(backportComment.contains("<!-- backport " + releaseHash.hex() + " -->"));
             assertEquals(issue1Number + ": An issue", pr.store().title());
@@ -1316,7 +1317,7 @@ class BackportTests {
             var prAsReviewer = reviewer.pullRequest(pr.id());
             prAsReviewer.addReview(Review.Verdict.APPROVED, "Looks good");
             TestBotRunner.runPeriodicItems(bot);
-            assertLastCommentContains(pr, "This change now passes all *automated* pre-integration checks");
+            assertFirstCommentContains(pr, "This change now passes all *automated* pre-integration checks");
 
             // Integrate
             author.pullRequest(pr.id());
@@ -1405,7 +1406,7 @@ class BackportTests {
 
             // The bot should reply with a backport message
             TestBotRunner.runPeriodicItems(bot);
-            var backportComment = pr.comments().get(0).body();
+            var backportComment = pr.comments().get(1).body();
             assertTrue(backportComment.contains("<!-- backport error -->"));
             assertTrue(backportComment.contains("the commit `" + releaseHash.hex() + "` does not refer to an issue"));
             assertFalse(pr.store().labelNames().contains("backport"));
@@ -1455,14 +1456,14 @@ class BackportTests {
             var pr = credentials.createPullRequest(author, "master", "edit",
                     "Backport " + "FOO-" + issue1.id().split("-")[1]);
             TestBotRunner.runPeriodicItems(bot);
-            var backportComment = pr.comments().get(0).body();
+            var backportComment = pr.comments().get(1).body();
             assertTrue(backportComment.contains("does not match project"));
             assertFalse(pr.store().labelNames().contains("backport"));
 
             // Use bad issue ID
             pr.setTitle("Backport TEST-4711");
             TestBotRunner.runPeriodicItems(bot);
-            backportComment = pr.comments().get(1).body();
+            backportComment = pr.comments().get(2).body();
             assertTrue(backportComment.contains("does not exist in project"));
             assertFalse(pr.store().labelNames().contains("backport"));
 
@@ -1470,7 +1471,7 @@ class BackportTests {
             // Use the full issue ID
             pr.setTitle("Backport " + issue1.id());
             TestBotRunner.runPeriodicItems(bot);
-            backportComment = pr.comments().get(2).body();
+            backportComment = pr.comments().get(3).body();
             assertTrue(backportComment.contains("This backport pull request has now been updated with the original issue"));
             assertEquals(issue1Number + ": An issue", pr.store().title());
             assertTrue(pr.store().labelNames().contains("backport"));
@@ -1478,7 +1479,7 @@ class BackportTests {
             // Case insensitive
             pr.setTitle("bAcKpoRT" + issue1.id());
             TestBotRunner.runPeriodicItems(bot);
-            backportComment = pr.comments().get(2).body();
+            backportComment = pr.comments().get(4).body();
             assertTrue(backportComment.contains("This backport pull request has now been updated with the original issue"));
             assertEquals(issue1Number + ": An issue", pr.store().title());
             assertTrue(pr.store().labelNames().contains("backport"));
@@ -1486,7 +1487,7 @@ class BackportTests {
             // Set the title without project name
             pr.setTitle("Backport " + issue1.id().split("-")[1]);
             TestBotRunner.runPeriodicItems(bot);
-            backportComment = pr.comments().get(3).body();
+            backportComment = pr.comments().get(5).body();
             assertTrue(backportComment.contains("This backport pull request has now been updated with the original issue"));
             assertEquals(issue1Number + ": An issue", pr.store().title());
             assertTrue(pr.store().labelNames().contains("backport"));
@@ -1495,7 +1496,7 @@ class BackportTests {
             var prAsReviewer = reviewer.pullRequest(pr.id());
             prAsReviewer.addReview(Review.Verdict.APPROVED, "Looks good");
             TestBotRunner.runPeriodicItems(bot);
-            assertLastCommentContains(pr, "This change now passes all *automated* pre-integration checks");
+            assertFirstCommentContains(pr, "This change now passes all *automated* pre-integration checks");
 
             // Integrate
             var prAsCommitter = author.pullRequest(pr.id());
@@ -1597,14 +1598,13 @@ class BackportTests {
 
             // The bot should reply with a backport message
             TestBotRunner.runPeriodicItems(bot);
-            var backportComment = pr.comments().get(0).body();
+            var backportComment = pr.comments().get(1).body();
             assertTrue(backportComment.contains("This backport pull request has now been updated with issue"));
             assertTrue(backportComment.contains("<!-- backport " + releaseHash.hex() + " -->"));
             assertEquals(issue1Number + ": An issue", pr.store().title());
             assertTrue(pr.store().labelNames().contains("backport"));
             assertTrue(pr.store().labelNames().contains("clean"));
-            var mergeReadyComment = pr.comments().get(1).body();
-            assertTrue(mergeReadyComment.contains("This change now passes all *automated* pre-integration checks"));
+            assertFirstCommentContains(pr, "This change now passes all *automated* pre-integration checks");
 
             // Update the PR title and use the hash from release2 instead
             pr.setTitle("Backport " + releaseHash2.hex());
@@ -1618,15 +1618,13 @@ class BackportTests {
             assertTrue(pr.store().labelNames().contains("backport"));
             // The backport is no longer clean as the release2 version of the change was different
             assertFalse(pr.store().labelNames().contains("clean"));
-            mergeReadyComment = pr.comments().get(1).body();
-            assertTrue(mergeReadyComment.contains("This change is no longer ready for integration - check the PR body for details"));
+            assertFirstCommentContains(pr, "This change is no longer ready for integration - check the PR body for details");
 
             // Approve PR and re-run bot
             var prAsReviewer = reviewer.pullRequest(pr.id());
             prAsReviewer.addReview(Review.Verdict.APPROVED, "Looks good");
             TestBotRunner.runPeriodicItems(bot);
-            mergeReadyComment = pr.comments().get(1).body();
-            assertTrue(mergeReadyComment.contains("This change now passes all *automated* pre-integration checks"));
+            assertFirstCommentContains(pr, "This change now passes all *automated* pre-integration checks");
 
             // Integrate
             author.pullRequest(pr.id());
@@ -1724,7 +1722,7 @@ class BackportTests {
 
             // The bot should reply with a backport message
             TestBotRunner.runPeriodicItems(bot);
-            var backportComment = pr.comments().get(0).body();
+            var backportComment = pr.comments().get(1).body();
             assertTrue(backportComment.contains("This backport pull request has now been updated with issue"));
             assertTrue(backportComment.contains("<!-- backport " + releaseHash2.hex() + " -->"));
             assertEquals(issue1Number + ": An issue", pr.store().title());
@@ -1735,7 +1733,7 @@ class BackportTests {
             // correct the Backport original commit Hash
             pr.setTitle("Backport "+releaseHash.hex());
             TestBotRunner.runPeriodicItems(bot);
-            var backportComment2 = pr.comments().get(1).body();
+            var backportComment2 = pr.comments().get(2).body();
             assertTrue(backportComment2.contains("This backport pull request has now been updated with issue"));
             assertTrue(backportComment2.contains("<!-- backport " + releaseHash.hex() + " -->"));
             assertEquals(issue1Number + ": An issue", pr.store().title());
@@ -1747,7 +1745,7 @@ class BackportTests {
             var prAsReviewer = reviewer.pullRequest(pr.id());
             prAsReviewer.addReview(Review.Verdict.APPROVED, "Looks good");
             TestBotRunner.runPeriodicItems(bot);
-            assertLastCommentContains(pr, "This change now passes all *automated* pre-integration checks");
+            assertFirstCommentContains(pr, "This change now passes all *automated* pre-integration checks");
 
             // Integrate
             author.pullRequest(pr.id());
@@ -1837,7 +1835,7 @@ class BackportTests {
 
             // The bot should reply with a backport message and that the PR is not ready
             TestBotRunner.runPeriodicItems(bot);
-            var backportComment = pr.comments().get(0).body();
+            var backportComment = pr.comments().get(1).body();
             assertTrue(backportComment.contains("This backport pull request has now been updated with issue"));
             assertTrue(backportComment.contains("<!-- backport " + releaseHash.hex() + " -->"));
             assertEquals(issue1Number + ": An issue", pr.store().title());
@@ -1956,7 +1954,7 @@ class BackportTests {
             // The bot should reply with a backport message
             TestBotRunner.runPeriodicItems(bot);
             var comments = pr.comments();
-            var backportComment = comments.get(0).body();
+            var backportComment = comments.get(1).body();
             assertTrue(backportComment.contains("This backport pull request has now been updated with issue"));
             assertTrue(backportComment.contains("<!-- backport " + releaseHash.hex() + " -->"));
             assertEquals(issue1Number + ": An issue", pr.store().title());
@@ -1969,7 +1967,7 @@ class BackportTests {
 
             pr.addComment("/reviewers 1");
             TestBotRunner.runPeriodicItems(bot);
-            assertTrue(pr.store().comments().get(1).body().contains("This change is no longer ready for integration - check the PR body for details."));
+            assertFirstCommentContains(pr, "This change is no longer ready for integration - check the PR body for details.");
             assertTrue(pr.store().body().contains("Change must be properly reviewed (2 reviews required"));
             assertFalse(pr.store().labelNames().contains("ready"));
 
@@ -1979,12 +1977,12 @@ class BackportTests {
             integratorPr.addReview(Review.Verdict.APPROVED, "LGTM");
 
             TestBotRunner.runPeriodicItems(bot);
-            assertTrue(pr.store().comments().get(1).body().contains("This change now passes all *automated* pre-integration checks."));
+            assertFirstCommentContains(pr, "This change now passes all *automated* pre-integration checks.");
             assertTrue(pr.store().labelNames().contains("ready"));
 
             pr.addComment("/reviewers 3");
             TestBotRunner.runPeriodicItems(bot);
-            assertTrue(pr.store().comments().get(1).body().contains("This change is no longer ready for integration - check the PR body for details."));
+            assertFirstCommentContains(pr, "This change is no longer ready for integration - check the PR body for details.");
             assertTrue(pr.store().body().contains("Change must be properly reviewed (3 reviews required"));
             assertFalse(pr.store().labelNames().contains("ready"));
         }
@@ -2087,7 +2085,7 @@ class BackportTests {
             // The bot should reply with a backport message
             TestBotRunner.runPeriodicItems(bot);
             var comments = pr.comments();
-            var backportComment = comments.get(0).body();
+            var backportComment = comments.get(1).body();
             assertTrue(backportComment.contains("This backport pull request has now been updated with issue"));
             assertTrue(backportComment.contains("<!-- backport " + updateReleaseHash.hex() + " -->"));
             assertEquals(issue1Number + ": An issue", pr.store().title());

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CSRCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CSRCommandTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1027,8 +1027,8 @@ class CSRCommandTests {
             TestBotRunner.runPeriodicItems(prBot);
             assertFalse(pr.store().body().contains("- [ ] " + generateCSRProgressMessage(backportCsr)));
             assertFalse(pr.store().labelNames().contains("csr"));
-            assertTrue(pr.comments().get(pr.comments().size() - 2).body().contains("determined that a [CSR](https://wiki.openjdk.org/display/csr/Main) request " +
-                    "is not needed for this pull request."));
+            assertLastCommentContains(pr, "determined that a [CSR](https://wiki.openjdk.org/display/csr/Main) request " +
+                    "is not needed for this pull request.");
 
             // re-run prBot.
             pr.addComment("/csr");

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CleanCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CleanCommandTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -127,7 +127,7 @@ public class CleanCommandTests {
             // The bot should reply with a backport message
             TestBotRunner.runPeriodicItems(bot);
             var comments = pr.comments();
-            var backportComment = comments.get(0).body();
+            var backportComment = comments.get(1).body();
             assertTrue(backportComment.contains("This backport pull request has now been updated with issue"));
             assertTrue(backportComment.contains("<!-- backport " + releaseHash.hex() + " -->"));
             assertEquals(issue1Number + ": An issue", pr.store().title());
@@ -203,7 +203,7 @@ public class CleanCommandTests {
             // The bot should reply with a backport message
             TestBotRunner.runPeriodicItems(bot);
             var comments = pr.comments();
-            var backportComment = comments.get(0).body();
+            var backportComment = comments.get(1).body();
             assertTrue(backportComment.contains("This backport pull request has now been updated with issue"));
             assertTrue(backportComment.contains("<!-- backport " + upstreamHash.hex() + " -->"));
             assertEquals(issue2Number + ": Another issue", pr.store().title());
@@ -283,7 +283,7 @@ public class CleanCommandTests {
             // The bot should reply with a backport message
             TestBotRunner.runPeriodicItems(bot);
             var comments = pr.comments();
-            var backportComment = comments.get(0).body();
+            var backportComment = comments.get(1).body();
             assertTrue(backportComment.contains("This backport pull request has now been updated with issue"));
             assertTrue(backportComment.contains("<!-- backport " + upstreamHash.hex() + " -->"));
             assertEquals(issue2Number + ": Another issue", pr.store().title());

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IssueTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IssueTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -760,11 +760,11 @@ class IssueTests {
             assertTrue(pr.title().startsWith(issue1.id().split("-")[1] + ": "));
 
             var comments = pr.comments();
-            assertEquals(3, comments.size());
+            assertEquals(4, comments.size());
 
-            assertTrue(comments.get(0).body().contains("current title does not contain an issue reference"));
-            assertTrue(comments.get(1).body().contains("Adding additional issue to"));
+            assertTrue(comments.get(1).body().contains("current title does not contain an issue reference"));
             assertTrue(comments.get(2).body().contains("Adding additional issue to"));
+            assertTrue(comments.get(3).body().contains("Adding additional issue to"));
         }
     }
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@ import java.util.*;
 import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.openjdk.skara.bots.pr.PullRequestAsserts.assertFirstCommentContains;
 import static org.openjdk.skara.bots.pr.PullRequestAsserts.assertLastCommentContains;
 
 public class LabelTests {
@@ -227,7 +228,7 @@ public class LabelTests {
             // The bot will not add any label automatically
             TestBotRunner.runPeriodicItems(prBot);
             assertEquals(Set.of("1", "rfr"), new HashSet<>(pr.store().labelNames()));
-            assertEquals(1, pr.comments().size());
+            assertEquals(2, pr.comments().size());
             assertLastCommentContains(pr, "The `1` label was successfully added.");
 
             // Add another file to trigger a group match
@@ -391,6 +392,7 @@ public class LabelTests {
             var editHash = CheckableRepository.appendAndCommit(localRepo);
             localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "123: This is a pull request");
+            TestBotRunner.runPeriodicItems(prBot);
 
             // Add a label with -dev suffix
             pr.addComment("/label add 1");
@@ -405,9 +407,9 @@ public class LabelTests {
             TestBotRunner.runPeriodicItems(prBot);
 
             // The bot should reply with a integration message
-            assertLastCommentContains(pr,"This change now passes all *automated* pre-integration checks");
-            assertLastCommentContains(pr,":mag: One or more changes in this pull request modifies files");
-            assertLastCommentContains(pr,"in areas of the source code that often require two reviewers.");
+            assertFirstCommentContains(pr, "This change now passes all *automated* pre-integration checks");
+            assertFirstCommentContains(pr, ":mag: One or more changes in this pull request modifies files");
+            assertFirstCommentContains(pr, "in areas of the source code that often require two reviewers.");
         }
     }
 
@@ -445,6 +447,7 @@ public class LabelTests {
             var editHash = CheckableRepository.appendAndCommit(localRepo);
             localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "123: This is a pull request");
+            TestBotRunner.runPeriodicItems(prBot);
 
             // Add a label with 24h hint
             pr.addComment("/label add 1");
@@ -459,10 +462,10 @@ public class LabelTests {
             TestBotRunner.runPeriodicItems(prBot);
 
             // The bot should reply with a integration message
-            assertLastCommentContains(pr,"This change now passes all *automated* pre-integration checks");
-            assertLastCommentContains(pr,":earth_americas: Applicable reviewers for one or more changes ");
-            assertLastCommentContains(pr,"in this pull request are spread across multiple different time zones.");
-            assertLastCommentContains(pr,"been out for review for at least 24 hours");
+            assertFirstCommentContains(pr,"This change now passes all *automated* pre-integration checks");
+            assertFirstCommentContains(pr,":earth_americas: Applicable reviewers for one or more changes ");
+            assertFirstCommentContains(pr,"in this pull request are spread across multiple different time zones.");
+            assertFirstCommentContains(pr,"been out for review for at least 24 hours");
         }
     }
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
@@ -1642,7 +1642,7 @@ class MergeTests {
             TestBotRunner.runPeriodicItems(mergeBot);
 
             // Merging latest master should not trigger a warning
-            assertEquals(0, pr.comments().size());
+            assertEquals(1, pr.comments().size());
 
             localRepo.merge(otherHash2);
             var mergeHash = localRepo.commit("Merge commit", "some", "some@one");
@@ -1815,9 +1815,8 @@ class MergeTests {
 
             // Let the bot check the status
             TestBotRunner.runPeriodicItems(mergeBot);
-            var comment = pr.store().comments().get(pr.store().comments().size() - 1);
-            assertEquals(1, pr.store().comments().size());
-            assertTrue(comment.body().contains("can not be source repo for merge-style pull requests in this repository."));
+            assertEquals(2, pr.comments().size());
+            assertLastCommentContains(pr, "can not be source repo for merge-style pull requests in this repository.");
         }
     }
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestAsserts.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestAsserts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,5 +32,12 @@ public class PullRequestAsserts {
         assertTrue(!comments.isEmpty());
         var lastComment = comments.get(comments.size() - 1);
         assertTrue(lastComment.body().contains(contains), lastComment.body());
+    }
+
+    public static void assertFirstCommentContains(PullRequest pr, String contains) {
+        var comments = pr.comments();
+        assertTrue(!comments.isEmpty());
+        var firstComment = comments.get(0);
+        assertTrue(firstComment.body().contains(contains), firstComment.body());
     }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestCommandTests.java
@@ -139,19 +139,19 @@ class PullRequestCommandTests {
             TestBotRunner.runPeriodicItems(mergeBot);
 
             // Each command should get a separate reply
-            assertEquals(4, pr.comments().size());
-            assertTrue(pr.comments().get(1).body().contains("Contributor `A <a@b.c>` successfully added"), pr.comments().get(1).body());
-            assertTrue(pr.comments().get(2).body().contains("Setting summary to:\n" +
+            assertEquals(5, pr.comments().size());
+            assertTrue(pr.comments().get(2).body().contains("Contributor `A <a@b.c>` successfully added"), pr.comments().get(2).body());
+            assertTrue(pr.comments().get(3).body().contains("Setting summary to:\n" +
                                                                     "\n" +
                                                                     "```\n" +
                                                                     "line 1\n" +
-                                                                    "line 2"), pr.comments().get(2).body());
-            assertTrue(pr.comments().get(3).body().contains("Contributor `B <b@c.d>` successfully added"), pr.comments().get(3).body());
+                                                                    "line 2"), pr.comments().get(3).body());
+            assertTrue(pr.comments().get(4).body().contains("Contributor `B <b@c.d>` successfully added"), pr.comments().get(4).body());
 
             // They should only be executed once
             TestBotRunner.runPeriodicItems(mergeBot);
             TestBotRunner.runPeriodicItems(mergeBot);
-            assertEquals(4, pr.comments().size());
+            assertEquals(5, pr.comments().size());
         }
     }
 
@@ -184,14 +184,14 @@ class PullRequestCommandTests {
             // The bot should not reply
             assertEquals(1, pr.comments().size());
             TestBotRunner.runPeriodicItems(mergeBot);
-            assertEquals(1, pr.comments().size());
+            assertEquals(2, pr.comments().size());
 
             // But if we add an overriding marker, it should
             botPr.addComment("/help\n<!-- Valid self-command -->");
 
-            assertEquals(2, pr.comments().size());
-            TestBotRunner.runPeriodicItems(mergeBot);
             assertEquals(3, pr.comments().size());
+            TestBotRunner.runPeriodicItems(mergeBot);
+            assertEquals(4, pr.comments().size());
 
             var help = pr.comments().stream()
                          .filter(comment -> comment.body().contains("Available commands"))
@@ -301,8 +301,7 @@ class PullRequestCommandTests {
             TestBotRunner.runPeriodicItems(mergeBot);
 
             // The bot should not reply since the external command will be handled by another bot
-            var lastComment = pr.comments().get(pr.comments().size() - 1);
-            assertEquals(externalCommandComment, lastComment);
+            assertLastCommentContains(pr, "This change is not yet ready to be integrated.");
 
             // Issue the help command
             pr.addComment("/help");

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ReviewerTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ReviewerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.openjdk.skara.bots.pr.PullRequestAsserts.assertFirstCommentContains;
 import static org.openjdk.skara.bots.pr.PullRequestAsserts.assertLastCommentContains;
 
 class ReviewerTests {
@@ -495,6 +496,7 @@ class ReviewerTests {
             var editHash = CheckableRepository.appendAndCommit(localRepo);
             localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
+            TestBotRunner.runPeriodicItems(prBot);
 
             // Credit two additional reviewers
             pr.addComment("/reviewer credit integrationreviewer1 integrationcommitter3");
@@ -510,7 +512,7 @@ class ReviewerTests {
             TestBotRunner.runPeriodicItems(prBot);
 
             // Check the ready comment
-            assertLastCommentContains(pr, "Reviewed-by: integrationreviewer2, integrationreviewer1, integrationcommitter3");
+            assertFirstCommentContains(pr, "Reviewed-by: integrationreviewer2, integrationreviewer1, integrationcommitter3");
 
             // Check the PR body
             assertTrue(pr.store().body().contains(" * Generated Reviewer 1 - **Reviewer** ⚠️ Added manually"));


### PR DESCRIPTION
As Magnus said in the issue description, sometimes it's hard for users to find the merge ready comment. So he would like to see that this message is added as soon as possible, after the bridgekeeper has done its job. 

In this patch, on the very beginning of CheckWorkItem, skara bot would post a placeholder message to the PR and update it later.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2070](https://bugs.openjdk.org/browse/SKARA-2070): Get a placeholder message spot for integration message (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1619/head:pull/1619` \
`$ git checkout pull/1619`

Update a local copy of the PR: \
`$ git checkout pull/1619` \
`$ git pull https://git.openjdk.org/skara.git pull/1619/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1619`

View PR using the GUI difftool: \
`$ git pr show -t 1619`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1619.diff">https://git.openjdk.org/skara/pull/1619.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1619#issuecomment-1986576829)