### PR TITLE
2198: Backport PRs should check if a CSR is required

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CSRCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CSRCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,6 +33,7 @@ import java.util.regex.Pattern;
 
 import static org.openjdk.skara.bots.common.CommandNameEnum.csr;
 import static org.openjdk.skara.bots.common.PullRequestConstants.*;
+import static org.openjdk.skara.bots.pr.CheckRun.CSR_PROCESS_LINK;
 
 public class CSRCommand implements CommandHandler {
 
@@ -40,36 +41,36 @@ public class CSRCommand implements CommandHandler {
     private static final Pattern RESOLVED_CSR_PROGRESS_PATTERN = Pattern.compile("- \\[x\\] Change requires CSR request \\[(.*?)\\]\\((.*?)\\) to be approved");
 
     private static void showHelp(PrintWriter writer) {
-        writer.println("usage: `/csr [needed|unneeded]`, requires that the issue the pull request refers to links to an approved [CSR](https://wiki.openjdk.org/display/csr/Main) request.");
+        writer.println("usage: `/csr [needed|unneeded]`, requires that the issue the pull request refers to links to an approved [CSR](" + CSR_PROCESS_LINK + ") request.");
     }
 
     private static void csrReply(PrintWriter writer) {
         writer.println("has indicated that a " +
-                      "[compatibility and specification](https://wiki.openjdk.org/display/csr/Main) (CSR) request " +
-                      "is needed for this pull request.");
+                "[compatibility and specification](" + CSR_PROCESS_LINK + ") (CSR) request " +
+                "is needed for this pull request.");
         writer.println(CSR_NEEDED_MARKER);
     }
 
     private static void jbsReply(PullRequest pr, PrintWriter writer) {
         writer.println("@" + pr.author().username() + " this pull request must refer to an issue in " +
-                      "[JBS](https://bugs.openjdk.org) to be able to link it to a [CSR](https://wiki.openjdk.org/display/csr/Main) request. To refer this pull request to " +
-                      "an issue in JBS, please update the title of this pull request to just the issue ID.");
+                "[JBS](https://bugs.openjdk.org) to be able to link it to a [CSR](" + CSR_PROCESS_LINK + ") request. To refer this pull request to " +
+                "an issue in JBS, please update the title of this pull request to just the issue ID.");
     }
 
     private static void multipleIssueReply(PullRequest pr, PrintWriter writer) {
-        writer.println("@" + pr.author().username() + " please create a [CSR](https://wiki.openjdk.org/display/csr/Main) request, " +
+        writer.println("@" + pr.author().username() + " please create a [CSR](" + CSR_PROCESS_LINK + ") request, " +
                 "with the correct fix version, for at least one of the issues associated with this pull request." +
                 " This pull request cannot be integrated until all the CSR request are approved.");
     }
 
     private static void singleIssueLinkReply(PullRequest pr, IssueTrackerIssue issue, PrintWriter writer) {
-        writer.println("@" + pr.author().username() + " please create a [CSR](https://wiki.openjdk.org/display/csr/Main) request for issue " +
+        writer.println("@" + pr.author().username() + " please create a [CSR](" + CSR_PROCESS_LINK + ") request for issue " +
                 "[" + issue.id() + "](" + issue.webUrl() + ") with the correct fix version. " +
                 "This pull request cannot be integrated until the CSR request is approved.");
     }
 
     private static void csrUnneededReply(PullRequest pr, PrintWriter writer) {
-        writer.println("determined that a [CSR](https://wiki.openjdk.org/display/csr/Main) request " +
+        writer.println("determined that a [CSR](" + CSR_PROCESS_LINK + ") request " +
                 "is not needed for this pull request.");
         writer.println(CSR_UNNEEDED_MARKER);
         if (pr.labelNames().contains(CSR_LABEL)) {
@@ -126,7 +127,7 @@ public class CSRCommand implements CommandHandler {
         }
 
         if (labels.contains(CSR_LABEL)) {
-            reply.println("an approved [CSR](https://wiki.openjdk.org/display/csr/Main) request " +
+            reply.println("an approved [CSR](" + CSR_PROCESS_LINK + ") request " +
                     "is already required for this pull request.");
             reply.println(CSR_NEEDED_MARKER);
             return;

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -1643,9 +1643,7 @@ class CheckRun {
     }
 
     /**
-     * Iterate through each entry in the regularIssuesMap. If the value is present, get all CSR links associated with this issue.
-     * "all CSR links" means that the CSR linked with the primary issue and the CSRs linked with any backport issues of the primary issue.
-     * Constructs a map from main issue ID to all CSR links.
+     * Creates a map from issue ID to a list of all CSRs linked from the issue or any backport of the issue.
      */
     private Map<String, List<Link>> issueToCsrLinksMap(Map<Issue, Optional<IssueTrackerIssue>> regularIssuesMap) {
         Map<String, List<Link>> issueToCsrLinksMap = new HashMap<>();

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -1574,7 +1574,8 @@ class CheckRun {
             if (hasResolvedCSR) {
                 newLabels.add("csr");
                 pr.addComment("At least one of the associated issues of this backport has a resolved CSR.\n" +
-                        "This backport might also need a CSR. \"csr\" label will be added to this PR.");
+                        "This backport might also need a CSR. `csr` label will be added to this PR.\n" +
+                        "Please go through the [CSR](https://wiki.openjdk.org/display/csr/Main) process or using command `csr unneeded` to remove the CSR requirement.");
             }
         }
     }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -1574,10 +1574,11 @@ class CheckRun {
 
             if (hasResolvedCSR) {
                 newLabels.add("csr");
-                pr.addComment("At least one of the associated issues of this backport has a resolved CSR.\n" +
-                        "This backport might also need a CSR. `csr` label will be added to this PR.\n" +
-                        "Please go through the [CSR](" + CSR_PROCESS_LINK +
-                        ") process or using command `csr unneeded` to remove the CSR requirement.");
+                pr.addComment("At least one of the issues associated with this backport has a resolved " +
+                        "[CSR](" + CSR_PROCESS_LINK + ") for a different version. As this means that this " +
+                        "backport may also need a CSR, the `csr` label is being added to this pull request " +
+                        "to signal this potential requirement. The command `/csr unneeded` can be used to " + 
+                        "remove the label in case a CSR is not needed.");
             }
         }
     }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -1574,11 +1574,11 @@ class CheckRun {
                             csrIssue.resolution().map(res -> res.equals("Approved")).orElse(false));
 
             if (hasResolvedCSR) {
+                newLabels.add("csr");
                 var existing = findComment(BACKPORT_CSR_MARKER);
                 if (existing.isPresent()) {
                     return;
                 }
-                newLabels.add("csr");
                 pr.addComment("At least one of the issues associated with this backport has a resolved " +
                         "[CSR](" + CSR_PROCESS_LINK + ") for a different version. As this means that this " +
                         "backport may also need a CSR, the `csr` label is being added to this pull request " +

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -1351,15 +1351,15 @@ class CheckRun {
             // issues without CSR issues and JEP issues
             var regularIssuesMap = regularIssuesMap();
             var jepIssue = jepIssue().orElse(null);
-            var issueToCsrLinksMap = issueToCsrLinksMap(regularIssuesMap);
-            var issueToCsrMap = issueToCsrMap(issueToCsrLinksMap, version);
+            var issueToAllCsrLinksMap = issueToCsrLinksMap(regularIssuesMap);
+            var issueToCsrMap = issueToCsrMap(issueToAllCsrLinksMap, version);
             var csrIssues = issueToCsrMap.values().stream().toList();
 
             // Check the status of csr issues and determine whether to add or remove csr label here
             updateCSRLabel(version, issueToCsrMap);
 
             // In a backport PR, Check if one of associated issues has a resolved CSR for a different fixVersion
-            updateBackportCSRLabel(issueToCsrLinksMap, issueToCsrMap);
+            updateBackportCSRLabel(issueToAllCsrLinksMap, issueToCsrMap);
 
             if (needUpdateAdditionalProgresses) {
                 additionalProgresses = botSpecificProgresses(regularIssuesMap, csrIssues, jepIssue, version);
@@ -1642,6 +1642,11 @@ class CheckRun {
         pr.addComment(message);
     }
 
+    /**
+     * Iterate through each entry in the regularIssuesMap. If the value is present, get all CSR links associated with this issue.
+     * "all CSR links" means that the CSR linked with the primary issue and the CSRs linked with any backport issues of the primary issue.
+     * Constructs a map from main issue ID to all CSR links.
+     */
     private Map<String, List<Link>> issueToCsrLinksMap(Map<Issue, Optional<IssueTrackerIssue>> regularIssuesMap) {
         Map<String, List<Link>> issueToCsrLinksMap = new HashMap<>();
         for (var issue : regularIssuesMap.values()) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -74,6 +74,7 @@ class CheckRun {
     private static final String FULL_NAME_WARNING_MARKER = "<!-- PullRequestBot full name warning comment -->";
     private static final String APPROVAL_NEEDED_MARKER = "<!-- PullRequestBot approval needed comment -->";
     private static final Set<String> PRIMARY_TYPES = Set.of("Bug", "New Feature", "Enhancement", "Task", "Sub-task");
+    protected static final String CSR_PROCESS_LINK = "https://wiki.openjdk.org/display/csr/Main";
     private final Set<String> newLabels;
     private final boolean reviewCleanBackport;
     private final Approval approval;
@@ -1575,7 +1576,8 @@ class CheckRun {
                 newLabels.add("csr");
                 pr.addComment("At least one of the associated issues of this backport has a resolved CSR.\n" +
                         "This backport might also need a CSR. `csr` label will be added to this PR.\n" +
-                        "Please go through the [CSR](https://wiki.openjdk.org/display/csr/Main) process or using command `csr unneeded` to remove the CSR requirement.");
+                        "Please go through the [CSR](" + CSR_PROCESS_LINK +
+                        ") process or using command `csr unneeded` to remove the CSR requirement.");
             }
         }
     }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -73,6 +73,7 @@ class CheckRun {
             "If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.\n-->";
     private static final String FULL_NAME_WARNING_MARKER = "<!-- PullRequestBot full name warning comment -->";
     private static final String APPROVAL_NEEDED_MARKER = "<!-- PullRequestBot approval needed comment -->";
+    private static final String BACKPORT_CSR_MARKER = "<!-- PullRequestBot backport csr comment -->";
     private static final Set<String> PRIMARY_TYPES = Set.of("Bug", "New Feature", "Enhancement", "Task", "Sub-task");
     protected static final String CSR_PROCESS_LINK = "https://wiki.openjdk.org/display/csr/Main";
     private final Set<String> newLabels;
@@ -1573,12 +1574,17 @@ class CheckRun {
                             csrIssue.resolution().map(res -> res.equals("Approved")).orElse(false));
 
             if (hasResolvedCSR) {
+                var existing = findComment(BACKPORT_CSR_MARKER);
+                if (existing.isPresent()) {
+                    return;
+                }
                 newLabels.add("csr");
                 pr.addComment("At least one of the issues associated with this backport has a resolved " +
                         "[CSR](" + CSR_PROCESS_LINK + ") for a different version. As this means that this " +
                         "backport may also need a CSR, the `csr` label is being added to this pull request " +
-                        "to signal this potential requirement. The command `/csr unneeded` can be used to " + 
-                        "remove the label in case a CSR is not needed.");
+                        "to signal this potential requirement. The command `/csr unneeded` can be used to " +
+                        "remove the label in case a CSR is not needed." +
+                        BACKPORT_CSR_MARKER);
             }
         }
     }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -1645,7 +1645,7 @@ class CheckRun {
     /**
      * Creates a map from issue ID to a list of all CSRs linked from the issue or any backport of the issue.
      */
-    private Map<String, List<Link>> issueToCsrLinksMap(Map<Issue, Optional<IssueTrackerIssue>> regularIssuesMap) {
+    private Map<String, List<IssueTrackerIssue>> issueToAllCsrsMap(Map<Issue, Optional<IssueTrackerIssue>> regularIssuesMap) {
         Map<String, List<Link>> issueToCsrLinksMap = new HashMap<>();
         for (var issue : regularIssuesMap.values()) {
             if (issue.isPresent()) {

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CSRCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CSRCommandTests.java
@@ -852,12 +852,8 @@ class CSRCommandTests {
             TestBotRunner.runPeriodicItems(prBot);
             assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion (No fixVersion in .jcheck/conf) to be approved (needs to be created)"));
             assertTrue(pr.store().labelNames().contains("csr"));
-            assertLastCommentContains(pr, "has indicated that a " +
-                    "[compatibility and specification](https://wiki.openjdk.org/display/csr/Main) (CSR) request " +
-                    "is needed for this pull request.");
-            assertLastCommentContains(pr, "please create a [CSR](https://wiki.openjdk.org/display/csr/Main) request");
-            assertLastCommentContains(pr, "with the correct fix version");
-            assertLastCommentContains(pr, "This pull request cannot be integrated until the CSR request is approved.");
+            assertLastCommentContains(pr, "@user1 an approved [CSR](https://wiki.openjdk.org/display/csr/Main) request is already required for this pull request.");
+
             // Use `/csr unneeded` to revert the change.
             pr.addComment("/csr unneeded");
             TestBotRunner.runPeriodicItems(prBot);
@@ -883,12 +879,8 @@ class CSRCommandTests {
             TestBotRunner.runPeriodicItems(prBot);
             assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion (No fixVersion in .jcheck/conf) to be approved (needs to be created)"));
             assertTrue(pr.store().labelNames().contains("csr"));
-            assertLastCommentContains(pr, "has indicated that a " +
-                    "[compatibility and specification](https://wiki.openjdk.org/display/csr/Main) (CSR) request " +
-                    "is needed for this pull request.");
-            assertLastCommentContains(pr, "please create a [CSR](https://wiki.openjdk.org/display/csr/Main) request");
-            assertLastCommentContains(pr, "with the correct fix version");
-            assertLastCommentContains(pr, "This pull request cannot be integrated until the CSR request is approved.");
+            assertLastCommentContains(pr, "@user1 an approved [CSR](https://wiki.openjdk.org/display/csr/Main) request is already required for this pull request.");
+
             // Use `/csr unneeded` to revert the change.
             pr.addComment("/csr unneeded");
             TestBotRunner.runPeriodicItems(prBot);
@@ -914,12 +906,8 @@ class CSRCommandTests {
             TestBotRunner.runPeriodicItems(prBot);
             assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion 17 to be approved (needs to be created)"));
             assertTrue(pr.store().labelNames().contains("csr"));
-            assertLastCommentContains(pr, "has indicated that a " +
-                    "[compatibility and specification](https://wiki.openjdk.org/display/csr/Main) (CSR) request " +
-                    "is needed for this pull request.");
-            assertLastCommentContains(pr, "please create a [CSR](https://wiki.openjdk.org/display/csr/Main) request");
-            assertLastCommentContains(pr, "with the correct fix version");
-            assertLastCommentContains(pr, "This pull request cannot be integrated until the CSR request is approved.");
+            assertLastCommentContains(pr, "@user1 an approved [CSR](https://wiki.openjdk.org/display/csr/Main) request is already required for this pull request.");
+
             // Use `/csr unneeded` to revert the change.
             pr.addComment("/csr unneeded");
             TestBotRunner.runPeriodicItems(prBot);
@@ -961,12 +949,8 @@ class CSRCommandTests {
             TestBotRunner.runPeriodicItems(prBot);
             assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion 17 to be approved (needs to be created)"));
             assertTrue(pr.store().labelNames().contains("csr"));
-            assertLastCommentContains(pr, "has indicated that a " +
-                    "[compatibility and specification](https://wiki.openjdk.org/display/csr/Main) (CSR) request " +
-                    "is needed for this pull request.");
-            assertLastCommentContains(pr, "please create a [CSR](https://wiki.openjdk.org/display/csr/Main) request");
-            assertLastCommentContains(pr, "with the correct fix version");
-            assertLastCommentContains(pr, "This pull request cannot be integrated until the CSR request is approved.");
+            assertLastCommentContains(pr, "@user1 an approved [CSR](https://wiki.openjdk.org/display/csr/Main) request is already required for this pull request.");
+
             // Use `/csr unneeded` to revert the change.
             pr.addComment("/csr unneeded");
             TestBotRunner.runPeriodicItems(prBot);

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CSRCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CSRCommandTests.java
@@ -39,6 +39,7 @@ import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.openjdk.skara.bots.pr.PullRequestAsserts.assertLastCommentContains;
+import static org.openjdk.skara.bots.pr.CheckRun.CSR_PROCESS_LINK;
 
 class CSRCommandTests {
     @Test
@@ -81,7 +82,7 @@ class CSRCommandTests {
 
             // The bot should reply with a message that a CSR is needed
             assertLastCommentContains(pr, "has indicated that a " +
-                                          "[compatibility and specification](https://wiki.openjdk.org/display/csr/Main) (CSR) request " +
+                                          "[compatibility and specification](" + CSR_PROCESS_LINK + ") (CSR) request " +
                                           "is needed for this pull request.");
             assertTrue(pr.store().labelNames().contains("csr"));
             // The PR body should contain the progress about CSR request
@@ -92,7 +93,7 @@ class CSRCommandTests {
             TestBotRunner.runPeriodicItems(prBot);
 
             // The bot should reply with a message that a CSR is no longer needed
-            assertLastCommentContains(pr, "determined that a [CSR](https://wiki.openjdk.org/display/csr/Main) request " +
+            assertLastCommentContains(pr, "determined that a [CSR](" + CSR_PROCESS_LINK + ") request " +
                                           "is not needed for this pull request.");
             assertFalse(pr.store().labelNames().contains("csr"));
             // The PR body shouldn't contain the progress about CSR request
@@ -104,7 +105,7 @@ class CSRCommandTests {
 
             // The bot should reply with a message that a CSR is needed
             assertLastCommentContains(pr, "has indicated that a " +
-                                          "[compatibility and specification](https://wiki.openjdk.org/display/csr/Main) (CSR) request " +
+                                          "[compatibility and specification](" + CSR_PROCESS_LINK + ") (CSR) request " +
                                           "is needed for this pull request.");
             assertTrue(pr.store().labelNames().contains("csr"));
             // The PR body should contain the progress about CSR request
@@ -206,7 +207,7 @@ class CSRCommandTests {
 
             // The bot should reply with a message that the CSR is already aproved
             assertLastCommentContains(pr, "has indicated that a " +
-                                          "[compatibility and specification](https://wiki.openjdk.org/display/csr/Main) " +
+                                          "[compatibility and specification](" + CSR_PROCESS_LINK + ") " +
                                           "(CSR) request is needed for this pull request.");
             assertLastCommentContains(pr, "this pull request must refer to an issue in [JBS]");
             assertLastCommentContains(pr, "To refer this pull request to an issue in JBS");
@@ -274,7 +275,7 @@ class CSRCommandTests {
 
             // The bot should reply with a message that a CSR is needed
             assertLastCommentContains(pr, "has indicated that a " +
-                                          "[compatibility and specification](https://wiki.openjdk.org/display/csr/Main) (CSR) request " +
+                                          "[compatibility and specification](" + CSR_PROCESS_LINK + ") (CSR) request " +
                                           "is needed for this pull request.");
             assertTrue(pr.store().labelNames().contains("csr"));
             // The PR body should contain the progress about CSR request
@@ -338,7 +339,7 @@ class CSRCommandTests {
 
             // Show help
             assertLastCommentContains(pr, "usage: `/csr [needed|unneeded]`, requires that the issue the pull request refers to links " +
-                                          "to an approved [CSR](https://wiki.openjdk.org/display/csr/Main) request.");
+                                          "to an approved [CSR](" + CSR_PROCESS_LINK + ") request.");
             assertFalse(pr.store().labelNames().contains("csr"));
             // The PR body shouldn't contain the progress about CSR request
             assertFalse(pr.store().body().contains("Change requires a CSR request matching fixVersion 0.1 to be approved (needs to be created)"));
@@ -384,10 +385,10 @@ class CSRCommandTests {
 
             // The bot should reply with a message that the PR must refer to an issue in JBS
             assertLastCommentContains(pr, "has indicated that a " +
-                                          "[compatibility and specification](https://wiki.openjdk.org/display/csr/Main) " +
+                                          "[compatibility and specification](" + CSR_PROCESS_LINK + ") " +
                                           "(CSR) request is needed for this pull request.");
             assertLastCommentContains(pr, "this pull request must refer to an issue in [JBS]");
-            assertLastCommentContains(pr, "to be able to link it to a [CSR](https://wiki.openjdk.org/display/csr/Main) request. To refer this pull request to an issue in JBS");
+            assertLastCommentContains(pr, "to be able to link it to a [CSR](" + CSR_PROCESS_LINK + ") request. To refer this pull request to an issue in JBS");
             assertTrue(pr.store().labelNames().contains("csr"));
             // The PR body should contain the progress about CSR request
             assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion 0.1 to be approved (needs to be created)"));
@@ -434,7 +435,7 @@ class CSRCommandTests {
 
             // The bot should reply with a message that a CSR is needed
             assertLastCommentContains(pr, "has indicated that a " +
-                                          "[compatibility and specification](https://wiki.openjdk.org/display/csr/Main) (CSR) request " +
+                                          "[compatibility and specification](" + CSR_PROCESS_LINK + ") (CSR) request " +
                                           "is needed for this pull request.");
             assertTrue(pr.store().labelNames().contains("csr"));
             // The PR body should contain the progress about CSR request
@@ -505,7 +506,7 @@ class CSRCommandTests {
 
             // The bot should reply with a message that there is already an approved CSR request
             // Before '/csr' is handled, csr label is added to this pr
-            assertLastCommentContains(pr, "an approved [CSR](https://wiki.openjdk.org/display/csr/Main) request is already required for this pull request.");
+            assertLastCommentContains(pr, "an approved [CSR](" + CSR_PROCESS_LINK + ") request is already required for this pull request.");
             assertLastCommentContains(pr, "<!-- csr: 'needed' -->");
             // The PR body should contain the progress about CSR request
             assertTrue(pr.store().body().contains("- [ ] " + generateCSRProgressMessage(csr)));
@@ -531,7 +532,7 @@ class CSRCommandTests {
             TestBotRunner.runPeriodicItems(prBot);
 
             // The bot should reply with a message that a CSR is no longer needed
-            assertLastCommentContains(pr, "determined that a [CSR](https://wiki.openjdk.org/display/csr/Main) request " +
+            assertLastCommentContains(pr, "determined that a [CSR](" + CSR_PROCESS_LINK + ") request " +
                     "is not needed for this pull request.");
             assertFalse(pr.store().labelNames().contains("csr"));
             // The PR body shouldn't contain the progress about CSR request
@@ -591,7 +592,7 @@ class CSRCommandTests {
 
             // The bot should reply with a message that there is already an approved CSR request
             // Before '/csr' is handled, csr label is added to this pr
-            assertLastCommentContains(pr, "an approved [CSR](https://wiki.openjdk.org/display/csr/Main) request is already required for this pull request.");
+            assertLastCommentContains(pr, "an approved [CSR](" + CSR_PROCESS_LINK + ") request is already required for this pull request.");
             assertLastCommentContains(pr, "<!-- csr: 'needed' -->");
             // The PR body should contain the progress about CSR request
             assertTrue(pr.store().body().contains("- [ ] " + generateCSRProgressMessage(csr)));
@@ -617,7 +618,7 @@ class CSRCommandTests {
             TestBotRunner.runPeriodicItems(prBot);
 
             // The bot should reply with a message that a CSR is no longer needed
-            assertLastCommentContains(pr, "determined that a [CSR](https://wiki.openjdk.org/display/csr/Main) request " +
+            assertLastCommentContains(pr, "determined that a [CSR](" + CSR_PROCESS_LINK + ") request " +
                     "is not needed for this pull request.");
             assertFalse(pr.store().labelNames().contains("csr"));
             // The PR body shouldn't contain the progress about CSR request
@@ -659,7 +660,7 @@ class CSRCommandTests {
 
             // The bot should reply with a message that a CSR is needed
             assertLastCommentContains(pr, "has indicated that a " +
-                                          "[compatibility and specification](https://wiki.openjdk.org/display/csr/Main) (CSR) request " +
+                                          "[compatibility and specification](" + CSR_PROCESS_LINK + ") (CSR) request " +
                                           "is needed for this pull request.");
             assertTrue(pr.store().labelNames().contains("csr"));
             // The PR body should contain the progress about CSR request
@@ -720,7 +721,7 @@ class CSRCommandTests {
 
             // The bot should reply with a message that a CSR is needed
             assertLastCommentContains(pr, "has indicated that a " +
-                                          "[compatibility and specification](https://wiki.openjdk.org/display/csr/Main) (CSR) request " +
+                                          "[compatibility and specification](" + CSR_PROCESS_LINK + ") (CSR) request " +
                                           "is needed for this pull request.");
             assertTrue(pr.store().labelNames().contains("csr"));
 
@@ -775,7 +776,7 @@ class CSRCommandTests {
             pr.addComment("/csr");
             TestBotRunner.runPeriodicItems(enableCsrBot);
             assertLastCommentContains(pr, "has indicated that a " +
-                    "[compatibility and specification](https://wiki.openjdk.org/display/csr/Main) (CSR) request " +
+                    "[compatibility and specification](" + CSR_PROCESS_LINK + ") (CSR) request " +
                     "is needed for this pull request.");
             assertTrue(pr.store().labelNames().contains("csr"));
             assertTrue(pr.store().body().contains("Change requires a CSR request matching fixVersion 0.1 to be approved (needs to be created)"));
@@ -861,14 +862,14 @@ class CSRCommandTests {
             TestBotRunner.runPeriodicItems(prBot);
             assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion (No fixVersion in .jcheck/conf) to be approved (needs to be created)"));
             assertTrue(pr.store().labelNames().contains("csr"));
-            assertLastCommentContains(pr, "@user1 an approved [CSR](https://wiki.openjdk.org/display/csr/Main) request is already required for this pull request.");
+            assertLastCommentContains(pr, "@user1 an approved [CSR](" + CSR_PROCESS_LINK + ") request is already required for this pull request.");
 
             // Use `/csr unneeded` to revert the change.
             pr.addComment("/csr unneeded");
             TestBotRunner.runPeriodicItems(prBot);
             assertFalse(pr.store().body().contains("Change requires a CSR request matching fixVersion (No fixVersion in .jcheck/conf) to be approved (needs to be created)"));
             assertFalse(pr.store().labelNames().contains("csr"));
-            assertLastCommentContains(pr, "determined that a [CSR](https://wiki.openjdk.org/display/csr/Main) request " +
+            assertLastCommentContains(pr, "determined that a [CSR](" + CSR_PROCESS_LINK + ") request " +
                     "is not needed for this pull request.");
 
             // Run pr bot again, "csr" label should not be added because reviewer issued "/csr unneeded"
@@ -894,14 +895,14 @@ class CSRCommandTests {
             TestBotRunner.runPeriodicItems(prBot);
             assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion (No fixVersion in .jcheck/conf) to be approved (needs to be created)"));
             assertTrue(pr.store().labelNames().contains("csr"));
-            assertLastCommentContains(pr, "@user1 an approved [CSR](https://wiki.openjdk.org/display/csr/Main) request is already required for this pull request.");
+            assertLastCommentContains(pr, "@user1 an approved [CSR](" + CSR_PROCESS_LINK + ") request is already required for this pull request.");
 
             // Use `/csr unneeded` to revert the change.
             pr.addComment("/csr unneeded");
             TestBotRunner.runPeriodicItems(prBot);
             assertFalse(pr.store().body().contains("Change requires a CSR request matching fixVersion (No fixVersion in .jcheck/conf) to be approved (needs to be created)"));
             assertFalse(pr.store().labelNames().contains("csr"));
-            assertLastCommentContains(pr, "determined that a [CSR](https://wiki.openjdk.org/display/csr/Main) request " +
+            assertLastCommentContains(pr, "determined that a [CSR](" + CSR_PROCESS_LINK + ") request " +
                     "is not needed for this pull request.");
 
             // Set the `version` in `.jcheck/conf` as 17 which is an available version.
@@ -921,14 +922,14 @@ class CSRCommandTests {
             TestBotRunner.runPeriodicItems(prBot);
             assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion 17 to be approved (needs to be created)"));
             assertTrue(pr.store().labelNames().contains("csr"));
-            assertLastCommentContains(pr, "@user1 an approved [CSR](https://wiki.openjdk.org/display/csr/Main) request is already required for this pull request.");
+            assertLastCommentContains(pr, "@user1 an approved [CSR](" + CSR_PROCESS_LINK + ") request is already required for this pull request.");
 
             // Use `/csr unneeded` to revert the change.
             pr.addComment("/csr unneeded");
             TestBotRunner.runPeriodicItems(prBot);
             assertFalse(pr.store().body().contains("Change requires a CSR request matching fixVersion 17 to be approved (needs to be created)"));
             assertFalse(pr.store().labelNames().contains("csr"));
-            assertLastCommentContains(pr, "determined that a [CSR](https://wiki.openjdk.org/display/csr/Main) request " +
+            assertLastCommentContains(pr, "determined that a [CSR](" + CSR_PROCESS_LINK + ") request " +
                     "is not needed for this pull request.");
 
             // Set the fix versions of the primary CSR to 17 and 18.
@@ -964,14 +965,14 @@ class CSRCommandTests {
             TestBotRunner.runPeriodicItems(prBot);
             assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion 17 to be approved (needs to be created)"));
             assertTrue(pr.store().labelNames().contains("csr"));
-            assertLastCommentContains(pr, "@user1 an approved [CSR](https://wiki.openjdk.org/display/csr/Main) request is already required for this pull request.");
+            assertLastCommentContains(pr, "@user1 an approved [CSR](" + CSR_PROCESS_LINK + ") request is already required for this pull request.");
 
             // Use `/csr unneeded` to revert the change.
             pr.addComment("/csr unneeded");
             TestBotRunner.runPeriodicItems(prBot);
             assertFalse(pr.store().body().contains("Change requires a CSR request matching fixVersion 17 to be approved (needs to be created)"));
             assertFalse(pr.store().labelNames().contains("csr"));
-            assertLastCommentContains(pr, "determined that a [CSR](https://wiki.openjdk.org/display/csr/Main) request " +
+            assertLastCommentContains(pr, "determined that a [CSR](" + CSR_PROCESS_LINK + ") request " +
                     "is not needed for this pull request.");
 
             // Create a backport CSR whose fix version is 17.
@@ -987,7 +988,7 @@ class CSRCommandTests {
             TestBotRunner.runPeriodicItems(prBot);
             assertTrue(pr.store().body().contains("- [ ] " + generateCSRProgressMessage(backportCsr)));
             assertTrue(pr.store().labelNames().contains("csr"));
-            assertLastCommentContains(pr, "an approved [CSR](https://wiki.openjdk.org/display/csr/Main) request is already required for this pull request.");
+            assertLastCommentContains(pr, "an approved [CSR](" + CSR_PROCESS_LINK + ") request is already required for this pull request.");
             // Use `/csr unneeded` to revert the change.
             pr.addComment("/csr unneeded");
             TestBotRunner.runPeriodicItems(prBot);
@@ -1016,7 +1017,7 @@ class CSRCommandTests {
             TestBotRunner.runPeriodicItems(prBot);
             assertTrue(pr.store().body().contains("- [ ] " + generateCSRProgressMessage(backportCsr)));
             assertTrue(pr.store().labelNames().contains("csr"));
-            assertLastCommentContains(pr, "an approved [CSR](https://wiki.openjdk.org/display/csr/Main) request is already required for this pull request.");
+            assertLastCommentContains(pr, "an approved [CSR](" + CSR_PROCESS_LINK + ") request is already required for this pull request.");
             assertLastCommentContains(pr, "<!-- csr: 'needed' -->");
             // Set the backport CSR to have multiple fix versions, excluded 11.
             backportCsr.setProperty("fixVersions", JSON.array().add("17").add("8"));
@@ -1026,7 +1027,7 @@ class CSRCommandTests {
             TestBotRunner.runPeriodicItems(prBot);
             assertFalse(pr.store().body().contains("- [ ] " + generateCSRProgressMessage(backportCsr)));
             assertFalse(pr.store().labelNames().contains("csr"));
-            assertLastCommentContains(pr, "determined that a [CSR](https://wiki.openjdk.org/display/csr/Main) request " +
+            assertLastCommentContains(pr, "determined that a [CSR](" + CSR_PROCESS_LINK + ") request " +
                     "is not needed for this pull request.");
 
             // re-run prBot.
@@ -1035,9 +1036,9 @@ class CSRCommandTests {
             assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion 11 to be approved (needs to be created)"));
             assertTrue(pr.store().labelNames().contains("csr"));
             assertLastCommentContains(pr, "has indicated that a " +
-                    "[compatibility and specification](https://wiki.openjdk.org/display/csr/Main) (CSR) request " +
+                    "[compatibility and specification](" + CSR_PROCESS_LINK + ") (CSR) request " +
                     "is needed for this pull request.");
-            assertLastCommentContains(pr, "please create a [CSR](https://wiki.openjdk.org/display/csr/Main) request");
+            assertLastCommentContains(pr, "please create a [CSR](" + CSR_PROCESS_LINK + ") request");
             assertLastCommentContains(pr, "with the correct fix version");
             assertLastCommentContains(pr, "This pull request cannot be integrated until the CSR request is approved.");
         }
@@ -1101,7 +1102,7 @@ class CSRCommandTests {
 
             // The bot should reply with a message that a CSR is needed
             assertLastCommentContains(pr, "has indicated that a " +
-                    "[compatibility and specification](https://wiki.openjdk.org/display/csr/Main) (CSR) request " +
+                    "[compatibility and specification](" + CSR_PROCESS_LINK + ") (CSR) request " +
                     "is needed for this pull request.");
             assertTrue(pr.store().labelNames().contains("csr"));
             // The PR body should contain the progress about CSR request
@@ -1143,7 +1144,7 @@ class CSRCommandTests {
 
             // The bot should reply with a message that a CSR is needed
             assertLastCommentContains(pr, "has indicated that a " +
-                    "[compatibility and specification](https://wiki.openjdk.org/display/csr/Main) (CSR) request " +
+                    "[compatibility and specification](" + CSR_PROCESS_LINK + ") (CSR) request " +
                     "is needed for this pull request.");
             assertTrue(pr.store().labelNames().contains("csr"));
             // The PR body should contain the progress about CSR request
@@ -1274,7 +1275,7 @@ class CSRCommandTests {
             TestBotRunner.runPeriodicItems(prBot);
             assertTrue(pr.store().labelNames().contains("csr"));
             assertLastCommentContains(pr, "has indicated that a " +
-                    "[compatibility and specification](https://wiki.openjdk.org/display/csr/Main) (CSR) request " +
+                    "[compatibility and specification](" + CSR_PROCESS_LINK + ") (CSR) request " +
                     "is needed for this pull request.");
             assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion 0.1 to be approved (needs to be created)"));
             assertFalse(pr.store().body().contains(generateCSRProgressMessage(csr)));

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CSRCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CSRCommandTests.java
@@ -852,8 +852,7 @@ class CSRCommandTests {
             TestBotRunner.runPeriodicItems(prBot);
             assertEquals(3 ,pr.store().comments().size());
             assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion (No fixVersion in .jcheck/conf) to be approved (needs to be created)"));
-            assertLastCommentContains(pr, "At least one of the associated issues of this backport has a resolved CSR.\n" +
-                    "This backport might also need a CSR. `csr` label will be added to this PR.");
+            assertLastCommentContains(pr, "this backport may also need a CSR");
             TestBotRunner.runPeriodicItems(prBot);
             assertEquals(3 ,pr.store().comments().size());
 
@@ -1366,7 +1365,7 @@ class CSRCommandTests {
             assertTrue(pr.store().body().contains("- [ ] Change requires CSR request [TEST-4](http://localhost/project/testTEST-4) to be approved"));
             assertTrue(pr.store().labelNames().contains("csr"));
             // The bot shouldn't post backport csr comment because there is a backport csr
-            assertTrue(pr.store().comments().stream().noneMatch(comment -> comment.body().contains("This backport might also need a CSR")));
+            assertTrue(pr.store().comments().stream().noneMatch(comment -> comment.body().contains("this backport may also need a CSR")));
 
             // Change the fixVersion of the backportCSR
             backportCsr.setProperty("fixVersions", JSON.array().add("19"));
@@ -1375,7 +1374,7 @@ class CSRCommandTests {
             assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion 17 to be approved (needs to be created)"));
             assertTrue(pr.store().labelNames().contains("csr"));
             // The bot shouldn't post backport csr comment because csr label is still there
-            assertTrue(pr.store().comments().stream().noneMatch(comment -> comment.body().contains("This backport might also need a CSR")));
+            assertTrue(pr.store().comments().stream().noneMatch(comment -> comment.body().contains("this backport may also need a CSR")));
 
             // Use '/csr unneeded'
             var prAsReviewer = reviewer.pullRequest(pr.id());
@@ -1384,7 +1383,7 @@ class CSRCommandTests {
             TestBotRunner.runPeriodicItems(prBot);
             assertFalse(pr.store().labelNames().contains("csr"));
             // The bot shouldn't post backport csr comment because csr label has been removed by command
-            assertTrue(pr.store().comments().stream().noneMatch(comment -> comment.body().contains("This backport might also need a CSR")));
+            assertTrue(pr.store().comments().stream().noneMatch(comment -> comment.body().contains("this backport may also need a CSR")));
 
             // Require CSR again
             prAsReviewer.addComment("/csr");
@@ -1392,7 +1391,7 @@ class CSRCommandTests {
             TestBotRunner.runPeriodicItems(prBot);
             assertTrue(pr.store().labelNames().contains("csr"));
             // The bot shouldn't post backport csr comment because csr label has been added by command
-            assertTrue(pr.store().comments().stream().noneMatch(comment -> comment.body().contains("This backport might also need a CSR")));
+            assertTrue(pr.store().comments().stream().noneMatch(comment -> comment.body().contains("this backport may also need a CSR")));
         }
     }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CSRCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CSRCommandTests.java
@@ -852,7 +852,7 @@ class CSRCommandTests {
             assertEquals(3 ,pr.store().comments().size());
             assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion (No fixVersion in .jcheck/conf) to be approved (needs to be created)"));
             assertLastCommentContains(pr, "At least one of the associated issues of this backport has a resolved CSR.\n" +
-                    "This backport might also need a CSR. \"csr\" label will be added to this PR.");
+                    "This backport might also need a CSR. `csr` label will be added to this PR.");
             TestBotRunner.runPeriodicItems(prBot);
             assertEquals(3 ,pr.store().comments().size());
 

--- a/jbs/src/main/java/org/openjdk/skara/jbs/Backports.java
+++ b/jbs/src/main/java/org/openjdk/skara/jbs/Backports.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -316,7 +316,7 @@ public class Backports {
     /**
      * Find the CSR of the provided issue
      */
-    private static Optional<Link> csrLink(IssueTrackerIssue issue) {
+    public static Optional<Link> csrLink(IssueTrackerIssue issue) {
         return issue == null ? Optional.empty() : issue.links().stream()
                 .filter(link -> link.relationship().isPresent() && "csr for".equals(link.relationship().get())).findAny();
     }


### PR DESCRIPTION
This patch is trying to let the pr bot automatically requires csr for a backport PR if one of the associated has a resolved CSR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2198](https://bugs.openjdk.org/browse/SKARA-2198): Backport PRs should check if a CSR is required (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1623/head:pull/1623` \
`$ git checkout pull/1623`

Update a local copy of the PR: \
`$ git checkout pull/1623` \
`$ git pull https://git.openjdk.org/skara.git pull/1623/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1623`

View PR using the GUI difftool: \
`$ git pr show -t 1623`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1623.diff">https://git.openjdk.org/skara/pull/1623.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1623#issuecomment-2010772471)