### PR TITLE
2233: TestHost does not set assignees correctly for backports

### DIFF
--- a/test/src/main/java/org/openjdk/skara/test/TestHost.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHost.java
@@ -94,9 +94,6 @@ public class TestHost implements Forge, IssueTracker {
             var props = new HashMap<String, JSONValue>();
             props.put("issuetype", JSON.of("Backport"));
             // Propagate properties set in POST request body
-            if (body.contains("assignee")) {
-                props.put("assignee", body.get("assignee"));
-            }
             if (body.contains("level")) {
                 props.put("security", body.get("level"));
             }
@@ -115,6 +112,10 @@ public class TestHost implements Forge, IssueTracker {
             }
 
             var backport = project.createIssue(primary.title(), Arrays.asList(primary.body().split("\n")), props);
+            if (body.contains("assignee")) {
+                var user = host.user(body.get("assignee").asString()).orElseThrow();
+                backport.setAssignees(List.of(user));
+            }
             backport.addLink(Link.create(primary, "backport of").build());
             primary.addLink(Link.create(backport, "backported by").build());
             return JSON.object().put("key", backport.id());


### PR DESCRIPTION
Hi all,

please review this small patch that makes `TestHost` set assignees correctly for any backport it creates. For now have I opted to just throw if the `HostUser` isn't found. In the future we could instead invoke the `RestRequest.ErrorTransform` if we ever have a need to test what happens when the value for the `assignee` property in the body to the backports endpoint contains an unknown username (we currently do not have that need).

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2233](https://bugs.openjdk.org/browse/SKARA-2233): TestHost does not set assignees correctly for backports (**Bug** - P4)


### Reviewers
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1636/head:pull/1636` \
`$ git checkout pull/1636`

Update a local copy of the PR: \
`$ git checkout pull/1636` \
`$ git pull https://git.openjdk.org/skara.git pull/1636/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1636`

View PR using the GUI difftool: \
`$ git pr show -t 1636`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1636.diff">https://git.openjdk.org/skara/pull/1636.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1636#issuecomment-2051314237)