### PR TITLE
2544: SKARA bot ignores GitHub comments in some cases

### DIFF
--- a/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
+++ b/forge/src/main/java/org/openjdk/skara/forge/github/GitHubRepository.java
@@ -145,7 +145,6 @@ public class GitHubRepository implements HostedRepository {
                       .param("state", "all")
                       .param("sort", "updated")
                       .param("direction", "desc")
-                      .maxPages(1)
                       .execute().asArray().stream()
                       .map(jsonValue -> new GitHubPullRequest(this, jsonValue, request))
                       .collect(Collectors.toList());
@@ -166,7 +165,6 @@ public class GitHubRepository implements HostedRepository {
                       .param("state", "all")
                       .param("sort", "updated")
                       .param("direction", "desc")
-                      .maxPages(1)
                       .execute().asArray().stream()
                       .map(jsonValue -> new GitHubPullRequest(this, jsonValue, request))
                       .filter(pr -> !pr.updatedAt().isBefore(updatedAfter))


### PR DESCRIPTION
When querying pull requests in GitHub, we should query all the pull requests instead of the first page, otherwise, in some cases, some prs will be ignored.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2544](https://bugs.openjdk.org/browse/SKARA-2544): SKARA bot ignores GitHub comments in some cases (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1736/head:pull/1736` \
`$ git checkout pull/1736`

Update a local copy of the PR: \
`$ git checkout pull/1736` \
`$ git pull https://git.openjdk.org/skara.git pull/1736/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1736`

View PR using the GUI difftool: \
`$ git pr show -t 1736`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1736.diff">https://git.openjdk.org/skara/pull/1736.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1736#issuecomment-3255490393)
</details>
