### PR TITLE
2373: Support repo-<project> style fix versions

### DIFF
--- a/jbs/src/main/java/org/openjdk/skara/jbs/JdkVersion.java
+++ b/jbs/src/main/java/org/openjdk/skara/jbs/JdkVersion.java
@@ -45,6 +45,8 @@ public class JdkVersion implements Comparable<JdkVersion> {
 
     private final static Pattern legacyPrefixPattern = Pattern.compile("^([^\\d]*)\\d+$");
 
+    private final static Pattern projectRepoPattern = Pattern.compile("repo-([a-z0-9]*)");
+
     private static List<String> splitComponents(String raw) {
         var finalComponents = new ArrayList<String>();
 
@@ -79,7 +81,6 @@ public class JdkVersion implements Comparable<JdkVersion> {
 
         // Check for team/project special version
         if (finalComponents.isEmpty()) {
-            var projectRepoPattern = Pattern.compile("repo-([a-z0-9]*)");
             var matcher = projectRepoPattern.matcher(raw);
             if (matcher.matches()) {
                 var project = matcher.group(1);

--- a/jbs/src/main/java/org/openjdk/skara/jbs/JdkVersion.java
+++ b/jbs/src/main/java/org/openjdk/skara/jbs/JdkVersion.java
@@ -77,6 +77,17 @@ public class JdkVersion implements Comparable<JdkVersion> {
             }
         }
 
+        // Check for team/project special version
+        if (finalComponents.isEmpty()) {
+            var projectRepoPattern = Pattern.compile("repo-([a-z0-9]*)");
+            var matcher = projectRepoPattern.matcher(raw);
+            if (matcher.matches()) {
+                var project = matcher.group(1);
+                finalComponents.add("repo");
+                finalComponents.add(project);
+            }
+        }
+
         // If no legacy match, use the JEP322 scheme
         if (finalComponents.isEmpty()) {
             // The input strings here never contain a $PRE string, but the $OPT string

--- a/jbs/src/test/java/org/openjdk/skara/jbs/BackportsTests.java
+++ b/jbs/src/test/java/org/openjdk/skara/jbs/BackportsTests.java
@@ -902,6 +902,20 @@ public class BackportsTests {
         }
     }
 
+    /**
+     * Verify that repo-project versions do not get labeled.
+     */
+    @Test
+    void repoProject(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo)) {
+            var backports = new BackportManager(credentials, "17");
+            backports.assertLabeled();
+
+            backports.addBackports("16", "16.0.2", "repo-foo");
+            backports.assertLabeled("16.0.2", "17");
+        }
+    }
+
     @Test
     void openjdk7u(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo)) {

--- a/jbs/src/test/java/org/openjdk/skara/jbs/JdkVersionTests.java
+++ b/jbs/src/test/java/org/openjdk/skara/jbs/JdkVersionTests.java
@@ -150,4 +150,10 @@ public class JdkVersionTests {
         assertEquals(List.of("8", "333"), from("8u333-foo").components());
         assertEquals("foo", from("8u333-foo").opt().orElseThrow());
     }
+
+    @Test
+    void teamRepo() {
+        assertEquals(List.of("repo", "foo"), from("repo-foo").components());
+        assertTrue(from("20").compareTo(from("repo-foo")) < 0);
+    }
 }


### PR DESCRIPTION
This patch adds parsing logic for handling version strings on the form "repo-<project>". This form is commonly used in JBS for project repos, but Skara is currently unable to actually parse them.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2373](https://bugs.openjdk.org/browse/SKARA-2373): Support repo-&lt;project&gt; style fix versions (**Bug** - P3)


### Reviewers
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1686/head:pull/1686` \
`$ git checkout pull/1686`

Update a local copy of the PR: \
`$ git checkout pull/1686` \
`$ git pull https://git.openjdk.org/skara.git pull/1686/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1686`

View PR using the GUI difftool: \
`$ git pr show -t 1686`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1686.diff">https://git.openjdk.org/skara/pull/1686.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1686#issuecomment-2357119542)