### PR TITLE
2387: Revert SKARA-2386 and cache issueProject in JiraHost

### DIFF
--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/IssueTracker.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/IssueTracker.java
@@ -62,6 +62,10 @@ public interface IssueTracker extends Host {
         }
     }
 
+    /**
+     * Creates and caches a new project if it hasn't been initialized.
+     * Subsequent calls with the same name will return the cached instance.
+     */
     IssueProject project(String name);
     Optional<CustomEndpoint> lookupCustomEndpoint(String path);
     URI uri();

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraHost.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraHost.java
@@ -169,7 +169,7 @@ public class JiraHost implements IssueTracker {
 
     @Override
     public IssueProject project(String name) {
-        return issueProjects.computeIfAbsent(name, n -> new JiraProject(this, request, name));
+        return issueProjects.computeIfAbsent(name, n -> new JiraProject(this, request, n));
     }
 
     @Override

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraHost.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraHost.java
@@ -84,6 +84,7 @@ public class JiraHost implements IssueTracker {
     private final String visibilityRole;
     private final RestRequest request;
     private final RestRequest backportRequest;
+    private final Map<String, IssueProject> issueProjects = new HashMap<>();
 
     private HostUser currentUser;
     private ZoneId timeZone;
@@ -168,7 +169,7 @@ public class JiraHost implements IssueTracker {
 
     @Override
     public IssueProject project(String name) {
-        return new JiraProject(this, request, name);
+        return issueProjects.computeIfAbsent(name, n -> new JiraProject(this, request, name));
     }
 
     @Override


### PR DESCRIPTION
In [SKARA-2386](https://bugs.openjdk.org/browse/SKARA-2386), we are using the issueProject name as the key of different maps in PullRequestBotFactory. But they are not unified.

For issueProjectMap, the key is the full name of the issue project like "bugs/JDK". For other maps, the key is only the project name like "JDK".

This will make the factory not be able to generate IssueBot correctly.

Currently, I think maybe it's better to revert [SKARA-2386](https://bugs.openjdk.org/browse/SKARA-2386) and cache the issueProject in JiraHost to fix the problem.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2387](https://bugs.openjdk.org/browse/SKARA-2387): Revert SKARA-2386 and cache issueProject in JiraHost (**Bug** - P2)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1690/head:pull/1690` \
`$ git checkout pull/1690`

Update a local copy of the PR: \
`$ git checkout pull/1690` \
`$ git pull https://git.openjdk.org/skara.git pull/1690/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1690`

View PR using the GUI difftool: \
`$ git pr show -t 1690`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1690.diff">https://git.openjdk.org/skara/pull/1690.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1690#issuecomment-2402935631)