### PR TITLE
2535: Merge JShell's file locations mapping into the 'compiler' label, and deleting mapping for 'kulla'

### DIFF
--- a/config/mailinglist/rules/jdk.json
+++ b/config/mailinglist/rules/jdk.json
@@ -47,14 +47,19 @@
             "make/jdk/src/classes/build/tools/taglet/Preview.java",
             "make/langtools/",
             "make/modules/jdk.compiler/",
+            "make/modules/jdk.jshell",
             "make/scripts/generate-symbol-data.sh",
             "src/java.base/share/classes/jdk/internal/javac/",
             "src/java.compiler/",
             "src/jdk.compiler/",
+            "src/jdk.editpad/",
+            "src/jdk.internal.ed/",
+            "src/jdk.internal.le/",
             "src/jdk.jartool/(?!.*/jarsigner)",
             "src/jdk.jdeps/share/classes/com/sun/tools/classfile/",
             "src/jdk.jdeps/share/classes/com/sun/tools/javap/",
             "src/jdk.jdeps/share/classes/com/sun/tools/jdeprscan/",
+            "src/jdk.jshell/",
             "test/langtools/TEST.ROOT",
             "test/langtools/TEST.groups",
             "test/langtools/ProblemList-graal.txt",
@@ -62,6 +67,7 @@
             "test/langtools/req.flg",
             "test/langtools/lib/combo/TEST.properties",
             "test/langtools/jdk/internal/shellsupport/",
+            "test/langtools/jdk/jshell/",
             "test/langtools/lib/annotations",
             "test/langtools/lib/combo/tools/javac/",
             "test/langtools/tools/"
@@ -490,14 +496,6 @@
             "test/jdk/javax/management/",
             "test/jdk/sun/management/",
             "test/jdk/com/sun/jmx"
-        ],
-        "kulla": [
-            "make/modules/jdk.jshell",
-            "src/jdk.editpad/",
-            "src/jdk.internal.ed/",
-            "src/jdk.internal.le/",
-            "src/jdk.jshell/",
-            "test/langtools/jdk/jshell/"
         ],
         "net": [
             "make/modules/jdk.net",


### PR DESCRIPTION
There's a proposal to dissolve the Kulla project (the project that introduced JShell into JDK), and use the `compiler-dev` mailing list instead of `kulla-dev`:
https://mail.openjdk.org/pipermail/kulla-dev/2025-June/005928.html

The idea in this PR is to merge the file mappings used for JShell into the `compiler` label, so that changes touching JShell get the `compiler` label, and the e-mails are sent to `compiler-dev`.

Please let me now if there's something better than can be done, or what more is needed to stop using the `kulla-dev` list.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2535](https://bugs.openjdk.org/browse/SKARA-2535): Merge JShell's file locations mapping into the 'compiler' label, and deleting mapping for 'kulla' (**Task** - P4)


### Reviewers
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1724/head:pull/1724` \
`$ git checkout pull/1724`

Update a local copy of the PR: \
`$ git checkout pull/1724` \
`$ git pull https://git.openjdk.org/skara.git pull/1724/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1724`

View PR using the GUI difftool: \
`$ git pr show -t 1724`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1724.diff">https://git.openjdk.org/skara/pull/1724.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1724#issuecomment-3035010923)
</details>
