### PR TITLE
2229: TestHost propagates too many properties to backports

### DIFF
--- a/test/src/main/java/org/openjdk/skara/test/TestHost.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHost.java
@@ -101,13 +101,13 @@ public class TestHost implements Forge, IssueTracker {
                 props.put("security", body.get("level"));
             }
             if (body.contains("fixVersion")) {
-                props.put("fixVersion", body.get("fixVersion"));
+                props.put("fixVersions", JSON.array().add(body.get("fixVersion")));
             }
 
             // Propagate properties from the primary issue *except* those
             // that can be set via the POST request body. The custom
             // RESOLVED_IN_BUILD property should also not propagate
-            var ignore = Set.of("assignee", "security", "fixVersion", RESOLVED_IN_BUILD);
+            var ignore = Set.of("issuetype", "assignee", "security", "fixVersions", RESOLVED_IN_BUILD);
             for (var entry : primary.properties().entrySet()) {
                 if (!ignore.contains(entry.getKey())) {
                     props.put(entry.getKey(), entry.getValue());


### PR DESCRIPTION
Hi all.

please review this small patch that fixes an issue with how `TestHost` creates "backports". The problem is that the current implementation propagates too many properties from the primary issue to the backport (including for example `"issuetype"` which causes the backport to become a bug/enhancement 😄 ).

This patch also set `fixVersions` properly for the created "backport" - the `fixVersions` property is of type `Array`, not `String`.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2229](https://bugs.openjdk.org/browse/SKARA-2229): TestHost propagates too many properties to backports (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1633/head:pull/1633` \
`$ git checkout pull/1633`

Update a local copy of the PR: \
`$ git checkout pull/1633` \
`$ git pull https://git.openjdk.org/skara.git pull/1633/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1633`

View PR using the GUI difftool: \
`$ git pr show -t 1633`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1633.diff">https://git.openjdk.org/skara/pull/1633.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1633#issuecomment-2049289781)