### PR TITLE
2258: Skara won't allow "/csr unneeded" after CSR has been Withdrawn

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -260,7 +260,7 @@ class CheckRun {
         return ret;
     }
 
-    private boolean isWithdrawnCSR(IssueTrackerIssue csr) {
+    public static boolean isWithdrawnCSR(IssueTrackerIssue csr) {
         if (csr.isClosed()) {
             var resolution = csr.resolution();
             if (resolution.isPresent()) {


### PR DESCRIPTION
When processing "/csr unneeded" command, skara bot will use pr body to check if there are any open csrs  associated with the pr. However, there is a race condition here, after the user withdraws the csr, the bot needs some time to update the pr body. Therefore, if the user issues "/csr unneeded" immediately after withdrawing the csr in JBS, it's very likely that the bot would use stale pr body and make the wrong judgement.

I think the solution here is that when the bot finds existing csrs, the bot should fetch the csrs from JBS and double check if the csr issue is still open. Since the case is not very common, I believe this won't add many GET requests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2258](https://bugs.openjdk.org/browse/SKARA-2258): Skara won't allow "/csr unneeded" after CSR has been Withdrawn (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1654/head:pull/1654` \
`$ git checkout pull/1654`

Update a local copy of the PR: \
`$ git checkout pull/1654` \
`$ git pull https://git.openjdk.org/skara.git pull/1654/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1654`

View PR using the GUI difftool: \
`$ git pr show -t 1654`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1654.diff">https://git.openjdk.org/skara/pull/1654.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1654#issuecomment-2146135948)