### PR TITLE
2367: Customize bot messages based on forge

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
@@ -69,11 +69,6 @@ public class BackportCommand implements CommandHandler {
         return true;
     }
 
-    private static final String USER_INVALID_WARNING = "To use the `/backport` command, you need to be in the OpenJDK [census](https://openjdk.org/census)"
-            + " and your GitHub account needs to be linked with your OpenJDK username"
-            + " ([how to associate your GitHub account with your OpenJDK username]"
-            + "(https://wiki.openjdk.org/display/skara#Skara-AssociatingyourGitHubaccountandyourOpenJDKusername)).";
-
     private static final String INSUFFICIENT_ACCESS_WARNING = "The backport can not be created because you don't have access to the target repository.";
 
     private static final int BRANCHES_LIMIT = 10;
@@ -82,7 +77,7 @@ public class BackportCommand implements CommandHandler {
     public void handle(PullRequestBot bot, PullRequest pr, CensusInstance censusInstance, ScratchArea scratchArea, CommandInvocation command,
                        List<Comment> allComments, PrintWriter reply, List<String> labelsToAdd, List<String> labelsToRemove) {
         if (censusInstance.contributor(command.user()).isEmpty()) {
-            reply.println(USER_INVALID_WARNING);
+            printInvalidUserWarning(bot, reply);
             return;
         }
 
@@ -241,7 +236,7 @@ public class BackportCommand implements CommandHandler {
     public void handle(PullRequestBot bot, HostedCommit commit, LimitedCensusInstance censusInstance,
                        ScratchArea scratchArea, CommandInvocation command, List<Comment> allComments, PrintWriter reply) {
         if (censusInstance.contributor(command.user()).isEmpty() && !command.user().equals(bot.repo().forge().currentUser())) {
-            reply.println(USER_INVALID_WARNING);
+            printInvalidUserWarning(bot, reply);
             return;
         }
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BranchCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BranchCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@ package org.openjdk.skara.bots.pr;
 import org.openjdk.skara.forge.HostedBranch;
 import org.openjdk.skara.forge.HostedCommit;
 import org.openjdk.skara.issuetracker.Comment;
-import org.openjdk.skara.vcs.*;
 import org.openjdk.skara.jcheck.JCheckConfiguration;
 
 import java.io.PrintWriter;
@@ -73,10 +72,7 @@ public class BranchCommand implements CommandHandler {
                 return;
             }
             if (censusInstance.contributor(command.user()).isEmpty()) {
-                reply.println("To use the `/branch` command, you need to be in the OpenJDK [census](https://openjdk.org/census)"
-                        + " and your GitHub account needs to be linked with your OpenJDK username"
-                        + " ([how to associate your GitHub account with your OpenJDK username]"
-                        + "(https://wiki.openjdk.org/display/skara#Skara-AssociatingyourGitHubaccountandyourOpenJDKusername)).");
+                printInvalidUserWarning(bot, reply);
                 return;
             }
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandHandler.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,5 +58,16 @@ interface CommandHandler {
     }
     default boolean allowedInPullRequest() {
         return true;
+    }
+
+    default void printInvalidUserWarning(PullRequestBot bot, PrintWriter reply) {
+        if (bot.repo().forge().name().equals("GitHub")) {
+            reply.println(String.format("To use the `/%s` command, you need to be in the OpenJDK [census](https://openjdk.org/census)"
+                    + " and your GitHub account needs to be linked with your OpenJDK username"
+                    + " ([how to associate your GitHub account with your OpenJDK username]"
+                    + "(https://wiki.openjdk.org/display/skara#Skara-AssociatingyourGitHubaccountandyourOpenJDKusername)).", name()));
+        } else {
+            reply.println(String.format("To use the `/%s` command, you need to be listed as a contributor in this [census](%s)", name(), bot.censusRepo().authenticatedUrl()));
+        }
     }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/TagCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/TagCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,10 +69,7 @@ public class TagCommand implements CommandHandler {
                 return;
             }
             if (censusInstance.contributor(command.user()).isEmpty()) {
-                reply.println("To use the `/tag` command, you need to be in the OpenJDK [census](https://openjdk.org/census)"
-                        + " and your GitHub account needs to be linked with your OpenJDK username"
-                        + " ([how to associate your GitHub account with your OpenJDK username]"
-                        + "(https://wiki.openjdk.org/display/skara#Skara-AssociatingyourGitHubaccountandyourOpenJDKusername)).");
+                printInvalidUserWarning(bot, reply);
                 return;
             }
 


### PR DESCRIPTION
When an invalid user attempts to issue a Skara command, the Skara bot should print a customized message that is based on the forge.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2367](https://bugs.openjdk.org/browse/SKARA-2367): Customize bot messages based on forge (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1685/head:pull/1685` \
`$ git checkout pull/1685`

Update a local copy of the PR: \
`$ git checkout pull/1685` \
`$ git pull https://git.openjdk.org/skara.git pull/1685/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1685`

View PR using the GUI difftool: \
`$ git pr show -t 1685`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1685.diff">https://git.openjdk.org/skara/pull/1685.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1685#issuecomment-2342030498)