### PR TITLE
2245: Don't check security in JiraIssueTrackerFactory

### DIFF
--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraIssueTrackerFactory.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraIssueTrackerFactory.java
@@ -44,7 +44,7 @@ public class JiraIssueTrackerFactory implements IssueTrackerFactory {
                 var vaultUrl = URIBuilder.base(credential.username()).build();
                 var jiraVault = new JiraVault(vaultUrl, credential.password(), uri);
 
-                if (configuration.contains("security") && configuration.contains("visibility")) {
+                if (configuration.contains("visibility")) {
                     return new JiraHost(uri, jiraVault, configuration.get("visibility").asString());
                 }
                 return new JiraHost(uri, jiraVault);


### PR DESCRIPTION
In [SKARA-2244](https://bugs.openjdk.org/browse/SKARA-2244), we removed security in JiraHost but I forget to remove the condition of 'configuration.contains("security")' in JiraIssueTrackerFactory.
So currently, if there is no security field in the configuration file, the factory would also ignore the visibility.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2245](https://bugs.openjdk.org/browse/SKARA-2245): Don't check security in JiraIssueTrackerFactory (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1643/head:pull/1643` \
`$ git checkout pull/1643`

Update a local copy of the PR: \
`$ git checkout pull/1643` \
`$ git pull https://git.openjdk.org/skara.git pull/1643/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1643`

View PR using the GUI difftool: \
`$ git pr show -t 1643`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1643.diff">https://git.openjdk.org/skara/pull/1643.diff</a>

</details>
