### PR TITLE
2338: Fix trivial typo in numeral

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveMessages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -113,7 +113,7 @@ class ArchiveMessages {
             case 6: return "six";
             case 7: return "seven";
             case 8: return "eight";
-            case 9: return "ten";
+            case 9: return "nine";
             default: return Integer.toString(number);
         }
     }


### PR DESCRIPTION
The bug is insignificant and only affects generated emails; for example:

 * https://mail.openjdk.org/pipermail/core-libs-dev/2021-October/082663.html
 * https://mail.openjdk.org/pipermail/core-libs-dev/2024-February/118754.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2338](https://bugs.openjdk.org/browse/SKARA-2338): Fix trivial typo in numeral (**Bug** - P5)


### Reviewers
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - **Reviewer**) ⚠️ Review applies to [e3366a98](https://git.openjdk.org/skara/pull/1681/files/e3366a98fd9a528fbff03333951b27e021736b3f)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1681/head:pull/1681` \
`$ git checkout pull/1681`

Update a local copy of the PR: \
`$ git checkout pull/1681` \
`$ git pull https://git.openjdk.org/skara.git pull/1681/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1681`

View PR using the GUI difftool: \
`$ git pr show -t 1681`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1681.diff">https://git.openjdk.org/skara/pull/1681.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1681#issuecomment-2244949008)