### PR TITLE
2323: Use stream-bearing methods of java.nio.file.Files correctly

### DIFF
--- a/bots/hgbridge/src/main/java/org/openjdk/skara/bots/hgbridge/Exporter.java
+++ b/bots/hgbridge/src/main/java/org/openjdk/skara/bots/hgbridge/Exporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,10 +68,11 @@ class Exporter {
 
     private static List<Mark> loadMarks(Path p) throws IOException {
         if (Files.exists(p)) {
-            return Files.lines(p)
-                        .map(line -> line.split(","))
-                        .map(entry -> new Mark(Integer.parseInt(entry[0]), new Hash(entry[1]), new Hash(entry[2])))
-                        .collect(Collectors.toList());
+            try (var lines = Files.lines(p)) {
+                return lines.map(line -> line.split(","))
+                            .map(entry -> new Mark(Integer.parseInt(entry[0]), new Hash(entry[1]), new Hash(entry[2])))
+                            .collect(Collectors.toList());
+            }
         } else {
             return new ArrayList<>();
         }
@@ -85,9 +86,8 @@ class Exporter {
     }
 
     private static void clearDirectory(Path directory) {
-        try {
-            Files.walk(directory)
-                 .map(Path::toFile)
+        try (var paths = Files.walk(directory)) {
+            paths.map(Path::toFile)
                  .sorted(Comparator.reverseOrder())
                  .forEach(File::delete);
         } catch (IOException io) {

--- a/bots/hgbridge/src/test/java/org/openjdk/skara/bots/hgbridge/BridgeBotTests.java
+++ b/bots/hgbridge/src/test/java/org/openjdk/skara/bots/hgbridge/BridgeBotTests.java
@@ -226,16 +226,17 @@ class BridgeBotTests {
             assertTrue(localGitCommits.contains(FIRST_CONVERTED_HASH));
 
             // Now corrupt the .hg folder in the permanent storage
-            Files.walk(storageFolder.path())
-                 .filter(p -> p.toString().contains("/.hg/"))
-                 .filter(p -> p.toFile().isFile())
-                 .forEach(p -> {
-                     try {
-                         Files.delete(p);
-                     } catch (IOException e) {
-                         throw new UncheckedIOException(e);
-                     }
-                 });
+            try (var paths = Files.walk(storageFolder.path())) {
+                paths.filter(p -> p.toString().contains("/.hg/"))
+                     .filter(p -> p.toFile().isFile())
+                     .forEach(p -> {
+                         try {
+                             Files.delete(p);
+                         } catch (IOException e) {
+                             throw new UncheckedIOException(e);
+                         }
+                     });
+            }
 
             // Now export it again - should still be intact
             TestBotRunner.runPeriodicItems(bridge);
@@ -353,16 +354,17 @@ class BridgeBotTests {
             assertFalse(localGitCommits.contains(FIRST_CONVERTED_HASH));
 
             // Remove the successful push markers
-            Files.walk(storageFolder.path())
-                 .filter(p -> p.toString().contains(".success.txt"))
-                 .filter(p -> p.toFile().isFile())
-                 .forEach(p -> {
-                     try {
-                         Files.delete(p);
-                     } catch (IOException e) {
-                         throw new UncheckedIOException(e);
-                     }
-                 });
+            try (var paths = Files.walk(storageFolder.path())) {
+                paths.filter(p -> p.toString().contains(".success.txt"))
+                     .filter(p -> p.toFile().isFile())
+                     .forEach(p -> {
+                         try {
+                             Files.delete(p);
+                         } catch (IOException e) {
+                             throw new UncheckedIOException(e);
+                         }
+                     });
+            }
 
             // Now run the exporter again - it should do the push again
             TestBotRunner.runPeriodicItems(bridge);

--- a/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
+++ b/bots/merge/src/main/java/org/openjdk/skara/bots/merge/MergeBot.java
@@ -251,10 +251,11 @@ class MergeBot implements Bot, WorkItem {
     }
 
     private static void deleteDirectory(Path dir) throws IOException {
-        Files.walk(dir)
-             .map(Path::toFile)
-             .sorted(Comparator.reverseOrder())
-             .forEach(File::delete);
+        try (var paths = Files.walk(dir)) {
+            paths.map(Path::toFile)
+                 .sorted(Comparator.reverseOrder())
+                 .forEach(File::delete);
+        }
     }
 
     private Repository cloneAndSyncFork(Path to) throws IOException {

--- a/bots/mirror/src/main/java/org/openjdk/skara/bots/mirror/MirrorBot.java
+++ b/bots/mirror/src/main/java/org/openjdk/skara/bots/mirror/MirrorBot.java
@@ -92,10 +92,11 @@ class MirrorBot implements Bot, WorkItem {
                 repo = Repository.get(dir).orElseGet(() -> {
                     log.info("The existing scratch directory is not a valid repository. Recloning " + from.name());
                     try {
-                        Files.walk(dir)
-                                .map(Path::toFile)
-                                .sorted(Comparator.reverseOrder())
-                                .forEach(File::delete);
+                        try (var paths = Files.walk(dir)) {
+                            paths.map(Path::toFile)
+                                 .sorted(Comparator.reverseOrder())
+                                 .forEach(File::delete);
+                        }
                         return Repository.mirror(from.authenticatedUrl(), dir);
                     } catch (IOException io) {
                         throw new RuntimeException(io);

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -47,9 +47,8 @@ class MailingListBridgeBotTests {
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots.mlbridge.test");
 
     private Optional<String> archiveContents(Path archive, String prId) {
-        try {
-            var mbox = Files.find(archive, 50, (path, attrs) -> path.toString().endsWith(".mbox"))
-                            .filter(path -> path.getFileName().toString().contains(prId))
+        try (var paths = Files.find(archive, 50, (path, attrs) -> path.toString().endsWith(".mbox"))) {
+            var mbox = paths.filter(path -> path.getFileName().toString().contains(prId))
                             .findAny();
             if (mbox.isEmpty()) {
                 return Optional.empty();
@@ -90,8 +89,8 @@ class MailingListBridgeBotTests {
     }
 
     private boolean webrevContains(Path webrev, String text) {
-        try {
-            var index = Files.find(webrev, 5, (path, attrs) -> path.toString().endsWith("index.html")).findAny();
+        try (var paths = Files.find(webrev, 5, (path, attrs) -> path.toString().endsWith("index.html"))) {
+            var index = paths.findAny();
             if (index.isEmpty()) {
                 return false;
             }

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/json/JsonNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/json/JsonNotifierTests.java
@@ -38,10 +38,11 @@ import static org.openjdk.skara.bots.notify.TestUtils.*;
 
 public class JsonNotifierTests {
     private List<Path> findJsonFiles(Path folder, String partialName) throws IOException {
-        return Files.walk(folder)
-                    .filter(path -> path.toString().endsWith(".json"))
-                    .filter(path -> path.toString().contains(partialName))
-                    .collect(Collectors.toList());
+        try (var paths = Files.walk(folder)) {
+            return paths.filter(path -> path.toString().endsWith(".json"))
+                        .filter(path -> path.toString().contains(partialName))
+                        .collect(Collectors.toList());
+        }
     }
 
     @Test

--- a/cli/src/main/java/org/openjdk/skara/cli/GitTrees.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitTrees.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,14 +54,14 @@ public class GitTrees {
     }
 
     private static List<Path> subrepos(Path root, boolean isMercurial) throws IOException {
-        var r = Files.walk(root)
-                    .filter(d -> d.getFileName().toString().equals(isMercurial ? ".hg" : ".git"))
-                    .map(d -> d.getParent())
-                    .filter(d -> !d.equals(root))
-                    .map(d -> root.relativize(d))
-                    .sorted()
-                    .collect(Collectors.toList());
-        return r;
+        try (var paths = Files.walk(root)) {
+            return paths.filter(d -> d.getFileName().toString().equals(isMercurial ? ".hg" : ".git"))
+                        .map(d -> d.getParent())
+                        .filter(d -> !d.equals(root))
+                        .map(d -> root.relativize(d))
+                        .sorted()
+                        .collect(Collectors.toList());
+        }
     }
 
     private static Path treesFile(Path root, boolean isMercurial) {

--- a/cli/src/main/java/org/openjdk/skara/cli/GitWebrev.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/GitWebrev.java
@@ -44,11 +44,10 @@ public class GitWebrev {
     private static final List<String> KNOWN_JBS_PROJECTS =
         List.of("JDK", "CODETOOLS", "SKARA", "JMC");
     private static void clearDirectory(Path directory) {
-        try {
-            Files.walk(directory)
-                    .map(Path::toFile)
-                    .sorted(Comparator.reverseOrder())
-                    .forEach(File::delete);
+        try (var paths = Files.walk(directory)) {
+            paths.map(Path::toFile)
+                 .sorted(Comparator.reverseOrder())
+                 .forEach(File::delete);
         } catch (IOException io) {
             throw new RuntimeException(io);
         }

--- a/cli/src/main/java/org/openjdk/skara/cli/debug/GitMlRules.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/debug/GitMlRules.java
@@ -678,10 +678,11 @@ public class GitMlRules {
                 if (path.toFile().isFile()) {
                     requestedFiles.add(repoRoot.relativize(path).toString());
                 } else {
-                    Files.walk(path)
-                         .filter(p -> p.toFile().isFile())
-                         .map(p -> repoRoot.relativize(p).toString())
-                         .forEach(requestedFiles::add);
+                    try (var paths = Files.walk(path)) {
+                        paths.filter(p -> p.toFile().isFile())
+                             .map(p -> repoRoot.relativize(p).toString())
+                             .forEach(requestedFiles::add);
+                    }
                 }
             }
 

--- a/cli/src/main/java/org/openjdk/skara/cli/debug/GitVerifyImport.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/debug/GitVerifyImport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -141,19 +141,21 @@ public class GitVerifyImport {
 
         var hgRoot = hg.root();
         var hgFiles = new HashSet<Path>();
-        Files.walk(hgRoot)
-             .filter(p -> !Files.isDirectory(p))
-             .map(hgRoot::relativize)
-             .filter(p -> !p.startsWith(".hg"))
-             .forEach(f -> hgFiles.add(f));
+        try (var paths = Files.walk(hgRoot)) {
+            paths.filter(p -> !Files.isDirectory(p))
+                 .map(hgRoot::relativize)
+                 .filter(p -> !p.startsWith(".hg"))
+                 .forEach(f -> hgFiles.add(f));
+        }
 
         var gitRoot = git.root();
         var gitFiles = new HashSet<Path>();
-        Files.walk(gitRoot)
-             .filter(p -> !Files.isDirectory(p))
-             .map(gitRoot::relativize)
-             .filter(p -> !p.startsWith(".git"))
-             .forEach(f -> gitFiles.add(f));
+        try (var paths = Files.walk(gitRoot)) {
+            paths.filter(p -> !Files.isDirectory(p))
+                 .map(gitRoot::relativize)
+                 .filter(p -> !p.startsWith(".git"))
+                 .forEach(f -> gitFiles.add(f));
+        }
 
         if (!hgFiles.equals(gitFiles)) {
             if (isVerbose) {

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepositoryPool.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepositoryPool.java
@@ -52,9 +52,8 @@ public class HostedRepositoryPool {
         }
 
         private void clearDirectory(Path directory) {
-            try {
-                Files.walk(directory)
-                     .map(Path::toFile)
+            try (var paths = Files.walk(directory)) {
+                paths.map(Path::toFile)
                      .sorted(Comparator.reverseOrder())
                      .forEach(File::delete);
             } catch (IOException io) {

--- a/gradle/plugins/skara-images/src/main/java/org/openjdk/skara/gradle/images/DownloadJDKTask.java
+++ b/gradle/plugins/skara-images/src/main/java/org/openjdk/skara/gradle/images/DownloadJDKTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -86,10 +86,11 @@ public class DownloadJDKTask extends DefaultTask {
     }
 
     private static void clearDirectory(Path directory) throws IOException {
-        Files.walk(directory)
-                .map(Path::toFile)
-                .sorted(Comparator.reverseOrder())
-                .forEach(File::delete);
+        try (var paths = Files.walk(directory)) {
+            paths.map(Path::toFile)
+                 .sorted(Comparator.reverseOrder())
+                 .forEach(File::delete);
+        }
     }
 
     private void unpack(Path file, Path dist) throws IOException {

--- a/gradle/plugins/skara-images/src/main/java/org/openjdk/skara/gradle/images/LaunchersTask.java
+++ b/gradle/plugins/skara-images/src/main/java/org/openjdk/skara/gradle/images/LaunchersTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,10 +69,11 @@ public class LaunchersTask extends DefaultTask {
     }
 
     private static void clearDirectory(Path directory) throws IOException {
-        Files.walk(directory)
-                .map(Path::toFile)
-                .sorted(Comparator.reverseOrder())
-                .forEach(File::delete);
+        try (var paths = Files.walk(directory)) {
+            paths.map(Path::toFile)
+                 .sorted(Comparator.reverseOrder())
+                 .forEach(File::delete);
+        }
     }
 
     @TaskAction

--- a/gradle/plugins/skara-version/src/main/java/org/openjdk/skara/gradle/version/VersionPlugin.java
+++ b/gradle/plugins/skara-version/src/main/java/org/openjdk/skara/gradle/version/VersionPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@ import org.gradle.api.GradleException;
 import java.nio.file.Files;
 import java.nio.charset.StandardCharsets;
 import java.io.IOException;
-
-import static java.util.stream.Collectors.toList;
+import java.util.Optional;
 
 public class VersionPlugin implements Plugin<Project> {
     public void apply(Project project) {
@@ -53,9 +52,12 @@ public class VersionPlugin implements Plugin<Project> {
                 var root = project.getRootProject().getRootDir().toPath();
                 var versionTxt = root.resolve("version.txt");
                 if (Files.exists(versionTxt)) {
-                    var lines = Files.lines(versionTxt).collect(toList());
-                    if (!lines.isEmpty()) {
-                        project.setProperty("version", lines.get(0));
+                    Optional<String> firstLine;
+                    try (var lines = Files.lines(versionTxt)) {
+                        firstLine = lines.findFirst();
+                    }
+                    if (firstLine.isPresent()) {
+                        project.setProperty("version", firstLine.get());
                     } else {
                         project.setProperty("version", "unknown");
                     }

--- a/test/src/main/java/org/openjdk/skara/test/TemporaryDirectory.java
+++ b/test/src/main/java/org/openjdk/skara/test/TemporaryDirectory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,9 +50,8 @@ public class TemporaryDirectory implements AutoCloseable {
     @Override
     public void close() {
         if (shouldRemove) {
-            try {
-                Files.walk(p)
-                     .map(Path::toFile)
+            try (var paths = Files.walk(p)) {
+                paths.map(Path::toFile)
                      .sorted(Comparator.reverseOrder())
                      .forEach(File::delete);
             } catch (IOException io) {

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -478,10 +478,11 @@ public class GitRepository implements Repository {
     public Repository reinitialize() throws IOException {
         cachedRoot = null;
 
-        Files.walk(dir)
-             .map(Path::toFile)
-             .sorted(Comparator.reverseOrder())
-             .forEach(File::delete);
+        try (var paths = Files.walk(dir)) {
+            paths.map(Path::toFile)
+                 .sorted(Comparator.reverseOrder())
+                 .forEach(File::delete);
+        }
 
         return init();
     }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -453,10 +453,11 @@ public class HgRepository implements Repository {
 
     @Override
     public Repository reinitialize() throws IOException {
-        Files.walk(dir)
-             .map(Path::toFile)
-             .sorted(Comparator.reverseOrder())
-             .forEach(File::delete);
+        try (var paths = Files.walk(dir)) {
+            paths.map(Path::toFile)
+                 .sorted(Comparator.reverseOrder())
+                 .forEach(File::delete);
+        }
 
         return init();
     }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/convert/HgToGitConverter.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/openjdk/convert/HgToGitConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -661,9 +661,11 @@ public class HgToGitConverter implements Converter {
         }
 
         if (Files.isDirectory(gitRoot)) {
-            for (var path : Files.walk(gitRoot).collect(Collectors.toList())) {
-                if (path.getFileName().toString().startsWith("fast_import_crash")) {
-                    log.warning(Files.readString(path));
+            try (var paths = Files.walk(gitRoot)) {
+                for (var path : paths.toList()) {
+                    if (path.getFileName().toString().startsWith("fast_import_crash")) {
+                        log.warning(Files.readString(path));
+                    }
                 }
             }
         }

--- a/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2693,14 +2693,18 @@ public class RepositoryTests {
             var untracked = dir.path().resolve("UNTRACKED");
             Files.write(untracked, List.of("Hello, untracked!"));
 
-            var paths = Files.list(r.root()).collect(Collectors.toList());
-            assertTrue(paths.contains(untracked));
-            assertTrue(paths.contains(readme));
+            try (var list = Files.list(r.root())) {
+                var paths = list.toList();
+                assertTrue(paths.contains(untracked));
+                assertTrue(paths.contains(readme));
+            }
 
             r.deleteUntrackedFiles();
-            paths = Files.list(r.root()).collect(Collectors.toList());
-            assertFalse(paths.contains(untracked));
-            assertTrue(paths.contains(readme));
+            try (var list = Files.list(r.root())) {
+                var paths = list.toList();
+                assertFalse(paths.contains(untracked));
+                assertTrue(paths.contains(readme));
+            }
         }
     }
 


### PR DESCRIPTION
Streams returned from methods of `java.nio.file.Files` should be closed. A typical documentation note reads as follows:

> This method must be used within a try-with-resources statement or similar control structure to ensure that the stream's <resource> is closed promptly after the stream's operations have completed.

In a few occasions, code was additionally lightly simplified:

  - LinkTask.java#L131
  - LinkTask.java#L179
  - VersionPlugin.java#L55-L60