### PR TITLE
2239: Stop logging "issue: bad whitespace"

### DIFF
--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/WhitespaceCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/WhitespaceCheck.java
@@ -71,7 +71,6 @@ public class WhitespaceCheck extends CommitCheck {
                                     }
                                 }
                                 Collections.reverse(errors);
-                                log.finer("issue: bad whitespace");
                                 issues.add(new WhitespaceIssue(path, line, row, errors, metadata));
                             }
                         }


### PR DESCRIPTION
There is no point to log "issue: bad whitespace" in whitespace jcheck.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2239](https://bugs.openjdk.org/browse/SKARA-2239): Stop logging "issue: bad whitespace" (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1640/head:pull/1640` \
`$ git checkout pull/1640`

Update a local copy of the PR: \
`$ git checkout pull/1640` \
`$ git pull https://git.openjdk.org/skara.git pull/1640/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1640`

View PR using the GUI difftool: \
`$ git pr show -t 1640`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1640.diff">https://git.openjdk.org/skara/pull/1640.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1640#issuecomment-2067036769)