### PR TITLE
2335: Avoid creating unneeded objects

### DIFF
--- a/bots/hgbridge/src/main/java/org/openjdk/skara/bots/hgbridge/JBridgeBotFactory.java
+++ b/bots/hgbridge/src/main/java/org/openjdk/skara/bots/hgbridge/JBridgeBotFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,7 +49,6 @@ public class JBridgeBotFactory implements BotFactory {
 
     @Override
     public List<Bot> create(BotConfiguration configuration) {
-        var ret = new ArrayList<Bot>();
         var specific = configuration.specific();
         var storage = configuration.storageFolder();
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewersTracker.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewersTracker.java
@@ -111,7 +111,6 @@ class ReviewersTracker {
     }
 
     static Optional<AdditionalRequiredReviewers> additionalRequiredReviewers(HostUser botUser, List<Comment> comments) {
-        var ret = new HashMap<String, Integer>();
         var reviewersActions = comments.stream()
                                        .filter(comment -> comment.author().equals(botUser))
                                        .map(comment -> REVIEWERS_MARKER_PATTERN.matcher(comment.body()))

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CleanCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CleanCommandTests.java
@@ -79,8 +79,7 @@ public class CleanCommandTests {
     @Test
     void alreadyCleanPullRequest(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
-             var tempFolder = new TemporaryDirectory(false);
-             var pushedFolder = new TemporaryDirectory(false)) {
+             var tempFolder = new TemporaryDirectory(false)) {
 
             var author = credentials.getHostedRepository();
             var integrator = credentials.getHostedRepository();
@@ -147,8 +146,7 @@ public class CleanCommandTests {
     @Test
     void makeNonCleanBackportClean(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
-             var tempFolder = new TemporaryDirectory(false);
-             var pushedFolder = new TemporaryDirectory(false)) {
+             var tempFolder = new TemporaryDirectory(false)) {
 
             var author = credentials.getHostedRepository();
             var integrator = credentials.getHostedRepository();
@@ -225,8 +223,7 @@ public class CleanCommandTests {
     @Test
     void authorShouldNotBeAllowed(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
-             var tempFolder = new TemporaryDirectory(false);
-             var pushedFolder = new TemporaryDirectory(false)) {
+             var tempFolder = new TemporaryDirectory(false)) {
 
             var author = credentials.getHostedRepository();
             var contributor = credentials.getHostedRepository();

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrateTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IntegrateTests.java
@@ -711,8 +711,7 @@ class IntegrateTests {
     @Test
     void missingContributingFile(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
-             var tempFolder = new TemporaryDirectory();
-             var pushedFolder = new TemporaryDirectory()) {
+             var tempFolder = new TemporaryDirectory()) {
 
             var author = credentials.getHostedRepository();
             var integrator = credentials.getHostedRepository();
@@ -747,8 +746,7 @@ class IntegrateTests {
     @Test
     void existingContributingFile(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
-             var tempFolder = new TemporaryDirectory();
-             var pushedFolder = new TemporaryDirectory()) {
+             var tempFolder = new TemporaryDirectory()) {
 
             var author = credentials.getHostedRepository();
             var integrator = credentials.getHostedRepository();
@@ -787,8 +785,7 @@ class IntegrateTests {
     @Test
     void contributorMissingEmail(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
-             var tempFolder = new TemporaryDirectory();
-             var pushedFolder = new TemporaryDirectory()) {
+             var tempFolder = new TemporaryDirectory()) {
             var author = credentials.getHostedRepository();
             var reviewer = credentials.getHostedRepository();
             var committer = credentials.getHostedRepository();
@@ -828,8 +825,7 @@ class IntegrateTests {
     @Test
     void invalidHash(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
-             var tempFolder = new TemporaryDirectory();
-             var pushedFolder = new TemporaryDirectory()) {
+             var tempFolder = new TemporaryDirectory()) {
 
             var author = credentials.getHostedRepository();
             var integrator = credentials.getHostedRepository();
@@ -1111,8 +1107,7 @@ class IntegrateTests {
     @Test
     void retryAfterInterrupt(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
-             var tempFolder = new TemporaryDirectory();
-             var censusFolder = new TemporaryDirectory()) {
+             var tempFolder = new TemporaryDirectory()) {
 
             var author = credentials.getHostedRepository();
             var integrator = credentials.getHostedRepository();
@@ -1237,8 +1232,7 @@ class IntegrateTests {
     @Test
     void retryAfterInterruptExtraChange(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
-             var tempFolder = new TemporaryDirectory();
-             var censusFolder = new TemporaryDirectory()) {
+             var tempFolder = new TemporaryDirectory()) {
 
             var author = credentials.getHostedRepository();
             var integrator = credentials.getHostedRepository();

--- a/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
+++ b/vcs/src/test/java/org/openjdk/skara/vcs/RepositoryTests.java
@@ -742,7 +742,6 @@ public class RepositoryTests {
     void testBranchesOnEmptyRepository(VCS vcs) throws IOException {
         try (var dir = new TemporaryDirectory()) {
             var r = TestableRepository.init(dir.path(), vcs);
-            var expected = vcs == VCS.GIT ? List.of() : List.of(new Branch("default"));
             assertEquals(List.of(), r.branches());
         }
     }
@@ -2168,7 +2167,6 @@ public class RepositoryTests {
         try (var dir = new TemporaryDirectory()) {
             var repo = TestableRepository.init(dir.path(), vcs);
             var readme = repo.root().resolve("README");
-            var now = ZonedDateTime.now();
             Files.writeString(readme, "Hello\n");
             repo.add(readme);
             var head = repo.commit("Added README", "duke", "duke@openjdk.org");


### PR DESCRIPTION
This PR removes needless objects, some of which are resources. Removing those objects should have no effect.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2335](https://bugs.openjdk.org/browse/SKARA-2335): Avoid creating unneeded objects (**Bug** - P5)


### Reviewers
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - **Reviewer**) ⚠️ Review applies to [4c16b10b](https://git.openjdk.org/skara/pull/1680/files/4c16b10b647dfdde961daf86107bf91fed4cc957)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1680/head:pull/1680` \
`$ git checkout pull/1680`

Update a local copy of the PR: \
`$ git checkout pull/1680` \
`$ git pull https://git.openjdk.org/skara.git pull/1680/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1680`

View PR using the GUI difftool: \
`$ git pr show -t 1680`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1680.diff">https://git.openjdk.org/skara/pull/1680.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1680#issuecomment-2239052022)