### PR TITLE
2328: Ignore bot user's comment when determining the latest action time of a PR

### DIFF
--- a/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestPrunerBot.java
+++ b/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestPrunerBot.java
@@ -37,10 +37,12 @@ class PullRequestPrunerBotWorkItem implements WorkItem {
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots");;
     private final PullRequest pr;
     private final Duration maxAge;
+    private final Set<String> ignoredUsers;
 
-    PullRequestPrunerBotWorkItem(PullRequest pr, Duration maxAge) {
+    PullRequestPrunerBotWorkItem(PullRequest pr, Duration maxAge, Set<String> ignoredUsers) {
         this.pr = pr;
         this.maxAge = maxAge;
+        this.ignoredUsers = ignoredUsers;
     }
 
     @Override
@@ -75,7 +77,10 @@ class PullRequestPrunerBotWorkItem implements WorkItem {
     public Collection<WorkItem> run(Path scratchPath) {
         var comments = pr.comments();
         if (comments.size() > 0) {
-            var lastComment = comments.getLast();
+            var lastComment = comments.stream()
+                    .filter(comment -> !ignoredUsers.contains(comment.author().username()))
+                    .toList()
+                    .getLast();
             if (lastComment.author().equals(pr.repository().forge().currentUser()) && lastComment.body().contains(NOTICE_MARKER)) {
                 var message = "@" + pr.author().username() + " This pull request has been inactive for more than " +
                         formatDuration(maxAge.multipliedBy(2)) + " and will now be automatically closed. If you would " +
@@ -122,9 +127,11 @@ public class PullRequestPrunerBot implements Bot {
     private final Logger log = Logger.getLogger("org.openjdk.skara.bots.bridgekeeper");
 
     private Duration currentMaxAge;
+    private Set<String> ignoredUsers;
 
-    PullRequestPrunerBot(Map<HostedRepository, Duration> maxAges) {
+    PullRequestPrunerBot(Map<HostedRepository, Duration> maxAges, Set<String> ignoredUsers) {
         this.maxAges = maxAges;
+        this.ignoredUsers = ignoredUsers;
     }
 
     @Override
@@ -153,7 +160,7 @@ public class PullRequestPrunerBot implements Bot {
         // Latest prune-delaying action (deliberately excluding pr.updatedAt, as it can be updated spuriously)
         var latestAction = Stream.of(Stream.of(pr.createdAt()),
                                    pr.comments().stream()
-                                     .filter(comment -> !comment.author().equals(pr.repository().forge().currentUser()))
+                                     .filter(comment -> !ignoredUsers.contains(comment.author().username()))
                                      .map(Comment::updatedAt),
                                    pr.reviews().stream()
                                      .map(Review::createdAt),
@@ -165,7 +172,7 @@ public class PullRequestPrunerBot implements Bot {
         var actualMaxAge = pr.isDraft() ? currentMaxAge.multipliedBy(2) : currentMaxAge;
         var oldestAllowed = ZonedDateTime.now().minus(actualMaxAge);
         if (latestAction.isBefore(oldestAllowed)) {
-            var item = new PullRequestPrunerBotWorkItem(pr, actualMaxAge);
+            var item = new PullRequestPrunerBotWorkItem(pr, actualMaxAge, ignoredUsers);
             ret.add(item);
         }
 
@@ -184,5 +191,9 @@ public class PullRequestPrunerBot implements Bot {
 
     public Map<HostedRepository, Duration> getMaxAges() {
         return maxAges;
+    }
+
+    public Set<String> getIgnoredUsers() {
+        return ignoredUsers;
     }
 }

--- a/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestPrunerBot.java
+++ b/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestPrunerBot.java
@@ -153,6 +153,7 @@ public class PullRequestPrunerBot implements Bot {
         // Latest prune-delaying action (deliberately excluding pr.updatedAt, as it can be updated spuriously)
         var latestAction = Stream.of(Stream.of(pr.createdAt()),
                                    pr.comments().stream()
+                                     .filter(comment -> !comment.author().equals(pr.repository().forge().currentUser()))
                                      .map(Comment::updatedAt),
                                    pr.reviews().stream()
                                      .map(Review::createdAt),

--- a/bots/bridgekeeper/src/test/java/org/openjdk/skara/bots/bridgekeeper/BridgekeeperBotFactoryTest.java
+++ b/bots/bridgekeeper/src/test/java/org/openjdk/skara/bots/bridgekeeper/BridgekeeperBotFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ import org.openjdk.skara.test.TestBotFactory;
 import org.openjdk.skara.test.TestHostedRepository;
 
 import java.time.Duration;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -47,14 +48,22 @@ public class BridgekeeperBotFactoryTest {
                     "data3"
                   ],
                   "pruned": {
-                    "pruned1": {
-                      "maxage": "P1D"
+                    "ignored": {
+                        "users": [
+                            "user1",
+                            "user2"
+                        ]
                     },
-                    "pruned2": {
-                      "maxage": "PT48H"
-                    },
-                    "pruned3": {
-                      "maxage": "PT4320M"
+                    "repositories": {
+                        "pruned1": {
+                          "maxage": "P1D"
+                        },
+                        "pruned2": {
+                          "maxage": "PT48H"
+                        },
+                        "pruned3": {
+                          "maxage": "PT4320M"
+                        }
                     }
                   }
                 }
@@ -112,5 +121,6 @@ public class BridgekeeperBotFactoryTest {
         assertEquals(Duration.ofDays(1), maxAges.get(pruned1));
         assertEquals(Duration.ofDays(2), maxAges.get(pruned2));
         assertEquals(Duration.ofDays(3), maxAges.get(pruned3));
+        assertEquals(Set.of("user1", "user2"), pullRequestPrunerBot.getIgnoredUsers());
     }
 }


### PR DESCRIPTION
PullRequestPrunerBot is responsible for closing PRs that have not been active for a certain time. However, it currently doesn't ignore comments from bot users when determining the latest action time of a PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2328](https://bugs.openjdk.org/browse/SKARA-2328): Ignore bot user's comment when determining the latest action time of a PR (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1687/head:pull/1687` \
`$ git checkout pull/1687`

Update a local copy of the PR: \
`$ git checkout pull/1687` \
`$ git pull https://git.openjdk.org/skara.git pull/1687/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1687`

View PR using the GUI difftool: \
`$ git pr show -t 1687`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1687.diff">https://git.openjdk.org/skara/pull/1687.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1687#issuecomment-2379783748)