### PR TITLE
2466: Cut down list of other commits from 10 to 3

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -49,7 +49,6 @@ import static org.openjdk.skara.bots.common.PullRequestConstants.*;
 
 class CheckRun {
     public static final String MSG_EMPTY_BODY = "The pull request body must not be empty.";
-    private static final int COMMIT_LIST_LIMIT = 3;
 
     private final CheckWorkItem workItem;
     private final PullRequest pr;
@@ -1065,10 +1064,10 @@ class CheckRun {
             message.append(pr.targetRef());
             message.append("` branch:\n\n");
             divergingCommits.stream()
-                            .limit(COMMIT_LIST_LIMIT)
+                            .limit(CheckablePullRequest.COMMIT_LIST_LIMIT)
                             .forEach(c -> message.append(" * ").append(c.hash().hex()).append(": ").append(c.message().get(0)).append("\n"));
-            if (divergingCommits.size() > COMMIT_LIST_LIMIT) {
-                message.append(" * ... and ").append(divergingCommits.size() - COMMIT_LIST_LIMIT).append(" more: ")
+            if (divergingCommits.size() > CheckablePullRequest.COMMIT_LIST_LIMIT) {
+                message.append(" * ... and ").append(divergingCommits.size() -CheckablePullRequest. COMMIT_LIST_LIMIT).append(" more: ")
                        .append(pr.repository().webUrl(baseHash.hex(), pr.targetRef())).append("\n");
             } else {
                 message.append("\n");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -49,6 +49,7 @@ import static org.openjdk.skara.bots.common.PullRequestConstants.*;
 
 class CheckRun {
     public static final String MSG_EMPTY_BODY = "The pull request body must not be empty.";
+    private static final int COMMIT_LIST_LIMIT = 3;
 
     private final CheckWorkItem workItem;
     private final PullRequest pr;
@@ -1064,10 +1065,10 @@ class CheckRun {
             message.append(pr.targetRef());
             message.append("` branch:\n\n");
             divergingCommits.stream()
-                            .limit(10)
+                            .limit(COMMIT_LIST_LIMIT)
                             .forEach(c -> message.append(" * ").append(c.hash().hex()).append(": ").append(c.message().get(0)).append("\n"));
-            if (divergingCommits.size() > 10) {
-                message.append(" * ... and ").append(divergingCommits.size() - 10).append(" more: ")
+            if (divergingCommits.size() > COMMIT_LIST_LIMIT) {
+                message.append(" * ... and ").append(divergingCommits.size() - COMMIT_LIST_LIMIT).append(" more: ")
                        .append(pr.repository().webUrl(baseHash.hex(), pr.targetRef())).append("\n");
             } else {
                 message.append("\n");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
@@ -40,9 +40,10 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class CheckablePullRequest {
+    public static final int COMMIT_LIST_LIMIT = 3;
+
     private static final Pattern BACKPORT_PATTERN = Pattern.compile("<!-- backport ([0-9a-z]{40}) -->");
     private static final Pattern BACKPORT_REPO_PATTERN = Pattern.compile("<!-- repo (.+) -->");
-    private static final int COMMIT_LIST_LIMIT = 3;
 
     private final PullRequest pr;
     private final Repository localRepo;

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,6 +42,7 @@ import java.util.stream.Stream;
 public class CheckablePullRequest {
     private static final Pattern BACKPORT_PATTERN = Pattern.compile("<!-- backport ([0-9a-z]{40}) -->");
     private static final Pattern BACKPORT_REPO_PATTERN = Pattern.compile("<!-- repo (.+) -->");
+    private static final int COMMIT_LIST_LIMIT = 3;
 
     private final PullRequest pr;
     private final Repository localRepo;
@@ -270,12 +271,12 @@ public class CheckablePullRequest {
             reply.print(pr.targetRef());
             reply.print("` branch:\n\n");
             divergingCommits.stream()
-                            .limit(10)
+                            .limit(COMMIT_LIST_LIMIT)
                             .forEach(c -> reply.println(" * " + c.hash().hex() + ": " + c.message().get(0)));
-            if (divergingCommits.size() > 10) {
+            if (divergingCommits.size() > COMMIT_LIST_LIMIT) {
                 try {
                     var baseHash = localRepo.mergeBase(targetHash(), pr.headHash());
-                    reply.println(" * ... and " + (divergingCommits.size() - 10) + " more: " +
+                    reply.println(" * ... and " + (divergingCommits.size() - COMMIT_LIST_LIMIT) + " more: " +
                                           pr.repository().webUrl(baseHash.hex(), pr.targetRef()));
                 } catch (IOException e) {
                     throw new UncheckedIOException(e);


### PR DESCRIPTION
Skara prints a list of other commits that has been integrated before a PR is automatically rebased. I think the idea was to put transparency to the rebasing process, but in actuality it only adds noise.

I think it could be removed entirely (in general, I think the Skara bot messages are *waaaay* to chatty), but as a start, it the list could be shortened radically. I chose 3 as the lowest number that is still a "crowd".

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2466](https://bugs.openjdk.org/browse/SKARA-2466): Cut down list of other commits from 10 to 3 (**Enhancement** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1710/head:pull/1710` \
`$ git checkout pull/1710`

Update a local copy of the PR: \
`$ git checkout pull/1710` \
`$ git pull https://git.openjdk.org/skara.git pull/1710/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1710`

View PR using the GUI difftool: \
`$ git pr show -t 1710`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1710.diff">https://git.openjdk.org/skara/pull/1710.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1710#issuecomment-2751863251)
</details>
