### PR TITLE
SKARA-1357

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
@@ -335,6 +335,9 @@ class PullRequestCheckIssueVisitor implements IssueVisitor {
         if (!issue.filesWithCopyrightYearIssue().isEmpty()) {
             messages.add("Found outdated copyright year in [" + String.join(", ", issue.filesWithCopyrightYearIssue()) + "]");
         }
+        if (!issue.filesWithCopyrightMissingIssue().isEmpty()) {
+            messages.add("Can't find copyright header in [" + String.join(", ", issue.filesWithCopyrightMissingIssue()) + "]");
+        }
         addMessage(issue.check(), String.join("\n", messages),
                 issue.severity());
     }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
@@ -325,4 +325,17 @@ class PullRequestCheckIssueVisitor implements IssueVisitor {
         addMessage(issue.check(), String.join("\n", messages),
                 issue.severity());
     }
+
+    @Override
+    public void visit(CopyrightIssue issue) {
+        List<String> messages = new ArrayList<>();
+        if (!issue.filesWithCopyrightFormatIssue().isEmpty()) {
+            messages.add("Found copyright format issue in [" + String.join(", ", issue.filesWithCopyrightFormatIssue()) + "]");
+        }
+        if (!issue.filesWithCopyrightYearIssue().isEmpty()) {
+            messages.add("Found outdated copyright year in [" + String.join(", ", issue.filesWithCopyrightYearIssue()) + "]");
+        }
+        addMessage(issue.check(), String.join("\n", messages),
+                issue.severity());
+    }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -3715,7 +3715,7 @@ class CheckTests {
                     .build();
 
             // Populate the projects repository
-            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(), Path.of("appendable.txt"));
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(), Path.of("appendable.txt"),Set.of("author", "reviewers", "whitespace"), Set.of("issuestitle"), "0.1");
             var masterHash = localRepo.resolve("master").orElseThrow();
             localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
@@ -3790,7 +3790,7 @@ class CheckTests {
                     .build();
 
             // Populate the projects repository
-            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(), Path.of("appendable.txt"));
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(), Path.of("appendable.txt"),Set.of("author", "reviewers", "whitespace"), Set.of("copyright"), "0.1");
             var masterHash = localRepo.resolve("master").orElseThrow();
             localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -3267,7 +3267,7 @@ class CheckTests {
             assertEquals(1, checks.size());
             check = checks.get("jcheck");
             assertEquals(CheckStatus.FAILURE, check.status());
-            assertEquals("line 19: entry must be of form 'key = value'", check.summary().get());
+            assertEquals("line 22: entry must be of form 'key = value'", check.summary().get());
             assertEquals("Exception occurred during source jcheck - the operation will be retried", check.title().get());
 
             // Restore .jcheck/conf and add whitespace issue check

--- a/cli/src/main/java/org/openjdk/skara/cli/JCheckCLIVisitor.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/JCheckCLIVisitor.java
@@ -335,6 +335,9 @@ class JCheckCLIVisitor implements IssueVisitor {
             if (!i.filesWithCopyrightYearIssue().isEmpty()) {
                 println(i, "Found outdated copyright year in [" + String.join(", ", i.filesWithCopyrightYearIssue()) + "]");
             }
+            if (!i.filesWithCopyrightMissingIssue().isEmpty()) {
+                println(i, "Can't find copyright header in [" + String.join(", ", i.filesWithCopyrightMissingIssue()) + "]");
+            }
             for (var line : i.commit().message()) {
                 System.out.println("> " + line);
             }

--- a/cli/src/main/java/org/openjdk/skara/cli/JCheckCLIVisitor.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/JCheckCLIVisitor.java
@@ -326,6 +326,22 @@ class JCheckCLIVisitor implements IssueVisitor {
         }
     }
 
+    @Override
+    public void visit(CopyrightIssue i) {
+        if (!ignore.contains(i.check().name()) && !isLax) {
+            if (!i.filesWithCopyrightFormatIssue().isEmpty()) {
+                println(i, "Found copyright format issue in [" + String.join(", ", i.filesWithCopyrightFormatIssue()) + "]");
+            }
+            if (!i.filesWithCopyrightYearIssue().isEmpty()) {
+                println(i, "Found outdated copyright year in [" + String.join(", ", i.filesWithCopyrightYearIssue()) + "]");
+            }
+            for (var line : i.commit().message()) {
+                System.out.println("> " + line);
+            }
+            hasDisplayedErrors = i.severity() == Severity.ERROR;
+        }
+    }
+
     public boolean hasDisplayedErrors() {
         return hasDisplayedErrors;
     }

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/ChecksConfiguration.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/ChecksConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,8 @@ public class ChecksConfiguration {
                                 MergeConfiguration.DEFAULT,
                                 CommitterConfiguration.DEFAULT,
                                 IssuesConfiguration.DEFAULT,
-                                ProblemListsConfiguration.DEFAULT);
+                                ProblemListsConfiguration.DEFAULT,
+                                CopyrightConfiguration.DEFAULT);
 
     private final List<String> error;
     private final List<String> warning;
@@ -46,6 +47,7 @@ public class ChecksConfiguration {
     private final CommitterConfiguration committer;
     private final IssuesConfiguration issues;
     private final ProblemListsConfiguration problemlists;
+    private final CopyrightConfiguration copyright;
 
     ChecksConfiguration(List<String> error,
                         List<String> warning,
@@ -54,7 +56,8 @@ public class ChecksConfiguration {
                         MergeConfiguration merge,
                         CommitterConfiguration committer,
                         IssuesConfiguration issues,
-                        ProblemListsConfiguration problemlists) {
+                        ProblemListsConfiguration problemlists,
+                        CopyrightConfiguration copyright) {
         this.error = error;
         this.warning = warning;
         this.whitespace = whitespace;
@@ -63,6 +66,7 @@ public class ChecksConfiguration {
         this.committer = committer;
         this.issues = issues;
         this.problemlists = problemlists;
+        this.copyright = copyright;
     }
 
     public List<String> error() {
@@ -115,6 +119,10 @@ public class ChecksConfiguration {
         return problemlists;
     }
 
+    public CopyrightConfiguration copyright(){
+        return copyright;
+    }
+
     static String name() {
         return "checks";
     }
@@ -133,6 +141,7 @@ public class ChecksConfiguration {
         var committer = CommitterConfiguration.parse(s.subsection(CommitterConfiguration.name()));
         var issues = IssuesConfiguration.parse(s.subsection(IssuesConfiguration.name()));
         var problemlists = ProblemListsConfiguration.parse(s.subsection(ProblemListsConfiguration.name()));
-        return new ChecksConfiguration(error, warning, whitespace, reviewers, merge, committer, issues, problemlists);
+        var copyright = CopyrightConfiguration.parse(s.subsection(CopyrightConfiguration.name()));
+        return new ChecksConfiguration(error, warning, whitespace, reviewers, merge, committer, issues, problemlists, copyright);
     }
 }

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/CopyrightCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/CopyrightCheck.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.jcheck;
+
+import org.openjdk.skara.census.Census;
+import org.openjdk.skara.vcs.Commit;
+import org.openjdk.skara.vcs.ReadOnlyRepository;
+import org.openjdk.skara.vcs.openjdk.CommitMessage;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.time.Year;
+import java.util.List;
+import java.util.regex.Pattern;
+
+public class CopyrightCheck extends CommitCheck {
+
+    private final ReadOnlyRepository repo;
+
+    private final static Pattern COPYRIGHT_PATTERN = Pattern.compile(".*Copyright \\(c\\) (\\d{4})(?:, (\\d{4}))?, Oracle and/or its affiliates\\. All rights reserved\\.");
+
+    CopyrightCheck(ReadOnlyRepository repo) {
+        this.repo = repo;
+    }
+
+    @Override
+    Iterator<Issue> check(Commit commit, CommitMessage message, JCheckConfiguration conf, Census census) {
+        var metadata = CommitIssue.metadata(commit, message, conf, this);
+        var pattern = Pattern.compile(conf.checks().copyright().files());
+
+        var filesWithCopyrightFormatIssue = new ArrayList<String>();
+        var filesWithCopyrightYearIssue = new ArrayList<String>();
+
+        for (var diff : commit.parentDiffs()) {
+            for (var patch : diff.patches()) {
+                if (patch.target().path().isEmpty() || patch.isBinary()) {
+                    continue;
+                }
+                var path = patch.target().path().get();
+                if (pattern.matcher(path.toString()).matches()) {
+                    try {
+                        var lines = repo.lines(path, commit.hash()).orElse(List.of());
+                        for (String line : lines) {
+                            if (line.contains("Copyright (c)") && line.contains("Oracle")) {
+                                var matcher = COPYRIGHT_PATTERN.matcher(line);
+                                if (matcher.matches()) {
+                                    int minYear = Integer.parseInt(matcher.group(1));
+                                    int maxYear = matcher.group(2) != null ? Integer.parseInt(matcher.group(2)) : minYear;
+                                    int currentYear = Year.now().getValue();
+                                    if (currentYear != maxYear) {
+                                        filesWithCopyrightYearIssue.add(path.toString());
+                                    }
+                                } else {
+                                    filesWithCopyrightFormatIssue.add(path.toString());
+                                }
+                            }
+                        }
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            }
+        }
+
+        if (!filesWithCopyrightFormatIssue.isEmpty() || !filesWithCopyrightYearIssue.isEmpty()) {
+            return iterator(new CopyrightIssue(metadata, filesWithCopyrightFormatIssue, filesWithCopyrightYearIssue));
+        }
+
+        return iterator();
+    }
+
+    @Override
+    public String name() {
+        return "copyright";
+    }
+
+    @Override
+    public String description() {
+        return "Copyright should be properly formatted";
+    }
+}

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/CopyrightConfiguration.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/CopyrightConfiguration.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.jcheck;
+
+import org.openjdk.skara.ini.Section;
+
+public class CopyrightConfiguration {
+    static final CopyrightConfiguration DEFAULT =
+            new CopyrightConfiguration(".*\\.cpp|.*\\.hpp|.*\\.c|.*\\.h|.*\\.java");
+
+    private final String files;
+
+    CopyrightConfiguration(String files) {
+        this.files = files;
+    }
+
+    public String files() {
+        return files;
+    }
+
+    static String name() {
+        return "copyright";
+    }
+
+    static CopyrightConfiguration parse(Section s) {
+        if (s == null) {
+            return DEFAULT;
+        }
+
+        var files = s.get("files", DEFAULT.files());
+        return new CopyrightConfiguration(files);
+    }
+}

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/CopyrightIssue.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/CopyrightIssue.java
@@ -28,11 +28,14 @@ public class CopyrightIssue extends CommitIssue {
 
     List<String> filesWithCopyrightFormatIssue;
     List<String> filesWithCopyrightYearIssue;
+    List<String> filesWithCopyrightMissingIssue;
 
-    CopyrightIssue(CommitIssue.Metadata metadata, List<String> filesWithCopyrightFormatIssue, List<String> filesWithCopyrightYearIssue) {
+    CopyrightIssue(CommitIssue.Metadata metadata, List<String> filesWithCopyrightFormatIssue, List<String> filesWithCopyrightYearIssue,
+                   List<String> filesWithCopyrightMissingIssue) {
         super(metadata);
         this.filesWithCopyrightFormatIssue = filesWithCopyrightFormatIssue;
         this.filesWithCopyrightYearIssue = filesWithCopyrightYearIssue;
+        this.filesWithCopyrightMissingIssue = filesWithCopyrightMissingIssue;
     }
 
     @Override
@@ -46,5 +49,9 @@ public class CopyrightIssue extends CommitIssue {
 
     public List<String> filesWithCopyrightYearIssue() {
         return filesWithCopyrightYearIssue;
+    }
+
+    public List<String> filesWithCopyrightMissingIssue() {
+        return filesWithCopyrightMissingIssue;
     }
 }

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/CopyrightIssue.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/CopyrightIssue.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.jcheck;
+
+import java.util.List;
+
+public class CopyrightIssue extends CommitIssue {
+
+    List<String> filesWithCopyrightFormatIssue;
+    List<String> filesWithCopyrightYearIssue;
+
+    CopyrightIssue(CommitIssue.Metadata metadata, List<String> filesWithCopyrightFormatIssue, List<String> filesWithCopyrightYearIssue) {
+        super(metadata);
+        this.filesWithCopyrightFormatIssue = filesWithCopyrightFormatIssue;
+        this.filesWithCopyrightYearIssue = filesWithCopyrightYearIssue;
+    }
+
+    @Override
+    public void accept(IssueVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    public List<String> filesWithCopyrightFormatIssue() {
+        return filesWithCopyrightFormatIssue;
+    }
+
+    public List<String> filesWithCopyrightYearIssue() {
+        return filesWithCopyrightYearIssue;
+    }
+}

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/IssueVisitor.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/IssueVisitor.java
@@ -45,4 +45,5 @@ public interface IssueVisitor {
     void visit(SymlinkIssue issue);
     void visit(ProblemListsIssue problemListIssue);
     void visit(IssuesTitleIssue issuesTitleIssue);
+    void visit(CopyrightIssue copyrightIssue);
 }

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/JCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/JCheck.java
@@ -90,7 +90,8 @@ public class JCheck {
             new SymlinkCheck(),
             new BinaryCheck(),
             new ProblemListsCheck(repository),
-            new IssuesTitleCheck()
+            new IssuesTitleCheck(),
+            new CopyrightCheck(repository)
         );
         repositoryChecks = List.of(
             new BranchesCheck(allowedBranches),

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/CopyrightCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/CopyrightCheckTests.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.jcheck;
+
+import org.junit.jupiter.api.Test;
+import org.openjdk.skara.test.TemporaryDirectory;
+import org.openjdk.skara.test.TestableRepository;
+import org.openjdk.skara.vcs.Commit;
+import org.openjdk.skara.vcs.VCS;
+import org.openjdk.skara.vcs.openjdk.CommitMessage;
+import org.openjdk.skara.vcs.openjdk.CommitMessageParsers;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class CopyrightCheckTests {
+
+    private static JCheckConfiguration conf() {
+        return JCheckConfiguration.parse(List.of(
+                "[general]",
+                "project = test",
+                "[checks]",
+                "error = copyright"
+        ));
+    }
+
+    private static CommitMessage message(Commit c) {
+        return CommitMessageParsers.v1.parse(c);
+    }
+
+    @Test
+    void CopyrightFormatIssueWithTrailingWhiteSpace() throws IOException {
+        try (var dir = new TemporaryDirectory()) {
+            var r = TestableRepository.init(dir.path(), VCS.GIT);
+
+            var afile = dir.path().resolve("a.java");
+            Files.write(afile, List.of("/*\n" +
+                    " * Copyright (c) 2024,  Oracle and/or its affiliates. All rights reserved.\n" +
+                    " * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.\n" +
+                    " */\n"));
+            r.add(afile);
+            var first = r.commit("1: Added a.java", "duke", "duke@openjdk.org");
+
+            var check = new CopyrightCheck(r);
+            var commit = r.lookup(first).orElseThrow();
+            var issue = (CopyrightIssue) check.check(commit, message(commit), conf(), null).next();
+            assertTrue(issue.filesWithCopyrightYearIssue.isEmpty());
+            assertEquals(1, issue.filesWithCopyrightFormatIssue.size());
+
+            // Now, remove the trailing whitespace
+            Files.write(afile, List.of("/*\n" +
+                    " * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.\n" +
+                    " * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.\n" +
+                    " */\n"));
+            r.add(afile);
+            var second = r.commit("2: Modified a.java", "duke", "duke@openjdk.org");
+            check = new CopyrightCheck(r);
+            commit = r.lookup(second).orElseThrow();
+            assertFalse(check.check(commit, message(commit), conf(), null).hasNext());
+        }
+    }
+
+    @Test
+    void CopyrightYearIssue() throws IOException {
+        try (var dir = new TemporaryDirectory()) {
+            var r = TestableRepository.init(dir.path(), VCS.GIT);
+
+            var afile = dir.path().resolve("a.java");
+            Files.write(afile, List.of("/*\n" +
+                    " * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.\n" +
+                    " * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.\n" +
+                    " */\n"));
+            r.add(afile);
+            var first = r.commit("1: Added a.java", "duke", "duke@openjdk.org");
+
+            var check = new CopyrightCheck(r);
+            var commit = r.lookup(first).orElseThrow();
+            var issue = (CopyrightIssue) check.check(commit, message(commit), conf(), null).next();
+            assertEquals(1, issue.filesWithCopyrightYearIssue.size());
+            assertTrue(issue.filesWithCopyrightFormatIssue.isEmpty());
+
+            // Update the copyright year
+            Files.write(afile, List.of("/*\n" +
+                    " * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.\n" +
+                    " * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.\n" +
+                    " */\n"));
+            r.add(afile);
+            var second = r.commit("2: Modified a.java", "duke", "duke@openjdk.org");
+            check = new CopyrightCheck(r);
+            commit = r.lookup(second).orElseThrow();
+            assertFalse(check.check(commit, message(commit), conf(), null).hasNext());
+        }
+    }
+}

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/JCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/JCheckTests.java
@@ -243,6 +243,11 @@ class JCheckTests {
             issues.add(e);
         }
 
+        @Override
+        public void visit(CopyrightIssue e) {
+            issues.add(e);
+        }
+
         Set<Issue> issues() {
             return issues;
         }

--- a/test/src/main/java/org/openjdk/skara/test/CheckableRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/CheckableRepository.java
@@ -93,11 +93,11 @@ public class CheckableRepository {
     }
 
     public static Repository init(Path path, VCS vcs, Path appendableFilePath, Set<String> errorChecks, String version) throws IOException {
-        return init(path, vcs, appendableFilePath, errorChecks, Set.of("issuestitle", "copyright"), version);
+        return init(path, vcs, appendableFilePath, errorChecks, Set.of(), version);
     }
 
     public static Repository init(Path path, VCS vcs, Path appendableFilePath) throws IOException {
-        return init(path, vcs, appendableFilePath, Set.of("author", "reviewers", "whitespace"), Set.of("issuestitle","copyright"), "0.1");
+        return init(path, vcs, appendableFilePath, Set.of("author", "reviewers", "whitespace"), Set.of(), "0.1");
     }
 
     public static Repository init(Path path, VCS vcs) throws IOException {

--- a/test/src/main/java/org/openjdk/skara/test/CheckableRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/CheckableRepository.java
@@ -81,6 +81,9 @@ public class CheckableRepository {
             output.append("\n");
             output.append("[checks \"reviewers\"]\n");
             output.append("reviewers=1\n");
+            output.append("\n");
+            output.append("[checks \"copyright\"]\n");
+            output.append("files=.*\\.txt\n");
         }
         repo.add(checkConf);
 
@@ -90,11 +93,11 @@ public class CheckableRepository {
     }
 
     public static Repository init(Path path, VCS vcs, Path appendableFilePath, Set<String> errorChecks, String version) throws IOException {
-        return init(path, vcs, appendableFilePath, errorChecks, Set.of("issuestitle"), version);
+        return init(path, vcs, appendableFilePath, errorChecks, Set.of("issuestitle", "copyright"), version);
     }
 
     public static Repository init(Path path, VCS vcs, Path appendableFilePath) throws IOException {
-        return init(path, vcs, appendableFilePath, Set.of("author", "reviewers", "whitespace"), Set.of("issuestitle"), "0.1");
+        return init(path, vcs, appendableFilePath, Set.of("author", "reviewers", "whitespace"), Set.of("issuestitle","copyright"), "0.1");
     }
 
     public static Repository init(Path path, VCS vcs) throws IOException {


### PR DESCRIPTION
This patch introduces a copyright jcheck.
For pull requests, the check checks the copyright header in all modified files(if the file name matches the regex in .jcheck/conf)