### PR TITLE
2491: GitLabRepository::recentCommitComments can miss commits

### DIFF
--- a/forge/src/test/java/org/openjdk/skara/forge/gitlab/GitLabIntegrationTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/gitlab/GitLabIntegrationTests.java
@@ -315,6 +315,12 @@ class GitLabIntegrationTests {
                 ZonedDateTime.now().minus(Duration.ofDays(4)));
 
         assertFalse(comments.isEmpty());
+
+        // Pause here to update the local repository to trigger another code path
+        var comments2 = gitLabRepo.recentCommitComments(localRepo, Set.of(), List.of(new Branch("master")),
+                ZonedDateTime.now().minus(Duration.ofDays(4)));
+
+        assertFalse(comments2.isEmpty());
     }
 
     @Test

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/TestRepository.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/TestRepository.java
@@ -349,6 +349,11 @@ class TestRepository implements ReadOnlyRepository {
     }
 
     @Override
+    public int commitCount(List<Branch> branches) throws IOException {
+        return 0;
+    }
+
+    @Override
     public Hash initialHash() {
         return null;
     }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/ReadOnlyRepository.java
@@ -171,6 +171,8 @@ public interface ReadOnlyRepository {
 
     int commitCount() throws IOException;
 
+    int commitCount(List<Branch> branches) throws IOException;
+
     /**
      * Returns the special hash that references the virtual commit before the first real commit in a repository.
      */

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -1711,6 +1711,16 @@ public class GitRepository implements Repository {
     }
 
     @Override
+    public int commitCount(List<Branch> branches) throws IOException {
+        var args = new ArrayList<String>();
+        args.addAll(List.of("git", "rev-list", "--count"));
+        args.addAll(branches.stream().map(Branch::name).toList());
+        try (var p = capture(args)) {
+            return Integer.parseInt(await(p).stdout().getFirst());
+        }
+    }
+
+    @Override
     public Hash initialHash() {
         return EMPTY_TREE;
     }

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -1543,6 +1543,11 @@ public class HgRepository implements Repository {
     }
 
     @Override
+    public int commitCount(List<Branch> branches) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public Hash initialHash() {
         return NULL_REVISION;
     }


### PR DESCRIPTION
The mechanism for polling GitLab for commit comments has a flaw that may cause it to start missing relevant comments. The underlying issue is that we are trusting timestamps on commits which may originate from a client machine, where the system clock may be wrong.

If a user changes their system clock to a date in the future and commits, that commit ends up having a future date. If this commit is then pushed to their personal fork and included in a merge request, then this commit will end up in a pr/X branch in the main/parent repository.

The rather convoluted mechanism for polling for commit comments (for the purpose of finding commit commands) for GitLab involves maintaining a mapping from commit title message to commit hash. This map is needed because the only way to find comments globally for a repository is to query for "events", and the event object only has the commit title, not the hash. Then for all possibly relevant events, we look up the commits in the map.

This map is initially generated from a local repository using a git command like this: "git rev-list <branch list>". After the first initialization, it is then updated using API calls to the server, querying for commits after a timestamp. The timestamp is the latest found already in the map. This is where the flaw lies. There is no guarantee that the timestamps are ever increasing, so once a commit with a faulty future timestamp ends up in the map, no new commits will ever be added when attempting to update it.

When I wrote this code, I think I assumed the timestamps would be strictly increasing because all official commits are generated by Skara. That still holds true for commits in repos and branches where we have strict Skara controlled pull requests. The problem here is that the API query does not limit commits to the specified branches, it gets all commits after the timestamp, which includes commits in pr/X branches as well as unreferenced commits.

A quick solution here would be to change the query to use branches. That would require doing a call per branch. I think a better solution would be to stick to one source for commits to the map, the local repository. It is already updated before each time we check for new commit comments. The challenge then is to identify the new commits to complement the map without having to rebuild it from scratch each time. I can't think of an exact way to accomplish this, but think we can get away with a good enough approximation. We can count the number of commits in the repo using "git rev-list --count <ref list>". Then when we iterate over the commits from commitMetaData iterator, we only go until the map contains the same number of commits as the repo has. At that point we know we have added all new commits. Most of the time, the rev-list loop (in topo-order) should return all the new commits first. It's only if we have a branched history within a branch that commits could be iterated in a different order, but worst case we just reprocess the unique ancestors of in each merge parent before we have passed all new commits.

While working on this I also realized that the current implementation has another flaw in that it assumes the list of branches given will always be the same. This is currently true in the affected bot, but that's not something the HostedRepository API should be assuming. I implemented a simple invalidation of the map in case the set of branches are different from the last call. This isn't an elegant solution but it at least keeps the API clean for now and if we actually need to handle this usecase, we can figure something else out then.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2491](https://bugs.openjdk.org/browse/SKARA-2491): GitLabRepository::recentCommitComments can miss commits (**Bug** - P3)


### Reviewers
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1717/head:pull/1717` \
`$ git checkout pull/1717`

Update a local copy of the PR: \
`$ git checkout pull/1717` \
`$ git pull https://git.openjdk.org/skara.git pull/1717/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1717`

View PR using the GUI difftool: \
`$ git pr show -t 1717`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1717.diff">https://git.openjdk.org/skara/pull/1717.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1717#issuecomment-2848230044)
</details>
