### PR TITLE
2242: Creating pull request on github assumes source is personal fork of user

### DIFF
--- a/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
+++ b/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
@@ -581,13 +581,12 @@ class MergeBot implements Bot, WorkItem {
                     message.add("");
                     message.add("/integrate auto");
 
-                    var prFromFork = fork.createPullRequest(prTarget,
-                                                            toBranch.name(),
-                                                            branchDesc,
-                                                            title,
-                                                            message);
-                    var prFromTarget = target.pullRequest(prFromFork.id());
-                    prFromTarget.addLabel("failed-auto-merge");
+                    var pr = fork.createPullRequest(prTarget,
+                            toBranch.name(),
+                            branchDesc,
+                            title,
+                            message);
+                    pr.addLabel("failed-auto-merge");
                 }
             }
         } catch (IOException e) {

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -121,11 +121,9 @@ public class GitHubRepository implements HostedRepository {
         }
 
         var upstream = (GitHubRepository) target;
-        var user = forge().currentUser().username();
-        var namespace = user.endsWith("[bot]") ? "" : user + ":";
         var params = JSON.object()
                          .put("title", title)
-                         .put("head", namespace + sourceRef)
+                         .put("head", group() + ":" + sourceRef)
                          .put("base", targetRef)
                          .put("body", String.join("\n", body))
                          .put("draft", draft);
@@ -133,7 +131,7 @@ public class GitHubRepository implements HostedRepository {
                                  .body(params)
                                  .execute();
 
-        return new GitHubPullRequest(upstream, pr, request);
+        return new GitHubPullRequest(upstream, pr, upstream.request);
     }
 
     @Override


### PR DESCRIPTION
This patch fixes the behavior of `GitHubRepository::createPullRequest`. The API pretty clearly indicates that it's meant to create a pull request from the called repository, to the target repository provided as argument. Instead it creates a pull request from the fork owned by the current user to the target repository provided as argument. If the current user has `[bot]` in the name, then the PR will be created using the target repository as source instead. In either case, the called repository is ignored and sometimes just happens to coincide with the fork of the current user.

The existing behavior is perplexing but I'm pretty sure I'm right. I'm changing it to explicitly take the "group" value of the called repository as "namespace" instead. This will equal the username when the called repository is a user fork, or the group/org if the called repository is in a GitHub org. In the case where source and target are the same repo, it will also do the right thing.

In addition to this error, I noted that the returned PullRequest instance is inconsistent. It is given the HostedRepository of the target, which is correct, but the `request` object of the called repository, which is wrong. This caused all calls to the returned PullRequest object to return 404. In MergeBot, this was worked around by explicitly fetching a new instance from the target repository. By fixing this, that workaround in MergeBot could be removed.

I added three manual/integration tests for this that I have manually verified using the playground repository, my personal fork of the same and the fork in the openjdk-bots org.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2242](https://bugs.openjdk.org/browse/SKARA-2242): Creating pull request on github assumes source is personal fork of user (**Bug** - P2)


### Reviewers
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1641/head:pull/1641` \
`$ git checkout pull/1641`

Update a local copy of the PR: \
`$ git checkout pull/1641` \
`$ git pull https://git.openjdk.org/skara.git pull/1641/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1641`

View PR using the GUI difftool: \
`$ git pr show -t 1641`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1641.diff">https://git.openjdk.org/skara/pull/1641.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1641#issuecomment-2078219410)