### PR TITLE
2497: Mailing list bridge is still failing to send some emails

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/gitlab/GitLabRepository.java
@@ -343,18 +343,18 @@ public class GitLabRepository implements HostedRepository {
             // Use POST to create a new file
             request.post("repository/files/" + encodedFileName)
                     .body(body)
-                    .onError(writeFilecontentsOnError(filename, content, branch))
+                    .onError(writeFileContentsOnError(filename, content, branch))
                     .execute();
         } else {
             // USE PUT to update the file
             request.put("repository/files/" + encodedFileName)
                     .body(body)
-                    .onError(writeFilecontentsOnError(filename, content, branch))
+                    .onError(writeFileContentsOnError(filename, content, branch))
                     .execute();
         }
     }
 
-    private RestRequest.ErrorTransform writeFilecontentsOnError(String filename, String content, Branch branch) {
+    private RestRequest.ErrorTransform writeFileContentsOnError(String filename, String content, Branch branch) {
         return response -> {
             // When GitLab returns 400, it may have still performed the update, so
             // need to check the current file contents.

--- a/forge/src/test/java/org/openjdk/skara/forge/gitlab/GitLabIntegrationTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/gitlab/GitLabIntegrationTests.java
@@ -148,7 +148,7 @@ class GitLabIntegrationTests {
     }
 
     @Test
-    @EnabledIfTestProperties({"gitlab.user", "gitlab.pat", "gitlab.uri", "gitlab.group",
+    @EnabledIfTestProperties({"gitlab.user", "gitlab.pat", "gitlab.uri",
                               "gitlab.repository", "gitlab.repository.branch"})
     void writeFileContents() {
         var gitLabRepo = gitLabHost.repository(props.get("gitlab.repository")).orElseThrow();


### PR DESCRIPTION
The fix in [SKARA-2470](https://bugs.openjdk.org/browse/SKARA-2470) seems to have been successful. However, the fix was only applied to the PUT operation, which is used when updating the archive with additional emails, not the POST which is used for the initial email.

I ran the manual test for this method to verify that it still works for normal operations.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2497](https://bugs.openjdk.org/browse/SKARA-2497): Mailing list bridge is still failing to send some emails (**Bug** - P3)


### Reviewers
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1722/head:pull/1722` \
`$ git checkout pull/1722`

Update a local copy of the PR: \
`$ git checkout pull/1722` \
`$ git pull https://git.openjdk.org/skara.git pull/1722/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1722`

View PR using the GUI difftool: \
`$ git pr show -t 1722`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1722.diff">https://git.openjdk.org/skara/pull/1722.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1722#issuecomment-2939977495)
</details>
