### PR TITLE
2331: Improve review notes

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -599,31 +599,31 @@ class CheckRun {
 
     private Optional<String> getReviewersList(boolean tooFewReviewers) {
         var reviewers = activeReviews.stream()
-                               .filter(review -> review.verdict() == Review.Verdict.APPROVED)
-                               .map(review -> {
-                                   var entry = " * " + formatReviewer(review.reviewer());
-                                   if (!review.targetRef().equals(pr.targetRef())) {
-                                       entry += " 🔄 Re-review required (review was made when pull request targeted the [" + review.targetRef()
-                                               + "](" + pr.repository().webUrl(new Branch(review.targetRef())) + ") branch)";
-                                   } else {
-                                       var hash = review.hash();
-                                       if (hash.isPresent()) {
-                                           if (!hash.get().equals(pr.headHash())) {
-                                               if (!reviewCoverage.covers(review) && tooFewReviewers) {
-                                                   entry += " 🔄 Re-review required (review applies to [" + hash.get().abbreviate()
-                                                           + "](" + pr.filesUrl(hash.get()) + "))";
-                                               } else {
-                                                   entry += " ⚠️ Review applies to [" + hash.get().abbreviate()
-                                                           + "](" + pr.filesUrl(hash.get()) + ")";
-                                               }
-                                           }
-                                       } else {
-                                           entry += " 🔄 Re-review required (review applies to a commit that is no longer present)";
-                                       }
-                                   }
-                                   return entry;
-                               })
-                               .collect(Collectors.joining("\n"));
+                .filter(review -> review.verdict() == Review.Verdict.APPROVED)
+                .map(review -> {
+                    var entry = " * " + formatReviewer(review.reviewer());
+                    if (!review.targetRef().equals(pr.targetRef())) {
+                        entry += " 🔄 Re-review required (review was made when pull request targeted the [" + review.targetRef()
+                                + "](" + pr.repository().webUrl(new Branch(review.targetRef())) + ") branch)";
+                    } else {
+                        var hash = review.hash();
+                        if (hash.isPresent()) {
+                            if (!hash.get().equals(pr.headHash())) {
+                                if (!reviewCoverage.covers(review) && tooFewReviewers) {
+                                    entry += " 🔄 Re-review required (review applies to [" + hash.get().abbreviate()
+                                            + "](" + pr.filesUrl(hash.get()) + "))";
+                                } else {
+                                    entry += " ⚠️ Review applies to [" + hash.get().abbreviate()
+                                            + "](" + pr.filesUrl(hash.get()) + ")";
+                                }
+                            }
+                        } else {
+                            entry += " 🔄 Re-review required (review applies to a commit that is no longer present)";
+                        }
+                    }
+                    return entry;
+                })
+                .collect(Collectors.joining("\n"));
 
         // Check for manually added reviewers
         if (useStaleReviews) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -607,12 +607,14 @@ class CheckRun {
                                    } else {
                                        var hash = review.hash();
                                        if (hash.isPresent()) {
-                                           if (!reviewCoverage.covers(review)) {
-                                               entry += " 🔄 Re-review required (review applies to [" + hash.get().abbreviate()
-                                                       + "](" + pr.filesUrl(hash.get()) + "))";
-                                           } else {
-                                               entry += " ⚠️ Review applies to [" + hash.get().abbreviate()
-                                                       + "](" + pr.filesUrl(hash.get()) + ")";
+                                           if (!hash.get().equals(pr.headHash())) {
+                                               if (!reviewCoverage.covers(review)) {
+                                                   entry += " 🔄 Re-review required (review applies to [" + hash.get().abbreviate()
+                                                           + "](" + pr.filesUrl(hash.get()) + "))";
+                                               } else {
+                                                   entry += " ⚠️ Review applies to [" + hash.get().abbreviate()
+                                                           + "](" + pr.filesUrl(hash.get()) + ")";
+                                               }
                                            }
                                        } else {
                                            entry += " 🔄 Re-review required (review applies to a commit that is no longer present)";

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -603,7 +603,7 @@ class CheckRun {
                 .map(review -> {
                     var entry = " * " + formatReviewer(review.reviewer());
                     if (!review.targetRef().equals(pr.targetRef())) {
-                        if (useStaleReviews || tooFewReviewers) {
+                        if (tooFewReviewers) {
                             entry += " 🔄 Re-review required (review was made when pull request targeted the [" + review.targetRef()
                                     + "](" + pr.repository().webUrl(new Branch(review.targetRef())) + ") branch)";
                         } else {
@@ -624,7 +624,7 @@ class CheckRun {
                                 }
                             }
                         } else {
-                            if (useStaleReviews || tooFewReviewers) {
+                            if (tooFewReviewers) {
                                 entry += " 🔄 Re-review required (review applies to a commit that is no longer present)";
                             } else {
                                 entry += " Review applies to a commit that is no longer present";

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -603,7 +603,7 @@ class CheckRun {
                 .map(review -> {
                     var entry = " * " + formatReviewer(review.reviewer());
                     if (!review.targetRef().equals(pr.targetRef())) {
-                        if (tooFewReviewers) {
+                        if (useStaleReviews || tooFewReviewers) {
                             entry += " 🔄 Re-review required (review was made when pull request targeted the [" + review.targetRef()
                                     + "](" + pr.repository().webUrl(new Branch(review.targetRef())) + ") branch)";
                         } else {
@@ -614,17 +614,19 @@ class CheckRun {
                         var hash = review.hash();
                         if (hash.isPresent()) {
                             if (!hash.get().equals(pr.headHash())) {
-                                if (reviewCoverage.covers(review) || !tooFewReviewers) {
-                                    entry += (tooFewReviewers ? " ⚠️ " : " ")
-                                            + "Review applies to [" + hash.get().abbreviate()
+                                if (useStaleReviews) {
+                                    entry += " ⚠️ Review applies to [" + hash.get().abbreviate()
                                             + "](" + pr.filesUrl(hash.get()) + ")";
-                                } else {
+                                } else if (!reviewCoverage.covers(review) && tooFewReviewers) {
                                     entry += " 🔄 Re-review required (review applies to [" + hash.get().abbreviate()
                                             + "](" + pr.filesUrl(hash.get()) + "))";
+                                } else {
+                                    entry += " Review applies to [" + hash.get().abbreviate()
+                                            + "](" + pr.filesUrl(hash.get()) + ")";
                                 }
                             }
                         } else {
-                            if (tooFewReviewers) {
+                            if (useStaleReviews || tooFewReviewers) {
                                 entry += " 🔄 Re-review required (review applies to a commit that is no longer present)";
                             } else {
                                 entry += " Review applies to a commit that is no longer present";

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -1359,8 +1359,8 @@ class CheckRun {
             } else {
                 // Determine current status
                 jcheckType = "target jcheck";
-                var issues = checkablePullRequest.executeChecks(localHash, censusInstance, visitor, targetJCheckConf);
-                tooFewReviewers = issues.stream().anyMatch(TooFewReviewersIssue.class::isInstance);
+                var jcheckIssues = checkablePullRequest.executeChecks(localHash, censusInstance, visitor, targetJCheckConf);
+                tooFewReviewers = jcheckIssues.stream().anyMatch(TooFewReviewersIssue.class::isInstance);
 
                 // If the PR updates .jcheck/conf then Need to run JCheck again using the configuration
                 // from the resulting commit. Not needed if we are overriding the JCheck configuration since

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
@@ -231,12 +231,14 @@ public class CheckablePullRequest {
                     () -> new IllegalStateException("Cannot parse JCheck configuration with additional configuration for commit with hash " + hash.hex()));
     }
 
-    void executeChecks(Hash hash, CensusInstance censusInstance, PullRequestCheckIssueVisitor visitor, JCheckConfiguration conf) throws IOException {
+    List<org.openjdk.skara.jcheck.Issue> executeChecks(Hash hash, CensusInstance censusInstance, PullRequestCheckIssueVisitor visitor, JCheckConfiguration conf) throws IOException {
         visitor.setConfiguration(conf);
         try (var issues = JCheck.check(localRepo, censusInstance.census(), CommitMessageParsers.v1, hash, conf)) {
-            for (var issue : issues) {
+            var list = issues.asList();
+            for (var issue : list) {
                 issue.accept(visitor);
             }
+            return list;
         }
     }
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -205,6 +205,8 @@ class CheckTests {
             var reviewerPr = reviewer.pullRequest(authorPr.id());
             reviewerPr.addReview(Review.Verdict.APPROVED, "Reviewers");
             TestBotRunner.runPeriodicItems(checkBot);
+            assertFalse(authorPr.store().body().contains("Re-review required"));
+            assertFalse(authorPr.store().body().contains("Review applies to"));
 
             // Check that it has been approved
             assertTrue(authorPr.store().body().contains("Reviewers"));
@@ -1557,6 +1559,7 @@ class CheckTests {
             // The PR should be flagged as ready
             assertTrue(pr.store().labelNames().contains("ready"));
             assertFalse(pr.store().body().contains("Re-review required"));
+            assertFalse(pr.store().body().contains("Review applies to"));
 
             // Add another commit
             editHash = CheckableRepository.replaceAndCommit(localRepo, "Another line");
@@ -1691,6 +1694,8 @@ class CheckTests {
             TestBotRunner.runPeriodicItems(checkBot);
 
             assertTrue(pr.store().labelNames().contains("ready"));
+            assertFalse(pr.store().body().contains("Re-review required"));
+            assertFalse(pr.store().body().contains("Review applies to"));
 
             localRepo.checkout(new Branch("master"));
             Files.writeString(f, """

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -1576,6 +1576,12 @@ class CheckTests {
             // Approve again by reviewer1
             approvalPr.addReview(Review.Verdict.APPROVED, "Approved again");
 
+            // Check the status again
+            TestBotRunner.runPeriodicItems(checkBot);
+
+            assertFalse(pr.store().body().contains("Re-review required"));
+            assertTrue(pr.store().body().contains("Review applies to"));
+
             // Change the target ref of the PR
             localRepo.push(masterHash, author.authenticatedUrl(), "other-branch", true);
             pr.setTargetRef("other-branch");

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -1571,7 +1571,7 @@ class CheckTests {
             // The PR should no longer be ready, as the reviews are stale
             assertFalse(pr.store().labelNames().contains("ready"));
             assertTrue(pr.store().labelNames().contains("rfr"));
-            assertTrue(pr.store().body().contains("Re-review required"));
+            assertTrue(pr.store().body().contains("🔄 Re-review required"));
 
             // Approve again by reviewer1
             approvalPr.addReview(Review.Verdict.APPROVED, "Approved again");
@@ -1580,6 +1580,7 @@ class CheckTests {
             TestBotRunner.runPeriodicItems(checkBot);
 
             assertFalse(pr.store().body().contains("Re-review required"));
+            assertFalse(pr.store().body().contains("⚠️ Review applies to"));
             assertTrue(pr.store().body().contains("Review applies to"));
 
             // Change the target ref of the PR
@@ -1592,7 +1593,7 @@ class CheckTests {
             // The PR should no longer be ready, as the review is stale
             assertFalse(pr.store().labelNames().contains("ready"));
             assertTrue(pr.store().labelNames().contains("rfr"));
-            assertTrue(pr.store().body().contains("Re-review required"));
+            assertTrue(pr.store().body().contains("🔄 Re-review required"));
 
             // Approve yet again
             approvalPr.addReview(Review.Verdict.APPROVED, "Approved again");
@@ -1603,7 +1604,8 @@ class CheckTests {
 
             // The PR should be flagged as ready
             assertTrue(pr.store().labelNames().contains("ready"));
-            assertTrue(pr.store().body().contains("Re-review required"));
+            assertFalse(pr.store().body().contains("🔄 Re-review required"));
+            assertTrue(pr.store().body().contains("Review was made when pull request targeted"));
 
             // Change target ref back to the original branch
             pr.setTargetRef("master");
@@ -1613,7 +1615,8 @@ class CheckTests {
 
             // The PR should be flagged as ready, since the old review with that target is now valid again
             assertTrue(pr.store().labelNames().contains("ready"));
-            assertTrue(pr.store().body().contains("Re-review required"));
+            assertTrue(pr.store().body().contains("Review applies to"));
+            assertTrue(pr.store().body().contains("Review was made when pull request targeted"));
             // Credit line should include reviewers with stale reviews
             assertLastCommentContains(pr, "Reviewed-by: integrationreviewer2, integrationreviewer3, integrationreviewer4");
         }
@@ -1728,6 +1731,8 @@ class CheckTests {
             TestBotRunner.runPeriodicItems(checkBot);
 
             assertTrue(pr.store().labelNames().contains("ready"));
+            assertFalse(pr.store().body().contains("Re-review required"));
+            assertFalse(pr.store().body().contains("Review applies to"));
 
             localRepo.checkout(new Branch("feature"));
             localRepo.merge(new Branch("master"));
@@ -1738,6 +1743,8 @@ class CheckTests {
             TestBotRunner.runPeriodicItems(checkBot);
 
             assertTrue(pr.store().labelNames().contains("ready"));
+            assertFalse(pr.store().body().contains(" ⚠️ Review applies to"));
+            assertTrue(pr.store().body().contains("Review applies to"));
 
             localRepo.checkout(new Branch("master"));
             Files.writeString(f, """
@@ -1763,6 +1770,8 @@ class CheckTests {
             TestBotRunner.runPeriodicItems(checkBot);
 
             assertTrue(pr.store().labelNames().contains("ready"));
+            assertFalse(pr.store().body().contains(" ⚠️ Review applies to"));
+            assertTrue(pr.store().body().contains("Review applies to"));
 
             localRepo.checkout(new Branch("feature"));
             Files.writeString(f, """
@@ -1787,7 +1796,8 @@ class CheckTests {
             TestBotRunner.runPeriodicItems(checkBot);
 
             assertFalse(pr.store().labelNames().contains("ready"));
-            assertTrue(pr.store().body().contains("Re-review required"));
+            assertFalse(pr.store().body().contains("Review applies to"));
+            assertTrue(pr.store().body().contains(" 🔄 Re-review required"));
 
             approvalPr = reviewer.pullRequest(pr.id());
             approvalPr.addReview(Review.Verdict.APPROVED, "Approved");
@@ -1795,6 +1805,8 @@ class CheckTests {
             TestBotRunner.runPeriodicItems(checkBot);
 
             assertTrue(pr.store().labelNames().contains("ready"));
+            assertFalse(pr.store().body().contains("Review applies to"));
+            assertFalse(pr.store().body().contains("Re-review required"));
 
             localRepo.merge(new Branch("master"));
             localRepo.add(f);
@@ -1804,6 +1816,8 @@ class CheckTests {
             TestBotRunner.runPeriodicItems(checkBot);
 
             assertTrue(pr.store().labelNames().contains("ready"));
+            assertFalse(pr.store().body().contains(" ⚠️ Review applies to"));
+            assertTrue(pr.store().body().contains("Review applies to"));
 
             localRepo.checkout(new Branch("master"));
             Files.writeString(f, """
@@ -1877,7 +1891,7 @@ class CheckTests {
             TestBotRunner.runPeriodicItems(checkBot);
 
             assertFalse(pr.store().labelNames().contains("ready"));
-            assertTrue(pr.store().body().contains("Re-review required"));
+            assertTrue(pr.store().body().contains(" 🔄 Re-review required"));
         }
     }
 


### PR DESCRIPTION
There are two variants of a note that can be added to an item in the "Reviewers" list of a PR body:

  - 🔄 Re-review required ...
  - ⚠️ Review applies to ...

That note may confuse or draw unneeded attention to the PR body.

Firstly, as a result of recently integrated [SKARA-2312][], "⚠️ Review applies to ..." is also added to an item (i.e. review) that applies to the head of the PR. Secondly, "🔄 Re-review required (review applies to ..." may be present for some items even though a PR has the green "ready" label.

[SKARA-2312]: https://bugs.openjdk.org/browse/SKARA-2312

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [SKARA-2331](https://bugs.openjdk.org/browse/SKARA-2331): Improve review notes (**Bug** - P4)


### Reviewers
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - **Reviewer**) ⚠️ Review applies to [cd128621](https://git.openjdk.org/skara/pull/1679/files/cd1286215f146eca53dda62da07ab2ec65a3e0fd)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to [f4dde9b4](https://git.openjdk.org/skara/pull/1679/files/f4dde9b421993259f1c86b79314c1a494a3a1b3d)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**) ⚠️ Review applies to [f4dde9b4](https://git.openjdk.org/skara/pull/1679/files/f4dde9b421993259f1c86b79314c1a494a3a1b3d)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1679/head:pull/1679` \
`$ git checkout pull/1679`

Update a local copy of the PR: \
`$ git checkout pull/1679` \
`$ git pull https://git.openjdk.org/skara.git pull/1679/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1679`

View PR using the GUI difftool: \
`$ git pr show -t 1679`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1679.diff">https://git.openjdk.org/skara/pull/1679.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1679#issuecomment-2236214613)