### PR TITLE
1919: Make it possible to disable the "/clean" command per repository

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CleanCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CleanCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,6 +53,11 @@ public class CleanCommand implements CommandHandler {
     @Override
     public void handle(PullRequestBot bot, PullRequest pr, CensusInstance censusInstance, ScratchArea scratchArea, CommandInvocation command, List<Comment> allComments, PrintWriter reply)
     {
+        if (!bot.cleanCommandEnabled()) {
+            reply.println("The `/clean` pull request command is not enabled for this repository");
+            return;
+        }
+
         if (!censusInstance.isCommitter(command.user())) {
             reply.println("Only OpenJDK [Committers](https://openjdk.org/bylaws#committer) can use the `/clean` command");
             return;

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -80,6 +80,7 @@ class PullRequestBot implements Bot {
     private final Approval approval;
     private boolean initialRun = true;
     private final boolean versionMismatchWarning;
+    private final boolean cleanCommandEnabled;
 
     private Instant lastFullUpdate;
 
@@ -94,7 +95,7 @@ class PullRequestBot implements Bot {
                    Set<String> integrators, Set<Integer> excludeCommitCommentsFrom, boolean enableCsr, boolean enableJep,
                    boolean reviewCleanBackport, String mlbridgeBotName, MergePullRequestReviewConfiguration reviewMerge, boolean processPR, boolean processCommit,
                    boolean enableMerge, Set<String> mergeSources, boolean jcheckMerge, boolean enableBackport,
-                   Map<String, List<PRRecord>> issuePRMap, Approval approval, boolean versionMismatchWarning) {
+                   Map<String, List<PRRecord>> issuePRMap, Approval approval, boolean versionMismatchWarning, boolean cleanCommandEnabled) {
         remoteRepo = repo;
         this.censusRepo = censusRepo;
         this.censusRef = censusRef;
@@ -131,6 +132,7 @@ class PullRequestBot implements Bot {
         this.issuePRMap = issuePRMap;
         this.approval = approval;
         this.versionMismatchWarning = versionMismatchWarning;
+        this.cleanCommandEnabled = cleanCommandEnabled;
 
         autoLabelled = new HashSet<>();
         poller = new PullRequestPoller(repo, true);
@@ -401,6 +403,10 @@ class PullRequestBot implements Bot {
 
     public boolean versionMismatchWarning() {
         return versionMismatchWarning;
+    }
+
+    public boolean cleanCommandEnabled() {
+        return cleanCommandEnabled;
     }
 
     public void addIssuePRMapping(String issueId, PRRecord prRecord) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,6 +67,7 @@ public class PullRequestBotBuilder {
     private Map<String, List<PRRecord>> issuePRMap;
     private Approval approval = null;
     private boolean versionMismatchWarning = false;
+    private boolean cleanCommandEnabled = true;
 
     PullRequestBotBuilder() {
     }
@@ -251,12 +252,17 @@ public class PullRequestBotBuilder {
         return this;
     }
 
+    public PullRequestBotBuilder cleanCommandEnabled(boolean cleanCommandEnabled) {
+        this.cleanCommandEnabled = cleanCommandEnabled;
+        return this;
+    }
+
     public PullRequestBot build() {
         return new PullRequestBot(repo, censusRepo, censusRef, labelConfiguration, externalPullRequestCommands,
                 externalCommitCommands, blockingCheckLabels, readyLabels, twoReviewersLabels, twentyFourHoursLabels,
                 readyComments, issueProject, ignoreStaleReviews, allowedTargetBranches, seedStorage, confOverrideRepo,
                 confOverrideName, confOverrideRef, censusLink, forks, integrators, excludeCommitCommentsFrom, enableCsr,
                 enableJep, reviewCleanBackport, mlbridgeBotName, reviewMerge, processPR, processCommit, enableMerge,
-                mergeSources, jcheckMerge, enableBackport, issuePRMap, approval, versionMismatchWarning);
+                mergeSources, jcheckMerge, enableBackport, issuePRMap, approval, versionMismatchWarning, cleanCommandEnabled);
     }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -261,6 +261,10 @@ public class PullRequestBotFactory implements BotFactory {
 
             if (repo.value().contains("versionMismatchWarning")) {
                 botBuilder.versionMismatchWarning(repo.value().get("versionMismatchWarning").asBoolean());
+            }
+
+            if (repo.value().contains("cleanCommandEnabled")) {
+                botBuilder.cleanCommandEnabled(repo.value().get("cleanCommandEnabled").asBoolean());
             }
 
             var prBot = botBuilder.build();

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestBotFactoryTest.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestBotFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -156,6 +156,7 @@ class PullRequestBotFactoryTest {
                               }
                           },
                           "versionMismatchWarning": true,
+                          "cleanCommandEnabled": false,
                         }
                       },
                       "forks": {
@@ -208,6 +209,7 @@ class PullRequestBotFactoryTest {
             assertFalse(pullRequestBot5.jcheckMerge());
             assertTrue(pullRequestBot5.enableBackport());
             assertFalse(pullRequestBot5.versionMismatchWarning());
+            assertTrue(pullRequestBot5.cleanCommandEnabled());
 
             var pullRequestBot6 = (PullRequestBot) bots.stream()
                     .filter(bot -> bot.toString().equals("PullRequestBot@repo6"))
@@ -242,6 +244,7 @@ class PullRequestBotFactoryTest {
             assertFalse(pullRequestBot7.jcheckMerge());
             assertEquals("https://example.com", pullRequestBot7.approval().documentLink());
             assertTrue(pullRequestBot7.versionMismatchWarning());
+            assertFalse(pullRequestBot7.cleanCommandEnabled());
 
             var csrIssueBot1 = (CSRIssueBot) bots.stream()
                     .filter(bot -> bot.toString().equals("CSRIssueBot@TEST"))


### PR DESCRIPTION
This patch is trying to make it possible to configure the "/clean" command to be disabled on a repository.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1919](https://bugs.openjdk.org/browse/SKARA-1919): Make it possible to disable the "/clean" command per repository (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1629/head:pull/1629` \
`$ git checkout pull/1629`

Update a local copy of the PR: \
`$ git checkout pull/1629` \
`$ git pull https://git.openjdk.org/skara.git pull/1629/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1629`

View PR using the GUI difftool: \
`$ git pr show -t 1629`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1629.diff">https://git.openjdk.org/skara/pull/1629.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1629#issuecomment-2038181072)