### PR TITLE
2340: CommitCommentsWorkItem executing in GitLab takes a lot of time

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -529,7 +529,7 @@ public class GitLabRepository implements HostedRepository {
                       .collect(Collectors.toList());
     }
 
-    private Set<Hash> commitsWithTitle(String commitTitle, Map<String, Set<Hash>> commitTitlesToHashes) {
+    private Set<Hash> commitsWithTitle(String commitTitle, Map<String, SequencedSet<Hash>> commitTitlesToHashes) {
         if (commitTitlesToHashes.containsKey(commitTitle)) {
             return commitTitlesToHashes.get(commitTitle);
         }
@@ -550,7 +550,7 @@ public class GitLabRepository implements HostedRepository {
 
     private Optional<CommitComment> findComment(String commitTitle,
             String commentId,
-            Map<String, Set<Hash>> commitTitleToCommits) {
+            Map<String, SequencedSet<Hash>> commitTitleToCommits) {
         var candidates = commitsWithTitle(commitTitle, commitTitleToCommits);
         // Even if there is only one candidate, we need to make sure the comment
         // exists on that commit before we try to process it. If this fails it's
@@ -612,10 +612,11 @@ public class GitLabRepository implements HostedRepository {
      * this is called, the full map is built from the local repository. After that
      * it's just refreshed from the server.
      */
-    private final Map<String, Set<Hash>> commitTitleToCommits = new HashMap<>();
+    private final Map<String, SequencedSet<Hash>> commitTitleToCommits = new HashMap<>();
     private boolean commitTitleToCommitsInitialized = false;
     private ZonedDateTime lastCommitTime = ZonedDateTime.ofInstant(Instant.EPOCH, ZoneId.systemDefault());
-    private Map<String, Set<Hash>> getCommitTitleToCommitsMap(ReadOnlyRepository localRepo, List<Branch> branches) {
+
+    private Map<String, SequencedSet<Hash>> getCommitTitleToCommitsMap(ReadOnlyRepository localRepo, List<Branch> branches) {
         if (!commitTitleToCommitsInitialized) {
             try {
                 for (var commit : localRepo.commitMetadataFor(branches)) {
@@ -643,7 +644,7 @@ public class GitLabRepository implements HostedRepository {
         for (var commit : commits) {
             var hash = new Hash(commit.get("id").asString());
             var title = commit.get("title").asString();
-            ((LinkedHashSet<Hash>) commitTitleToCommits.computeIfAbsent(title, t -> new LinkedHashSet<>())).addFirst(hash);
+            commitTitleToCommits.computeIfAbsent(title, t -> new LinkedHashSet<>()).addFirst(hash);
             var authored = ZonedDateTime.parse(commit.get("authored_date").asString());
             if (lastCommitTime.isBefore(authored)) {
                 lastCommitTime = authored;


### PR DESCRIPTION
Currently, if a user comments under a commit named "Merge" in GitLab, the CommitCommentsWorkItem will take about 8 hours to complete.
After investigation, I think there is a bug in GitLabRepository#getCommitTitleToCommitsMap

For GitLab repos, we need to build a hash map for mapping commit title to commits. The implementation of the map is Map<String, LinkedHashSet<Hash>>. We use LinkedHashSet here because we want the bot to check latest commits first.

If the map has already been built, then the bot will query new commits in the repo and adds the commits into the map. However, when adding the new commit hash to the map, the bot add it to the end of the LinkedHashSet. So new commits will be checked very late.

For commit titles like "Merge", sometimes, there can be around 50K commits in a repo. If the latest "Merge" commit is added to the tail of the LinkedHashSet, the bot must check all previous commits first, which takes a lot of time.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2340](https://bugs.openjdk.org/browse/SKARA-2340): CommitCommentsWorkItem executing in GitLab takes a lot of time (**Bug** - P2)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to [db3c7597](https://git.openjdk.org/skara/pull/1682/files/db3c75979be82f30363e348674f893d7e41c97ed)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1682/head:pull/1682` \
`$ git checkout pull/1682`

Update a local copy of the PR: \
`$ git checkout pull/1682` \
`$ git pull https://git.openjdk.org/skara.git pull/1682/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1682`

View PR using the GUI difftool: \
`$ git pr show -t 1682`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1682.diff">https://git.openjdk.org/skara/pull/1682.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1682#issuecomment-2269693969)