### PR TITLE
2495: Touch Command should return early on closed pull requests

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/TouchCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/TouchCommand.java
@@ -60,6 +60,7 @@ public class TouchCommand implements CommandHandler {
 
         if (pr.isClosed()) {
             reply.println("This command can only be used in open pull requests.");
+            return;
         }
 
         reply.println("The pull request is being re-evaluated and the inactivity timeout has been reset." + TOUCH_COMMAND_RESPONSE_MARKER);


### PR DESCRIPTION
In [SKARA-2480](https://bugs.openjdk.org/browse/SKARA-2480), I added a new pull request command /touch. When the /touch command is issued on a closed pull request, Skara should return immediately. I forgot to add the return statement in that logic.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2495](https://bugs.openjdk.org/browse/SKARA-2495): Touch Command should return early on closed pull requests (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1718/head:pull/1718` \
`$ git checkout pull/1718`

Update a local copy of the PR: \
`$ git checkout pull/1718` \
`$ git pull https://git.openjdk.org/skara.git pull/1718/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1718`

View PR using the GUI difftool: \
`$ git pr show -t 1718`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1718.diff">https://git.openjdk.org/skara/pull/1718.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1718#issuecomment-2859465053)
</details>
