### PR TITLE
2327: Skip CheckTests.acceptSimpleMerges on older Git

### DIFF
--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -30,6 +30,7 @@ import org.openjdk.skara.json.JSON;
 import org.openjdk.skara.test.*;
 import org.openjdk.skara.vcs.Branch;
 import org.openjdk.skara.vcs.Repository;
+import org.openjdk.skara.vcs.git.GitVersion;
 
 import java.io.*;
 import java.nio.file.*;
@@ -1611,6 +1612,8 @@ class CheckTests {
 
     @Test
     void acceptSimpleMerges(TestInfo testInfo) throws IOException {
+        var v = GitVersion.get();
+        Assumptions.assumeTrue(v.major() > 2 || (v.major() == 2 && v.minor() >= 36), v.toString());
         try (var credentials = new HostCredentials(testInfo);
              var tempFolder = new TemporaryDirectory()) {
 

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -1005,6 +1005,7 @@ public class GitRepository implements Repository {
 
     @Override
     public boolean isRemergeDiffEmpty(Hash mergeCommitHash) throws IOException {
+        // requires git 2.36 or newer
         try (var p = Process.capture("git", "show", "--remerge-diff", "--format=%b", mergeCommitHash.hex())
                 .workdir(dir)
                 .environ(currentEnv)


### PR DESCRIPTION
Please review this test fix.

A recently added test fails in environments with Git versions older than 2.36. This is because the test verifies functionality that uses `--remerge-diff` added to [Git 2.36]( https://github.blog/2022-04-18-highlights-from-git-2-36/).

Note that it's sufficient to conditionally skip the test. We don't need to amend the logic being tested, as bots are run on Git 2.36 or newer. The test assumes 2.36 as the minimum Git version. The test uses the existing functionality provided by `org.openjdk.skara.vcs.git.GitVersion`. Hope, that new dependency is okay.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2327](https://bugs.openjdk.org/browse/SKARA-2327): Skip CheckTests.acceptSimpleMerges on older Git (**Bug** - P4)


### Reviewers
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1677/head:pull/1677` \
`$ git checkout pull/1677`

Update a local copy of the PR: \
`$ git checkout pull/1677` \
`$ git pull https://git.openjdk.org/skara.git pull/1677/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1677`

View PR using the GUI difftool: \
`$ git pr show -t 1677`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1677.diff">https://git.openjdk.org/skara/pull/1677.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1677#issuecomment-2224091977)