### PR TITLE
2234: /reviewers N should remove ready status for merge pull requests

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -80,12 +80,12 @@ class CheckRun {
     private final Set<String> newLabels;
     private final boolean reviewCleanBackport;
     private final Approval approval;
+    private final boolean reviewersCommandIssued;
 
     private Duration expiresIn;
     // Only set if approval is configured for the repo
     private String realTargetRef;
     private boolean missingApprovalRequest = false;
-    private final boolean reviewersCommandIssued;
 
     private CheckRun(CheckWorkItem workItem, PullRequest pr, Repository localRepo, List<Comment> comments,
                      List<Review> allReviews, List<Review> activeReviews, Set<String> labels,

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
@@ -289,31 +289,6 @@ class MergeTests {
                     .filter(comment -> comment.body().contains("Pushed as commit"))
                     .count();
             assertEquals(1, pushed);
-
-            // The change should now be present on the master branch
-            var pushedRepoFolder = tempFolder.path().resolve("pushedrepo");
-            var pushedRepo = Repository.materialize(pushedRepoFolder, author.authenticatedUrl(), "master");
-            assertTrue(CheckableRepository.hasBeenEdited(pushedRepo));
-
-            // The commits from the "other" branch should be preserved and not squashed (but not the merge commit)
-            var headHash = pushedRepo.resolve("HEAD").orElseThrow();
-            Set<Hash> commits;
-            try (var tempCommits = pushedRepo.commits(masterHash.hex() + ".." + headHash.hex())) {
-                commits = tempCommits.stream()
-                        .map(Commit::hash)
-                        .collect(Collectors.toSet());
-            }
-            assertTrue(commits.contains(otherHash1));
-            assertTrue(commits.contains(otherHash2));
-            assertFalse(commits.contains(mergeHash));
-
-            // Author and committer should updated in the merge commit
-            var headCommit = pushedRepo.commits(headHash.hex() + "^.." + headHash.hex()).asList().get(0);
-            assertEquals("Merge " + author.name() + ":other_/-1.2", headCommit.message().get(0));
-            assertEquals("Generated Committer 1", headCommit.author().name());
-            assertEquals("integrationcommitter1@openjdk.org", headCommit.author().email());
-            assertEquals("Generated Committer 1", headCommit.committer().name());
-            assertEquals("integrationcommitter1@openjdk.org", headCommit.committer().email());
         }
     }
 


### PR DESCRIPTION
In this pr https://github.com/openjdk/jfx22u/pull/26, Kevin issued "/reviewers 1" in the merge pull request but skara didn't remove the ready label.

Jfx22u was not configured with “reviewMerge”, so the reviewers jcheck were skipped. The reason we can see `Change must be properly reviewed (1 review required, with at least 1 Reviewer)` in the PR body is because of [SKARA-1824](https://bugs.openjdk.org/browse/SKARA-1824).

To resolve this issue, we should enable `reviewMerge` when a reviewers command is issued in a merge pull request.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2234](https://bugs.openjdk.org/browse/SKARA-2234): /reviewers N should remove ready status for merge pull requests (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1639/head:pull/1639` \
`$ git checkout pull/1639`

Update a local copy of the PR: \
`$ git checkout pull/1639` \
`$ git pull https://git.openjdk.org/skara.git pull/1639/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1639`

View PR using the GUI difftool: \
`$ git pr show -t 1639`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1639.diff">https://git.openjdk.org/skara/pull/1639.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1639#issuecomment-2059658551)