### PR TITLE
2214: Require CSR again if all of the CSRs are withdrawn in a Backport CSR PR

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -1559,7 +1559,11 @@ class CheckRun {
     }
 
     private void updateBackportCSRLabel(Map<String, List<IssueTrackerIssue>> issueToAllCsrsMap, Map<String, IssueTrackerIssue> issueToCsrMap) {
-        if (newLabels.contains("backport") && !newLabels.contains("csr") && issueToCsrMap.isEmpty() && !isCSRManuallyUnneeded(comments)) {
+        // Ignore withdrawn CSRs
+        boolean associatedWithValidCSR = issueToCsrMap.values().stream()
+                .anyMatch(value -> !isWithdrawnCSR(value));
+
+        if (newLabels.contains("backport") && !newLabels.contains("csr") && !associatedWithValidCSR && !isCSRManuallyUnneeded(comments)) {
             boolean hasResolvedCSR = issueToAllCsrsMap.values().stream()
                     .flatMap(List::stream)
                     .anyMatch(csrIssue -> csrIssue.state() == org.openjdk.skara.issuetracker.Issue.State.CLOSED &&


### PR DESCRIPTION
When testing [SKARA-2198](https://bugs.openjdk.org/browse/SKARA-2198), I found that there is a bug.

When determining if the bot should add the csr label to a backport CSR pr, if the bot found the pr is already associated with any CSR(regardless if it's withdrawn or not), then the bot would not add the csr label.

This is a bug. A user could create a CSR for this pr and withdraw it, then the user could bypass the CSR request.

The bot should ignore withdrawn CSRs in this case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2214](https://bugs.openjdk.org/browse/SKARA-2214): Require CSR again if all of the CSRs are withdrawn in a Backport CSR PR (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1625/head:pull/1625` \
`$ git checkout pull/1625`

Update a local copy of the PR: \
`$ git checkout pull/1625` \
`$ git pull https://git.openjdk.org/skara.git pull/1625/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1625`

View PR using the GUI difftool: \
`$ git pr show -t 1625`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1625.diff">https://git.openjdk.org/skara/pull/1625.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1625#issuecomment-2021183585)