### PR TITLE
2317: Avoid use of deprecated Thread.getId()

### DIFF
--- a/bot/src/test/java/org/openjdk/skara/bot/BotTaskAggregationHandlerTests.java
+++ b/bot/src/test/java/org/openjdk/skara/bot/BotTaskAggregationHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -116,9 +116,9 @@ class BotTaskAggregationHandlerTests {
                 Logger log = Logger.getGlobal();
                 countDownLatch.await();
                 for (int i = 0; i < numLoops; ++i) {
-                    log.log(Level.FINEST, Long.toString(Thread.currentThread().getId()), BotRunner.TaskPhases.BEGIN);
-                    log.log(Level.FINEST, Long.toString(Thread.currentThread().getId()), BotRunner.TaskPhases.END);
-                    log.log(Level.FINEST, Long.toString(Thread.currentThread().getId()));
+                    log.log(Level.FINEST, Long.toString(Thread.currentThread().threadId()), BotRunner.TaskPhases.BEGIN);
+                    log.log(Level.FINEST, Long.toString(Thread.currentThread().threadId()), BotRunner.TaskPhases.END);
+                    log.log(Level.FINEST, Long.toString(Thread.currentThread().threadId()));
                 }
             } catch (InterruptedException e) {
                 fail(e);


### PR DESCRIPTION
`Thread.getId()` was deprecated in JDK 19, as part of [JDK-8284161]. Skara build now produces warnings because of that method:

    Task :bot:compileTestJava
    Note: skara/bot/src/test/java/org/openjdk/skara/bot/BotTaskAggregationHandlerTests.java uses or overrides a deprecated API.

[JDK-8284161]: https://bugs.openjdk.org/browse/JDK-8284161

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2317](https://bugs.openjdk.org/browse/SKARA-2317): Avoid use of deprecated Thread.getId() (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1669/head:pull/1669` \
`$ git checkout pull/1669`

Update a local copy of the PR: \
`$ git checkout pull/1669` \
`$ git pull https://git.openjdk.org/skara.git pull/1669/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1669`

View PR using the GUI difftool: \
`$ git pr show -t 1669`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1669.diff">https://git.openjdk.org/skara/pull/1669.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1669#issuecomment-2210601364)