### PR TITLE
2321: Prefer pattern matching for instanceof

### DIFF
--- a/args/src/main/java/org/openjdk/skara/args/Flag.java
+++ b/args/src/main/java/org/openjdk/skara/args/Flag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,11 +67,10 @@ public class Flag {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof Flag)) {
+        if (!(o instanceof Flag other)) {
             return false;
         }
 
-        Flag other = (Flag) o;
         return Objects.equals(isSwitch, other.isSwitch) &&
                Objects.equals(shortcut, other.shortcut) &&
                Objects.equals(fullname, other.fullname) &&

--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -123,8 +123,8 @@ public class BotRunner {
 
         private static Optional<ThreadMXBean> getThreadMXBean() {
             var bean = ManagementFactory.getThreadMXBean();
-            return bean instanceof ThreadMXBean ?
-                Optional.of((ThreadMXBean) bean) : Optional.empty();
+            return bean instanceof ThreadMXBean b ?
+                Optional.of(b) : Optional.empty();
         }
 
         private static void enableThreadCpuTime() {

--- a/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestCloserBot.java
+++ b/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestCloserBot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,10 +82,9 @@ class PullRequestCloserBotWorkItem implements WorkItem {
 
     @Override
     public boolean concurrentWith(WorkItem other) {
-        if (!(other instanceof PullRequestCloserBotWorkItem)) {
+        if (!(other instanceof PullRequestCloserBotWorkItem otherItem)) {
             return true;
         }
-        PullRequestCloserBotWorkItem otherItem = (PullRequestCloserBotWorkItem)other;
         if (!pr.isSame(otherItem.pr)) {
             return true;
         }

--- a/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestPrunerBot.java
+++ b/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestPrunerBot.java
@@ -45,10 +45,9 @@ class PullRequestPrunerBotWorkItem implements WorkItem {
 
     @Override
     public boolean concurrentWith(WorkItem other) {
-        if (!(other instanceof PullRequestPrunerBotWorkItem)) {
+        if (!(other instanceof PullRequestPrunerBotWorkItem otherItem)) {
             return true;
         }
-        PullRequestPrunerBotWorkItem otherItem = (PullRequestPrunerBotWorkItem) other;
         if (!pr.isSame(otherItem.pr)) {
             return true;
         }

--- a/bots/censussync/src/main/java/org/openjdk/skara/bots/censussync/CensusSyncSplitBot.java
+++ b/bots/censussync/src/main/java/org/openjdk/skara/bots/censussync/CensusSyncSplitBot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,10 +57,9 @@ public class CensusSyncSplitBot implements Bot, WorkItem {
 
     @Override
     public boolean concurrentWith(WorkItem other) {
-        if (!(other instanceof CensusSyncSplitBot)) {
+        if (!(other instanceof CensusSyncSplitBot o)) {
             return true;
         }
-        var o = (CensusSyncSplitBot) other;
         return !o.to.equals(to);
     }
 

--- a/bots/censussync/src/main/java/org/openjdk/skara/bots/censussync/CensusSyncUnifyBot.java
+++ b/bots/censussync/src/main/java/org/openjdk/skara/bots/censussync/CensusSyncUnifyBot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,10 +52,9 @@ public class CensusSyncUnifyBot implements Bot, WorkItem {
 
     @Override
     public boolean concurrentWith(WorkItem other) {
-        if (!(other instanceof CensusSyncUnifyBot)) {
+        if (!(other instanceof CensusSyncUnifyBot o)) {
             return true;
         }
-        var o = (CensusSyncUnifyBot) other;
         return !o.to.equals(to);
     }
 

--- a/bots/checkout/src/main/java/org/openjdk/skara/bots/checkout/CheckoutBot.java
+++ b/bots/checkout/src/main/java/org/openjdk/skara/bots/checkout/CheckoutBot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,10 +64,9 @@ public class CheckoutBot implements Bot, WorkItem {
 
     @Override
     public boolean concurrentWith(WorkItem other) {
-        if (!(other instanceof CheckoutBot)) {
+        if (!(other instanceof CheckoutBot o)) {
             return true;
         }
-        var o = (CheckoutBot) other;
         return !(o.to.equals(to) || o.from.equals(from));
     }
 

--- a/bots/forward/src/main/java/org/openjdk/skara/bots/forward/ForwardBot.java
+++ b/bots/forward/src/main/java/org/openjdk/skara/bots/forward/ForwardBot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,10 +55,9 @@ class ForwardBot implements Bot, WorkItem {
 
     @Override
     public boolean concurrentWith(WorkItem other) {
-        if (!(other instanceof ForwardBot)) {
+        if (!(other instanceof ForwardBot otherBot)) {
             return true;
         }
-        var otherBot = (ForwardBot) other;
         return !toHostedRepo.name().equals(otherBot.toHostedRepo.name());
     }
 

--- a/bots/hgbridge/src/main/java/org/openjdk/skara/bots/hgbridge/JBridgeBot.java
+++ b/bots/hgbridge/src/main/java/org/openjdk/skara/bots/hgbridge/JBridgeBot.java
@@ -55,8 +55,7 @@ public class JBridgeBot implements Bot, WorkItem {
 
     @Override
     public boolean concurrentWith(WorkItem other) {
-        if (other instanceof JBridgeBot) {
-            JBridgeBot otherBridgeBot = (JBridgeBot)other;
+        if (other instanceof JBridgeBot otherBridgeBot) {
             return !exporterConfig.source().equals(otherBridgeBot.exporterConfig.source());
         } else {
             return true;

--- a/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
+++ b/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
@@ -275,10 +275,9 @@ class MergeBot implements Bot, WorkItem {
 
     @Override
     public boolean concurrentWith(WorkItem other) {
-        if (!(other instanceof MergeBot)) {
+        if (!(other instanceof MergeBot otherBot)) {
             return true;
         }
-        var otherBot = (MergeBot) other;
         return !target.name().equals(otherBot.target.name());
     }
 

--- a/bots/mirror/src/main/java/org/openjdk/skara/bots/mirror/MirrorBot.java
+++ b/bots/mirror/src/main/java/org/openjdk/skara/bots/mirror/MirrorBot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,10 +68,9 @@ class MirrorBot implements Bot, WorkItem {
 
     @Override
     public boolean concurrentWith(WorkItem other) {
-        if (!(other instanceof MirrorBot)) {
+        if (!(other instanceof MirrorBot otherBot)) {
             return true;
         }
-        var otherBot = (MirrorBot) other;
         return !to.name().equals(otherBot.to.name());
     }
 

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveReaderWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveReaderWorkItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,10 +45,9 @@ public class ArchiveReaderWorkItem implements WorkItem {
 
     @Override
     public boolean concurrentWith(WorkItem other) {
-        if (!(other instanceof ArchiveReaderWorkItem)) {
+        if (!(other instanceof ArchiveReaderWorkItem otherItem)) {
             return true;
         }
-        ArchiveReaderWorkItem otherItem = (ArchiveReaderWorkItem)other;
         if (!list.equals(otherItem.list)) {
             return true;
         }

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/CommentPosterWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/CommentPosterWorkItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,10 +54,9 @@ public class CommentPosterWorkItem implements WorkItem {
 
     @Override
     public boolean concurrentWith(WorkItem other) {
-        if (!(other instanceof CommentPosterWorkItem)) {
+        if (!(other instanceof CommentPosterWorkItem otherItem)) {
             return true;
         }
-        CommentPosterWorkItem otherItem = (CommentPosterWorkItem) other;
         if (!pr.isSame(otherItem.pr)) {
             return true;
         }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/PullRequestWorkItem.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/PullRequestWorkItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -142,10 +142,9 @@ public class PullRequestWorkItem implements WorkItem {
 
     @Override
     public boolean concurrentWith(WorkItem other) {
-        if (!(other instanceof PullRequestWorkItem)) {
+        if (!(other instanceof PullRequestWorkItem otherItem)) {
             return true;
         }
-        PullRequestWorkItem otherItem = (PullRequestWorkItem)other;
         if (!pr.isSame(otherItem.pr)) {
             return true;
         }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryWorkItem.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/RepositoryWorkItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -333,10 +333,9 @@ public class RepositoryWorkItem implements WorkItem {
 
     @Override
     public boolean concurrentWith(WorkItem other) {
-        if (!(other instanceof RepositoryWorkItem)) {
+        if (!(other instanceof RepositoryWorkItem otherItem)) {
             return true;
         }
-        RepositoryWorkItem otherItem = (RepositoryWorkItem) other;
         if (!repository.name().equals(otherItem.repository.name())) {
             return true;
         }

--- a/bots/submit/src/main/java/org/openjdk/skara/bots/submit/SubmitBotWorkItem.java
+++ b/bots/submit/src/main/java/org/openjdk/skara/bots/submit/SubmitBotWorkItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,10 +51,9 @@ public class SubmitBotWorkItem implements WorkItem {
 
     @Override
     public boolean concurrentWith(WorkItem other) {
-        if (!(other instanceof SubmitBotWorkItem)) {
+        if (!(other instanceof SubmitBotWorkItem otherItem)) {
             return true;
         }
-        SubmitBotWorkItem otherItem = (SubmitBotWorkItem)other;
         if (!executor.checkName().equals(otherItem.executor.checkName())) {
             return true;
         }

--- a/bots/synclabel/src/main/java/org/openjdk/skara/bots/synclabel/SyncLabelBotFindMainIssueWorkItem.java
+++ b/bots/synclabel/src/main/java/org/openjdk/skara/bots/synclabel/SyncLabelBotFindMainIssueWorkItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,10 +41,9 @@ public class SyncLabelBotFindMainIssueWorkItem implements WorkItem {
 
     @Override
     public boolean concurrentWith(WorkItem other) {
-        if (!(other instanceof SyncLabelBotFindMainIssueWorkItem)) {
+        if (!(other instanceof SyncLabelBotFindMainIssueWorkItem o)) {
             return true;
         }
-        var o = (SyncLabelBotFindMainIssueWorkItem) other;
         return !o.issueId.equals(issueId);
     }
 

--- a/bots/synclabel/src/main/java/org/openjdk/skara/bots/synclabel/SyncLabelBotUpdateLabelWorkItem.java
+++ b/bots/synclabel/src/main/java/org/openjdk/skara/bots/synclabel/SyncLabelBotUpdateLabelWorkItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,10 +43,9 @@ public class SyncLabelBotUpdateLabelWorkItem implements WorkItem {
 
     @Override
     public boolean concurrentWith(WorkItem other) {
-        if (!(other instanceof SyncLabelBotUpdateLabelWorkItem)) {
+        if (!(other instanceof SyncLabelBotUpdateLabelWorkItem o)) {
             return true;
         }
-        var o = (SyncLabelBotUpdateLabelWorkItem) other;
         return !o.mainIssueId.equals(mainIssueId);
     }
 

--- a/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestUpdateNeededWorkItem.java
+++ b/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestUpdateNeededWorkItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,10 +50,9 @@ public class TestUpdateNeededWorkItem implements WorkItem {
 
     @Override
     public boolean concurrentWith(WorkItem other) {
-        if (!(other instanceof TestUpdateNeededWorkItem)) {
+        if (!(other instanceof TestUpdateNeededWorkItem o)) {
             return true;
         }
-        var o = (TestUpdateNeededWorkItem) other;
         if (!pr.isSame(o.pr)) {
             return true;
         }

--- a/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestWorkItem.java
+++ b/bots/tester/src/main/java/org/openjdk/skara/bots/tester/TestWorkItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,10 +67,9 @@ public class TestWorkItem implements WorkItem {
 
     @Override
     public boolean concurrentWith(WorkItem other) {
-        if (!(other instanceof TestWorkItem)) {
+        if (!(other instanceof TestWorkItem o)) {
             return true;
         }
-        var o = (TestWorkItem) other;
         if (!pr.isSame(o.pr)) {
             return true;
         }

--- a/bots/topological/src/main/java/org/openjdk/skara/bots/topological/TopologicalBot.java
+++ b/bots/topological/src/main/java/org/openjdk/skara/bots/topological/TopologicalBot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,10 +56,9 @@ class TopologicalBot implements Bot, WorkItem {
 
     @Override
     public boolean concurrentWith(WorkItem other) {
-        if (!(other instanceof TopologicalBot)) {
+        if (!(other instanceof TopologicalBot otherBot)) {
             return true;
         }
-        var otherBot = (TopologicalBot) other;
         return !hostedRepo.name().equals(otherBot.hostedRepo.name());
     }
 

--- a/census/src/main/java/org/openjdk/skara/census/Contributor.java
+++ b/census/src/main/java/org/openjdk/skara/census/Contributor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,8 +62,7 @@ public class Contributor {
 
     @Override
     public boolean equals(Object o) {
-        if (o instanceof Contributor) {
-            var other = (Contributor) o;
+        if (o instanceof Contributor other) {
             return Objects.equals(username, other.username) &&
                    Objects.equals(fullName, other.fullName);
         }

--- a/census/src/main/java/org/openjdk/skara/census/Group.java
+++ b/census/src/main/java/org/openjdk/skara/census/Group.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -131,8 +131,7 @@ public class Group {
 
     @Override
     public boolean equals(Object o) {
-        if (o instanceof Group) {
-            var other = (Group) o;
+        if (o instanceof Group other) {
             return Objects.equals(name, other.name) &&
                    Objects.equals(fullName, other.fullName);
         }

--- a/census/src/main/java/org/openjdk/skara/census/Member.java
+++ b/census/src/main/java/org/openjdk/skara/census/Member.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -80,8 +80,7 @@ class Member {
 
     @Override
     public boolean equals(Object o) {
-        if (o instanceof Member) {
-            var other = (Member) o;
+        if (o instanceof Member other) {
             return contributor.equals(other.contributor()) &&
                    since == other.since() &&
                    until == other.until();

--- a/census/src/main/java/org/openjdk/skara/census/Project.java
+++ b/census/src/main/java/org/openjdk/skara/census/Project.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -233,11 +233,10 @@ public class Project {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof Project)) {
+        if (!(o instanceof Project p)) {
             return false;
         }
 
-        var p = (Project) o;
         return Objects.equals(name, p.name) &&
                Objects.equals(fullName, p.fullName) &&
                Objects.equals(sponsor, p.sponsor) &&

--- a/census/src/main/java/org/openjdk/skara/census/Version.java
+++ b/census/src/main/java/org/openjdk/skara/census/Version.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,11 +62,10 @@ public class Version {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof Version)) {
+        if (!(o instanceof Version other)) {
             return false;
         }
 
-        var other = (Version) o;
         return Objects.equals(format, other.format()) &&
                Objects.equals(timestamp, other.timestamp());
     }

--- a/ci/src/main/java/org/openjdk/skara/ci/Build.java
+++ b/ci/src/main/java/org/openjdk/skara/ci/Build.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -94,11 +94,10 @@ public class Build {
             return true;
         }
 
-        if (!(other instanceof Build)) {
+        if (!(other instanceof Build o)) {
             return false;
         }
 
-        var o = (Build) other;
         return Objects.equals(os, o.os) &&
                Objects.equals(cpu, o.cpu) &&
                Objects.equals(debugLevel, o.debugLevel);

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedBranch.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedBranch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,11 +55,10 @@ public class HostedBranch {
 
     @Override
     public boolean equals(Object other) {
-        if (!(other instanceof HostedBranch)) {
+        if (!(other instanceof HostedBranch o)) {
             return false;
         }
 
-        var o = (HostedBranch) other;
         return Objects.equals(name, o.name) && Objects.equals(hash, o.hash);
     }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedCommit.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedCommit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,11 +62,10 @@ public class HostedCommit extends Commit {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof HostedCommit)) {
+        if (!(o instanceof HostedCommit other)) {
             return false;
         }
 
-        var other = (HostedCommit) o;
         return Objects.equals(url, other.url);
     }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -116,11 +116,10 @@ public class GitHubRepository implements HostedRepository {
                                          String title,
                                          List<String> body,
                                          boolean draft) {
-        if (!(target instanceof GitHubRepository)) {
+        if (!(target instanceof GitHubRepository upstream)) {
             throw new IllegalArgumentException("target repository must be a GitHub repository");
         }
 
-        var upstream = (GitHubRepository) target;
         var params = JSON.object()
                          .put("title", title)
                          .put("head", group() + ":" + sourceRef)

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -107,7 +107,7 @@ public class GitLabRepository implements HostedRepository {
                                          String title,
                                          List<String> body,
                                          boolean draft) {
-        if (!(target instanceof GitLabRepository)) {
+        if (!(target instanceof GitLabRepository targetRepo)) {
             throw new IllegalArgumentException("target must be a GitLab repository");
         }
 
@@ -119,7 +119,6 @@ public class GitLabRepository implements HostedRepository {
                         .body("target_project_id", Long.toString(target.id()))
                         .execute();
 
-        var targetRepo = (GitLabRepository) target;
         return new GitLabMergeRequest(targetRepo, gitLabHost, pr, targetRepo.request);
     }
 

--- a/gradle/plugins/skara-images/src/main/java/org/openjdk/skara/gradle/images/ImagesPlugin.java
+++ b/gradle/plugins/skara-images/src/main/java/org/openjdk/skara/gradle/images/ImagesPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -113,8 +113,8 @@ public class ImagesPlugin implements Plugin<Project> {
                 var linkTaskName = "link" + subName;
                 project.getTasks().register(linkTaskName, LinkTask.class, (task) -> {
                     for (var jarTask : project.getTasksByName("jar", true)) {
-                        if (jarTask instanceof Jar) {
-                            task.getModulePath().add(((Jar) jarTask).getArchiveFile());
+                        if (jarTask instanceof Jar jt) {
+                            task.getModulePath().add((jt).getArchiveFile());
                         }
                     }
 

--- a/gradle/plugins/skara-reproduce/src/main/java/org/openjdk/skara/gradle/reproduce/ReproducePlugin.java
+++ b/gradle/plugins/skara-reproduce/src/main/java/org/openjdk/skara/gradle/reproduce/ReproducePlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,8 +35,7 @@ public class ReproducePlugin implements Plugin<Project> {
         project.afterEvaluate((p) -> {
             for (var entry : project.getAllTasks(true).entrySet()) {
                 for (var task : entry.getValue()) {
-                    if (task instanceof AbstractArchiveTask) {
-                        var archiveTask = (AbstractArchiveTask) task;
+                    if (task instanceof AbstractArchiveTask archiveTask) {
                         archiveTask.setPreserveFileTimestamps(false);
                         archiveTask.setReproducibleFileOrder(true);
                     }

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/Label.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/Label.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,11 +58,10 @@ public class Label implements Comparable<Label> {
             return true;
         }
 
-        if (!(o instanceof Label)) {
+        if (!(o instanceof Label l)) {
             return false;
         }
 
-        var l = (Label) o;
         return Objects.equals(name, l.name) &&
                Objects.equals(description, l.description);
     }

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/WhitespaceIssue.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/WhitespaceIssue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -79,11 +79,10 @@ public class WhitespaceIssue extends CommitIssue {
                 return true;
             }
 
-            if (!(other instanceof Error)) {
+            if (!(other instanceof Error o)) {
                 return false;
             }
 
-            var o = (Error) other;
             return Objects.equals(index, o.index) &&
                    Objects.equals(kind, o.kind);
         }

--- a/metrics/src/main/java/org/openjdk/skara/metrics/CollectorRegistry.java
+++ b/metrics/src/main/java/org/openjdk/skara/metrics/CollectorRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -165,16 +165,14 @@ public final class CollectorRegistry {
         }
 
         var bean = ManagementFactory.getOperatingSystemMXBean();
-        if (bean instanceof UnixOperatingSystemMXBean) {
-            var osBean = (UnixOperatingSystemMXBean) bean;
+        if (bean instanceof UnixOperatingSystemMXBean osBean) {
             var numOpenFds = osBean.getOpenFileDescriptorCount();
             result.add(new Metric(Metric.Type.GAUGE, "process_open_fds", List.of(), numOpenFds));
             var maxFds = osBean.getMaxFileDescriptorCount();
             result.add(new Metric(Metric.Type.GAUGE, "process_max_fds", List.of(), maxFds));
         }
 
-        if (bean instanceof OperatingSystemMXBean) {
-            var osBean = (OperatingSystemMXBean) bean;
+        if (bean instanceof OperatingSystemMXBean osBean) {
             var vmMaxBytes = osBean.getCommittedVirtualMemorySize();
             result.add(new Metric(Metric.Type.GAUGE, "process_virtual_memory_max_bytes", List.of(), vmMaxBytes));
 

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Author.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Author.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,11 +73,10 @@ public class Author {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof Author)) {
+        if (!(o instanceof Author other)) {
             return false;
         }
 
-        var other = (Author) o;
         return Objects.equals(name, other.name) &&
                Objects.equals(email, other.email);
     }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Bookmark.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Bookmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,11 +45,10 @@ public class Bookmark {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof Bookmark)) {
+        if (!(o instanceof Bookmark other)) {
             return false;
         }
 
-        var other = (Bookmark) o;
         return name.equals(other.name);
     }
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Branch.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Branch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,11 +58,10 @@ public class Branch {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof Branch)) {
+        if (!(o instanceof Branch other)) {
             return false;
         }
 
-        var other = (Branch) o;
         return name.equals(other.name);
     }
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Commit.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Commit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -95,11 +95,10 @@ public class Commit {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof Commit)) {
+        if (!(o instanceof Commit other)) {
             return false;
         }
 
-        var other = (Commit) o;
         return Objects.equals(metadata, other.metadata) && Objects.equals(parentDiffs, other.parentDiffs);
     }
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/CommitMetadata.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/CommitMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -103,11 +103,10 @@ public class CommitMetadata {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof CommitMetadata)) {
+        if (!(o instanceof CommitMetadata other)) {
             return false;
         }
 
-        var other = (CommitMetadata) o;
         return Objects.equals(hash, other.hash) &&
                Objects.equals(parents, other.parents) &&
                Objects.equals(author, other.author) &&

--- a/vcs/src/main/java/org/openjdk/skara/vcs/FileEntry.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/FileEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,11 +61,10 @@ public class FileEntry {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof FileEntry)) {
+        if (!(o instanceof FileEntry e)) {
             return false;
         }
 
-        var e = (FileEntry) o;
         return Objects.equals(commit, e.commit) &&
                Objects.equals(type, e.type) &&
                Objects.equals(hash, e.hash) &&

--- a/vcs/src/main/java/org/openjdk/skara/vcs/FileType.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/FileType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -137,11 +137,11 @@ public class FileType {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof FileType)) {
+        if (!(o instanceof FileType ft)) {
             return false;
         }
 
-        return type == ((FileType) o).type;
+        return type == ft.type;
     }
 
     @Override

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Hash.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Hash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,7 @@ public class Hash {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof Hash)) {
+        if (!(o instanceof Hash h)) {
             return false;
         }
 
@@ -49,7 +49,7 @@ public class Hash {
             return true;
         }
 
-        return hex.equals(((Hash) o).hex());
+        return hex.equals(h.hex());
     }
 
     @Override

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Range.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Range.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -101,11 +101,10 @@ public class Range {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof Range)) {
+        if (!(o instanceof Range other)) {
             return false;
         }
 
-        var other = (Range) o;
         return start == other.start && count == other.count;
     }
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Reference.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Reference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,11 +48,10 @@ public class Reference {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof Reference)) {
+        if (!(o instanceof Reference r)) {
             return false;
         }
 
-        var r = (Reference) o;
         return Objects.equals(name, r.name) && Objects.equals(hash, r.hash);
     }
 

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Status.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Status.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -179,11 +179,10 @@ public class Status {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof Status)) {
+        if (!(o instanceof Status other)) {
             return false;
         }
 
-        var other = (Status) o;
         return Objects.equals(op, other.op) &&
                Objects.equals(score, other.score);
     }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Submodule.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Submodule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,11 +64,10 @@ public class Submodule {
             return true;
         }
 
-        if (!(other instanceof Submodule)) {
+        if (!(other instanceof Submodule o)) {
             return false;
         }
 
-        var o = (Submodule) other;
         return Objects.equals(hash, o.hash) &&
                Objects.equals(path, o.path) &&
                Objects.equals(pullPath, o.pullPath);

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Tag.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Tag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,11 +68,10 @@ public class Tag {
                 return true;
             }
 
-            if (!(other instanceof Annotated)) {
+            if (!(other instanceof Annotated o)) {
                 return false;
             }
 
-            var o = (Annotated) other;
             return Objects.equals(name, o.name) &&
                    Objects.equals(target, o.target) &&
                    Objects.equals(author, o.author) &&
@@ -113,11 +112,10 @@ public class Tag {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof Tag)) {
+        if (!(o instanceof Tag other)) {
             return false;
         }
 
-        var other = (Tag) o;
         return Objects.equals(name, other.name);
     }
 }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/WebrevStats.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/WebrevStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,11 +60,10 @@ public class WebrevStats {
             return true;
         }
 
-        if (!(other instanceof WebrevStats)) {
+        if (!(other instanceof WebrevStats o)) {
             return false;
         }
 
-        var o = (WebrevStats) other;
         return Objects.equals(added, o.added) &&
                Objects.equals(removed, o.removed) &&
                Objects.equals(modified, o.modified);

--- a/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/convert/Mark.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/convert/Mark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -85,8 +85,7 @@ public class Mark implements Comparable<Mark> {
             return true;
         }
 
-        if (o instanceof Mark) {
-            var m = (Mark) o;
+        if (o instanceof Mark m) {
             return Objects.equals(key, m.key) &&
                    Objects.equals(hg, m.hg) &&
                    Objects.equals(git, m.git) &&

--- a/vcs/src/main/java/org/openjdk/skara/vcs/tools/PatchHeader.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/tools/PatchHeader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -151,11 +151,10 @@ public class PatchHeader {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof PatchHeader)) {
+        if (!(o instanceof PatchHeader other)) {
             return false;
         }
 
-        var other = (PatchHeader) o;
         return Objects.equals(sourcePath, other.sourcePath()) &&
                Objects.equals(sourceFileType, other.sourceFileType()) &&
                Objects.equals(sourceHash, other.sourceHash()) &&


### PR DESCRIPTION
Pattern matching for `instanceof` was introduced in JDK 16, by JEP 394. It's already been used by new code in Skara, but the older code can benefit from it too.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2321](https://bugs.openjdk.org/browse/SKARA-2321): Prefer pattern matching for instanceof (**Bug** - P4)


### Reviewers
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1673/head:pull/1673` \
`$ git checkout pull/1673`

Update a local copy of the PR: \
`$ git checkout pull/1673` \
`$ git pull https://git.openjdk.org/skara.git pull/1673/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1673`

View PR using the GUI difftool: \
`$ git pr show -t 1673`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1673.diff">https://git.openjdk.org/skara/pull/1673.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1673#issuecomment-2214732546)