### PR TITLE
SKARA-2481

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
 
   linux:
     name: Linux x64
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     needs: prerequisites
     if: needs.prerequisites.outputs.should_run
 


### PR DESCRIPTION
Ubuntu-20.04 was deprecated on April 15th, 2025.
https://github.com/actions/runner-images/issues/11101