### PR TITLE
2566: When rfr is pending on other workItems, the pr bot shouldn't actively remove the label

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -461,13 +461,6 @@ class CheckRun {
             return false;
         }
 
-        // If rfr is still pending for other workItems, so don't mark this pr as rfr, wait for another round of CheckWorkItem
-        if (rfrPendingOnOtherWorkItems) {
-            newLabels.remove("rfr");
-            log.info("rfr is pending on other workItems for pr: " + pr.id());
-            return false;
-        }
-
         // Additional errors are not allowed
         if (!additionalErrors.isEmpty()) {
             newLabels.remove("rfr");
@@ -477,6 +470,12 @@ class CheckRun {
         // Draft requests are not for review
         if (pr.isDraft()) {
             newLabels.remove("rfr");
+            return false;
+        }
+
+        // If rfr is still pending for other workItems, so don't mark this pr as rfr, wait for another round of CheckWorkItem
+        if (rfrPendingOnOtherWorkItems) {
+            log.info("rfr is pending on other workItems for pr: " + pr.id());
             return false;
         }
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -473,20 +473,21 @@ class CheckRun {
             return false;
         }
 
+        // Check if the visitor found any issues that should be resolved before reviewing
+        if (!visitor.isReadyForReview()) {
+            newLabels.remove("rfr");
+            return false;
+        }
+
         // If rfr is still pending on other workItems, so don't actively mark this pr as rfr, wait for another round of CheckWorkItem
         if (rfrPendingOnOtherWorkItems) {
             log.info("rfr is pending on other workItems for pr: " + pr.id());
             return newLabels.contains("rfr");
         }
 
-        // Check if the visitor found any issues that should be resolved before reviewing
-        if (visitor.isReadyForReview()) {
-            newLabels.add("rfr");
-            return true;
-        } else {
-            newLabels.remove("rfr");
-            return false;
-        }
+        // No issues found, add rfr label now
+        newLabels.add("rfr");
+        return true;
     }
 
     private boolean updateClean(Commit commit) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -473,10 +473,10 @@ class CheckRun {
             return false;
         }
 
-        // If rfr is still pending for other workItems, so don't mark this pr as rfr, wait for another round of CheckWorkItem
+        // If rfr is still pending on other workItems, so don't actively mark this pr as rfr, wait for another round of CheckWorkItem
         if (rfrPendingOnOtherWorkItems) {
             log.info("rfr is pending on other workItems for pr: " + pr.id());
-            return false;
+            return newLabels.contains("rfr");
         }
 
         // Check if the visitor found any issues that should be resolved before reviewing


### PR DESCRIPTION
I restarted the pr bot today and a user reported that the pr bot removed 'rfr' label on a pull request. It's the side effect of [SKARA-2552](https://bugs.openjdk.org/browse/SKARA-2552), when the bot was evaluating the pull request, the labelerWorkItem wasn't done, so rfrPendingOnOtherWorkItems was set to true. In this case, the bot should just not add 'rfr' label, but not actively remove the 'rfr' label

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2566](https://bugs.openjdk.org/browse/SKARA-2566): When rfr is pending on other workItems, the pr bot shouldn't actively remove the label (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1732/head:pull/1732` \
`$ git checkout pull/1732`

Update a local copy of the PR: \
`$ git checkout pull/1732` \
`$ git pull https://git.openjdk.org/skara.git pull/1732/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1732`

View PR using the GUI difftool: \
`$ git pr show -t 1732`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1732.diff">https://git.openjdk.org/skara/pull/1732.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1732#issuecomment-3208948979)
</details>
