### PR TITLE
2420: Remove closed pr from all entries in targetRefPRMap

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -190,13 +190,9 @@ class PullRequestBot implements Bot {
             for (var pr : prs) {
                 var targetRef = pr.targetRef();
                 var prId = pr.id();
+                targetRefPRMap.values().forEach(s -> s.remove(prId));
                 if (pr.isOpen()) {
-                    targetRefPRMap.values().forEach(s -> s.remove(prId));
                     targetRefPRMap.computeIfAbsent(targetRef, key -> new HashSet<>()).add(prId);
-                } else {
-                    if (targetRefPRMap.containsKey(targetRef)) {
-                        targetRefPRMap.get(targetRef).remove(prId);
-                    }
                 }
             }
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -238,6 +238,9 @@ class PullRequestBot implements Bot {
                     jCheckConfMap.put(targetRef, currConf);
                 }
             } catch (UncheckedRestException e) {
+                // If the targetRef is invalid, fileContents() will throw a 404 instead of returning
+                // empty. In this case we should ignore this and continue processing other PRs.
+                // Any invalid refs will get removed from targetRefMap in the next round.
                 if (e.getStatusCode() != 404) {
                     throw e;
                 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -238,7 +238,7 @@ class PullRequestBot implements Bot {
                     jCheckConfMap.put(targetRef, currConf);
                 }
             } catch (UncheckedRestException e) {
-                if (e.getStatusCode() != 404 || !e.getMessage().contains("Commit Not Found")) {
+                if (e.getStatusCode() != 404) {
                     throw e;
                 }
             }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -196,8 +196,12 @@ class PullRequestBot implements Bot {
                 }
             }
 
+            var activeBranches = remoteRepo.branches().stream()
+                    .map(HostedBranch::name)
+                    .toList();
+
             var keysToRemove = targetRefPRMap.keySet().stream()
-                    .filter(key -> targetRefPRMap.get(key).isEmpty())
+                    .filter(key -> targetRefPRMap.get(key).isEmpty() || !activeBranches.contains(key))
                     .toList();
             keysToRemove.forEach(targetRefPRMap::remove);
 

--- a/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/HostedRepository.java
@@ -94,7 +94,8 @@ public interface HostedRepository {
     URI url();
 
     /**
-     * Returns contents of the file, if the file does not exist, returns Optional.empty().
+     * Returns contents of the file, if the file does not exist, returns Optional.empty(),
+     * if the ref does not exist, throws exception.
      */
     Optional<String> fileContents(String filename, String ref);
 

--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -280,7 +280,9 @@ public class GitHubRepository implements HostedRepository {
         } catch (UncheckedRestException e) {
             // The onError handler is not used with executeUnparsed, so have to
             // resort to catching exception for 404 handling.
-            if (e.getStatusCode() == 404) {
+            // For GitHub, if ref not found, it returns "No commit found for the ref ",
+            // if file not found, it returns "Not Found".
+            if (e.getStatusCode() == 404 && e.getMessage().contains("Not Found")) {
                 return Optional.empty();
             } else {
                 throw e;

--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -306,6 +306,8 @@ public class GitLabRepository implements HostedRepository {
                 .onError(response -> {
                     // Retry once with additional escaping of the path fragment
                     // Only retry when the error is exactly "File Not Found"
+                    // For GitLab, if ref not found, it returns "404 Commit Not Found",
+                    // if file not found, it returns "404 File Not Found"
                     if (response.statusCode() == 404 && JSON.parse(response.body()).get("message").asString().endsWith("File Not Found")) {
                         log.warning("First time request returned bad status: " + response.statusCode());
                         log.info("First time response body: " + response.body());

--- a/network/src/main/java/org/openjdk/skara/network/RestRequest.java
+++ b/network/src/main/java/org/openjdk/skara/network/RestRequest.java
@@ -567,7 +567,12 @@ public class RestRequest {
         var response = sendRequest(request, queryBuilder.skipLimiter);
         responseCounter.labels(Integer.toString(response.statusCode()), Boolean.toString(false)).inc();
         if (response.statusCode() >= 400) {
-            throw new UncheckedRestException(response.statusCode(), response.request());
+            var responseJSONValue = JSON.parse(response.body());
+            if (responseJSONValue.contains("message")) {
+                throw new UncheckedRestException(responseJSONValue.get("message").asString(), response.statusCode(), response.request());
+            } else {
+                throw new UncheckedRestException(response.statusCode(), response.request());
+            }
         }
         return response.body();
     }


### PR DESCRIPTION
In [SKARA-1937](https://bugs.openjdk.org/browse/SKARA-1937), we introduced a feature that pull request bot can re-evaluate all PRs when jcheck configuration changes. When implementing it, I let pull request bot maintains a hash map called targetRefPRMap. The key is the name of targetRef and the value is the list of pr which targets to the targetRef. Currently, when a pr is closed, the bot will unlink it with its current targetRef. There was an issue happened recently, there was an entry {pr/96=[pr/97]} in the hash map, and before pr/97 was integrated, the user retargeted the pr from pr/96 to master, so the bot fails to remove the association between pr/96 and pr/97.

I think the right behavior here is that when pull request bot finds an updated pr, it should unlink this pr with all targetRefs and if this pr is still open, the bot should link the pr with current targetRef.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2420](https://bugs.openjdk.org/browse/SKARA-2420): Remove closed pr from all entries in targetRefPRMap (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1701/head:pull/1701` \
`$ git checkout pull/1701`

Update a local copy of the PR: \
`$ git checkout pull/1701` \
`$ git pull https://git.openjdk.org/skara.git pull/1701/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1701`

View PR using the GUI difftool: \
`$ git pr show -t 1701`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1701.diff">https://git.openjdk.org/skara/pull/1701.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1701#issuecomment-2518794479)
</details>
