### PR TITLE
2279: Improve JSONNumber::asInt usage to prevent future break

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/Review.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/Review.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,11 +34,11 @@ public class Review {
     private final HostUser reviewer;
     private final Verdict verdict;
     private final Hash hash;
-    private final int id;
+    private final String id;
     private final String body;
     private final String targetRef;
 
-    public Review(ZonedDateTime createdAt, HostUser reviewer, Verdict verdict, Hash hash, int id, String body,
+    public Review(ZonedDateTime createdAt, HostUser reviewer, Verdict verdict, Hash hash, String id, String body,
             String targetRef) {
         this.createdAt = createdAt;
         this.reviewer = reviewer;
@@ -73,7 +73,7 @@ public class Review {
         return Optional.ofNullable(hash);
     }
 
-    public int id() {
+    public String id() {
         return id;
     }
 

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -107,7 +107,7 @@ public class GitHubPullRequest implements PullRequest {
                             verdict = Review.Verdict.NONE;
                             break;
                     }
-                    var id = obj.get("id").asInt();
+                    var id = obj.get("id").toString();
                     var body = obj.get("body").asString();
                     var createdAt = ZonedDateTime.parse(obj.get("submitted_at").asString());
                     return new Review(createdAt, reviewer, verdict, hash, id, body, currentTargetRef);
@@ -349,7 +349,7 @@ public class GitHubPullRequest implements PullRequest {
     }
 
     private Comment parseComment(JSONValue comment) {
-        var ret = new Comment(Long.toString(comment.get("id").asLong()),
+        var ret = new Comment(comment.get("id").toString(),
                               comment.get("body").asString(),
                               host.parseUserField(comment),
                               ZonedDateTime.parse(comment.get("created_at").asString()),

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -137,7 +137,7 @@ public class GitLabMergeRequest implements PullRequest {
                                            hash = cd.hash;
                                        }
                                    }
-                                   var id = obj.get("id").asInt();
+                                   var id = obj.get("id").toString();
                                    return new Review(createdAt, reviewer, verdict, hash, id, "", currentTargetRef);
                                }).toList();
         var targetRefChanges = targetRefChanges(notes);

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -509,7 +509,7 @@ public class GitLabRepository implements HostedRepository {
             return new CommitComment(hash,
                     path,
                     line,
-                    String.valueOf(note.get("id").asInt()),
+                    note.get("id").toString(),
                     note.get("body").asString(),
                     gitLabHost.parseAuthorField(note),
                     ZonedDateTime.parse(note.get("created_at").asString()),
@@ -603,7 +603,7 @@ public class GitLabRepository implements HostedRepository {
 
         return notes.stream()
                 .map(o -> findComment(o.get("target_title").asString(),
-                        String.valueOf(o.get("note").get("id").asInt()), commitTitleToCommits))
+                        o.get("note").get("id").toString(), commitTitleToCommits))
                 .flatMap(Optional::stream)
                 .toList();
     }

--- a/forge/src/test/java/org/openjdk/skara/forge/PullRequestTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/PullRequestTests.java
@@ -34,7 +34,7 @@ public class PullRequestTests {
     @Test
     void calculateReviewTargetRefsSimple() {
         assertEquals(List.of(), PullRequest.calculateReviewTargetRefs(List.of(), List.of()));
-        var review1 = newReview(ZonedDateTime.now(), 1, "master");
+        var review1 = newReview(ZonedDateTime.now(), "1", "master");
         assertEquals(List.of(review1), PullRequest.calculateReviewTargetRefs(List.of(review1), List.of()));
     }
 
@@ -45,9 +45,9 @@ public class PullRequestTests {
         var refChange1 = new ReferenceChange("first", "second", now.minus(Duration.ofMinutes(4)));
         var refChange2 = new ReferenceChange("second", "third", now.minus(Duration.ofMinutes(2)));
 
-        var review1 = newReview(now.minus(Duration.ofMinutes(5)), 1, "third");
-        var review2 = newReview(now.minus(Duration.ofMinutes(3)), 2, "third");
-        var review3 = newReview(now.minus(Duration.ofMinutes(1)), 3, "third");
+        var review1 = newReview(now.minus(Duration.ofMinutes(5)), "1", "third");
+        var review2 = newReview(now.minus(Duration.ofMinutes(3)), "2", "third");
+        var review3 = newReview(now.minus(Duration.ofMinutes(1)), "3", "third");
 
         var reviews = PullRequest.calculateReviewTargetRefs(List.of(review1, review2, review3), List.of(refChange2, refChange1));
 
@@ -64,9 +64,9 @@ public class PullRequestTests {
         var refChange1 = new ReferenceChange("first", "pr/4711", now.minus(Duration.ofMinutes(4)));
         var refChange2 = new ReferenceChange("pr/4711", "third", now.minus(Duration.ofMinutes(2)));
 
-        var review1 = newReview(now.minus(Duration.ofMinutes(5)), 1, "");
-        var review2 = newReview(now.minus(Duration.ofMinutes(3)), 2, "");
-        var review3 = newReview(now.minus(Duration.ofMinutes(1)), 3, "third");
+        var review1 = newReview(now.minus(Duration.ofMinutes(5)), "1", "");
+        var review2 = newReview(now.minus(Duration.ofMinutes(3)), "2", "");
+        var review3 = newReview(now.minus(Duration.ofMinutes(1)), "3", "third");
 
         var reviews = PullRequest.calculateReviewTargetRefs(List.of(review1, review2, review3), List.of(refChange1, refChange2));
 
@@ -83,9 +83,9 @@ public class PullRequestTests {
         var refChange1 = new ReferenceChange("first", "pr/4711", now.minus(Duration.ofMinutes(4)));
         var refChange2 = new ReferenceChange("pr/4711", "pr/4712", now.minus(Duration.ofMinutes(2)));
 
-        var review1 = newReview(now.minus(Duration.ofMinutes(5)), 1, "");
-        var review2 = newReview(now.minus(Duration.ofMinutes(3)), 2, "foo");
-        var review3 = newReview(now.minus(Duration.ofMinutes(1)), 3, "pr/4712");
+        var review1 = newReview(now.minus(Duration.ofMinutes(5)), "1", "");
+        var review2 = newReview(now.minus(Duration.ofMinutes(3)), "2", "foo");
+        var review3 = newReview(now.minus(Duration.ofMinutes(1)), "3", "pr/4712");
 
         var reviews = PullRequest.calculateReviewTargetRefs(List.of(review1, review2, review3), List.of(refChange1, refChange2));
 
@@ -98,7 +98,7 @@ public class PullRequestTests {
     /**
      * Creates a new review with just the relevant fields.
      */
-    private Review newReview(ZonedDateTime createdAt, int id, String targetRef) {
+    private Review newReview(ZonedDateTime createdAt, String id, String targetRef) {
         return new Review(createdAt, null, Review.Verdict.APPROVED, null, id, null, targetRef);
     }
 }

--- a/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,7 +87,7 @@ public class TestPullRequest extends TestIssue implements PullRequest {
         try {
             var review = new Review(ZonedDateTime.now(), user,
                                     verdict, targetRepository.localRepository().resolve(store().sourceRef()).orElseThrow(),
-                                    store().reviews().size(),
+                                    String.valueOf(store().reviews().size()),
                                     body, targetRef);
 
             store().reviews().add(review);


### PR DESCRIPTION
[SKARA-2277](https://bugs.openjdk.org/browse/SKARA-2277) is an instance of a breakage caused by improper usage of JSONNumber::asInt. In our project, there are other usages of JSONNumber::asInt, we should clean them up to prevent future break.

As Erik said, he thinks it's fine to treat user ids and repository ids as int.

Here are the other 2 places that might break.

GitLabRepository::toCommitComment treats note ids as int.
GitHubPullRequest::reviews treats review ids as int.

Besides, I changed the type of id from int to String in Review.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2279](https://bugs.openjdk.org/browse/SKARA-2279): Improve JSONNumber::asInt usage to prevent future break (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1657/head:pull/1657` \
`$ git checkout pull/1657`

Update a local copy of the PR: \
`$ git checkout pull/1657` \
`$ git pull https://git.openjdk.org/skara.git pull/1657/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1657`

View PR using the GUI difftool: \
`$ git pr show -t 1657`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1657.diff">https://git.openjdk.org/skara/pull/1657.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1657#issuecomment-2153443720)