### PR TITLE
2451: Skara bot fails to transition bug to Resolved due to empty response from api

### DIFF
--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraIssue.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraIssue.java
@@ -250,6 +250,10 @@ public class JiraIssue implements IssueTrackerIssue {
     public void setState(State state) {
         var availableTransitions = availableTransitions();
 
+        if (availableTransitions.isEmpty()) {
+            throw new RuntimeException("Available transition states are empty");
+        }
+
         // Handle special cases
         if (state == State.RESOLVED) {
             if (!availableTransitions.containsKey("Resolved")) {
@@ -261,6 +265,7 @@ public class JiraIssue implements IssueTrackerIssue {
                     }
                 } else {
                     // The issue is most likely closed - skip transitioning
+                    log.warning("Can't transition the issue to Resolved or Open");
                     return;
                 }
             }

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraIssue.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraIssue.java
@@ -251,7 +251,7 @@ public class JiraIssue implements IssueTrackerIssue {
         var availableTransitions = availableTransitions();
 
         if (availableTransitions.isEmpty()) {
-            throw new RuntimeException("Available transition states are empty");
+            throw new RuntimeException("Available transition states is empty");
         }
 
         // Handle special cases


### PR DESCRIPTION
A user reported that one backport issue was not automatically resolved by the Skara bot. From the logs, Erik found that the bot didn't actually send the request to transition the bug to resolved and he noticed that around that time, the bot was renewing the access token for jbs.

When updating the state of an issue, the Skara bot first attempts to fetch the available transitions for that issue by calling this API:
https://bugs.openjdk.org/rest/api/2/issue/issue_id/transitions.

I called the API without authentication, I was expecting a 401 Unauthorized response. However, I received an empty response:
`{"expand":"transitions","transitions":[]}.`

Due to this empty response, the Skara bot did not attempt to transition the bug to any state.

In my opinion, availableTransitions would be empty only when requesting the API without authentication,  so skara bot would throw an exception in this case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2451](https://bugs.openjdk.org/browse/SKARA-2451): Skara bot fails to transition bug to Resolved due to empty response from api (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1706/head:pull/1706` \
`$ git checkout pull/1706`

Update a local copy of the PR: \
`$ git checkout pull/1706` \
`$ git pull https://git.openjdk.org/skara.git pull/1706/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1706`

View PR using the GUI difftool: \
`$ git pr show -t 1706`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1706.diff">https://git.openjdk.org/skara/pull/1706.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1706#issuecomment-2695148403)
</details>
