### PR TITLE
2246: Check if the pull request is still open before issuing "integrate" automatically

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -688,7 +688,7 @@ class CheckWorkItem extends PullRequestWorkItem {
             }
         }
 
-        if (pr.labelNames().contains("auto") && pr.labelNames().contains("ready")
+        if (pr.isOpen() && pr.labelNames().contains("auto") && pr.labelNames().contains("ready")
                 && !pr.labelNames().contains("sponsor") && !unhandledIntegrateCommand(comments)) {
             var comment = pr.addComment("/integrate\n" + PullRequestCommandWorkItem.VALID_BOT_COMMAND_MARKER);
             var autoAdded = pr.labelAddedAt("auto").orElseThrow();


### PR DESCRIPTION
IntegrateCommand has feature which is "/integrate auto". This command could make the pull request be automatically integrated when it is ready. But there is a bug.

Let's say we have a merge pull request, it has the auto label and it has the merge-conflict label(the pr has some merge conflicts need to be resolved manually).
1. A user pushes a commit to the source branch , it resolves the merge conflict
2. In CheckWorkItem#1, the new commit triggers CheckRun, so pull request bot removes merge-conflict label and added clean and ready
3. The user uses “Merge” button to merge the source branch into target branch in GitHub/GitLab
4. In the end of CheckWorkItem#1, pull request bot finds auto label and ready label, then issues “/integrate” command
5. When processing the /integrate command, pull request bot finds it’s not able to merge.
6. In another CheckWorkItem#2, nothing in the pull request has changed, so CheckRun will be skipped. But in the end of CheckWorkItem#2, pr bot will find auto label and ready label, and will issue another“/integrate” command

So the pull request bot will be stuck in a loop of step 4,5,6.

To resolve this issue, as Erik suggested, in step4, we should check if the pr is still open.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2246](https://bugs.openjdk.org/browse/SKARA-2246): Check if the pull request is still open before issuing "integrate" automatically (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1644/head:pull/1644` \
`$ git checkout pull/1644`

Update a local copy of the PR: \
`$ git checkout pull/1644` \
`$ git pull https://git.openjdk.org/skara.git pull/1644/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1644`

View PR using the GUI difftool: \
`$ git pr show -t 1644`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1644.diff">https://git.openjdk.org/skara/pull/1644.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1644#issuecomment-2083705231)