### PR TITLE
1553: Update PR titles automatically from JBS

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -648,7 +648,7 @@ class CheckRun {
         }
     }
 
-    private boolean relaxedEquals(String s1, String s2) {
+    static boolean relaxedEquals(String s1, String s2) {
         return s1.trim()
                  .replaceAll("\\s+", " ")
                  .equalsIgnoreCase(s2.trim()

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -857,7 +857,7 @@ class CheckTests {
             TestBotRunner.runPeriodicItems(checkBot);
 
             // The PR title should contain the issue title without trailing space
-            assertEquals("TEST-2: My second issue ending in space", prCutOff2.store().title());
+            assertEquals("2: My second issue ending in space", prCutOff2.store().title());
         }
     }
 
@@ -1848,6 +1848,18 @@ class CheckTests {
             assertEquals(CheckStatus.SUCCESS, bugPR.checks(bugHash).get("jcheck").status());
 
             // Verify that the title is expanded
+            assertEquals(numericId + ": " + bug.title(), bugPR.store().title());
+
+            // Now update pr title to non-canonical form
+            bugPR.setTitle(bug.id() + " " + bug.title());
+            TestBotRunner.runPeriodicItems(checkBot);
+            // Verify that the title is in canonical form
+            assertEquals(numericId + ": " + bug.title(), bugPR.store().title());
+
+            // Now update pr title to another non-canonical form
+            bugPR.setTitle(bug.id() + ": " + bug.title());
+            TestBotRunner.runPeriodicItems(checkBot);
+            // Verify that the title is in canonical form
             assertEquals(numericId + ": " + bug.title(), bugPR.store().title());
         }
     }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IssueBotTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IssueBotTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -137,12 +137,27 @@ public class IssueBotTests {
             // issue metadata should not be updated because no update in the issue
             assertEquals(issueMetadata2, issueMetadata3);
 
+            // Update issue title and run prBot first
+            // There should be no update in the check
+            issue.setTitle("This is an Issue");
+            TestBotRunner.runPeriodicItems(prBot);
+            check = pr.checks(editHash).get("jcheck");
+            var completedTime7 = check.completedAt().get();
+            assertEquals(completedTime6, completedTime7);
+
+            // Run issueBot
+            TestBotRunner.runPeriodicItems(issueBot);
+            check = pr.checks(editHash).get("jcheck");
+            var completedTime8 = check.completedAt().get();
+            assertNotEquals(completedTime7, completedTime8);
+            assertEquals("1: This is an Issue", pr.store().title());
+
             // Extra run of prBot and issueBot
             TestBotRunner.runPeriodicItems(prBot);
             TestBotRunner.runPeriodicItems(issueBot);
             check = pr.checks(editHash).get("jcheck");
-            var completedTime7 = check.completedAt().get();
-            assertEquals(completedTime6, completedTime7);
+            var completedTime9 = check.completedAt().get();
+            assertEquals(completedTime8, completedTime9);
         }
     }
 


### PR DESCRIPTION
As Magnus and Erik proposed, Skara bot should rewrite PR titles to a canonical form(numbers for the bugId, followed by a ':' and then the bug title, e.g. "1: This is an issue").
Especially, Skara bot should rewrite PR title in the form of "JDK-1 This is an issue" or "JDK-1: This is an issue" to the canonical form.

Furthermore, sometimes, a user would update the issue title in JBS and forget updating the pr title. With this patch, If the change is minor like changing the case of some characters or adding/removing spaces, Skara bot will update it automatically for the user, otherwise, Skara bot would still add an integration blocker " ⚠️ Title mismatch between PR and JBS.",

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-1553](https://bugs.openjdk.org/browse/SKARA-1553): Update PR titles automatically from JBS (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1631/head:pull/1631` \
`$ git checkout pull/1631`

Update a local copy of the PR: \
`$ git checkout pull/1631` \
`$ git pull https://git.openjdk.org/skara.git pull/1631/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1631`

View PR using the GUI difftool: \
`$ git pr show -t 1631`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1631.diff">https://git.openjdk.org/skara/pull/1631.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1631#issuecomment-2046192644)