### PR TITLE
2272: Improve issuestitleCheck

### DIFF
--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -3446,7 +3446,7 @@ class CheckTests {
             var issue2 = issues.createIssue("this is an issue2 etc.", List.of("Hello"), Map.of());
             pr.addComment("/issue add " + issue2.id());
             TestBotRunner.runPeriodicItems(prBot);
-            assertTrue(pr.store().body().contains("Found trailing period in issue title for `2: this is an issue2 etc.`"));
+            assertFalse(pr.store().body().contains("Found trailing period in issue title for `2: this is an issue2 etc.`"));
             assertTrue(pr.store().body().contains("Found leading lowercase letter in issue title for `2: this is an issue2 etc.`"));
 
             // Change the leading letter to upper case
@@ -3455,7 +3455,7 @@ class CheckTests {
             TestBotRunner.runPeriodicItems(prBot);
             // The additional issue marker should be updated, so the warning of leading lowercase letter no longer exists
             assertFalse(pr.store().body().contains("Found leading lowercase letter in issue title for `2: this is an issue2 etc.`"));
-            assertTrue(pr.store().body().contains("Found trailing period in issue title for `2: This is an issue2 etc.`"));
+            assertFalse(pr.store().body().contains("Found trailing period in issue title for `2: This is an issue2 etc.`"));
 
             // Approve it as Reviewer, warnings shouldn't prevent adding ready label to the pr
             var reviewerPr = reviewer.pullRequest(pr.id());

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/IssuesTitleCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/IssuesTitleCheck.java
@@ -28,10 +28,15 @@ import org.openjdk.skara.vcs.openjdk.CommitMessage;
 
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import java.util.logging.Logger;
+import java.util.regex.Pattern;
 
 public class IssuesTitleCheck extends CommitCheck {
     private final Logger log = Logger.getLogger("org.openjdk.skara.jcheck.issuesTitle");
+    private final static List<String> VALID_WORD_WITH_TRAILING_PERIOD = List.of("et al.", "etc.", "...");
+    private final static List<String> EXECUTABLE_NAMES = List.of("javac", "dpkg");
+    private final static Pattern FILE_OR_FUNCTION_PATTERN = Pattern.compile(".*[()/._].*");
 
     @Override
     Iterator<Issue> check(Commit commit, CommitMessage message, JCheckConfiguration conf, Census census) {
@@ -48,10 +53,10 @@ public class IssuesTitleCheck extends CommitCheck {
         var issuesWithLeadingLowerCaseLetter = new ArrayList<String>();
 
         for (var issue : message.issues()) {
-            if (issue.description().endsWith(".")) {
+            if (hasTrailingPeriod(issue.description())) {
                 issuesWithTrailingPeriod.add("`" + issue + "`");
             }
-            if (Character.isLowerCase(issue.description().charAt(0))) {
+            if (hasLeadingLowerCaseLetter(issue.description())) {
                 issuesWithLeadingLowerCaseLetter.add("`" + issue + "`");
             }
         }
@@ -71,4 +76,33 @@ public class IssuesTitleCheck extends CommitCheck {
         return "Issue's title should be properly formatted";
     }
 
+    private boolean hasTrailingPeriod(String description) {
+        if (!description.endsWith(".")) {
+            return false;
+        }
+        for (String phrase : VALID_WORD_WITH_TRAILING_PERIOD) {
+            if (description.endsWith(phrase)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean hasLeadingLowerCaseLetter(String description) {
+        if (Character.isUpperCase(description.charAt(0))) {
+            return false;
+        }
+        var firstWord = description.split(" ")[0];
+        // If first word is valid executable name, ignore it
+        for (String name : EXECUTABLE_NAMES) {
+            if (firstWord.equals(name)) {
+                return false;
+            }
+        }
+        // If first word contains special character, it's very likely a reference to file or function, ignore it
+        if (FILE_OR_FUNCTION_PATTERN.matcher(firstWord).matches()) {
+            return false;
+        }
+        return true;
+    }
 }

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/IssuesTitleCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/IssuesTitleCheck.java
@@ -36,7 +36,7 @@ public class IssuesTitleCheck extends CommitCheck {
     private final Logger log = Logger.getLogger("org.openjdk.skara.jcheck.issuesTitle");
     private final static List<String> VALID_WORD_WITH_TRAILING_PERIOD = List.of("et al.", "etc.", "...");
     private final static List<String> EXECUTABLE_NAMES = List.of("javac", "dpkg");
-    private final static Pattern FILE_OR_FUNCTION_PATTERN = Pattern.compile(".*[()/._].*");
+    private final static Pattern FILE_OR_FUNCTION_PATTERN = Pattern.compile(".*[()/._:].*");
 
     @Override
     Iterator<Issue> check(Commit commit, CommitMessage message, JCheckConfiguration conf, Census census) {

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/IssuesTitleCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/IssuesTitleCheck.java
@@ -35,7 +35,6 @@ import java.util.regex.Pattern;
 public class IssuesTitleCheck extends CommitCheck {
     private final Logger log = Logger.getLogger("org.openjdk.skara.jcheck.issuesTitle");
     private final static List<String> VALID_WORD_WITH_TRAILING_PERIOD = List.of("et al.", "etc.", "...");
-    private final static List<String> EXECUTABLE_NAMES = List.of("javac", "dpkg");
     private final static Pattern FILE_OR_FUNCTION_PATTERN = Pattern.compile(".*[()/._:].*");
 
     @Override
@@ -93,16 +92,7 @@ public class IssuesTitleCheck extends CommitCheck {
             return false;
         }
         var firstWord = description.split(" ")[0];
-        // If first word is valid executable name, ignore it
-        for (String name : EXECUTABLE_NAMES) {
-            if (firstWord.equals(name)) {
-                return false;
-            }
-        }
         // If first word contains special character, it's very likely a reference to file or function, ignore it
-        if (FILE_OR_FUNCTION_PATTERN.matcher(firstWord).matches()) {
-            return false;
-        }
-        return true;
+        return !FILE_OR_FUNCTION_PATTERN.matcher(firstWord).matches();
     }
 }


### PR DESCRIPTION
IssuestitleCheck was enabled in jdk recently, but this seems triggers too many false positive warnings and makes people feel annoying.

In this patch, I am trying to make the issuestitle check more tolerant. For some known cases, issuestitle check wouldn't generate issues.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2272](https://bugs.openjdk.org/browse/SKARA-2272): Improve issuestitleCheck (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1653/head:pull/1653` \
`$ git checkout pull/1653`

Update a local copy of the PR: \
`$ git checkout pull/1653` \
`$ git pull https://git.openjdk.org/skara.git pull/1653/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1653`

View PR using the GUI difftool: \
`$ git pr show -t 1653`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1653.diff">https://git.openjdk.org/skara/pull/1653.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1653#issuecomment-2142844774)