### PR TITLE
2286: Git jcheck --working-tree/--staged not compatible with some checks

### DIFF
--- a/cli/src/main/java/org/openjdk/skara/cli/GitJCheck.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitJCheck.java
@@ -325,10 +325,12 @@ public class GitJCheck {
         if (staged) {
             ranges.clear();
             ranges.add(STAGED_REV);
+            System.out.println("When jcheck is running on staged, the following checks are not available: DuplicateIssuesCheck, IssuesCheck, IssuesTitleCheck, MergeMessageCheck, MessageCheck, ProblemListsCheck, ReviewersCheck.");
         }
         if (workingTree) {
             ranges.clear();
             ranges.add(WORKING_TREE_REV);
+            System.out.println("When jcheck is running on working-tree, the following checks are not available: DuplicateIssuesCheck, IssuesCheck, IssuesTitleCheck, MergeMessageCheck, MessageCheck, ProblemListsCheck, ReviewersCheck.");
         }
 
         var isLax = getSwitch("lax", arguments);

--- a/cli/src/main/java/org/openjdk/skara/cli/GitJCheck.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitJCheck.java
@@ -331,7 +331,8 @@ public class GitJCheck {
         if (workingTree) {
             ranges.clear();
             ranges.add(WORKING_TREE_REV);
-            System.out.println("When jcheck is running on working-tree, the following commit checks are available: " + JCheck.commitCheckNamesForStagedOrWorkingTree());
+            System.out.println("When jcheck is running on working-tree, only the following commit checks are available: " +
+                    JCheck.commitCheckNamesForStagedOrWorkingTree());
         }
 
         var isLax = getSwitch("lax", arguments);

--- a/cli/src/main/java/org/openjdk/skara/cli/GitJCheck.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitJCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -325,12 +325,12 @@ public class GitJCheck {
         if (staged) {
             ranges.clear();
             ranges.add(STAGED_REV);
-            System.out.println("When jcheck is running on staged, the following checks are not available: DuplicateIssuesCheck, IssuesCheck, IssuesTitleCheck, MergeMessageCheck, MessageCheck, ProblemListsCheck, ReviewersCheck.");
+            System.out.println("When jcheck is running on staged, the following commit checks are available: " + JCheck.commitCheckNamesForStagedOrWorkingTree());
         }
         if (workingTree) {
             ranges.clear();
             ranges.add(WORKING_TREE_REV);
-            System.out.println("When jcheck is running on working-tree, the following checks are not available: DuplicateIssuesCheck, IssuesCheck, IssuesTitleCheck, MergeMessageCheck, MessageCheck, ProblemListsCheck, ReviewersCheck.");
+            System.out.println("When jcheck is running on working-tree, the following commit checks are available: " + JCheck.commitCheckNamesForStagedOrWorkingTree());
         }
 
         var isLax = getSwitch("lax", arguments);

--- a/cli/src/main/java/org/openjdk/skara/cli/GitJCheck.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitJCheck.java
@@ -325,7 +325,8 @@ public class GitJCheck {
         if (staged) {
             ranges.clear();
             ranges.add(STAGED_REV);
-            System.out.println("When jcheck is running on staged, the following commit checks are available: " + JCheck.commitCheckNamesForStagedOrWorkingTree());
+            System.out.println("When jcheck is running on staged, only the following commit checks are available: " +
+                    JCheck.commitCheckNamesForStagedOrWorkingTree());
         }
         if (workingTree) {
             ranges.clear();

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/JCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/JCheck.java
@@ -89,16 +89,10 @@ public class JCheck {
                 new AuthorCheck(),
                 new CommitterCheck(),
                 new WhitespaceCheck(),
-                new MergeMessageCheck(),
                 new HgTagCommitCheck(utils),
-                new DuplicateIssuesCheck(repository),
-                new ReviewersCheck(utils),
-                new MessageCheck(utils),
-                new IssuesCheck(utils),
                 new ExecutableCheck(),
                 new SymlinkCheck(),
-                new BinaryCheck(),
-                new IssuesTitleCheck()
+                new BinaryCheck()
         );
         repositoryChecks = List.of(
             new BranchesCheck(allowedBranches),

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/JCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/JCheck.java
@@ -41,7 +41,14 @@ public class JCheck {
     private final CommitMessageParser parser;
     private final String revisionRange;
     private final List<CommitCheck> commitChecks;
-    private final List<CommitCheck> commitChecksForStagedOrWorkingTree;
+    private final static List<CommitCheck> commitChecksForStagedOrWorkingTree = List.of(
+            new AuthorCheck(),
+            new CommitterCheck(),
+            new WhitespaceCheck(),
+            new ExecutableCheck(),
+            new SymlinkCheck(),
+            new BinaryCheck()
+    );
     private final List<RepositoryCheck> repositoryChecks;
     private final List<String> additionalConfiguration;
     private final JCheckConfiguration overridingConfiguration;
@@ -84,15 +91,6 @@ public class JCheck {
             new BinaryCheck(),
             new ProblemListsCheck(repository),
             new IssuesTitleCheck()
-        );
-        commitChecksForStagedOrWorkingTree = List.of(
-                new AuthorCheck(),
-                new CommitterCheck(),
-                new WhitespaceCheck(),
-                new HgTagCommitCheck(utils),
-                new ExecutableCheck(),
-                new SymlinkCheck(),
-                new BinaryCheck()
         );
         repositoryChecks = List.of(
             new BranchesCheck(allowedBranches),
@@ -321,5 +319,11 @@ public class JCheck {
                                 conf,
                                 null);
         return jcheck.checksForRange();
+    }
+
+    public static List<String> commitCheckNamesForStagedOrWorkingTree() {
+        return commitChecksForStagedOrWorkingTree.stream()
+                .map(Check::name)
+                .toList();
     }
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -1716,7 +1716,7 @@ public class GitRepository implements Repository {
     public Commit staged() throws IOException {
         var author = new Author(username().orElse("jcheck"), email().orElse("jcheck@none.none"));
         var commitMetaData = new CommitMetadata(new Hash("staged"), List.of(head()), author, ZonedDateTime.now(),
-                author, ZonedDateTime.now(), List.of(""));
+                author, ZonedDateTime.now(), List.of("Fake commit message for staged"));
         return new Commit(commitMetaData, List.of(diffStaged()));
     }
 
@@ -1727,7 +1727,7 @@ public class GitRepository implements Repository {
     public Commit workingTree() throws IOException {
         var author = new Author(username().orElse("jcheck"), email().orElse("jcheck@none.none"));
         var commitMetaData = new CommitMetadata(new Hash("working-tree"), List.of(head()), author, ZonedDateTime.now(),
-                author, ZonedDateTime.now(), List.of(""));
+                author, ZonedDateTime.now(), List.of("Fake commit message for working-tree"));
         return new Commit(commitMetaData, List.of(diff(head())));
     }
 


### PR DESCRIPTION
In [SKARA-1690](https://bugs.openjdk.org/browse/SKARA-1690), I tried to make SKARA CLI able to run jcheck on the diff in current working tree. But seems like this feature is not compatible with some jchecks like problemLists check.

When jcheck is checking staged or working-tree, I think there is no point to run some checks that require real commit message. Therefore I disabled the checks and Skara CLI will print a prompt to user.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2286](https://bugs.openjdk.org/browse/SKARA-2286): Git jcheck --working-tree/--staged not compatible with some checks (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1658/head:pull/1658` \
`$ git checkout pull/1658`

Update a local copy of the PR: \
`$ git checkout pull/1658` \
`$ git pull https://git.openjdk.org/skara.git pull/1658/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1658`

View PR using the GUI difftool: \
`$ git pr show -t 1658`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1658.diff">https://git.openjdk.org/skara/pull/1658.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1658#issuecomment-2155175587)