### PR TITLE
2256: Return IssuesTitleIssue when either issuesWithTrailingPeriod or issuesWithLeadingLowerCaseLetter is not empty

### DIFF
--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/IssuesTitleCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/IssuesTitleCheck.java
@@ -55,7 +55,7 @@ public class IssuesTitleCheck extends CommitCheck {
                 issuesWithLeadingLowerCaseLetter.add("`" + issue + "`");
             }
         }
-        if (!issuesWithTrailingPeriod.isEmpty()) {
+        if (!issuesWithTrailingPeriod.isEmpty() || !issuesWithLeadingLowerCaseLetter.isEmpty()) {
             return iterator(new IssuesTitleIssue(metadata, issuesWithTrailingPeriod, issuesWithLeadingLowerCaseLetter));
         }
         return iterator();


### PR DESCRIPTION
In SKARA-2170, I made a mistake, when checking if the issuestitle check fails, the bot only checks if issuesWithTrailingPeriod isn't empty. However, issuestitle check should also fail when issuesWithLeadingLowerCaseLetter is not empty.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2256](https://bugs.openjdk.org/browse/SKARA-2256): Return IssuesTitleIssue when either issuesWithTrailingPeriod or issuesWithLeadingLowerCaseLetter is not empty (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1650/head:pull/1650` \
`$ git checkout pull/1650`

Update a local copy of the PR: \
`$ git checkout pull/1650` \
`$ git pull https://git.openjdk.org/skara.git pull/1650/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1650`

View PR using the GUI difftool: \
`$ git pr show -t 1650`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1650.diff">https://git.openjdk.org/skara/pull/1650.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1650#issuecomment-2103438096)