### PR TITLE
2479: PR marked as ready with jcheck error

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -1470,7 +1470,7 @@ class CheckRun {
             var commitMessage = String.join("\n", commit.message());
 
             var readyToPostApprovalNeededComment = readyForReview &&
-                    visitor.hasErrors(reviewNeeded) &&
+                    !visitor.hasErrors(reviewNeeded) &&
                     integrationBlockers.isEmpty() &&
                     !statusMessage.contains(TEMPORARY_ISSUE_FAILURE_MARKER);
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -1469,11 +1469,9 @@ class CheckRun {
             var commit = localRepo.lookup(amendedHash).orElseThrow();
             var commitMessage = String.join("\n", commit.message());
 
-            var onlyReviewersCheckFailed = visitor.errorFailedChecksMessages().stream()
-                    .allMatch(message -> message.contains("Too few reviewers"));
-
             var readyToPostApprovalNeededComment = readyForReview &&
-                    ((!reviewNeeded && onlyReviewersCheckFailed) || visitor.errorFailedChecksMessages().isEmpty()) &&
+                    ((!reviewNeeded && visitor.errorFailedCheckMessagesWithoutReviewersCheck().isEmpty()) ||
+                            visitor.errorFailedChecksMessages().isEmpty()) &&
                     integrationBlockers.isEmpty() &&
                     !statusMessage.contains(TEMPORARY_ISSUE_FAILURE_MARKER);
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -1469,10 +1469,11 @@ class CheckRun {
             var commit = localRepo.lookup(amendedHash).orElseThrow();
             var commitMessage = String.join("\n", commit.message());
 
+            var onlyReviewersCheckFailed = visitor.errorFailedChecksMessages().stream()
+                    .allMatch(message -> message.contains("Too few reviewers"));
+
             var readyToPostApprovalNeededComment = readyForReview &&
-                    ((!reviewNeeded && visitor.errorFailedChecksMessages().stream()
-                            .allMatch(message -> message.contains("Too few reviewers"))
-                    ) || visitor.errorFailedChecksMessages().isEmpty()) &&
+                    ((!reviewNeeded && onlyReviewersCheckFailed) || visitor.errorFailedChecksMessages().isEmpty()) &&
                     integrationBlockers.isEmpty() &&
                     !statusMessage.contains(TEMPORARY_ISSUE_FAILURE_MARKER);
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -1470,8 +1470,7 @@ class CheckRun {
             var commitMessage = String.join("\n", commit.message());
 
             var readyToPostApprovalNeededComment = readyForReview &&
-                    ((!reviewNeeded && visitor.errorFailedCheckMessagesWithoutReviewersCheck().isEmpty()) ||
-                            visitor.errorFailedChecksMessages().isEmpty()) &&
+                    visitor.hasErrors(reviewNeeded) &&
                     integrationBlockers.isEmpty() &&
                     !statusMessage.contains(TEMPORARY_ISSUE_FAILURE_MARKER);
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -1470,7 +1470,9 @@ class CheckRun {
             var commitMessage = String.join("\n", commit.message());
 
             var readyToPostApprovalNeededComment = readyForReview &&
-                    (!reviewNeeded || visitor.errorFailedChecksMessages().isEmpty()) &&
+                    ((!reviewNeeded && visitor.errorFailedChecksMessages().stream()
+                            .allMatch(message -> message.contains("Too few reviewers"))
+                    ) || visitor.errorFailedChecksMessages().isEmpty()) &&
                     integrationBlockers.isEmpty() &&
                     !statusMessage.contains(TEMPORARY_ISSUE_FAILURE_MARKER);
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
@@ -72,6 +72,14 @@ class PullRequestCheckIssueVisitor implements IssueVisitor {
         return errorFailedChecks.values().stream().flatMap(List::stream).toList();
     }
 
+    List<String> errorFailedCheckMessagesWithoutReviewersCheck() {
+        return errorFailedChecks.keySet().stream()
+                .filter(check -> !check.equals(ReviewersCheck.class))
+                .map(errorFailedChecks::get)
+                .flatMap(List::stream)
+                .toList();
+    }
+
     List<String> warningFailedChecksMessages() {
         return warningFailedChecks.values().stream().flatMap(List::stream).toList();
     }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
@@ -72,12 +72,14 @@ class PullRequestCheckIssueVisitor implements IssueVisitor {
         return errorFailedChecks.values().stream().flatMap(List::stream).toList();
     }
 
-    List<String> errorFailedCheckMessagesWithoutReviewersCheck() {
-        return errorFailedChecks.keySet().stream()
-                .filter(check -> !check.equals(ReviewersCheck.class))
-                .map(errorFailedChecks::get)
-                .flatMap(List::stream)
-                .toList();
+
+    boolean hasErrors(boolean reviewNeeded) {
+        if (reviewNeeded) {
+            return !errorFailedChecks.isEmpty();
+        } else {
+            return errorFailedChecks.keySet().stream()
+                    .anyMatch(check -> !check.equals(ReviewersCheck.class));
+        }
     }
 
     List<String> warningFailedChecksMessages() {


### PR DESCRIPTION
Currently, when determining if a PR is ready, if the PR doesn't require a review, it also ignores all jcheck failures. Instead, only reviewers check should be ignored in this case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2479](https://bugs.openjdk.org/browse/SKARA-2479): PR marked as ready with jcheck error (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1714/head:pull/1714` \
`$ git checkout pull/1714`

Update a local copy of the PR: \
`$ git checkout pull/1714` \
`$ git pull https://git.openjdk.org/skara.git pull/1714/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1714`

View PR using the GUI difftool: \
`$ git pr show -t 1714`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1714.diff">https://git.openjdk.org/skara/pull/1714.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1714#issuecomment-2813639949)
</details>
