### PR TITLE
2230

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
@@ -366,7 +366,7 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
                             }
                         }
                         log.info("Setting fixVersion for " + issue.id() + " to " + requestedVersion);
-                        issue.setProperty("fixVersions", JSON.of(requestedVersion));
+                        issue.setProperty("fixVersions", JSON.array().add(requestedVersion));
                     }
                 }
             }


### PR DESCRIPTION
Hi all,

please review this small patch that makes `IssueNotifier` use an array when setting the `fixVersions` property of an issue. There is currently code in `JiraProject.encodeProperty` that enables production code to use a plain string fox `fixVersions`, but such code will then break when using a `TestIssueTrackerIssue` (that does not feature any special encoding of the fixVersion). To allow the production code to work with both unit tests and production JIRA instances the production code should use an array and not a string when setting `fixVersions`.

From a production code point of view this change will not cause any change in behaviour as `JiraProject.encodeProperty` calls `stream()` on its argument, which for `JSONString` is a stream of the string itself and for a `JSONArray` with one item is a stream of the single item (so the resulting streams are identical). The reason the tests are working today is because no test code is directly reading the `fixVersions` property, all test code (and production code) immediately calls `.stream` on the `JSONValue` for the `"fixVersions"` key (which as described results in identical streams for a `JSONString` and `JSONArray` instance with exactly one value). All test code that is setting the `fixVersions` property are correctly using a `JSONArray` as the value.

Thanks,
Erik