### PR TITLE
2708: Two-Reviewers requirement shouldn't apply to Backport/Merge PRs

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -47,7 +47,6 @@ import java.util.stream.*;
 
 import static org.openjdk.skara.bots.common.PullRequestConstants.*;
 import static org.openjdk.skara.bots.pr.LabelerWorkItem.INITIAL_LABEL_MESSAGE;
-import static org.openjdk.skara.bots.pr.ReviewersTracker.DEFAULT_SOURCE;
 
 class CheckRun {
     public static final String MSG_EMPTY_BODY = "The pull request body must not be empty.";
@@ -114,7 +113,8 @@ class CheckRun {
         this.approval = approval;
         this.requiredCheckedLines = requiredCheckedLines;
         var additionalRequiredReviewers = ReviewersTracker.additionalRequiredReviewers(pr.repository().forge().currentUser(), comments);
-        this.reviewersCommandIssuedByUser = additionalRequiredReviewers.isPresent() && additionalRequiredReviewers.get().source() == DEFAULT_SOURCE;
+        this.reviewersCommandIssuedByUser = additionalRequiredReviewers.isPresent()
+                && additionalRequiredReviewers.get().source() == ReviewersTracker.Source.USER;
 
         // If reviewers command is issued, enable reviewers check for merge pull requests
         if (reviewersCommandIssuedByUser) {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -47,6 +47,7 @@ import java.util.stream.*;
 
 import static org.openjdk.skara.bots.common.PullRequestConstants.*;
 import static org.openjdk.skara.bots.pr.LabelerWorkItem.INITIAL_LABEL_MESSAGE;
+import static org.openjdk.skara.bots.pr.ReviewersTracker.DEFAULT_SOURCE;
 
 class CheckRun {
     public static final String MSG_EMPTY_BODY = "The pull request body must not be empty.";
@@ -85,7 +86,7 @@ class CheckRun {
     private final boolean reviewCleanBackport;
     private final List<String> requiredCheckedLines;
     private final Approval approval;
-    private final boolean reviewersCommandIssued;
+    private final boolean reviewersCommandIssuedByUser;
     private final ReviewCoverage reviewCoverage;
 
     private Duration expiresIn;
@@ -112,10 +113,11 @@ class CheckRun {
         this.reviewCleanBackport = reviewCleanBackport;
         this.approval = approval;
         this.requiredCheckedLines = requiredCheckedLines;
-        this.reviewersCommandIssued = ReviewersTracker.additionalRequiredReviewers(pr.repository().forge().currentUser(), comments).isPresent();
+        var additionalRequiredReviewers = ReviewersTracker.additionalRequiredReviewers(pr.repository().forge().currentUser(), comments);
+        this.reviewersCommandIssuedByUser = additionalRequiredReviewers.isPresent() && additionalRequiredReviewers.get().source() == DEFAULT_SOURCE;
 
         // If reviewers command is issued, enable reviewers check for merge pull requests
-        if (reviewersCommandIssued) {
+        if (reviewersCommandIssuedByUser) {
             reviewMerge = MergePullRequestReviewConfiguration.ALWAYS;
         }
 
@@ -1527,7 +1529,7 @@ class CheckRun {
             integrationBlockers.addAll(mergeJCheckMessageWithTargetConf);
             integrationBlockers.addAll(mergeJCheckMessageWithCommitConf);
 
-            var reviewNeeded = !isCleanBackport || reviewCleanBackport || reviewersCommandIssued;
+            var reviewNeeded = !isCleanBackport || reviewCleanBackport || reviewersCommandIssuedByUser;
 
             // Calculate and update the status message if needed
             var statusMessage = getStatusMessage(visitor, additionalErrors, additionalProgresses, integrationBlockers, warnings,

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -182,7 +182,7 @@ class CheckWorkItem extends PullRequestWorkItem {
             } else if (latestTwoReviewersComment.get().body().contains(TWO_REVIEWERS_APPLIED_MARKER)) {
                 var marker = ReviewersTracker.setReviewersMarker(0, "authors", ReviewersTracker.Source.BOT);
                 var prType = PullRequestUtils.isMerge(pr) ? "merge" : "backport";
-                var reviewersClearedComment = pr.addComment("This PR is now a " + prType + " PR, the extra reviewers requirement has been cleared.\n"
+                var reviewersClearedComment = pr.addComment("This is now a " + prType + " PR, the extra reviewers requirement has been cleared.\n"
                         + marker + "\n" + TWO_REVIEWERS_CLEARED_MARKER);
                 return Stream.concat(comments.stream(), Stream.of(reviewersClearedComment)).toList();
             }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -182,7 +182,8 @@ class CheckWorkItem extends PullRequestWorkItem {
                 return comments;
             } else if (latestTwoReviewersComment.get().body().contains(TWO_REVIEWERS_APPLIED_MARKER)) {
                 var marker = ReviewersTracker.setReviewersMarker(0, "authors", "bot");
-                var reviewersClearedComment = pr.addComment("This PR is now a backport or merge PR, so the extra reviewers requirement has been cleared.\n"
+                var prType = PullRequestUtils.isMerge(pr) ? "merge" : "backport";
+                var reviewersClearedComment = pr.addComment("This PR is now a " + prType + " PR, so the extra reviewers requirement has been cleared.\n"
                         + marker + "\n" + TWO_REVIEWERS_CLEARED_MARKER);
                 return Stream.concat(comments.stream(), Stream.of(reviewersClearedComment)).toList();
             }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -182,7 +182,7 @@ class CheckWorkItem extends PullRequestWorkItem {
             } else if (latestTwoReviewersComment.get().body().contains(TWO_REVIEWERS_APPLIED_MARKER)) {
                 var marker = ReviewersTracker.setReviewersMarker(0, "authors", ReviewersTracker.Source.BOT);
                 var prType = PullRequestUtils.isMerge(pr) ? "merge" : "backport";
-                var reviewersClearedComment = pr.addComment("This PR is now a " + prType + " PR, so the extra reviewers requirement has been cleared.\n"
+                var reviewersClearedComment = pr.addComment("This PR is now a " + prType + " PR, the extra reviewers requirement has been cleared.\n"
                         + marker + "\n" + TWO_REVIEWERS_CLEARED_MARKER);
                 return Stream.concat(comments.stream(), Stream.of(reviewersClearedComment)).toList();
             }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -63,6 +63,8 @@ class CheckWorkItem extends PullRequestWorkItem {
     private static final Pattern BACKPORT_ISSUE_TITLE_PATTERN = Pattern.compile("^Backport\\s*(?:(?<prefix>[A-Za-z][A-Za-z0-9]+)-)?(?<id>[0-9]+)\\s*$", Pattern.CASE_INSENSITIVE);
     private static final Pattern METADATA_COMMENTS_PATTERN = Pattern.compile(
             "<!-- (?:backport)|(?:(add|remove) (?:contributor|reviewer))|(?:summary: ')|(?:solves: ')|(?:additional required reviewers)|(?:jep: ')|(?:csr: ')|(?:trailer:)");
+    private static final String TWO_REVIEWERS_APPLIED_MARKER = "<!-- two-reviewers applied -->";
+    private static final String TWO_REVIEWERS_CLEARED_MARKER = "<!-- two-reviewers cleared -->";
     private static final String ELLIPSIS = "…";
     protected static final String FORCE_PUSH_MARKER = "<!-- force-push suggestion -->";
     protected static final String FORCE_PUSH_SUGGESTION= """
@@ -157,33 +159,60 @@ class CheckWorkItem extends PullRequestWorkItem {
         if (bot.twoReviewersLabels().isEmpty()) {
             return comments;
         }
-        if (Collections.disjoint(pr.labelNames(), bot.twoReviewersLabels())) {
-            return comments;
-        }
 
         var botUser = pr.repository().forge().currentUser();
-        if (ReviewersTracker.additionalRequiredReviewers(botUser, comments).isPresent()) {
+        // If there is any user issued reviewers command, don't override it
+        var additionalRequiredReviewers = ReviewersTracker.additionalRequiredReviewers(botUser, comments);
+        if (additionalRequiredReviewers.isPresent() && additionalRequiredReviewers.get().source().equals("user")) {
             return comments;
         }
 
-        var matchingLabels = pr.labelNames().stream()
-                .filter(label -> bot.twoReviewersLabels().contains(label))
-                .sorted()
-                .toList();
-        var labelsNoun = matchingLabels.size() == 1 ? "this label" : "these labels";
+        var latestTwoReviewersComment = comments.stream()
+                .filter(comment -> comment.author().equals(pr.repository().forge().currentUser()))
+                .filter(comment -> comment.body().contains(TWO_REVIEWERS_APPLIED_MARKER) || comment.body().contains(TWO_REVIEWERS_CLEARED_MARKER))
+                .reduce((a, b) -> b);
 
-        var marker = ReviewersTracker.setReviewersMarker(2, "authors");
+        if (pr.labelNames().contains("backport") || BACKPORT_ISSUE_TITLE_PATTERN.matcher(pr.title()).matches()
+                || BACKPORT_HASH_TITLE_PATTERN.matcher(pr.title()).matches() || PullRequestUtils.isMerge(pr)) {
+            // Backport or Merge PR
+            if (latestTwoReviewersComment.isEmpty()) {
+                return comments;
+            } else if (latestTwoReviewersComment.get().body().contains(TWO_REVIEWERS_CLEARED_MARKER)) {
+                return comments;
+            } else if (latestTwoReviewersComment.get().body().contains(TWO_REVIEWERS_APPLIED_MARKER)) {
+                var marker = ReviewersTracker.setReviewersMarker(0, "authors", "bot");
+                var reviewersClearedComment = pr.addComment("This PR is now a backport or merge PR, so the extra reviewers requirement has been cleared.\n"
+                        + marker + "\n" + TWO_REVIEWERS_CLEARED_MARKER);
+                return Stream.concat(comments.stream(), Stream.of(reviewersClearedComment)).toList();
+            }
+        } else {
+            // Normal PR
+            if (Collections.disjoint(pr.labelNames(), bot.twoReviewersLabels())) {
+                return comments;
+            }
 
-        var matchingLabelsList = matchingLabels.stream()
-                .map(label -> "`" + label + "`")
-                .collect(Collectors.joining(", "));
+            if (latestTwoReviewersComment.isEmpty() || latestTwoReviewersComment.get().body().contains(TWO_REVIEWERS_CLEARED_MARKER)) {
+                var matchingLabels = pr.labelNames().stream()
+                        .filter(label -> bot.twoReviewersLabels().contains(label))
+                        .sorted()
+                        .toList();
+                var labelsNoun = matchingLabels.size() == 1 ? "this label" : "these labels";
 
-        var markerComment = pr.addComment(
-                "The total number of required reviews for this PR has been set to 2 based on the presence of " +
-                labelsNoun + ": " + matchingLabelsList + ". " +
-                "This can be overridden with the `/reviewers` command.\n" +
-                marker);
-        return Stream.concat(comments.stream(), Stream.of(markerComment)).toList();
+                var marker = ReviewersTracker.setReviewersMarker(2, "authors", "bot");
+
+                var matchingLabelsList = matchingLabels.stream()
+                        .map(label -> "`" + label + "`")
+                        .collect(Collectors.joining(", "));
+
+                var reviewersAppliedComment = pr.addComment(
+                        "The total number of required reviews for this PR has been set to 2 based on the presence of " +
+                                labelsNoun + ": " + matchingLabelsList + ". " +
+                                "This can be overridden with the `/reviewers` command.\n" +
+                                marker + "\n" + TWO_REVIEWERS_APPLIED_MARKER);
+                return Stream.concat(comments.stream(), Stream.of(reviewersAppliedComment)).toList();
+            }
+        }
+        return comments;
     }
 
     /**

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -53,7 +53,6 @@ import java.util.stream.Stream;
 import static org.openjdk.skara.bots.common.PullRequestConstants.*;
 import static org.openjdk.skara.bots.pr.CheckRun.MERGE_READY_MARKER;
 import static org.openjdk.skara.bots.pr.CheckRun.PLACEHOLDER_MARKER;
-import static org.openjdk.skara.bots.pr.ReviewersTracker.DEFAULT_SOURCE;
 import static org.openjdk.skara.forge.PullRequestUtils.mergeSourcePattern;
 
 class CheckWorkItem extends PullRequestWorkItem {
@@ -164,14 +163,14 @@ class CheckWorkItem extends PullRequestWorkItem {
         var botUser = pr.repository().forge().currentUser();
         // If there is any user issued reviewers command, don't override it
         var additionalRequiredReviewers = ReviewersTracker.additionalRequiredReviewers(botUser, comments);
-        if (additionalRequiredReviewers.isPresent() && additionalRequiredReviewers.get().source().equals(DEFAULT_SOURCE)) {
+        if (additionalRequiredReviewers.isPresent() && additionalRequiredReviewers.get().source() == ReviewersTracker.Source.USER) {
             return comments;
         }
 
-        var latestTwoReviewersComment = comments.stream()
+        var latestTwoReviewersComment = comments.reversed().stream()
                 .filter(comment -> comment.author().equals(pr.repository().forge().currentUser()))
                 .filter(comment -> comment.body().contains(TWO_REVIEWERS_APPLIED_MARKER) || comment.body().contains(TWO_REVIEWERS_CLEARED_MARKER))
-                .reduce((a, b) -> b);
+                .findFirst();
 
         if (pr.labelNames().contains("backport") || BACKPORT_ISSUE_TITLE_PATTERN.matcher(pr.title()).matches()
                 || BACKPORT_HASH_TITLE_PATTERN.matcher(pr.title()).matches() || PullRequestUtils.isMerge(pr)) {
@@ -181,7 +180,7 @@ class CheckWorkItem extends PullRequestWorkItem {
             } else if (latestTwoReviewersComment.get().body().contains(TWO_REVIEWERS_CLEARED_MARKER)) {
                 return comments;
             } else if (latestTwoReviewersComment.get().body().contains(TWO_REVIEWERS_APPLIED_MARKER)) {
-                var marker = ReviewersTracker.setReviewersMarker(0, "authors", "bot");
+                var marker = ReviewersTracker.setReviewersMarker(0, "authors", ReviewersTracker.Source.BOT);
                 var prType = PullRequestUtils.isMerge(pr) ? "merge" : "backport";
                 var reviewersClearedComment = pr.addComment("This PR is now a " + prType + " PR, so the extra reviewers requirement has been cleared.\n"
                         + marker + "\n" + TWO_REVIEWERS_CLEARED_MARKER);
@@ -200,7 +199,7 @@ class CheckWorkItem extends PullRequestWorkItem {
                         .toList();
                 var labelsNoun = matchingLabels.size() == 1 ? "this label" : "these labels";
 
-                var marker = ReviewersTracker.setReviewersMarker(2, "authors", "bot");
+                var marker = ReviewersTracker.setReviewersMarker(2, "authors", ReviewersTracker.Source.BOT);
 
                 var matchingLabelsList = matchingLabels.stream()
                         .map(label -> "`" + label + "`")

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckWorkItem.java
@@ -53,6 +53,7 @@ import java.util.stream.Stream;
 import static org.openjdk.skara.bots.common.PullRequestConstants.*;
 import static org.openjdk.skara.bots.pr.CheckRun.MERGE_READY_MARKER;
 import static org.openjdk.skara.bots.pr.CheckRun.PLACEHOLDER_MARKER;
+import static org.openjdk.skara.bots.pr.ReviewersTracker.DEFAULT_SOURCE;
 import static org.openjdk.skara.forge.PullRequestUtils.mergeSourcePattern;
 
 class CheckWorkItem extends PullRequestWorkItem {
@@ -163,7 +164,7 @@ class CheckWorkItem extends PullRequestWorkItem {
         var botUser = pr.repository().forge().currentUser();
         // If there is any user issued reviewers command, don't override it
         var additionalRequiredReviewers = ReviewersTracker.additionalRequiredReviewers(botUser, comments);
-        if (additionalRequiredReviewers.isPresent() && additionalRequiredReviewers.get().source().equals("user")) {
+        if (additionalRequiredReviewers.isPresent() && additionalRequiredReviewers.get().source().equals(DEFAULT_SOURCE)) {
             return comments;
         }
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewersTracker.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewersTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,12 +30,13 @@ import java.util.*;
 import java.util.regex.*;
 
 class ReviewersTracker {
+    protected static final String DEFAULT_SOURCE = "user";
     private static final String REVIEWERS_MARKER = "<!-- additional required reviewers id marker (%d) (%s) (%s)-->";
     private static final Pattern REVIEWERS_MARKER_PATTERN = Pattern.compile(
             "<!-- additional required reviewers id marker \\((\\d+)\\) \\((\\w+)\\)(?: \\(([^)]*)\\))?\\s*-->");
 
     static String setReviewersMarker(int numReviewers, String role) {
-        return setReviewersMarker(numReviewers, role, "user");
+        return setReviewersMarker(numReviewers, role, DEFAULT_SOURCE);
     }
 
     static String setReviewersMarker(int numReviewers, String role, String source) {
@@ -101,7 +102,7 @@ class ReviewersTracker {
         private String source;
 
         AdditionalRequiredReviewers(int number, String role) {
-            this(number, role, "user");
+            this(number, role, DEFAULT_SOURCE);
         }
 
         AdditionalRequiredReviewers(int number, String role, String source) {
@@ -135,7 +136,7 @@ class ReviewersTracker {
         var last = reviewersActions.getLast();
         var source = last.group(3);
         if (source == null || source.isBlank()) {
-            source = "user";
+            source = DEFAULT_SOURCE;
         }
         return Optional.of(new AdditionalRequiredReviewers(Integer.parseInt(last.group(1)), last.group(2), source));
     }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewersTracker.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewersTracker.java
@@ -28,15 +28,18 @@ import org.openjdk.skara.jcheck.JCheckConfiguration;
 
 import java.util.*;
 import java.util.regex.*;
-import java.util.stream.Collectors;
 
 class ReviewersTracker {
-    private static final String REVIEWERS_MARKER = "<!-- additional required reviewers id marker (%d) (%s) -->";
+    private static final String REVIEWERS_MARKER = "<!-- additional required reviewers id marker (%d) (%s) (%s)-->";
     private static final Pattern REVIEWERS_MARKER_PATTERN = Pattern.compile(
-            "<!-- additional required reviewers id marker \\((\\d+)\\) \\((\\w+)\\) -->");
+            "<!-- additional required reviewers id marker \\((\\d+)\\) \\((\\w+)\\)(?: \\(([^)]*)\\))?\\s*-->");
 
     static String setReviewersMarker(int numReviewers, String role) {
-        return String.format(REVIEWERS_MARKER, numReviewers, role);
+        return setReviewersMarker(numReviewers, role, "user");
+    }
+
+    static String setReviewersMarker(int numReviewers, String role, String source) {
+        return String.format(REVIEWERS_MARKER, numReviewers, role, source);
     }
 
     static LinkedHashMap<String, Integer> updatedRoleLimits(JCheckConfiguration checkConfiguration, int count, String role) {
@@ -95,10 +98,16 @@ class ReviewersTracker {
     static class AdditionalRequiredReviewers {
         private int number;
         private String role;
+        private String source;
 
         AdditionalRequiredReviewers(int number, String role) {
+            this(number, role, "user");
+        }
+
+        AdditionalRequiredReviewers(int number, String role, String source) {
             this.number = number;
             this.role = role;
+            this.source = source;
         }
 
         int number() {
@@ -108,6 +117,10 @@ class ReviewersTracker {
         String role() {
             return role;
         }
+
+        String source() {
+            return source;
+        }
     }
 
     static Optional<AdditionalRequiredReviewers> additionalRequiredReviewers(HostUser botUser, List<Comment> comments) {
@@ -115,11 +128,15 @@ class ReviewersTracker {
                                        .filter(comment -> comment.author().equals(botUser))
                                        .map(comment -> REVIEWERS_MARKER_PATTERN.matcher(comment.body()))
                                        .filter(Matcher::find)
-                                       .collect(Collectors.toList());
+                                       .toList();
         if (reviewersActions.isEmpty()) {
             return Optional.empty();
         }
         var last = reviewersActions.getLast();
-        return Optional.of(new AdditionalRequiredReviewers(Integer.parseInt(last.group(1)), last.group(2)));
+        var source = last.group(3);
+        if (source == null || source.isBlank()) {
+            source = "user";
+        }
+        return Optional.of(new AdditionalRequiredReviewers(Integer.parseInt(last.group(1)), last.group(2), source));
     }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewersTracker.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/ReviewersTracker.java
@@ -30,7 +30,7 @@ import java.util.*;
 import java.util.regex.*;
 
 class ReviewersTracker {
-    protected static final String DEFAULT_SOURCE = "user";
+    static final Source DEFAULT_SOURCE = Source.USER;
     private static final String REVIEWERS_MARKER = "<!-- additional required reviewers id marker (%d) (%s) (%s)-->";
     private static final Pattern REVIEWERS_MARKER_PATTERN = Pattern.compile(
             "<!-- additional required reviewers id marker \\((\\d+)\\) \\((\\w+)\\)(?: \\(([^)]*)\\))?\\s*-->");
@@ -39,8 +39,8 @@ class ReviewersTracker {
         return setReviewersMarker(numReviewers, role, DEFAULT_SOURCE);
     }
 
-    static String setReviewersMarker(int numReviewers, String role, String source) {
-        return String.format(REVIEWERS_MARKER, numReviewers, role, source);
+    static String setReviewersMarker(int numReviewers, String role, Source source) {
+        return String.format(REVIEWERS_MARKER, numReviewers, role, source.value());
     }
 
     static LinkedHashMap<String, Integer> updatedRoleLimits(JCheckConfiguration checkConfiguration, int count, String role) {
@@ -96,16 +96,38 @@ class ReviewersTracker {
         return updatedLimits;
     }
 
+    enum Source {
+        USER("user"),
+        BOT("bot");
+
+        private final String value;
+
+        Source(String value) {
+            this.value = value;
+        }
+
+        String value() {
+            return value;
+        }
+
+        static Source fromValue(String value) {
+            return Arrays.stream(values())
+                    .filter(source -> source.value.equals(value))
+                    .findFirst()
+                    .orElse(USER);
+        }
+    }
+
     static class AdditionalRequiredReviewers {
         private int number;
         private String role;
-        private String source;
+        private Source source;
 
         AdditionalRequiredReviewers(int number, String role) {
             this(number, role, DEFAULT_SOURCE);
         }
 
-        AdditionalRequiredReviewers(int number, String role, String source) {
+        AdditionalRequiredReviewers(int number, String role, Source source) {
             this.number = number;
             this.role = role;
             this.source = source;
@@ -119,7 +141,7 @@ class ReviewersTracker {
             return role;
         }
 
-        String source() {
+        Source source() {
             return source;
         }
     }
@@ -134,10 +156,10 @@ class ReviewersTracker {
             return Optional.empty();
         }
         var last = reviewersActions.getLast();
-        var source = last.group(3);
-        if (source == null || source.isBlank()) {
-            source = DEFAULT_SOURCE;
-        }
+        var sourceValue = last.group(3);
+        var source = sourceValue == null || sourceValue.isBlank()
+                ? DEFAULT_SOURCE
+                : Source.fromValue(sourceValue);
         return Optional.of(new AdditionalRequiredReviewers(Integer.parseInt(last.group(1)), last.group(2), source));
     }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelerTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelerTests.java
@@ -596,12 +596,96 @@ class LabelerTests {
             pr.addLabel("backport");
             TestBotRunner.runPeriodicItems(labelBot);
             TestBotRunner.runPeriodicItems(labelBot);
-            assertLastCommentContains(pr, "This PR is now a backport or merge PR, so the extra reviewers requirement has been cleared.");
+            assertLastCommentContains(pr, "This PR is now a backport PR, so the extra reviewers requirement has been cleared.");
 
             pr.removeLabel("backport");
             TestBotRunner.runPeriodicItems(labelBot);
             TestBotRunner.runPeriodicItems(labelBot);
             assertLastCommentContains(pr, "The total number of required reviews for this PR has been set to 2 based on the presence of this label: `hotspot`.");
+        }
+    }
+
+    @Test
+    void twoReviewersRuleClearedForMergeStylePR(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var reviewer = credentials.getHostedRepository();
+
+            var labelConfiguration = LabelConfigurationJson.builder()
+                    .addMatchers("hotspot", List.of(Pattern.compile("hotspot.txt")))
+                    .build();
+            var censusBuilder = credentials.getCensusBuilder()
+                    .addAuthor(author.forge().currentUser().id())
+                    .addReviewer(reviewer.forge().currentUser().id());
+            var labelBot = PullRequestBot.newBuilder()
+                    .repo(author)
+                    .censusRepo(censusBuilder.build())
+                    .labelConfiguration(labelConfiguration)
+                    .twoReviewersLabels(Set.of("hotspot"))
+                    .reviewMerge(MergePullRequestReviewConfiguration.ALWAYS)
+                    .build();
+
+            var localRepoFolder = tempFolder.path();
+            var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
+
+            var hotspotFile = localRepoFolder.resolve("hotspot.txt");
+            Files.writeString(hotspotFile, "hotspot");
+            localRepo.add(hotspotFile);
+            var hotspotHash = localRepo.commit("touch hotspot area", "test", "test@test");
+            localRepo.push(hotspotHash, author.authenticatedUrl(), "edit");
+            var otherHash1 = CheckableRepository.appendAndCommit(localRepo, "First change in other",
+                    "First other\n\nReviewed-by: integrationreviewer2");
+            localRepo.push(otherHash1, author.authenticatedUrl(), "other", true);
+
+            var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
+
+            TestBotRunner.runPeriodicItems(labelBot);
+            TestBotRunner.runPeriodicItems(labelBot);
+            assertLastCommentContains(pr, "The total number of required reviews for this PR has been set to 2 based on the presence of this label: `hotspot`.");
+            assertTrue(pr.store().body().contains("2 reviews required"));
+
+            // Convert to Merge Style PR
+            pr.setTitle("Merge " + author.name() + ":other");
+            TestBotRunner.runPeriodicItems(labelBot);
+            TestBotRunner.runPeriodicItems(labelBot);
+            assertLastCommentContains(pr, "This PR is now a merge PR, so the extra reviewers requirement has been cleared.");
+            assertTrue(pr.store().body().contains("1 review required"));
+
+            // Convert back to normal PR
+            pr.setTitle("123: Not a merge PR");
+            TestBotRunner.runPeriodicItems(labelBot);
+            TestBotRunner.runPeriodicItems(labelBot);
+            assertLastCommentContains(pr, "The total number of required reviews for this PR has been set to 2 based on the presence of this label: `hotspot`.");
+            assertTrue(pr.store().body().contains("2 reviews required"));
+
+            // Convert to Merge Style PR again
+            pr.setTitle("Merge " + author.name() + ":other");
+            TestBotRunner.runPeriodicItems(labelBot);
+            TestBotRunner.runPeriodicItems(labelBot);
+            assertLastCommentContains(pr, "This PR is now a merge PR, so the extra reviewers requirement has been cleared.");
+            assertTrue(pr.store().body().contains("1 review required"));
+
+            // Issue a reviewers comment
+            var reviewPR = reviewer.pullRequest(pr.id());
+            reviewPR.addComment("/reviewers 4");
+            TestBotRunner.runPeriodicItems(labelBot);
+            TestBotRunner.runPeriodicItems(labelBot);
+            assertLastCommentContains(pr, "The total number of required reviews for this PR (including the jcheck configuration and the last /reviewers command) is now set to 4");
+            assertTrue(pr.store().body().contains("4 reviews required"));
+
+            //Convert back to normal PR
+            pr.setTitle("123: Not a merge PR");
+            TestBotRunner.runPeriodicItems(labelBot);
+            TestBotRunner.runPeriodicItems(labelBot);
+            // Shouldn't have the two reviewers comment posted
+            assertLastCommentContains(pr, "The total number of required reviews for this PR (including the jcheck configuration and the last /reviewers command) is now set to 4");
+            assertTrue(pr.store().body().contains("4 reviews required"));
         }
     }
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelerTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelerTests.java
@@ -619,7 +619,7 @@ class LabelerTests {
             var comments = pr.comments();
             // Two reviewers requirement should be cleared
             var twoReviewersClearedComment = comments.get(3).body();
-            assertTrue(twoReviewersClearedComment.contains("This PR is now a backport PR, the extra reviewers requirement has been cleared."));
+            assertTrue(twoReviewersClearedComment.contains("This is now a backport PR, the extra reviewers requirement has been cleared."));
             assertTrue(pr.store().body().contains("1 review required"));
             // The bot should reply with a backport message
             var backportComment = comments.get(4).body();
@@ -678,7 +678,7 @@ class LabelerTests {
             // Convert to Merge Style PR
             pr.setTitle("Merge " + author.name() + ":other");
             TestBotRunner.runPeriodicItems(labelBot);
-            assertLastCommentContains(pr, "This PR is now a merge PR, the extra reviewers requirement has been cleared.");
+            assertLastCommentContains(pr, "This is now a merge PR, the extra reviewers requirement has been cleared.");
             assertTrue(pr.store().body().contains("1 review required"));
 
             // Convert back to normal PR
@@ -690,7 +690,7 @@ class LabelerTests {
             // Convert to Merge Style PR again
             pr.setTitle("Merge " + author.name() + ":other");
             TestBotRunner.runPeriodicItems(labelBot);
-            assertLastCommentContains(pr, "This PR is now a merge PR, the extra reviewers requirement has been cleared.");
+            assertLastCommentContains(pr, "This is now a merge PR, the extra reviewers requirement has been cleared.");
             assertTrue(pr.store().body().contains("1 review required"));
 
             // Issue a reviewers comment

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelerTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelerTests.java
@@ -23,6 +23,7 @@
 package org.openjdk.skara.bots.pr;
 
 import org.openjdk.skara.forge.*;
+import org.openjdk.skara.jcheck.ReviewersCheck;
 import org.openjdk.skara.test.*;
 
 import org.junit.jupiter.api.*;
@@ -556,52 +557,80 @@ class LabelerTests {
     @Test
     void twoReviewersRuleClearedForBackportPR(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
-             var tempFolder = new TemporaryDirectory()) {
-            var author = credentials.getHostedRepository();
-            var reviewer = credentials.getHostedRepository();
+             var tempFolder = new TemporaryDirectory(false)) {
 
+            var author = credentials.getHostedRepository();
+            var integrator = credentials.getHostedRepository();
+            var reviewer = credentials.getHostedRepository();
+            var issues = credentials.getIssueProject();
+            var censusBuilder = credentials.getCensusBuilder()
+                    .addCommitter(author.forge().currentUser().id())
+                    .addReviewer(integrator.forge().currentUser().id())
+                    .addReviewer(reviewer.forge().currentUser().id());
             var labelConfiguration = LabelConfigurationJson.builder()
                     .addMatchers("hotspot", List.of(Pattern.compile("hotspot.txt")))
                     .build();
-            var censusBuilder = credentials.getCensusBuilder()
-                    .addAuthor(author.forge().currentUser().id())
-                    .addReviewer(reviewer.forge().currentUser().id());
-            var labelBot = PullRequestBot.newBuilder()
-                    .repo(author)
+            var bot = PullRequestBot.newBuilder()
+                    .repo(integrator)
                     .censusRepo(censusBuilder.build())
+                    .issueProject(issues)
                     .labelConfiguration(labelConfiguration)
                     .twoReviewersLabels(Set.of("hotspot"))
+                    .issuePRMap(new HashMap<>())
+                    .reviewCleanBackport(true)
                     .build();
 
-            var localRepoFolder = tempFolder.path();
-            var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
+            // Populate the projects repository
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
             var masterHash = localRepo.resolve("master").orElseThrow();
             localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
 
-            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            var releaseBranch = localRepo.branch(masterHash, "release");
+            localRepo.checkout(releaseBranch);
+            var newFile = localRepo.root().resolve("hotspot.txt");
+            Files.writeString(newFile, "hello");
+            localRepo.add(newFile);
+            var issue1 = credentials.createIssue(issues, "An issue");
+            var issue1Number = issue1.id().split("-")[1];
+            var originalMessage = issue1Number + ": An issue\n" +
+                    "\n" +
+                    "Reviewed-by: integrationreviewer2";
+            var releaseHash = localRepo.commit(originalMessage, "integrationcommitter1", "integrationcommitter1@openjdk.org");
+            localRepo.push(releaseHash, author.authenticatedUrl(), "refs/heads/release", true);
+
+            // "backport" the new file to the master branch
+            localRepo.checkout(localRepo.defaultBranch());
+            var editBranch = localRepo.branch(masterHash, "edit");
+            localRepo.checkout(editBranch);
+            var newFile2 = localRepo.root().resolve("hotspot.txt");
+            Files.writeString(newFile2, "hello");
+            localRepo.add(newFile2);
+            var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
             localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
+            //var pr = credentials.createPullRequest(author, "master", "edit", "Backport " + releaseHash.hex(), List.of());
+            var pr = credentials.createPullRequest(author, "master", "edit", "Wrong title", List.of("body"));
 
-            var hotspotFile = localRepoFolder.resolve("hotspot.txt");
-            Files.writeString(hotspotFile, "hotspot");
-            localRepo.add(hotspotFile);
-            var hotspotHash = localRepo.commit("touch hotspot area", "test", "test@test");
-            localRepo.push(hotspotHash, author.authenticatedUrl(), "edit");
-
-            var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
-
-            TestBotRunner.runPeriodicItems(labelBot);
-            TestBotRunner.runPeriodicItems(labelBot);
+            TestBotRunner.runPeriodicItems(bot);
+            TestBotRunner.runPeriodicItems(bot);
             assertLastCommentContains(pr, "The total number of required reviews for this PR has been set to 2 based on the presence of this label: `hotspot`.");
+            assertTrue(pr.store().body().contains("2 reviews required"));
 
-            pr.addLabel("backport");
-            TestBotRunner.runPeriodicItems(labelBot);
-            TestBotRunner.runPeriodicItems(labelBot);
-            assertLastCommentContains(pr, "This PR is now a backport PR, so the extra reviewers requirement has been cleared.");
-
-            pr.removeLabel("backport");
-            TestBotRunner.runPeriodicItems(labelBot);
-            TestBotRunner.runPeriodicItems(labelBot);
-            assertLastCommentContains(pr, "The total number of required reviews for this PR has been set to 2 based on the presence of this label: `hotspot`.");
+            // Correct the title
+            pr.setTitle("Backport " + releaseHash.hex());
+            TestBotRunner.runPeriodicItems(bot);
+            TestBotRunner.runPeriodicItems(bot);
+            var comments = pr.comments();
+            // Two reviewers requirement should be cleared
+            var twoReviewersClearedComment = comments.get(3).body();
+            assertTrue(twoReviewersClearedComment.contains("This PR is now a backport PR, so the extra reviewers requirement has been cleared."));
+            assertTrue(pr.store().body().contains("1 review required"));
+            // The bot should reply with a backport message
+            var backportComment = comments.get(4).body();
+            assertTrue(backportComment.contains("This backport pull request has now been updated with issue"));
+            assertTrue(backportComment.contains("<!-- backport " + releaseHash.hex() + " -->"));
+            assertEquals(issue1Number + ": An issue", pr.store().title());
+            assertTrue(pr.store().labelNames().contains("backport"));
+            assertTrue(pr.store().labelNames().contains("clean"));
         }
     }
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelerTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelerTests.java
@@ -554,6 +554,58 @@ class LabelerTests {
     }
 
     @Test
+    void twoReviewersRuleClearedForBackportPR(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var reviewer = credentials.getHostedRepository();
+
+            var labelConfiguration = LabelConfigurationJson.builder()
+                    .addMatchers("hotspot", List.of(Pattern.compile("hotspot.txt")))
+                    .build();
+            var censusBuilder = credentials.getCensusBuilder()
+                    .addAuthor(author.forge().currentUser().id())
+                    .addReviewer(reviewer.forge().currentUser().id());
+            var labelBot = PullRequestBot.newBuilder()
+                    .repo(author)
+                    .censusRepo(censusBuilder.build())
+                    .labelConfiguration(labelConfiguration)
+                    .twoReviewersLabels(Set.of("hotspot"))
+                    .build();
+
+            var localRepoFolder = tempFolder.path();
+            var localRepo = CheckableRepository.init(localRepoFolder, author.repositoryType());
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
+
+            var hotspotFile = localRepoFolder.resolve("hotspot.txt");
+            Files.writeString(hotspotFile, "hotspot");
+            localRepo.add(hotspotFile);
+            var hotspotHash = localRepo.commit("touch hotspot area", "test", "test@test");
+            localRepo.push(hotspotHash, author.authenticatedUrl(), "edit");
+
+            var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
+
+            TestBotRunner.runPeriodicItems(labelBot);
+            TestBotRunner.runPeriodicItems(labelBot);
+            assertLastCommentContains(pr, "The total number of required reviews for this PR has been set to 2 based on the presence of this label: `hotspot`.");
+
+            pr.addLabel("backport");
+            TestBotRunner.runPeriodicItems(labelBot);
+            TestBotRunner.runPeriodicItems(labelBot);
+            assertLastCommentContains(pr, "This PR is now a backport or merge PR, so the extra reviewers requirement has been cleared.");
+
+            pr.removeLabel("backport");
+            TestBotRunner.runPeriodicItems(labelBot);
+            TestBotRunner.runPeriodicItems(labelBot);
+            assertLastCommentContains(pr, "The total number of required reviews for this PR has been set to 2 based on the presence of this label: `hotspot`.");
+        }
+    }
+
+    @Test
     void explicitReviewersCommandWinsOverTwoReviewersLabel(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
              var tempFolder = new TemporaryDirectory()) {

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelerTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/LabelerTests.java
@@ -607,10 +607,8 @@ class LabelerTests {
             localRepo.add(newFile2);
             var editHash = localRepo.commit("Backport", "duke", "duke@openjdk.org");
             localRepo.push(editHash, author.authenticatedUrl(), "refs/heads/edit", true);
-            //var pr = credentials.createPullRequest(author, "master", "edit", "Backport " + releaseHash.hex(), List.of());
             var pr = credentials.createPullRequest(author, "master", "edit", "Wrong title", List.of("body"));
 
-            TestBotRunner.runPeriodicItems(bot);
             TestBotRunner.runPeriodicItems(bot);
             assertLastCommentContains(pr, "The total number of required reviews for this PR has been set to 2 based on the presence of this label: `hotspot`.");
             assertTrue(pr.store().body().contains("2 reviews required"));
@@ -618,11 +616,10 @@ class LabelerTests {
             // Correct the title
             pr.setTitle("Backport " + releaseHash.hex());
             TestBotRunner.runPeriodicItems(bot);
-            TestBotRunner.runPeriodicItems(bot);
             var comments = pr.comments();
             // Two reviewers requirement should be cleared
             var twoReviewersClearedComment = comments.get(3).body();
-            assertTrue(twoReviewersClearedComment.contains("This PR is now a backport PR, so the extra reviewers requirement has been cleared."));
+            assertTrue(twoReviewersClearedComment.contains("This PR is now a backport PR, the extra reviewers requirement has been cleared."));
             assertTrue(pr.store().body().contains("1 review required"));
             // The bot should reply with a backport message
             var backportComment = comments.get(4).body();
@@ -675,20 +672,17 @@ class LabelerTests {
             var pr = credentials.createPullRequest(author, "master", "edit", "This is a pull request");
 
             TestBotRunner.runPeriodicItems(labelBot);
-            TestBotRunner.runPeriodicItems(labelBot);
             assertLastCommentContains(pr, "The total number of required reviews for this PR has been set to 2 based on the presence of this label: `hotspot`.");
             assertTrue(pr.store().body().contains("2 reviews required"));
 
             // Convert to Merge Style PR
             pr.setTitle("Merge " + author.name() + ":other");
             TestBotRunner.runPeriodicItems(labelBot);
-            TestBotRunner.runPeriodicItems(labelBot);
-            assertLastCommentContains(pr, "This PR is now a merge PR, so the extra reviewers requirement has been cleared.");
+            assertLastCommentContains(pr, "This PR is now a merge PR, the extra reviewers requirement has been cleared.");
             assertTrue(pr.store().body().contains("1 review required"));
 
             // Convert back to normal PR
             pr.setTitle("123: Not a merge PR");
-            TestBotRunner.runPeriodicItems(labelBot);
             TestBotRunner.runPeriodicItems(labelBot);
             assertLastCommentContains(pr, "The total number of required reviews for this PR has been set to 2 based on the presence of this label: `hotspot`.");
             assertTrue(pr.store().body().contains("2 reviews required"));
@@ -696,21 +690,18 @@ class LabelerTests {
             // Convert to Merge Style PR again
             pr.setTitle("Merge " + author.name() + ":other");
             TestBotRunner.runPeriodicItems(labelBot);
-            TestBotRunner.runPeriodicItems(labelBot);
-            assertLastCommentContains(pr, "This PR is now a merge PR, so the extra reviewers requirement has been cleared.");
+            assertLastCommentContains(pr, "This PR is now a merge PR, the extra reviewers requirement has been cleared.");
             assertTrue(pr.store().body().contains("1 review required"));
 
             // Issue a reviewers comment
             var reviewPR = reviewer.pullRequest(pr.id());
             reviewPR.addComment("/reviewers 4");
             TestBotRunner.runPeriodicItems(labelBot);
-            TestBotRunner.runPeriodicItems(labelBot);
             assertLastCommentContains(pr, "The total number of required reviews for this PR (including the jcheck configuration and the last /reviewers command) is now set to 4");
             assertTrue(pr.store().body().contains("4 reviews required"));
 
             //Convert back to normal PR
             pr.setTitle("123: Not a merge PR");
-            TestBotRunner.runPeriodicItems(labelBot);
             TestBotRunner.runPeriodicItems(labelBot);
             // Shouldn't have the two reviewers comment posted
             assertLastCommentContains(pr, "The total number of required reviews for this PR (including the jcheck configuration and the last /reviewers command) is now set to 4");


### PR DESCRIPTION
In [SKARA-2573](https://bugs.openjdk.org/browse/SKARA-2573), I implemented a feature that if the PR touches certain areas, the reviewers count will be automatically increased to two.

Now, this requirement also applies to Merge/Backport PRs, but it shouldn't.

If there is any user issued reviewers command, then the two reviewers check will be skipped.
The two reviewers requirement will be applied to PRs if the PR touches certain areas.
If the PR is converted to a Merge/Backport PR later, the requirement will be cleared.
If the PR is converted back to a normal PR again, the requirement will be added back.

I didn’t think it will be too complicated, but somehow, I made the logic a bit complicated…

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2708](https://bugs.openjdk.org/browse/SKARA-2708): Two-Reviewers requirement shouldn't apply to Backport/Merge PRs (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1768/head:pull/1768` \
`$ git checkout pull/1768`

Update a local copy of the PR: \
`$ git checkout pull/1768` \
`$ git pull https://git.openjdk.org/skara.git pull/1768/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1768`

View PR using the GUI difftool: \
`$ git pr show -t 1768`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1768.diff">https://git.openjdk.org/skara/pull/1768.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1768#issuecomment-4220438175)
</details>
