### PR TITLE
2391: Update .github/workflows/ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
 
   mac:
     name: macOS x64
-    runs-on: "macos-12"
+    runs-on: "macos-14"
     needs: prerequisites
 
     steps:


### PR DESCRIPTION
Today I received an email from Github and in the email, GitHub says they are going to remove macOS 12 runner image soon.
We should update our configuration since we are using macOS 12 runner right now.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2391](https://bugs.openjdk.org/browse/SKARA-2391): Update .github/workflows/ci.yml (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1691/head:pull/1691` \
`$ git checkout pull/1691`

Update a local copy of the PR: \
`$ git checkout pull/1691` \
`$ git pull https://git.openjdk.org/skara.git pull/1691/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1691`

View PR using the GUI difftool: \
`$ git pr show -t 1691`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1691.diff">https://git.openjdk.org/skara/pull/1691.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1691#issuecomment-2418049665)