### PR TITLE
2452: Client CLI build fails on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
           ${{ needs.prerequisites.outputs.merge_target_command }}
 
       - name: Build and test
-        run: sh gradlew test --info --stacktrace
+        run: sh gradlew test local --info --stacktrace
 
   mac:
     name: macOS x64
@@ -101,7 +101,7 @@ jobs:
         run: brew install mercurial
 
       - name: Build and test
-        run: sh gradlew test --info --stacktrace
+        run: sh gradlew test local --info --stacktrace
 
   win:
     name: Windows x64
@@ -120,5 +120,5 @@ jobs:
           ${{ needs.prerequisites.outputs.merge_target_command }}
 
       - name: Build and test
-        run: gradlew.bat test --info --stacktrace
+        run: gradlew.bat test local --info --stacktrace
         shell: cmd

--- a/build.gradle
+++ b/build.gradle
@@ -184,7 +184,7 @@ def getCPU() {
 
 task local(type: Copy) {
     doFirst {
-        delete project.buildDir
+        delete project.buildDir.toString() + '/cli'
     }
 
     def os = getOS()
@@ -202,7 +202,7 @@ task local(type: Copy) {
                       '/cli/build/distributions/cli' +
                       '-' + project.version + '-' +
                       os + '-' + cpu + '.zip'))
-    into project.buildDir
+    into project.buildDir.toString() + '/cli'
 }
 
 task bots(type: Copy) {

--- a/skara.sh
+++ b/skara.sh
@@ -37,9 +37,9 @@ else
 
 fi
 
-if [ -d "${DIR}/build" ]; then
+if [ -d "${DIR}/build/cli" ]; then
     rm -rf "${DIR}/bin"
-    mv "${DIR}/build" "${DIR}/bin"
+    mv "${DIR}/build/cli" "${DIR}/bin"
 fi
 
 if [ "${OS}" = "Linux" -o "${OS}" = "Darwin" ]; then


### PR DESCRIPTION
Building the default target "local" fails on Windows with the error message below. I think this started happening when we upgraded the Gradle version last. This is the target that the automatic CLI build/installation runs.

```
* What went wrong: Execution failed for task ':local'. > Cannot access a file in the destination directory. Copying to a directory which contains unreadable content is not supported. Declare the task as untracked by using Task.doNotTrackState(). For more information, please refer to https://docs.gradle.org/8.5/userguide/incremental_build.html#disable-state-tracking in the Gradle documentation.  > Failed to create MD5 hash for file content.
```

I'm working around/fixing it by moving the output dir of the `local` task to its own subdir in the project build dir. I'm also adding the target `local` explicitly to the GHA tasks so that this kind of problem gets caught there. I intentionally did this in a separate commit to demonstrate that it would fail for this branch/PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2452](https://bugs.openjdk.org/browse/SKARA-2452): Client CLI build fails on Windows (**Bug** - P3)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1707/head:pull/1707` \
`$ git checkout pull/1707`

Update a local copy of the PR: \
`$ git checkout pull/1707` \
`$ git pull https://git.openjdk.org/skara.git pull/1707/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1707`

View PR using the GUI difftool: \
`$ git pr show -t 1707`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1707.diff">https://git.openjdk.org/skara/pull/1707.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1707#issuecomment-2695802729)
</details>
