### PR TITLE
SKARA-2236

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
@@ -145,10 +145,18 @@ class ArchiveWorkItem implements WorkItem {
 
     private boolean ignoreComment(HostUser author, String body, ZonedDateTime createdTime, ZonedDateTime lastDraftTime, boolean isComment) {
         if (pr.repository().forge().currentUser().equals(author)) {
-            return !PullRequestConstants.READY_FOR_SPONSOR_MARKER_PATTERN.matcher(body).find();
+            if (pr.isOpen()) {
+                return !PullRequestConstants.READY_FOR_SPONSOR_MARKER_PATTERN.matcher(body).find();
+            } else {
+                return true;
+            }
         }
         if (bot.ignoredUsers().contains(author.username())) {
-            return !PullRequestConstants.READY_FOR_SPONSOR_MARKER_PATTERN.matcher(body).find();
+            if (pr.isOpen()) {
+                return !PullRequestConstants.READY_FOR_SPONSOR_MARKER_PATTERN.matcher(body).find() && pr.isOpen();
+            } else {
+                return true;
+            }
         }
 
         // Check if this comment only contains command lines


### PR DESCRIPTION
After we deployed [SKARA-2302](https://bugs.openjdk.org/browse/SKARA-2302) and [SKARA-2322](https://bugs.openjdk.org/browse/SKARA-2322), some users complained about receiving numerous "ready for sponsor" emails from closed PRs.
We should prevent the bot from retroactively sending out these emails.