### PR TITLE
2290: Update PullRequest::updateReview

### DIFF
--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
@@ -68,7 +68,7 @@ class InMemoryPullRequest implements PullRequest {
     }
 
     @Override
-    public void updateReview(int id, String body) {
+    public void updateReview(String id, String body) {
     }
 
     @Override

--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
@@ -50,7 +50,7 @@ public interface PullRequest extends Issue {
     /**
      * Updates the comment body of a review.
      */
-    void updateReview(int id, String body);
+    void updateReview(String id, String body);
 
     /**
      * Add a file specific comment.

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubPullRequest.java
@@ -181,7 +181,7 @@ public class GitHubPullRequest implements PullRequest {
     }
 
     @Override
-    public void updateReview(int id, String body) {
+    public void updateReview(String id, String body) {
         request.put("pulls/" + json.get("number").toString() + "/reviews/" + id)
                .body("body", body)
                .execute();

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabMergeRequest.java
@@ -199,7 +199,7 @@ public class GitLabMergeRequest implements PullRequest {
     }
 
     @Override
-    public void updateReview(int id, String body) {
+    public void updateReview(String id, String body) {
         throw new RuntimeException("not implemented yet");
     }
 

--- a/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
@@ -99,7 +99,7 @@ public class TestPullRequest extends TestIssue implements PullRequest {
     }
 
     @Override
-    public void updateReview(int id, String body) {
+    public void updateReview(String id, String body) {
         throw new RuntimeException("not implemented yet");
     }
 


### PR DESCRIPTION
In [SKARA-2279](https://bugs.openjdk.org/browse/SKARA-2279), I changed the type of id from int to String in Review.java, but I didn't update the type of id in the interface of PullRequest::updateReview.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2290](https://bugs.openjdk.org/browse/SKARA-2290): Update PullRequest::updateReview (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1659/head:pull/1659` \
`$ git checkout pull/1659`

Update a local copy of the PR: \
`$ git checkout pull/1659` \
`$ git pull https://git.openjdk.org/skara.git pull/1659/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1659`

View PR using the GUI difftool: \
`$ git pr show -t 1659`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1659.diff">https://git.openjdk.org/skara/pull/1659.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1659#issuecomment-2155313472)