### PR TITLE
2418: Scratch dir clash in notifier

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/PullRequestWorkItem.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/PullRequestWorkItem.java
@@ -229,7 +229,7 @@ public class PullRequestWorkItem implements WorkItem {
             log.warning("Found temporary issue failure, the notifiers will be stopped until the temporary issue failure resolved.");
             return List.of();
         }
-        var historyPath = scratchPath.resolve("notify").resolve("history");
+        var historyPath = scratchPath.resolve("notify").resolve("history").resolve("pr");
         var listenerScratchPath = scratchPath.resolve("notify").resolve("listener");
         var storage = prStateStorageBuilder
                 .serializer(this::serializePrState)


### PR DESCRIPTION
The notifier RepositoryWorkItem and PullRequestWorkItem have a clash between directory location for the history repos. In RepositoryWorkItem we store the tags and branches history in these directories:

```
<scratch>/notify/history/tags
<scratch>/notify/history/branches
```

While in the PullRequestWorkItem, the history is stored in:

```
<scratch>/notify/history
```

Having repositories nested inside each other like this is causing inefficiencies at the very least, but could also potentially be harmful. As a quick fix, I propose we move the pr history to

 ```
 <scratch>/notify/history/pr
 ```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2418](https://bugs.openjdk.org/browse/SKARA-2418): Scratch dir clash in notifier (**Bug** - P4)


### Reviewers
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1700/head:pull/1700` \
`$ git checkout pull/1700`

Update a local copy of the PR: \
`$ git checkout pull/1700` \
`$ git pull https://git.openjdk.org/skara.git pull/1700/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1700`

View PR using the GUI difftool: \
`$ git pr show -t 1700`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1700.diff">https://git.openjdk.org/skara/pull/1700.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1700#issuecomment-2515333654)
</details>
