### PR TITLE
2431: Add core-libs mailing list mapping entry for src/java.base/aix/native/libjava/

### DIFF
--- a/config/mailinglist/rules/jdk.json
+++ b/config/mailinglist/rules/jdk.json
@@ -80,6 +80,7 @@
             "make/modules/java.base/",
             "make/modules/java.prefs",
             "src/java.base/aix/native/libjli",
+            "src/java.base/aix/native/libjava/",
             "src/java.base/linux/classes/jdk",
             "src/java.base/linux/native/libjava/",
             "src/java.base/macosx/classes/jdk",


### PR DESCRIPTION
Add to core-libs mapping "src/java.base/aix/native/libjava/"

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2431](https://bugs.openjdk.org/browse/SKARA-2431): Add core-libs mailing list mapping entry for src/java.base/aix/native/libjava/ (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - no project role)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1704/head:pull/1704` \
`$ git checkout pull/1704`

Update a local copy of the PR: \
`$ git checkout pull/1704` \
`$ git pull https://git.openjdk.org/skara.git pull/1704/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1704`

View PR using the GUI difftool: \
`$ git pr show -t 1704`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1704.diff">https://git.openjdk.org/skara/pull/1704.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1704#issuecomment-2580842267)
</details>
