### PR TITLE
2316: Prefer not to specify UTF-8 if it's used by default

### DIFF
--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunnerConfiguration.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunnerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,6 @@ import org.openjdk.skara.vcs.VCS;
 
 import java.io.*;
 import java.net.URI;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.time.Duration;
 import java.util.*;
@@ -85,7 +84,7 @@ public class BotRunnerConfiguration {
                 if (github.contains("app")) {
                     var keyFile = cwd.resolve(github.get("app").get("key").asString());
                     try {
-                        var keyContents = Files.readString(keyFile, StandardCharsets.UTF_8);
+                        var keyContents = Files.readString(keyFile);
                         var pat = new Credential(github.get("app").get("id").asString() + ";" +
                                 github.get("app").get("installation").asString(),
                                 keyContents);

--- a/bots/cli/src/main/java/org/openjdk/skara/bots/cli/BotLauncher.java
+++ b/bots/cli/src/main/java/org/openjdk/skara/bots/cli/BotLauncher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,6 @@ import org.openjdk.skara.proxy.HttpProxy;
 import org.openjdk.skara.version.Version;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.time.Duration;
 import java.util.*;
@@ -118,7 +117,7 @@ public class BotLauncher {
 
     private static JSONObject readConfiguration(Path jsonFile) {
         try {
-            return JWCC.parse(Files.readString(jsonFile, StandardCharsets.UTF_8)).asObject();
+            return JWCC.parse(Files.readString(jsonFile)).asObject();
         } catch (IOException e) {
             throw new RuntimeException("Failed to open configuration file: " + jsonFile);
         }

--- a/bots/hgbridge/src/main/java/org/openjdk/skara/bots/hgbridge/ExporterConfig.java
+++ b/bots/hgbridge/src/main/java/org/openjdk/skara/bots/hgbridge/ExporterConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@ import org.openjdk.skara.vcs.openjdk.convert.*;
 
 import java.io.IOException;
 import java.net.URI;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -142,7 +141,7 @@ class ExporterConfig {
     private <K, V> Map<K, V> parseMap(Path base, List<String> files, FieldParser<K> keyParser, FieldParser<V> valueParser) throws IOException {
         var ret = new HashMap<K, V>();
         for (var file : files) {
-            var jsonData = Files.readString(base.resolve(file), StandardCharsets.UTF_8);
+            var jsonData = Files.readString(base.resolve(file));
             var json = JSON.parse(jsonData);
             for (var field : json.fields()) {
                 ret.put(keyParser.parse(field), valueParser.parse(field));
@@ -158,7 +157,7 @@ class ExporterConfig {
     private <E> Set<E> parseCommits(Path base, List<String> files, ValueParser<E> valueParser) throws IOException {
         var ret = new HashSet<E>();
         for (var file : files) {
-            var jsonData = Files.readString(base.resolve(file), StandardCharsets.UTF_8);
+            var jsonData = Files.readString(base.resolve(file));
             var json = JSON.parse(jsonData);
             for (var value : json.get("commits").asArray()) {
                 ret.add(valueParser.parse(value));

--- a/bots/hgbridge/src/main/java/org/openjdk/skara/bots/hgbridge/JBridgeBot.java
+++ b/bots/hgbridge/src/main/java/org/openjdk/skara/bots/hgbridge/JBridgeBot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -86,7 +86,7 @@ public class JBridgeBot implements Bot, WorkItem {
             }
         }
 
-        Files.writeString(markDest, updated, StandardCharsets.UTF_8);
+        Files.writeString(markDest, updated);
         marksRepo.add(markDest);
         var hash = marksRepo.commit("Updated marks", exporterConfig.marksAuthorName(), exporterConfig.marksAuthorEmail());
         marksRepo.push(hash, exporterConfig.marksRepo().authenticatedUrl(), exporterConfig.marksRef());

--- a/bots/hgbridge/src/test/java/org/openjdk/skara/bots/hgbridge/BridgeBotTests.java
+++ b/bots/hgbridge/src/test/java/org/openjdk/skara/bots/hgbridge/BridgeBotTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,6 @@ import org.junit.jupiter.api.*;
 
 import java.io.*;
 import java.net.URI;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -76,7 +75,7 @@ class BridgeBotTests {
 
             var initialFile = marksLocalRepo.root().resolve("init.txt");
             if (!Files.exists(initialFile)) {
-                Files.writeString(initialFile, "Hello", StandardCharsets.UTF_8);
+                Files.writeString(initialFile, "Hello");
                 marksLocalRepo.add(initialFile);
                 var hash = marksLocalRepo.commit("First", "duke", "duke@duke.duke");
                 marksLocalRepo.checkout(hash, true); // Have to move away from the master branch to allow pushes
@@ -142,7 +141,7 @@ class BridgeBotTests {
             runHgCommand(localRepo, "update", "null");
             runHgCommand(localRepo, "branch", "testlock");
             var lockFile = localRepo.root().resolve("lock.txt");
-            Files.writeString(lockFile, ZonedDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME), StandardCharsets.UTF_8);
+            Files.writeString(lockFile, ZonedDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME));
             localRepo.add(lockFile);
             localRepo.commit("Lock", "duke", "Duke <duke@openjdk.org>");
         } catch (IOException e) {

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -34,7 +34,6 @@ import org.openjdk.skara.test.*;
 import org.openjdk.skara.vcs.Repository;
 
 import java.io.*;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.time.*;
 import java.util.*;
@@ -55,7 +54,7 @@ class MailingListBridgeBotTests {
             if (mbox.isEmpty()) {
                 return Optional.empty();
             }
-            return Optional.of(Files.readString(mbox.get(), StandardCharsets.UTF_8));
+            return Optional.of(Files.readString(mbox.get()));
         } catch (IOException e) {
             return Optional.empty();
         }
@@ -96,7 +95,7 @@ class MailingListBridgeBotTests {
             if (index.isEmpty()) {
                 return false;
             }
-            var lines = Files.readString(index.get(), StandardCharsets.UTF_8);
+            var lines = Files.readString(index.get());
             return lines.contains(text);
         } catch (IOException e) {
             return false;
@@ -1139,7 +1138,7 @@ class MailingListBridgeBotTests {
             var reviewFile1 = Path.of("reviewfile.txt");
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(), reviewFile1);
             var reviewFile2 = Path.of("aardvark_reviewfile.txt");
-            Files.writeString(localRepo.root().resolve(reviewFile2), "1\n2\n3\n4\n5\n6\n", StandardCharsets.UTF_8);
+            Files.writeString(localRepo.root().resolve(reviewFile2), "1\n2\n3\n4\n5\n6\n");
             localRepo.add(reviewFile2);
             var masterHash = localRepo.commit("Another one", "duke", "duke@openjdk.org");
             localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
@@ -1471,10 +1470,10 @@ class MailingListBridgeBotTests {
             localRepo.push(initialHash, author.authenticatedUrl(), "master");
 
             // Make a change with a corresponding PR
-            var current = Files.readString(localRepo.root().resolve(reviewFile), StandardCharsets.UTF_8);
+            var current = Files.readString(localRepo.root().resolve(reviewFile));
             var updated = current.replaceAll("Line 2", "Line 2 edit\nLine 2.5");
             updated = updated.replaceAll("Line 13", "Line 12.5\nLine 13 edit");
-            Files.writeString(localRepo.root().resolve(reviewFile), updated, StandardCharsets.UTF_8);
+            Files.writeString(localRepo.root().resolve(reviewFile), updated);
             var editHash = CheckableRepository.appendAndCommit(localRepo);
             localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(archive, "master", "edit", "This is a pull request");

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/WebrevStorageTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/WebrevStorageTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,6 @@ import org.openjdk.skara.vcs.*;
 import org.junit.jupiter.api.*;
 
 import java.io.*;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.util.UUID;
 
@@ -165,7 +164,7 @@ class WebrevStorageTests {
 
                 try {
                     var repo = Repository.materialize(scratchPath, archive.authenticatedUrl(), ref);
-                    Files.writeString(repo.root().resolve("intercept.txt"), UUID.randomUUID().toString(), StandardCharsets.UTF_8);
+                    Files.writeString(repo.root().resolve("intercept.txt"), UUID.randomUUID().toString());
                     repo.add(repo.root().resolve("intercept.txt"));
                     var commit = repo.commit("Concurrent unrelated commit", "duke", "duke@openjdk.org");
                     repo.push(commit, archive.authenticatedUrl(), ref);

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/json/JsonWriter.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/json/JsonWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@ package org.openjdk.skara.bots.notify.json;
 import org.openjdk.skara.json.*;
 
 import java.io.*;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.util.UUID;
 
@@ -41,7 +40,7 @@ class JsonWriter implements AutoCloseable {
         var finalName = path.resolve(String.format("%s.%03d.json", baseName, sequence));
 
         try {
-            Files.write(tempName, current.toString().getBytes(StandardCharsets.UTF_8));
+            Files.writeString(tempName, current.toString());
             Files.move(tempName, finalName);
         } catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
@@ -33,7 +33,6 @@ import org.openjdk.skara.vcs.Branch;
 
 import java.io.IOException;
 import java.net.URI;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.util.*;
 import java.util.regex.Pattern;
@@ -1360,9 +1359,9 @@ public class IssueNotifierTests {
             localRepo.fetch(repo.authenticatedUrl(), "+history:history").orElseThrow();
             localRepo.checkout(new Branch("history"), true);
             var historyFile = repoFolder.resolve("test.tags.txt");
-            var processed = new ArrayList<>(Files.readAllLines(historyFile, StandardCharsets.UTF_8));
+            var processed = new ArrayList<>(Files.readAllLines(historyFile));
             processed.add("jdk-16+10 issue done");
-            Files.writeString(historyFile, String.join("\n", processed), StandardCharsets.UTF_8);
+            Files.writeString(historyFile, String.join("\n", processed));
             localRepo.add(historyFile);
             var updatedHash = localRepo.commit("Marking jdk-16+10 as done", "duke", "duke@openjdk.org");
             localRepo.push(updatedHash, repo.authenticatedUrl(), "history");
@@ -1377,7 +1376,7 @@ public class IssueNotifierTests {
             // Flag it as in need of retry
             processed.removeLast();
             processed.add("jdk-16+10 issue retry");
-            Files.writeString(repoFolder.resolve("test.tags.txt"), String.join("\n", processed), StandardCharsets.UTF_8);
+            Files.writeString(repoFolder.resolve("test.tags.txt"), String.join("\n", processed));
             localRepo.add(historyFile);
             var retryHash = localRepo.commit("Marking jdk-16+10 as needing retry", "duke", "duke@openjdk.org");
             localRepo.push(retryHash, repo.authenticatedUrl(), "history");

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/json/JsonNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/json/JsonNotifierTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@ import org.openjdk.skara.json.*;
 import org.openjdk.skara.test.*;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -82,9 +81,9 @@ public class JsonNotifierTests {
             TestBotRunner.runPeriodicItems(notifyBot);
             var jsonFiles = findJsonFiles(jsonFolder, "");
             assertEquals(2, jsonFiles.size());
-            var jsonData = Files.readString(jsonFiles.get(0), StandardCharsets.UTF_8);
+            var jsonData = Files.readString(jsonFiles.get(0));
             if (JSON.parse(jsonData).asArray().size() != 1) {
-                jsonData = Files.readString(jsonFiles.get(1), StandardCharsets.UTF_8);
+                jsonData = Files.readString(jsonFiles.get(1));
             }
             var json = JSON.parse(jsonData);
             assertEquals(1, json.asArray().size());
@@ -141,7 +140,7 @@ public class JsonNotifierTests {
             assertEquals(4, jsonFiles.size());
 
             for (var file : jsonFiles) {
-                var jsonData = Files.readString(file, StandardCharsets.UTF_8);
+                var jsonData = Files.readString(file);
                 var json = JSON.parse(jsonData);
 
                 if (json.asArray().get(0).contains("date")) {

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/BackportTests.java
@@ -30,7 +30,6 @@ import org.openjdk.skara.vcs.*;
 import org.openjdk.skara.vcs.openjdk.CommitMessageParsers;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.util.*;
 import java.util.regex.Pattern;
@@ -1910,7 +1909,7 @@ class BackportTests {
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
 
             var confPath = localRepo.root().resolve(".jcheck/conf");
-            var defaultConf = Files.readString(confPath, StandardCharsets.UTF_8);
+            var defaultConf = Files.readString(confPath);
             var newConf = defaultConf.replace("reviewers=1", """
                     lead=0
                     reviewers=2

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CSRBotTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CSRBotTests.java
@@ -33,7 +33,6 @@ import org.openjdk.skara.test.TemporaryDirectory;
 import org.openjdk.skara.test.TestBotRunner;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.List;
@@ -409,9 +408,9 @@ class CSRBotTests {
             assertTrue(pr.store().labelNames().contains("backport"));
 
             // Remove `version=0.1` from `.jcheck/conf`, set the version as null in the edit branch
-            var defaultConf = Files.readString(localRepo.root().resolve(".jcheck/conf"), StandardCharsets.UTF_8);
+            var defaultConf = Files.readString(localRepo.root().resolve(".jcheck/conf"));
             var newConf = defaultConf.replace("version=0.1", "");
-            Files.writeString(localRepo.root().resolve(".jcheck/conf"), newConf, StandardCharsets.UTF_8);
+            Files.writeString(localRepo.root().resolve(".jcheck/conf"), newConf);
             localRepo.add(localRepo.root().resolve(".jcheck/conf"));
             var confHash = localRepo.commit("Set version as null", "duke", "duke@openjdk.org");
             localRepo.push(confHash, author.authenticatedUrl(), "edit", true);
@@ -422,9 +421,9 @@ class CSRBotTests {
             assertFalse(pr.store().labelNames().contains("csr"));
 
             // Add `version=bla` to `.jcheck/conf`, set the version as a wrong value
-            defaultConf = Files.readString(localRepo.root().resolve(".jcheck/conf"), StandardCharsets.UTF_8);
+            defaultConf = Files.readString(localRepo.root().resolve(".jcheck/conf"));
             newConf = defaultConf.replace("project=test", "project=test\nversion=bla");
-            Files.writeString(localRepo.root().resolve(".jcheck/conf"), newConf, StandardCharsets.UTF_8);
+            Files.writeString(localRepo.root().resolve(".jcheck/conf"), newConf);
             localRepo.add(localRepo.root().resolve(".jcheck/conf"));
             confHash = localRepo.commit("Set the version as a wrong value", "duke", "duke@openjdk.org");
             localRepo.push(confHash, author.authenticatedUrl(), "edit", true);
@@ -437,9 +436,9 @@ class CSRBotTests {
             assertEquals(1, pr.diff().patches().size());
 
             // Set the `version` in `.jcheck/conf` as 17 which is an available version.
-            defaultConf = Files.readString(localRepo.root().resolve(".jcheck/conf"), StandardCharsets.UTF_8);
+            defaultConf = Files.readString(localRepo.root().resolve(".jcheck/conf"));
             newConf = defaultConf.replace("version=bla", "version=17");
-            Files.writeString(localRepo.root().resolve(".jcheck/conf"), newConf, StandardCharsets.UTF_8);
+            Files.writeString(localRepo.root().resolve(".jcheck/conf"), newConf);
             localRepo.add(localRepo.root().resolve(".jcheck/conf"));
             confHash = localRepo.commit("Set the version as 17", "duke", "duke@openjdk.org");
             localRepo.push(confHash, author.authenticatedUrl(), "edit", true);
@@ -494,9 +493,9 @@ class CSRBotTests {
             // Set the backport CSR to have multiple fix versions, included 11.
             backportCsr.setProperty("fixVersions", JSON.array().add("17").add("11").add("8"));
             // Set the `version` in `.jcheck/conf` as 11.
-            defaultConf = Files.readString(localRepo.root().resolve(".jcheck/conf"), StandardCharsets.UTF_8);
+            defaultConf = Files.readString(localRepo.root().resolve(".jcheck/conf"));
             newConf = defaultConf.replace("version=17", "version=11");
-            Files.writeString(localRepo.root().resolve(".jcheck/conf"), newConf, StandardCharsets.UTF_8);
+            Files.writeString(localRepo.root().resolve(".jcheck/conf"), newConf);
             localRepo.add(localRepo.root().resolve(".jcheck/conf"));
             confHash = localRepo.commit("Set the version as 11", "duke", "duke@openjdk.org");
             localRepo.push(confHash, author.authenticatedUrl(), "edit", true);
@@ -670,9 +669,9 @@ class CSRBotTests {
 
             // Change .jcheck/conf in targetBranch
             localRepo.checkout(masterHash);
-            var defaultConf = Files.readString(localRepo.root().resolve(".jcheck/conf"), StandardCharsets.UTF_8);
+            var defaultConf = Files.readString(localRepo.root().resolve(".jcheck/conf"));
             var newConf = defaultConf.replace("version=0.1", "version=17");
-            Files.writeString(localRepo.root().resolve(".jcheck/conf"), newConf, StandardCharsets.UTF_8);
+            Files.writeString(localRepo.root().resolve(".jcheck/conf"), newConf);
             localRepo.add(localRepo.root().resolve(".jcheck/conf"));
             var confHash = localRepo.commit("Set version as 17", "duke", "duke@openjdk.org");
             localRepo.push(confHash, author.authenticatedUrl(), "master", true);

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CSRCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CSRCommandTests.java
@@ -33,7 +33,6 @@ import org.openjdk.skara.vcs.Hash;
 import org.openjdk.skara.vcs.Repository;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.*;
 
@@ -838,9 +837,9 @@ class CSRCommandTests {
 
             // Remove `version=0.1` from `.jcheck/conf`, set the version as null
             localRepo.checkout(localRepo.defaultBranch());
-            var defaultConf = Files.readString(localRepo.root().resolve(".jcheck/conf"), StandardCharsets.UTF_8);
+            var defaultConf = Files.readString(localRepo.root().resolve(".jcheck/conf"));
             var newConf = defaultConf.replace("version=0.1", "");
-            Files.writeString(localRepo.root().resolve(".jcheck/conf"), newConf, StandardCharsets.UTF_8);
+            Files.writeString(localRepo.root().resolve(".jcheck/conf"), newConf);
             localRepo.add(localRepo.root().resolve(".jcheck/conf"));
             var confHash = localRepo.commit("Set version as null", "duke", "duke@openjdk.org");
             localRepo.push(confHash, author.authenticatedUrl(), "master", true);
@@ -879,9 +878,9 @@ class CSRCommandTests {
 
             // Add `version=bla` to `.jcheck/conf`, set the version as a wrong value
             localRepo.checkout(localRepo.defaultBranch());
-            defaultConf = Files.readString(localRepo.root().resolve(".jcheck/conf"), StandardCharsets.UTF_8);
+            defaultConf = Files.readString(localRepo.root().resolve(".jcheck/conf"));
             newConf = defaultConf.replace("project=test", "project=test\nversion=bla");
-            Files.writeString(localRepo.root().resolve(".jcheck/conf"), newConf, StandardCharsets.UTF_8);
+            Files.writeString(localRepo.root().resolve(".jcheck/conf"), newConf);
             localRepo.add(localRepo.root().resolve(".jcheck/conf"));
             confHash = localRepo.commit("Set the version as a wrong value", "duke", "duke@openjdk.org");
             localRepo.push(confHash, author.authenticatedUrl(), "master", true);
@@ -906,9 +905,9 @@ class CSRCommandTests {
 
             // Set the `version` in `.jcheck/conf` as 17 which is an available version.
             localRepo.checkout(localRepo.defaultBranch());
-            defaultConf = Files.readString(localRepo.root().resolve(".jcheck/conf"), StandardCharsets.UTF_8);
+            defaultConf = Files.readString(localRepo.root().resolve(".jcheck/conf"));
             newConf = defaultConf.replace("version=bla", "version=17");
-            Files.writeString(localRepo.root().resolve(".jcheck/conf"), newConf, StandardCharsets.UTF_8);
+            Files.writeString(localRepo.root().resolve(".jcheck/conf"), newConf);
             localRepo.add(localRepo.root().resolve(".jcheck/conf"));
             confHash = localRepo.commit("Set the version as 17", "duke", "duke@openjdk.org");
             localRepo.push(confHash, author.authenticatedUrl(), "master", true);
@@ -1001,9 +1000,9 @@ class CSRCommandTests {
             backportCsr.setProperty("fixVersions", JSON.array().add("17").add("11").add("8"));
             // Set the `version` in `.jcheck/conf` as 11.
             localRepo.checkout(localRepo.defaultBranch());
-            defaultConf = Files.readString(localRepo.root().resolve(".jcheck/conf"), StandardCharsets.UTF_8);
+            defaultConf = Files.readString(localRepo.root().resolve(".jcheck/conf"));
             newConf = defaultConf.replace("version=17", "version=11");
-            Files.writeString(localRepo.root().resolve(".jcheck/conf"), newConf, StandardCharsets.UTF_8);
+            Files.writeString(localRepo.root().resolve(".jcheck/conf"), newConf);
             localRepo.add(localRepo.root().resolve(".jcheck/conf"));
             confHash = localRepo.commit("Set the version as 11", "duke", "duke@openjdk.org");
             localRepo.push(confHash, author.authenticatedUrl(), "master", true);
@@ -1351,9 +1350,9 @@ class CSRCommandTests {
 
             // Set the `version` in `.jcheck/conf` as 17 which is an available version.
             localRepo.checkout(localRepo.defaultBranch());
-            var defaultConf = Files.readString(localRepo.root().resolve(".jcheck/conf"), StandardCharsets.UTF_8);
+            var defaultConf = Files.readString(localRepo.root().resolve(".jcheck/conf"));
             var newConf = defaultConf.replace("version=0.1", "version=17");
-            Files.writeString(localRepo.root().resolve(".jcheck/conf"), newConf, StandardCharsets.UTF_8);
+            Files.writeString(localRepo.root().resolve(".jcheck/conf"), newConf);
             localRepo.add(localRepo.root().resolve(".jcheck/conf"));
             var confHash = localRepo.commit("Set the version as 17", "duke", "duke@openjdk.org");
             localRepo.push(confHash, author.authenticatedUrl(), "master", true);

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -31,7 +31,6 @@ import org.openjdk.skara.test.*;
 import org.openjdk.skara.vcs.Repository;
 
 import java.io.*;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.nio.file.attribute.PosixFilePermission;
 import java.time.*;
@@ -622,10 +621,10 @@ class CheckTests {
             localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Make a change with a corresponding PR
-            Files.writeString(tempFolder.path().resolve("executable1.exe"), "Executable file contents", StandardCharsets.UTF_8);
+            Files.writeString(tempFolder.path().resolve("executable1.exe"), "Executable file contents");
             Files.setPosixFilePermissions(tempFolder.path().resolve("executable1.exe"), Set.of(PosixFilePermission.OWNER_EXECUTE, PosixFilePermission.OWNER_READ));
             localRepo.add(Path.of("executable1.exe"));
-            Files.writeString(tempFolder.path().resolve("executable2.exe"), "Executable file contents", StandardCharsets.UTF_8);
+            Files.writeString(tempFolder.path().resolve("executable2.exe"), "Executable file contents");
             Files.setPosixFilePermissions(tempFolder.path().resolve("executable2.exe"), Set.of(PosixFilePermission.OWNER_EXECUTE, PosixFilePermission.OWNER_READ));
             localRepo.add(Path.of("executable2.exe"));
             var editHash = localRepo.commit("Make it executable", "duke", "duke@openjdk.org");
@@ -1083,9 +1082,9 @@ class CheckTests {
 
             // Set the version to 17
             localRepo.checkout(localRepo.defaultBranch());
-            var defaultConf = Files.readString(localRepo.root().resolve(".jcheck/conf"), StandardCharsets.UTF_8);
+            var defaultConf = Files.readString(localRepo.root().resolve(".jcheck/conf"));
             var newConf = defaultConf.replace("project=test", "project=test\nversion=17");
-            Files.writeString(localRepo.root().resolve(".jcheck/conf"), newConf, StandardCharsets.UTF_8);
+            Files.writeString(localRepo.root().resolve(".jcheck/conf"), newConf);
             localRepo.add(localRepo.root().resolve(".jcheck/conf"));
             var confHash = localRepo.commit("Set version as 17", "duke", "duke@openjdk.org");
             localRepo.push(confHash, author.authenticatedUrl(), "master", true);
@@ -1414,7 +1413,7 @@ class CheckTests {
 
             // Break the jcheck configuration on the "edit" branch
             var confPath = tempFolder.path().resolve(".jcheck/conf");
-            Files.writeString(confPath, "Hello there!", StandardCharsets.UTF_8);
+            Files.writeString(confPath, "Hello there!");
             localRepo.add(confPath);
             var editHash = CheckableRepository.appendAndCommit(localRepo, "A change");
             localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
@@ -1935,9 +1934,9 @@ class CheckTests {
             localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Create a different conf on a different branch
-            var defaultConf = Files.readString(localRepo.root().resolve(".jcheck/conf"), StandardCharsets.UTF_8);
+            var defaultConf = Files.readString(localRepo.root().resolve(".jcheck/conf"));
             var newConf = defaultConf.replace("reviewers=1", "reviewers=0");
-            Files.writeString(localRepo.root().resolve("jcheck.conf"), newConf, StandardCharsets.UTF_8);
+            Files.writeString(localRepo.root().resolve("jcheck.conf"), newConf);
             localRepo.add(localRepo.root().resolve("jcheck.conf"));
             var confHash = localRepo.commit("Separate conf", "duke", "duke@openjdk.org");
             localRepo.push(confHash, author.authenticatedUrl(), "jcheck-branch", true);
@@ -1977,9 +1976,9 @@ class CheckTests {
             localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Create a different conf on a different branch
-            var defaultConf = Files.readString(localRepo.root().resolve(".jcheck/conf"), StandardCharsets.UTF_8);
+            var defaultConf = Files.readString(localRepo.root().resolve(".jcheck/conf"));
             var newConf = defaultConf.replace("reviewers=1", "reviewers=0");
-            Files.writeString(localRepo.root().resolve("jcheck.conf"), newConf, StandardCharsets.UTF_8);
+            Files.writeString(localRepo.root().resolve("jcheck.conf"), newConf);
             localRepo.add(localRepo.root().resolve("jcheck.conf"));
             var confHash = localRepo.commit("Separate conf", "duke", "duke@openjdk.org");
             localRepo.push(confHash, author.authenticatedUrl(), "jcheck-branch", true);
@@ -2107,9 +2106,9 @@ class CheckTests {
             PullRequestUtils.postPullRequestLinkComment(issue, pr);
 
             // Remove `version=0.1` from `.jcheck/conf`, set the version as null
-            var defaultConf = Files.readString(localRepo.root().resolve(".jcheck/conf"), StandardCharsets.UTF_8);
+            var defaultConf = Files.readString(localRepo.root().resolve(".jcheck/conf"));
             var newConf = defaultConf.replace("version=0.1", "");
-            Files.writeString(localRepo.root().resolve(".jcheck/conf"), newConf, StandardCharsets.UTF_8);
+            Files.writeString(localRepo.root().resolve(".jcheck/conf"), newConf);
             localRepo.add(localRepo.root().resolve(".jcheck/conf"));
             var confHash = localRepo.commit("Set version as null", "duke", "duke@openjdk.org");
             localRepo.push(confHash, author.authenticatedUrl(), "edit", true);
@@ -2125,9 +2124,9 @@ class CheckTests {
             assertFalse(pr.store().body().contains(csr.title()));
 
             // Add `version=bla` to `.jcheck/conf`, set the version as a wrong value
-            defaultConf = Files.readString(localRepo.root().resolve(".jcheck/conf"), StandardCharsets.UTF_8);
+            defaultConf = Files.readString(localRepo.root().resolve(".jcheck/conf"));
             newConf = defaultConf.replace("project=test", "project=test\nversion=bla");
-            Files.writeString(localRepo.root().resolve(".jcheck/conf"), newConf, StandardCharsets.UTF_8);
+            Files.writeString(localRepo.root().resolve(".jcheck/conf"), newConf);
             localRepo.add(localRepo.root().resolve(".jcheck/conf"));
             confHash = localRepo.commit("Set the version as a wrong value", "duke", "duke@openjdk.org");
             localRepo.push(confHash, author.authenticatedUrl(), "edit", true);
@@ -2142,9 +2141,9 @@ class CheckTests {
             assertFalse(pr.store().body().contains(csr.title()));
 
             // Set the `version` in `.jcheck/conf` as 17 which is an available version.
-            defaultConf = Files.readString(localRepo.root().resolve(".jcheck/conf"), StandardCharsets.UTF_8);
+            defaultConf = Files.readString(localRepo.root().resolve(".jcheck/conf"));
             newConf = defaultConf.replace("version=bla", "version=17");
-            Files.writeString(localRepo.root().resolve(".jcheck/conf"), newConf, StandardCharsets.UTF_8);
+            Files.writeString(localRepo.root().resolve(".jcheck/conf"), newConf);
             localRepo.add(localRepo.root().resolve(".jcheck/conf"));
             confHash = localRepo.commit("Set the version as 17", "duke", "duke@openjdk.org");
             localRepo.push(confHash, author.authenticatedUrl(), "edit", true);
@@ -2212,9 +2211,9 @@ class CheckTests {
             // Set the backport CSR to have multiple fix versions, included 11.
             backportCsr.setProperty("fixVersions", JSON.array().add("17").add("11").add("8"));
             // Set the `version` in `.jcheck/conf` as 11.
-            defaultConf = Files.readString(localRepo.root().resolve(".jcheck/conf"), StandardCharsets.UTF_8);
+            defaultConf = Files.readString(localRepo.root().resolve(".jcheck/conf"));
             newConf = defaultConf.replace("version=17", "version=11");
-            Files.writeString(localRepo.root().resolve(".jcheck/conf"), newConf, StandardCharsets.UTF_8);
+            Files.writeString(localRepo.root().resolve(".jcheck/conf"), newConf);
             localRepo.add(localRepo.root().resolve(".jcheck/conf"));
             confHash = localRepo.commit("Set the version as 11", "duke", "duke@openjdk.org");
             localRepo.push(confHash, author.authenticatedUrl(), "edit", true);
@@ -3171,9 +3170,9 @@ class CheckTests {
 
             //Make a change to .jcheck/conf in target branch
             localRepo.checkout(localRepo.defaultBranch());
-            var defaultConf = Files.readString(localRepo.root().resolve(".jcheck/conf"), StandardCharsets.UTF_8);
+            var defaultConf = Files.readString(localRepo.root().resolve(".jcheck/conf"));
             var newConf = defaultConf.replace("reviewers=1", "reviewers=2");
-            Files.writeString(localRepo.root().resolve(".jcheck/conf"), newConf, StandardCharsets.UTF_8);
+            Files.writeString(localRepo.root().resolve(".jcheck/conf"), newConf);
             localRepo.add(localRepo.root().resolve(".jcheck/conf"));
             var confHash = localRepo.commit("set reviewers=2", "duke", "duke@openjdk.org");
             localRepo.push(confHash, author.authenticatedUrl(), "master", true);
@@ -3273,9 +3272,9 @@ class CheckTests {
             localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
             // Create a different conf on a different branch
-            var defaultConf = Files.readString(localRepo.root().resolve(".jcheck/conf"), StandardCharsets.UTF_8);
+            var defaultConf = Files.readString(localRepo.root().resolve(".jcheck/conf"));
             var newConf = defaultConf.replace("reviewers=1", "reviewers=0");
-            Files.writeString(localRepo.root().resolve("jcheck.conf"), newConf, StandardCharsets.UTF_8);
+            Files.writeString(localRepo.root().resolve("jcheck.conf"), newConf);
             localRepo.add(localRepo.root().resolve("jcheck.conf"));
             var confHash = localRepo.commit("Separate conf", "duke", "duke@openjdk.org");
             localRepo.push(confHash, author.authenticatedUrl(), "jcheck-branch", true);

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrateTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrateTests.java
@@ -29,7 +29,6 @@ import org.openjdk.skara.test.*;
 import org.openjdk.skara.vcs.*;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.util.*;
 
@@ -581,7 +580,7 @@ class IntegrateTests {
             // Break the census to cause an exception
             var localCensus = Repository.materialize(censusFolder.path(), censusRepo.authenticatedUrl(), "+master:current_census");
             var currentCensusHash = localCensus.resolve("current_census").orElseThrow();
-            Files.writeString(censusFolder.path().resolve("contributors.xml"), "This is not xml", StandardCharsets.UTF_8);
+            Files.writeString(censusFolder.path().resolve("contributors.xml"), "This is not xml");
             localCensus.add(censusFolder.path().resolve("contributors.xml"));
             var badCensusHash = localCensus.commit("Bad census update", "duke", "duke@openjdk.org");
             localCensus.push(badCensusHash, censusRepo.authenticatedUrl(), "master", true);

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
@@ -32,7 +32,6 @@ import org.openjdk.skara.vcs.*;
 import org.junit.jupiter.api.*;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -74,7 +73,7 @@ class MergeTests {
             localRepo.checkout(masterHash, true);
 
             // Make a change with a corresponding PR
-            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated", StandardCharsets.UTF_8);
+            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated");
             localRepo.add(unrelated);
             var updatedMaster = localRepo.commit("Unrelated", "some", "some@one");
             localRepo.merge(otherHash2);
@@ -159,7 +158,7 @@ class MergeTests {
             localRepo.checkout(masterHash, true);
 
             // Make a change with a corresponding PR
-            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated", StandardCharsets.UTF_8);
+            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated");
             localRepo.add(unrelated);
             var updatedMaster = localRepo.commit("Unrelated", "some", "some@one");
             localRepo.merge(otherHash2);
@@ -255,7 +254,7 @@ class MergeTests {
             localRepo.checkout(masterHash, true);
 
             // Make a change with a corresponding PR
-            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated", StandardCharsets.UTF_8);
+            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated");
             localRepo.add(unrelated);
             var updatedMaster = localRepo.commit("Unrelated", "some", "some@one");
             localRepo.merge(otherHash2);
@@ -350,7 +349,7 @@ class MergeTests {
             localRepo.checkout(masterHash, true);
 
             // Make a change with a corresponding PR
-            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated", StandardCharsets.UTF_8);
+            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated");
             localRepo.add(unrelated);
             var updatedMaster = localRepo.commit("Unrelated", "some", "some@one");
             localRepo.merge(otherHash2);
@@ -417,7 +416,7 @@ class MergeTests {
             localRepo.checkout(masterHash, true);
 
             // Make a change with a corresponding PR
-            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated", StandardCharsets.UTF_8);
+            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated");
             localRepo.add(unrelated);
             var updatedMaster = localRepo.commit("Unrelated", "some", "some@one");
             localRepo.merge(otherHash2);
@@ -478,7 +477,7 @@ class MergeTests {
             localRepo.checkout(masterHash, true);
 
             // Make a change with a corresponding PR
-            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated", StandardCharsets.UTF_8);
+            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated");
             localRepo.add(unrelated);
             var updatedMaster = localRepo.commit("Unrelated", "some", "some@one");
             localRepo.merge(otherHash2);
@@ -535,7 +534,7 @@ class MergeTests {
             localRepo.checkout(masterHash, true);
 
             // Make a change with a corresponding PR
-            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated", StandardCharsets.UTF_8);
+            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated");
             localRepo.add(unrelated);
             var updatedMaster = localRepo.commit("Unrelated", "some", "some@one");
             localRepo.merge(otherHash2);
@@ -621,7 +620,7 @@ class MergeTests {
             localRepo.checkout(masterHash, true);
 
             // Make a change with a corresponding PR
-            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated", StandardCharsets.UTF_8);
+            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated");
             localRepo.add(unrelated);
             var updatedMaster = localRepo.commit("Unrelated", "some", "some@one");
             localRepo.merge(otherHash2);
@@ -683,7 +682,7 @@ class MergeTests {
             localRepo.checkout(masterHash, true);
 
             // Make a change with a corresponding PR
-            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated", StandardCharsets.UTF_8);
+            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated");
             localRepo.add(unrelated);
             var updatedMaster = localRepo.commit("Unrelated", "some", "some@one");
             localRepo.merge(otherHash2);
@@ -765,7 +764,7 @@ class MergeTests {
             localRepo.checkout(masterHash, true);
 
             // Make a change with a corresponding PR
-            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated", StandardCharsets.UTF_8);
+            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated");
             localRepo.add(unrelated);
             var updatedMaster = localRepo.commit("Unrelated", "some", "some@one");
             localRepo.push(updatedMaster, author.authenticatedUrl(), "master");
@@ -851,7 +850,7 @@ class MergeTests {
             localRepo.checkout(masterHash, true);
 
             // Make a change with a corresponding PR
-            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated", StandardCharsets.UTF_8);
+            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated");
             localRepo.add(unrelated);
             var updatedMaster = localRepo.commit("Unrelated", "some", "some@one");
             localRepo.push(updatedMaster, author.authenticatedUrl(), "master");
@@ -935,7 +934,7 @@ class MergeTests {
             localRepo.checkout(masterHash, true);
 
             // Make a change with a corresponding PR
-            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated", StandardCharsets.UTF_8);
+            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated");
             localRepo.add(unrelated);
             var updatedMaster = localRepo.commit("Unrelated", "some", "some@one");
             localRepo.push(updatedMaster, author.authenticatedUrl(), "master");
@@ -954,7 +953,7 @@ class MergeTests {
 
             // Push something new to master
             localRepo.checkout(updatedMaster, true);
-            var newMaster = Files.writeString(localRepo.root().resolve("newmaster.txt"), "New on master", StandardCharsets.UTF_8);
+            var newMaster = Files.writeString(localRepo.root().resolve("newmaster.txt"), "New on master");
             localRepo.add(newMaster);
             var newMasterHash = localRepo.commit("New commit on master", "some", "some@one");
             localRepo.push(newMasterHash, author.authenticatedUrl(), "master");
@@ -1029,7 +1028,7 @@ class MergeTests {
             localRepo.checkout(masterHash, true);
 
             // Make a change with a corresponding PR
-            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated", StandardCharsets.UTF_8);
+            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated");
             localRepo.add(unrelated);
             var updatedMaster = localRepo.commit("Unrelated", "some", "some@one");
             localRepo.push(updatedMaster, author.authenticatedUrl(), "master");
@@ -1048,7 +1047,7 @@ class MergeTests {
 
             // Push something new to master
             localRepo.checkout(updatedMaster, true);
-            var newMaster = Files.writeString(localRepo.root().resolve("newmaster.txt"), "New on master", StandardCharsets.UTF_8);
+            var newMaster = Files.writeString(localRepo.root().resolve("newmaster.txt"), "New on master");
             localRepo.add(newMaster);
             var newMasterHash = localRepo.commit("New commit on master", "some", "some@one");
             localRepo.push(newMasterHash, author.authenticatedUrl(), "master");
@@ -1140,7 +1139,7 @@ class MergeTests {
             localRepo.checkout(masterHash, true);
 
             // Make a change with a corresponding PR
-            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated", StandardCharsets.UTF_8);
+            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated");
             localRepo.add(unrelated);
             localRepo.commit("Unrelated", "some", "some@one");
             localRepo.merge(otherHash);
@@ -1205,7 +1204,7 @@ class MergeTests {
             localRepo.checkout(masterHash, true);
 
             // Make a change with a corresponding PR
-            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated", StandardCharsets.UTF_8);
+            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated");
             localRepo.add(unrelated);
             var updatedMaster = localRepo.commit("Unrelated", "some", "some@one");
             localRepo.push(updatedMaster, author.authenticatedUrl(), "master");
@@ -1265,7 +1264,7 @@ class MergeTests {
             localRepo.checkout(masterHash, true);
 
             // Make a change with a corresponding PR
-            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated", StandardCharsets.UTF_8);
+            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated");
             localRepo.add(unrelated);
             var updatedMaster = localRepo.commit("Unrelated", "some", "some@one");
             localRepo.push(updatedMaster, author.authenticatedUrl(), "master");
@@ -1325,7 +1324,7 @@ class MergeTests {
             localRepo.checkout(masterHash, true);
 
             // Make a change with a corresponding PR
-            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated", StandardCharsets.UTF_8);
+            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated");
             localRepo.add(unrelated);
             var updatedMaster = localRepo.commit("Unrelated", "some", "some@one");
             localRepo.push(updatedMaster, author.authenticatedUrl(), "master");
@@ -1391,7 +1390,7 @@ class MergeTests {
 
             // Make a change with a corresponding PR
             localRepo.checkout(masterHash, true);
-            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated", StandardCharsets.UTF_8);
+            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated");
             localRepo.add(unrelated);
             var updatedMaster = localRepo.commit("Unrelated", "some", "some@one");
             localRepo.push(updatedMaster, author.authenticatedUrl(), "master");
@@ -1451,7 +1450,7 @@ class MergeTests {
             localRepo.checkout(masterHash, true);
 
             // Make a change with a corresponding PR
-            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated", StandardCharsets.UTF_8);
+            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated");
             localRepo.add(unrelated);
             var updatedMaster = localRepo.commit("Unrelated", "some", "some@one");
             localRepo.push(updatedMaster, author.authenticatedUrl(), "master");
@@ -1516,7 +1515,7 @@ class MergeTests {
             localRepo.checkout(masterHash, true);
 
             // Make a change with a corresponding PR
-            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated", StandardCharsets.UTF_8);
+            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated");
             localRepo.add(unrelated);
             localRepo.commit("Unrelated", "some", "some@one");
             var mergeCmd = Process.command("git", "merge", "--no-commit", "--allow-unrelated-histories", "-s", "ours", otherHash.hex())
@@ -1583,7 +1582,7 @@ class MergeTests {
             localRepo.checkout(masterHash, true);
 
             // Make a change with a corresponding PR
-            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated", StandardCharsets.UTF_8);
+            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated");
             localRepo.add(unrelated);
             var updatedMaster = localRepo.commit("Unrelated", "some", "some@one");
             localRepo.push(updatedMaster, author.authenticatedUrl(), "master");
@@ -1639,7 +1638,7 @@ class MergeTests {
             localRepo.checkout(masterHash, true);
 
             // Make a change with a corresponding PR
-            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated", StandardCharsets.UTF_8);
+            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated");
             localRepo.add(unrelated);
             var updatedMaster = localRepo.commit("Unrelated", "some", "some@one");
             localRepo.push(updatedMaster, author.authenticatedUrl(), "master");
@@ -1689,14 +1688,14 @@ class MergeTests {
             localRepo.checkout(masterHash, true);
 
             // Make a change with a corresponding PR
-            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated", StandardCharsets.UTF_8);
+            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated");
             localRepo.add(unrelated);
             var updatedMaster = localRepo.commit( "Unrelated", "some", "some@one");
             localRepo.push(updatedMaster, author.authenticatedUrl(), "master");
 
             // Go back to the original master again
             localRepo.checkout(masterHash, true);
-            var editChange = Files.writeString(localRepo.root().resolve("edit.txt"), "Edit", StandardCharsets.UTF_8);
+            var editChange = Files.writeString(localRepo.root().resolve("edit.txt"), "Edit");
             localRepo.add(editChange);
             var editHash = localRepo.commit( "Edit", "some", "some@one");
 
@@ -1755,7 +1754,7 @@ class MergeTests {
             localRepo.checkout(masterHash, true);
 
             // Make a change with a corresponding PR
-            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated", StandardCharsets.UTF_8);
+            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated");
             localRepo.add(unrelated);
             var updatedMaster = localRepo.commit("Unrelated", "some", "some@one");
             localRepo.push(updatedMaster, author.authenticatedUrl(), "master");
@@ -1800,9 +1799,9 @@ class MergeTests {
             localRepo.checkout(masterHash, true);
 
             // update
-            var defaultAppendable = Files.readString(localRepo.root().resolve("appendable.txt"), StandardCharsets.UTF_8);
+            var defaultAppendable = Files.readString(localRepo.root().resolve("appendable.txt"));
             var newAppendable = "11111\n" + defaultAppendable;
-            Files.writeString(localRepo.root().resolve("appendable.txt"), newAppendable, StandardCharsets.UTF_8);
+            Files.writeString(localRepo.root().resolve("appendable.txt"), newAppendable);
             localRepo.add(localRepo.root().resolve("appendable.txt"));
             localRepo.commit("updated", "test", "test@test.com");
 
@@ -1919,7 +1918,7 @@ class MergeTests {
             localRepo.checkout(masterHash, true);
 
             // Make a change with a corresponding PR
-            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated", StandardCharsets.UTF_8);
+            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated");
             localRepo.add(unrelated);
             var updatedMaster = localRepo.commit("Unrelated", "some", "some@one");
             localRepo.merge(otherHash2);
@@ -1975,7 +1974,7 @@ class MergeTests {
             localRepo.push(otherHash1, author.authenticatedUrl(), "other_/-1.2", true);
 
             var confPath = localRepoFolder.resolve(".jcheck/conf");
-            Files.writeString(confPath, "Hello there!", StandardCharsets.UTF_8);
+            Files.writeString(confPath, "Hello there!");
             localRepo.add(confPath);
             var otherHash2 = CheckableRepository.appendAndCommit(localRepo, "Second change in other_/-1.2\n\r",
                     "Second other_/-1.2\n\nReviewed-by: integrationreviewer2");
@@ -1985,7 +1984,7 @@ class MergeTests {
             localRepo.checkout(masterHash, true);
 
             // Make a change with a corresponding PR
-            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated", StandardCharsets.UTF_8);
+            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated");
             localRepo.add(unrelated);
             var updatedMaster = localRepo.commit("Unrelated", "some", "some@one");
             localRepo.merge(otherHash2);
@@ -2043,7 +2042,7 @@ class MergeTests {
             localRepo.checkout(masterHash, true);
 
             // Make a change with a corresponding PR
-            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated", StandardCharsets.UTF_8);
+            var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated");
             localRepo.add(unrelated);
             var updatedMaster = localRepo.commit("Unrelated", "some", "some@one");
             localRepo.push(updatedMaster, author.authenticatedUrl(), "master");

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ReviewersTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ReviewersTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@ import org.openjdk.skara.test.*;
 import org.junit.jupiter.api.*;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -452,7 +451,7 @@ public class ReviewersTests {
 
             // Change the jcheck configuration
             var confPath = localRepo.root().resolve(".jcheck/conf");
-            var defaultConf = Files.readString(confPath, StandardCharsets.UTF_8);
+            var defaultConf = Files.readString(confPath);
             var newConf = defaultConf.replace("reviewers=1", """
                                                     lead=1
                                                     reviewers=1
@@ -579,7 +578,7 @@ public class ReviewersTests {
 
             // Change the jcheck configuration
             var confPath = localRepo.root().resolve(".jcheck/conf");
-            var defaultConf = Files.readString(confPath, StandardCharsets.UTF_8);
+            var defaultConf = Files.readString(confPath);
             var newConf = defaultConf.replace("reviewers=1", """
                                                     lead=0
                                                     reviewers=0

--- a/cli/src/main/java/org/openjdk/skara/cli/debug/GitMlRules.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/debug/GitMlRules.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,6 @@ import org.openjdk.skara.vcs.openjdk.*;
 import java.io.*;
 import java.net.URI;
 import java.net.http.*;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.time.*;
 import java.time.format.DateTimeFormatter;
@@ -141,12 +140,12 @@ public class GitMlRules {
                                          var cacheFile = tmpFolder.resolve(req.uri().getPath().replace("/pipermail/", "").replace("/", "-"));
                                          if (Files.exists(cacheFile)) {
                                              log.fine("Reading " + req.uri() + " from cache");
-                                             return Files.readString(cacheFile, StandardCharsets.UTF_8);
+                                             return Files.readString(cacheFile);
                                          }
                                          System.out.println("Fetching " + req.uri().toString());
                                          var body = client.send(req, HttpResponse.BodyHandlers.ofString());
                                          System.out.println("Done fetching " + req.uri().toString());
-                                         Files.writeString(cacheFile, body.body(), StandardCharsets.UTF_8);
+                                         Files.writeString(cacheFile, body.body());
                                          return body.body();
                                      } catch (IOException | InterruptedException e) {
                                          throw new RuntimeException(e);
@@ -398,7 +397,7 @@ public class GitMlRules {
 
         RuleParser(String rulesFile) throws IOException {
             System.out.println("Reading rules file...");
-            var rules = JSON.parse(Files.readString(Path.of(rulesFile), StandardCharsets.UTF_8));
+            var rules = JSON.parse(Files.readString(Path.of(rulesFile)));
 
             matchers = rules.get("matchers").fields().stream()
                             .collect(Collectors.toMap(JSONObject.Field::name,
@@ -662,7 +661,7 @@ public class GitMlRules {
                     "\n}";
             if (arguments.contains("output")) {
                 System.out.println("Writing final output to " + arguments.get("output").asString());
-                Files.writeString(Path.of(arguments.get("output").asString()), finalResult, StandardCharsets.UTF_8);
+                Files.writeString(Path.of(arguments.get("output").asString()), finalResult);
             } else {
                 System.out.println(finalResult);
             }

--- a/forge/src/main/java/org/openjdk/skara/forge/internal/ForgeUtils.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/internal/ForgeUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,6 @@ package org.openjdk.skara.forge.internal;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.regex.Pattern;
@@ -49,7 +48,7 @@ public class ForgeUtils {
         var cfgFile = cfgPath.resolve("config");
         var existing = "";
         try {
-            existing = Files.readString(cfgFile, StandardCharsets.UTF_8);
+            existing = Files.readString(cfgFile);
         } catch (IOException ignored) {
         }
 
@@ -65,7 +64,7 @@ public class ForgeUtils {
                 "\n";
 
         try {
-            Files.writeString(cfgFile, result + filtered.strip() + "\n", StandardCharsets.UTF_8);
+            Files.writeString(cfgFile, result + filtered.strip() + "\n");
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/forge/src/test/java/org/openjdk/skara/forge/ForgeIntegrationTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/ForgeIntegrationTests.java
@@ -35,7 +35,6 @@ import org.openjdk.skara.test.TestProperties;
 import org.openjdk.skara.test.EnabledIfTestProperties;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
@@ -61,7 +60,7 @@ class ForgeIntegrationTests {
         var installation = props.get("github.app.installation");
         var keyFile = Paths.get(props.get("github.app.key.file"));
 
-        var keyContents = Files.readString(keyFile, StandardCharsets.UTF_8);
+        var keyContents = Files.readString(keyFile);
         var app = new GitHubApplication(keyContents, id, installation);
         var gitHubHost = new GitHubHost(uri, app, null, null, null, Set.of());
 

--- a/mailinglist/src/main/java/org/openjdk/skara/mailinglist/mboxfile/MboxFileListReader.java
+++ b/mailinglist/src/main/java/org/openjdk/skara/mailinglist/mboxfile/MboxFileListReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@ import org.openjdk.skara.email.*;
 import org.openjdk.skara.mailinglist.*;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.time.*;
 import java.util.*;
@@ -49,7 +48,7 @@ public class MboxFileListReader implements MailingListReader {
         for (var name : names) {
             try {
                 var file = base.resolve(name + ".mbox");
-                var currentMbox = Files.readString(file, StandardCharsets.UTF_8);
+                var currentMbox = Files.readString(file);
                 emails.addAll(Mbox.splitMbox(currentMbox, EmailAddress.from(name + "@mbox.file")));
             } catch (IOException e) {
                 log.info("Failed to open mbox file");

--- a/mailinglist/src/main/java/org/openjdk/skara/mailinglist/mboxfile/MboxFileListServer.java
+++ b/mailinglist/src/main/java/org/openjdk/skara/mailinglist/mboxfile/MboxFileListServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@ import org.openjdk.skara.email.Email;
 import org.openjdk.skara.mailinglist.*;
 
 import java.io.*;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.util.Arrays;
 import java.util.stream.Collectors;
@@ -50,10 +49,10 @@ public class MboxFileListServer implements MailingListServer {
             }
         }
         try {
-            Files.writeString(file, mboxMail, StandardCharsets.UTF_8, StandardOpenOption.APPEND);
+            Files.writeString(file, mboxMail, StandardOpenOption.APPEND);
         } catch (IOException e) {
             try {
-                Files.writeString(file, mboxMail, StandardCharsets.UTF_8, StandardOpenOption.CREATE_NEW);
+                Files.writeString(file, mboxMail, StandardOpenOption.CREATE_NEW);
             } catch (IOException e1) {
                 throw new UncheckedIOException(e);
             }
@@ -63,7 +62,7 @@ public class MboxFileListServer implements MailingListServer {
     private void postReply(Path file, Email mail) {
         var mboxMail = Mbox.fromMail(mail);
         try {
-            Files.writeString(file, mboxMail, StandardCharsets.UTF_8, StandardOpenOption.APPEND);
+            Files.writeString(file, mboxMail, StandardOpenOption.APPEND);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/mailinglist/src/test/java/org/openjdk/skara/mailinglist/MboxTests.java
+++ b/mailinglist/src/test/java/org/openjdk/skara/mailinglist/MboxTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,6 @@ import org.openjdk.skara.email.*;
 import org.openjdk.skara.test.TemporaryDirectory;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.time.Duration;
 
@@ -188,7 +187,7 @@ class MboxTests {
                                       Sometimes there are unencoded from lines as well
 
                                       From this point onwards, it may be hard to parse this
-                                      """, StandardCharsets.UTF_8);
+                                      """);
             var mbox = MailingListServerFactory.createMboxFileServer(folder.path());
             var list = mbox.getListReader("test");
             var conversations = list.conversations(Duration.ofDays(365 * 100));
@@ -221,8 +220,7 @@ class MboxTests {
                                       Message-ID: <def456@example.com>
 
                                       Second message
-                                      """,
-                              StandardCharsets.UTF_8);
+                                      """);
             var mbox = MailingListServerFactory.createMboxFileServer(folder.path());
             var list = mbox.getListReader("test");
             var conversations = list.conversations(Duration.ofDays(365 * 100));
@@ -262,8 +260,7 @@ class MboxTests {
                                       Message-ID: <def456@example.com>
 
                                       Second message
-                                      """,
-                              StandardCharsets.UTF_8);
+                                      """);
             var mbox = MailingListServerFactory.createMboxFileServer(folder.path());
             var list = mbox.getListReader("test");
             var conversations = list.conversations(Duration.ofDays(365 * 100));
@@ -303,8 +300,7 @@ class MboxTests {
                                       Message-ID: <ghi789@example.com>
 
                                       Third message
-                                      """,
-                              StandardCharsets.UTF_8);
+                                      """);
             var rawMbox2 = folder.path().resolve("test2.mbox");
             Files.writeString(rawMbox2, """
                                       From test3 at example.com  Wed Aug 21 17:42:50 2019
@@ -324,8 +320,7 @@ class MboxTests {
                                       Message-ID: <def456@example.com>
 
                                       Second message
-                                      """,
-                              StandardCharsets.UTF_8);
+                                      """);
             var mbox = MailingListServerFactory.createMboxFileServer(folder.path());
             var list = mbox.getListReader("test1", "test2");
             var conversations = list.conversations(Duration.ofDays(365 * 100));
@@ -356,8 +351,7 @@ class MboxTests {
                                       Message-ID: <ghi789@example.com>
 
                                       Third message
-                                      """,
-                              StandardCharsets.UTF_8);
+                                      """);
             var rawMbox2 = folder.path().resolve("test2.mbox");
             Files.writeString(rawMbox2, """
                                       From test2 at example.com  Wed Aug 21 17:32:50 2019
@@ -368,8 +362,7 @@ class MboxTests {
                                       Message-ID: <def456@example.com>
 
                                       Second message
-                                      """,
-                              StandardCharsets.UTF_8);
+                                      """);
             var mbox = MailingListServerFactory.createMboxFileServer(folder.path());
             var list = mbox.getListReader("test1", "test2");
             var conversations = list.conversations(Duration.ofDays(365 * 100));
@@ -407,8 +400,7 @@ class MboxTests {
                                       Message-ID: <ghi789@example.com>
 
                                       Third message
-                                      """,
-                    StandardCharsets.UTF_8);
+                                      """);
             var mbox = MailingListServerFactory.createMboxFileServer(folder.path());
             var list = mbox.getListReader("test1");
             var conversations = list.conversations(Duration.ofDays(365 * 100));

--- a/storage/src/main/java/org/openjdk/skara/storage/FileStorage.java
+++ b/storage/src/main/java/org/openjdk/skara/storage/FileStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,6 @@
 package org.openjdk.skara.storage;
 
 import java.io.*;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.util.*;
 
@@ -45,7 +44,7 @@ class FileStorage<T> implements Storage<T> {
     public Set<T> current() {
         if (current == null) {
             try {
-                current = Files.readString(file, StandardCharsets.UTF_8);
+                current = Files.readString(file);
             } catch (IOException e) {
                 current = "";
             }
@@ -68,7 +67,7 @@ class FileStorage<T> implements Storage<T> {
             if (!Files.exists(file)) {
                 Files.createFile(file);
             }
-            Files.writeString(file, updated, StandardCharsets.UTF_8);
+            Files.writeString(file, updated);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/test/src/main/java/org/openjdk/skara/test/CheckableRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/CheckableRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@ package org.openjdk.skara.test;
 import org.openjdk.skara.vcs.*;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.util.Set;
 
@@ -33,7 +32,7 @@ public class CheckableRepository {
     private static String markerLine = "The very first line\n";
 
     private static Path checkableFile(Path path) throws IOException {
-        try (var checkable = Files.newBufferedReader(path.resolve(".checkable/name.txt"), StandardCharsets.UTF_8)) {
+        try (var checkable = Files.newBufferedReader(path.resolve(".checkable/name.txt"))) {
             var checkableName = checkable.readLine();
             return path.resolve(checkableName);
         }

--- a/test/src/main/java/org/openjdk/skara/test/HostCredentials.java
+++ b/test/src/main/java/org/openjdk/skara/test/HostCredentials.java
@@ -74,7 +74,7 @@ public class HostCredentials implements AutoCloseable {
             var apps = config.get("apps").asArray();
             var key = configDir.resolve(apps.get(userIndex).get("key").asString());
             try {
-                var keyContents = Files.readString(key, StandardCharsets.UTF_8);
+                var keyContents = Files.readString(key);
                 var pat = new Credential(apps.get(userIndex).get("id").asString() + ";" +
                                                  apps.get(userIndex).get("installation").asString(),
                                          keyContents);
@@ -290,7 +290,7 @@ public class HostCredentials implements AutoCloseable {
             }
 
             if (Files.exists(lockFile)) {
-                var currentLock = Files.readString(lockFile, StandardCharsets.UTF_8).strip();
+                var currentLock = Files.readString(lockFile).strip();
                 var lockTime = ZonedDateTime.parse(currentLock, DateTimeFormatter.ISO_DATE_TIME);
                 if (lockTime.isBefore(ZonedDateTime.now().minus(Duration.ofMinutes(10)))) {
                     log.info("Stale lock encountered - overwriting it");
@@ -324,7 +324,7 @@ public class HostCredentials implements AutoCloseable {
 
     public Hash commitLock(Repository localRepo) throws IOException {
         var lockFile = localRepo.root().resolve("lock.txt");
-        Files.writeString(lockFile, ZonedDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME), StandardCharsets.UTF_8);
+        Files.writeString(lockFile, ZonedDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME));
         localRepo.add(lockFile);
         var lockHash = localRepo.commit("Lock", "test", "test@test.test");
         localRepo.branch(lockHash, "testlock");

--- a/test/src/main/java/org/openjdk/skara/test/TestHost.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHost.java
@@ -33,7 +33,6 @@ import org.openjdk.skara.vcs.*;
 import java.io.*;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.time.ZonedDateTime;
 import java.util.*;
@@ -157,7 +156,7 @@ public class TestHost implements Forge, IssueTracker {
         data.folders.add(folder);
         try {
             var repo = TestableRepository.init(folder.path().resolve("hosted.git"), VCS.GIT);
-            Files.writeString(repo.root().resolve("content.txt"), "Initial content", StandardCharsets.UTF_8);
+            Files.writeString(repo.root().resolve("content.txt"), "Initial content");
             repo.add(repo.root().resolve("content.txt"));
             var hash = repo.commit("Initial content", "author", "author@none");
             repo.push(hash, repo.root().toUri(), "testhostcontent");

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Diff.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Diff.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@ import java.io.StringWriter;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import java.nio.file.Files;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -78,7 +77,7 @@ public class Diff {
     }
 
     public void toFile(Path p) throws IOException {
-        try (var w = Files.newBufferedWriter(p, StandardCharsets.UTF_8)) {
+        try (var w = Files.newBufferedWriter(p)) {
             write(w);
         }
     }

--- a/webrev/src/main/java/org/openjdk/skara/webrev/Webrev.java
+++ b/webrev/src/main/java/org/openjdk/skara/webrev/Webrev.java
@@ -30,7 +30,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.channels.FileChannel;
 import java.nio.file.*;
-import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -331,9 +330,9 @@ public class Webrev {
                 commits.add(c);
             }
 
-            Files.writeString(output.resolve("metadata.json"), metadata.toString(), StandardCharsets.UTF_8);
-            Files.writeString(output.resolve("comparison.json"), comparison.toString(), StandardCharsets.UTF_8);
-            Files.writeString(output.resolve("commits.json"), commits.toString(), StandardCharsets.UTF_8);
+            Files.writeString(output.resolve("metadata.json"), metadata.toString());
+            Files.writeString(output.resolve("comparison.json"), comparison.toString());
+            Files.writeString(output.resolve("commits.json"), commits.toString());
         }
 
         private void generate(Diff diff, Hash tailEnd, Hash head) throws IOException, DiffTooLargeException {

--- a/webrev/src/test/java/org/openjdk/skara/webrev/WebrevTests.java
+++ b/webrev/src/test/java/org/openjdk/skara/webrev/WebrevTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -48,10 +47,10 @@ class WebrevTests {
              var webrevFolder = new TemporaryDirectory()) {
             var repo = TestableRepository.init(repoFolder.path(), vcs);
             var file = repoFolder.path().resolve("x.txt");
-            Files.writeString(file, "1\n2\n3\n", StandardCharsets.UTF_8);
+            Files.writeString(file, "1\n2\n3\n");
             repo.add(file);
             var hash1 = repo.commit("Commit", "a", "a@a.a");
-            Files.writeString(file, "1\n2\n3\n4\n", StandardCharsets.UTF_8);
+            Files.writeString(file, "1\n2\n3\n4\n");
             repo.add(file);
             var hash2 = repo.commit("Commit 2", "a", "a@a.a");
 
@@ -68,10 +67,10 @@ class WebrevTests {
              var webrevFolder = new TemporaryDirectory()) {
             var repo = TestableRepository.init(repoFolder.path(), vcs);
             var file = repoFolder.path().resolve("x.txt");
-            Files.writeString(file, "1\n2\n3\n4\n5\n6\n7\n8\n9\n", StandardCharsets.UTF_8);
+            Files.writeString(file, "1\n2\n3\n4\n5\n6\n7\n8\n9\n");
             repo.add(file);
             var hash1 = repo.commit("Commit", "a", "a@a.a");
-            Files.writeString(file, "1\n2\n3\n4\n5\n5.1\n5.2\n6\n7\n8\n9\n", StandardCharsets.UTF_8);
+            Files.writeString(file, "1\n2\n3\n4\n5\n5.1\n5.2\n6\n7\n8\n9\n");
             repo.add(file);
             var hash2 = repo.commit("Commit 2", "a", "a@a.a");
 
@@ -87,10 +86,10 @@ class WebrevTests {
         var webrevFolder = new TemporaryDirectory()) {
             var repo = TestableRepository.init(repoFolder.path(), vcs);
             var file = repoFolder.path().resolve("x.txt");
-            Files.writeString(file, "1\n2\n3\n", StandardCharsets.UTF_8);
+            Files.writeString(file, "1\n2\n3\n");
             repo.add(file);
             var hash1 = repo.commit("Commit", "a", "a@a.a");
-            Files.writeString(file, "0\n1\n2\n3\n", StandardCharsets.UTF_8);
+            Files.writeString(file, "0\n1\n2\n3\n");
             repo.add(file);
             var hash2 = repo.commit("Commit 2", "a", "a@a.a");
 
@@ -106,10 +105,10 @@ class WebrevTests {
              var webrevFolder = new TemporaryDirectory()) {
             var repo = TestableRepository.init(repoFolder.path(), vcs);
             var file = repoFolder.path().resolve("x.txt");
-            Files.writeString(file, "1\n2\n3\n4\n5\n6\n7\n8\n9\n", StandardCharsets.UTF_8);
+            Files.writeString(file, "1\n2\n3\n4\n5\n6\n7\n8\n9\n");
             repo.add(file);
             var hash1 = repo.commit("Commit", "a", "a@a.a");
-            Files.writeString(file, "5\n6\n7\n8\n9\n", StandardCharsets.UTF_8);
+            Files.writeString(file, "5\n6\n7\n8\n9\n");
             repo.add(file);
             var hash2 = repo.commit("Commit 2", "a", "a@a.a");
 
@@ -183,10 +182,10 @@ class WebrevTests {
              var webrevFolder = new TemporaryDirectory()) {
             var repo = TestableRepository.init(repoFolder.path(), vcs);
             var file = repoFolder.path().resolve("index.html");
-            Files.writeString(file, "1\n2\n3\n", StandardCharsets.UTF_8);
+            Files.writeString(file, "1\n2\n3\n");
             repo.add(file);
             var hash1 = repo.commit("Commit", "a", "a@a.a");
-            Files.writeString(file, "1\n2\n3\n4\n", StandardCharsets.UTF_8);
+            Files.writeString(file, "1\n2\n3\n4\n");
             repo.add(file);
             var hash2 = repo.commit("Commit 2", "a", "a@a.a");
 

--- a/xml/src/main/java/org/openjdk/skara/xml/XML.java
+++ b/xml/src/main/java/org/openjdk/skara/xml/XML.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,6 @@
 package org.openjdk.skara.xml;
 
 import java.io.*;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.util.*;
 import org.w3c.dom.*;
@@ -39,7 +38,7 @@ public class XML {
         try {
             var factory = DocumentBuilderFactory.newInstance();
             var builder = factory.newDocumentBuilder();
-            return builder.parse(new InputSource(new ByteArrayInputStream(p.getBytes(StandardCharsets.UTF_8))));
+            return builder.parse(new InputSource(new StringReader(p)));
         } catch (ParserConfigurationException | SAXException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
Please review this clean-up. It's about not specifying UTF-8 encoding when it's the default, such as in `Files.{readString, writeString}`.

The change is very uniform, except for two cases, where specifying the encoding was avoided by slightly more involved refactoring:

  * `JsonWriter:44`
  * `XML:42`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2316](https://bugs.openjdk.org/browse/SKARA-2316): Prefer not to specify UTF-8 if it's used by default (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1668/head:pull/1668` \
`$ git checkout pull/1668`

Update a local copy of the PR: \
`$ git checkout pull/1668` \
`$ git pull https://git.openjdk.org/skara.git pull/1668/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1668`

View PR using the GUI difftool: \
`$ git pr show -t 1668`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1668.diff">https://git.openjdk.org/skara/pull/1668.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1668#issuecomment-2210544376)