### PR TITLE
2322: Notify when PR is ready for sponsor in GitLab

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
@@ -145,7 +145,7 @@ class ArchiveWorkItem implements WorkItem {
 
     private boolean ignoreComment(HostUser author, String body, ZonedDateTime createdTime, ZonedDateTime lastDraftTime, boolean isComment) {
         if (pr.repository().forge().currentUser().equals(author)) {
-            return true;
+            return !PullRequestConstants.READY_FOR_SPONSOR_MARKER_PATTERN.matcher(body).find();
         }
         if (bot.ignoredUsers().contains(author.username())) {
             return !PullRequestConstants.READY_FOR_SPONSOR_MARKER_PATTERN.matcher(body).find();


### PR DESCRIPTION
In [SKARA-2302](https://bugs.openjdk.org/browse/SKARA-2302), I tried to let the bot send an email notification about the "pr is ready for sponsor" comment.
But today, I noticed that it only works in GitHub not works in GitLab.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2322](https://bugs.openjdk.org/browse/SKARA-2322): Notify when PR is ready for sponsor in GitLab (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1674/head:pull/1674` \
`$ git checkout pull/1674`

Update a local copy of the PR: \
`$ git checkout pull/1674` \
`$ git pull https://git.openjdk.org/skara.git pull/1674/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1674`

View PR using the GUI difftool: \
`$ git pr show -t 1674`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1674.diff">https://git.openjdk.org/skara/pull/1674.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1674#issuecomment-2215501313)