### PR TITLE
2363: When jcheck result is too big, it can't be published to Github

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -413,10 +413,13 @@ class CheckRun {
             checkBuilder.complete(true);
         } else {
             checkBuilder.title("Required");
-            var summary = Stream.concat(visitor.errorFailedChecksMessages().stream(), additionalErrors.stream())
-                                .sorted()
-                                .map(m -> "- " + m)
-                                .collect(Collectors.joining("\n"));
+            var summary = Stream.concat(visitor.errorFailedChecksMessages().stream().limit(MESSAGE_LIMIT), additionalErrors.stream().limit(MESSAGE_LIMIT))
+                    .sorted()
+                    .map(m -> "- " + m)
+                    .collect(Collectors.joining("\n"));
+            if (visitor.errorFailedChecksMessages().size() > MESSAGE_LIMIT || additionalErrors.size() > MESSAGE_LIMIT) {
+                summary = summary + "\nThere are more errors that are not displayed due to the size limit.";
+            }
             checkBuilder.summary(summary);
             for (var annotation : visitor.getAnnotations()) {
                 checkBuilder.annotation(annotation);


### PR DESCRIPTION
Sometimes, a pull request contains too many whitespace errors and it will generate a large jcheck result. Therefore, when the bot is trying  to post it to GitHub, it will fail and keep retrying.

This patch is trying to limit the size of jcheck error message.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2363](https://bugs.openjdk.org/browse/SKARA-2363): When jcheck result is too big, it can't be published to Github (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1688/head:pull/1688` \
`$ git checkout pull/1688`

Update a local copy of the PR: \
`$ git checkout pull/1688` \
`$ git pull https://git.openjdk.org/skara.git pull/1688/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1688`

View PR using the GUI difftool: \
`$ git pr show -t 1688`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1688.diff">https://git.openjdk.org/skara/pull/1688.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1688#issuecomment-2397801071)