### PR TITLE
2329: Close org.openjdk.skara.process.Execution

### DIFF
--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
@@ -1518,14 +1518,15 @@ class MergeTests {
             var unrelated = Files.writeString(localRepo.root().resolve("unrelated.txt"), "Unrelated");
             localRepo.add(unrelated);
             localRepo.commit("Unrelated", "some", "some@one");
-            var mergeCmd = Process.command("git", "merge", "--no-commit", "--allow-unrelated-histories", "-s", "ours", otherHash.hex())
-                                  .workdir(localRepo.root())
-                                  .environ("GIT_AUTHOR_NAME", "some")
-                                  .environ("GIT_AUTHOR_EMAIL", "some@one")
-                                  .environ("GIT_COMMITTER_NAME", "another")
-                                  .environ("GIT_COMMITTER_EMAIL", "another@one")
-                                  .execute();
-            mergeCmd.check();
+            try (var p = Process.command("git", "merge", "--no-commit", "--allow-unrelated-histories", "-s", "ours", otherHash.hex())
+                    .workdir(localRepo.root())
+                    .environ("GIT_AUTHOR_NAME", "some")
+                    .environ("GIT_AUTHOR_EMAIL", "some@one")
+                    .environ("GIT_COMMITTER_NAME", "another")
+                    .environ("GIT_COMMITTER_EMAIL", "another@one")
+                    .execute()) {
+                p.check();
+            }
 
             //localRepo.merge(otherHash);
             var mergeHash = localRepo.commit("Merge commit", "some", "some@one");


### PR DESCRIPTION
Please review this trivial fix: org.openjdk.skara.process.Execution is AutoCloseable and a few tests don't close it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2329](https://bugs.openjdk.org/browse/SKARA-2329): Close org.openjdk.skara.process.Execution (**Bug** - P4)


### Reviewers
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - **Reviewer**) ⚠️ Review applies to [0f022fad](https://git.openjdk.org/skara/pull/1678/files/0f022fad0ee10b09c7e2d9c55102f814ed7dce4f)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1678/head:pull/1678` \
`$ git checkout pull/1678`

Update a local copy of the PR: \
`$ git checkout pull/1678` \
`$ git pull https://git.openjdk.org/skara.git pull/1678/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1678`

View PR using the GUI difftool: \
`$ git pr show -t 1678`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1678.diff">https://git.openjdk.org/skara/pull/1678.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1678#issuecomment-2230342096)