### PR TITLE
2395: Make it configurable to disable the contributor check for the /backport command

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
@@ -76,7 +76,7 @@ public class BackportCommand implements CommandHandler {
     @Override
     public void handle(PullRequestBot bot, PullRequest pr, CensusInstance censusInstance, ScratchArea scratchArea, CommandInvocation command,
                        List<Comment> allComments, PrintWriter reply, List<String> labelsToAdd, List<String> labelsToRemove) {
-        if (censusInstance.contributor(command.user()).isEmpty()) {
+        if (bot.checkContributorStatusForBackportCommand() && censusInstance.contributor(command.user()).isEmpty()) {
             printInvalidUserWarning(bot, reply);
             return;
         }
@@ -235,7 +235,8 @@ public class BackportCommand implements CommandHandler {
     @Override
     public void handle(PullRequestBot bot, HostedCommit commit, LimitedCensusInstance censusInstance,
                        ScratchArea scratchArea, CommandInvocation command, List<Comment> allComments, PrintWriter reply) {
-        if (censusInstance.contributor(command.user()).isEmpty() && !command.user().equals(bot.repo().forge().currentUser())) {
+        if (bot.checkContributorStatusForBackportCommand() && censusInstance.contributor(command.user()).isEmpty()
+                && !command.user().equals(bot.repo().forge().currentUser())) {
             printInvalidUserWarning(bot, reply);
             return;
         }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -82,6 +82,7 @@ class PullRequestBot implements Bot {
     private boolean initialRun = true;
     private final boolean versionMismatchWarning;
     private final boolean cleanCommandEnabled;
+    private final boolean checkContributorStatusForBackportCommand;
 
     private Instant lastFullUpdate;
 
@@ -96,7 +97,8 @@ class PullRequestBot implements Bot {
                    Set<String> integrators, Set<Integer> excludeCommitCommentsFrom, boolean enableCsr, boolean enableJep,
                    boolean reviewCleanBackport, String mlbridgeBotName, MergePullRequestReviewConfiguration reviewMerge, boolean processPR, boolean processCommit,
                    boolean enableMerge, Set<String> mergeSources, boolean jcheckMerge, boolean enableBackport,
-                   Map<String, List<PRRecord>> issuePRMap, Approval approval, boolean versionMismatchWarning, boolean cleanCommandEnabled) {
+                   Map<String, List<PRRecord>> issuePRMap, Approval approval, boolean versionMismatchWarning, boolean cleanCommandEnabled,
+                   boolean checkContributorStatusForBackportCommand) {
         remoteRepo = repo;
         this.censusRepo = censusRepo;
         this.censusRef = censusRef;
@@ -135,6 +137,7 @@ class PullRequestBot implements Bot {
         this.approval = approval;
         this.versionMismatchWarning = versionMismatchWarning;
         this.cleanCommandEnabled = cleanCommandEnabled;
+        this.checkContributorStatusForBackportCommand = checkContributorStatusForBackportCommand;
 
         autoLabelled = new HashSet<>();
         poller = new PullRequestPoller(repo, true);
@@ -413,6 +416,10 @@ class PullRequestBot implements Bot {
 
     public boolean cleanCommandEnabled() {
         return cleanCommandEnabled;
+    }
+
+    public boolean checkContributorStatusForBackportCommand() {
+        return checkContributorStatusForBackportCommand;
     }
 
     public void addIssuePRMapping(String issueId, PRRecord prRecord) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
@@ -69,6 +69,7 @@ public class PullRequestBotBuilder {
     private Approval approval = null;
     private boolean versionMismatchWarning = false;
     private boolean cleanCommandEnabled = true;
+    private boolean checkContributorStatusForBackportCommand = true;
 
     PullRequestBotBuilder() {
     }
@@ -263,12 +264,18 @@ public class PullRequestBotBuilder {
         return this;
     }
 
+    public PullRequestBotBuilder checkContributorStatusForBackportCommand(boolean checkContributorStatusForBackportCommand) {
+        this.checkContributorStatusForBackportCommand = checkContributorStatusForBackportCommand;
+        return this;
+    }
+
     public PullRequestBot build() {
         return new PullRequestBot(repo, censusRepo, censusRef, labelConfiguration, externalPullRequestCommands,
                 externalCommitCommands, blockingCheckLabels, readyLabels, twoReviewersLabels, twentyFourHoursLabels,
                 readyComments, issueProject, useStaleReviews, acceptSimpleMerges, allowedTargetBranches, seedStorage, confOverrideRepo,
                 confOverrideName, confOverrideRef, censusLink, forks, integrators, excludeCommitCommentsFrom, enableCsr,
                 enableJep, reviewCleanBackport, mlbridgeBotName, reviewMerge, processPR, processCommit, enableMerge,
-                mergeSources, jcheckMerge, enableBackport, issuePRMap, approval, versionMismatchWarning, cleanCommandEnabled);
+                mergeSources, jcheckMerge, enableBackport, issuePRMap, approval, versionMismatchWarning, cleanCommandEnabled,
+                checkContributorStatusForBackportCommand);
     }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
@@ -270,6 +270,10 @@ public class PullRequestBotFactory implements BotFactory {
                 botBuilder.cleanCommandEnabled(repo.value().get("cleanCommandEnabled").asBoolean());
             }
 
+            if (repo.value().contains("checkContributorStatusForBackportCommand")) {
+                botBuilder.checkContributorStatusForBackportCommand(repo.value().get("checkContributorStatusForBackportCommand").asBoolean());
+            }
+
             var prBot = botBuilder.build();
             pullRequestBotMap.put(repository.name(), prBot);
             ret.add(prBot);


### PR DESCRIPTION
In a discussion with Erik offline, he pointed out that the /backport command is different from all other commit commands. Instead of affecting the current repository, it only reads information from it and creates a branch in a fork of another repository. On GitHub, since anyone can comment on commits, it makes sense to have access control. However, in GitLab, where only authorized engineers can access the relevant repositories, we can safely disable the contributor check. In summary, it makes sense to make it configurable to disable the contributor check for the /backport command.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2395](https://bugs.openjdk.org/browse/SKARA-2395): Make it configurable to disable the contributor check for the /backport command (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1692/head:pull/1692` \
`$ git checkout pull/1692`

Update a local copy of the PR: \
`$ git checkout pull/1692` \
`$ git pull https://git.openjdk.org/skara.git pull/1692/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1692`

View PR using the GUI difftool: \
`$ git pr show -t 1692`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1692.diff">https://git.openjdk.org/skara/pull/1692.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1692#issuecomment-2427330102)