### PR TITLE
2300: Do not list non-OpenJDK reviewers in Reviewers list

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -868,12 +868,12 @@ class CheckRun {
             progressBody.append(reviewers);
         });
 
-        // Generate Reviewers list for non-recognized users
+        // Generate Reviewers list for reviewers without OpenJDK IDs
         var nonRecognizedReviews = activeReviews.stream()
                 .filter(review -> censusInstance.contributor(review.reviewer()).isEmpty())
                 .toList();
         getReviewersList(nonRecognizedReviews, tooFewReviewers).ifPresent(reviewers -> {
-            progressBody.append("\n\n### Non-Recognized Reviewers\n");
+            progressBody.append("\n\n### Reviewers without OpenJDK IDs\n");
             progressBody.append(reviewers);
         });
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -600,8 +600,8 @@ class CheckRun {
         return text;
     }
 
-    private Optional<String> getReviewersList(boolean tooFewReviewers) {
-        var reviewers = activeReviews.stream()
+    private Optional<String> getReviewersList(List<Review> reviews, boolean tooFewReviewers) {
+        var reviewers = reviews.stream()
                 .filter(review -> review.verdict() == Review.Verdict.APPROVED)
                 .map(review -> {
                     var entry = " * " + formatReviewer(review.reviewer());
@@ -859,8 +859,21 @@ class CheckRun {
             }
         }
 
-        getReviewersList(tooFewReviewers).ifPresent(reviewers -> {
+        // Generate Reviewers list for recognized users
+        var recognizedReviews = activeReviews.stream()
+                .filter(review -> censusInstance.contributor(review.reviewer()).isPresent())
+                .toList();
+        getReviewersList(recognizedReviews, tooFewReviewers).ifPresent(reviewers -> {
             progressBody.append("\n\n### Reviewers\n");
+            progressBody.append(reviewers);
+        });
+
+        // Generate Reviewers list for non-recognized users
+        var nonRecognizedReviews = activeReviews.stream()
+                .filter(review -> censusInstance.contributor(review.reviewer()).isEmpty())
+                .toList();
+        getReviewersList(nonRecognizedReviews, tooFewReviewers).ifPresent(reviewers -> {
+            progressBody.append("\n\n### Non-Recognized Reviewers\n");
             progressBody.append(reviewers);
         });
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -213,7 +213,7 @@ class CheckTests {
 
             // Check that it has been approved
             assertTrue(authorPr.store().body().contains("Reviewers"));
-            assertTrue(authorPr.store().body().contains("Non-Recognized Reviewers"));
+            assertTrue(authorPr.store().body().contains("Reviewers without OpenJDK IDs"));
 
             // Update the file after approval
             editHash = CheckableRepository.appendAndCommit(localRepo, "Now I've gone and changed it");
@@ -231,7 +231,7 @@ class CheckTests {
 
             // Check that it has been approved (once) and is no longer stale
             assertTrue(authorPr.store().body().contains("Reviewers"));
-            assertFalse(authorPr.store().body().contains("Non-Recognized Reviewers"));
+            assertFalse(authorPr.store().body().contains("Reviewers without OpenJDK IDs"));
             assertEquals(1, authorPr.store().body().split("Generated Reviewer", -1).length - 1);
             assertTrue(authorPr.reviews().size() >= 1);
             assertFalse(authorPr.store().body().contains("Note"));


### PR DESCRIPTION
This PR is trying to make skara bot list non-recognized user in a separate section in the PR body.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2300](https://bugs.openjdk.org/browse/SKARA-2300): Do not list non-OpenJDK reviewers in Reviewers list (**Enhancement** - P4)


### Reviewers
 * [Pavel Rappo](https://openjdk.org/census#prappo) (@pavelrappo - Committer)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1693/head:pull/1693` \
`$ git checkout pull/1693`

Update a local copy of the PR: \
`$ git checkout pull/1693` \
`$ git pull https://git.openjdk.org/skara.git pull/1693/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1693`

View PR using the GUI difftool: \
`$ git pr show -t 1693`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1693.diff">https://git.openjdk.org/skara/pull/1693.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1693#issuecomment-2430203599)