### PR TITLE
SKARA-2527

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckablePullRequest.java
@@ -172,8 +172,12 @@ public class CheckablePullRequest {
                 throw new CommitFailure("Merge PRs can only be created by known OpenJDK authors.");
             }
 
-            var head = localRepo.lookup(pr.headHash()).orElseThrow();
-            author = head.author();
+            if (!pr.author().fullName().isBlank() && pr.author().email().isPresent()) {
+                author = new Author(pr.author().fullName(), pr.author().email().get());
+            } else {
+                var head = localRepo.lookup(pr.headHash()).orElseThrow();
+                author = head.author();
+            }
         } else {
             author = new Author(contributor.fullName().orElseThrow(), contributor.username() + "@" + censusDomain);
         }


### PR DESCRIPTION
When determining the author of a commit, if the author of pr doesn't have OpenJDK Id, the bot falls back to use the author from the last commit of the pr, in this way, the bot may give credit to the wrong person. 
In this patch, if the author of pr doesn't have OpenJDK Id, the bot will try to parse full name and email from the forge first, if it fails, then it will fall back to use the author of the last commit.