### PR TITLE
2277: Integer Overflow when parsing GitHub comment id

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -349,7 +349,7 @@ public class GitHubPullRequest implements PullRequest {
     }
 
     private Comment parseComment(JSONValue comment) {
-        var ret = new Comment(Integer.toString(comment.get("id").asInt()),
+        var ret = new Comment(comment.get("id").asString(),
                               comment.get("body").asString(),
                               host.parseUserField(comment),
                               ZonedDateTime.parse(comment.get("created_at").asString()),

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -349,7 +349,7 @@ public class GitHubPullRequest implements PullRequest {
     }
 
     private Comment parseComment(JSONValue comment) {
-        var ret = new Comment(comment.get("id").asString(),
+        var ret = new Comment(Long.toString(comment.get("id").asLong()),
                               comment.get("body").asString(),
                               host.parseUserField(comment),
                               ZonedDateTime.parse(comment.get("created_at").asString()),


### PR DESCRIPTION
When parsing the comment id from Github, skara bot would convert the JSONValue to integer, then convert integer to string and now this is causing integer overflow.

I thought we should just convert it from JSONValue to String.
But Erik pointed out this won't work. We should convert it to long and convert long to string

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2277](https://bugs.openjdk.org/browse/SKARA-2277): Integer Overflow when parsing GitHub comment id (**Bug** - P1)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1655/head:pull/1655` \
`$ git checkout pull/1655`

Update a local copy of the PR: \
`$ git checkout pull/1655` \
`$ git pull https://git.openjdk.org/skara.git pull/1655/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1655`

View PR using the GUI difftool: \
`$ git pr show -t 1655`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1655.diff">https://git.openjdk.org/skara/pull/1655.diff</a>

</details>
