### PR TITLE
2401: Link to Webrev should be part of the Reviewing section

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -889,8 +889,7 @@ class CheckRun {
 
         var webrevCommentLink = getWebrevCommentLink();
         if (webrevCommentLink.isPresent()) {
-            progressBody.append("\n\n### Webrev\n");
-            progressBody.append(webrevCommentLink.get());
+            progressBody.append(makeCollapsible("Using Webrev", webrevCommentLink.get()));
         }
         return progressBody.toString();
     }


### PR DESCRIPTION
When we added the link to the webrev comment in the PR body, for some reason it got its own header `### Webrev`. But Webrevs are just another way of reviewing, so it should be put under the `### Reviewing` header.

That is, the reviewing html code should look something like this:
```
...
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/XXX.diff">[https://git.openjdk.org/jdk/pull/XXX.diff&lt;/a](https://git.openjdk.org/jdk/pull/XXX.diff%3C/a)>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/XXX#issuecomment-YYY)

</details>
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2401](https://bugs.openjdk.org/browse/SKARA-2401): Link to Webrev should be part of the Reviewing section (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1695/head:pull/1695` \
`$ git checkout pull/1695`

Update a local copy of the PR: \
`$ git checkout pull/1695` \
`$ git pull https://git.openjdk.org/skara.git pull/1695/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1695`

View PR using the GUI difftool: \
`$ git pr show -t 1695`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1695.diff">https://git.openjdk.org/skara/pull/1695.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1695#issuecomment-2446797869)