### PR TITLE
2200: The jdk/internal/javac package should be mapped to the compiler label

### DIFF
--- a/config/mailinglist/rules/jdk.json
+++ b/config/mailinglist/rules/jdk.json
@@ -48,7 +48,7 @@
             "make/langtools/",
             "make/modules/jdk.compiler/",
             "make/scripts/generate-symbol-data.sh",
-            "src/java.base/share/classes/jdk/internal/PreviewFeature.java",
+            "src/java.base/share/classes/jdk/internal/javac/",
             "src/java.compiler/",
             "src/jdk.compiler/",
             "src/jdk.jartool/(?!.*/jarsigner)",


### PR DESCRIPTION
Originally, `jdk/internal/PreviewFeature.java` was mapped to the compiler label, but this has been moved into `jdk/internal/javac`, breaking the mapping. Re-mapping `jdk/internal/javac` back to compiler. Keeping the mapping to core-libs, partially because changes there may be relevant to core-libs as well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2200](https://bugs.openjdk.org/browse/SKARA-2200): The jdk/internal/javac package should be mapped to the compiler label (**Bug** - P4)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - no project role)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1621/head:pull/1621` \
`$ git checkout pull/1621`

Update a local copy of the PR: \
`$ git checkout pull/1621` \
`$ git pull https://git.openjdk.org/skara.git pull/1621/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1621`

View PR using the GUI difftool: \
`$ git pr show -t 1621`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1621.diff">https://git.openjdk.org/skara/pull/1621.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1621#issuecomment-2004316772)