### PR TITLE
2470: Mailing list bridge is failing to send some emails

### DIFF
--- a/network/src/main/java/org/openjdk/skara/network/RestRequest.java
+++ b/network/src/main/java/org/openjdk/skara/network/RestRequest.java
@@ -402,7 +402,8 @@ public class RestRequest {
                     return transformed;
                 }
             }
-            log.warning("Request returned bad status: " + response.statusCode());
+            log.warning("Request " + response.request().method() + " " + response.request().uri()
+                    + " returned bad status: " + response.statusCode());
             log.info(queryBuilder.toString());
             log.info(response.body());
             throw new UncheckedRestException(response.statusCode(), response.request());

--- a/network/src/main/java/org/openjdk/skara/network/UncheckedRestException.java
+++ b/network/src/main/java/org/openjdk/skara/network/UncheckedRestException.java
@@ -30,9 +30,8 @@ import java.net.http.HttpRequest;
  * has already been logged.
  */
 public class UncheckedRestException extends RuntimeException {
-    int statusCode;
-
-    HttpRequest request;
+    private final int statusCode;
+    private final HttpRequest request;
 
     public UncheckedRestException(int statusCode, HttpRequest request) {
         this("Request returned bad status", null, statusCode, request);
@@ -43,7 +42,7 @@ public class UncheckedRestException extends RuntimeException {
     }
 
     public UncheckedRestException(String message, Throwable cause, int statusCode, HttpRequest request) {
-        super("[" + statusCode + "] " + message, cause);
+        super("[" + statusCode + "][" + request.method() + "][" + request.uri() + "] " + message, cause);
         this.statusCode = statusCode;
         this.request = request;
     }


### PR DESCRIPTION
The mlbridge bot sometimes fails to send emails based on PR activity/comments. The emails get generated and the bot attempts to store them in the mailing list archive repo, which we are storing in a GitLab server. The PUT call returns 400, which the bot interprets as a failure and aborts the WorkItem. On the next run of that WorkItem, the emails are found in the archive, which the bot interprets as having been sent, so no new attempt is made. The issue here is that GitLab returns a failure code but still stores the data.

To try to work around this, I'm adding a fallback check when receiving 400 when storing a file. The check tries to fetch the current contents of the file and compares it to what we attempted to store. If equal, the error is ignored and the store procedure is considered successful.

Testing this is tricky, so this code is basically untested. I'm also adding more logging and more information to existing related logging so that we can monitor this behavior better and see if this workaround is having any effect.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2470](https://bugs.openjdk.org/browse/SKARA-2470): Mailing list bridge is failing to send some emails (**Bug** - P3)


### Reviewers
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1713/head:pull/1713` \
`$ git checkout pull/1713`

Update a local copy of the PR: \
`$ git checkout pull/1713` \
`$ git pull https://git.openjdk.org/skara.git pull/1713/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1713`

View PR using the GUI difftool: \
`$ git pr show -t 1713`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1713.diff">https://git.openjdk.org/skara/pull/1713.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1713#issuecomment-2784750683)
</details>
