### PR TITLE
2278: Issuestitle Check shouldn't treat special character as leading lowercase letter

### DIFF
--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -3421,7 +3421,7 @@ class CheckTests {
             localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // An issue with trailing period
-            var issue1 = issues.createIssue("This is an issue.", List.of("Hello"), Map.of());
+            var issue1 = issues.createIssue("    This is an issue.   ", List.of("Hello"), Map.of());
 
             // Make a change with a corresponding PR
             var editHash = CheckableRepository.appendAndCommit(localRepo);
@@ -3435,15 +3435,15 @@ class CheckTests {
             assertTrue(pr.store().body().contains("Found trailing period in issue title for `1: This is an issue.`"));
 
             // Remove the trailing period in the title
-            pr.setTitle("1: This is an issue");
-            issue1.setTitle("This is an issue");
+            pr.setTitle("1:     This is an issue");
+            issue1.setTitle("    This is an issue");
 
             TestBotRunner.runPeriodicItems(prBot);
             assertFalse(pr.store().body().contains("Warning"));
             assertFalse(pr.store().body().contains("Found trailing period in issue title for 1: This is an issue."));
 
             // Create another issue with trailing period
-            var issue2 = issues.createIssue("this is an issue2 etc.", List.of("Hello"), Map.of());
+            var issue2 = issues.createIssue("   this is an issue2 etc.    ", List.of("Hello"), Map.of());
             pr.addComment("/issue add " + issue2.id());
             TestBotRunner.runPeriodicItems(prBot);
             assertFalse(pr.store().body().contains("Found trailing period in issue title for `2: this is an issue2 etc.`"));

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/IssuesTitleCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/IssuesTitleCheck.java
@@ -35,7 +35,7 @@ import java.util.regex.Pattern;
 public class IssuesTitleCheck extends CommitCheck {
     private final Logger log = Logger.getLogger("org.openjdk.skara.jcheck.issuesTitle");
     private final static List<String> VALID_WORD_WITH_TRAILING_PERIOD = List.of("et al.", "etc.", "...");
-    private final static Pattern FILE_OR_FUNCTION_PATTERN = Pattern.compile(".*[()/._:].*");
+    private final static Pattern ALL_LOWER_CASE_PATTERN = Pattern.compile("[a-z]+");
 
     @Override
     Iterator<Issue> check(Commit commit, CommitMessage message, JCheckConfiguration conf, Census census) {
@@ -88,11 +88,6 @@ public class IssuesTitleCheck extends CommitCheck {
     }
 
     private boolean hasLeadingLowerCaseLetter(String description) {
-        if (!Character.isLowerCase(description.charAt(0))) {
-            return false;
-        }
-        var firstWord = description.split(" ")[0];
-        // If first word contains special character, it's very likely a reference to file or function, ignore it
-        return !FILE_OR_FUNCTION_PATTERN.matcher(firstWord).matches();
+        return ALL_LOWER_CASE_PATTERN.matcher(description.split(" ")[0]).matches();
     }
 }

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/IssuesTitleCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/IssuesTitleCheck.java
@@ -35,7 +35,7 @@ import java.util.regex.Pattern;
 public class IssuesTitleCheck extends CommitCheck {
     private final Logger log = Logger.getLogger("org.openjdk.skara.jcheck.issuesTitle");
     private final static List<String> VALID_WORD_WITH_TRAILING_PERIOD = List.of("et al.", "etc.", "...");
-    private final static Pattern ALL_LOWER_CASE_PATTERN = Pattern.compile("[a-z]+");
+    private final static Pattern FIRST_WORD_ALL_LOWER_CASE_PATTERN = Pattern.compile("[a-z]+(?:\\h.*)?");
 
     @Override
     Iterator<Issue> check(Commit commit, CommitMessage message, JCheckConfiguration conf, Census census) {
@@ -55,7 +55,7 @@ public class IssuesTitleCheck extends CommitCheck {
             if (hasTrailingPeriod(issue.description())) {
                 issuesWithTrailingPeriod.add("`" + issue + "`");
             }
-            if (hasLeadingLowerCaseLetter(issue.description())) {
+            if (FIRST_WORD_ALL_LOWER_CASE_PATTERN.matcher(issue.description()).matches()) {
                 issuesWithLeadingLowerCaseLetter.add("`" + issue + "`");
             }
         }
@@ -85,9 +85,5 @@ public class IssuesTitleCheck extends CommitCheck {
             }
         }
         return true;
-    }
-
-    private boolean hasLeadingLowerCaseLetter(String description) {
-        return ALL_LOWER_CASE_PATTERN.matcher(description.split(" ")[0]).matches();
     }
 }

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/IssuesTitleCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/IssuesTitleCheck.java
@@ -88,7 +88,7 @@ public class IssuesTitleCheck extends CommitCheck {
     }
 
     private boolean hasLeadingLowerCaseLetter(String description) {
-        if (Character.isUpperCase(description.charAt(0))) {
+        if (!Character.isLowerCase(description.charAt(0))) {
             return false;
         }
         var firstWord = description.split(" ")[0];


### PR DESCRIPTION
Currently, in IssuesTitleCheck::hasLeadingLowercaseLetter, the method checks if the leading character is uppercase, if so, it returns false. Otherwise, it will treat the character as lowercase. This is wrong because it treats special characters as lowercase letters. The solution is to make the method to check if the leading character is a lowercase letter.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2278](https://bugs.openjdk.org/browse/SKARA-2278): Issuestitle Check shouldn't treat special character as leading lowercase letter (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Contributors
 * Kevin Rushforth `<kcr@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1656/head:pull/1656` \
`$ git checkout pull/1656`

Update a local copy of the PR: \
`$ git checkout pull/1656` \
`$ git pull https://git.openjdk.org/skara.git pull/1656/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1656`

View PR using the GUI difftool: \
`$ git pr show -t 1656`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1656.diff">https://git.openjdk.org/skara/pull/1656.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1656#issuecomment-2148030237)