### PR TITLE
2201: Only fetch comments once in PullRequestWorkItem in pr bot

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CSRCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CSRCommand.java
@@ -165,7 +165,7 @@ public class CSRCommand implements CommandHandler {
             reply.println(CSR_NEEDED_MARKER);
         } else {
             csrReply(reply);
-            var issues = SolvesTracker.currentSolved(pr.repository().forge().currentUser(), pr.comments(), pr.title());
+            var issues = SolvesTracker.currentSolved(pr.repository().forge().currentUser(), allComments, pr.title());
             if (issues.isEmpty()) {
                 singleIssueLinkReply(pr, jbsMainIssueOpt.get(), reply);
             } else {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -451,11 +451,10 @@ class CheckRun {
         }
 
         var botUser = pr.repository().forge().currentUser();
-        var isCleanLabelManuallyAdded =
-            pr.comments()
-              .stream()
-              .filter(c -> c.author().equals(botUser))
-              .anyMatch(c -> c.body().contains("This backport pull request is now marked as clean"));
+        var isCleanLabelManuallyAdded = comments
+                .stream()
+                .filter(c -> c.author().equals(botUser))
+                .anyMatch(c -> c.body().contains("This backport pull request is now marked as clean"));
 
         if (!isCleanLabelManuallyAdded && !isClean && hasCleanLabel) {
             log.info("Removing label clean");
@@ -1437,7 +1436,7 @@ class CheckRun {
             }
 
             // Calculate current metadata to avoid unnecessary future checks
-            var metadata = workItem.getMetadata(workItem.getPRMetadata(censusInstance, title, updatedBody, pr.comments(), activeReviews,
+            var metadata = workItem.getMetadata(workItem.getPRMetadata(censusInstance, title, updatedBody, comments, activeReviews,
                     newLabels, pr.targetRef(), pr.isDraft()), workItem.getIssueMetadata(updatedBody), expiresIn);
             checkBuilder.metadata(metadata);
         } catch (Exception e) {
@@ -1548,7 +1547,7 @@ class CheckRun {
                 existingApprovedCSR = true;
             }
         }
-        if (notExistingUnresolvedCSR && (!isCSRNeeded(pr.comments()) || existingApprovedCSR) && pr.labelNames().contains(CSR_LABEL)) {
+        if (notExistingUnresolvedCSR && (!isCSRNeeded(comments) || existingApprovedCSR) && pr.labelNames().contains(CSR_LABEL)) {
             log.info("All CSR issues closed and approved for " + describe(pr) + ", removing CSR label");
             newLabels.remove(CSR_LABEL);
         }


### PR DESCRIPTION
In pr bot, we are still fetching comments from the remote forge instead of using the cache after [SKARA-1709](https://bugs.openjdk.org/browse/SKARA-1709).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2201](https://bugs.openjdk.org/browse/SKARA-2201): Only fetch comments once in PullRequestWorkItem in pr bot (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1622/head:pull/1622` \
`$ git checkout pull/1622`

Update a local copy of the PR: \
`$ git checkout pull/1622` \
`$ git pull https://git.openjdk.org/skara.git pull/1622/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1622`

View PR using the GUI difftool: \
`$ git pr show -t 1622`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1622.diff">https://git.openjdk.org/skara/pull/1622.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1622#issuecomment-2004585822)