### PR TITLE
2226: Make it possible to avoid "forward backports"

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierBuilder.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierBuilder.java
@@ -50,6 +50,7 @@ class IssueNotifierBuilder {
     private Set<String> tagIgnoreOpt = Set.of();
     private boolean tagMatchPrefix = false;
     private List<IssueNotifier.BranchSecurity> defaultSecurity = List.of();
+    private boolean avoidForwardports = false;
 
     IssueNotifierBuilder issueProject(IssueProject issueProject) {
         this.issueProject = issueProject;
@@ -152,6 +153,11 @@ class IssueNotifierBuilder {
         return this;
     }
 
+    public IssueNotifierBuilder avoidForwardports(boolean avoidForwardports) {
+        this.avoidForwardports = avoidForwardports;
+        return this;
+    }
+
     public boolean prOnly() {
         return prOnly;
     }
@@ -164,6 +170,6 @@ class IssueNotifierBuilder {
         return new IssueNotifier(issueProject, reviewLink, reviewIcon, commitLink, commitIcon,
                 setFixVersion, fixVersions, altFixVersions, prOnly,
                 repoOnly, buildName, censusRepository, censusRef, namespace, useHeadVersion, originalRepository,
-                resolve, tagIgnoreOpt, tagMatchPrefix, defaultSecurity);
+                resolve, tagIgnoreOpt, tagMatchPrefix, defaultSecurity, avoidForwardports);
     }
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierFactory.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierFactory.java
@@ -135,6 +135,10 @@ public class IssueNotifierFactory implements NotifierFactory {
             builder.defaultSecurity(defaultSecurity);
         }
 
+        if (notifierConfiguration.contains("avoidforwardports")) {
+            builder.avoidForwardports(notifierConfiguration.get("avoidforwardports").asBoolean());
+        }
+
         return builder.build();
     }
 }

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
@@ -2459,8 +2459,8 @@ public class IssueNotifierTests {
             issue.addLabel("test");
             issue.addLabel("temporary");
 
-            // Create an explicit "forwardport"
-            var backport = issueProject.createIssue("This is a forwardport", List.of("Indeed"),
+            // Create an explicit backport
+            var backport = issueProject.createIssue("This is a backport", List.of("Indeed"),
                     Map.of("issuetype", JSON.of("Backport")));
             backport.setProperty("fixVersions", JSON.array().add("21"));
 

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
@@ -2238,4 +2238,264 @@ public class IssueNotifierTests {
             assertEquals(1, updatedIssue.links().size());
         }
     }
+
+    @Test
+    void testAvoidForwardports(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var repo = credentials.getHostedRepository();
+            var repoFolder = tempFolder.path().resolve("repo");
+            var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType(), Path.of("appendable.txt"), Set.of(), null);
+            credentials.commitLock(localRepo);
+            localRepo.pushAll(repo.authenticatedUrl());
+
+            var storageFolder = tempFolder.path().resolve("storage");
+            var issueProject = credentials.getIssueProject();
+            var jbsNotifierConfig = JSON.object().put("fixversions", JSON.object().put(".*aster", "22")).put("avoidforwardports", true);
+            var notifyBot = testBotBuilder(repo, issueProject, storageFolder, jbsNotifierConfig).create("notify", JSON.object());
+
+            // Initialize history
+            TestBotRunner.runPeriodicItems(notifyBot);
+
+            // Create an issue and commit a fix
+            var issue = issueProject.createIssue("This is an issue", List.of("Indeed"),
+                    Map.of("issuetype", JSON.of("Enhancement"),
+                            SUBCOMPONENT, JSON.of("java.io"),
+                            RESOLVED_IN_BUILD, JSON.of("b07")
+                    ));
+            issue.setProperty("fixVersions", JSON.array().add("21"));
+            issue.setProperty("priority", JSON.of("1"));
+            issue.addLabel("test");
+            issue.addLabel("temporary");
+
+            var authorEmailAddress = issueProject.issueTracker().currentUser().username() + "@openjdk.org";
+            var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", issue.id() + ": Fix that issue", "Duke", authorEmailAddress);
+            localRepo.push(editHash, repo.authenticatedUrl(), "master");
+            TestBotRunner.runPeriodicItems(notifyBot);
+
+            // The fixVersion should have been set to 22
+            var updatedIssue = issueProject.issue(issue.id()).orElseThrow();
+            assertEquals(Set.of("22"), fixVersions(updatedIssue));
+            assertEquals(RESOLVED, updatedIssue.state());
+            assertEquals(List.of(issueProject.issueTracker().currentUser()), updatedIssue.assignees());
+
+            // There should be a link
+            var links = updatedIssue.links();
+            assertEquals(1, links.size());
+            var link = links.get(0);
+            var backport = link.issue().orElseThrow();
+
+            // The backport issue should have the issue's fixVersions
+            assertEquals(Set.of("21"), fixVersions(backport));
+            assertEquals(OPEN, backport.state());
+            assertEquals(List.of(issueProject.issueTracker().currentUser()), backport.assignees());
+
+            // Custom properties should also propagate
+            assertEquals("1", backport.properties().get("priority").asString());
+            assertEquals("java.io", backport.properties().get(SUBCOMPONENT).asString());
+            assertFalse(backport.properties().containsKey(RESOLVED_IN_BUILD));
+
+            // Labels should not
+            assertEquals(0, backport.labelNames().size());
+        }
+    }
+
+    @Test
+    void testAvoidForwardportsShouldCreateBackport(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var repo = credentials.getHostedRepository();
+            var repoFolder = tempFolder.path().resolve("repo");
+            var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType(), Path.of("appendable.txt"), Set.of(), null);
+            credentials.commitLock(localRepo);
+            localRepo.pushAll(repo.authenticatedUrl());
+
+            var storageFolder = tempFolder.path().resolve("storage");
+            var issueProject = credentials.getIssueProject();
+            var jbsNotifierConfig = JSON.object().put("fixversions", JSON.object().put(".*aster", "21")).put("avoidforwardports", true);
+            var notifyBot = testBotBuilder(repo, issueProject, storageFolder, jbsNotifierConfig).create("notify", JSON.object());
+
+            // Initialize history
+            TestBotRunner.runPeriodicItems(notifyBot);
+
+            // Create an issue and commit a fix
+            var issue = issueProject.createIssue("This is an issue", List.of("Indeed"),
+                    Map.of("issuetype", JSON.of("Enhancement"),
+                            SUBCOMPONENT, JSON.of("java.io"),
+                            RESOLVED_IN_BUILD, JSON.of("b07")
+                    ));
+            issue.setProperty("fixVersions", JSON.array().add("22"));
+            issue.setProperty("priority", JSON.of("1"));
+            issue.addLabel("test");
+            issue.addLabel("temporary");
+
+            var authorEmailAddress = issueProject.issueTracker().currentUser().username() + "@openjdk.org";
+            var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", issue.id() + ": Fix that issue", "Duke", authorEmailAddress);
+            localRepo.push(editHash, repo.authenticatedUrl(), "master");
+            TestBotRunner.runPeriodicItems(notifyBot);
+
+            // The fixVersion should not have been updated
+            var updatedIssue = issueProject.issue(issue.id()).orElseThrow();
+            assertEquals(Set.of("22"), fixVersions(updatedIssue));
+            assertEquals(OPEN, updatedIssue.state());
+            assertEquals(List.of(), updatedIssue.assignees());
+
+            // There should be a link
+            var links = updatedIssue.links();
+            assertEquals(1, links.size());
+            var link = links.get(0);
+            var backport = link.issue().orElseThrow();
+
+            // The backport issue should have the repository's fixVersions
+            assertEquals(Set.of("21"), fixVersions(backport));
+            assertEquals(RESOLVED, backport.state());
+            assertEquals(List.of(issueProject.issueTracker().currentUser()), backport.assignees());
+
+            // Custom properties should also propagate
+            assertEquals("1", backport.properties().get("priority").asString());
+            assertEquals("java.io", backport.properties().get(SUBCOMPONENT).asString());
+            assertFalse(backport.properties().containsKey(RESOLVED_IN_BUILD));
+
+            // Labels should not
+            assertEquals(0, backport.labelNames().size());
+        }
+    }
+
+    @Test
+    void testAvoidForwardportsShouldUseExistingForwardport(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var repo = credentials.getHostedRepository();
+            var repoFolder = tempFolder.path().resolve("repo");
+            var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType(), Path.of("appendable.txt"), Set.of(), null);
+            credentials.commitLock(localRepo);
+            localRepo.pushAll(repo.authenticatedUrl());
+
+            var storageFolder = tempFolder.path().resolve("storage");
+            var issueProject = credentials.getIssueProject();
+            var jbsNotifierConfig = JSON.object().put("fixversions", JSON.object().put(".*aster", "22")).put("avoidforwardports", true);
+            var notifyBot = testBotBuilder(repo, issueProject, storageFolder, jbsNotifierConfig).create("notify", JSON.object());
+
+            // Initialize history
+            TestBotRunner.runPeriodicItems(notifyBot);
+
+            // Create an issue
+            var issue = issueProject.createIssue("This is an issue", List.of("Indeed"),
+                    Map.of("issuetype", JSON.of("Enhancement"),
+                            SUBCOMPONENT, JSON.of("java.io"),
+                            RESOLVED_IN_BUILD, JSON.of("b07")
+                    ));
+            issue.setProperty("fixVersions", JSON.array().add("21"));
+            issue.setProperty("priority", JSON.of("1"));
+            issue.addLabel("test");
+            issue.addLabel("temporary");
+
+            // Create an explicit "forwardport"
+            var forwardPort = issueProject.createIssue("This is a forwardport", List.of("Indeed"),
+                    Map.of("issuetype", JSON.of("Backport")));
+            forwardPort.setProperty("fixVersions", JSON.array().add("22"));
+
+            issue.addLink(Link.create(forwardPort, "backported by").build());
+            forwardPort.addLink(Link.create(issue, "backport of").build());
+
+            // Commit a fix for the issue
+            var authorEmailAddress = issueProject.issueTracker().currentUser().username() + "@openjdk.org";
+            var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", issue.id() + ": Fix that issue", "Duke", authorEmailAddress);
+            localRepo.push(editHash, repo.authenticatedUrl(), "master");
+            TestBotRunner.runPeriodicItems(notifyBot);
+
+            // The fixVersion should not have been updated
+            var updatedIssue = issueProject.issue(issue.id()).orElseThrow();
+            assertEquals(Set.of("21"), fixVersions(updatedIssue));
+            assertEquals(OPEN, updatedIssue.state());
+            assertEquals(List.of(), updatedIssue.assignees());
+
+            // There should still be just a single link
+            var links = updatedIssue.links();
+            assertEquals(1, links.size());
+            var link = links.get(0);
+            var backport = link.issue().orElseThrow();
+
+            // The forwardport issue should have the repository's fixVersions
+            assertEquals(Set.of("22"), fixVersions(backport));
+            assertEquals(RESOLVED, backport.state());
+            assertEquals(List.of(issueProject.issueTracker().currentUser()), backport.assignees());
+
+            // No properties should have propagated
+            assertFalse(backport.properties().containsKey(SUBCOMPONENT));
+            assertFalse(backport.properties().containsKey(RESOLVED_IN_BUILD));
+
+            // Not Labels should have propagated
+            assertEquals(0, backport.labelNames().size());
+        }
+    }
+
+    @Test
+    void testAvoidForwardportsShouldUseExistingBackport(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var repo = credentials.getHostedRepository();
+            var repoFolder = tempFolder.path().resolve("repo");
+            var localRepo = CheckableRepository.init(repoFolder, repo.repositoryType(), Path.of("appendable.txt"), Set.of(), null);
+            credentials.commitLock(localRepo);
+            localRepo.pushAll(repo.authenticatedUrl());
+
+            var storageFolder = tempFolder.path().resolve("storage");
+            var issueProject = credentials.getIssueProject();
+            var jbsNotifierConfig = JSON.object().put("fixversions", JSON.object().put(".*aster", "21")).put("avoidforwardports", true);
+            var notifyBot = testBotBuilder(repo, issueProject, storageFolder, jbsNotifierConfig).create("notify", JSON.object());
+
+            // Initialize history
+            TestBotRunner.runPeriodicItems(notifyBot);
+
+            // Create an issue
+            var issue = issueProject.createIssue("This is an issue", List.of("Indeed"),
+                    Map.of("issuetype", JSON.of("Enhancement"),
+                            SUBCOMPONENT, JSON.of("java.io"),
+                            RESOLVED_IN_BUILD, JSON.of("b07")
+                    ));
+            issue.setProperty("fixVersions", JSON.array().add("22"));
+            issue.setProperty("priority", JSON.of("1"));
+            issue.addLabel("test");
+            issue.addLabel("temporary");
+
+            // Create an explicit "forwardport"
+            var backport = issueProject.createIssue("This is a forwardport", List.of("Indeed"),
+                    Map.of("issuetype", JSON.of("Backport")));
+            backport.setProperty("fixVersions", JSON.array().add("21"));
+
+            issue.addLink(Link.create(backport, "backported by").build());
+            backport.addLink(Link.create(issue, "backport of").build());
+
+            // Commit a fix for the issue
+            var authorEmailAddress = issueProject.issueTracker().currentUser().username() + "@openjdk.org";
+            var editHash = CheckableRepository.appendAndCommit(localRepo, "Another line", issue.id() + ": Fix that issue", "Duke", authorEmailAddress);
+            localRepo.push(editHash, repo.authenticatedUrl(), "master");
+            TestBotRunner.runPeriodicItems(notifyBot);
+
+            // The fixVersion should not have been updated
+            var updatedIssue = issueProject.issue(issue.id()).orElseThrow();
+            assertEquals(Set.of("22"), fixVersions(updatedIssue));
+            assertEquals(OPEN, updatedIssue.state());
+            assertEquals(List.of(), updatedIssue.assignees());
+
+            // There should still be just a single link
+            var links = updatedIssue.links();
+            assertEquals(1, links.size());
+            var link = links.get(0);
+            var updatedBackport = link.issue().orElseThrow();
+
+            // The backport issue should have the repository's fixVersions
+            assertEquals(Set.of("21"), fixVersions(updatedBackport));
+            assertEquals(RESOLVED, updatedBackport.state());
+            assertEquals(List.of(issueProject.issueTracker().currentUser()), updatedBackport.assignees());
+
+            // No properties should have propagated
+            assertFalse(updatedBackport.properties().containsKey(SUBCOMPONENT));
+            assertFalse(updatedBackport.properties().containsKey(RESOLVED_IN_BUILD));
+
+            // Not Labels should have propagated
+            assertEquals(0, updatedBackport.labelNames().size());
+        }
+    }
 }


### PR DESCRIPTION
Hi all,

please review this re-implementation of avoiding so called "forward backports", this time around in the `IssueNotifier`, meaning that Skara will avoid to create a "forward backport" _after_ a pull request has been integrated. Solving the problem in the `IssueNotifier` turned out to be a much more natural fit, so thanks @zhaosongzs and @erikj79 for the discussion in #1630.

The new implementation will avoid creating a "foward backport" if _no_ suitable backport (or "forward backport") is found. That is, if JBS already contains a backport (or "forward backport") that can be used, then that backport (or "forward backport") will be used. This makes sense to me because in this scenario the user has (most likely) set up the issues in JBS for this to happen. But when Skara decides to create a _new_ backport, then (if `"avoidforwardports"` is `true` in the configuration) the code will never create "forward backport", instead opting to create a backport with the primary issue's `fixVersions` and setting `fixVersions` of the primary issue to the value found in the repository's `.jcheck/conf`.

I also added a number of new unit tests. Note that this pull request depends on #1636 in order for the tests to pass, so the tests will fail until #1636 is integrated.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2226](https://bugs.openjdk.org/browse/SKARA-2226): Make it possible to avoid "forward backports" (**Enhancement** - P4)


### Reviewers
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to [26b3bf4c](https://git.openjdk.org/skara/pull/1637/files/26b3bf4c7a5eb4302712da50fe518e1a552ddcc1)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1637/head:pull/1637` \
`$ git checkout pull/1637`

Update a local copy of the PR: \
`$ git checkout pull/1637` \
`$ git pull https://git.openjdk.org/skara.git pull/1637/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1637`

View PR using the GUI difftool: \
`$ git pr show -t 1637`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1637.diff">https://git.openjdk.org/skara/pull/1637.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1637#issuecomment-2051329703)