### PR TITLE
2254: TestInfoBotWorkItem should handle Runtime Exception

### DIFF
--- a/bots/testinfo/src/main/java/org/openjdk/skara/bots/testinfo/TestInfoBotWorkItem.java
+++ b/bots/testinfo/src/main/java/org/openjdk/skara/bots/testinfo/TestInfoBotWorkItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -165,5 +165,10 @@ public class TestInfoBotWorkItem implements WorkItem {
     @Override
     public String workItemName() {
         return botName();
+    }
+
+    @Override
+    public void handleRuntimeException(RuntimeException e) {
+        retry.accept(Duration.ofMinutes(2));
     }
 }


### PR DESCRIPTION
I created a PR in SKARA(https://github.com/openjdk/skara/pull/1647) and I found the GitHub actions are in the running state for more than about 2 hours. But actually, the GitHub actions are finished(https://github.com/zhaosongzs/skara/actions/runs/8990857032/job/24697152747). From the log, I could see TestInfoBotWorkItem got 500 error when querying the checks for this pr. However, TestInfoBotWorkItem wasn't retried. After investigation, I found TestInfoBotWorkItem doesn't handleRuntimeException.

The GitHub actions in https://github.com/openjdk/skara/pull/1647 are done right now because I mentioned that pr in this one. So the pr was updated and triggered a new TestInfoBotWorkItem

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2254](https://bugs.openjdk.org/browse/SKARA-2254): TestInfoBotWorkItem should handle Runtime Exception (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1648/head:pull/1648` \
`$ git checkout pull/1648`

Update a local copy of the PR: \
`$ git checkout pull/1648` \
`$ git pull https://git.openjdk.org/skara.git pull/1648/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1648`

View PR using the GUI difftool: \
`$ git pr show -t 1648`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1648.diff">https://git.openjdk.org/skara/pull/1648.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1648#issuecomment-2099329593)