### PR TITLE
2065: Update PR labels when new files are touched

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -1603,7 +1603,6 @@ class CheckRun {
         }
     }
 
-
     private boolean isFileUpdated(Path filename, Hash from, Hash to) throws IOException {
         return !localRepo.diff(from, to, List.of(filename)).patches().isEmpty();
     }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -78,7 +78,6 @@ class CheckRun {
     private static final String APPROVAL_NEEDED_MARKER = "<!-- PullRequestBot approval needed comment -->";
     private static final String BACKPORT_CSR_MARKER = "<!-- PullRequestBot backport csr comment -->";
     private static final Set<String> PRIMARY_TYPES = Set.of("Bug", "New Feature", "Enhancement", "Task", "Sub-task");
-    private static final Pattern LABEL_COMMIT_PATTERN = Pattern.compile("<!-- PullRequest Bot label commit '(.*?)' -->");
     protected static final String CSR_PROCESS_LINK = "https://wiki.openjdk.org/display/csr/Main";
     private static final Path JCHECK_CONF_PATH = Path.of(".jcheck", "conf");
     private static final int MESSAGE_LIMIT = 50;
@@ -269,31 +268,8 @@ class CheckRun {
 
         // If the bot has label configuration
         if (!workItem.bot.labelConfiguration().allowed().isEmpty()) {
-            // If the pr is already auto labelled
+            // If the pr is already auto labelled, check if the pull request is associated with at least one component
             if (workItem.bot.isAutoLabelled(pr)) {
-                // Update PR labels when new files are touched
-                var labelComment = findComment(LabelerWorkItem.INITIAL_LABEL_MESSAGE);
-                if (labelComment.isPresent()) {
-                    var line = labelComment.get().body().lines()
-                            .map(LABEL_COMMIT_PATTERN::matcher)
-                            .filter(Matcher::find)
-                            .findFirst();
-                    if (line.isPresent()) {
-                        var evaluatedCommitHash = line.get().group(1);
-                        var changedFiles = PullRequestUtils.changedFiles(pr, localRepo, new Hash(evaluatedCommitHash));
-                        var newLabelsNeedToBeAdded = workItem.bot.labelConfiguration().label(changedFiles);
-                        newLabels.addAll(newLabelsNeedToBeAdded);
-                        var upgradedLabels = workItem.bot.labelConfiguration().upgradeLabelsToGroups(newLabels);
-                        newLabels.addAll(upgradedLabels);
-                        newLabels.removeIf(label -> !upgradedLabels.contains(label));
-                    }
-                    pr.updateComment(labelComment.get().id(), labelComment.get().body().replaceAll(
-                            "(<!-- PullRequest Bot label commit ')[^']*(' -->)",
-                            "$1" + pr.headHash().toString() + "$2"
-                    ));
-                }
-
-                // Check if the pull request is associated with at least one component
                 var existingAllowed = new HashSet<>(newLabels);
                 existingAllowed.retainAll(workItem.bot.labelConfiguration().allowed());
                 if (existingAllowed.isEmpty()) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -43,7 +43,6 @@ import java.time.*;
 import java.util.*;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.*;
 
 import static org.openjdk.skara.bots.common.PullRequestConstants.*;
@@ -239,7 +238,7 @@ class CheckRun {
     }
 
     // Additional bot-specific checks that are not handled by JCheck
-    private List<String> botSpecificChecks(boolean isCleanBackport) throws IOException {
+    private List<String> botSpecificChecks(boolean isCleanBackport) {
         var ret = new ArrayList<String>();
 
         var bodyWithoutStatus = bodyWithoutStatus();
@@ -270,7 +269,7 @@ class CheckRun {
         if (!workItem.bot.labelConfiguration().allowed().isEmpty()) {
             // If the pr is already auto labelled, check if the pull request is associated with at least one component
             if (workItem.bot.isAutoLabelled(pr)) {
-                var existingAllowed = new HashSet<>(newLabels);
+                var existingAllowed = new HashSet<>(pr.labelNames());
                 existingAllowed.retainAll(workItem.bot.labelConfiguration().allowed());
                 if (existingAllowed.isEmpty()) {
                     ret.add("This pull request must be associated with at least one component. " +
@@ -1483,7 +1482,6 @@ class CheckRun {
             }
 
             updateCheckBuilder(checkBuilder, visitor, additionalErrors);
-
             var readyForReview = updateReadyForReview(visitor, additionalErrors, regularIssuesMap);
 
             var integrationBlockers = botSpecificIntegrationBlockers(regularIssuesMap);

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -1462,7 +1462,7 @@ class CheckRun {
             updateCheckBuilder(checkBuilder, visitor, additionalErrors);
 
 
-            if (workItem.bot.isAutoLabelled(pr)) {
+            if (!workItem.bot.labelConfiguration().allowed().isEmpty() && workItem.bot.isAutoLabelled(pr)) {
                 var labelComment = findComment(LabelerWorkItem.INITIAL_LABEL_MESSAGE);
                 if (labelComment.isPresent()) {
                     var line = labelComment.get().body().lines()

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelCommand.java
@@ -154,13 +154,14 @@ public class LabelCommand implements CommandHandler {
         for (var label : labelsToAdd) {
             if (!currentLabels.contains(label)) {
                 var groupLabel = bot.labelConfiguration().groupLabel(label);
-                if (groupLabel.isEmpty()) {
-                    pr.addLabel(label);
-                    reply.println(LabelTracker.addLabelMarker(label));
-                    reply.println("The `" + label + "` label was successfully added.");
-                } else {
+                if (groupLabel.isPresent() && currentLabels.contains(groupLabel.get())) {
                     reply.println(LabelTracker.addLabelMarker(label));
                     reply.println("The `" + groupLabel.get() + "` group label was already applied, so `" + label + "` label will not be added.");
+                } else {
+                    pr.addLabel(label);
+                    currentLabels.add(label);
+                    reply.println(LabelTracker.addLabelMarker(label));
+                    reply.println("The `" + label + "` label was successfully added.");
                 }
             } else {
                 reply.println("The `" + label + "` label was already applied.");
@@ -172,6 +173,7 @@ public class LabelCommand implements CommandHandler {
         for (var label : labelsToRemove) {
             if (currentLabels.contains(label)) {
                 pr.removeLabel(label);
+                currentLabels.remove(label);
                 reply.println(LabelTracker.removeLabelMarker(label));
                 reply.println("The `" + label + "` label was successfully removed.");
             } else {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelCommand.java
@@ -160,7 +160,7 @@ public class LabelCommand implements CommandHandler {
                     reply.println("The `" + label + "` label was successfully added.");
                 } else {
                     reply.println(LabelTracker.addLabelMarker(label));
-                    reply.println("The group label `" + groupLabel.get() + "` label was already applied.");
+                    reply.println("The `" + groupLabel.get() + "` group label was already applied, so `" + label + "` label will not be added.");
                 }
             } else {
                 reply.println("The `" + label + "` label was already applied.");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelCommand.java
@@ -84,7 +84,7 @@ public class LabelCommand implements CommandHandler {
                 return;
             }
             if (argumentMatcher.group(1).equals("add")) {
-                addLabels(labels, currentLabels, pr, reply);
+                addLabels(labels, currentLabels, pr, reply, bot);
             } else if (argumentMatcher.group(1).equals("remove")) {
                 removeLabels(labels, currentLabels, pr, reply);
             }
@@ -118,7 +118,7 @@ public class LabelCommand implements CommandHandler {
                 return;
             }
 
-            addLabels(labelsToAdd, currentLabels, pr, reply);
+            addLabels(labelsToAdd, currentLabels, pr, reply, bot);
             removeLabels(labelsToRemove, currentLabels, pr, reply);
             upgradeLabelsToGroups(pr, bot);
         }
@@ -150,12 +150,18 @@ public class LabelCommand implements CommandHandler {
         return invalidLabels;
     }
 
-    private void addLabels(List<String> labelsToAdd,Set<String> currentLabels, PullRequest pr, PrintWriter reply) {
+    private void addLabels(List<String> labelsToAdd, Set<String> currentLabels, PullRequest pr, PrintWriter reply, PullRequestBot bot) {
         for (var label : labelsToAdd) {
             if (!currentLabels.contains(label)) {
-                pr.addLabel(label);
-                reply.println(LabelTracker.addLabelMarker(label));
-                reply.println("The `" + label + "` label was successfully added.");
+                var groupLabel = bot.labelConfiguration().groupLabel(label);
+                if (groupLabel.isEmpty()) {
+                    pr.addLabel(label);
+                    reply.println(LabelTracker.addLabelMarker(label));
+                    reply.println("The `" + label + "` label was successfully added.");
+                } else {
+                    reply.println(LabelTracker.addLabelMarker(label));
+                    reply.println("The group label `" + groupLabel.get() + "` label was already applied.");
+                }
             } else {
                 reply.println("The `" + label + "` label was already applied.");
             }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
@@ -111,7 +111,7 @@ public class LabelerWorkItem extends PullRequestWorkItem {
                 message.append(" pull request command.");
             }
         } else {
-            message.append("There is manual label command issued before auto labeling, auto labelling is skipped.");
+            message.append("A manual label command was issued before auto-labeling, so auto-labeling was skipped.");
         }
 
         message.append("\n");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
@@ -175,11 +175,16 @@ public class LabelerWorkItem extends PullRequestWorkItem {
             // Initial auto labeling
             try {
                 var localRepo = IntegrateCommand.materializeLocalRepo(bot, pr, scratchArea);
-                var labelsToAdd = getLabels(localRepo);
-                newLabels.addAll(labelsToAdd);
+                newLabels.addAll(getLabels(localRepo));
                 newLabels = bot.labelConfiguration().upgradeLabelsToGroups(newLabels);
                 syncLabels(pr, oldLabels, newLabels, log);
-                createInitialLabelMessage(comments, new ArrayList<>(labelsToAdd), pr.headHash().toString());
+                var labelsAdded = new HashSet<String>();
+                for (var newLabel : newLabels) {
+                    if (!oldLabels.contains(newLabel)) {
+                        labelsAdded.add(newLabel);
+                    }
+                }
+                createInitialLabelMessage(comments, new ArrayList<>(labelsAdded), pr.headHash().toString());
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
@@ -148,8 +148,10 @@ public class LabelerWorkItem extends PullRequestWorkItem {
 
                     syncLabels(pr, oldLabels, newLabels, log);
 
-                    if (!newLabelsNeedToBeAdded.isEmpty()) {
-                        addLabelAutoUpdateAdditionalComment(comments, new ArrayList<>(newLabelsNeedToBeAdded), pr.headHash().hex());
+                    // The labels actually added
+                    newLabels.removeAll(oldLabels);
+                    if (!newLabels.isEmpty()) {
+                        addLabelAutoUpdateAdditionalComment(comments, new ArrayList<>(newLabels), pr.headHash().hex());
                     }
 
                     pr.updateComment(initialLabelComment.get().id(), initialLabelComment.get().body().replaceAll(

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
@@ -186,12 +186,10 @@ public class LabelerWorkItem extends PullRequestWorkItem {
                             "$1" + pr.headHash().toString() + "$2"
                     ));
                 }
-                if (labelAdded) {
-                    return needsRfrCheck(newLabels);
-                }
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }
+            // No need to return CheckWorkItem, if there is any label added, in the next round of CheckWorkItem, it will re-evaluate the pr
             return List.of();
         }
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
@@ -138,7 +138,6 @@ public class LabelerWorkItem extends PullRequestWorkItem {
         // Updating labels when new files are touched
         if (bot.isAutoLabelled(pr)) {
             try {
-                var labelAdded = false;
                 var oldLabels = new HashSet<>(pr.labelNames());
                 var newLabels = new HashSet<>(pr.labelNames());
 
@@ -170,7 +169,6 @@ public class LabelerWorkItem extends PullRequestWorkItem {
                         if (!oldLabels.contains(newLabel)) {
                             log.info("Adding label " + newLabel);
                             pr.addLabel(newLabel);
-                            labelAdded = true;
                         }
                     }
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
@@ -187,7 +187,7 @@ public class LabelerWorkItem extends PullRequestWorkItem {
                     ));
                 }
                 if (labelAdded) {
-                    return needsRfrCheck(new ArrayList<>(newLabels));
+                    return needsRfrCheck(newLabels);
                 }
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
@@ -197,7 +197,7 @@ public class LabelerWorkItem extends PullRequestWorkItem {
 
         // Initial auto labeling
         var comments = prComments();
-        var labelNames = pr.labelNames();
+        var labelNames = new HashSet<>(pr.labelNames());
         var manuallyAdded = LabelTracker.currentAdded(pr.repository().forge().currentUser(), comments);
         var manuallyRemoved = LabelTracker.currentRemoved(pr.repository().forge().currentUser(), comments);
 
@@ -249,7 +249,7 @@ public class LabelerWorkItem extends PullRequestWorkItem {
         return needsRfrCheck(labelNames);
     }
 
-    private Collection<WorkItem> needsRfrCheck(List<String> labelNames) {
+    private Collection<WorkItem> needsRfrCheck(Set<String> labelNames) {
         if (!labelNames.contains("rfr")) {
             return List.of(CheckWorkItem.fromWorkItemWithForceUpdate(bot, prId, errorHandler, triggerUpdatedAt));
         }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
@@ -145,12 +145,7 @@ public class LabelerWorkItem extends PullRequestWorkItem {
             try {
                 var oldLabels = new HashSet<>(pr.labelNames());
                 var newLabels = new HashSet<>(pr.labelNames());
-
-                var path = scratchArea.get(pr.repository());
-                var seedPath = bot.seedStorage().orElse(scratchArea.getSeeds());
-                var hostedRepositoryPool = new HostedRepositoryPool(seedPath);
-                var localRepo = PullRequestUtils.materialize(hostedRepositoryPool, pr, path);
-
+                var localRepo = IntegrateCommand.materializeLocalRepo(bot, pr, scratchArea);
                 var labelComment = findComment(prComments(), INITIAL_LABEL_MESSAGE);
 
                 if (labelComment.isPresent()) {
@@ -188,6 +183,8 @@ public class LabelerWorkItem extends PullRequestWorkItem {
                             "(<!-- PullRequest Bot label commit ')[^']*(' -->)",
                             "$1" + pr.headHash().toString() + "$2"
                     ));
+                } else {
+                    log.severe("This pr is marked as auto labeled but no auto label comment found, pr id: " + pr.id());
                 }
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
@@ -219,10 +216,7 @@ public class LabelerWorkItem extends PullRequestWorkItem {
         }
 
         try {
-            var path = scratchArea.get(pr.repository());
-            var seedPath = bot.seedStorage().orElse(scratchArea.getSeeds());
-            var hostedRepositoryPool = new HostedRepositoryPool(seedPath);
-            var localRepo = PullRequestUtils.materialize(hostedRepositoryPool, pr, path);
+            var localRepo = IntegrateCommand.materializeLocalRepo(bot, pr, scratchArea);
             var newLabels = getLabels(localRepo);
             var currentLabels = pr.labelNames().stream()
                                   .filter(key -> bot.labelConfiguration().allowed().contains(key))

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
@@ -196,7 +196,7 @@ public class LabelerWorkItem extends PullRequestWorkItem {
                     .map(label -> "`" + label + "`")
                     .collect(Collectors.joining(", ")));
             message.append(labelsAdded.size() == 1 ? " has" : " have");
-            message.append(" been added to this pr.");
+            message.append(" been added to this pr based on the files touched in your new commit(s).");
         }
         message.append("\n");
         message.append(String.format(AUTO_LABEL_ADDITIONAL_COMMENT_MARKER, commitHash));

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
@@ -135,6 +135,11 @@ public class LabelerWorkItem extends PullRequestWorkItem {
             return List.of();
         }
 
+        // If the label comment can be found, mark the pr as auto labelled
+        if (findComment(prComments(), INITIAL_LABEL_MESSAGE).isPresent()) {
+            bot.setAutoLabelled(pr);
+        }
+
         // Updating labels when new files are touched
         if (bot.isAutoLabelled(pr)) {
             try {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/LabelerWorkItem.java
@@ -34,7 +34,8 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 public class LabelerWorkItem extends PullRequestWorkItem {
-    private static final String INITIAL_LABEL_MESSAGE = "<!-- PullRequestBot initial label help comment -->";
+    protected static final String INITIAL_LABEL_MESSAGE = "<!-- PullRequestBot initial label help comment -->";
+    private static final String LABEL_COMMIT_MARKER = "<!-- PullRequest Bot label commit '%s' -->";
 
     LabelerWorkItem(PullRequestBot bot, String prId, Consumer<RuntimeException> errorHandler,
             ZonedDateTime prUpdatedAt) {
@@ -59,7 +60,7 @@ public class LabelerWorkItem extends PullRequestWorkItem {
                        .findAny();
     }
 
-    private void updateLabelMessage(List<Comment> comments, List<String> newLabels) {
+    private void updateLabelMessage(List<Comment> comments, List<String> newLabels, String commitHash) {
         var existing = findComment(comments, INITIAL_LABEL_MESSAGE);
         if (existing.isPresent()) {
             // Only add the comment once per PR
@@ -111,6 +112,8 @@ public class LabelerWorkItem extends PullRequestWorkItem {
 
         message.append("\n");
         message.append(INITIAL_LABEL_MESSAGE);
+        message.append("\n");
+        message.append(String.format(LABEL_COMMIT_MARKER, commitHash));
         pr.addComment(message.toString());
     }
 
@@ -160,7 +163,7 @@ public class LabelerWorkItem extends PullRequestWorkItem {
                      .filter(label -> !currentLabels.contains(label))
                      .filter(label -> !manuallyRemoved.contains(label))
                                        .collect(Collectors.toList());
-            updateLabelMessage(comments, labelsToAdd);
+            updateLabelMessage(comments, labelsToAdd, pr.headHash().toString());
             labelsToAdd.forEach(pr::addLabel);
 
             // Remove set labels no longer present unless it has been manually added

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -58,7 +58,6 @@ class PullRequestBot implements Bot {
     private final String confOverrideName;
     private final String confOverrideRef;
     private final String censusLink;
-    private final Set<String> autoLabelled;
     private final Map<String, HostedRepository> forks;
     private final Set<String> integrators;
     private final Set<Integer> excludeCommitCommentsFrom;
@@ -140,7 +139,6 @@ class PullRequestBot implements Bot {
         this.cleanCommandEnabled = cleanCommandEnabled;
         this.checkContributorStatusForBackportCommand = checkContributorStatusForBackportCommand;
 
-        autoLabelled = new HashSet<>();
         poller = new PullRequestPoller(repo, true);
 
         // Only check recently updated when starting up to avoid congestion
@@ -366,18 +364,6 @@ class PullRequestBot implements Bot {
 
     public Map<String, HostedRepository> forks() {
         return forks;
-    }
-
-    public boolean isAutoLabelled(PullRequest pr) {
-        synchronized (autoLabelled) {
-            return autoLabelled.contains(pr.id());
-        }
-    }
-
-    public void setAutoLabelled(PullRequest pr) {
-        synchronized (autoLabelled) {
-            autoLabelled.add(pr.id());
-        }
     }
 
     public boolean reviewCleanBackport() {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
@@ -190,12 +190,7 @@ public class PullRequestCommandWorkItem extends PullRequestWorkItem {
 
             // If there is no label configuration, don't generate LabelerWorkItem
             if (bot.labelConfiguration().allowed().isEmpty()) {
-                bot.setAutoLabelled(pr);
                 return List.of();
-            }
-
-            if (!bot.isAutoLabelled(pr)) {
-                return List.of(new LabelerWorkItem(bot, prId, errorHandler, triggerUpdatedAt));
             }
 
             if (!pr.isClosed()) {
@@ -258,9 +253,6 @@ public class PullRequestCommandWorkItem extends PullRequestWorkItem {
         // to run again to correct the state of the PR.
         if (!pr.labelNames().contains("integrated") || pr.findIntegratedCommitHash().isEmpty()) {
             processCommand(pr, census, scratchArea, command, comments, false);
-            if (command.name().equals("label") || command.name().equals("cc")) {
-                return List.of(CheckWorkItem.fromWorkItem(bot, prId, errorHandler, triggerUpdatedAt), new LabelerWorkItem(bot, prId, errorHandler, triggerUpdatedAt));
-            }
             // Run another check to reflect potential changes from commands
             return List.of(CheckWorkItem.fromWorkItem(bot, prId, errorHandler, triggerUpdatedAt));
         } else {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCommandWorkItem.java
@@ -38,8 +38,6 @@ import java.util.stream.*;
 
 import static org.openjdk.skara.bots.pr.CommitCommandWorkItem.COMMAND_REPLY_MARKER;
 import static org.openjdk.skara.bots.pr.CommitCommandWorkItem.COMMAND_REPLY_PATTERN;
-import static org.openjdk.skara.bots.pr.LabelerWorkItem.INITIAL_LABEL_MESSAGE;
-import static org.openjdk.skara.bots.pr.LabelerWorkItem.LABEL_COMMIT_PATTERN;
 
 public class PullRequestCommandWorkItem extends PullRequestWorkItem {
     private static final Logger log = Logger.getLogger("org.openjdk.skara.bots.pr");

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ApprovalAndApproveCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/ApprovalAndApproveCommandTests.java
@@ -274,7 +274,7 @@ public class ApprovalAndApproveCommandTests {
             assertLastCommentContains(pr, "1: The approval request has been approved.");
             assertLastCommentContains(pr, "2: The approval request has been approved.");
             TestBotRunner.runPeriodicItems(issueBot);
-            assertTrue(pr.labelNames().contains("ready"));
+            assertTrue(pr.store().labelNames().contains("ready"));
         }
     }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelTests.java
@@ -230,9 +230,10 @@ public class LabelTests {
             // The bot will not add any label automatically
             TestBotRunner.runPeriodicItems(prBot);
             // Since there is already a component associated, rfr should be added
+            assertLastCommentContains(pr, "A manual label command was issued before auto-labeling, so auto-labeling was skipped.");
             assertEquals(Set.of("1", "rfr"), new HashSet<>(pr.store().labelNames()));
-            assertEquals(2, pr.comments().size());
-            assertLastCommentContains(pr, "The `1` label was successfully added.");
+            assertEquals(3, pr.comments().size());
+            assertTrue(pr.store().comments().get(1).body().contains("The `1` label was successfully added."));
 
             // Add another file to trigger a group match
             Files.writeString(localRepoFolder.resolve("test.cpp"), "Hello there");
@@ -249,7 +250,7 @@ public class LabelTests {
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(pr, "The `group` label was successfully added.");
             assertLastCommentContains(pr, "The `2` label was successfully added.");
-            assertEquals(Set.of("1", "2", "group", "rfr"), new HashSet<>(pr.store().labelNames()));
+            assertEquals(Set.of("group", "rfr"), new HashSet<>(pr.store().labelNames()));
         }
     }
 
@@ -344,6 +345,8 @@ public class LabelTests {
             var editHash = CheckableRepository.appendAndCommit(localRepo);
             localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
             var pr = credentials.createPullRequest(author, "master", "edit", "123: This is a pull request");
+
+            TestBotRunner.runPeriodicItems(prBot);
 
             // Add a label with -dev suffix
             pr.addComment("/label add 1-dev");

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@ import org.openjdk.skara.test.*;
 
 import java.io.IOException;
 import java.nio.file.*;
-import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.regex.Pattern;
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelTests.java
@@ -594,8 +594,6 @@ public class LabelTests {
         }
     }
 
-
-
     @Test
     void autoAdjustLabel(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelTests.java
@@ -249,7 +249,7 @@ public class LabelTests {
             pr.addComment("/label add group 2");
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(pr, "The `group` label was already applied.");
-            assertLastCommentContains(pr, "The `2` label was successfully added.");
+            assertLastCommentContains(pr, "The `group` group label was already applied, so `2` label will not be added.");
             assertEquals(Set.of("group", "rfr"), new HashSet<>(pr.store().labelNames()));
         }
     }
@@ -549,9 +549,9 @@ public class LabelTests {
             TestBotRunner.runPeriodicItems(prBot);
 
             // The bot should reply with the success messages
-            assertLastCommentContains(pr,"The `2` label was successfully added.");
+            assertLastCommentContains(pr,"The `group` group label was already applied, so `2` label will not be added.");
             assertLastCommentContains(pr,"The `group` label was successfully removed.");
-            assertEquals(Set.of("2", "rfr"), new HashSet<>(pr.store().labelNames()));
+            assertEquals(Set.of(), new HashSet<>(pr.store().labelNames()));
 
             // Mixed `+/-` labels again and check that the alias works as well
             pr.addComment("/label group, +1, -2");
@@ -559,8 +559,8 @@ public class LabelTests {
 
             // The bot should reply with the success messages
             assertLastCommentContains(pr,"The `group` label was successfully added.");
-            assertLastCommentContains(pr,"The `1` label was successfully added.");
-            assertLastCommentContains(pr,"The `2` label was successfully removed.");
+            assertLastCommentContains(pr,"The `group` group label was already applied, so `1` label will not be added.");
+            assertLastCommentContains(pr,"The `2` label was not set.");
             assertEquals(Set.of("rfr", "group"), new HashSet<>(pr.store().labelNames()));
 
             // Mixed `+/-` labels and intentional whitespace.

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelTests.java
@@ -181,6 +181,8 @@ public class LabelTests {
 
             // The bot should add label "1" since test.cpp is touched
             TestBotRunner.runPeriodicItems(prBot);
+            // After label "1" is added, in the next CheckWorkItem, rfr should be added
+            TestBotRunner.runPeriodicItems(prBot);
             assertEquals(Set.of("1", "rfr"), new HashSet<>(pr.store().labelNames()));
 
             // Adding the label manually is fine

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelTests.java
@@ -242,14 +242,13 @@ public class LabelTests {
             editHash = localRepo.commit("Another one", "duke", "duke@openjdk.org");
             localRepo.push(editHash, author.authenticatedUrl(), "edit");
 
-            // The bot will still not do any automatic labelling
             TestBotRunner.runPeriodicItems(prBot);
-            assertEquals(Set.of("1", "rfr"), new HashSet<>(pr.store().labelNames()));
+            assertEquals(Set.of("group", "rfr"), new HashSet<>(pr.store().labelNames()));
 
             // Adding manually is still fine
             pr.addComment("/label add group 2");
             TestBotRunner.runPeriodicItems(prBot);
-            assertLastCommentContains(pr, "The `group` label was successfully added.");
+            assertLastCommentContains(pr, "The `group` label was already applied.");
             assertLastCommentContains(pr, "The `2` label was successfully added.");
             assertEquals(Set.of("group", "rfr"), new HashSet<>(pr.store().labelNames()));
         }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelTests.java
@@ -228,11 +228,11 @@ public class LabelTests {
             var pr = credentials.createPullRequest(author, "master", "edit", "123: This is a pull request");
             pr.setBody("/cc 1");
 
-            // The bot will not add any label automatically
+            // Although manually added label 1, the auto labeling should still happen
             TestBotRunner.runPeriodicItems(prBot);
             // Since there is already a component associated, rfr should be added
-            assertLastCommentContains(pr, "A manual label command was issued before auto-labeling, so auto-labeling was skipped.");
-            assertEquals(Set.of("1", "rfr"), new HashSet<>(pr.store().labelNames()));
+            assertLastCommentContains(pr, "The following label will be automatically applied to this pull request:");
+            assertEquals(Set.of("group", "rfr"), new HashSet<>(pr.store().labelNames()));
             assertEquals(3, pr.comments().size());
             assertTrue(pr.store().comments().get(1).body().contains("The `1` label was successfully added."));
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelTests.java
@@ -142,6 +142,7 @@ public class LabelTests {
                                                            .addMatchers("1", List.of(Pattern.compile("cpp$")))
                                                            .addMatchers("2", List.of(Pattern.compile("hpp$")))
                                                            .addGroup("group", List.of("1", "2"))
+                                                           .addGroup("group2", List.of("1", "3"))
                                                            .addExtra("extra")
                                                            .build();
             var prBot = PullRequestBot.newBuilder()
@@ -190,6 +191,16 @@ public class LabelTests {
             TestBotRunner.runPeriodicItems(prBot);
             assertLastCommentContains(pr, "The `group` label was successfully added.");
             assertEquals(Set.of("group", "rfr"), new HashSet<>(pr.store().labelNames()));
+
+            pr.addComment("/label add group2");
+            TestBotRunner.runPeriodicItems(prBot);
+            assertLastCommentContains(pr, "The `group2` label was successfully added.");
+            assertEquals(Set.of("group", "group2", "rfr"), new HashSet<>(pr.store().labelNames()));
+
+            pr.addComment("/label add 1");
+            TestBotRunner.runPeriodicItems(prBot);
+            assertLastCommentContains(pr, "The `group2`, `group` group labels were already applied, so `1` label will not be added.");
+            assertEquals(Set.of("group", "group2", "rfr"), new HashSet<>(pr.store().labelNames()));
         }
     }
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelTests.java
@@ -591,7 +591,7 @@ public class LabelTests {
 
 
     @Test
-    void adjustAutoApplied222(TestInfo testInfo) throws IOException {
+    void autoAdjustLabel(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
              var tempFolder = new TemporaryDirectory()) {
             var author = credentials.getHostedRepository();

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelTests.java
@@ -586,4 +586,59 @@ public class LabelTests {
             assertEquals(Set.of("1", "rfr", "group"), new HashSet<>(pr.store().labelNames()));
         }
     }
+
+
+
+    @Test
+    void adjustAutoApplied222(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var integrator = credentials.getHostedRepository();
+
+            var censusBuilder = credentials.getCensusBuilder()
+                    .addReviewer(integrator.forge().currentUser().id())
+                    .addCommitter(author.forge().currentUser().id());
+            var labelConfiguration = LabelConfigurationJson.builder()
+                    .addMatchers("1", List.of(Pattern.compile("cpp$")))
+                    .addMatchers("2", List.of(Pattern.compile("hpp$")))
+                    .addMatchers("3", List.of(Pattern.compile("txt$")))
+                    .addGroup("group1", List.of("1", "2"))
+                    .addExtra("extra")
+                    .build();
+            var prBot = PullRequestBot.newBuilder()
+                    .repo(integrator)
+                    .censusRepo(censusBuilder.build())
+                    .labelConfiguration(labelConfiguration)
+                    .build();
+
+            // Populate the projects repository
+            var localRepoFolder = tempFolder.path().resolve("localrepo");
+            var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType(), Path.of("test.hpp"));
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            assertFalse(CheckableRepository.hasBeenEdited(localRepo));
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+
+            // Make a change with a corresponding PR
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", "123: This is a pull request");
+
+            // The bot should have applied one label automatically
+            TestBotRunner.runPeriodicItems(prBot);
+            assertEquals(Set.of("2", "rfr"), new HashSet<>(pr.store().labelNames()));
+            assertLastCommentContains(pr, "The following label will be automatically applied");
+            assertLastCommentContains(pr, "`2`");
+
+            var test1Cpp = localRepo.root().resolve("test1.cpp");
+            try (var output = Files.newBufferedWriter(test1Cpp)) {
+                output.append("test");
+            }
+            localRepo.add(test1Cpp);
+            var addHash = localRepo.commit("add cpp file", "duke", "duke@openjdk.org");
+            localRepo.push(addHash, author.authenticatedUrl(), "edit", true);
+            TestBotRunner.runPeriodicItems(prBot);
+            assertEquals(Set.of("group1", "rfr"), new HashSet<>(pr.store().labelNames()));
+        }
+    }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelTests.java
@@ -28,6 +28,7 @@ import org.openjdk.skara.test.*;
 
 import java.io.IOException;
 import java.nio.file.*;
+import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.regex.Pattern;
 
@@ -639,6 +640,18 @@ public class LabelTests {
             localRepo.push(addHash, author.authenticatedUrl(), "edit", true);
             TestBotRunner.runPeriodicItems(prBot);
             assertEquals(Set.of("group1", "rfr"), new HashSet<>(pr.store().labelNames()));
+
+            // Simulate force-push.
+            localRepo.checkout(editHash);
+            var test1txt = localRepo.root().resolve("test1.txt");
+            try (var output = Files.newBufferedWriter(test1txt)) {
+                output.append("test");
+            }
+            localRepo.add(test1txt);
+            var forcePushHash = localRepo.commit("add txt file", "duke", "duke@openjdk.org");
+            localRepo.push(forcePushHash, author.authenticatedUrl(), "edit", true);
+            TestBotRunner.runPeriodicItems(prBot);
+            assertEquals(Set.of("group1", "rfr", "3"), new HashSet<>(pr.store().labelNames()));
         }
     }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelerTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelerTests.java
@@ -69,7 +69,7 @@ class LabelerTests {
 
             // Check the status - rfr label should not be set since the pr is not associated with any component
             TestBotRunner.runPeriodicItems(labelBot);
-            assertEquals(Set.of(), new HashSet<>(pr.labelNames()));
+            assertEquals(Set.of(), new HashSet<>(pr.store().labelNames()));
             assertLastCommentContains(pr, "However, no automatic labelling rule matches the changes in this pull request.");
             assertLastCommentContains(pr, "<details>");
             assertLastCommentContains(pr, "<summary>Applicable Labels</summary>");
@@ -119,7 +119,7 @@ class LabelerTests {
 
             // Check the status - there should now be a test1 label
             TestBotRunner.runPeriodicItems(labelBot);
-            assertEquals(Set.of("rfr", "test1"), new HashSet<>(pr.labelNames()));
+            assertEquals(Set.of("rfr", "test1"), new HashSet<>(pr.store().labelNames()));
         }
     }
 
@@ -170,7 +170,7 @@ class LabelerTests {
 
             // Check the status - there should now be a test1 label
             TestBotRunner.runPeriodicItems(labelBot);
-            assertEquals(Set.of("rfr", "test1"), new HashSet<>(pr.labelNames()));
+            assertEquals(Set.of("rfr", "test1"), new HashSet<>(pr.store().labelNames()));
         }
     }
 
@@ -218,7 +218,7 @@ class LabelerTests {
 
             // Check the status - there should be test1 and test2
             TestBotRunner.runPeriodicItems(labelBot);
-            assertEquals(Set.of("rfr", "test2", "test1"), new HashSet<>(pr.labelNames()));
+            assertEquals(Set.of("rfr", "test2", "test1"), new HashSet<>(pr.store().labelNames()));
         }
     }
 
@@ -265,7 +265,7 @@ class LabelerTests {
 
             // Check the status - there should be test1 and test2
             TestBotRunner.runPeriodicItems(labelBot);
-            assertEquals(Set.of("rfr", "test2", "test1"), new HashSet<>(pr.labelNames()));
+            assertEquals(Set.of("rfr", "test2", "test1"), new HashSet<>(pr.store().labelNames()));
         }
     }
 
@@ -312,7 +312,7 @@ class LabelerTests {
 
             // Check the status - the test1 label should have been added
             TestBotRunner.runPeriodicItems(labelBot);
-            assertEquals(Set.of("rfr", "test1", "test42"), new HashSet<>(pr.labelNames()));
+            assertEquals(Set.of("rfr", "test1", "test42"), new HashSet<>(pr.store().labelNames()));
         }
     }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelerTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelerTests.java
@@ -212,13 +212,13 @@ class LabelerTests {
 
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
-            // Issue a manual label command
+            // Issue a manual label command, this shouldn't affect the auto labeling
             var reviewerPr = reviewer.pullRequest(pr.id());
             reviewerPr.addComment("/label add test2");
 
-            // Check the status - there should still only be a test2 label
+            // Check the status - there should be test1 and test2
             TestBotRunner.runPeriodicItems(labelBot);
-            assertEquals(Set.of("rfr", "test2"), new HashSet<>(pr.labelNames()));
+            assertEquals(Set.of("rfr", "test2", "test1"), new HashSet<>(pr.labelNames()));
         }
     }
 
@@ -260,12 +260,12 @@ class LabelerTests {
 
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
-            // Manually set a label
+            // Manually set a label shouldn't affect auto labeling
             pr.addLabel("test2");
 
-            // Check the status - there should still only be a test2 label
+            // Check the status - there should be test1 and test2
             TestBotRunner.runPeriodicItems(labelBot);
-            assertEquals(Set.of("rfr", "test2"), new HashSet<>(pr.labelNames()));
+            assertEquals(Set.of("rfr", "test2", "test1"), new HashSet<>(pr.labelNames()));
         }
     }
 

--- a/forge/src/main/java/org/openjdk/skara/forge/LabelConfiguration.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/LabelConfiguration.java
@@ -23,6 +23,7 @@
 package org.openjdk.skara.forge;
 
 import java.nio.file.Path;
+import java.util.Optional;
 import java.util.Set;
 
 public interface LabelConfiguration {
@@ -30,4 +31,5 @@ public interface LabelConfiguration {
     Set<String> allowed();
     boolean isAllowed(String s);
     Set<String> upgradeLabelsToGroups(Set<String> labels);
+    Optional<String> groupLabel(String label);
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/LabelConfiguration.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/LabelConfiguration.java
@@ -23,7 +23,6 @@
 package org.openjdk.skara.forge;
 
 import java.nio.file.Path;
-import java.util.Optional;
 import java.util.Set;
 
 public interface LabelConfiguration {
@@ -31,5 +30,8 @@ public interface LabelConfiguration {
     Set<String> allowed();
     boolean isAllowed(String s);
     Set<String> upgradeLabelsToGroups(Set<String> labels);
-    Optional<String> groupLabel(String label);
+    /**
+     * Returns the set of groups that this label belongs to.
+     */
+    Set<String> groupLabel(String label);
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/LabelConfiguration.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/LabelConfiguration.java
@@ -33,5 +33,5 @@ public interface LabelConfiguration {
     /**
      * Returns the set of groups that this label belongs to.
      */
-    Set<String> groupLabel(String label);
+    Set<String> groupLabels(String label);
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/LabelConfiguration.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/LabelConfiguration.java
@@ -29,4 +29,5 @@ public interface LabelConfiguration {
     Set<String> label(Set<Path> changes);
     Set<String> allowed();
     boolean isAllowed(String s);
+    Set<String> upgradeLabelsToGroups(Set<String> labels);
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/LabelConfigurationHostedRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/LabelConfigurationHostedRepository.java
@@ -77,8 +77,8 @@ public class LabelConfigurationHostedRepository implements LabelConfiguration {
     }
 
     @Override
-    public Set<String> groupLabel(String label) {
-        return labelConfiguration().groupLabel(label);
+    public Set<String> groupLabels(String label) {
+        return labelConfiguration().groupLabels(label);
     }
 }
 

--- a/forge/src/main/java/org/openjdk/skara/forge/LabelConfigurationHostedRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/LabelConfigurationHostedRepository.java
@@ -25,7 +25,6 @@ package org.openjdk.skara.forge;
 import org.openjdk.skara.json.JSON;
 
 import java.nio.file.Path;
-import java.util.Optional;
 import java.util.Set;
 
 public class LabelConfigurationHostedRepository implements LabelConfiguration {
@@ -78,7 +77,7 @@ public class LabelConfigurationHostedRepository implements LabelConfiguration {
     }
 
     @Override
-    public Optional<String> groupLabel(String label) {
+    public Set<String> groupLabel(String label) {
         return labelConfiguration().groupLabel(label);
     }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/LabelConfigurationHostedRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/LabelConfigurationHostedRepository.java
@@ -25,6 +25,7 @@ package org.openjdk.skara.forge;
 import org.openjdk.skara.json.JSON;
 
 import java.nio.file.Path;
+import java.util.Optional;
 import java.util.Set;
 
 public class LabelConfigurationHostedRepository implements LabelConfiguration {
@@ -74,6 +75,11 @@ public class LabelConfigurationHostedRepository implements LabelConfiguration {
     @Override
     public Set<String> upgradeLabelsToGroups(Set<String> labels) {
         return labelConfiguration().upgradeLabelsToGroups(labels);
+    }
+
+    @Override
+    public Optional<String> groupLabel(String label) {
+        return labelConfiguration().groupLabel(label);
     }
 }
 

--- a/forge/src/main/java/org/openjdk/skara/forge/LabelConfigurationHostedRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/LabelConfigurationHostedRepository.java
@@ -70,5 +70,10 @@ public class LabelConfigurationHostedRepository implements LabelConfiguration {
     public boolean isAllowed(String s) {
         return labelConfiguration().isAllowed(s);
     }
+
+    @Override
+    public Set<String> upgradeLabelsToGroups(Set<String> labels) {
+        return labelConfiguration().upgradeLabelsToGroups(labels);
+    }
 }
 

--- a/forge/src/main/java/org/openjdk/skara/forge/LabelConfigurationJson.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/LabelConfigurationJson.java
@@ -168,7 +168,7 @@ public class LabelConfigurationJson implements LabelConfiguration {
         return ret;
     }
 
-    public Set<String> groupLabel(String label) {
+    public Set<String> groupLabels(String label) {
         var ret = new HashSet<String>();
         for (var group : groups.entrySet()) {
             if (group.getValue().contains(label)) {

--- a/forge/src/main/java/org/openjdk/skara/forge/LabelConfigurationJson.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/LabelConfigurationJson.java
@@ -167,4 +167,13 @@ public class LabelConfigurationJson implements LabelConfiguration {
         }
         return ret;
     }
+
+    public Optional<String> groupLabel(String label) {
+        for (var group : groups.entrySet()) {
+            if (group.getValue().contains(label)) {
+                return Optional.of(group.getKey());
+            }
+        }
+        return Optional.empty();
+    }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/LabelConfigurationJson.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/LabelConfigurationJson.java
@@ -168,12 +168,13 @@ public class LabelConfigurationJson implements LabelConfiguration {
         return ret;
     }
 
-    public Optional<String> groupLabel(String label) {
+    public Set<String> groupLabel(String label) {
+        var ret = new HashSet<String>();
         for (var group : groups.entrySet()) {
             if (group.getValue().contains(label)) {
-                return Optional.of(group.getKey());
+                ret.add(group.getKey());
             }
         }
-        return Optional.empty();
+        return ret;
     }
 }

--- a/forge/src/main/java/org/openjdk/skara/forge/LabelConfigurationJson.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/LabelConfigurationJson.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -130,6 +130,19 @@ public class LabelConfigurationJson implements LabelConfiguration {
             }
         }
 
+        return upgradeLabelsToGroups(labels);
+    }
+
+    public Set<String> allowed() {
+        return allowed;
+    }
+
+    public boolean isAllowed(String s) {
+        return allowed.contains(s);
+    }
+
+    @Override
+    public Set<String> upgradeLabelsToGroups(Set<String> labels) {
         var ret = new HashSet<>(labels);
         // If the current labels matches at least two members of a group, use the group
         for (var group : groups.entrySet()) {
@@ -152,15 +165,6 @@ public class LabelConfigurationJson implements LabelConfiguration {
                 ret.removeAll(group.getValue());
             }
         }
-
         return ret;
-    }
-
-    public Set<String> allowed() {
-        return allowed;
-    }
-
-    public boolean isAllowed(String s) {
-        return allowed.contains(s);
     }
 }

--- a/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestPullRequest.java
@@ -51,7 +51,6 @@ public class TestPullRequest extends TestIssue implements PullRequest {
     protected final String sourceRef;
     protected final String targetRef;
     protected final boolean draft;
-    private List<Label> labels;
 
     public TestPullRequest(TestPullRequestStore store, TestHostedRepository targetRepository) {
         super(store, targetRepository.forge().currentUser());
@@ -314,19 +313,6 @@ public class TestPullRequest extends TestIssue implements PullRequest {
     @Override
     public Object snapshot() {
         return List.of(this, comments(), reviews());
-    }
-
-    /**
-     * Mimic GitHub/GitLab where the labels are fetched lazily and cached.
-     * In GitLabMergeRequest, the labels are actually part of the main json, but
-     * are still re-fetched once on the first call to labels().
-     */
-    @Override
-    public List<Label> labels() {
-        if (labels == null) {
-            labels = store().labels().keySet().stream().map(Label::new).collect(Collectors.toList());
-        }
-        return labels;
     }
 
     /**


### PR DESCRIPTION
This patch is trying to make the pr bot be able to update PR labels when new files are touched.
The main idea is from Erik. For a new PR, the bot will run a labelerWorkItem to auto label the PR first, and the commit hash will be stored in a comment.

With this patch, here are some new behaviors of the bot:
(1) The user didn't issue manual label command before auto labeling, LabelerWorkItem will do the initial auto labeling and store the commit hash in the comment. 
(2) If the user issued manual label command before auto labeling, the initial auto labeling will be skipped, the bot would still post a comment and store the hash in the comment.
(3) The user pushes a new commit or few commits to a pr that already auto labeled, the bot will evaluate the diff between stored hash and current head, then add new labels or upgrading labels to group labels, in the end, update the stored hash in the comment.
(4) The user force pushes to the pr that already auto labeled, the bot will evaluate the diff between baseHash and current head.
(5) The user issues a command to add a label to the pr(or even the user add the label via the forge UI), the bot will check if the labels can be upgraded to group labels.

The side effect of this feature I can imagine is that a user thinks a file is not related to a component and removed it manually, but later, every time when he touches the file, the label will be added back.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2065](https://bugs.openjdk.org/browse/SKARA-2065): Update PR labels when new files are touched (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1735/head:pull/1735` \
`$ git checkout pull/1735`

Update a local copy of the PR: \
`$ git checkout pull/1735` \
`$ git pull https://git.openjdk.org/skara.git pull/1735/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1735`

View PR using the GUI difftool: \
`$ git pr show -t 1735`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1735.diff">https://git.openjdk.org/skara/pull/1735.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1735#issuecomment-3229478499)
</details>
