### PR TITLE
2563: NPE when reviewers id changed due to census update

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/BackportCommand.java
@@ -321,11 +321,15 @@ public class BackportCommand implements CommandHandler {
             if (message.reviewers().isEmpty()) {
                 info += " and had no reviewers";
             } else {
-                var reviewers = message.reviewers()
-                        .stream()
-                        .map(r -> censusInstance.census().contributor(r))
-                        .map(c -> c.fullName().isPresent() ? c.fullName().get() : c.username())
-                        .collect(Collectors.toList());
+                var reviewers = new ArrayList<String>();
+                for (var username : message.reviewers()) {
+                    var reviewerEntry = censusInstance.census.contributor(username);
+                    if (reviewerEntry != null) {
+                        reviewers.add(reviewerEntry.fullName().isPresent() ? reviewerEntry.fullName().get() : reviewerEntry.username());
+                    } else {
+                        reviewers.add(username);
+                    }
+                }
                 var numReviewers = reviewers.size();
                 var listing = numReviewers == 1 ?
                         reviewers.get(0) :


### PR DESCRIPTION
When Skara Bot processes the backport command, it attempts to parse reviewers IDs from the original commit message. It then looks up these reviewers IDs in the current repository census to get the reviewers' full names, and then put the full names in the pull request description for backport.

A corner case may occur if the repository census is updated between the original commit and the backport creation. In this case, the reviewer ID in the original commit may be from a previous census, but later the bot could lookup the ID in the updated census. If the reviewer ID is no longer present in the updated census, this can result in a NPE.

We should fallback to use the id instead of full name.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2563](https://bugs.openjdk.org/browse/SKARA-2563): NPE when reviewers id changed due to census update (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1733/head:pull/1733` \
`$ git checkout pull/1733`

Update a local copy of the PR: \
`$ git checkout pull/1733` \
`$ git pull https://git.openjdk.org/skara.git pull/1733/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1733`

View PR using the GUI difftool: \
`$ git pr show -t 1733`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1733.diff">https://git.openjdk.org/skara/pull/1733.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1733#issuecomment-3215084002)
</details>
