### PR TITLE
2397: Jira Issues with resoultion "delivered" should not be changed to "fixed"

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
@@ -372,6 +372,8 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
                     issue.addComment(commitNotification);
                 }
                 log.info("Resolving issue " + issue.id() + " from state " + issue.state());
+                // If the issue here was found by findAltFixedVersionIssue(), issue.isFixed() should return true,
+                // so issue notifier won't do anything to the issue except posting a comment
                 if (!issue.isFixed()) {
                     issue.setState(Issue.State.RESOLVED);
                 } else {

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/issue/IssueNotifierTests.java
@@ -2527,6 +2527,7 @@ public class IssueNotifierTests {
             issue.addLabel("test");
             issue.addLabel("temporary");
             issue.setState(RESOLVED);
+            issue.setProperty("resolution", JSON.object().put("name", JSON.of("Delivered")));
             issue.setAssignees(List.of(issueProject.issueTracker().currentUser()));
 
             var authorEmailAddress = issueProject.issueTracker().currentUser().username() + "@openjdk.org";
@@ -2539,6 +2540,8 @@ public class IssueNotifierTests {
             assertEquals(Set.of("21"), fixVersions(updatedIssue));
             assertEquals(RESOLVED, updatedIssue.state());
             assertEquals(List.of(issueProject.issueTracker().currentUser()), updatedIssue.assignees());
+            // The resolution of the issue should still be "Delivered"
+            assertEquals("Delivered", issue.properties().get("resolution").get("name").asString());
 
             // There should be a link
             var links = updatedIssue.links();

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraIssue.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraIssue.java
@@ -45,6 +45,7 @@ public class JiraIssue implements IssueTrackerIssue {
 
     private static final DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
     private static final List<String> FILTER_OUT_FIELDS = List.of("fields.customfield_11700");
+    private static final List<String> VALID_RESOLUTIONS = List.of("Fixed", "Delivered");
 
     private List<Label> labels;
 
@@ -223,7 +224,7 @@ public class JiraIssue implements IssueTrackerIssue {
         if (isResolved() || isClosed()) {
             var resolution = json.get("fields").get("resolution");
             if (!resolution.isNull()) {
-                return "Fixed".equals(resolution.get("name").asString());
+                return VALID_RESOLUTIONS.contains(resolution.get("name").asString());
             }
         }
         return false;

--- a/test/src/main/java/org/openjdk/skara/test/TestIssueTrackerIssue.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestIssueTrackerIssue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,6 +52,7 @@ public class TestIssueTrackerIssue extends TestIssue implements IssueTrackerIssu
     public TestIssueTrackerIssueStore store() {
         return (TestIssueTrackerIssueStore) super.store();
     }
+    private static final List<String> VALID_RESOLUTIONS = List.of("Fixed", "Delivered");
 
     @Override
     public void setState(State state) {
@@ -85,7 +86,7 @@ public class TestIssueTrackerIssue extends TestIssue implements IssueTrackerIssu
     @Override
     public boolean isFixed() {
         if (super.isFixed()) {
-            return resolution().map(r -> r.equals("Fixed")).orElse(Boolean.FALSE);
+            return resolution().map(VALID_RESOLUTIONS::contains).orElse(Boolean.FALSE);
         }
         return false;
     }


### PR DESCRIPTION
Currently, the Skara bot doesn't recognize "Delivered" as a valid resolution for resolved issues. As a result, when the bot finds an issue in a Resolved or Closed state with "Delivered" resolution, it will change the resolution to "Fixed." However, it shouldn't.

This patch is trying to make the bot recognize "Delivered" as a valid resolution for resolved issues, preventing unnecessary changes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2397](https://bugs.openjdk.org/browse/SKARA-2397): Jira Issues with resoultion "delivered" should not be changed to "fixed" (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1694/head:pull/1694` \
`$ git checkout pull/1694`

Update a local copy of the PR: \
`$ git checkout pull/1694` \
`$ git pull https://git.openjdk.org/skara.git pull/1694/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1694`

View PR using the GUI difftool: \
`$ git pr show -t 1694`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1694.diff">https://git.openjdk.org/skara/pull/1694.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1694#issuecomment-2433569656)