### PR TITLE
2318: Prefer Thread.sleep(Duration)

### DIFF
--- a/bot/src/main/java/org/openjdk/skara/bot/BotWatchdog.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotWatchdog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@ import java.time.Duration;
 
 public class BotWatchdog {
     private final Thread watchThread;
-    private final long maxWaitMillis;
     private final Duration maxWait;
     private final Runnable callBack;
     private volatile boolean hasBeenPinged = false;
@@ -34,7 +33,7 @@ public class BotWatchdog {
     private void threadMain() {
         while (true) {
             try {
-                Thread.sleep(maxWaitMillis);
+                Thread.sleep(maxWait);
                 if (!hasBeenPinged) {
                     System.out.println("No watchdog ping detected for " + maxWait + " - exiting...");
                     callBack.run();
@@ -49,7 +48,6 @@ public class BotWatchdog {
     BotWatchdog(Duration maxWait, Runnable callBack) {
         this.maxWait = maxWait;
         this.callBack = callBack;
-        maxWaitMillis = maxWait.toMillis();
         watchThread = new Thread(this::threadMain);
         watchThread.setName("BotWatchdog");
         watchThread.setDaemon(true);

--- a/bots/cli/src/test/java/org/openjdk/skara/bots/cli/BotSlackHandlerTests.java
+++ b/bots/cli/src/test/java/org/openjdk/skara/bots/cli/BotSlackHandlerTests.java
@@ -98,7 +98,7 @@ class BotSlackHandlerTests {
             assertEquals("test", lastRequest.get("username").asString(), lastRequest.toString());
             assertTrue(lastRequest.get("text").asString().contains("Hello"), lastRequest.toString());
 
-            Thread.sleep(maxDuration.toMillis());
+            Thread.sleep(maxDuration);
             var record = new LogRecord(Level.INFO, "Hello a final time!");
             handler.publish(record);
             lastRequest = requests.getLast().asObject();

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
@@ -277,7 +277,7 @@ class WebrevStorage {
                     }
                 }
                 log.info(response.statusCode() + " when checking " + uncachedUri + " - waiting...");
-                Thread.sleep(Duration.ofSeconds(10).toMillis());
+                Thread.sleep(Duration.ofSeconds(10));
             } catch (InterruptedException ignored) {
             }
         }

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -2667,7 +2667,7 @@ class MailingListBridgeBotTests {
             pr.setBody("This is now ready");
 
             var mlBot = mlBotBuilder.cooldown(cooldown).build();
-            Thread.sleep(cooldown.toMillis());
+            Thread.sleep(cooldown);
             TestBotRunner.runPeriodicItems(mlBot);
             listServer.processIncoming();
 
@@ -2692,7 +2692,7 @@ class MailingListBridgeBotTests {
                 } else {
                     log.info("Didn't do the test in time - retrying (elapsed: " + elapsed + " required: " + cooldown + ")");
                     // Ensure that the cooldown expires
-                    Thread.sleep(cooldown.toMillis());
+                    Thread.sleep(cooldown);
                     // If no mail was received, we have to flush it out
                     if (noMailReceived) {
                         TestBotRunner.runPeriodicItems(mlBot);
@@ -2705,7 +2705,7 @@ class MailingListBridgeBotTests {
             assertTrue(noMailReceived);
 
             // But after the cooldown period has passed, it should
-            Thread.sleep(cooldown.toMillis());
+            Thread.sleep(cooldown);
             TestBotRunner.runPeriodicItems(mlBot);
             listServer.processIncoming();
 
@@ -2931,7 +2931,7 @@ class MailingListBridgeBotTests {
             pr.setBody("This is now ready");
 
             var mlBot = mlBotBuilder.cooldown(cooldown).build();
-            Thread.sleep(cooldown.toMillis());
+            Thread.sleep(cooldown);
             TestBotRunner.runPeriodicItems(mlBot);
             listServer.processIncoming();
 
@@ -2957,7 +2957,7 @@ class MailingListBridgeBotTests {
                 } else {
                     log.info("Didn't do the test in time - retrying (elapsed: " + elapsed + " required: " + cooldown + ")");
                     // Ensure that the cooldown expires
-                    Thread.sleep(cooldown.toMillis());
+                    Thread.sleep(cooldown);
                     // If no mail was received, we have to flush it out
                     if (noMailReceived) {
                         TestBotRunner.runPeriodicItems(mlBot);
@@ -2970,7 +2970,7 @@ class MailingListBridgeBotTests {
             assertTrue(noMailReceived);
 
             // But after the cooldown period has passed, it should
-            Thread.sleep(cooldown.toMillis());
+            Thread.sleep(cooldown);
             TestBotRunner.runPeriodicItems(mlBot);
             listServer.processIncoming();
 

--- a/bots/submit/src/main/java/org/openjdk/skara/bots/submit/ShellExecutor.java
+++ b/bots/submit/src/main/java/org/openjdk/skara/bots/submit/ShellExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -88,7 +88,7 @@ public class ShellExecutor implements SubmitExecutor {
 
             var watchdog = new Thread(() -> {
                 try {
-                    Thread.sleep(timeout.toMillis());
+                    Thread.sleep(timeout);
                 } catch (InterruptedException ignored) {
                 }
                 process.destroyForcibly();

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubHost.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubHost.java
@@ -300,7 +300,7 @@ public class GitHubHost implements Forge {
             }
             log.fine("Searching too fast - waiting");
             try {
-                Thread.sleep(Duration.ofMillis(500).toMillis());
+                Thread.sleep(Duration.ofMillis(500));
             } catch (InterruptedException ignored) {
             }
         }

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -406,7 +406,7 @@ public class GitLabRepository implements HostedRepository {
         var forkedRepoName = namespace + "/" + nameOnly;
         while (!gitLabHost.isProjectForkComplete(forkedRepoName)) {
             try {
-                Thread.sleep(Duration.ofSeconds(1).toMillis());
+                Thread.sleep(Duration.ofSeconds(1));
             } catch (InterruptedException e) {
                 e.printStackTrace();
             }

--- a/mailinglist/src/main/java/org/openjdk/skara/mailinglist/mailman/MailmanServer.java
+++ b/mailinglist/src/main/java/org/openjdk/skara/mailinglist/mailman/MailmanServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,7 +55,7 @@ public class MailmanServer implements MailingListServer {
     void sendMessage(Email message) {
         while (lastSend.plus(sendInterval).isAfter(Instant.now())) {
             try {
-                Thread.sleep(sendInterval.dividedBy(10).toMillis());
+                Thread.sleep(sendInterval.dividedBy(10));
             } catch (InterruptedException ignored) {
             }
         }

--- a/network/src/main/java/org/openjdk/skara/network/RestRequest.java
+++ b/network/src/main/java/org/openjdk/skara/network/RestRequest.java
@@ -348,7 +348,7 @@ public class RestRequest {
             } catch (InterruptedException | IOException e) {
                 if (retryCount < 5) {
                     try {
-                        Thread.sleep(retryCount * retryBackoffStep.toMillis());
+                        Thread.sleep(retryBackoffStep.multipliedBy(retryCount));
                     } catch (InterruptedException ignored) {
                     }
                 } else {

--- a/network/src/main/java/org/openjdk/skara/network/RestRequestCache.java
+++ b/network/src/main/java/org/openjdk/skara/network/RestRequestCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -232,7 +232,7 @@ enum RestRequestCache {
                 var requiredDelay = Duration.between(Instant.now().minus(Duration.ofSeconds(1)), lastUpdate);
                 if (!requiredDelay.isNegative()) {
                     try {
-                        Thread.sleep(requiredDelay.toMillis());
+                        Thread.sleep(requiredDelay);
                     } catch (InterruptedException e) {
                         Thread.currentThread().interrupt();
                     }

--- a/test/src/main/java/org/openjdk/skara/test/HostCredentials.java
+++ b/test/src/main/java/org/openjdk/skara/test/HostCredentials.java
@@ -355,7 +355,7 @@ public class HostCredentials implements AutoCloseable {
                     throw e;
                 }
                 try {
-                    Thread.sleep(Duration.ofSeconds(1).toMillis());
+                    Thread.sleep(Duration.ofSeconds(1));
                     retryCount++;
                 } catch (InterruptedException ignored) {
                 }


### PR DESCRIPTION
`Thread.sleep(java.time.Duration)` was introduced in JDK 19, as part of [JDK-8284161], and standardised in JDK 21, as part of [JDK-8304919].

[JDK-8284161]: https://bugs.openjdk.org/browse/JDK-8284161
[JDK-8304919]: https://bugs.openjdk.org/browse/JDK-8304919

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2318](https://bugs.openjdk.org/browse/SKARA-2318): Prefer Thread.sleep(Duration) (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1670/head:pull/1670` \
`$ git checkout pull/1670`

Update a local copy of the PR: \
`$ git checkout pull/1670` \
`$ git pull https://git.openjdk.org/skara.git pull/1670/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1670`

View PR using the GUI difftool: \
`$ git pr show -t 1670`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1670.diff">https://git.openjdk.org/skara/pull/1670.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1670#issuecomment-2210632531)