### PR TITLE
SKARA-2586

### DIFF
--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifier.java
@@ -88,14 +88,19 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
     private CensusInstance census = null;
 
     // If true, avoid creating a "forward backport" when creating a new backport
-    private boolean avoidForwardports;
+    private final boolean avoidForwardports;
+
+    // If true, allow multiple values in the Fix Versions field instead of using
+    // backport records for every additional fix version.
+    private final boolean multiFixVersions;
 
     IssueNotifier(IssueProject issueProject, boolean reviewLink, URI reviewIcon, boolean commitLink, URI commitIcon,
                   boolean setFixVersion, LinkedHashMap<Pattern, String> fixVersions, LinkedHashMap<Pattern, List<Pattern>> altFixVersions,
                   boolean prOnly, boolean repoOnly, String buildName,
                   HostedRepository censusRepository, String censusRef, String namespace, boolean useHeadVersion,
                   HostedRepository originalRepository, boolean resolve, Set<String> tagIgnoreOpt,
-                  boolean tagMatchPrefix, List<BranchSecurity> defaultSecurity, boolean avoidForwardports) {
+                  boolean tagMatchPrefix, List<BranchSecurity> defaultSecurity, boolean avoidForwardports,
+                  boolean multiFixVersions) {
         this.issueProject = issueProject;
         this.reviewLink = reviewLink;
         this.reviewIcon = reviewIcon;
@@ -117,6 +122,7 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
         this.tagMatchPrefix = tagMatchPrefix;
         this.defaultSecurity = defaultSecurity;
         this.avoidForwardports = avoidForwardports;
+        this.multiFixVersions = multiFixVersions;
     }
 
     static IssueNotifierBuilder newBuilder() {
@@ -338,32 +344,40 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
                         // Do not update fixVersion
                         requestedVersion = null;
                     } else if (requestedVersion != null) {
-                        var fixVersion = JdkVersion.parse(requestedVersion).orElseThrow();
-                        var existing = Backports.findIssue(issue, fixVersion);
-                        if (existing.isEmpty()) {
-                            var issueFixVersion = Backports.mainFixVersion(issue);
-                            try {
-                                if (issue.isOpen() && avoidForwardports && issueFixVersion.isPresent() && fixVersion.compareTo(issueFixVersion.get()) > 0) {
-                                    log.info("Avoiding 'forwardport', creating new backport for " + issue.id() + " with fixVersion " + issueFixVersion.get().raw());
-                                    Backports.createBackport(issue, issueFixVersion.get().raw(), username.orElse(null), defaultSecurity(branch));
-                                } else {
-                                    log.info("Creating new backport for " + issue.id() + " with fixVersion " + requestedVersion);
-                                    issue = Backports.createBackport(issue, requestedVersion, username.orElse(null), defaultSecurity(branch));
+                        if (!multiFixVersions) {
+                            var fixVersion = JdkVersion.parse(requestedVersion).orElseThrow();
+                            var existing = Backports.findIssue(issue, fixVersion);
+                            if (existing.isEmpty()) {
+                                var issueFixVersion = Backports.mainFixVersion(issue);
+                                try {
+                                    if (issue.isOpen() && avoidForwardports && issueFixVersion.isPresent() &&
+                                            fixVersion.compareTo(issueFixVersion.get()) > 0) {
+                                        log.info("Avoiding 'forwardport', creating new backport for " + issue.id() +
+                                                " with fixVersion " + issueFixVersion.get().raw());
+                                        Backports.createBackport(issue, issueFixVersion.get().raw(), username.orElse(null), defaultSecurity(branch));
+                                    } else {
+                                        log.info("Creating new backport for " + issue.id() + " with fixVersion " +
+                                                requestedVersion);
+                                        issue =
+                                                Backports.createBackport(issue, requestedVersion, username.orElse(null), defaultSecurity(branch));
+                                    }
+                                } catch (UncheckedRestException e) {
+                                    existing = Backports.findIssue(issue, fixVersion);
+                                    if (existing.isPresent()) {
+                                        log.info(
+                                                "Race condition occurred while creating backport issue, returning the existing backport for " +
+                                                        issue.id() + " and requested fixVersion "
+                                                        + requestedVersion + " " + existing.get().id());
+                                        issue = existing.get();
+                                    } else {
+                                        throw e;
+                                    }
                                 }
-                            } catch (UncheckedRestException e) {
-                                existing = Backports.findIssue(issue, fixVersion);
-                                if (existing.isPresent()) {
-                                    log.info("Race condition occurred while creating backport issue, returning the existing backport for " + issue.id() + " and requested fixVersion "
-                                            + requestedVersion + " " + existing.get().id());
-                                    issue = existing.get();
-                                } else {
-                                    throw e;
-                                }
+                            } else {
+                                log.info("Found existing backport for " + issue.id() + " and requested fixVersion "
+                                        + requestedVersion + " " + existing.get().id());
+                                issue = existing.get();
                             }
-                        } else {
-                            log.info("Found existing backport for " + issue.id() + " and requested fixVersion "
-                                    + requestedVersion + " " + existing.get().id());
-                            issue = existing.get();
                         }
                     }
                 }
@@ -404,8 +418,17 @@ class IssueNotifier implements Notifier, PullRequestListener, RepositoryListener
                                 log.info("Not replacing build " + oldBuild.asString() + " with " + buildName + " for issue " + issue.id());
                             }
                         }
-                        log.info("Setting fixVersion for " + issue.id() + " to " + requestedVersion);
-                        issue.setProperty("fixVersions", JSON.array().add(requestedVersion));
+                        if (multiFixVersions) {
+                            var currentFixVersions = Backports.fixVersions(issue);
+                            log.info("Adding fixVersion " + requestedVersion + " to " + issue.id() + " current: " + currentFixVersions);
+                            var jsonFixVersions = JSON.array();
+                            currentFixVersions.forEach(jsonFixVersions::add);
+                            jsonFixVersions.add(requestedVersion);
+                            issue.setProperty("fixVersions", jsonFixVersions);
+                        } else {
+                            log.info("Setting fixVersion for " + issue.id() + " to " + requestedVersion);
+                            issue.setProperty("fixVersions", JSON.array().add(requestedVersion));
+                        }
                     }
                 }
             }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierBuilder.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierBuilder.java
@@ -51,6 +51,7 @@ class IssueNotifierBuilder {
     private boolean tagMatchPrefix = false;
     private List<IssueNotifier.BranchSecurity> defaultSecurity = List.of();
     private boolean avoidForwardports = false;
+    private boolean multiFixVersions = false;
 
     IssueNotifierBuilder issueProject(IssueProject issueProject) {
         this.issueProject = issueProject;
@@ -158,6 +159,11 @@ class IssueNotifierBuilder {
         return this;
     }
 
+    public IssueNotifierBuilder multiFixVersions(boolean multiFixVersions) {
+        this.multiFixVersions = multiFixVersions;
+        return this;
+    }
+
     public boolean prOnly() {
         return prOnly;
     }
@@ -170,6 +176,6 @@ class IssueNotifierBuilder {
         return new IssueNotifier(issueProject, reviewLink, reviewIcon, commitLink, commitIcon,
                 setFixVersion, fixVersions, altFixVersions, prOnly,
                 repoOnly, buildName, censusRepository, censusRef, namespace, useHeadVersion, originalRepository,
-                resolve, tagIgnoreOpt, tagMatchPrefix, defaultSecurity, avoidForwardports);
+                resolve, tagIgnoreOpt, tagMatchPrefix, defaultSecurity, avoidForwardports, multiFixVersions);
     }
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierFactory.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/issue/IssueNotifierFactory.java
@@ -139,6 +139,10 @@ public class IssueNotifierFactory implements NotifierFactory {
             builder.avoidForwardports(notifierConfiguration.get("avoidforwardports").asBoolean());
         }
 
+        if (notifierConfiguration.contains("multifixversions")) {
+            builder.multiFixVersions(notifierConfiguration.get("multifixversions").asBoolean());
+        }
+
         return builder.build();
     }
 }

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/NotifyBotFactoryTest.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/NotifyBotFactoryTest.java
@@ -116,7 +116,8 @@ class NotifyBotFactoryTest {
                           "issue": {
                             "project": "test_bugs/TEST",
                             "pronly": true,
-                            "resolve": false
+                            "resolve": false,
+                            "multifixversions": true,
                           },
                           "comment": {
                             "project": "test_bugs/TEST"

--- a/jbs/src/main/java/org/openjdk/skara/jbs/JdkVersion.java
+++ b/jbs/src/main/java/org/openjdk/skara/jbs/JdkVersion.java
@@ -45,7 +45,7 @@ public class JdkVersion implements Comparable<JdkVersion> {
 
     private final static Pattern legacyPrefixPattern = Pattern.compile("^([^\\d]*)\\d+$");
 
-    private final static Pattern projectRepoPattern = Pattern.compile("repo-([a-z0-9]*)");
+    private final static Pattern projectRepoPattern = Pattern.compile("(repo|branch)-([a-z0-9]*)");
 
     private static List<String> splitComponents(String raw) {
         var finalComponents = new ArrayList<String>();
@@ -83,9 +83,8 @@ public class JdkVersion implements Comparable<JdkVersion> {
         if (finalComponents.isEmpty()) {
             var matcher = projectRepoPattern.matcher(raw);
             if (matcher.matches()) {
-                var project = matcher.group(1);
-                finalComponents.add("repo");
-                finalComponents.add(project);
+                finalComponents.add(matcher.group(1));
+                finalComponents.add(matcher.group(2));
             }
         }
 

--- a/jbs/src/test/java/org/openjdk/skara/jbs/JdkVersionTests.java
+++ b/jbs/src/test/java/org/openjdk/skara/jbs/JdkVersionTests.java
@@ -156,4 +156,10 @@ public class JdkVersionTests {
         assertEquals(List.of("repo", "foo"), from("repo-foo").components());
         assertTrue(from("20").compareTo(from("repo-foo")) < 0);
     }
+
+    @Test
+    void teamBranch() {
+        assertEquals(List.of("branch", "foo"), from("branch-foo").components());
+        assertTrue(from("20").compareTo(from("branch-foo")) < 0);
+    }
 }


### PR DESCRIPTION
In some projects, other than the JDK, we would like to use Skara in a simplified Jira workflow, where we use the multi value aspect of the Jira FixVersion field instead of creating backport records. To support this I propose to add a configuration option in the IssueNotifier "multifixversion", with default value false, which corresponds to the current behavior with backports. When set to true, then instead of creating backports, the notifier would just pile on additional fix versions when a commit is integrated into multiple different branches.

In addition to this, I would like to also add handling of a "branch-" prefix for a version strings. This would mimic the current "repo-" prefix which is already in use for JDK projects.
