### PR TITLE
SKARA-2415

### DIFF
--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitCommits.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitCommits.java
@@ -135,10 +135,24 @@ class GitCommits implements Commits, AutoCloseable {
             }
         }
 
+        RuntimeException runtimeException = null;
+
         for (var i = 0; i < processes.size(); i++) {
             var p = processes.get(i);
             var command = commands.get(i);
-            close(p, command);
+            try {
+                close(p, command);
+            } catch (Exception e) {
+                if (runtimeException == null) {
+                    runtimeException = new RuntimeException(e);
+                } else {
+                    runtimeException.addSuppressed(e);
+                }
+            }
+        }
+
+        if (runtimeException != null) {
+            throw runtimeException;
         }
     }
 


### PR DESCRIPTION
As Pavel pointed out in the pull request of [SKARA-2410](https://bugs.openjdk.org/browse/SKARA-2410)(https://github.com/openjdk/skara/pull/1697), with current implementation , GitCommits::close may have created multiple processes and only destroy one of them.

As Erik and Pavel suggested, we should make sure close() is called on each process.