### PR TITLE
2311: Use getLast and removeLast methods for lists

### DIFF
--- a/args/src/main/java/org/openjdk/skara/args/ArgumentParser.java
+++ b/args/src/main/java/org/openjdk/skara/args/ArgumentParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/args/src/main/java/org/openjdk/skara/args/ArgumentParser.java
+++ b/args/src/main/java/org/openjdk/skara/args/ArgumentParser.java
@@ -215,7 +215,7 @@ public class ArgumentParser {
                         showUsage();
                         System.exit(1);
                     }
-                    var last = inputs.get(inputs.size() - 1);
+                    var last = inputs.getLast();
                     if ((last.getPosition() + last.getOccurrences()) <= argPos && !last.isTrailing()) {
                         // this input is not permitted
                         System.err.println("error: unexpected input: " + arg);

--- a/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestPrunerBot.java
+++ b/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestPrunerBot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestPrunerBot.java
+++ b/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestPrunerBot.java
@@ -76,7 +76,7 @@ class PullRequestPrunerBotWorkItem implements WorkItem {
     public Collection<WorkItem> run(Path scratchPath) {
         var comments = pr.comments();
         if (comments.size() > 0) {
-            var lastComment = comments.get(comments.size() - 1);
+            var lastComment = comments.getLast();
             if (lastComment.author().equals(pr.repository().forge().currentUser()) && lastComment.body().contains(NOTICE_MARKER)) {
                 var message = "@" + pr.author().username() + " This pull request has been inactive for more than " +
                         formatDuration(maxAge.multipliedBy(2)) + " and will now be automatically closed. If you would " +

--- a/bots/bridgekeeper/src/test/java/org/openjdk/skara/bots/bridgekeeper/PullRequestPrunerBotTests.java
+++ b/bots/bridgekeeper/src/test/java/org/openjdk/skara/bots/bridgekeeper/PullRequestPrunerBotTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/bots/bridgekeeper/src/test/java/org/openjdk/skara/bots/bridgekeeper/PullRequestPrunerBotTests.java
+++ b/bots/bridgekeeper/src/test/java/org/openjdk/skara/bots/bridgekeeper/PullRequestPrunerBotTests.java
@@ -81,7 +81,7 @@ class PullRequestPrunerBotTests {
             assertEquals(0, prs.size());
 
             // There should be a mention on how to reopen
-            var comment = pr.comments().get(pr.comments().size() - 1).body();
+            var comment = pr.comments().getLast().body();
             assertTrue(comment.contains("`/open`"), comment);
         }
     }

--- a/bots/cli/src/test/java/org/openjdk/skara/bots/cli/BotSlackHandlerTests.java
+++ b/bots/cli/src/test/java/org/openjdk/skara/bots/cli/BotSlackHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/bots/cli/src/test/java/org/openjdk/skara/bots/cli/BotSlackHandlerTests.java
+++ b/bots/cli/src/test/java/org/openjdk/skara/bots/cli/BotSlackHandlerTests.java
@@ -94,14 +94,14 @@ class BotSlackHandlerTests {
             assertTrue(wasThrottled, "Did not get throttled, is maxDuration too low?");
 
             var requests = receiver.getRequests();
-            var lastRequest = requests.get(requests.size() - 1).asObject();
+            var lastRequest = requests.getLast().asObject();
             assertEquals("test", lastRequest.get("username").asString(), lastRequest.toString());
             assertTrue(lastRequest.get("text").asString().contains("Hello"), lastRequest.toString());
 
             Thread.sleep(maxDuration.toMillis());
             var record = new LogRecord(Level.INFO, "Hello a final time!");
             handler.publish(record);
-            lastRequest = requests.get(requests.size() - 1).asObject();
+            lastRequest = requests.getLast().asObject();
             assertEquals("test", lastRequest.get("username").asString(), lastRequest.toString());
             assertTrue(lastRequest.get("text").asString().contains("Hello a final time!"), lastRequest.toString());
             assertTrue(lastRequest.get("text").asString().contains("dropped"), lastRequest.toString());

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveItem.java
@@ -418,7 +418,7 @@ class ArchiveItem {
             if (mentionedParent.isPresent()) {
                 return mentionedParent.get();
             } else {
-                return eligible.get(eligible.size() - 1);
+                return eligible.getLast();
             }
         }
     }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/mailinglist/MailingListNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/mailinglist/MailingListNotifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/mailinglist/MailingListNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/mailinglist/MailingListNotifier.java
@@ -198,7 +198,7 @@ class MailingListNotifier implements Notifier, RepositoryListener {
         }
 
         var subject = commitsToSubject(repository, commits, branch);
-        var lastCommit = commits.get(commits.size() - 1);
+        var lastCommit = commits.getLast();
         var commitAddress = filteredAuthor(EmailAddress.from(lastCommit.committer().name(), lastCommit.committer().email()));
         var email = Email.create(subject, writer.toString())
                          .sender(sender)
@@ -246,13 +246,13 @@ class MailingListNotifier implements Notifier, RepositoryListener {
             return;
         }
         if (!reportNewBuilds) {
-            onNewTagCommit(repository, localRepository, scratchPath, commits.get(commits.size() - 1), tag.tag(), annotation);
+            onNewTagCommit(repository, localRepository, scratchPath, commits.getLast(), tag.tag(), annotation);
             return;
         }
         var writer = new StringWriter();
         var printer = new PrintWriter(writer);
 
-        var taggedCommit = commits.get(commits.size() - 1);
+        var taggedCommit = commits.getLast();
         if (annotation != null) {
             printer.println(tagAnnotationToText(repository, annotation));
         }
@@ -368,7 +368,7 @@ class MailingListNotifier implements Notifier, RepositoryListener {
         }
 
         var subject = newBranchSubject(repository, localRepository, commits, parent, branch);
-        var finalAuthor = commits.size() > 0 ? commitToAuthor(commits.get(commits.size() - 1)) : sender;
+        var finalAuthor = commits.size() > 0 ? commitToAuthor(commits.getLast()) : sender;
 
         var email = Email.create(subject, writer.toString())
                          .sender(sender)

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
@@ -1375,7 +1375,7 @@ public class IssueNotifierTests {
             assertEquals("b110", updatedIssue.properties().get(RESOLVED_IN_BUILD).asString());
 
             // Flag it as in need of retry
-            processed.remove(processed.size() - 1);
+            processed.removeLast();
             processed.add("jdk-16+10 issue retry");
             Files.writeString(repoFolder.resolve("test.tags.txt"), String.join("\n", processed), StandardCharsets.UTF_8);
             localRepo.add(historyFile);

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifierTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/prbranch/PullRequestBranchNotifierTests.java
@@ -279,7 +279,7 @@ public class PullRequestBranchNotifierTests {
             assertEquals("master", followUpPr.store().targetRef());
 
             // Instructions on how to adapt to the newly integrated changes should have been posted
-            var lastComment = followUpPr.comments().get(followUpPr.comments().size() - 1);
+            var lastComment = followUpPr.comments().getLast();
             assertTrue(lastComment.body().contains("The parent pull request that this pull request "
                     + "depends on has been closed without being integrated"), lastComment.body());
 
@@ -302,7 +302,7 @@ public class PullRequestBranchNotifierTests {
 
             // The another follow-up PR should have been retargeted
             assertEquals("master", anotherFollowUpPr.store().targetRef());
-            lastComment = anotherFollowUpPr.comments().get(anotherFollowUpPr.comments().size() - 1);
+            lastComment = anotherFollowUpPr.comments().getLast();
             assertTrue(lastComment.body().contains("The parent pull request that this "
                     + "pull request depends on has now been integrated"), lastComment.body());
             assertTrue(lastComment.body().contains("git checkout another-followup"), lastComment.body());

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReadyForSponsorTracker.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReadyForSponsorTracker.java
@@ -49,7 +49,7 @@ class ReadyForSponsorTracker {
         if (ready.size() == 0) {
             return Optional.empty();
         } else {
-            return Optional.of(ready.get(ready.size() - 1));
+            return Optional.of(ready.getLast());
         }
     }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewersTracker.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewersTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewersTracker.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewersTracker.java
@@ -120,7 +120,7 @@ class ReviewersTracker {
         if (reviewersActions.isEmpty()) {
             return Optional.empty();
         }
-        var last = reviewersActions.get(reviewersActions.size() - 1);
+        var last = reviewersActions.getLast();
         return Optional.of(new AdditionalRequiredReviewers(Integer.parseInt(last.group(1)), last.group(2)));
     }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportTests.java
@@ -112,7 +112,7 @@ class BackportTests {
             assertLastCommentContains(pr, "Pushed as commit");
 
             String hex = null;
-            var comment = pr.comments().get(pr.comments().size() - 1);
+            var comment = pr.comments().getLast();
             var lines = comment.body().split("\n");
             var pattern = Pattern.compile(".* Pushed as commit ([0-9a-z]{40}).*");
             for (var line : lines) {
@@ -214,7 +214,7 @@ class BackportTests {
             assertLastCommentContains(pr, "Pushed as commit");
 
             String hex = null;
-            var comment = pr.comments().get(pr.comments().size() - 1);
+            var comment = pr.comments().getLast();
             var lines = comment.body().split("\n");
             var pattern = Pattern.compile(".* Pushed as commit ([0-9a-z]{40}).*");
             for (var line : lines) {
@@ -318,7 +318,7 @@ class BackportTests {
             assertLastCommentContains(pr, "Pushed as commit");
 
             String hex = null;
-            var comment = pr.comments().get(pr.comments().size() - 1);
+            var comment = pr.comments().getLast();
             var lines = comment.body().split("\n");
             var pattern = Pattern.compile(".* Pushed as commit ([0-9a-z]{40}).*");
             for (var line : lines) {
@@ -883,7 +883,7 @@ class BackportTests {
             assertLastCommentContains(pr, "Pushed as commit");
 
             String hex = null;
-            var comment = pr.comments().get(pr.comments().size() - 1);
+            var comment = pr.comments().getLast();
             var lines = comment.body().split("\n");
             var pattern = Pattern.compile(".* Pushed as commit ([0-9a-z]{40}).*");
             for (var line : lines) {
@@ -992,7 +992,7 @@ class BackportTests {
             assertLastCommentContains(pr, "Pushed as commit");
 
             String hex = null;
-            var comment = pr.comments().get(pr.comments().size() - 1);
+            var comment = pr.comments().getLast();
             var lines = comment.body().split("\n");
             var pattern = Pattern.compile(".* Pushed as commit ([0-9a-z]{40}).*");
             for (var line : lines) {
@@ -1328,7 +1328,7 @@ class BackportTests {
             assertLastCommentContains(pr, "Pushed as commit");
 
             String hex = null;
-            var comment = pr.comments().get(pr.comments().size() - 1);
+            var comment = pr.comments().getLast();
             var lines = comment.body().split("\n");
             var pattern = Pattern.compile(".* Pushed as commit ([0-9a-z]{40}).*");
             for (var line : lines) {
@@ -1507,7 +1507,7 @@ class BackportTests {
             assertLastCommentContains(pr, "Pushed as commit");
 
             String hex = null;
-            var comment = pr.comments().get(pr.comments().size() - 1);
+            var comment = pr.comments().getLast();
             var lines = comment.body().split("\n");
             var pattern = Pattern.compile(".* Pushed as commit ([0-9a-z]{40}).*");
             for (var line : lines) {
@@ -1635,7 +1635,7 @@ class BackportTests {
             assertLastCommentContains(pr, "Pushed as commit");
 
             String hex = null;
-            var comment = pr.comments().get(pr.comments().size() - 1);
+            var comment = pr.comments().getLast();
             var lines = comment.body().split("\n");
             var pattern = Pattern.compile(".* Pushed as commit ([0-9a-z]{40}).*");
             for (var line : lines) {
@@ -1756,7 +1756,7 @@ class BackportTests {
             assertLastCommentContains(pr, "Pushed as commit");
 
             String hex = null;
-            var comment = pr.comments().get(pr.comments().size() - 1);
+            var comment = pr.comments().getLast();
             var lines = comment.body().split("\n");
             var pattern = Pattern.compile(".* Pushed as commit ([0-9a-z]{40}).*");
             for (var line : lines) {
@@ -1859,7 +1859,7 @@ class BackportTests {
             assertLastCommentContains(pr, "Pushed as commit");
 
             String hex = null;
-            var comment = pr.comments().get(pr.comments().size() - 1);
+            var comment = pr.comments().getLast();
             var lines = comment.body().split("\n");
             var pattern = Pattern.compile(".* Pushed as commit ([0-9a-z]{40}).*");
             for (var line : lines) {

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CSRBotTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CSRBotTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CSRBotTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CSRBotTests.java
@@ -567,7 +567,7 @@ class CSRBotTests {
             // Add issue2 to this pr
             pr.addComment("/issue " + issue2.id());
             TestBotRunner.runPeriodicItems(prBot);
-            assertTrue(pr.store().comments().get(pr.store().comments().size() - 1).body().contains("solves: '2'"));
+            assertTrue(pr.store().comments().getLast().body().contains("solves: '2'"));
 
             // Add a csr to issue2
             var csr2 = issueProject.createIssue("This is an CSR for issue2", List.of(), Map.of());
@@ -587,7 +587,7 @@ class CSRBotTests {
             // Add issue3 to this pr
             pr.addComment("/issue " + issue3.id());
             TestBotRunner.runPeriodicItems(prBot);
-            assertTrue(pr.store().comments().get(pr.store().comments().size() - 1).body().contains("solves: '4'"));
+            assertTrue(pr.store().comments().getLast().body().contains("solves: '4'"));
 
             // Withdrawn the csr for issue2
             csr2.setState(Issue.State.CLOSED);
@@ -684,7 +684,7 @@ class CSRBotTests {
             reviewer.pullRequest(pr.id()).addComment("/csr unneeded");
             TestBotRunner.runPeriodicItems(prBot);
 
-            assertTrue(pr.store().comments().get(pr.store().comments().size() - 1).body()
+            assertTrue(pr.store().comments().getLast().body()
                     .contains("@user2 The CSR requirement cannot be removed as CSR issues already exist. " +
                             "Please withdraw [TEST-2](http://localhost/project/testTEST-2) and then use the command `/csr unneeded` again."));
         }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -2636,7 +2636,7 @@ class CheckTests {
 
             // The PR shouldn't have the force-push suggestion comment
             assertEquals(2, pr.comments().size());
-            var lastComment = pr.comments().get(pr.comments().size() - 1);
+            var lastComment = pr.comments().getLast();
             assertTrue(lastComment.body().contains("initial"));
             assertFalse(lastComment.body().contains(FORCE_PUSH_MARKER));
             assertFalse(lastComment.body().contains(FORCE_PUSH_SUGGESTION));
@@ -2649,7 +2649,7 @@ class CheckTests {
 
             // The PR shouldn't have the force-push suggestion comment.
             assertEquals(3, pr.comments().size());
-            lastComment = pr.comments().get(pr.comments().size() - 1);
+            lastComment = pr.comments().getLast();
             assertTrue(lastComment.body().contains("Normally push"));
             assertFalse(lastComment.body().contains(FORCE_PUSH_MARKER));
             assertFalse(lastComment.body().contains(FORCE_PUSH_SUGGESTION));
@@ -2666,7 +2666,7 @@ class CheckTests {
 
             // The last comment of the PR should be the force-push suggestion comment.
             assertEquals(5, pr.comments().size());
-            lastComment = pr.comments().get(pr.comments().size() - 1);
+            lastComment = pr.comments().getLast();
             assertFalse(lastComment.body().contains("Force-push"));
             assertTrue(lastComment.body().contains(FORCE_PUSH_MARKER));
             assertTrue(lastComment.body().contains(FORCE_PUSH_SUGGESTION));
@@ -2682,7 +2682,7 @@ class CheckTests {
 
             // The last comment of the PR shouldn't be the force-push suggestion comment.
             assertEquals(6, pr.comments().size());
-            lastComment = pr.comments().get(pr.comments().size() - 1);
+            lastComment = pr.comments().getLast();
             assertTrue(lastComment.body().contains("Normally push in draft"));
             assertFalse(lastComment.body().contains(FORCE_PUSH_MARKER));
             assertFalse(lastComment.body().contains(FORCE_PUSH_SUGGESTION));
@@ -2699,7 +2699,7 @@ class CheckTests {
 
             // The last comment of the PR should not be the force-push suggestion comment.
             assertEquals(7, pr.comments().size());
-            lastComment = pr.comments().get(pr.comments().size() - 1);
+            lastComment = pr.comments().getLast();
             assertTrue(lastComment.body().contains("Force-push in draft"));
             assertFalse(lastComment.body().contains(FORCE_PUSH_MARKER));
             assertFalse(lastComment.body().contains(FORCE_PUSH_SUGGESTION));
@@ -2710,7 +2710,7 @@ class CheckTests {
             // Nothing should happen
             TestBotRunner.runPeriodicItems(checkBot);
             assertEquals(7, pr.comments().size());
-            lastComment = pr.comments().get(pr.comments().size() - 1);
+            lastComment = pr.comments().getLast();
             assertTrue(lastComment.body().contains("Force-push in draft"));
             assertFalse(lastComment.body().contains(FORCE_PUSH_MARKER));
             assertFalse(lastComment.body().contains(FORCE_PUSH_SUGGESTION));
@@ -2727,7 +2727,7 @@ class CheckTests {
 
             // The last comment of the PR should be the force-push suggestion comment.
             assertEquals(9, pr.comments().size());
-            lastComment = pr.comments().get(pr.comments().size() - 1);
+            lastComment = pr.comments().getLast();
             assertFalse(lastComment.body().contains("Force-push"));
             assertTrue(lastComment.body().contains(FORCE_PUSH_MARKER));
             assertTrue(lastComment.body().contains(FORCE_PUSH_SUGGESTION));
@@ -3062,13 +3062,13 @@ class CheckTests {
             // Check the status
             TestBotRunner.runPeriodicItems(prBot);
 
-            var comment = pr.comments().get(pr.comments().size() - 1);
+            var comment = pr.comments().getLast();
             assertEquals(2, pr.comments().size());
             assertTrue(comment.body().contains("Merge-style pull requests are not allowed in this repository"));
 
             pr.setTitle("Merge test:dev");
             TestBotRunner.runPeriodicItems(prBot);
-            comment = pr.comments().get(pr.comments().size() - 1);
+            comment = pr.comments().getLast();
             assertEquals(2, pr.comments().size());
             assertTrue(comment.body().contains("Merge-style pull requests are not allowed in this repository"));
 
@@ -3110,13 +3110,13 @@ class CheckTests {
             // Check the status
             TestBotRunner.runPeriodicItems(prBot);
 
-            var comment = pr.comments().get(pr.comments().size() - 1);
+            var comment = pr.comments().getLast();
             assertEquals(2, pr.comments().size());
             assertTrue(comment.body().contains("backports are not allowed in this repository"));
 
             pr.setTitle("Backport 123");
             TestBotRunner.runPeriodicItems(prBot);
-            comment = pr.comments().get(pr.comments().size() - 1);
+            comment = pr.comments().getLast();
             assertEquals(2, pr.comments().size());
             assertTrue(comment.body().contains("backports are not allowed in this repository"));
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CommitCommandAsserts.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CommitCommandAsserts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CommitCommandAsserts.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CommitCommandAsserts.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class CommitCommandAsserts {
     public static void assertLastCommentContains(List<CommitComment> comments, String contains) {
         assertTrue(!comments.isEmpty());
-        var lastComment = comments.get(comments.size() - 1);
+        var lastComment = comments.getLast();
         assertTrue(lastComment.body().contains(contains), lastComment.body());
     }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrateTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrateTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrateTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrateTests.java
@@ -740,7 +740,7 @@ class IntegrateTests {
             TestBotRunner.runPeriodicItems(prBot);
 
             // The bot should reply with an instructional message and no link to CONTRIBUTING.md
-            var lastComment = pr.comments().get(pr.comments().size() - 1);
+            var lastComment = pr.comments().getLast();
             assertFalse(lastComment.body().contains("CONTRIBUTING.md"));
         }
     }
@@ -780,7 +780,7 @@ class IntegrateTests {
             TestBotRunner.runPeriodicItems(prBot);
 
             // The bot should reply with an instructional message and no link to CONTRIBUTING.md
-            var lastComment = pr.comments().get(pr.comments().size() - 1);
+            var lastComment = pr.comments().getLast();
             assertTrue(lastComment.body().contains("CONTRIBUTING.md"));
         }
     }
@@ -1216,7 +1216,7 @@ class IntegrateTests {
 
             TestBotRunner.runPeriodicItems(mergeBot);
 
-            assertTrue(pr.comments().get(pr.comments().size() - 1).body()
+            assertTrue(pr.comments().getLast().body()
                     .contains("can only be used in open pull requests"));
         }
     }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IssueTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IssueTests.java
@@ -540,7 +540,7 @@ class IssueTests {
 
     private static IssueTrackerIssue issueFromLastComment(PullRequest pr, IssueProject issueProject) {
         var comments = pr.comments();
-        var lastComment = comments.get(comments.size() - 1);
+        var lastComment = comments.getLast();
         var addedIssueMatcher = addedIssuePattern.matcher(lastComment.body());
         assertTrue(addedIssueMatcher.find(), lastComment.body());
         return issueProject.issue(addedIssueMatcher.group(1)).orElseThrow();

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestAsserts.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestAsserts.java
@@ -30,7 +30,7 @@ public class PullRequestAsserts {
     public static void assertLastCommentContains(PullRequest pr, String contains) {
         var comments = pr.comments();
         assertTrue(!comments.isEmpty());
-        var lastComment = comments.get(comments.size() - 1);
+        var lastComment = comments.getLast();
         assertTrue(lastComment.body().contains(contains), lastComment.body());
     }
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/SponsorTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/SponsorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/SponsorTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/SponsorTests.java
@@ -965,7 +965,7 @@ class SponsorTests {
 
             TestBotRunner.runPeriodicItems(mergeBot);
 
-            assertTrue(pr.comments().get(pr.comments().size() - 1).body()
+            assertTrue(pr.comments().getLast().body()
                     .contains("can only be used in open pull requests"));
         }
     }

--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
@@ -256,7 +256,7 @@ public interface PullRequest extends Issue {
         var sortedEvents = events.stream()
                 .sorted(Comparator.comparing(ReferenceChange::at))
                 .toList();
-        var lastTargetRef = sortedEvents.get(events.size() - 1).to();
+        var lastTargetRef = sortedEvents.getLast().to();
         return reviews.stream().map(orig -> {
                     for (var event : sortedEvents) {
                         if (event.at().isAfter(orig.createdAt())

--- a/test/src/main/java/org/openjdk/skara/test/HostCredentials.java
+++ b/test/src/main/java/org/openjdk/skara/test/HostCredentials.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/src/main/java/org/openjdk/skara/test/HostCredentials.java
+++ b/test/src/main/java/org/openjdk/skara/test/HostCredentials.java
@@ -197,7 +197,7 @@ public class HostCredentials implements AutoCloseable {
             } else {
                 hosts.add(TestHost.createFromExisting(hosts.get(0), userIndex));
             }
-            return hosts.get(hosts.size() - 1);
+            return hosts.getLast();
         }
 
         @Override

--- a/vcs/src/test/java/org/openjdk/skara/vcs/openjdk/converter/GitToHgConverterTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/openjdk/converter/GitToHgConverterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/vcs/src/test/java/org/openjdk/skara/vcs/openjdk/converter/GitToHgConverterTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/openjdk/converter/GitToHgConverterTests.java
@@ -510,7 +510,7 @@ class GitToHgConverterTests {
             var hgRepo = TestableRepository.init(hgRoot.path(), VCS.HG);
             var converter = new GitToHgConverter();
             var marks = converter.convert(gitRepo, hgRepo);
-            var lastMark = marks.get(marks.size() - 1);
+            var lastMark = marks.getLast();
             assertEquals(second, lastMark.git());
             assertTrue(lastMark.tag().isPresent());
 

--- a/webrev/src/main/java/org/openjdk/skara/webrev/HunkCoalescer.java
+++ b/webrev/src/main/java/org/openjdk/skara/webrev/HunkCoalescer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/webrev/src/main/java/org/openjdk/skara/webrev/HunkCoalescer.java
+++ b/webrev/src/main/java/org/openjdk/skara/webrev/HunkCoalescer.java
@@ -145,7 +145,7 @@ class HunkCoalescer {
 
         while (!hunks.isEmpty()) {
             var next = hunks.peekFirst();
-            var last = hunksInRange.get(hunksInRange.size() - 1);
+            var last = hunksInRange.getLast();
             var destEnd = last.target().range().end() + numContextLines;
             var sourceEnd = last.source().range().end() + numContextLines;
             var nextDestStart = next.target().range().start() - numContextLines;
@@ -297,7 +297,7 @@ class HunkCoalescer {
             var hunkGroup = nextGroup(worklist);
 
             var first = hunkGroup.get(0);
-            var last = hunkGroup.get(hunkGroup.size() - 1);
+            var last = hunkGroup.getLast();
             var header = calculateCoalescedHeader(first, last);
 
             var contextBefore = createContextBeforeGroup(header, first);


### PR DESCRIPTION
Please review this simple refactoring to change most if not all occurrences of `list.get(x.size() - 1)` to `list.getLast()`.

`getLast` was introduced in JDK 21, as part of JEP 431: Sequenced Collections, which also introduced a counterpart method, `getFirst()`. While there are also a lot of occurrences of `list.get(0)` in Skara codebase, changing them to `list.getFirst()` might be of insufficient benefit and, hence, is not proposed in this PR. I don't think that coinciding `get(0)` and `getLast()` would look inconsistent.

The copyright years will be updated after this PR has been reviewed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2311](https://bugs.openjdk.org/browse/SKARA-2311): Use getLast and removeLast methods for lists (**Bug** - P4)


### Reviewers
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - **Reviewer**) ⚠️ Review applies to [9680af96](https://git.openjdk.org/skara/pull/1665/files/9680af963f8b2849a5ac54357b7df6e62f75210a)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1665/head:pull/1665` \
`$ git checkout pull/1665`

Update a local copy of the PR: \
`$ git checkout pull/1665` \
`$ git pull https://git.openjdk.org/skara.git pull/1665/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1665`

View PR using the GUI difftool: \
`$ git pr show -t 1665`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1665.diff">https://git.openjdk.org/skara/pull/1665.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1665#issuecomment-2197373442)