### PR TITLE
2252: Backport command branch names not unique enough

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
@@ -284,7 +284,7 @@ public class BackportCommand implements CommandHandler {
         try {
             var hash = commit.hash();
             Hash backportHash;
-            var backportBranchName = "backport-" + realUser.username() + "-" + hash.abbreviate();
+            var backportBranchName = "backport-" + realUser.username() + "-" + hash.abbreviate() + "-" + targetBranchName;
             var backportBranchHash = fork.branchHash(backportBranchName);
 
             var message = CommitMessageParsers.v1.parse(commit);


### PR DESCRIPTION
To avoid the name clash of backport branch in the bot's fork, we could add `targetBranchName` to the backport branch name.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2252](https://bugs.openjdk.org/browse/SKARA-2252): Backport command branch names not unique enough (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1651/head:pull/1651` \
`$ git checkout pull/1651`

Update a local copy of the PR: \
`$ git checkout pull/1651` \
`$ git pull https://git.openjdk.org/skara.git pull/1651/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1651`

View PR using the GUI difftool: \
`$ git pr show -t 1651`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1651.diff">https://git.openjdk.org/skara/pull/1651.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1651#issuecomment-2105092750)