### PR TITLE
2556: LablerWorkItem adds unnecessary overhead when the bot restarts

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
@@ -122,7 +122,7 @@ public class LabelerWorkItem extends PullRequestWorkItem {
 
         if (bot.labelConfiguration().allowed().isEmpty()) {
             bot.setAutoLabelled(pr);
-            return List.of(CheckWorkItem.fromWorkItemWithForceUpdate(bot, prId, errorHandler, triggerUpdatedAt));
+            return List.of();
         }
 
         var comments = prComments();

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
@@ -116,12 +116,12 @@ public class LabelerWorkItem extends PullRequestWorkItem {
 
     @Override
     public Collection<WorkItem> prRun(ScratchArea scratchArea) {
-        if (bot.isAutoLabelled(pr) || pr.isClosed()) {
+        if (bot.labelConfiguration().allowed().isEmpty()) {
+            bot.setAutoLabelled(pr);
             return List.of();
         }
 
-        if (bot.labelConfiguration().allowed().isEmpty()) {
-            bot.setAutoLabelled(pr);
+        if (bot.isAutoLabelled(pr) || pr.isClosed()) {
             return List.of();
         }
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
@@ -116,7 +116,7 @@ public class LabelerWorkItem extends PullRequestWorkItem {
 
     @Override
     public Collection<WorkItem> prRun(ScratchArea scratchArea) {
-        if (bot.isAutoLabelled(pr)) {
+        if (bot.isAutoLabelled(pr) || pr.isClosed()) {
             return List.of();
         }
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -188,7 +188,7 @@ public class PullRequestCommandWorkItem extends PullRequestWorkItem {
         if (nextCommand.isEmpty()) {
             log.info("No new non-external PR commands found, stopping further processing");
 
-            if (!bot.isAutoLabelled(pr)) {
+            if (!bot.isAutoLabelled(pr) && !pr.isClosed()) {
                 // When all commands are processed, it's time to check labels
                 return List.of(new LabelerWorkItem(bot, prId, errorHandler, triggerUpdatedAt));
             } else {


### PR DESCRIPTION
In [SKARA-2408](https://bugs.openjdk.org/browse/SKARA-2408) and [SKARA-2552](https://bugs.openjdk.org/browse/SKARA-2552), I updated the bot to do one more CheckWorkItem with force update after a pr is marked as auto labeled.

Currently, when the pr bot restarts, the bot would schedule a PullRequestCommandWorkItem for every pr(including closed prs), in the end of PullRequestCommandWorkItem, a LabelerWorkItem will be scheduled for each pr as well. In the LabelerWorkItem, when it finds the bot doesn't have label configuration, the bot will mark the pr as auto labelled and schedule a CheckWorkItem with forceUpdate. This is the issue, the bot shouldn't schedule any CheckWorkItem when the bot doesn't have label configuration. Otherwise, the bot would re-evaluate all the prs with forceUpdate.

Also, if the pr is already closed, the LabelerWorkItem shouldn't schedule any CheckWorkItem for it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2556](https://bugs.openjdk.org/browse/SKARA-2556): LablerWorkItem adds unnecessary overhead when the bot restarts (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1729/head:pull/1729` \
`$ git checkout pull/1729`

Update a local copy of the PR: \
`$ git checkout pull/1729` \
`$ git pull https://git.openjdk.org/skara.git pull/1729/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1729`

View PR using the GUI difftool: \
`$ git pr show -t 1729`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1729.diff">https://git.openjdk.org/skara/pull/1729.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1729#issuecomment-3161713062)
</details>
