### PR TITLE
2304: /backport jdk23 should provide a more helpful message

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
@@ -198,13 +198,6 @@ public class BackportCommand implements CommandHandler {
 
         var potentialTargetRepo = repoNameOptional.flatMap(forge::repository);
         if (potentialTargetRepo.isEmpty()) {
-            var branchNamesInCurrentRepo = bot.repo().branches().stream().map(HostedBranch::name).toList();
-            if (branchNamesInCurrentRepo.contains(repoName)) {
-                reply.println("There is a branch `" + repoName + "` in the current repository `" + bot.repo().name() + "`.");
-                reply.println("To target a backport to this branch in the current repository use:");
-                reply.println("`/backport :" + repoName + "`");
-                reply.println();
-            }
             reply.println("The target repository `" + repoNameArg + "` is not a valid target for backports. ");
             reply.print("List of valid target repositories: ");
             reply.println(String.join(", ", bot.forks().keySet().stream()
@@ -212,6 +205,13 @@ public class BackportCommand implements CommandHandler {
                     .map(repo -> "`" + repo + "`")
                     .toList()) + ".");
             reply.println("Supplying the organization/group prefix is optional.");
+            var branchNamesInCurrentRepo = bot.repo().branches().stream().map(HostedBranch::name).toList();
+            if (branchNamesInCurrentRepo.contains(repoName)) {
+                reply.println();
+                reply.println("There is a branch `" + repoName + "` in the current repository `" + bot.repo().name() + "`.");
+                reply.println("To target a backport to this branch in the current repository use:");
+                reply.println("`/backport :" + repoName + "`");
+            }
             return null;
         }
         return potentialTargetRepo.get();

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.skara.bots.pr;
 
+import org.openjdk.skara.forge.HostedBranch;
 import org.openjdk.skara.forge.HostedCommit;
 import org.openjdk.skara.forge.HostedRepository;
 import org.openjdk.skara.forge.PullRequest;
@@ -35,6 +36,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.time.format.DateTimeFormatter;
@@ -73,6 +75,8 @@ public class BackportCommand implements CommandHandler {
             + "(https://wiki.openjdk.org/display/skara#Skara-AssociatingyourGitHubaccountandyourOpenJDKusername)).";
 
     private static final String INSUFFICIENT_ACCESS_WARNING = "The backport can not be created because you don't have access to the target repository.";
+
+    private static final int BRANCHES_LIMIT = 10;
 
     @Override
     public void handle(PullRequestBot bot, PullRequest pr, CensusInstance censusInstance, ScratchArea scratchArea, CommandInvocation command,
@@ -194,9 +198,19 @@ public class BackportCommand implements CommandHandler {
 
         var potentialTargetRepo = repoNameOptional.flatMap(forge::repository);
         if (potentialTargetRepo.isEmpty()) {
+            var branchNamesInCurrentRepo = bot.repo().branches().stream().map(HostedBranch::name).toList();
+            if (branchNamesInCurrentRepo.contains(repoName)) {
+                reply.println("There is a branch `" + repoName + "` in current repository `" + bot.repo().name() + "`.");
+                reply.println("To target a backport to this branch in current repository:");
+                reply.println("`/backport :" + repoName + "`");
+                reply.println();
+            }
             reply.println("The target repository `" + repoNameArg + "` is not a valid target for backports. ");
             reply.print("List of valid target repositories: ");
-            reply.println(String.join(", ", bot.forks().keySet().stream().sorted().toList()) + ".");
+            reply.println(String.join(", ", bot.forks().keySet().stream()
+                    .sorted()
+                    .map(repo -> "`" + repo + "`")
+                    .toList()) + ".");
             reply.println("Supplying the organization/group prefix is optional.");
             return null;
         }
@@ -208,6 +222,16 @@ public class BackportCommand implements CommandHandler {
         var targetBranchHash = targetRepo.branchHash(targetBranchName);
         if (targetBranchHash.isEmpty()) {
             reply.println("The target branch `" + targetBranchName + "` does not exist");
+            reply.print("List of target branches: ");
+            var branches = targetRepo.branches().stream()
+                    .map(HostedBranch::name)
+                    .filter(name -> !name.startsWith("pr/"))
+                    .sorted(Comparator.reverseOrder())
+                    .toList();
+            reply.println(String.join(", ", branches.stream()
+                    .limit(BRANCHES_LIMIT)
+                    .map(branch -> "`" + branch + "`")
+                    .toList()) + (branches.size() > BRANCHES_LIMIT ? "..." : "."));
             return null;
         }
         return new Branch(targetBranchName);

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
@@ -200,8 +200,8 @@ public class BackportCommand implements CommandHandler {
         if (potentialTargetRepo.isEmpty()) {
             var branchNamesInCurrentRepo = bot.repo().branches().stream().map(HostedBranch::name).toList();
             if (branchNamesInCurrentRepo.contains(repoName)) {
-                reply.println("There is a branch `" + repoName + "` in current repository `" + bot.repo().name() + "`.");
-                reply.println("To target a backport to this branch in current repository:");
+                reply.println("There is a branch `" + repoName + "` in the current repository `" + bot.repo().name() + "`.");
+                reply.println("To target a backport to this branch in the current repository use:");
                 reply.println("`/backport :" + repoName + "`");
                 reply.println();
             }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
@@ -222,7 +222,7 @@ public class BackportCommand implements CommandHandler {
         var targetBranchHash = targetRepo.branchHash(targetBranchName);
         if (targetBranchHash.isEmpty()) {
             reply.println("The target branch `" + targetBranchName + "` does not exist");
-            reply.print("List of target branches: ");
+            reply.print("List of valid branches: ");
             var branches = targetRepo.branches().stream()
                     .map(HostedBranch::name)
                     .filter(name -> !name.startsWith("pr/"))

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportCommitCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportCommitCommandTests.java
@@ -63,7 +63,10 @@ public class BackportCommitCommandTests {
             // Make a change in another branch
             var editHash = CheckableRepository.appendAndCommit(localRepo);
             localRepo.push(editHash, author.authenticatedUrl(), "edit");
-
+            // Create more branches
+            for (int i = 1; i <= 20; i++) {
+                localRepo.push(editHash, author.authenticatedUrl(), "jdk" + i, true);
+            }
             // Add a backport command
             author.addCommitComment(editHash, "/backport " + author.name());
             TestBotRunner.runPeriodicItems(bot);
@@ -95,6 +98,21 @@ public class BackportCommitCommandTests {
             botReply = recentCommitComments.get(0);
             assertTrue(botReply.body().contains("To create a pull request with this backport targeting " +
                     "[" + author.name() + ":" + author.defaultBranchName() + "]"));
+
+            author.addCommitComment(editHash, "/backport jdk11");
+            TestBotRunner.runPeriodicItems(bot);
+            recentCommitComments = author.recentCommitComments();
+            assertEquals(8, recentCommitComments.size());
+            botReply = recentCommitComments.get(0);
+            assertTrue(botReply.body().contains("There is a branch `jdk11` in current repository `test`."));
+
+            author.addCommitComment(editHash, "/backport :jdk31");
+            TestBotRunner.runPeriodicItems(bot);
+            recentCommitComments = author.recentCommitComments();
+            assertEquals(10, recentCommitComments.size());
+            botReply = recentCommitComments.get(0);
+            assertTrue(botReply.body().contains("List of target branches:"));
+
         }
     }
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportCommitCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportCommitCommandTests.java
@@ -104,15 +104,14 @@ public class BackportCommitCommandTests {
             recentCommitComments = author.recentCommitComments();
             assertEquals(8, recentCommitComments.size());
             botReply = recentCommitComments.get(0);
-            assertTrue(botReply.body().contains("There is a branch `jdk11` in current repository `test`."));
+            assertTrue(botReply.body().contains("There is a branch `jdk11` in the current repository `test`."));
 
             author.addCommitComment(editHash, "/backport :jdk31");
             TestBotRunner.runPeriodicItems(bot);
             recentCommitComments = author.recentCommitComments();
             assertEquals(10, recentCommitComments.size());
             botReply = recentCommitComments.get(0);
-            assertTrue(botReply.body().contains("List of target branches:"));
-
+            assertTrue(botReply.body().contains("List of valid branches:"));
         }
     }
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportCommitCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportCommitCommandTests.java
@@ -153,7 +153,7 @@ public class BackportCommitCommandTests {
             var botReply = recentCommitComments.get(0);
             assertTrue(botReply.body().contains("target repository"));
             assertTrue(botReply.body().contains("is not a valid target for backports"));
-            assertTrue(botReply.body().contains("List of valid target repositories: foobar/other-repo, test"));
+            assertTrue(botReply.body().contains("List of valid target repositories: `foobar/other-repo`, `test`"));
             assertEquals(List.of(), author.openPullRequests());
         }
     }
@@ -194,7 +194,7 @@ public class BackportCommitCommandTests {
             assertEquals(2, recentCommitComments.size());
             var botReply = recentCommitComments.get(0);
             assertTrue(botReply.body().contains("is not a valid target for backports"));
-            assertTrue(botReply.body().contains("List of valid target repositories: foobar/other-repo"));
+            assertTrue(botReply.body().contains("List of valid target repositories: `foobar/other-repo`"));
             assertEquals(List.of(), author.openPullRequests());
         }
     }


### PR DESCRIPTION
This patch is trying to improve the bot's replies of backport command.

1. If the user issued `/backport jdkX`, the bot would check if there is a `jdkX` branch in current repo, if so, the bot would tell the user that to target a backport to `jdkX` branch in current repo, he should issue `/backport :jdkX`.

2. When user specified branch name in the command but the branch doesn't exist, the bot will list 10 branch names in the target repo, the branch names are just sorted in reverse alphabetical order, so we can't guarantee they are the most relevant ones.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2304](https://bugs.openjdk.org/browse/SKARA-2304): /backport jdk23 should provide a more helpful message (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1667/head:pull/1667` \
`$ git checkout pull/1667`

Update a local copy of the PR: \
`$ git checkout pull/1667` \
`$ git pull https://git.openjdk.org/skara.git pull/1667/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1667`

View PR using the GUI difftool: \
`$ git pr show -t 1667`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1667.diff">https://git.openjdk.org/skara/pull/1667.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1667#issuecomment-2204345515)