### PR TITLE
2307: PullRequestCheckIssueVisitor generates only one error message per Issue type

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -77,6 +77,7 @@ class CheckRun {
     private static final Set<String> PRIMARY_TYPES = Set.of("Bug", "New Feature", "Enhancement", "Task", "Sub-task");
     protected static final String CSR_PROCESS_LINK = "https://wiki.openjdk.org/display/csr/Main";
     private static final Path JCHECK_CONF_PATH = Path.of(".jcheck", "conf");
+    private static final int MESSAGE_LIMIT = 50;
     private final Set<String> newLabels;
     private final boolean reviewCleanBackport;
     private final Approval approval;
@@ -581,10 +582,15 @@ class CheckRun {
     }
 
     private String warningListToText(List<String> additionalErrors) {
-        return additionalErrors.stream()
-                               .sorted()
-                               .map(err -> "&nbsp;⚠️ " + err)
-                               .collect(Collectors.joining("\n"));
+        var text = additionalErrors.stream()
+                .sorted()
+                .limit(MESSAGE_LIMIT)
+                .map(err -> "&nbsp;⚠️ " + err)
+                .collect(Collectors.joining("\n"));
+        if (additionalErrors.size() > MESSAGE_LIMIT) {
+            text = text + "\n...";
+        }
+        return text;
     }
 
     private Optional<String> getReviewersList() {


### PR DESCRIPTION
When testing [SKARA-2303](https://bugs.openjdk.org/browse/SKARA-2303), I found that even when there are few binary files in a diff, the pr body only warns about one binary file. Then I found that in PullRequestCheckIssueVisitor, we are using HashMap<Check, String> to store the error messages, so if there are few issues with the same type, the HashMap is only able to save the last error message.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2307](https://bugs.openjdk.org/browse/SKARA-2307): PullRequestCheckIssueVisitor generates only one error message per Issue type (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1662/head:pull/1662` \
`$ git checkout pull/1662`

Update a local copy of the PR: \
`$ git checkout pull/1662` \
`$ git pull https://git.openjdk.org/skara.git pull/1662/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1662`

View PR using the GUI difftool: \
`$ git pr show -t 1662`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1662.diff">https://git.openjdk.org/skara/pull/1662.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1662#issuecomment-2187681163)