### PR TITLE
2255: Keep additional issue marker updated

### DIFF
--- a/bots/common/src/main/java/org/openjdk/skara/bots/common/SolvesTracker.java
+++ b/bots/common/src/main/java/org/openjdk/skara/bots/common/SolvesTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@ import org.openjdk.skara.vcs.openjdk.Issue;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.regex.*;
-import java.util.stream.Collectors;
 
 public class SolvesTracker {
     private static final String SOLVES_MARKER = "<!-- solves: '%s' '%s' -->";
@@ -50,7 +49,7 @@ public class SolvesTracker {
                 .flatMap(comment -> comment.body().lines())
                 .map(MARKER_PATTERN::matcher)
                 .filter(Matcher::find)
-                .collect(Collectors.toList());
+                .toList();
         var current = new LinkedHashMap<String, Issue>();
         var titleIssue = Issue.fromStringRelaxed(title);
         for (var action : solvesActions) {
@@ -68,5 +67,12 @@ public class SolvesTracker {
         }
 
         return new ArrayList<>(current.values());
+    }
+
+    public static Optional<Comment> getLatestSolvesAction(HostUser botUser, List<Comment> comments, Issue issue) {
+        return comments.stream()
+                .filter(comment -> comment.author().equals(botUser))
+                .filter(comment -> comment.body().contains("<!-- solves: '" + issue.shortId() + "'"))
+                .max(Comparator.comparing(Comment::createdAt));
     }
 }

--- a/bots/common/src/main/java/org/openjdk/skara/bots/common/SolvesTracker.java
+++ b/bots/common/src/main/java/org/openjdk/skara/bots/common/SolvesTracker.java
@@ -69,7 +69,7 @@ public class SolvesTracker {
         return new ArrayList<>(current.values());
     }
 
-    public static Optional<Comment> getLatestSolvesAction(HostUser botUser, List<Comment> comments, Issue issue) {
+    public static Optional<Comment> getLatestSolvesActionComment(HostUser botUser, List<Comment> comments, Issue issue) {
         return comments.stream()
                 .filter(comment -> comment.author().equals(botUser))
                 .filter(comment -> comment.body().contains("<!-- solves: '" + issue.shortId() + "'"))

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -766,10 +766,7 @@ class CheckRun {
                                         "a new backport will be created when this pr is integrated.)");
                             }
                         }
-                        var titleIssue = Issue.fromStringRelaxed(pr.title());
-                        var isTitleIssue = titleIssue.isPresent() && titleIssue.get().shortId().equals(issue.shortId());
-                        // Only check title mismatch for title issue
-                        if (isTitleIssue && !relaxedEquals(issueTrackerIssue.get().title(), issue.description())) {
+                        if (!relaxedEquals(issueTrackerIssue.get().title(), issue.description())) {
                             progressBody.append(" ⚠️ Title mismatch between PR and JBS.");
                             setExpiration(Duration.ofMinutes(10));
                         }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -46,7 +46,6 @@ import java.time.*;
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.logging.Logger;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -414,7 +413,7 @@ class CheckWorkItem extends PullRequestWorkItem {
         var botUser = pr.repository().forge().currentUser();
         var issues = SolvesTracker.currentSolved(botUser, comments, pr.title());
         for (var issue : issues) {
-            var solvesComment = SolvesTracker.getLatestSolvesAction(botUser, comments, issue);
+            var solvesComment = SolvesTracker.getLatestSolvesActionComment(botUser, comments, issue);
             if (solvesComment.isPresent()) {
                 var issueTrackerIssue = issueTrackerIssue(issue.shortId());
                 if (issueTrackerIssue.isPresent() && !issue.description().equals(issueTrackerIssue.get().title())) {

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -3453,7 +3453,7 @@ class CheckTests {
             issue2.setTitle("This is an issue2 etc.");
             pr.setBody("update this pr");
             TestBotRunner.runPeriodicItems(prBot);
-            // The additional issue marker should be updated
+            // The additional issue marker should be updated, so the warning of leading lowercase letter no longer exists
             assertFalse(pr.store().body().contains("Found leading lowercase letter in issue title for `2: this is an issue2 etc.`"));
             assertTrue(pr.store().body().contains("Found trailing period in issue title for `2: This is an issue2 etc.`"));
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -3449,6 +3449,14 @@ class CheckTests {
             assertTrue(pr.store().body().contains("Found trailing period in issue title for `2: this is an issue2 etc.`"));
             assertTrue(pr.store().body().contains("Found leading lowercase letter in issue title for `2: this is an issue2 etc.`"));
 
+            // Change the leading letter to upper case
+            issue2.setTitle("This is an issue2 etc.");
+            pr.setBody("update this pr");
+            TestBotRunner.runPeriodicItems(prBot);
+            // The additional issue marker should be updated
+            assertFalse(pr.store().body().contains("Found leading lowercase letter in issue title for `2: this is an issue2 etc.`"));
+            assertTrue(pr.store().body().contains("Found trailing period in issue title for `2: This is an issue2 etc.`"));
+
             // Approve it as Reviewer, warnings shouldn't prevent adding ready label to the pr
             var reviewerPr = reviewer.pullRequest(pr.id());
             reviewerPr.addReview(Review.Verdict.APPROVED, "LGTM");

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IssueTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IssueTests.java
@@ -223,6 +223,12 @@ class IssueTests {
             assertLastCommentContains(pr, ": Second");
             assertLastCommentContains(pr, ": Third");
 
+            issue2.setTitle("Second2");
+            issue3.setTitle("Third3");
+            pr.setBody("update this pr");
+            TestBotRunner.runPeriodicItems(prBot);
+            assertFalse(pr.store().body().contains("Title mismatch between PR and JBS for issue"));
+
             // Remove one
             pr.addComment("/issue remove " + issue2.id());
             TestBotRunner.runPeriodicItems(prBot);
@@ -242,7 +248,7 @@ class IssueTests {
                             .findFirst()
                             .orElseThrow();
             assertTrue(preview.contains(issue1Number + ": Main"));
-            assertTrue(preview.contains(issue3Number + ": Third"));
+            assertTrue(preview.contains(issue3Number + ": Third3"));
             assertFalse(preview.contains("Second"));
 
             // Integrate
@@ -262,7 +268,7 @@ class IssueTests {
 
             // The additional issues should be present in the commit message
             assertEquals(List.of(issue1Number + ": Main",
-                                 issue3Number + ": Third",
+                                 issue3Number + ": Third3",
                                  "",
                                  "Reviewed-by: integrationreviewer1"), headCommit.message());
         }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IssueTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IssueTests.java
@@ -223,10 +223,12 @@ class IssueTests {
             assertLastCommentContains(pr, ": Second");
             assertLastCommentContains(pr, ": Third");
 
+            // Update the title of issue2 and issue3
             issue2.setTitle("Second2");
             issue3.setTitle("Third3");
             pr.setBody("update this pr");
             TestBotRunner.runPeriodicItems(prBot);
+            // PR body shouldn't contain title mismatch warning
             assertFalse(pr.store().body().contains("Title mismatch between PR and JBS for issue"));
 
             // Remove one


### PR DESCRIPTION
Currently, additional issue marker is not updated automatically, it means if user changed the title of an additional issue in JBS, the user will need to issue `/issue` command again to update the additional issue. However, for additional issues, users are not aware that skara bot would store the issue title in a hidden marker.  To avoid confusion, we'd better let skara bot update the hidden marker automatically when user changes the issue title in JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2255](https://bugs.openjdk.org/browse/SKARA-2255): Keep additional issue marker updated (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1649/head:pull/1649` \
`$ git checkout pull/1649`

Update a local copy of the PR: \
`$ git checkout pull/1649` \
`$ git pull https://git.openjdk.org/skara.git pull/1649/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1649`

View PR using the GUI difftool: \
`$ git pr show -t 1649`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1649.diff">https://git.openjdk.org/skara/pull/1649.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1649#issuecomment-2103208628)