### PR TITLE
2210: Use authenticatedUrl instead of webUrl in MergeBot

### DIFF
--- a/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
+++ b/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -491,9 +491,7 @@ class MergeBot implements Bot, WorkItem {
                     var status = repo.status();
                     repo.abortMerge();
 
-                    var fromRepoName = Path.of(fromRepo.webUrl().getPath()).getFileName();
-
-                    var numBranchesInFork = repo.remoteBranches(fork.webUrl().toString()).size();
+                    var numBranchesInFork = repo.remoteBranches(fork.authenticatedUrl().toString()).size();
                     var branchDesc = Integer.toString(numBranchesInFork + 1);
                     repo.push(fetchHead, fork.authenticatedUrl(), branchDesc);
 


### PR DESCRIPTION
Since the bot uses ssh to clone the repos in MergeBot, the bot should also use authenticatedUrl(ssh url) to access the remote repo. However, the mergeBot is still using webUrl(https url) in some places and it triggered an issue today.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2210](https://bugs.openjdk.org/browse/SKARA-2210): Use authenticatedUrl instead of webUrl in MergeBot (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1624/head:pull/1624` \
`$ git checkout pull/1624`

Update a local copy of the PR: \
`$ git checkout pull/1624` \
`$ git pull https://git.openjdk.org/skara.git pull/1624/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1624`

View PR using the GUI difftool: \
`$ git pr show -t 1624`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1624.diff">https://git.openjdk.org/skara/pull/1624.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1624#issuecomment-2018599436)