### PR TITLE
2197: Make the /backport command support a "repo:branch" argument

### DIFF
--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportCommitCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportCommitCommandTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -77,6 +77,24 @@ public class BackportCommitCommandTests {
             assertTrue(botReply.body().contains("with this backport"));
             assertTrue(botReply.body().contains("@" + botReply.author().username()));
             assertEquals(botReply.body().indexOf("@" + botReply.author().username()), botReply.body().lastIndexOf("@" + botReply.author().username()));
+
+            // Add a backport command
+            author.addCommitComment(editHash, "/backport " + author.name() + ":" + author.defaultBranchName());
+            TestBotRunner.runPeriodicItems(bot);
+            recentCommitComments = author.recentCommitComments();
+            assertEquals(4, recentCommitComments.size());
+            botReply = recentCommitComments.get(0);
+            assertTrue(botReply.body().contains("To create a pull request with this backport targeting " +
+                    "[" + author.name() + ":" + author.defaultBranchName() + "]"));
+
+            // Add a backport command
+            author.addCommitComment(editHash, "/backport :" + author.defaultBranchName());
+            TestBotRunner.runPeriodicItems(bot);
+            recentCommitComments = author.recentCommitComments();
+            assertEquals(6, recentCommitComments.size());
+            botReply = recentCommitComments.get(0);
+            assertTrue(botReply.body().contains("To create a pull request with this backport targeting " +
+                    "[" + author.name() + ":" + author.defaultBranchName() + "]"));
         }
     }
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportPRCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportPRCommandTests.java
@@ -54,7 +54,7 @@ public class BackportPRCommandTests {
                     .repo(bot)
                     .censusRepo(censusBuilder.build())
                     .seedStorage(seedFolder)
-                    .forks(Map.of("targetRepo", targetRepo, "targetRepo2", targetRepo2))
+                    .forks(Map.of("targetRepo", targetRepo, "targetRepo2", targetRepo2, "test", author))
                     .build();
 
             // Populate the projects repository
@@ -89,13 +89,25 @@ public class BackportPRCommandTests {
             assertLastCommentContains(pr, "Backport for repo `targetRepo2` on branch `dev` was successfully enabled");
             assertTrue(pr.store().labelNames().contains("backport=targetRepo2:dev"));
 
-            // disable backport for targetRepo on master
+            // Enable backport for test on master
+            pr.addComment("/backport :master");
+            TestBotRunner.runPeriodicItems(prBot);
+            assertLastCommentContains(pr, "Backport for repo `test` on branch `master` was successfully enabled");
+            assertTrue(pr.store().labelNames().contains("backport=test:master"));
+
+            // Disable backport for test on master
+            pr.addComment("/backport disable test:master");
+            TestBotRunner.runPeriodicItems(prBot);
+            assertLastCommentContains(pr, "Backport for repo `test` on branch `master` was successfully disabled");
+            assertFalse(pr.store().labelNames().contains("backport=test:master"));
+
+            // Disable backport for targetRepo on master
             reviewerPr.addComment("/backport disable targetRepo");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(pr, "Backport for repo `targetRepo` on branch `master` was successfully disabled.");
             assertFalse(pr.store().labelNames().contains("backport=targetRepo:master"));
 
-            // disable backport for targetRepo again
+            // Disable backport for targetRepo again
             reviewerPr.addComment("/backport disable targetRepo");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(pr, "Backport for repo `targetRepo` on branch `master` was already disabled.");
@@ -165,7 +177,7 @@ public class BackportPRCommandTests {
 
             TestBotRunner.runPeriodicItems(prBot);
 
-            //close the pr
+            // Close the pr
             pr.store().setState(Issue.State.CLOSED);
             pr.addComment("/backport targetRepo");
             TestBotRunner.runPeriodicItems(prBot);


### PR DESCRIPTION
This patch is trying to make /backport command support `repo:branch` argument.

And as ErikD suggested, `repo` should be optional if the user is backporting to a different branch in the same repository.

> To make it slightly more convenient to backport a commit to a branch in the same repository as the commit is residing in we would allow short form "/backport :branch" (this is also fully backwards compatible and cannot become ambiguous in the future).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2197](https://bugs.openjdk.org/browse/SKARA-2197): Make the /backport command support a "repo:branch" argument (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1620/head:pull/1620` \
`$ git checkout pull/1620`

Update a local copy of the PR: \
`$ git checkout pull/1620` \
`$ git pull https://git.openjdk.org/skara.git pull/1620/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1620`

View PR using the GUI difftool: \
`$ git pr show -t 1620`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1620.diff">https://git.openjdk.org/skara/pull/1620.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1620#issuecomment-2000276403)