### PR TITLE
2170: Warn on trailing period in PR titles

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -1290,7 +1290,7 @@ class CheckRun {
                                     .toList());
                             warnings.addAll(commitVisitor.warningFailedChecksMessages().stream()
                                     .map(StringBuilder::new)
-                                    .map(e -> e.append(" (in commit `").append(hash.hex()).append("` with target configuration)"))
+                                    .map(e -> e.append(" (in commit `").append(hash.hex()).append("` with commit configuration)"))
                                     .map(StringBuilder::toString)
                                     .toList());
                         }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -666,7 +666,7 @@ class CheckRun {
         progressBody.append("### Progress\n");
         progressBody.append(getChecksList(visitor, reviewNeeded, additionalProgresses));
 
-        var allAdditionalErrors = Stream.concat(visitor.hiddenMessages().stream(), additionalErrors.stream())
+        var allAdditionalErrors = Stream.concat(visitor.hiddenErrorMessages().stream(), additionalErrors.stream())
                                         .sorted()
                                         .collect(Collectors.toList());
         if (!allAdditionalErrors.isEmpty()) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
@@ -266,10 +266,10 @@ public class IntegrateCommand implements CommandHandler {
         var jcheckConf = checkablePr.parseJCheckConfiguration(targetHash);
         var visitor = checkablePr.createVisitor(jcheckConf);
         checkablePr.executeChecks(localHash, censusInstance, visitor, jcheckConf);
-        if (!visitor.messages().isEmpty()) {
+        if (!visitor.errorFailedChecksMessages().isEmpty()) {
             reply.print("Your integration request cannot be fulfilled at this time, as ");
             reply.println("your changes failed the final jcheck:");
-            visitor.messages().stream()
+            visitor.errorFailedChecksMessages().stream()
                   .map(line -> " * " + line)
                   .forEach(reply::println);
             return true;

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
@@ -290,7 +290,14 @@ class PullRequestCheckIssueVisitor implements IssueVisitor {
 
     @Override
     public void visit(IssuesTitleIssue issue) {
-        addMessage(issue.check(), "Found trailing period in " + String.join(" ,", issue.getIssuesWithTrailingPeriod()),
+        List<String> messages = new ArrayList<>();
+        if (!issue.issuesWithTrailingPeriod().isEmpty()) {
+            messages.add("Found trailing period in " + String.join(" ,", issue.issuesWithTrailingPeriod()));
+        }
+        if (!issue.issuesWithLeadingLowerCaseLetter().isEmpty()) {
+            messages.add("Found leading lowercase letter in " + String.join(" ,", issue.issuesWithLeadingLowerCaseLetter()));
+        }
+        addMessage(issue.check(), String.join("\n", messages),
                 issue.severity(), true);
     }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -3432,7 +3432,7 @@ class CheckTests {
             TestBotRunner.runPeriodicItems(prBot);
 
             assertTrue(pr.store().body().contains("Warning"));
-            assertTrue(pr.store().body().contains("Found trailing period in 1: This is an issue."));
+            assertTrue(pr.store().body().contains("Found trailing period in `1: This is an issue.`"));
 
             // Remove the trailing period in the title
             pr.setTitle("1: This is an issue");
@@ -3443,10 +3443,11 @@ class CheckTests {
             assertFalse(pr.store().body().contains("Found trailing period in 1: This is an issue."));
 
             // Create another issue with trailing period
-            var issue2 = issues.createIssue("This is an issue2 etc.", List.of("Hello"), Map.of());
+            var issue2 = issues.createIssue("this is an issue2 etc.", List.of("Hello"), Map.of());
             pr.addComment("/issue add " + issue2.id());
             TestBotRunner.runPeriodicItems(prBot);
-            assertTrue(pr.store().body().contains("Found trailing period in 2: This is an issue2 etc."));
+            assertTrue(pr.store().body().contains("Found trailing period in `2: this is an issue2 etc.`"));
+            assertTrue(pr.store().body().contains("Found leading lowercase letter in `2: this is an issue2 etc.`"));
 
             // Approve it as Reviewer, warnings shouldn't prevent adding ready label to the pr
             var reviewerPr = reviewer.pullRequest(pr.id());

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -2842,7 +2842,7 @@ class CheckTests {
             // pr body should have the integrationBlocker for whitespace and reviewer check, also warning for issuestitle check
             assertTrue(pr.store().body().contains("Whitespace errors (failed with updated jcheck configuration in pull request)"));
             assertTrue(pr.store().body().contains("Too few reviewers with at least role reviewer found (have 0, need at least 1) (failed with updated jcheck configuration in pull request)"));
-            assertTrue(pr.store().body().contains("Found trailing period in `1: This is an issue.` (failed with updated jcheck configuration in pull request)"));
+            assertTrue(pr.store().body().contains("Found trailing period in issue title for `1: This is an issue.` (failed with updated jcheck configuration in pull request)"));
 
             var approvalPr = reviewer.pullRequest(pr.id());
             approvalPr.addReview(Review.Verdict.APPROVED, "Approved");
@@ -3432,7 +3432,7 @@ class CheckTests {
             TestBotRunner.runPeriodicItems(prBot);
 
             assertTrue(pr.store().body().contains("Warning"));
-            assertTrue(pr.store().body().contains("Found trailing period in `1: This is an issue.`"));
+            assertTrue(pr.store().body().contains("Found trailing period in issue title for `1: This is an issue.`"));
 
             // Remove the trailing period in the title
             pr.setTitle("1: This is an issue");
@@ -3440,14 +3440,14 @@ class CheckTests {
 
             TestBotRunner.runPeriodicItems(prBot);
             assertFalse(pr.store().body().contains("Warning"));
-            assertFalse(pr.store().body().contains("Found trailing period in 1: This is an issue."));
+            assertFalse(pr.store().body().contains("Found trailing period in issue title for 1: This is an issue."));
 
             // Create another issue with trailing period
             var issue2 = issues.createIssue("this is an issue2 etc.", List.of("Hello"), Map.of());
             pr.addComment("/issue add " + issue2.id());
             TestBotRunner.runPeriodicItems(prBot);
-            assertTrue(pr.store().body().contains("Found trailing period in `2: this is an issue2 etc.`"));
-            assertTrue(pr.store().body().contains("Found leading lowercase letter in `2: this is an issue2 etc.`"));
+            assertTrue(pr.store().body().contains("Found trailing period in issue title for `2: this is an issue2 etc.`"));
+            assertTrue(pr.store().body().contains("Found leading lowercase letter in issue title for `2: this is an issue2 etc.`"));
 
             // Approve it as Reviewer, warnings shouldn't prevent adding ready label to the pr
             var reviewerPr = reviewer.pullRequest(pr.id());

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -2842,7 +2842,7 @@ class CheckTests {
             // pr body should have the integrationBlocker for whitespace and reviewer check, also warning for issuestitle check
             assertTrue(pr.store().body().contains("Whitespace errors (failed with updated jcheck configuration in pull request)"));
             assertTrue(pr.store().body().contains("Too few reviewers with at least role reviewer found (have 0, need at least 1) (failed with updated jcheck configuration in pull request)"));
-            assertTrue(pr.store().body().contains("Found trailing period in 1: This is an issue. (failed with updated jcheck configuration in pull request)"));
+            assertTrue(pr.store().body().contains("Found trailing period in `1: This is an issue.` (failed with updated jcheck configuration in pull request)"));
 
             var approvalPr = reviewer.pullRequest(pr.id());
             approvalPr.addReview(Review.Verdict.APPROVED, "Approved");

--- a/cli/src/main/java/org/openjdk/skara/cli/JCheckCLIVisitor.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/JCheckCLIVisitor.java
@@ -313,7 +313,7 @@ class JCheckCLIVisitor implements IssueVisitor {
     @Override
     public void visit(IssuesTitleIssue i) {
         if (!ignore.contains(i.check().name()) && !isLax) {
-            println(i, "Trailing period in issue title");
+            println(i, "Found trailing period in " + String.join(" ,", i.getIssuesWithTrailingPeriod()));
             for (var line : i.commit().message()) {
                 System.out.println("> " + line);
             }

--- a/cli/src/main/java/org/openjdk/skara/cli/JCheckCLIVisitor.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/JCheckCLIVisitor.java
@@ -78,28 +78,28 @@ class JCheckCLIVisitor implements IssueVisitor {
                          .collect(Collectors.toList());
             println(i, "issue id '" + id + "' in commit " + hash + " is already used in commits:");
             other.forEach(System.out::println);
-            hasDisplayedErrors = i.severity().equals(Severity.ERROR);
+            hasDisplayedErrors = i.severity() == Severity.ERROR;
         }
     }
 
     public void visit(TagIssue i) {
         if (!ignore.contains(i.check().name()) && !isLax) {
             println(i, "illegal tag name: " + i.tag().name());
-            hasDisplayedErrors = i.severity().equals(Severity.ERROR);
+            hasDisplayedErrors = i.severity() == Severity.ERROR;
         }
     }
 
     public void visit(BranchIssue i) {
         if (!ignore.contains(i.check().name())) {
             println(i, "illegal branch name: " + i.branch().name());
-            hasDisplayedErrors = i.severity().equals(Severity.ERROR);
+            hasDisplayedErrors = i.severity() == Severity.ERROR;
         }
     }
 
     public void visit(SelfReviewIssue i) {
         if (!ignore.contains(i.check().name()) && !isLax) {
             println(i, "self-reviews are not allowed");
-            hasDisplayedErrors = i.severity().equals(Severity.ERROR);
+            hasDisplayedErrors = i.severity() == Severity.ERROR;
         }
     }
 
@@ -109,7 +109,7 @@ class JCheckCLIVisitor implements IssueVisitor {
             var actual = i.numActual();
             var reviewers = required == 1 ? " reviewer" : " reviewers";
             println(i, required + reviewers + " required, found " + actual);
-            hasDisplayedErrors = i.severity().equals(Severity.ERROR);
+            hasDisplayedErrors = i.severity() == Severity.ERROR;
         }
     }
 
@@ -118,20 +118,20 @@ class JCheckCLIVisitor implements IssueVisitor {
             var invalid = String.join(", ", i.invalid());
             var wording = i.invalid().size() == 1 ? " is" : " are";
             println(i, invalid + wording + " not part of OpenJDK");
-            hasDisplayedErrors = i.severity().equals(Severity.ERROR);
+            hasDisplayedErrors = i.severity() == Severity.ERROR;
         }
     }
 
     public void visit(MergeMessageIssue i) {
         if (!ignore.contains(i.check().name()) && !isLax) {
             println(i, "merge commits should only use the commit message '" + i.expected() + "'");
-            hasDisplayedErrors = i.severity().equals(Severity.ERROR);
+            hasDisplayedErrors = i.severity() == Severity.ERROR;
         }
     }
 
     public void visit(HgTagCommitIssue i) {
         if (!ignore.contains(i.check().name()) && !isLax) {
-            hasDisplayedErrors = i.severity().equals(Severity.ERROR);
+            hasDisplayedErrors = i.severity() == Severity.ERROR;
             switch (i.error()) {
                 case TOO_MANY_LINES:
                     println(i, "message should only be one line");
@@ -154,7 +154,7 @@ class JCheckCLIVisitor implements IssueVisitor {
             var committer = i.commit().committer().name();
             var project = i.project().name();
             println(i, committer + " is not committer in project " + project);
-            hasDisplayedErrors = i.severity().equals(Severity.ERROR);
+            hasDisplayedErrors = i.severity() == Severity.ERROR;
         }
     }
 
@@ -212,7 +212,7 @@ class JCheckCLIVisitor implements IssueVisitor {
             var indent = prefix.replaceAll(".", " ");
             System.out.println(indent + i.escapeLine());
             System.out.println(indent + i.hints());
-            hasDisplayedErrors = i.severity().equals(Severity.ERROR);
+            hasDisplayedErrors = i.severity() == Severity.ERROR;
         }
     }
 
@@ -222,7 +222,7 @@ class JCheckCLIVisitor implements IssueVisitor {
             for (var line : i.message().additional()) {
                 System.out.println("> " + line);
             }
-            hasDisplayedErrors = i.severity().equals(Severity.ERROR);
+            hasDisplayedErrors = i.severity() == Severity.ERROR;
         }
     }
 
@@ -238,7 +238,7 @@ class JCheckCLIVisitor implements IssueVisitor {
             }
             println(i, "contains " + desc + " on line " + i.line() + " in commit message:");
             System.out.println("> " + i.commit().message().get(i.line() - 1));
-            hasDisplayedErrors = i.severity().equals(Severity.ERROR);
+            hasDisplayedErrors = i.severity() == Severity.ERROR;
         }
     }
 
@@ -248,42 +248,42 @@ class JCheckCLIVisitor implements IssueVisitor {
             for (var line : i.commit().message()) {
                 System.out.println("> " + line);
             }
-            hasDisplayedErrors = i.severity().equals(Severity.ERROR);
+            hasDisplayedErrors = i.severity() == Severity.ERROR;
         }
     }
 
     public void visit(ExecutableIssue i) {
         if (!ignore.contains(i.check().name())) {
             println(i, "file " + i.path() + " is executable");
-            hasDisplayedErrors = i.severity().equals(Severity.ERROR);
+            hasDisplayedErrors = i.severity() == Severity.ERROR;
         }
     }
 
     public void visit(SymlinkIssue i) {
         if (!ignore.contains(i.check().name())) {
             println(i, "file " + i.path() + " is symbolic link");
-            hasDisplayedErrors = i.severity().equals(Severity.ERROR);
+            hasDisplayedErrors = i.severity() == Severity.ERROR;
         }
     }
 
     public void visit(AuthorNameIssue i) {
         if (!ignore.contains(i.check().name())) {
             println(i, "missing author name");
-            hasDisplayedErrors = i.severity().equals(Severity.ERROR);
+            hasDisplayedErrors = i.severity() == Severity.ERROR;
         }
     }
 
     public void visit(AuthorEmailIssue i) {
         if (!ignore.contains(i.check().name()) && !isMercurial) {
             println(i, "missing author email");
-            hasDisplayedErrors = i.severity().equals(Severity.ERROR);
+            hasDisplayedErrors = i.severity() == Severity.ERROR;
         }
     }
 
     public void visit(CommitterNameIssue i) {
         if (!ignore.contains(i.check().name())) {
             println(i, "missing committer name");
-            hasDisplayedErrors = i.severity().equals(Severity.ERROR);
+            hasDisplayedErrors = i.severity() == Severity.ERROR;
         }
     }
 
@@ -291,14 +291,14 @@ class JCheckCLIVisitor implements IssueVisitor {
         if (!ignore.contains(i.check().name()) && !isMercurial) {
             var domain = i.expectedDomain();
             println(i, "missing committer email from domain " + domain);
-            hasDisplayedErrors = i.severity().equals(Severity.ERROR);
+            hasDisplayedErrors = i.severity() == Severity.ERROR;
         }
     }
 
     public void visit(BinaryIssue i) {
         if (!ignore.contains(i.check().name())) {
             println(i, "adds binary file: " + i.path().toString());
-            hasDisplayedErrors = i.severity().equals(Severity.ERROR);
+            hasDisplayedErrors = i.severity() == Severity.ERROR;
         }
     }
 
@@ -306,7 +306,7 @@ class JCheckCLIVisitor implements IssueVisitor {
     public void visit(ProblemListsIssue i) {
         if (!ignore.contains(i.check().name())) {
             println(i, i.issue() + " is used in problem lists " + i.files());
-            hasDisplayedErrors = i.severity().equals(Severity.ERROR);
+            hasDisplayedErrors = i.severity() == Severity.ERROR;
         }
     }
 
@@ -314,15 +314,15 @@ class JCheckCLIVisitor implements IssueVisitor {
     public void visit(IssuesTitleIssue i) {
         if (!ignore.contains(i.check().name()) && !isLax) {
             if (!i.issuesWithTrailingPeriod().isEmpty()) {
-                println(i, "Found trailing period in " + String.join(" ,", i.issuesWithTrailingPeriod()));
+                println(i, "Found trailing period in issue title for " + String.join(", ", i.issuesWithTrailingPeriod()));
             }
             if (!i.issuesWithLeadingLowerCaseLetter().isEmpty()) {
-                println(i, "Found leading lowercase letter in " + String.join(" ,", i.issuesWithLeadingLowerCaseLetter()));
+                println(i, "Found leading lowercase letter in issue title for " + String.join(", ", i.issuesWithLeadingLowerCaseLetter()));
             }
             for (var line : i.commit().message()) {
                 System.out.println("> " + line);
             }
-            hasDisplayedErrors = i.severity().equals(Severity.ERROR);
+            hasDisplayedErrors = i.severity() == Severity.ERROR;
         }
     }
 

--- a/cli/src/main/java/org/openjdk/skara/cli/JCheckCLIVisitor.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/JCheckCLIVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -78,28 +78,28 @@ class JCheckCLIVisitor implements IssueVisitor {
                          .collect(Collectors.toList());
             println(i, "issue id '" + id + "' in commit " + hash + " is already used in commits:");
             other.forEach(System.out::println);
-            hasDisplayedErrors = true;
+            hasDisplayedErrors = i.severity().equals(Severity.ERROR);
         }
     }
 
     public void visit(TagIssue i) {
         if (!ignore.contains(i.check().name()) && !isLax) {
             println(i, "illegal tag name: " + i.tag().name());
-            hasDisplayedErrors = true;
+            hasDisplayedErrors = i.severity().equals(Severity.ERROR);
         }
     }
 
     public void visit(BranchIssue i) {
         if (!ignore.contains(i.check().name())) {
             println(i, "illegal branch name: " + i.branch().name());
-            hasDisplayedErrors = true;
+            hasDisplayedErrors = i.severity().equals(Severity.ERROR);
         }
     }
 
     public void visit(SelfReviewIssue i) {
         if (!ignore.contains(i.check().name()) && !isLax) {
             println(i, "self-reviews are not allowed");
-            hasDisplayedErrors = true;
+            hasDisplayedErrors = i.severity().equals(Severity.ERROR);
         }
     }
 
@@ -109,7 +109,7 @@ class JCheckCLIVisitor implements IssueVisitor {
             var actual = i.numActual();
             var reviewers = required == 1 ? " reviewer" : " reviewers";
             println(i, required + reviewers + " required, found " + actual);
-            hasDisplayedErrors = true;
+            hasDisplayedErrors = i.severity().equals(Severity.ERROR);
         }
     }
 
@@ -118,20 +118,20 @@ class JCheckCLIVisitor implements IssueVisitor {
             var invalid = String.join(", ", i.invalid());
             var wording = i.invalid().size() == 1 ? " is" : " are";
             println(i, invalid + wording + " not part of OpenJDK");
-            hasDisplayedErrors = true;
+            hasDisplayedErrors = i.severity().equals(Severity.ERROR);
         }
     }
 
     public void visit(MergeMessageIssue i) {
         if (!ignore.contains(i.check().name()) && !isLax) {
             println(i, "merge commits should only use the commit message '" + i.expected() + "'");
-            hasDisplayedErrors = true;
+            hasDisplayedErrors = i.severity().equals(Severity.ERROR);
         }
     }
 
     public void visit(HgTagCommitIssue i) {
         if (!ignore.contains(i.check().name()) && !isLax) {
-            hasDisplayedErrors = true;
+            hasDisplayedErrors = i.severity().equals(Severity.ERROR);
             switch (i.error()) {
                 case TOO_MANY_LINES:
                     println(i, "message should only be one line");
@@ -154,7 +154,7 @@ class JCheckCLIVisitor implements IssueVisitor {
             var committer = i.commit().committer().name();
             var project = i.project().name();
             println(i, committer + " is not committer in project " + project);
-            hasDisplayedErrors = true;
+            hasDisplayedErrors = i.severity().equals(Severity.ERROR);
         }
     }
 
@@ -212,7 +212,7 @@ class JCheckCLIVisitor implements IssueVisitor {
             var indent = prefix.replaceAll(".", " ");
             System.out.println(indent + i.escapeLine());
             System.out.println(indent + i.hints());
-            hasDisplayedErrors = true;
+            hasDisplayedErrors = i.severity().equals(Severity.ERROR);
         }
     }
 
@@ -222,7 +222,7 @@ class JCheckCLIVisitor implements IssueVisitor {
             for (var line : i.message().additional()) {
                 System.out.println("> " + line);
             }
-            hasDisplayedErrors = true;
+            hasDisplayedErrors = i.severity().equals(Severity.ERROR);
         }
     }
 
@@ -238,7 +238,7 @@ class JCheckCLIVisitor implements IssueVisitor {
             }
             println(i, "contains " + desc + " on line " + i.line() + " in commit message:");
             System.out.println("> " + i.commit().message().get(i.line() - 1));
-            hasDisplayedErrors = true;
+            hasDisplayedErrors = i.severity().equals(Severity.ERROR);
         }
     }
 
@@ -248,42 +248,42 @@ class JCheckCLIVisitor implements IssueVisitor {
             for (var line : i.commit().message()) {
                 System.out.println("> " + line);
             }
-            hasDisplayedErrors = true;
+            hasDisplayedErrors = i.severity().equals(Severity.ERROR);
         }
     }
 
     public void visit(ExecutableIssue i) {
         if (!ignore.contains(i.check().name())) {
             println(i, "file " + i.path() + " is executable");
-            hasDisplayedErrors = true;
+            hasDisplayedErrors = i.severity().equals(Severity.ERROR);
         }
     }
 
     public void visit(SymlinkIssue i) {
         if (!ignore.contains(i.check().name())) {
             println(i, "file " + i.path() + " is symbolic link");
-            hasDisplayedErrors = true;
+            hasDisplayedErrors = i.severity().equals(Severity.ERROR);
         }
     }
 
     public void visit(AuthorNameIssue i) {
         if (!ignore.contains(i.check().name())) {
             println(i, "missing author name");
-            hasDisplayedErrors = true;
+            hasDisplayedErrors = i.severity().equals(Severity.ERROR);
         }
     }
 
     public void visit(AuthorEmailIssue i) {
         if (!ignore.contains(i.check().name()) && !isMercurial) {
             println(i, "missing author email");
-            hasDisplayedErrors = true;
+            hasDisplayedErrors = i.severity().equals(Severity.ERROR);
         }
     }
 
     public void visit(CommitterNameIssue i) {
         if (!ignore.contains(i.check().name())) {
             println(i, "missing committer name");
-            hasDisplayedErrors = true;
+            hasDisplayedErrors = i.severity().equals(Severity.ERROR);
         }
     }
 
@@ -291,22 +291,33 @@ class JCheckCLIVisitor implements IssueVisitor {
         if (!ignore.contains(i.check().name()) && !isMercurial) {
             var domain = i.expectedDomain();
             println(i, "missing committer email from domain " + domain);
-            hasDisplayedErrors = true;
+            hasDisplayedErrors = i.severity().equals(Severity.ERROR);
         }
     }
 
     public void visit(BinaryIssue i) {
         if (!ignore.contains(i.check().name())) {
             println(i, "adds binary file: " + i.path().toString());
-            hasDisplayedErrors = true;
+            hasDisplayedErrors = i.severity().equals(Severity.ERROR);
         }
     }
 
     @Override
     public void visit(ProblemListsIssue i) {
         if (!ignore.contains(i.check().name())) {
-            println(i,  i.issue() + " is used in problem lists " + i.files());
-            hasDisplayedErrors = true;
+            println(i, i.issue() + " is used in problem lists " + i.files());
+            hasDisplayedErrors = i.severity().equals(Severity.ERROR);
+        }
+    }
+
+    @Override
+    public void visit(IssuesTitleIssue i) {
+        if (!ignore.contains(i.check().name()) && !isLax) {
+            println(i, "Trailing period in issue title");
+            for (var line : i.commit().message()) {
+                System.out.println("> " + line);
+            }
+            hasDisplayedErrors = i.severity().equals(Severity.ERROR);
         }
     }
 

--- a/cli/src/main/java/org/openjdk/skara/cli/JCheckCLIVisitor.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/JCheckCLIVisitor.java
@@ -313,7 +313,12 @@ class JCheckCLIVisitor implements IssueVisitor {
     @Override
     public void visit(IssuesTitleIssue i) {
         if (!ignore.contains(i.check().name()) && !isLax) {
-            println(i, "Found trailing period in " + String.join(" ,", i.getIssuesWithTrailingPeriod()));
+            if (!i.issuesWithTrailingPeriod().isEmpty()) {
+                println(i, "Found trailing period in " + String.join(" ,", i.issuesWithTrailingPeriod()));
+            }
+            if (!i.issuesWithLeadingLowerCaseLetter().isEmpty()) {
+                println(i, "Found leading lowercase letter in " + String.join(" ,", i.issuesWithLeadingLowerCaseLetter()));
+            }
             for (var line : i.commit().message()) {
                 System.out.println("> " + line);
             }

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/IssuesTitleCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/IssuesTitleCheck.java
@@ -26,6 +26,7 @@ import org.openjdk.skara.census.Census;
 import org.openjdk.skara.vcs.Commit;
 import org.openjdk.skara.vcs.openjdk.CommitMessage;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.logging.Logger;
 
@@ -43,12 +44,15 @@ public class IssuesTitleCheck extends CommitCheck {
             return iterator();
         }
 
+        var issuesWithTrailingPeriod = new ArrayList<String>();
         for (var issue : message.issues()) {
             if (issue.description().endsWith(".")) {
-                return iterator(new IssuesTitleIssue(metadata));
+                issuesWithTrailingPeriod.add(issue.toString());
             }
         }
-
+        if (!issuesWithTrailingPeriod.isEmpty()) {
+            return iterator(new IssuesTitleIssue(metadata, issuesWithTrailingPeriod));
+        }
         return iterator();
     }
 

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/IssuesTitleCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/IssuesTitleCheck.java
@@ -68,7 +68,7 @@ public class IssuesTitleCheck extends CommitCheck {
 
     @Override
     public String description() {
-        return "Issue's title shouldn't have trailing period";
+        return "Issue's title should be properly formatted";
     }
 
 }

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/IssuesTitleCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/IssuesTitleCheck.java
@@ -49,10 +49,10 @@ public class IssuesTitleCheck extends CommitCheck {
 
         for (var issue : message.issues()) {
             if (issue.description().endsWith(".")) {
-                issuesWithTrailingPeriod.add(issue.toString());
+                issuesWithTrailingPeriod.add("`" + issue + "`");
             }
-            if(Character.isLowerCase(issue.description().charAt(0))){
-                issuesWithLeadingLowerCaseLetter.add(issue.toString());
+            if (Character.isLowerCase(issue.description().charAt(0))) {
+                issuesWithLeadingLowerCaseLetter.add("`" + issue + "`");
             }
         }
         if (!issuesWithTrailingPeriod.isEmpty()) {

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/IssuesTitleCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/IssuesTitleCheck.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.jcheck;
+
+import org.openjdk.skara.census.Census;
+import org.openjdk.skara.vcs.Commit;
+import org.openjdk.skara.vcs.openjdk.CommitMessage;
+
+import java.util.Iterator;
+import java.util.logging.Logger;
+
+public class IssuesTitleCheck extends CommitCheck {
+    private final Logger log = Logger.getLogger("org.openjdk.skara.jcheck.issuesTitle");
+
+    @Override
+    Iterator<Issue> check(Commit commit, CommitMessage message, JCheckConfiguration conf, Census census) {
+
+        var metadata = CommitIssue.metadata(commit, message, conf, this);
+
+        // if issues check is not required, skip issuesTitleCheck
+        if (conf.checks().issues().required() &&
+                (commit.message().isEmpty() || message.issues().isEmpty())) {
+            return iterator();
+        }
+
+        for (var issue : message.issues()) {
+            if (issue.description().endsWith(".")) {
+                return iterator(new IssuesTitleIssue(metadata));
+            }
+        }
+
+        return iterator();
+    }
+
+    @Override
+    public String name() {
+        return "issuestitle";
+    }
+
+    @Override
+    public String description() {
+        return "Issue's title shouldn't have trailing period";
+    }
+
+}

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/IssuesTitleCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/IssuesTitleCheck.java
@@ -45,13 +45,18 @@ public class IssuesTitleCheck extends CommitCheck {
         }
 
         var issuesWithTrailingPeriod = new ArrayList<String>();
+        var issuesWithLeadingLowerCaseLetter = new ArrayList<String>();
+
         for (var issue : message.issues()) {
             if (issue.description().endsWith(".")) {
                 issuesWithTrailingPeriod.add(issue.toString());
             }
+            if(Character.isLowerCase(issue.description().charAt(0))){
+                issuesWithLeadingLowerCaseLetter.add(issue.toString());
+            }
         }
         if (!issuesWithTrailingPeriod.isEmpty()) {
-            return iterator(new IssuesTitleIssue(metadata, issuesWithTrailingPeriod));
+            return iterator(new IssuesTitleIssue(metadata, issuesWithTrailingPeriod, issuesWithLeadingLowerCaseLetter));
         }
         return iterator();
     }

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/IssuesTitleIssue.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/IssuesTitleIssue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,27 +22,13 @@
  */
 package org.openjdk.skara.jcheck;
 
-public interface IssueVisitor {
-    void visit(TagIssue issue);
-    void visit(BranchIssue issue);
-    void visit(DuplicateIssuesIssue issue);
-    void visit(SelfReviewIssue issue);
-    void visit(TooFewReviewersIssue issue);
-    void visit(InvalidReviewersIssue issue);
-    void visit(MergeMessageIssue issue);
-    void visit(HgTagCommitIssue issue);
-    void visit(CommitterIssue issue);
-    void visit(CommitterNameIssue issue);
-    void visit(CommitterEmailIssue issue);
-    void visit(AuthorNameIssue issue);
-    void visit(AuthorEmailIssue issue);
-    void visit(WhitespaceIssue issue);
-    void visit(MessageIssue issue);
-    void visit(MessageWhitespaceIssue issue);
-    void visit(IssuesIssue issue);
-    void visit(ExecutableIssue issue);
-    void visit(BinaryIssue issue);
-    void visit(SymlinkIssue issue);
-    void visit(ProblemListsIssue problemListIssue);
-    void visit(IssuesTitleIssue issuesTitleIssue);
+public class IssuesTitleIssue extends CommitIssue {
+    IssuesTitleIssue(CommitIssue.Metadata metadata) {
+        super(metadata);
+    }
+
+    @Override
+    public void accept(IssueVisitor visitor) {
+        visitor.visit(this);
+    }
 }

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/IssuesTitleIssue.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/IssuesTitleIssue.java
@@ -22,13 +22,22 @@
  */
 package org.openjdk.skara.jcheck;
 
+import java.util.List;
+
 public class IssuesTitleIssue extends CommitIssue {
-    IssuesTitleIssue(CommitIssue.Metadata metadata) {
+    List<String> issuesWithTrailingPeriod;
+
+    IssuesTitleIssue(CommitIssue.Metadata metadata, List<String> issuesWithTrailingPeriod) {
         super(metadata);
+        this.issuesWithTrailingPeriod = issuesWithTrailingPeriod;
     }
 
     @Override
     public void accept(IssueVisitor visitor) {
         visitor.visit(this);
+    }
+
+    public List<String> getIssuesWithTrailingPeriod() {
+        return issuesWithTrailingPeriod;
     }
 }

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/IssuesTitleIssue.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/IssuesTitleIssue.java
@@ -26,10 +26,12 @@ import java.util.List;
 
 public class IssuesTitleIssue extends CommitIssue {
     List<String> issuesWithTrailingPeriod;
+    List<String> issuesWithLeadingLowerCaseLetter;
 
-    IssuesTitleIssue(CommitIssue.Metadata metadata, List<String> issuesWithTrailingPeriod) {
+    IssuesTitleIssue(CommitIssue.Metadata metadata, List<String> issuesWithTrailingPeriod, List<String> issuesWithLeadingLowerCaseLetter) {
         super(metadata);
         this.issuesWithTrailingPeriod = issuesWithTrailingPeriod;
+        this.issuesWithLeadingLowerCaseLetter = issuesWithLeadingLowerCaseLetter;
     }
 
     @Override
@@ -37,7 +39,11 @@ public class IssuesTitleIssue extends CommitIssue {
         visitor.visit(this);
     }
 
-    public List<String> getIssuesWithTrailingPeriod() {
+    public List<String> issuesWithTrailingPeriod() {
         return issuesWithTrailingPeriod;
+    }
+
+    public List<String> issuesWithLeadingLowerCaseLetter() {
+        return issuesWithLeadingLowerCaseLetter;
     }
 }

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/JCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/JCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -81,7 +81,8 @@ public class JCheck {
             new ExecutableCheck(),
             new SymlinkCheck(),
             new BinaryCheck(),
-            new ProblemListsCheck(repository)
+            new ProblemListsCheck(repository),
+            new IssuesTitleCheck()
         );
         repositoryChecks = List.of(
             new BranchesCheck(allowedBranches),

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/JCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/JCheckTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -235,6 +235,11 @@ class JCheckTests {
 
         @Override
         public void visit(ProblemListsIssue e) {
+            issues.add(e);
+        }
+
+        @Override
+        public void visit(IssuesTitleIssue e) {
             issues.add(e);
         }
 

--- a/test/src/main/java/org/openjdk/skara/test/CheckableRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/CheckableRepository.java
@@ -39,7 +39,7 @@ public class CheckableRepository {
         }
     }
 
-    public static Repository init(Path path, VCS vcs, Path appendableFilePath, Set<String> checks, String version) throws IOException {
+    public static Repository init(Path path, VCS vcs, Path appendableFilePath, Set<String> errorChecks, Set<String> warningChecks, String version) throws IOException {
         var repo = Repository.init(path, vcs);
 
         Files.createDirectories(path.resolve(".checkable"));
@@ -68,7 +68,10 @@ public class CheckableRepository {
             output.append("\n");
             output.append("[checks]\n");
             output.append("error=");
-            output.append(String.join(",", checks));
+            output.append(String.join(",", errorChecks));
+            output.append("\n");
+            output.append("warning=");
+            output.append(String.join(",", warningChecks));
             output.append("\n\n");
             output.append("[census]\n");
             output.append("version=0\n");
@@ -87,8 +90,12 @@ public class CheckableRepository {
         return repo;
     }
 
+    public static Repository init(Path path, VCS vcs, Path appendableFilePath, Set<String> errorChecks, String version) throws IOException {
+        return init(path, vcs, appendableFilePath, errorChecks, Set.of("issuestitle"), version);
+    }
+
     public static Repository init(Path path, VCS vcs, Path appendableFilePath) throws IOException {
-        return init(path, vcs, appendableFilePath, Set.of("author", "reviewers", "whitespace"), "0.1");
+        return init(path, vcs, appendableFilePath, Set.of("author", "reviewers", "whitespace"), Set.of("issuestitle"), "0.1");
     }
 
     public static Repository init(Path path, VCS vcs) throws IOException {


### PR DESCRIPTION
This patch is trying to add a new jcheck called "issuestitle". This jcheck would check if the issue's title has a trailing period or leading lowercase letter. And we would like to configure "issuestitle" jcheck as warning in the repos since in some cases, trailing periods or leading lowercase letter are valid.

When implementing this, I found that although we can configure a jcheck as warning in the jcheck configuration file(.jcheck/conf), we fail to differentiate between jchecks as error and jchecks as warning. When jchecks fail as warnings, they cause the local jcheck to exit with a status code of 1. Also, they will be integration blockers when Skara bots evaluate pull requests.  Therefore, in this patch, I also make Skara CLI and Skara bots be able to handle jcheck warnings properly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issues
 * [SKARA-2170](https://bugs.openjdk.org/browse/SKARA-2170): Warn on trailing period in PR titles (**Enhancement** - P4)
 * [SKARA-2248](https://bugs.openjdk.org/browse/SKARA-2248): Warn on leading lowercase letter in PR titles (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1638/head:pull/1638` \
`$ git checkout pull/1638`

Update a local copy of the PR: \
`$ git checkout pull/1638` \
`$ git pull https://git.openjdk.org/skara.git pull/1638/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1638`

View PR using the GUI difftool: \
`$ git pr show -t 1638`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1638.diff">https://git.openjdk.org/skara/pull/1638.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1638#issuecomment-2061996795)