### PR TITLE
2510: Bug closed due to inactivity even though there was "activity"

### DIFF
--- a/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestPrunerBot.java
+++ b/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestPrunerBot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestPrunerBot.java
+++ b/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestPrunerBot.java
@@ -81,7 +81,8 @@ class PullRequestPrunerBotWorkItem implements WorkItem {
                     .filter(comment -> !ignoredUsers.contains(comment.author().username()))
                     .toList()
                     .getLast();
-            if (lastComment.author().equals(pr.repository().forge().currentUser()) && lastComment.body().contains(NOTICE_MARKER)) {
+            if (lastComment.author().equals(pr.repository().forge().currentUser()) && lastComment.body().contains(NOTICE_MARKER)
+                    && !lastComment.createdAt().isBefore(pr.lastTouchedTime())) {
                 var message = "@" + pr.author().username() + " This pull request has been inactive for more than " +
                         formatDuration(maxAge.multipliedBy(2)) + " and will now be automatically closed. If you would " +
                         "like to continue working on this pull request in the future, feel free to reopen it! This can be done " +

--- a/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestPrunerBot.java
+++ b/bots/bridgekeeper/src/main/java/org/openjdk/skara/bots/bridgekeeper/PullRequestPrunerBot.java
@@ -158,7 +158,7 @@ public class PullRequestPrunerBot implements Bot {
         }
 
         // Latest prune-delaying action (deliberately excluding pr.updatedAt, as it can be updated spuriously)
-        var latestAction = Stream.of(Stream.of(pr.createdAt()),
+        var latestAction = Stream.of(Stream.of(pr.createdAt(), pr.lastTouchedTime()),
                                    pr.comments().stream()
                                      .filter(comment -> !ignoredUsers.contains(comment.author().username()))
                                      .map(Comment::updatedAt),

--- a/bots/bridgekeeper/src/test/java/org/openjdk/skara/bots/bridgekeeper/PullRequestPrunerBotTests.java
+++ b/bots/bridgekeeper/src/test/java/org/openjdk/skara/bots/bridgekeeper/PullRequestPrunerBotTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -77,7 +77,6 @@ class PullRequestPrunerBotTests {
             var editHash2 = CheckableRepository.appendAndCommit(localRepo);
             localRepo.push(editHash2, author.authenticatedUrl(), "edit", true);
             TestBotRunner.runPeriodicItems(bot);
-
             // Make sure the timeout expires again
             Thread.sleep(100);
             TestBotRunner.runPeriodicItems(bot);
@@ -105,10 +104,8 @@ class PullRequestPrunerBotTests {
 
             // Post a comment as ignored User
             ignoredUserPr.addComment("It should be ignored");
-
             // Make sure the timeout expires again
             Thread.sleep(100);
-
             // The bot should now close it
             TestBotRunner.runPeriodicItems(bot);
 

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
+++ b/bots/tester/src/test/java/org/openjdk/skara/bots/tester/InMemoryPullRequest.java
@@ -337,4 +337,9 @@ class InMemoryPullRequest implements PullRequest {
     public List<ReferenceChange> targetRefChanges() {
         return List.of();
     }
+
+    @Override
+    public ZonedDateTime lastTouchedTime() {
+        return null;
+    }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
@@ -244,6 +244,12 @@ public interface PullRequest extends Issue {
     Object snapshot();
 
     /**
+     * Returns the last time of the pull request touched by user
+     * Valid Touch includes "mark as ready", "reopen", "commit"
+     */
+    ZonedDateTime lastTouchedTime();
+
+    /**
      * Helper method for implementations of this interface. Creates a new list
      * of Review objects with the targetRef field updated to match the target
      * ref change events. Ideally this method should have been part of a common

--- a/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/PullRequest.java
@@ -245,7 +245,7 @@ public interface PullRequest extends Issue {
 
     /**
      * Returns the last time of the pull request touched by user
-     * Valid Touch includes "mark as ready", "reopen", "commit"
+     * Valid Touch includes "mark as ready", "convert to draft", "reopen", "commit"
      */
     ZonedDateTime lastTouchedTime();
 

--- a/forge/src/test/java/org/openjdk/skara/forge/github/GitHubIntegrationTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/github/GitHubIntegrationTests.java
@@ -509,4 +509,15 @@ class GitHubIntegrationTests {
         var prDiff = pr.diff();
         assertFalse(prDiff.complete());
     }
+
+    @Test
+    @EnabledIfTestProperties({"github.user", "github.pat", "github.repository", "github.prId"})
+    void testLastCommitTime() {
+        var githubRepoOpt = githubHost.repository(props.get("github.repository"));
+        assumeTrue(githubRepoOpt.isPresent());
+        var githubRepo = githubRepoOpt.get();
+
+        var pr = githubRepo.pullRequest(props.get("github.prId"));
+        var lastTouchedTime = pr.lastTouchedTime();
+    }
 }

--- a/forge/src/test/java/org/openjdk/skara/forge/gitlab/GitLabIntegrationTests.java
+++ b/forge/src/test/java/org/openjdk/skara/forge/gitlab/GitLabIntegrationTests.java
@@ -408,4 +408,14 @@ class GitLabIntegrationTests {
         var prDiff = pr.diff();
         assertFalse(prDiff.complete());
     }
+
+    @Test
+    @EnabledIfTestProperties({"gitlab.user", "gitlab.pat", "gitlab.uri", "gitlab.group",
+            "gitlab.repository", "gitlab.merge.request.id"})
+    void testLastCommitTIME() {
+        var gitLabRepo = gitLabHost.repository(props.get("gitlab.repository")).orElseThrow();
+
+        var pr = gitLabRepo.pullRequest(props.get("gitlab.merge.request.id"));
+        var lastTouchedTime = pr.lastTouchedTime();
+    }
 }

--- a/test/src/main/java/org/openjdk/skara/test/TestIssue.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestIssue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/src/main/java/org/openjdk/skara/test/TestIssue.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestIssue.java
@@ -164,6 +164,7 @@ public class TestIssue implements Issue {
     public void setState(State state) {
         store.setState(state);
         store.setLastUpdate(ZonedDateTime.now());
+        store.setLastTouchedTime(ZonedDateTime.now());
         store.setClosedBy(user);
     }
 

--- a/test/src/main/java/org/openjdk/skara/test/TestIssueStore.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestIssueStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,7 @@ public class TestIssueStore {
     private final List<HostUser> assignees = new ArrayList<>();
     private final ZonedDateTime created = ZonedDateTime.now();
     private ZonedDateTime lastUpdate = created;
-    private ZonedDateTime lastTouchedTime = created();
+    private ZonedDateTime lastTouchedTime = created;
     private HostUser closedBy = null;
 
     public TestIssueStore(String id, IssueProject issueProject, HostUser author, String title, List<String> body) {

--- a/test/src/main/java/org/openjdk/skara/test/TestIssueStore.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestIssueStore.java
@@ -48,6 +48,7 @@ public class TestIssueStore {
     private final List<HostUser> assignees = new ArrayList<>();
     private final ZonedDateTime created = ZonedDateTime.now();
     private ZonedDateTime lastUpdate = created;
+    private ZonedDateTime lastTouchedTime = created();
     private HostUser closedBy = null;
 
     public TestIssueStore(String id, IssueProject issueProject, HostUser author, String title, List<String> body) {
@@ -124,6 +125,14 @@ public class TestIssueStore {
 
     public void setLastUpdate(ZonedDateTime lastUpdate) {
         this.lastUpdate = lastUpdate;
+    }
+
+    public void setLastTouchedTime(ZonedDateTime lastTouchedTime) {
+        this.lastTouchedTime = lastTouchedTime;
+    }
+
+    public ZonedDateTime lastTouchedTime(){
+        return lastTouchedTime;
     }
 
     public void setClosedBy(HostUser closedBy) {

--- a/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
@@ -359,8 +359,9 @@ public class TestPullRequest extends TestIssue implements PullRequest {
         this.store().setReturnCompleteDiff(complete);
     }
 
+    // For TestPullRequest, we control the lastUpdate timestamp, so it won't be spurious
     @Override
     public ZonedDateTime lastTouchedTime() {
-        return null;
+        return store().lastUpdate();
     }
 }

--- a/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
@@ -362,6 +362,6 @@ public class TestPullRequest extends TestIssue implements PullRequest {
     // For TestPullRequest, we control the lastUpdate timestamp, so it won't be spurious
     @Override
     public ZonedDateTime lastTouchedTime() {
-        return store().lastUpdate();
+        return store().lastTouchedTime();
     }
 }

--- a/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
@@ -358,4 +358,9 @@ public class TestPullRequest extends TestIssue implements PullRequest {
     public void setReturnCompleteDiff(boolean complete){
         this.store().setReturnCompleteDiff(complete);
     }
+
+    @Override
+    public ZonedDateTime lastTouchedTime() {
+        return null;
+    }
 }

--- a/test/src/main/java/org/openjdk/skara/test/TestPullRequestStore.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestPullRequestStore.java
@@ -80,6 +80,7 @@ public class TestPullRequestStore extends TestIssueStore {
             if (headHash.isPresent() && !headHash.get().equals(this.headHash)) {
                 this.headHash = headHash.get();
                 setLastUpdate(ZonedDateTime.now());
+                setLastTouchedTime(ZonedDateTime.now());
             }
         } catch (IOException e) {
             throw new UncheckedIOException(e);
@@ -139,6 +140,7 @@ public class TestPullRequestStore extends TestIssueStore {
     public void setDraft(boolean draft) {
         this.draft = draft;
         setLastUpdate(ZonedDateTime.now());
+        setLastTouchedTime(ZonedDateTime.now());
         if (draft) {
             lastMarkedAsDraftTime = ZonedDateTime.now();
         } else {

--- a/test/src/main/java/org/openjdk/skara/test/TestPullRequestStore.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestPullRequestStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -138,6 +138,7 @@ public class TestPullRequestStore extends TestIssueStore {
 
     public void setDraft(boolean draft) {
         this.draft = draft;
+        setLastUpdate(ZonedDateTime.now());
         if (draft) {
             lastMarkedAsDraftTime = ZonedDateTime.now();
         } else {


### PR DESCRIPTION
Currently, the PullRequestPrunerBot considers only comments, reviews, and review comments as activity. Therefore, it can sometimes mistakenly close a user's pull request.

In this patch, I am trying to let PullRequestPrunerBot counts commits, pr state changes as valid activities.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2510](https://bugs.openjdk.org/browse/SKARA-2510): Bug closed due to inactivity even though there was "activity" (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1723/head:pull/1723` \
`$ git checkout pull/1723`

Update a local copy of the PR: \
`$ git checkout pull/1723` \
`$ git pull https://git.openjdk.org/skara.git pull/1723/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1723`

View PR using the GUI difftool: \
`$ git pr show -t 1723`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1723.diff">https://git.openjdk.org/skara/pull/1723.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1723#issuecomment-3033627499)
</details>
