### PR TITLE
2508: IssueNotifier should handle inactive JBS users

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -228,7 +228,7 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
                 log.info("Setting assignee for issue " + issue.id() + " to " + assignee.get());
                 issue.setAssignees(List.of(assignee.get()));
             } else {
-                log.warning("Skipping set assignee for issue " + issue.id() + " to " + assignee.get() + " because the user is inactive");
+                log.warning("Skipping setting assignee for issue " + issue.id() + " to " + assignee.get() + " because the user is inactive");
             }
         }
     }


### PR DESCRIPTION
This patch is trying to let IssueNotifier skip setting the assignee to an inactive user, otherwise, the bot will be stuck.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2508](https://bugs.openjdk.org/browse/SKARA-2508): IssueNotifier should handle inactive JBS users (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1720/head:pull/1720` \
`$ git checkout pull/1720`

Update a local copy of the PR: \
`$ git checkout pull/1720` \
`$ git pull https://git.openjdk.org/skara.git pull/1720/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1720`

View PR using the GUI difftool: \
`$ git pr show -t 1720`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1720.diff">https://git.openjdk.org/skara/pull/1720.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1720#issuecomment-2931426388)
</details>
