### PR TITLE
2411: Host::user should throw when failing

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubHost.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubHost.java
@@ -323,7 +323,7 @@ public class GitHubHost implements Forge {
     @Override
     public Optional<HostUser> user(String username) {
         var details = request.get("users/" + URLEncoder.encode(username, StandardCharsets.UTF_8))
-                             .onError(r -> Optional.of(JSON.of()))
+                             .onError(r -> r.statusCode() == 404 ? Optional.of(JSON.of()) : Optional.empty())
                              .execute();
         if (details.isNull()) {
             return Optional.empty();
@@ -335,7 +335,7 @@ public class GitHubHost implements Forge {
     @Override
     public Optional<HostUser> userById(String id) {
         var details = request.get("user/" + id)
-                .onError(r -> Optional.of(JSON.of()))
+                .onError(r -> r.statusCode() == 404 ? Optional.of(JSON.of()) : Optional.empty())
                 .execute();
         if (details.isNull()) {
             return Optional.empty();

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabHost.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabHost.java
@@ -163,7 +163,7 @@ public class GitLabHost implements Forge {
     public Optional<HostUser> user(String username) {
         var details = request.get("users")
                              .param("username", username)
-                             .onError(r -> Optional.of(JSON.of()))
+                             .onError(r -> r.statusCode() == 404 ? Optional.of(JSON.of()) : Optional.empty())
                              .execute();
 
         if (details.isNull()) {
@@ -181,7 +181,7 @@ public class GitLabHost implements Forge {
     @Override
     public Optional<HostUser> userById(String id) {
         var details = request.get("users/" + id)
-                .onError(r -> Optional.of(JSON.of()))
+                .onError(r -> r.statusCode() == 404 ? Optional.of(JSON.of()) : Optional.empty())
                 .execute();
 
         if (details.isNull()) {

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraHost.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraHost.java
@@ -176,7 +176,7 @@ public class JiraHost implements IssueTracker {
     public Optional<HostUser> user(String username) {
         var data = request.get("user")
                           .param("username", username)
-                          .onError(r -> Optional.of(JSON.of()))
+                          .onError(r -> r.statusCode() == 404 ? Optional.of(JSON.of()) : Optional.empty())
                           .execute();
         if (data.isNull()) {
             return Optional.empty();


### PR DESCRIPTION
The implementations of Host::user are all currently returning Optional::empty on any error return code. This means a that a bot checking for the existence of a user encounters an error with a host, e.g. JBS, it will think the user doesn't exist and take actions based on that assumption. This would be correct if the server response was 404, but in all other cases, it would be better if the WorkItem failed to be automatically retried later.

This patch changes the onError lambda for these methods so that it only handles the 404 case, and in all other cases lets the RestException be thrown. This matches the behavior of most other methods in these classes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2411](https://bugs.openjdk.org/browse/SKARA-2411): Host::user should throw when failing (**Bug** - P2)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1698/head:pull/1698` \
`$ git checkout pull/1698`

Update a local copy of the PR: \
`$ git checkout pull/1698` \
`$ git pull https://git.openjdk.org/skara.git pull/1698/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1698`

View PR using the GUI difftool: \
`$ git pr show -t 1698`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1698.diff">https://git.openjdk.org/skara/pull/1698.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1698#issuecomment-2488858043)
</details>
