### PR TITLE
2547: Notify graal mailing list for java man page changes

### DIFF
--- a/config/mailinglist/rules/jdk.json
+++ b/config/mailinglist/rules/jdk.json
@@ -233,6 +233,7 @@
         "graal": [
             "src/hotspot/share/jvmci/",
             "src/hotspot/share/opto/library_call.cpp",
+            "src/java.base/share/man/java.md",
             "src/jdk.internal.vm.ci/",
             "src/jdk.internal.vm.compiler/",
             "src/jdk.internal.vm.compiler.management/"


### PR DESCRIPTION
This allows Graal developers to make adaptions to java man page changes in time

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2547](https://bugs.openjdk.org/browse/SKARA-2547): Notify graal mailing list for java man page changes (**Task** - P4)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - no project role)
 * [Doug Simon](https://openjdk.org/census#dnsimon) (@dougxc - no project role)
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1725/head:pull/1725` \
`$ git checkout pull/1725`

Update a local copy of the PR: \
`$ git checkout pull/1725` \
`$ git pull https://git.openjdk.org/skara.git pull/1725/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1725`

View PR using the GUI difftool: \
`$ git pr show -t 1725`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1725.diff">https://git.openjdk.org/skara/pull/1725.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1725#issuecomment-3084317522)
</details>
