### PR TITLE
2348: Don't apply the logic of avoidForwardports if the issue has been resolved

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
@@ -335,9 +335,9 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
                             if (existing.isEmpty()) {
                                 var issueFixVersion = Backports.mainFixVersion(issue);
                                 try {
-                                    if (avoidForwardports && issueFixVersion.isPresent() && fixVersion.compareTo(issueFixVersion.get()) > 0) {
+                                    if (issue.isOpen() && avoidForwardports && issueFixVersion.isPresent() && fixVersion.compareTo(issueFixVersion.get()) > 0) {
                                         log.info("Avoiding 'forwardport', creating new backport for " + issue.id() + " with fixVersion " + issueFixVersion.get().raw());
-                                        Backports.createBackport(issue, issueFixVersion.get().raw() , username.orElse(null), defaultSecurity(branch));
+                                        Backports.createBackport(issue, issueFixVersion.get().raw(), username.orElse(null), defaultSecurity(branch));
                                     } else {
                                         log.info("Creating new backport for " + issue.id() + " with fixVersion " + requestedVersion);
                                         issue = Backports.createBackport(issue, requestedVersion, username.orElse(null), defaultSecurity(branch));


### PR DESCRIPTION
In [SKARA-2226](https://bugs.openjdk.org/browse/SKARA-2226), the issueNotifier was enhanced to avoid creating forward ports. However, there is a bug related with this feature. If the main issue has already been resolved and the fixVersion is targeted to release N-1, the issueNotifier will change the fixVersion to release N and create an open backport issue target to release N-1. The correct behavior should be to leave the main issue unchanged, create a backport target to release N, and resolve it accordingly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2348](https://bugs.openjdk.org/browse/SKARA-2348): Don't apply the logic of avoidForwardports if the issue has been resolved (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to [e478dac4](https://git.openjdk.org/skara/pull/1683/files/e478dac4946bc5156ba9ab4b43a907e423bd6735)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1683/head:pull/1683` \
`$ git checkout pull/1683`

Update a local copy of the PR: \
`$ git checkout pull/1683` \
`$ git pull https://git.openjdk.org/skara.git pull/1683/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1683`

View PR using the GUI difftool: \
`$ git pr show -t 1683`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1683.diff">https://git.openjdk.org/skara/pull/1683.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1683#issuecomment-2270060015)