### PR TITLE
2231: JCheck ran twice unnecessarily

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -1309,6 +1309,7 @@ class CheckRun {
                 // Determine current status
                 jcheckType = "target jcheck";
                 checkablePullRequest.executeChecks(localHash, censusInstance, visitor, targetJCheckConf);
+
                 // If the PR updates .jcheck/conf then Need to run JCheck again using the configuration
                 // from the resulting commit. Not needed if we are overriding the JCheck configuration since
                 // then we won't use the one in the repo anyway.


### PR DESCRIPTION
Recently, I found sometimes JCheck ran twice unnecessarily in some prs.
For example:
https://github.com/openjdk/jdk/pull/16005
https://github.com/openjdk/jdk/pull/14586

In the above prs, the authors didn't update .jcheck/conf in the source branch, but skara executed jcheck twice with the jcheck config in the merged commit(merged target branch and source branch).

After investigation,l  found that in this case, skara bot will make a mistake.
Let's say we have two branches:
Target branch: initialCommit <-- updateJCheckCommit <-- latestCommit
Source Branch: initialCommit <-- editCommit
In CheckRun, Skara bot would create a squashed commit(final head is editCommit and parent is latestCommit), and the squashed commit would include diffs in updateJCheckCommit, latestCommit, editCommit. Later, Skara bot would use CheckRun#isFileUpdated to check if .jcheck/conf is updated in the squashed commit and it will return true, therefore  run jcheck twice.

To resolve this problem, I think we should rewrite isFileUpdated, skara bot should find the common ancestor of target branch and source branch first, then check if the file is updated between mergeBase and the head of source branch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2231](https://bugs.openjdk.org/browse/SKARA-2231): JCheck ran twice unnecessarily (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1635/head:pull/1635` \
`$ git checkout pull/1635`

Update a local copy of the PR: \
`$ git checkout pull/1635` \
`$ git pull https://git.openjdk.org/skara.git pull/1635/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1635`

View PR using the GUI difftool: \
`$ git pr show -t 1635`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1635.diff">https://git.openjdk.org/skara/pull/1635.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1635#issuecomment-2050494385)