### PR TITLE
2446: src/hotspot/share/nmt/ should be associated with hotspot-runtime

### DIFF
--- a/config/mailinglist/rules/jdk.json
+++ b/config/mailinglist/rules/jdk.json
@@ -335,6 +335,7 @@
             "src/hotspot/share/libadt/",
             "src/hotspot/share/logging/",
             "src/hotspot/share/memory/",
+            "src/hotspot/share/nmt/",
             "src/hotspot/share/oops/",
             "src/hotspot/share/prims/(cds|jni|method|native|perf|resolved|stackwalk|unsafe).*",
             "src/hotspot/share/runtime/",


### PR DESCRIPTION
Hi,

 We moved NMT's code to its own subdirectory a while ago, but we never fixed the association for Skara. I, hopefully, filed the ticket in JBS correctly.

Thank you!

Johan

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2446](https://bugs.openjdk.org/browse/SKARA-2446): src/hotspot/share/nmt/ should be associated with hotspot-runtime (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1705/head:pull/1705` \
`$ git checkout pull/1705`

Update a local copy of the PR: \
`$ git checkout pull/1705` \
`$ git pull https://git.openjdk.org/skara.git pull/1705/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1705`

View PR using the GUI difftool: \
`$ git pr show -t 1705`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1705.diff">https://git.openjdk.org/skara/pull/1705.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1705#issuecomment-2681432878)
</details>
