### PR TITLE
2247: When pr's headHash is missing, stop further processing

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -438,7 +438,7 @@ class CheckWorkItem extends PullRequestWorkItem {
                     "$ git commit --allow-empty -m \"Empty commit\"\n" +
                     "$ git push\n" +
                     "```\n" +
-                    "If the issue still exists, please notify skara admins.";
+                    "If the issue still exists, please notify Skara admins.";
             addErrorComment(text, comments);
             return List.of();
         }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -430,6 +430,19 @@ class CheckWorkItem extends PullRequestWorkItem {
         var comments = prComments();
         comments = postPlaceholderForReadyComment(comments);
 
+        if (pr.headHash().hex() == null) {
+            String text = "The head hash of this pull request is missing.\n" +
+                    "Until this is resolved, this pull request cannot be processed.\n" +
+                    "Please try to use the following command to push an empty commit.\n" +
+                    "```bash\n" +
+                    "$ git commit --allow-empty -m \"Empty commit\"\n" +
+                    "$ git push\n" +
+                    "```\n" +
+                    "If the issue still exists, please notify skara admins.";
+            addErrorComment(text, comments);
+            return List.of();
+        }
+
         try {
             census = CensusInstance.createCensusInstance(hostedRepositoryPool, bot.censusRepo(), bot.censusRef(), scratchArea.getCensus(), pr,
                     bot.confOverrideRepository().orElse(null), bot.confOverrideName(), bot.confOverrideRef());

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -431,7 +431,7 @@ class CheckWorkItem extends PullRequestWorkItem {
         comments = postPlaceholderForReadyComment(comments);
 
         if (pr.headHash().hex() == null) {
-            String text = "The head hash of this pull request is missing." +
+            String text = "The head hash of this pull request is missing. " +
                     "Until this is resolved, this pull request cannot be processed." +
                     "This is likely caused by a caching problem in the server and can usually be worked around by pushing another commit to the pull request branch. " +
                     "The commit can be empty. Example:\n" +

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -431,9 +431,10 @@ class CheckWorkItem extends PullRequestWorkItem {
         comments = postPlaceholderForReadyComment(comments);
 
         if (pr.headHash().hex() == null) {
-            String text = "The head hash of this pull request is missing.\n" +
-                    "Until this is resolved, this pull request cannot be processed.\n" +
-                    "This is likely caused by a caching problem in the server and can usually be worked around by pushing another commit to the pull request branch. The commit can be empty. Example:\n" +
+            String text = "The head hash of this pull request is missing." +
+                    "Until this is resolved, this pull request cannot be processed." +
+                    "This is likely caused by a caching problem in the server and can usually be worked around by pushing another commit to the pull request branch. " +
+                    "The commit can be empty. Example:\n" +
                     "```bash\n" +
                     "$ git commit --allow-empty -m \"Empty commit\"\n" +
                     "$ git push\n" +

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -433,7 +433,7 @@ class CheckWorkItem extends PullRequestWorkItem {
         if (pr.headHash().hex() == null) {
             String text = "The head hash of this pull request is missing.\n" +
                     "Until this is resolved, this pull request cannot be processed.\n" +
-                    "Please try to use the following command to push an empty commit.\n" +
+                    "This is likely caused by a caching problem in the server and can usually be worked around by pushing another commit to the pull request branch. The commit can be empty. Example:\n" +
                     "```bash\n" +
                     "$ git commit --allow-empty -m \"Empty commit\"\n" +
                     "$ git push\n" +

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -433,7 +433,8 @@ class CheckWorkItem extends PullRequestWorkItem {
         if (pr.headHash().hex() == null) {
             String text = "The head hash of this pull request is missing. " +
                     "Until this is resolved, this pull request cannot be processed." +
-                    "This is likely caused by a caching problem in the server and can usually be worked around by pushing another commit to the pull request branch. " +
+                    "This is likely caused by a caching problem in the server " +
+                    "and can usually be worked around by pushing another commit to the pull request branch. " +
                     "The commit can be empty. Example:\n" +
                     "```bash\n" +
                     "$ git commit --allow-empty -m \"Empty commit\"\n" +


### PR DESCRIPTION
Kevin Rushforth found this GitLab issue few years ago.

Sometimes, pull requests in GitLab would be stuck. When it happens, it shows the number of commits as "0". Clicking on the "Changes" tab shows no diffs, and displays a warning banner: "Something went wrong on our end. Please try again!" This requires action on user's part to get them "unstuck".

In Skara side, when it happens, pull request bot would not be able to get the headHash of this pull request and then throw an exception and trigger an other round of CheckWorkItem. If the user doesn't fix it, skara bot will continuously work on the pull request.

To resolve it, we should try to make pull request bot be able to identify this situation and provide some guidance to the users.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2247](https://bugs.openjdk.org/browse/SKARA-2247): When pr's headHash is missing, stop further processing (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1645/head:pull/1645` \
`$ git checkout pull/1645`

Update a local copy of the PR: \
`$ git checkout pull/1645` \
`$ git pull https://git.openjdk.org/skara.git pull/1645/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1645`

View PR using the GUI difftool: \
`$ git pr show -t 1645`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1645.diff">https://git.openjdk.org/skara/pull/1645.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1645#issuecomment-2083773562)