### PR TITLE
2312: Do not require re-review for a simple merge

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -113,7 +113,7 @@ class CheckRun {
             reviewMerge = MergePullRequestReviewConfiguration.ALWAYS;
         }
 
-        reviewCoverage = new ReviewCoverage(workItem.bot.useStaleReviews(), workItem.bot.acceptSimpleMerges(), localRepo);
+        reviewCoverage = new ReviewCoverage(workItem.bot.useStaleReviews(), workItem.bot.acceptSimpleMerges(), localRepo, pr);
         baseHash = PullRequestUtils.baseHash(pr, localRepo);
         checkablePullRequest = new CheckablePullRequest(pr, localRepo, useStaleReviews,
                 workItem.bot.confOverrideRepository().orElse(null),
@@ -607,7 +607,7 @@ class CheckRun {
                                    } else {
                                        var hash = review.hash();
                                        if (hash.isPresent()) {
-                                           if (!reviewCoverage.covers(review, pr)) {
+                                           if (!reviewCoverage.covers(review)) {
                                                entry += " 🔄 Re-review required (review applies to [" + hash.get().abbreviate()
                                                        + "](" + pr.filesUrl(hash.get()) + "))";
                                            } else {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -712,7 +712,7 @@ class CheckWorkItem extends PullRequestWorkItem {
                 Repository localRepo = materializeLocalRepo(scratchArea, hostedRepositoryPool);
 
                 var expiresAt = CheckRun.execute(this, pr, localRepo, comments, allReviews,
-                        activeReviews, labels, census, bot.ignoreStaleReviews(), bot.integrators(), bot.reviewCleanBackport(),
+                        activeReviews, labels, census, bot.useStaleReviews(), bot.integrators(), bot.reviewCleanBackport(),
                         bot.reviewMerge(), bot.approval());
                 if (log.isLoggable(Level.INFO)) {
                     // Log latency from the original updatedAt of the PR when this WorkItem

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
@@ -45,17 +45,17 @@ public class CheckablePullRequest {
 
     private final PullRequest pr;
     private final Repository localRepo;
-    private final boolean ignoreStaleReviews;
+    private final boolean useStaleReviews;
     private final List<String> confOverride;
     private final List<Comment> comments;
     private final MergePullRequestReviewConfiguration reviewMerge;
     private final ReviewCoverage reviewCoverage;
 
-    CheckablePullRequest(PullRequest pr, Repository localRepo, boolean ignoreStaleReviews,
+    CheckablePullRequest(PullRequest pr, Repository localRepo, boolean useStaleReviews,
             HostedRepository jcheckRepo, String jcheckName, String jcheckRef, List<Comment> comments, MergePullRequestReviewConfiguration reviewMerge, ReviewCoverage reviewCoverage) {
         this.pr = pr;
         this.localRepo = localRepo;
-        this.ignoreStaleReviews = ignoreStaleReviews;
+        this.useStaleReviews = useStaleReviews;
         this.comments = comments;
         this.reviewMerge = reviewMerge;
         this.reviewCoverage = reviewCoverage;
@@ -78,7 +78,7 @@ public class CheckablePullRequest {
 
         if (manualReviewersAndStaleReviewers) {
             reviewers.addAll(Reviewers.reviewers(currentUser, comments));
-            if (ignoreStaleReviews) {
+            if (!useStaleReviews) {
                 var staleReviews = new ArrayList<Review>();
                 for (var review : activeReviews) {
                     if (review.verdict() == Review.Verdict.APPROVED && !eligibleReviews.contains(review)) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
@@ -71,7 +71,7 @@ public class CheckablePullRequest {
 
     private String commitMessage(Hash head, List<Review> activeReviews, Namespace namespace, boolean manualReviewersAndStaleReviewers, Hash original) throws IOException {
         var eligibleReviews = activeReviews.stream()
-                                           .filter(review -> reviewCoverage.covers(review, pr))
+                                           .filter(reviewCoverage::covers)
                                            .collect(Collectors.toList());
         var reviewers = reviewerNames(eligibleReviews, namespace);
         var currentUser = pr.repository().forge().currentUser();

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
@@ -198,7 +198,8 @@ public class IntegrateCommand implements CommandHandler {
                     bot.confOverrideName(),
                     bot.confOverrideRef(),
                     allComments,
-                    bot.reviewMerge());
+                    bot.reviewMerge(),
+                    new ReviewCoverage(bot.ignoreStaleReviews(), bot.includeSimpleMerges(), localRepo));
 
             if (targetHash != null && !checkablePr.targetHash().equals(targetHash)) {
                 reply.print("The head of the target branch is no longer at the requested hash " + targetHash);

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
@@ -193,13 +193,13 @@ public class IntegrateCommand implements CommandHandler {
             pr = pr.repository().pullRequest(pr.id());
 
             Repository localRepo = materializeLocalRepo(bot, pr, scratchArea);
-            var checkablePr = new CheckablePullRequest(pr, localRepo, bot.ignoreStaleReviews(),
+            var checkablePr = new CheckablePullRequest(pr, localRepo, bot.useStaleReviews(),
                     bot.confOverrideRepository().orElse(null),
                     bot.confOverrideName(),
                     bot.confOverrideRef(),
                     allComments,
                     bot.reviewMerge(),
-                    new ReviewCoverage(bot.ignoreStaleReviews(), bot.includeSimpleMerges(), localRepo));
+                    new ReviewCoverage(bot.useStaleReviews(), bot.acceptSimpleMerges(), localRepo));
 
             if (targetHash != null && !checkablePr.targetHash().equals(targetHash)) {
                 reply.print("The head of the target branch is no longer at the requested hash " + targetHash);

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IntegrateCommand.java
@@ -199,7 +199,7 @@ public class IntegrateCommand implements CommandHandler {
                     bot.confOverrideRef(),
                     allComments,
                     bot.reviewMerge(),
-                    new ReviewCoverage(bot.useStaleReviews(), bot.acceptSimpleMerges(), localRepo));
+                    new ReviewCoverage(bot.useStaleReviews(), bot.acceptSimpleMerges(), localRepo, pr));
 
             if (targetHash != null && !checkablePr.targetHash().equals(targetHash)) {
                 reply.print("The head of the target branch is no longer at the requested hash " + targetHash);

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -49,8 +49,8 @@ class PullRequestBot implements Bot {
     private final Set<String> twentyFourHoursLabels;
     private final Map<String, Pattern> readyComments;
     private final IssueProject issueProject;
-    private final boolean ignoreStaleReviews;
-    private final boolean includeSimpleMerges;
+    private final boolean useStaleReviews;
+    private final boolean acceptSimpleMerges;
     private final Pattern allowedTargetBranches;
     private final Path seedStorage;
     private final HostedRepository confOverrideRepo;
@@ -90,7 +90,7 @@ class PullRequestBot implements Bot {
                    Map<String, String> blockingCheckLabels, Set<String> readyLabels,
                    Set<String> twoReviewersLabels, Set<String> twentyFourHoursLabels,
                    Map<String, Pattern> readyComments, IssueProject issueProject,
-                   boolean ignoreStaleReviews, boolean includeSimpleMerges, Pattern allowedTargetBranches,
+                   boolean useStaleReviews, boolean acceptSimpleMerges, Pattern allowedTargetBranches,
                    Path seedStorage, HostedRepository confOverrideRepo, String confOverrideName,
                    String confOverrideRef, String censusLink, Map<String, HostedRepository> forks,
                    Set<String> integrators, Set<Integer> excludeCommitCommentsFrom, boolean enableCsr, boolean enableJep,
@@ -109,8 +109,8 @@ class PullRequestBot implements Bot {
         this.twentyFourHoursLabels = twentyFourHoursLabels;
         this.issueProject = issueProject;
         this.readyComments = readyComments;
-        this.ignoreStaleReviews = ignoreStaleReviews;
-        this.includeSimpleMerges = includeSimpleMerges;
+        this.useStaleReviews = useStaleReviews;
+        this.acceptSimpleMerges = acceptSimpleMerges;
         this.allowedTargetBranches = allowedTargetBranches;
         this.seedStorage = seedStorage;
         this.confOverrideRepo = confOverrideRepo;
@@ -300,12 +300,12 @@ class PullRequestBot implements Bot {
         return issueProject;
     }
 
-    boolean ignoreStaleReviews() {
-        return ignoreStaleReviews;
+    boolean useStaleReviews() {
+        return useStaleReviews;
     }
 
-    boolean includeSimpleMerges() {
-        return includeSimpleMerges;
+    boolean acceptSimpleMerges() {
+        return acceptSimpleMerges;
     }
 
     Pattern allowedTargetBranches() {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -50,6 +50,7 @@ class PullRequestBot implements Bot {
     private final Map<String, Pattern> readyComments;
     private final IssueProject issueProject;
     private final boolean ignoreStaleReviews;
+    private final boolean includeSimpleMerges;
     private final Pattern allowedTargetBranches;
     private final Path seedStorage;
     private final HostedRepository confOverrideRepo;
@@ -89,7 +90,7 @@ class PullRequestBot implements Bot {
                    Map<String, String> blockingCheckLabels, Set<String> readyLabels,
                    Set<String> twoReviewersLabels, Set<String> twentyFourHoursLabels,
                    Map<String, Pattern> readyComments, IssueProject issueProject,
-                   boolean ignoreStaleReviews, Pattern allowedTargetBranches,
+                   boolean ignoreStaleReviews, boolean includeSimpleMerges, Pattern allowedTargetBranches,
                    Path seedStorage, HostedRepository confOverrideRepo, String confOverrideName,
                    String confOverrideRef, String censusLink, Map<String, HostedRepository> forks,
                    Set<String> integrators, Set<Integer> excludeCommitCommentsFrom, boolean enableCsr, boolean enableJep,
@@ -109,6 +110,7 @@ class PullRequestBot implements Bot {
         this.issueProject = issueProject;
         this.readyComments = readyComments;
         this.ignoreStaleReviews = ignoreStaleReviews;
+        this.includeSimpleMerges = includeSimpleMerges;
         this.allowedTargetBranches = allowedTargetBranches;
         this.seedStorage = seedStorage;
         this.confOverrideRepo = confOverrideRepo;
@@ -300,6 +302,10 @@ class PullRequestBot implements Bot {
 
     boolean ignoreStaleReviews() {
         return ignoreStaleReviews;
+    }
+
+    boolean includeSimpleMerges() {
+        return includeSimpleMerges;
     }
 
     Pattern allowedTargetBranches() {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
@@ -43,8 +43,8 @@ public class PullRequestBotBuilder {
     private Set<String> twentyFourHoursLabels = Set.of();
     private Map<String, Pattern> readyComments = Map.of();
     private IssueProject issueProject = null;
-    private boolean ignoreStaleReviews = false;
-    private boolean includeSimpleMerges = false;
+    private boolean useStaleReviews = true;
+    private boolean acceptSimpleMerges = false;
     private Pattern allowedTargetBranches = Pattern.compile(".*");
     private Path seedStorage = null;
     private HostedRepository confOverrideRepo = null;
@@ -133,13 +133,13 @@ public class PullRequestBotBuilder {
         return this;
     }
 
-    public PullRequestBotBuilder ignoreStaleReviews(boolean ignoreStaleReviews) {
-        this.ignoreStaleReviews = ignoreStaleReviews;
+    public PullRequestBotBuilder useStaleReviews(boolean useStaleReviews) {
+        this.useStaleReviews = useStaleReviews;
         return this;
     }
 
-    public PullRequestBotBuilder includeSimpleMerges(boolean includeSimpleMerges) {
-        this.includeSimpleMerges = includeSimpleMerges;
+    public PullRequestBotBuilder acceptSimpleMerges(boolean acceptSimpleMerges) {
+        this.acceptSimpleMerges = acceptSimpleMerges;
         return this;
     }
 
@@ -266,7 +266,7 @@ public class PullRequestBotBuilder {
     public PullRequestBot build() {
         return new PullRequestBot(repo, censusRepo, censusRef, labelConfiguration, externalPullRequestCommands,
                 externalCommitCommands, blockingCheckLabels, readyLabels, twoReviewersLabels, twentyFourHoursLabels,
-                readyComments, issueProject, ignoreStaleReviews, includeSimpleMerges, allowedTargetBranches, seedStorage, confOverrideRepo,
+                readyComments, issueProject, useStaleReviews, acceptSimpleMerges, allowedTargetBranches, seedStorage, confOverrideRepo,
                 confOverrideName, confOverrideRef, censusLink, forks, integrators, excludeCommitCommentsFrom, enableCsr,
                 enableJep, reviewCleanBackport, mlbridgeBotName, reviewMerge, processPR, processCommit, enableMerge,
                 mergeSources, jcheckMerge, enableBackport, issuePRMap, approval, versionMismatchWarning, cleanCommandEnabled);

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
@@ -44,6 +44,7 @@ public class PullRequestBotBuilder {
     private Map<String, Pattern> readyComments = Map.of();
     private IssueProject issueProject = null;
     private boolean ignoreStaleReviews = false;
+    private boolean includeSimpleMerges = false;
     private Pattern allowedTargetBranches = Pattern.compile(".*");
     private Path seedStorage = null;
     private HostedRepository confOverrideRepo = null;
@@ -134,6 +135,11 @@ public class PullRequestBotBuilder {
 
     public PullRequestBotBuilder ignoreStaleReviews(boolean ignoreStaleReviews) {
         this.ignoreStaleReviews = ignoreStaleReviews;
+        return this;
+    }
+
+    public PullRequestBotBuilder includeSimpleMerges(boolean includeSimpleMerges) {
+        this.includeSimpleMerges = includeSimpleMerges;
         return this;
     }
 
@@ -260,7 +266,7 @@ public class PullRequestBotBuilder {
     public PullRequestBot build() {
         return new PullRequestBot(repo, censusRepo, censusRef, labelConfiguration, externalPullRequestCommands,
                 externalCommitCommands, blockingCheckLabels, readyLabels, twoReviewersLabels, twentyFourHoursLabels,
-                readyComments, issueProject, ignoreStaleReviews, allowedTargetBranches, seedStorage, confOverrideRepo,
+                readyComments, issueProject, ignoreStaleReviews, includeSimpleMerges, allowedTargetBranches, seedStorage, confOverrideRepo,
                 confOverrideName, confOverrideRef, censusLink, forks, integrators, excludeCommitCommentsFrom, enableCsr,
                 enableJep, reviewCleanBackport, mlbridgeBotName, reviewMerge, processPR, processCommit, enableMerge,
                 mergeSources, jcheckMerge, enableBackport, issuePRMap, approval, versionMismatchWarning, cleanCommandEnabled);

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
@@ -161,11 +161,11 @@ public class PullRequestBotFactory implements BotFactory {
                 issueProjectToIssuePRMapMap.putIfAbsent(issueProject, new ConcurrentHashMap<>());
                 botBuilder.issuePRMap(issueProjectToIssuePRMapMap.get(issueProject));
             }
-            if (repo.value().contains("ignorestale")) {
-                botBuilder.ignoreStaleReviews(repo.value().get("ignorestale").asBoolean());
+            if (repo.value().contains("useStaleReviews")) {
+                botBuilder.useStaleReviews(repo.value().get("useStaleReviews").asBoolean());
             }
-            if (repo.value().contains("includemerge")) {
-                botBuilder.includeSimpleMerges(repo.value().get("includemerge").asBoolean());
+            if (repo.value().contains("acceptSimpleMerges")) {
+                botBuilder.acceptSimpleMerges(repo.value().get("acceptSimpleMerges").asBoolean());
             }
             if (repo.value().contains("targetbranches")) {
                 botBuilder.allowedTargetBranches(repo.value().get("targetbranches").asString());

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
@@ -164,6 +164,9 @@ public class PullRequestBotFactory implements BotFactory {
             if (repo.value().contains("ignorestale")) {
                 botBuilder.ignoreStaleReviews(repo.value().get("ignorestale").asBoolean());
             }
+            if (repo.value().contains("includemerge")) {
+                botBuilder.includeSimpleMerges(repo.value().get("includemerge").asBoolean());
+            }
             if (repo.value().contains("targetbranches")) {
                 botBuilder.allowedTargetBranches(repo.value().get("targetbranches").asString());
             }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewCoverage.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewCoverage.java
@@ -35,13 +35,13 @@ import org.openjdk.skara.vcs.Repository;
 public class ReviewCoverage {
 
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots.pr");
-    private final boolean ignoreStaleReviews;
-    private final boolean includeSimpleMerges;
+    private final boolean useStaleReviews;
+    private final boolean acceptSimpleMerges;
     private final Repository repo;
 
-    public ReviewCoverage(boolean ignoreStaleReviews, boolean includeSimpleMerges, Repository repo) {
-        this.ignoreStaleReviews = ignoreStaleReviews;
-        this.includeSimpleMerges = includeSimpleMerges;
+    public ReviewCoverage(boolean useStaleReviews, boolean acceptSimpleMerges, Repository repo) {
+        this.useStaleReviews = useStaleReviews;
+        this.acceptSimpleMerges = acceptSimpleMerges;
         this.repo = repo;
     }
 
@@ -53,10 +53,10 @@ public class ReviewCoverage {
                 || !review.targetRef().equals(pr.targetRef())) {
             return false;
         }
-        if (!ignoreStaleReviews || r.get().equals(pr.headHash())) {
+        if (useStaleReviews || r.get().equals(pr.headHash())) {
             return true;
         }
-        if (!includeSimpleMerges) {
+        if (!acceptSimpleMerges) {
             return false;
         }
         boolean seenAtLeastOneCommit = false;

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewCoverage.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewCoverage.java
@@ -38,14 +38,19 @@ public class ReviewCoverage {
     private final boolean useStaleReviews;
     private final boolean acceptSimpleMerges;
     private final Repository repo;
+    private final PullRequest pr;
 
-    public ReviewCoverage(boolean useStaleReviews, boolean acceptSimpleMerges, Repository repo) {
+    public ReviewCoverage(boolean useStaleReviews,
+                          boolean acceptSimpleMerges,
+                          Repository repo,
+                          PullRequest pr) {
         this.useStaleReviews = useStaleReviews;
         this.acceptSimpleMerges = acceptSimpleMerges;
         this.repo = repo;
+        this.pr = pr;
     }
 
-    public boolean covers(Review review, PullRequest pr) {
+    public boolean covers(Review review) {
         var r = review.hash();
         // Reviews without a hash are never valid as they referred to no longer
         // existing commits.

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewCoverage.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewCoverage.java
@@ -23,7 +23,9 @@
 package org.openjdk.skara.bots.pr;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -39,6 +41,7 @@ public class ReviewCoverage {
     private final boolean acceptSimpleMerges;
     private final Repository repo;
     private final PullRequest pr;
+    private final Map<Review, Boolean> cache = new HashMap<>();
 
     public ReviewCoverage(boolean useStaleReviews,
                           boolean acceptSimpleMerges,
@@ -51,6 +54,10 @@ public class ReviewCoverage {
     }
 
     public boolean covers(Review review) {
+        return cache.computeIfAbsent(review, this::covers0);
+    }
+
+    private boolean covers0(Review review) {
         var r = review.hash();
         // Reviews without a hash are never valid as they referred to no longer
         // existing commits.

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewCoverage.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewCoverage.java
@@ -51,12 +51,15 @@ public class ReviewCoverage {
         // Reviews without a hash are never valid as they referred to no longer
         // existing commits.
         if (r.isEmpty() || review.verdict() != Review.Verdict.APPROVED
-                || !review.targetRef().equals(pr.targetRef()))
+                || !review.targetRef().equals(pr.targetRef())) {
             return false;
-        if (!ignoreStaleReviews || r.get().equals(pr.headHash()))
+        }
+        if (!ignoreStaleReviews || r.get().equals(pr.headHash())) {
             return true;
-        if (!includeSimpleMerges)
+        }
+        if (!includeSimpleMerges) {
             return false;
+        }
         if (!(repo instanceof GitRepository gitRepo)) {
             log.fine("Merge re-review check is unavailable on '" + repo.getClass() + "' repo");
             return false;

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewCoverage.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewCoverage.java
@@ -42,7 +42,7 @@ public class ReviewCoverage {
     private final boolean acceptSimpleMerges;
     private final Repository repo;
     private final PullRequest pr;
-    private final Map<Review, Boolean> cache = new HashMap<>();
+    private final Map<Review, Boolean> cachedCoverage = new HashMap<>();
     private Hash cachedTargetHash;
 
     public ReviewCoverage(boolean useStaleReviews,
@@ -56,7 +56,7 @@ public class ReviewCoverage {
     }
 
     public boolean covers(Review review) {
-        return cache.computeIfAbsent(review, this::covers0);
+        return cachedCoverage.computeIfAbsent(review, this::covers0);
     }
 
     private boolean covers0(Review review) {
@@ -95,7 +95,7 @@ public class ReviewCoverage {
                 }
             }
         } catch (IOException e) {
-            log.log(Level.FINE, "Error while looking for simple merges in a PR " + pr, e);
+            log.log(Level.FINE, "Error while looking for simple merges: " + pr.repository() + ", " + pr.id(), e);
             return false;
         }
         if (seenAtLeastOneCommit) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewCoverage.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewCoverage.java
@@ -65,8 +65,9 @@ public class ReviewCoverage {
             try (var commits = repo.commits(List.of(pr.headHash()), List.of(r.get(), targetHash))) {
                 for (var c : commits) {
                     seenAtLeastOneCommit = true;
-                    if (!c.isMerge() || c.numParents() != 2)
+                    if (!c.isMerge() || c.numParents() != 2) {
                         return false;
+                    }
                     // from https://git-scm.com/book/en/v2/Git-Tools-Revision-Selection
                     // we expect that ^1 has to belong to the PR and ^2 to the target
                     // branch; the former seems obvious and enforced by Git, while

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
@@ -96,13 +96,13 @@ public class SponsorCommand implements CommandHandler {
             pr = pr.repository().pullRequest(pr.id());
 
             var localRepo = IntegrateCommand.materializeLocalRepo(bot, pr, scratchArea);
-            var checkablePr = new CheckablePullRequest(pr, localRepo, bot.ignoreStaleReviews(),
+            var checkablePr = new CheckablePullRequest(pr, localRepo, bot.useStaleReviews(),
                     bot.confOverrideRepository().orElse(null),
                     bot.confOverrideName(),
                     bot.confOverrideRef(),
                     allComments,
                     bot.reviewMerge(),
-                    new ReviewCoverage(bot.ignoreStaleReviews(), bot.includeSimpleMerges(), localRepo));
+                    new ReviewCoverage(bot.useStaleReviews(), bot.acceptSimpleMerges(), localRepo));
 
             // Validate the target hash if requested
             if (!command.args().isBlank()) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
@@ -102,7 +102,7 @@ public class SponsorCommand implements CommandHandler {
                     bot.confOverrideRef(),
                     allComments,
                     bot.reviewMerge(),
-                    new ReviewCoverage(bot.useStaleReviews(), bot.acceptSimpleMerges(), localRepo));
+                    new ReviewCoverage(bot.useStaleReviews(), bot.acceptSimpleMerges(), localRepo, pr));
 
             // Validate the target hash if requested
             if (!command.args().isBlank()) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SponsorCommand.java
@@ -101,7 +101,8 @@ public class SponsorCommand implements CommandHandler {
                     bot.confOverrideName(),
                     bot.confOverrideRef(),
                     allComments,
-                    bot.reviewMerge());
+                    bot.reviewMerge(),
+                    new ReviewCoverage(bot.ignoreStaleReviews(), bot.includeSimpleMerges(), localRepo));
 
             // Validate the target hash if requested
             if (!command.args().isBlank()) {

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -1512,7 +1512,7 @@ class CheckTests {
     }
 
     @Test
-    void ignoreStale(TestInfo testInfo) throws IOException {
+    void useStaleReviews(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
              var tempFolder = new TemporaryDirectory()) {
 
@@ -1527,7 +1527,7 @@ class CheckTests {
                     .addReviewer(reviewer2.forge().currentUser().id())
                     .addReviewer(reviewer3.forge().currentUser().id());
 
-            var checkBot = PullRequestBot.newBuilder().repo(author).censusRepo(censusBuilder.build()).ignoreStaleReviews(true).build();
+            var checkBot = PullRequestBot.newBuilder().repo(author).censusRepo(censusBuilder.build()).useStaleReviews(false).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -1610,7 +1610,7 @@ class CheckTests {
     }
 
     @Test
-    void includeSimpleMerges(TestInfo testInfo) throws IOException {
+    void acceptSimpleMerges(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
              var tempFolder = new TemporaryDirectory()) {
 
@@ -1624,8 +1624,8 @@ class CheckTests {
             var checkBot = PullRequestBot.newBuilder()
                     .repo(author)
                     .censusRepo(censusBuilder.build())
-                    .ignoreStaleReviews(true)
-                    .includeSimpleMerges(true)
+                    .useStaleReviews(false)
+                    .acceptSimpleMerges(true)
                     .build();
 
             // create the repo using CheckableRepository, as it creates probably useful files, such as .jcheck/conf

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -28,6 +28,7 @@ import org.openjdk.skara.issuetracker.Issue;
 import org.openjdk.skara.issuetracker.Link;
 import org.openjdk.skara.json.JSON;
 import org.openjdk.skara.test.*;
+import org.openjdk.skara.vcs.Branch;
 import org.openjdk.skara.vcs.Repository;
 
 import java.io.*;
@@ -1605,6 +1606,264 @@ class CheckTests {
             assertTrue(pr.store().body().contains("Re-review required"));
             // Credit line should include reviewers with stale reviews
             assertLastCommentContains(pr, "Reviewed-by: integrationreviewer2, integrationreviewer3, integrationreviewer4");
+        }
+    }
+
+    @Test
+    void includeSimpleMerges(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+
+            var author = credentials.getHostedRepository();
+            var reviewer = credentials.getHostedRepository();
+
+            var censusBuilder = credentials.getCensusBuilder()
+                    .addAuthor(author.forge().currentUser().id())
+                    .addReviewer(reviewer.forge().currentUser().id());
+
+            var checkBot = PullRequestBot.newBuilder()
+                    .repo(author)
+                    .censusRepo(censusBuilder.build())
+                    .ignoreStaleReviews(true)
+                    .includeSimpleMerges(true)
+                    .build();
+
+            // create the repo using CheckableRepository, as it creates probably useful files, such as .jcheck/conf
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
+            // replace the default file with a bigger file for auto-merging purposes
+            localRepo.checkout(new Branch("master"));
+            Path f = localRepo.root().resolve("file.txt");
+            Files.writeString(f, """
+                    0
+                    1
+                    2
+                    3
+                    4
+                    5
+                    6
+                    7
+                    8
+                    9
+                    a
+                    b
+                    c
+                    d
+                    e
+                    f
+                    """);
+            localRepo.add(f);
+            var masterHash = localRepo.commit("master 1", author.name(), "someone@example.com");
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+            localRepo.branch(masterHash, "feature");
+            localRepo.checkout(new Branch("feature"));
+            Files.writeString(f, """
+                    1
+                    2
+                    3
+                    4
+                    5
+                    6
+                    7
+                    8
+                    9
+                    a
+                    b
+                    c
+                    d
+                    e
+                    f
+                    """);
+            localRepo.add(f);
+            var featureHash = localRepo.commit("feature 1", author.name(), "author@example.com");
+            localRepo.push(featureHash, author.authenticatedUrl(), "feature", true);
+            var pr = credentials.createPullRequest(author, "master", "feature", "This is a pull request");
+
+            TestBotRunner.runPeriodicItems(checkBot);
+
+            assertFalse(pr.store().labelNames().contains("ready"));
+
+            var approvalPr = reviewer.pullRequest(pr.id());
+            approvalPr.addReview(Review.Verdict.APPROVED, "Approved");
+
+            TestBotRunner.runPeriodicItems(checkBot);
+
+            assertTrue(pr.store().labelNames().contains("ready"));
+
+            localRepo.checkout(new Branch("master"));
+            Files.writeString(f, """
+                    0
+                    1
+                    2
+                    3
+                    4
+                    5
+                    6
+                    7
+                    8
+                    9
+                    a
+                    b
+                    c
+                    d
+                    e
+                    """);
+            localRepo.add(f);
+            masterHash = localRepo.commit("master 2", author.name(), "someone@example.com");
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+
+            TestBotRunner.runPeriodicItems(checkBot);
+
+            assertTrue(pr.store().labelNames().contains("ready"));
+
+            localRepo.checkout(new Branch("feature"));
+            localRepo.merge(new Branch("master"));
+            localRepo.add(f);
+            var mergeHash = localRepo.commit("Updated from master", author.name(), "author@example.com");
+            localRepo.push(mergeHash, author.authenticatedUrl(), "feature", true);
+
+            TestBotRunner.runPeriodicItems(checkBot);
+
+            assertTrue(pr.store().labelNames().contains("ready"));
+
+            localRepo.checkout(new Branch("master"));
+            Files.writeString(f, """
+                    0
+                    1
+                    2
+                    3
+                    4
+                    5
+                    6
+                    7
+                    8
+                    9
+                    a
+                    b
+                    c
+                    d
+                    """);
+            localRepo.add(f);
+            masterHash = localRepo.commit("master 3", author.name(), "someone@example.com");
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+
+            TestBotRunner.runPeriodicItems(checkBot);
+
+            assertTrue(pr.store().labelNames().contains("ready"));
+
+            localRepo.checkout(new Branch("feature"));
+            Files.writeString(f, """
+                    2
+                    3
+                    4
+                    5
+                    6
+                    7
+                    8
+                    9
+                    a
+                    b
+                    c
+                    d
+                    e
+                    """);
+            localRepo.add(f);
+            featureHash = localRepo.commit("feature 2", author.name(), "author@example.com");
+            localRepo.push(featureHash, author.authenticatedUrl(), "feature", true);
+
+            TestBotRunner.runPeriodicItems(checkBot);
+
+            assertFalse(pr.store().labelNames().contains("ready"));
+            assertTrue(pr.store().body().contains("Re-review required"));
+
+            approvalPr = reviewer.pullRequest(pr.id());
+            approvalPr.addReview(Review.Verdict.APPROVED, "Approved");
+
+            TestBotRunner.runPeriodicItems(checkBot);
+
+            assertTrue(pr.store().labelNames().contains("ready"));
+
+            localRepo.merge(new Branch("master"));
+            localRepo.add(f);
+            mergeHash = localRepo.commit("Updated from master 2", author.name(), "author@example.com");
+            localRepo.push(mergeHash, author.authenticatedUrl(), "feature", true);
+
+            TestBotRunner.runPeriodicItems(checkBot);
+
+            assertTrue(pr.store().labelNames().contains("ready"));
+
+            localRepo.checkout(new Branch("master"));
+            Files.writeString(f, """
+                    0
+                    1
+                    2
+                    3
+                    4
+                    5
+                    6
+                    7
+                    8
+                    9
+                    a
+                    b
+                    c
+                    """);
+            localRepo.add(f);
+            masterHash = localRepo.commit("master 4", author.name(), "someone@example.com");
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+
+            TestBotRunner.runPeriodicItems(checkBot);
+
+            assertTrue(pr.store().labelNames().contains("ready"));
+
+            localRepo.checkout(new Branch("feature"));
+            localRepo.merge(new Branch("master"));
+            localRepo.add(f);
+            mergeHash = localRepo.commit("Updated from master 3", author.name(), "author@example.com");
+            localRepo.push(mergeHash, author.authenticatedUrl(), "feature", true);
+
+            TestBotRunner.runPeriodicItems(checkBot);
+
+            assertTrue(pr.store().labelNames().contains("ready"));
+
+            localRepo.checkout(new Branch("master"));
+            Files.writeString(f, """
+                    0
+                    1
+                    2
+                    3
+                    4
+                    5
+                    6
+                    7
+                    8
+                    9
+                    a
+                    b
+                    """);
+            localRepo.add(f);
+            masterHash = localRepo.commit("master 5", author.name(), "someone@example.com");
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+
+            TestBotRunner.runPeriodicItems(checkBot);
+
+            assertTrue(pr.store().labelNames().contains("ready"));
+
+            localRepo.checkout(new Branch("feature"));
+            localRepo.merge(new Branch("master"));
+            Files.writeString(f, """
+                    w
+                    x
+                    y
+                    z
+                    """);
+            localRepo.add(f);
+            mergeHash = localRepo.commit("Updated from master 4", author.name(), "author@example.com");
+            localRepo.push(mergeHash, author.authenticatedUrl(), "feature", true);
+
+            TestBotRunner.runPeriodicItems(checkBot);
+
+            assertFalse(pr.store().labelNames().contains("ready"));
+            assertTrue(pr.store().body().contains("Re-review required"));
         }
     }
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestBotFactoryTest.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestBotFactoryTest.java
@@ -223,7 +223,7 @@ class PullRequestBotFactoryTest {
             assertEquals("{test=Signature needs verify}", pullRequestBot6.blockingCheckLabels().toString());
             assertEquals("[rfr]", pullRequestBot6.twoReviewersLabels().toString());
             assertEquals("[24h_test]", pullRequestBot6.twentyFourHoursLabels().toString());
-            assertFalse(pullRequestBot6.ignoreStaleReviews());
+            assertTrue(pullRequestBot6.useStaleReviews());
             assertEquals(".*", pullRequestBot6.allowedTargetBranches().toString());
             var integrators = pullRequestBot6.integrators();
             assertEquals(2, integrators.size());

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/TestRepository.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/TestRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -122,6 +122,11 @@ class TestRepository implements ReadOnlyRepository {
 
     @Override
     public Commits commits(String range, int n, boolean reverse) throws IOException {
+        return null;
+    }
+
+    @Override
+    public Commits commits(List<Hash> reachableFrom, List<Hash> unreachableFrom) throws IOException {
         return null;
     }
 

--- a/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,6 +45,7 @@ public interface ReadOnlyRepository {
     Commits commits(String range, boolean reverse) throws IOException;
     Commits commits(String range, int n) throws IOException;
     Commits commits(String range, int n, boolean reverse) throws IOException;
+    Commits commits(List<Hash> reachableFrom, List<Hash> unreachableFrom) throws IOException;
     Optional<Commit> lookup(Hash h) throws IOException;
     Optional<Commit> lookup(Branch b) throws IOException;
     Optional<Commit> lookup(Tag t) throws IOException;

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -235,6 +235,8 @@ public interface Repository extends ReadOnlyRepository {
         GitRepository.ignoreConfiguration();
         HgRepository.ignoreConfiguration();
     }
+
+    boolean isRemergeDiffEmpty(Hash mergeCommitHash) throws IOException;
 
     static Optional<Repository> get(Path p) throws IOException {
         var gitRepo = GitRepository.get(p);

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitCommits.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitCommits.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,8 @@ class GitCommits implements Commits, AutoCloseable {
 
     private final Path dir;
     private final String range;
+    private final List<Hash> from;
+    private final List<Hash> notFrom;
     private final boolean reverse;
     private final int num;
     private final String format;
@@ -47,8 +49,23 @@ class GitCommits implements Commits, AutoCloseable {
     public GitCommits(Path dir, String range, boolean reverse, int num) throws IOException {
         this.dir = dir;
         this.range = range;
+        this.from = null;
+        this.notFrom = null;
         this.reverse = reverse;
         this.num = num;
+        this.format = String.join("%n",
+                                  COMMIT_DELIMITER,
+                                  GitCommitMetadata.FORMAT);
+
+    }
+
+    public GitCommits(Path dir, List<Hash> reachableFrom, List<Hash> unreachableFrom) throws IOException {
+        this.dir = dir;
+        this.range = null;
+        this.reverse = false;
+        this.num = -1;
+        from = reachableFrom;
+        notFrom = unreachableFrom;
         this.format = String.join("%n",
                                   COMMIT_DELIMITER,
                                   GitCommitMetadata.FORMAT);
@@ -78,7 +95,15 @@ class GitCommits implements Commits, AutoCloseable {
             cmd.add("-n");
             cmd.add(Integer.toString(num));
         }
-        cmd.add(range);
+        if (range != null)
+            cmd.add(range);
+        else {
+            cmd.addAll(from.stream().map(Hash::hex).toList());
+            if (!notFrom.isEmpty()) {
+                cmd.add("--not");
+                cmd.addAll(notFrom.stream().map(Hash::hex).toList());
+            }
+        }
         var pb = new ProcessBuilder(cmd);
         pb.directory(dir.toFile());
         pb.environment().putAll(GitRepository.currentEnv);

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitCommits.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitCommits.java
@@ -64,8 +64,8 @@ class GitCommits implements Commits, AutoCloseable {
         this.range = null;
         this.reverse = false;
         this.num = -1;
-        from = reachableFrom;
-        notFrom = unreachableFrom;
+        this.from = reachableFrom;
+        this.notFrom = unreachableFrom;
         this.format = String.join("%n",
                                   COMMIT_DELIMITER,
                                   GitCommitMetadata.FORMAT);
@@ -95,9 +95,9 @@ class GitCommits implements Commits, AutoCloseable {
             cmd.add("-n");
             cmd.add(Integer.toString(num));
         }
-        if (range != null)
+        if (range != null) {
             cmd.add(range);
-        else {
+        } else {
             cmd.addAll(from.stream().map(Hash::hex).toList());
             if (!notFrom.isEmpty()) {
                 cmd.add("--not");

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -180,6 +180,7 @@ public class GitRepository implements Repository {
         return new GitCommits(dir, "--all", reverse, n);
     }
 
+    @Override
     public Commits commits(List<Hash> reachableFrom, List<Hash> unreachableFrom) throws IOException {
         return new GitCommits(dir, reachableFrom, unreachableFrom);
     }
@@ -1001,8 +1002,9 @@ public class GitRepository implements Repository {
         }
     }
 
-    public boolean isRemergeDiffEmpty(Hash hash) throws IOException {
-        try (var p = Process.capture("git", "show", "--remerge-diff", "--format=%b", hash.hex())
+    @Override
+    public boolean isRemergeDiffEmpty(Hash mergeCommitHash) throws IOException {
+        try (var p = Process.capture("git", "show", "--remerge-diff", "--format=%b", mergeCommitHash.hex())
                 .workdir(dir)
                 .environ(currentEnv)
                 .execute()) {

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -178,6 +178,10 @@ public class GitRepository implements Repository {
     @Override
     public Commits commits(int n, boolean reverse) throws IOException {
         return new GitCommits(dir, "--all", reverse, n);
+    }
+
+    public Commits commits(List<Hash> reachableFrom, List<Hash> unreachableFrom) throws IOException {
+        return new GitCommits(dir, reachableFrom, unreachableFrom);
     }
 
     @Override
@@ -994,6 +998,15 @@ public class GitRepository implements Repository {
                             .environ(currentEnv)
                             .execute()) {
             await(p);
+        }
+    }
+
+    public boolean isRemergeDiffEmpty(Hash hash) throws IOException {
+        try (var p = Process.capture("git", "show", "--remerge-diff", "--format=%b", hash.hex())
+                .workdir(dir)
+                .environ(currentEnv)
+                .execute()) {
+            return String.join("", await(p).stdout()).isEmpty();
         }
     }
 

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,6 +54,11 @@ public class HgRepository implements Repository {
 
     public static void ignoreConfiguration() {
         currentEnv = NO_CONFIG_ENV;
+    }
+
+    @Override
+    public boolean isRemergeDiffEmpty(Hash mergeCommitHash) throws IOException {
+        throw new UnsupportedOperationException();
     }
 
     private void copyResource(String name, Path p) throws IOException {
@@ -246,6 +251,11 @@ public class HgRepository implements Repository {
         var ext = Files.createTempFile("ext", ".py");
         copyResource(EXT_PY, ext);
         return new HgCommits(dir, range, ext, reverse, n);
+    }
+
+    @Override
+    public Commits commits(List<Hash> reachableFrom, List<Hash> unreachableFrom) throws IOException {
+        throw new UnsupportedOperationException();
     }
 
     @Override


### PR DESCRIPTION
If a repository is configured to ignore stale reviews, every commit to a PR made against that repo means that the PR needs to be re-reviewed. Re-reviewing is costly, and not all commits are worth that cost.

One example of such a commit is a simple merge. During a PR's lifetime, the PR's target branch (typically, repo's `master`) might be merged into the PR multiple times. Usually, such merges are trivial and would effectively be performed by Skara automatically if the PR didn't have them in the first place [^*]. For such commits, it makes sense to not require review.

This is my first contribution to Skara domain logic, which I've just started learning about. Also, while I tried to code this change according to Skara customs and idioms, I might have missed something. I guess what I'm saying is **take extra care** reviewing this PR. Thanks.


[^*]: This is the main assumption of this PR. Any simple merges present in a PR change the end result of that PR insignificantly, if at all.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2312](https://bugs.openjdk.org/browse/SKARA-2312): Do not require re-review for a simple merge (**Enhancement** - P4)


### Reviewers
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1672/head:pull/1672` \
`$ git checkout pull/1672`

Update a local copy of the PR: \
`$ git checkout pull/1672` \
`$ git pull https://git.openjdk.org/skara.git pull/1672/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1672`

View PR using the GUI difftool: \
`$ git pr show -t 1672`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1672.diff">https://git.openjdk.org/skara/pull/1672.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1672#issuecomment-2214349434)