### PR TITLE
2295: Rephrase error messages in PullRequestCheckIssueVisitor

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
@@ -149,9 +149,10 @@ class PullRequestCheckIssueVisitor implements IssueVisitor {
     }
 
     @Override
-    public void visit(SelfReviewIssue issue)
-    {
-        addMessage(issue.check(), "Self-reviews are not allowed", issue.severity());
+    public void visit(SelfReviewIssue issue) {
+        var message = issue.severity().equals(Severity.ERROR) ? "Self-reviews are not allowed" :
+                "Self-reviews are not recommended";
+        addMessage(issue.check(), message, issue.severity());
         setNotReadyForReviewOnError(issue.severity());
     }
 
@@ -205,14 +206,18 @@ class PullRequestCheckIssueVisitor implements IssueVisitor {
     @Override
     public void visit(AuthorNameIssue issue) {
         // We only get here for contributors without an OpenJDK username
-        addMessage(issue.check(), "Pull request's HEAD commit must contain a full name", issue.severity());
+        var message = issue.severity().equals(Severity.ERROR) ? "Pull request's HEAD commit must contain a full name" :
+                "Pull request's HEAD commit doesn't contain a full name";
+        addMessage(issue.check(), message, issue.severity());
         setNotReadyForReviewOnError(issue.severity());
     }
 
     @Override
     public void visit(AuthorEmailIssue issue) {
         // We only get here for contributors without an OpenJDK username
-        addMessage(issue.check(), "Pull request's HEAD commit must contain a valid e-mail", issue.severity());
+        var message = issue.severity().equals(Severity.ERROR) ? "Pull request's HEAD commit must contain a valid e-mail" :
+                "Pull request's HEAD commit doesn't contain a valid e-mail";
+        addMessage(issue.check(), message, issue.severity());
         setNotReadyForReviewOnError(issue.severity());
     }
 
@@ -241,10 +246,10 @@ class PullRequestCheckIssueVisitor implements IssueVisitor {
             annotationBuilder.endColumn(endColumn);
         }
 
-        var annotation = annotationBuilder.title("Whitespace error").build();
+        var annotation = annotationBuilder.title("Whitespace " + issue.severity().toString()).build();
         annotations.add(annotation);
 
-        addMessage(issue.check(), "Whitespace errors", issue.severity());
+        addMessage(issue.check(), "Whitespace " + issue.severity().toString() + "s", issue.severity());
         setNotReadyForReviewOnError(issue.severity());
     }
 
@@ -280,19 +285,25 @@ class PullRequestCheckIssueVisitor implements IssueVisitor {
 
     @Override
     public void visit(ExecutableIssue issue) {
-        addMessage(issue.check(), String.format("Patch contains an executable file (file: %s)", issue.path()), issue.severity());
+        var message = issue.severity().equals(Severity.ERROR) ? String.format("Executable files are not allowed (file: %s)", issue.path())
+                : String.format("Patch contains an executable file (%s)", issue.path());
+        addMessage(issue.check(), message, issue.severity());
         setNotReadyForReviewOnError(issue.severity());
     }
 
     @Override
     public void visit(SymlinkIssue issue) {
-        addMessage(issue.check(), String.format("Patch contains a symbolic link (file: %s)", issue.path()), issue.severity());
+        var message = issue.severity().equals(Severity.ERROR) ? String.format("Symbolic links are not allowed (file: %s)", issue.path())
+                : String.format("Patch contains a symbolic link (%s)", issue.path());
+        addMessage(issue.check(), message, issue.severity());
         setNotReadyForReviewOnError(issue.severity());
     }
 
     @Override
     public void visit(BinaryIssue issue) {
-        addMessage(issue.check(), String.format("Patch contains a binary file (file: %s)", issue.path()), issue.severity());
+        var message = issue.severity().equals(Severity.ERROR) ? String.format("Binary files are not allowed (file: %s)", issue.path())
+                : String.format("Patch contains a binary file (%s)", issue.path());
+        addMessage(issue.check(), message, issue.severity());
         setNotReadyForReviewOnError(issue.severity());
     }
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
@@ -280,19 +280,19 @@ class PullRequestCheckIssueVisitor implements IssueVisitor {
 
     @Override
     public void visit(ExecutableIssue issue) {
-        addMessage(issue.check(), String.format("Executable files are not allowed (file: %s)", issue.path()), issue.severity());
+        addMessage(issue.check(), String.format("Patch contains executable files (file: %s)", issue.path()), issue.severity());
         setNotReadyForReviewOnError(issue.severity());
     }
 
     @Override
     public void visit(SymlinkIssue issue) {
-        addMessage(issue.check(), String.format("Symbolic links are not allowed (file: %s)", issue.path()), issue.severity());
+        addMessage(issue.check(), String.format("Patch contains symbolic links (file: %s)", issue.path()), issue.severity());
         setNotReadyForReviewOnError(issue.severity());
     }
 
     @Override
     public void visit(BinaryIssue issue) {
-        addMessage(issue.check(), String.format("Binary files are not allowed (file: %s)", issue.path()), issue.severity());
+        addMessage(issue.check(), String.format("Patch contains binary files (file: %s)", issue.path()), issue.severity());
         setNotReadyForReviewOnError(issue.severity());
     }
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
@@ -280,19 +280,19 @@ class PullRequestCheckIssueVisitor implements IssueVisitor {
 
     @Override
     public void visit(ExecutableIssue issue) {
-        addMessage(issue.check(), String.format("Patch contains executable files (file: %s)", issue.path()), issue.severity());
+        addMessage(issue.check(), String.format("Patch contains an executable file (file: %s)", issue.path()), issue.severity());
         setNotReadyForReviewOnError(issue.severity());
     }
 
     @Override
     public void visit(SymlinkIssue issue) {
-        addMessage(issue.check(), String.format("Patch contains symbolic links (file: %s)", issue.path()), issue.severity());
+        addMessage(issue.check(), String.format("Patch contains a symbolic link (file: %s)", issue.path()), issue.severity());
         setNotReadyForReviewOnError(issue.severity());
     }
 
     @Override
     public void visit(BinaryIssue issue) {
-        addMessage(issue.check(), String.format("Patch contains binary files (file: %s)", issue.path()), issue.severity());
+        addMessage(issue.check(), String.format("Patch contains a binary file (file: %s)", issue.path()), issue.severity());
         setNotReadyForReviewOnError(issue.severity());
     }
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -638,11 +638,11 @@ class CheckTests {
             assertEquals(1, checks.size());
             var check = checks.get("jcheck");
             assertEquals(CheckStatus.FAILURE, check.status());
-            assertTrue(check.summary().orElseThrow().contains("Patch contains an executable file (file: executable.exe)"));
+            assertTrue(check.summary().orElseThrow().contains("Executable files are not allowed (file: executable.exe)"));
 
             // Additional errors should be displayed in the body
             assertTrue(pr.store().body().contains("## Error"));
-            assertTrue(pr.store().body().contains("Patch contains an executable file (file: executable.exe)"));
+            assertTrue(pr.store().body().contains("Executable files are not allowed (file: executable.exe)"));
 
             // The PR should not yet be ready for review
             assertFalse(pr.store().labelNames().contains("rfr"));

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -638,11 +638,11 @@ class CheckTests {
             assertEquals(1, checks.size());
             var check = checks.get("jcheck");
             assertEquals(CheckStatus.FAILURE, check.status());
-            assertTrue(check.summary().orElseThrow().contains("Executable files are not allowed (file: executable.exe)"));
+            assertTrue(check.summary().orElseThrow().contains("Patch contains an executable file (file: executable.exe)"));
 
             // Additional errors should be displayed in the body
             assertTrue(pr.store().body().contains("## Error"));
-            assertTrue(pr.store().body().contains("Executable files are not allowed (file: executable.exe)"));
+            assertTrue(pr.store().body().contains("Patch contains an executable file (file: executable.exe)"));
 
             // The PR should not yet be ready for review
             assertFalse(pr.store().labelNames().contains("rfr"));


### PR DESCRIPTION
PullRequestCheckIssueVisitor is responsible for generating error messages when jcheck fails. Currently, jcheck could be configured as different severity(error or warning). However, when generating error messages for some jchecks like binary check, the error message would be like "Binary files are not allowed", so if the binary check was configured as warning, this message seems too hard. Therefore, I would like to rephrase some error messages.

Erik suggested that we should generate different messages depending on the severity, but I think maybe it's unnecessary. The user does not need to judge the severity depending on the error message. The user only needs to check which section is the message under(Integration Blocker or Warning).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2295](https://bugs.openjdk.org/browse/SKARA-2295): Rephrase error messages in PullRequestCheckIssueVisitor (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1660/head:pull/1660` \
`$ git checkout pull/1660`

Update a local copy of the PR: \
`$ git checkout pull/1660` \
`$ git pull https://git.openjdk.org/skara.git pull/1660/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1660`

View PR using the GUI difftool: \
`$ git pr show -t 1660`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1660.diff">https://git.openjdk.org/skara/pull/1660.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1660#issuecomment-2168514343)