### PR TITLE
2468: PR bot mistakenly stop warning about empty pr body

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -240,7 +240,8 @@ class CheckRun {
     private List<String> botSpecificChecks(boolean iscleanBackport) {
         var ret = new ArrayList<String>();
 
-        if (bodyWithoutStatus().isBlank() && !iscleanBackport) {
+        var bodyWithoutStatus = bodyWithoutStatus();
+        if ((bodyWithoutStatus.isBlank() || bodyWithoutStatus.equals(EMPTY_PR_BODY_MARKER)) && !iscleanBackport) {
             ret.add(MSG_EMPTY_BODY);
         }
 


### PR DESCRIPTION
In a pull request, the user didn't put anything in the pr body. At first, skara bot successfully detected the empty body and showed the error "The pull request body must not be empty." However, after the pull request is updated, the error disappeared.
After investigation, I found that if the pr body is empty, skara bot would add a "EMPTY_PR_BODY_MARKER" to the pr body, and later, skara bot would mistakenly treat it as the body added by user.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2468](https://bugs.openjdk.org/browse/SKARA-2468): PR bot mistakenly stop warning about empty pr body (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1712/head:pull/1712` \
`$ git checkout pull/1712`

Update a local copy of the PR: \
`$ git checkout pull/1712` \
`$ git pull https://git.openjdk.org/skara.git pull/1712/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1712`

View PR using the GUI difftool: \
`$ git pr show -t 1712`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1712.diff">https://git.openjdk.org/skara/pull/1712.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1712#issuecomment-2752654407)
</details>
