### PR TITLE
2460: Some folders in test/hotspot/jtreg/testlibrary_tests/ should be mapped to hotspot-compiler

### DIFF
--- a/config/mailinglist/rules/jdk.json
+++ b/config/mailinglist/rules/jdk.json
@@ -273,6 +273,7 @@
             "test/hotspot/jtreg/testlibrary/ctw/",
             "test/hotspot/jtreg/testlibrary/jittester/",
             "test/hotspot/jtreg/testlibrary_tests/compile_framework/",
+            "test/hotspot/jtreg/testlibrary_tests/generators/",
             "test/hotspot/jtreg/testlibrary_tests/ir_framework/",
             "test/hotspot/jtreg/vmTestbase/jit/",
             "test/hotspot/jtreg/vmTestbase/vm/compiler/",

--- a/config/mailinglist/rules/jdk.json
+++ b/config/mailinglist/rules/jdk.json
@@ -275,6 +275,7 @@
             "test/hotspot/jtreg/testlibrary_tests/compile_framework/",
             "test/hotspot/jtreg/testlibrary_tests/generators/",
             "test/hotspot/jtreg/testlibrary_tests/ir_framework/",
+            "test/hotspot/jtreg/testlibrary_tests/verify/",
             "test/hotspot/jtreg/vmTestbase/jit/",
             "test/hotspot/jtreg/vmTestbase/vm/compiler/",
             "test/hotspot/jtreg/vmTestbase/vm/jit/",

--- a/config/mailinglist/rules/jdk.json
+++ b/config/mailinglist/rules/jdk.json
@@ -272,6 +272,8 @@
             "test/hotspot/jtreg/compiler/",
             "test/hotspot/jtreg/testlibrary/ctw/",
             "test/hotspot/jtreg/testlibrary/jittester/",
+            "test/hotspot/jtreg/testlibrary_tests/compile_framework/",
+            "test/hotspot/jtreg/testlibrary_tests/ir_framework/",
             "test/hotspot/jtreg/vmTestbase/jit/",
             "test/hotspot/jtreg/vmTestbase/vm/compiler/",
             "test/hotspot/jtreg/vmTestbase/vm/jit/",


### PR DESCRIPTION
The IR Test Framework ([JDK-8254129](https://bugs.openjdk.org/browse/JDK-8254129)) and the Compile Framework ([JDK-8337221](https://bugs.openjdk.org/browse/JDK-8337221)) are owned by hotspot-compiler.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2460](https://bugs.openjdk.org/browse/SKARA-2460): Some folders in test/hotspot/jtreg/testlibrary_tests/ should be mapped to hotspot-compiler (**Bug** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - no project role) Review applies to [3ba4a0ba](https://git.openjdk.org/skara/pull/1709/files/3ba4a0ba95a0948b8c138fb2e5535eca2838421d)
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - no project role)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1709/head:pull/1709` \
`$ git checkout pull/1709`

Update a local copy of the PR: \
`$ git checkout pull/1709` \
`$ git pull https://git.openjdk.org/skara.git pull/1709/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1709`

View PR using the GUI difftool: \
`$ git pr show -t 1709`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1709.diff">https://git.openjdk.org/skara/pull/1709.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1709#issuecomment-2747539702)
</details>
