### PR TITLE
2302: Notify when PR is ready for sponsor

### DIFF
--- a/bots/common/src/main/java/org/openjdk/skara/bots/common/PullRequestConstants.java
+++ b/bots/common/src/main/java/org/openjdk/skara/bots/common/PullRequestConstants.java
@@ -33,6 +33,7 @@ public class PullRequestConstants {
     public static final String JEP_MARKER = "<!-- jep: '%s' '%s' '%s' -->"; // <!-- jep: 'JEP-ID' 'ISSUE-ID' 'ISSUE-TITLE' -->
     public static final String WEBREV_COMMENT_MARKER = "<!-- mlbridge webrev comment -->";
     public static final String TEMPORARY_ISSUE_FAILURE_MARKER = "<!-- temporary issue failure -->";
+    public static final String READY_FOR_SPONSOR_MARKER = "<!-- integration requested: '%s' -->";
 
     // LABELS
     public static final String CSR_LABEL = "csr";
@@ -41,4 +42,5 @@ public class PullRequestConstants {
 
     // PATTERNS
     public static final Pattern JEP_MARKER_PATTERN = Pattern.compile("<!-- jep: '(.*?)' '(.*?)' '(.*?)' -->");
+    public static final Pattern READY_FOR_SPONSOR_MARKER_PATTERN = Pattern.compile("<!-- integration requested: '(.*?)' -->");
 }

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
@@ -26,6 +26,7 @@ import java.util.logging.Level;
 import org.openjdk.skara.bot.WorkItem;
 import org.openjdk.skara.bots.common.BotUtils;
 import org.openjdk.skara.bots.common.CommandNameEnum;
+import org.openjdk.skara.bots.common.PullRequestConstants;
 import org.openjdk.skara.email.*;
 import org.openjdk.skara.forge.*;
 import org.openjdk.skara.host.HostUser;
@@ -147,7 +148,7 @@ class ArchiveWorkItem implements WorkItem {
             return true;
         }
         if (bot.ignoredUsers().contains(author.username())) {
-            return true;
+            return !PullRequestConstants.READY_FOR_SPONSOR_MARKER_PATTERN.matcher(body).find();
         }
 
         // Check if this comment only contains command lines

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReadyForSponsorTracker.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReadyForSponsorTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,7 @@
  */
 package org.openjdk.skara.bots.pr;
 
+import org.openjdk.skara.bots.common.PullRequestConstants;
 import org.openjdk.skara.host.*;
 import org.openjdk.skara.issuetracker.Comment;
 import org.openjdk.skara.vcs.Hash;
@@ -31,21 +32,19 @@ import java.util.regex.*;
 import java.util.stream.Collectors;
 
 class ReadyForSponsorTracker {
-    private static final String MARKER = "<!-- integration requested: '%s' -->";
-    private static final Pattern MARKER_PATTERN = Pattern.compile("<!-- integration requested: '(.*?)' -->");
 
     static String addIntegrationMarker(Hash hash) {
-        return String.format(MARKER, hash.hex());
+        return String.format(PullRequestConstants.READY_FOR_SPONSOR_MARKER, hash.hex());
     }
 
     static Optional<Hash> latestReadyForSponsor(HostUser botUser, List<Comment> comments) {
         var ready = comments.stream()
-                                         .filter(comment -> comment.author().equals(botUser))
-                                         .map(comment -> MARKER_PATTERN.matcher(comment.body()))
-                                         .filter(Matcher::find)
-                            .map(matcher -> matcher.group(1))
-                            .map(Hash::new)
-                                         .collect(Collectors.toList());
+                .filter(comment -> comment.author().equals(botUser))
+                .map(comment -> PullRequestConstants.READY_FOR_SPONSOR_MARKER_PATTERN.matcher(comment.body()))
+                .filter(Matcher::find)
+                .map(matcher -> matcher.group(1))
+                .map(Hash::new)
+                .collect(Collectors.toList());
         if (ready.size() == 0) {
             return Optional.empty();
         } else {


### PR DESCRIPTION
This patch is trying to make skara bot be able to send an email notification about the "pr is ready for sponsor" comment.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2302](https://bugs.openjdk.org/browse/SKARA-2302): Notify when PR is ready for sponsor (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1663/head:pull/1663` \
`$ git checkout pull/1663`

Update a local copy of the PR: \
`$ git checkout pull/1663` \
`$ git pull https://git.openjdk.org/skara.git pull/1663/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1663`

View PR using the GUI difftool: \
`$ git pr show -t 1663`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1663.diff">https://git.openjdk.org/skara/pull/1663.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1663#issuecomment-2190213294)