### PR TITLE
2386: PullRequestBotFactory creates too many IssueBots

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
@@ -43,10 +43,16 @@ public class PullRequestBotFactory implements BotFactory {
     public List<Bot> create(BotConfiguration configuration) {
         var ret = new ArrayList<Bot>();
         var specific = configuration.specific();
-        var repositories = new HashMap<IssueProject, List<HostedRepository>>();
-        var repositoriesForCSR = new HashMap<IssueProject, List<HostedRepository>>();
+        // IssueProject name to list of repositories
+        var repositories = new HashMap<String, List<HostedRepository>>();
+        // IssueProject name to list of repositories for csr
+        var repositoriesForCSR = new HashMap<String, List<HostedRepository>>();
+        // IssueProject name to IssueProject instance
+        var issueProjectMap = new HashMap<String, IssueProject>();
+        // PullRequestBot name to PullRequestBot instance
         var pullRequestBotMap = new HashMap<String, PullRequestBot>();
-        var issueProjectToIssuePRMapMap = new HashMap<IssueProject, Map<String, List<PRRecord>>>();
+        // IssueProject name to IssuePRMap
+        var issueProjectToIssuePRMapMap = new HashMap<String, Map<String, List<PRRecord>>>();
 
         var externalPullRequestCommands = new HashMap<String, String>();
         if (specific.contains("external") && specific.get("external").contains("pr")) {
@@ -154,12 +160,12 @@ public class PullRequestBotFactory implements BotFactory {
             }
             IssueProject issueProject = null;
             if (repo.value().contains("issues")) {
-                issueProject = configuration.issueProject(repo.value().get("issues").asString());
+                issueProject = issueProjectMap.computeIfAbsent(repo.value().get("issues").asString(), configuration::issueProject);
                 botBuilder.issueProject(issueProject);
-                repositories.putIfAbsent(issueProject, new ArrayList<>());
-                repositories.get(issueProject).add(repository);
-                issueProjectToIssuePRMapMap.putIfAbsent(issueProject, new ConcurrentHashMap<>());
-                botBuilder.issuePRMap(issueProjectToIssuePRMapMap.get(issueProject));
+                repositories.putIfAbsent(issueProject.name(), new ArrayList<>());
+                repositories.get(issueProject.name()).add(repository);
+                issueProjectToIssuePRMapMap.putIfAbsent(issueProject.name(), new ConcurrentHashMap<>());
+                botBuilder.issuePRMap(issueProjectToIssuePRMapMap.get(issueProject.name()));
             }
             if (repo.value().contains("useStaleReviews")) {
                 botBuilder.useStaleReviews(repo.value().get("useStaleReviews").asBoolean());
@@ -184,8 +190,8 @@ public class PullRequestBotFactory implements BotFactory {
                 var enableCsr = repo.value().get("csr").asBoolean();
                 botBuilder.enableCsr(enableCsr);
                 if (enableCsr && issueProject != null) {
-                    repositoriesForCSR.putIfAbsent(issueProject, new ArrayList<>());
-                    repositoriesForCSR.get(issueProject).add(repository);
+                    repositoriesForCSR.putIfAbsent(issueProject.name(), new ArrayList<>());
+                    repositoriesForCSR.get(issueProject.name()).add(repository);
                 }
             }
             if (repo.value().contains("jep")) {
@@ -276,15 +282,15 @@ public class PullRequestBotFactory implements BotFactory {
         }
 
         // Create a CSRIssueBot for each issueProject which associated with at least one csr enabled repository
-        for (var issueProject : repositoriesForCSR.keySet()) {
-            ret.add(0, new CSRIssueBot(issueProject, repositoriesForCSR.get(issueProject), pullRequestBotMap,
-                    issueProjectToIssuePRMapMap.get(issueProject)));
+        for (var issueProjectName : repositoriesForCSR.keySet()) {
+            ret.add(0, new CSRIssueBot(issueProjectMap.get(issueProjectName), repositoriesForCSR.get(issueProjectName), pullRequestBotMap,
+                    issueProjectToIssuePRMapMap.get(issueProjectName)));
         }
 
         // Create an IssueBot for each issueProject
-        for (var issueProject : issueProjectToIssuePRMapMap.keySet()) {
-            ret.add(0, new IssueBot(issueProject, repositories.get(issueProject), pullRequestBotMap,
-                    issueProjectToIssuePRMapMap.get(issueProject)));
+        for (var issueProjectName : issueProjectToIssuePRMapMap.keySet()) {
+            ret.add(0, new IssueBot(issueProjectMap.get(issueProjectName), repositories.get(issueProjectName), pullRequestBotMap,
+                    issueProjectToIssuePRMapMap.get(issueProjectName)));
         }
 
         return ret;


### PR DESCRIPTION
Erik found that our bot creates multiple IssueBot instances for a single issue project. And he found that the root cause was the configuration::issueProject method always returning a new instance. Additionally, the equals() and hashcode() methods were not overridden in the JiraProject class.

This patch is trying to fix this issue as Erik suggested:
1. Caching the issueProject instances in a map.
2. Avoiding using IssueProject as a key in maps.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2386](https://bugs.openjdk.org/browse/SKARA-2386): PullRequestBotFactory creates too many IssueBots (**Bug** - P2)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1689/head:pull/1689` \
`$ git checkout pull/1689`

Update a local copy of the PR: \
`$ git checkout pull/1689` \
`$ git pull https://git.openjdk.org/skara.git pull/1689/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1689`

View PR using the GUI difftool: \
`$ git pr show -t 1689`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1689.diff">https://git.openjdk.org/skara/pull/1689.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1689#issuecomment-2400848117)