### PR TITLE
2266: TestInfoBot couldn't get checks after user changed their GitHub username

### DIFF
--- a/forge/src/test/java/org/openjdk/skara/forge/github/GitHubIntegrationTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/github/GitHubIntegrationTests.java
@@ -486,4 +486,12 @@ class GitHubIntegrationTests {
         assertEquals(sourceRepo.group(), pr.sourceRepository().orElseThrow().group());
         pr.setState(PullRequest.State.CLOSED);
     }
+
+    @Test
+    @EnabledIfTestProperties({"github.user", "github.pat", "github.stale.repository", "github.stale.commitHash"})
+    void testRedirectLink() {
+        var githubRepoOpt = githubHost.repository(props.get("github.stale.repository"));
+        var checks = githubRepoOpt.get().allChecks(new Hash(props.get("github.stale.commitHash")));
+        assertFalse(checks.isEmpty());
+    }
 }

--- a/network/src/main/java/org/openjdk/skara/network/RestRequest.java
+++ b/network/src/main/java/org/openjdk/skara/network/RestRequest.java
@@ -330,6 +330,10 @@ public class RestRequest {
                 response = cache.send(authId, request, skipLimiter);
                 // If the status code is 301(Moved Permanently), follow the redirect link
                 if (response.statusCode() == 301) {
+                    // Break the loop if the server keeps responding 301
+                    if (retryCount >= 2) {
+                        break;
+                    }
                     var location = response.headers().firstValue("location");
                     if (location.isPresent()) {
                         request = request.uri(URI.create(location.get()));

--- a/network/src/main/java/org/openjdk/skara/network/RestRequest.java
+++ b/network/src/main/java/org/openjdk/skara/network/RestRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -328,6 +328,14 @@ public class RestRequest {
         while (true) {
             try {
                 response = cache.send(authId, request, skipLimiter);
+                // If the status code is 301(Moved Permanently), follow the redirect link
+                if (response.statusCode() == 301) {
+                    var location = response.headers().firstValue("location");
+                    if (location.isPresent()) {
+                        request = request.uri(URI.create(location.get()));
+                        continue;
+                    }
+                }
                 // If we are using authorization and get a 401, we need to retry to give
                 // the authorization mechanism a chance to refresh stale tokens. Retry if
                 // we get a new set of authorization headers.

--- a/network/src/main/java/org/openjdk/skara/network/RestRequest.java
+++ b/network/src/main/java/org/openjdk/skara/network/RestRequest.java
@@ -333,13 +333,12 @@ public class RestRequest {
                     var location = response.headers().firstValue("location");
                     if (location.isPresent()) {
                         request = request.uri(URI.create(location.get()));
-                        continue;
                     }
                 }
                 // If we are using authorization and get a 401, we need to retry to give
                 // the authorization mechanism a chance to refresh stale tokens. Retry if
                 // we get a new set of authorization headers.
-                if (response.statusCode() == 401 && retryCount < 2 && authHeaders != null
+                else if (response.statusCode() == 401 && retryCount < 2 && authHeaders != null
                         && !authHeaders.equals(addAuthHeaders(request))) {
                     log.info("Failed authorization for request: " + request.build().uri()
                             + ", retry count: " + retryCount);

--- a/network/src/main/java/org/openjdk/skara/network/RestRequest.java
+++ b/network/src/main/java/org/openjdk/skara/network/RestRequest.java
@@ -329,11 +329,7 @@ public class RestRequest {
             try {
                 response = cache.send(authId, request, skipLimiter);
                 // If the status code is 301(Moved Permanently), follow the redirect link
-                if (response.statusCode() == 301) {
-                    // Break the loop if the server keeps responding 301
-                    if (retryCount >= 2) {
-                        break;
-                    }
+                if (response.statusCode() == 301 && retryCount < 2) {
                     var location = response.headers().firstValue("location");
                     if (location.isPresent()) {
                         request = request.uri(URI.create(location.get()));


### PR DESCRIPTION
TestInfoBot couldn't get checks after user changed their GitHub username, the root cause is that Skara bot can't correctly handle HTTP status code 301 in rest requests. 
This patch is trying to make skara bot follows the redirect link when it encounters 301 status code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2266](https://bugs.openjdk.org/browse/SKARA-2266): TestInfoBot couldn't get checks after user changed their GitHub username (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1652/head:pull/1652` \
`$ git checkout pull/1652`

Update a local copy of the PR: \
`$ git checkout pull/1652` \
`$ git pull https://git.openjdk.org/skara.git pull/1652/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1652`

View PR using the GUI difftool: \
`$ git pr show -t 1652`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1652.diff">https://git.openjdk.org/skara/pull/1652.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1652#issuecomment-2136148910)