### PR TITLE
SKARA-2480

### DIFF
--- a/bots/common/src/main/java/org/openjdk/skara/bots/common/CommandNameEnum.java
+++ b/bots/common/src/main/java/org/openjdk/skara/bots/common/CommandNameEnum.java
@@ -49,7 +49,8 @@ public enum CommandNameEnum {
     branch,
     approval(true),
     approve,
-    author;
+    author,
+    ping;
 
     private boolean isMultiLine = false;
 

--- a/bots/common/src/main/java/org/openjdk/skara/bots/common/PullRequestConstants.java
+++ b/bots/common/src/main/java/org/openjdk/skara/bots/common/PullRequestConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@ public class PullRequestConstants {
     public static final String WEBREV_COMMENT_MARKER = "<!-- mlbridge webrev comment -->";
     public static final String TEMPORARY_ISSUE_FAILURE_MARKER = "<!-- temporary issue failure -->";
     public static final String READY_FOR_SPONSOR_MARKER = "<!-- integration requested: '%s' -->";
+    public static final String PING_COMMAND_RESPONSE_MARKER = "<!-- ping command response-->";
 
     // LABELS
     public static final String CSR_LABEL = "csr";

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -50,6 +50,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.openjdk.skara.bots.common.PullRequestConstants.PING_COMMAND_RESPONSE_MARKER;
 import static org.openjdk.skara.bots.common.PullRequestConstants.WEBREV_COMMENT_MARKER;
 import static org.openjdk.skara.bots.pr.CheckRun.MERGE_READY_MARKER;
 import static org.openjdk.skara.bots.pr.CheckRun.PLACEHOLDER_MARKER;
@@ -172,11 +173,20 @@ class CheckWorkItem extends PullRequestWorkItem {
                                         .flatMap(comment -> comment.body().lines())
                                         .filter(line -> METADATA_COMMENTS_PATTERN.matcher(line).find())
                                         .collect(Collectors.joining());
+
+            // Webrev comment should trigger the update
             commentString = commentString + comments.stream()
                     .filter(comment -> comment.author().username().equals(bot.mlbridgeBotName()))
                     .flatMap(comment -> comment.body().lines())
                     .filter(line -> line.equals(WEBREV_COMMENT_MARKER))
                     .findFirst().orElse("");
+
+            // Ping command should trigger the update
+            commentString = commentString + comments.stream()
+                    .filter(comment -> comment.author().equals(pr.repository().forge().currentUser()))
+                    .flatMap(comment -> comment.body().lines())
+                    .filter(line -> line.contains(PING_COMMAND_RESPONSE_MARKER))
+                    .collect(Collectors.joining());
 
             var labelString = labels.stream()
                                     .sorted()

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandExtractor.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CommandExtractor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,7 +68,8 @@ public class CommandExtractor {
             Map.entry(branch.name(), new BranchCommand()),
             Map.entry(approval.name(), new ApprovalCommand()),
             Map.entry(approve.name(), new ApproveCommand()),
-            Map.entry(author.name(), new AuthorCommand())
+            Map.entry(author.name(), new AuthorCommand()),
+            Map.entry(ping.name(), new PingCommand())
     );
 
     static class HelpCommand implements CommandHandler {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PingCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PingCommand.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.pr;
+
+import org.openjdk.skara.forge.PullRequest;
+import org.openjdk.skara.issuetracker.Comment;
+
+import java.io.PrintWriter;
+import java.util.List;
+
+import static org.openjdk.skara.bots.common.CommandNameEnum.ping;
+import static org.openjdk.skara.bots.common.PullRequestConstants.PING_COMMAND_RESPONSE_MARKER;
+
+public class PingCommand implements CommandHandler {
+    private void showHelp(PrintWriter reply) {
+        reply.println("Usage: `/ping`");
+    }
+
+    @Override
+    public String description() {
+        return "Reset the timeouts for this pull request and re-evaluate the pull request.";
+    }
+
+    @Override
+    public String name() {
+        return ping.name();
+    }
+
+    @Override
+    public boolean allowedInBody() {
+        return false;
+    }
+
+    @Override
+    public void handle(PullRequestBot bot, PullRequest pr, CensusInstance censusInstance, ScratchArea scratchArea, CommandInvocation command, List<Comment> allComments, PrintWriter reply) {
+        if (!pr.author().equals(command.user()) && !censusInstance.isReviewer(command.user())) {
+            reply.println("Only the author of the pull request or [Reviewers](https://openjdk.org/bylaws#reviewer) are allowed to change the number of required reviewers.");
+            return;
+        }
+
+        if (pr.isClosed()) {
+            reply.println("This command can only be used in open pull requests.");
+        }
+
+        reply.println("The timeouts for this pull request has been reset and this pull request will be re-evaluated soon." + PING_COMMAND_RESPONSE_MARKER);
+    }
+}

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -100,11 +100,26 @@ class CheckTests {
             checks = pr.checks(editHash);
             assertEquals(1, checks.size());
             check = checks.get("jcheck");
+            var checkStartTime1 = check.startedAt();
             assertEquals(CheckStatus.SUCCESS, check.status());
 
             // The PR should now be ready
             assertTrue(pr.store().labelNames().contains("ready"));
             assertTrue(pr.store().body().contains("https://census.com/integrationreviewer2-profile"));
+
+            // Issue "Ping" command
+            approvalPr.addComment("/ping");
+            TestBotRunner.runPeriodicItems(checkBot);
+            check = pr.checks(editHash).get("jcheck");
+            var checkStartTime2 = check.startedAt();
+            assertNotEquals(checkStartTime1, checkStartTime2);
+
+            // Issue "Ping" again
+            approvalPr.addComment("/ping");
+            TestBotRunner.runPeriodicItems(checkBot);
+            check = pr.checks(editHash).get("jcheck");
+            var checkStartTime3 = check.startedAt();
+            assertNotEquals(checkStartTime2, checkStartTime3);
         }
     }
 


### PR DESCRIPTION
This PR is trying to add a new pull request "ping".

The reported wants to have a pull request command that can refresh the timeouts of the pr so that the pr wouldn't be closed by pullRequestPrunerBot.
 
The reported proposed to name the command "keep-alive" with alias "/ping", however, we store command names in an Enum class, so "keep-alive" is invalid. I think we just use "ping" as the command name.

Besides, I would like to let the command trigger a force update of the pr. Currently, there are some cases that skara bot won't re-evaluate the pr automatically and users need to do something to poke it(like editing the pr title), so I think it's better to have a pull request command to trigger the update.
 
 