### PR TITLE
2709: Trailer config support for list of values

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
@@ -22,7 +22,6 @@
  */
 package org.openjdk.skara.bots.pr;
 
-import java.util.stream.Stream;
 import org.openjdk.skara.bot.*;
 import org.openjdk.skara.forge.*;
 import org.openjdk.skara.issuetracker.IssueProject;
@@ -335,6 +334,8 @@ public class PullRequestBotFactory implements BotFactory {
                         } else {
                             patternList = List.of(Pattern.compile(values.asString()));
                         }
+                        // default type is "single"
+                        var type = TrailerCommand.TrailerType.fromString(js.contains("type") ? js.get("type").asString() : "single");
                         JSONValue jsonAlias = js.get("alias");
                         String alias;
                         if (jsonAlias == null) {
@@ -345,6 +346,7 @@ public class PullRequestBotFactory implements BotFactory {
                         return new TrailerCommand.TrailerConfig(js.get("key").asString(),
                                 alias,
                                 js.get("description").asString(),
+                                type,
                                 patternList);
                     })
                     .toList();

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/TrailerCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/TrailerCommand.java
@@ -105,7 +105,7 @@ public class TrailerCommand implements CommandHandler {
     private static boolean isValidValue(TrailerConfig config, String value) {
         return switch (config.type()) {
             case SINGLE -> matchesAnyPattern(value, config.values());
-            case LIST -> Arrays.stream(value.split(","))
+            case LIST -> Arrays.stream(value.split(",", -1))
                     .map(String::trim)
                     .allMatch(item -> !item.isEmpty() && matchesAnyPattern(item, config.values()));
         };

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/TrailerCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/TrailerCommand.java
@@ -23,6 +23,7 @@
 package org.openjdk.skara.bots.pr;
 
 import java.io.PrintWriter;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.regex.Pattern;
@@ -32,7 +33,21 @@ import org.openjdk.skara.issuetracker.Comment;
 import static org.openjdk.skara.bots.common.CommandNameEnum.trailer;
 
 public class TrailerCommand implements CommandHandler {
-    public record TrailerConfig(String key, String alias, String description, List<Pattern> values) {}
+    public enum TrailerType {
+        SINGLE,
+        LIST;
+
+        static TrailerType fromString(String value) {
+            return switch (value) {
+                case "single" -> SINGLE;
+                case "list" -> LIST;
+                default -> throw new IllegalArgumentException("Unknown trailer type: " + value
+                        + ", expected one of: single, list");
+            };
+        }
+    }
+
+    public record TrailerConfig(String key, String alias, String description, TrailerType type, List<Pattern> values) {}
 
     private static final Pattern COMMAND_PATTERN = Pattern.compile(
             "^(?:(set)\\s+([\\p{Alnum}-]+) (.+)?|(remove)\\s+([\\p{Alnum}-]+))$");
@@ -75,7 +90,25 @@ public class TrailerCommand implements CommandHandler {
                 reply.println("- Alias: " + trailerConfig.alias);
             }
             reply.println("- Description: " + trailerConfig.description);
+            reply.println("- Type: " + trailerConfig.type);
+            reply.println("- Valid value pattern(s):");
+            for (Pattern pattern : trailerConfig.values()) {
+                reply.println("  - `" + pattern.pattern() + "`");
+            }
         }
+    }
+
+    private static boolean matchesAnyPattern(String value, List<Pattern> patterns) {
+        return patterns.stream().anyMatch(p -> p.matcher(value).matches());
+    }
+
+    private static boolean isValidValue(TrailerConfig config, String value) {
+        return switch (config.type()) {
+            case SINGLE -> matchesAnyPattern(value, config.values());
+            case LIST -> Arrays.stream(value.split(","))
+                    .map(String::trim)
+                    .allMatch(item -> !item.isEmpty() && matchesAnyPattern(item, config.values()));
+        };
     }
 
     @Override
@@ -98,13 +131,17 @@ public class TrailerCommand implements CommandHandler {
             if (config.isPresent()) {
                 var configKey = config.get().key();
                 var value = matcher.group(3);
-                if (config.get().values().stream()
-                        .anyMatch(p -> p.matcher(value).matches())) {
+                if (isValidValue(config.get(), value)) {
                     reply.println(Trailers.setTrailerMarker(configKey, value));
                     reply.println("Trailer `" + configKey + "` with value `" + value + "` successfully set.");
                 } else {
-                    reply.println("Trailer value `" + value + "` for trailer `" + configKey
-                            + "` does not match any valid value pattern:");
+                    if (config.get().type() == TrailerType.LIST) {
+                        reply.println("Trailer value `" + value + "` for trailer `" + configKey
+                                + "` does not match any valid value pattern. Each list item must match one of:");
+                    } else {
+                        reply.println("Trailer value `" + value + "` for trailer `" + configKey
+                                + "` does not match any valid value pattern:");
+                    }
                     for (Pattern pattern : config.get().values()) {
                         reply.println("- `" + pattern.pattern() + "`");
                     }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestBotFactoryTest.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestBotFactoryTest.java
@@ -22,7 +22,6 @@
  */
 package org.openjdk.skara.bots.pr;
 
-import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
 import org.openjdk.skara.json.JWCC;
 import org.openjdk.skara.test.*;
@@ -69,6 +68,7 @@ class PullRequestBotFactoryTest {
                           "key": "global-trailer",
                           "alias": "global",
                           "description": "Example global trailer",
+                          "type": "single",
                           "values": "foo.*"
                         }
                       ],
@@ -171,7 +171,8 @@ class PullRequestBotFactoryTest {
                           "trailers": [
                             {
                               "key": "trailer-1",
-                              "description": "Example repo specific trailer"
+                              "description": "Example repo specific trailer",
+                              "type": "list",
                               "values": [
                                 "foo",
                                 "bar"
@@ -227,6 +228,7 @@ class PullRequestBotFactoryTest {
             assertEquals("global-trailer", trailerConfig.key());
             assertEquals("global", trailerConfig.alias());
             assertEquals("Example global trailer", trailerConfig.description());
+            assertEquals(TrailerCommand.TrailerType.SINGLE, trailerConfig.type());
             assertEquals("foo.*", trailerConfig.values().getFirst().pattern());
 
             var pullRequestBot5 = (PullRequestBot) bots.stream()
@@ -283,6 +285,7 @@ class PullRequestBotFactoryTest {
             assertEquals("trailer-1", trailerConfig1.key());
             assertNull(trailerConfig1.alias());
             assertEquals("Example repo specific trailer", trailerConfig1.description());
+            assertEquals(TrailerCommand.TrailerType.LIST, trailerConfig1.type());
             assertEquals("foo", trailerConfig1.values().getFirst().pattern());
             assertEquals("bar", trailerConfig1.values().get(1).pattern());
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/TrailersTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/TrailersTests.java
@@ -193,6 +193,13 @@ public class TrailersTests {
             assertTrue(reply.toString().contains("does not match any valid value pattern"), reply.toString());
             assertTrue(reply.toString().contains("- `foo-[0-9]`"), reply.toString());
             assertTrue(reply.toString().contains("- `bar-[0-9]`"), reply.toString());
+
+            command = new CommandInvocation("2", author, new TrailerCommand(), "trailer", "set Trailer-1 foo-1,", null);
+            reply = new StringWriter();
+            new TrailerCommand().handle(prBot, pr, null, null, command, null, new PrintWriter(reply));
+            assertTrue(reply.toString().contains("does not match any valid value pattern"), reply.toString());
+            assertTrue(reply.toString().contains("- `foo-[0-9]`"), reply.toString());
+            assertTrue(reply.toString().contains("- `bar-[0-9]`"), reply.toString());
         }
     }
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/TrailersTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/TrailersTests.java
@@ -131,7 +131,7 @@ public class TrailersTests {
                     .repo(repo)
                     .trailerConfigs(List.of(
                             new TrailerCommand.TrailerConfig("Trailer-1", "1", "Trailer description",
-                                    List.of(Pattern.compile(".*")))))
+                                    TrailerCommand.TrailerType.SINGLE, List.of(Pattern.compile(".*")))))
                     .build();
             var author = new HostUser.Builder().id("17").build();
             var pr = new TestPullRequest(new TestPullRequestStore(null, author, null, List.of(), repo, null, null, false), repo);
@@ -145,6 +145,58 @@ public class TrailersTests {
     }
 
     @Test
+    public void commandSetListTypeValid(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo)) {
+            var repo = (TestHostedRepository) credentials.getHostedRepository(FAKE_REPO);
+            var prBot = PullRequestBot.newBuilder()
+                    .repo(repo)
+                    .trailerConfigs(List.of(
+                            new TrailerCommand.TrailerConfig("Trailer-1", "1", "Trailer description",
+                                    TrailerCommand.TrailerType.LIST,
+                                    List.of(Pattern.compile("foo-[0-9]"), Pattern.compile("bar-[0-9]")))))
+                    .build();
+            var author = new HostUser.Builder().id("17").build();
+            var pr = new TestPullRequest(new TestPullRequestStore(null, author, null, List.of(), repo, null, null, false), repo);
+            var command = new CommandInvocation("1", author, new TrailerCommand(), "trailer", "set Trailer-1 foo-1, bar-2", null);
+
+            var reply = new StringWriter();
+            new TrailerCommand().handle(prBot, pr, null, null, command, null, new PrintWriter(reply));
+
+            assertTrue(reply.toString().contains("Trailer `Trailer-1` with value `foo-1, bar-2` successfully set"), reply.toString());
+
+            command = new CommandInvocation("2", author, new TrailerCommand(), "trailer", "set Trailer-1 bar-3", null);
+            reply = new StringWriter();
+            new TrailerCommand().handle(prBot, pr, null, null, command, null, new PrintWriter(reply));
+
+            assertTrue(reply.toString().contains("Trailer `Trailer-1` with value `bar-3` successfully set"), reply.toString());
+        }
+    }
+
+    @Test
+    public void commandSetListTypeInvalid(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo)) {
+            var repo = (TestHostedRepository) credentials.getHostedRepository(FAKE_REPO);
+            var prBot = PullRequestBot.newBuilder()
+                    .repo(repo)
+                    .trailerConfigs(List.of(
+                            new TrailerCommand.TrailerConfig("Trailer-1", "1", "Trailer description",
+                                    TrailerCommand.TrailerType.LIST,
+                                    List.of(Pattern.compile("foo-[0-9]"), Pattern.compile("bar-[0-9]")))))
+                    .build();
+            var author = new HostUser.Builder().id("17").build();
+            var pr = new TestPullRequest(new TestPullRequestStore(null, author, null, List.of(), repo, null, null, false), repo);
+            var command = new CommandInvocation("1", author, new TrailerCommand(), "trailer", "set Trailer-1 foo-1, bar-b", null);
+
+            var reply = new StringWriter();
+            new TrailerCommand().handle(prBot, pr, null, null, command, null, new PrintWriter(reply));
+
+            assertTrue(reply.toString().contains("does not match any valid value pattern"), reply.toString());
+            assertTrue(reply.toString().contains("- `foo-[0-9]`"), reply.toString());
+            assertTrue(reply.toString().contains("- `bar-[0-9]`"), reply.toString());
+        }
+    }
+
+    @Test
     public void commandInvalidValue(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo)) {
             var repo = (TestHostedRepository) credentials.getHostedRepository(FAKE_REPO);
@@ -152,7 +204,7 @@ public class TrailersTests {
                     .repo(repo)
                     .trailerConfigs(List.of(
                             new TrailerCommand.TrailerConfig("Trailer-1", "1", "Trailer description",
-                                    List.of(Pattern.compile("foo")))))
+                                    TrailerCommand.TrailerType.SINGLE, List.of(Pattern.compile("foo")))))
                     .build();
             var author = new HostUser.Builder().id("17").build();
             var pr = new TestPullRequest(new TestPullRequestStore(null, author, null, List.of(), repo, null, null, false), repo);
@@ -174,7 +226,7 @@ public class TrailersTests {
                     .repo(repo)
                     .trailerConfigs(List.of(
                             new TrailerCommand.TrailerConfig("Trailer-1", "1", "Trailer description",
-                                    List.of(Pattern.compile(".*")))))
+                                    TrailerCommand.TrailerType.SINGLE, List.of(Pattern.compile(".*")))))
                     .build();
             var author = new HostUser.Builder().id("17").build();
             var pr = new TestPullRequest(new TestPullRequestStore(null, author, null, List.of(), repo, null, null, false), repo);
@@ -195,7 +247,7 @@ public class TrailersTests {
                     .repo(repo)
                     .trailerConfigs(List.of(
                             new TrailerCommand.TrailerConfig("Trailer-1", "1", "Trailer description",
-                                    List.of(Pattern.compile(".*")))))
+                                    TrailerCommand.TrailerType.SINGLE, List.of(Pattern.compile(".*")))))
                     .build();
             var author = new HostUser.Builder().id("17").username("author").build();
             var otherUser = new HostUser.Builder().id("4711").username("other").build();
@@ -217,7 +269,7 @@ public class TrailersTests {
                     .repo(repo)
                     .trailerConfigs(List.of(
                             new TrailerCommand.TrailerConfig("Trailer-1", "1", "Trailer description",
-                                    List.of(Pattern.compile(".*")))))
+                                    TrailerCommand.TrailerType.SINGLE, List.of(Pattern.compile(".*")))))
                     .build();
             var author = new HostUser.Builder().id("17").username("author").build();
             var pr = new TestPullRequest(new TestPullRequestStore(null, author, null, List.of(), repo, null, null, false), repo);
@@ -240,7 +292,7 @@ public class TrailersTests {
                     .repo(repo)
                     .trailerConfigs(List.of(
                             new TrailerCommand.TrailerConfig("Trailer-1", "1", "Trailer description",
-                                    List.of(Pattern.compile(".*")))))
+                                    TrailerCommand.TrailerType.SINGLE, List.of(Pattern.compile(".*")))))
                     .build();
             var author = new HostUser.Builder().id("17").username("author").build();
             var pr = new TestPullRequest(new TestPullRequestStore(null, author, null, List.of(), repo, null, null, false), repo);
@@ -284,7 +336,7 @@ public class TrailersTests {
                     .repo(repo)
                     .trailerConfigs(List.of(
                             new TrailerCommand.TrailerConfig("Trailer-1", "1", "Trailer description",
-                                    List.of(Pattern.compile(".*")))))
+                                    TrailerCommand.TrailerType.SINGLE, List.of(Pattern.compile(".*")))))
                     .build();
             var author = new HostUser.Builder().id("17").username("author").build();
             var pr = new TestPullRequest(new TestPullRequestStore(null, author, null, List.of(), repo, null, null, false), repo);
@@ -307,7 +359,7 @@ public class TrailersTests {
                     .repo(repo)
                     .trailerConfigs(List.of(
                             new TrailerCommand.TrailerConfig("Trailer-1", "1", "Trailer description",
-                                    List.of(Pattern.compile(".*")))))
+                                    TrailerCommand.TrailerType.SINGLE, List.of(Pattern.compile(".*")))))
                     .build();
             var author = new HostUser.Builder().id("17").username("author").build();
             var pr = new TestPullRequest(new TestPullRequestStore(null, author, null, List.of(), repo, null, null, false), repo);
@@ -328,9 +380,9 @@ public class TrailersTests {
                     .repo(repo)
                     .trailerConfigs(List.of(
                             new TrailerCommand.TrailerConfig("Trailer-1", "1", "Trailer description",
-                                    List.of(Pattern.compile(".*"))),
+                                    TrailerCommand.TrailerType.SINGLE, List.of(Pattern.compile(".*"))),
                             new TrailerCommand.TrailerConfig("Trailer-2", "2", "Trailer description",
-                                    List.of(Pattern.compile(".*")))))
+                                    TrailerCommand.TrailerType.SINGLE, List.of(Pattern.compile(".*")))))
                     .build();
             var author = new HostUser.Builder().id("17").username("author").build();
             var pr = new TestPullRequest(new TestPullRequestStore(null, author, null, List.of(), repo, null, null, false), repo);
@@ -373,9 +425,9 @@ public class TrailersTests {
                     .repo(repo)
                     .trailerConfigs(List.of(
                             new TrailerCommand.TrailerConfig("Trailer-1", "1", "Trailer description",
-                                    List.of(Pattern.compile(".*"))),
+                                    TrailerCommand.TrailerType.SINGLE, List.of(Pattern.compile(".*"))),
                             new TrailerCommand.TrailerConfig("Trailer-2", "2", "Trailer description",
-                                    List.of(Pattern.compile(".*")))))
+                                    TrailerCommand.TrailerType.SINGLE, List.of(Pattern.compile(".*")))))
                     .build();
             var author = new HostUser.Builder().id("17").username("author").build();
             var pr = new TestPullRequest(new TestPullRequestStore(null, author, null, List.of(), repo, null, null, false), repo);
@@ -397,9 +449,9 @@ public class TrailersTests {
                     .repo(repo)
                     .trailerConfigs(List.of(
                             new TrailerCommand.TrailerConfig("Trailer-1", "1", "Trailer description",
-                                    List.of(Pattern.compile(".*"))),
+                                    TrailerCommand.TrailerType.SINGLE, List.of(Pattern.compile(".*"))),
                             new TrailerCommand.TrailerConfig("Trailer-2", "2", "Trailer description",
-                                    List.of(Pattern.compile(".*")))))
+                                    TrailerCommand.TrailerType.SINGLE, List.of(Pattern.compile(".*")))))
                     .build();
             var author = new HostUser.Builder().id("17").username("author").build();
             var pr = new TestPullRequest(new TestPullRequestStore(null, author, null, List.of(), repo, null, null, false), repo);
@@ -429,7 +481,7 @@ public class TrailersTests {
                     .censusRepo(censusBuilder.build())
                     .trailerConfigs(List.of(
                             new TrailerCommand.TrailerConfig("Trailer-1", "1", "Trailer description",
-                                    List.of(Pattern.compile(".*value")))))
+                                    TrailerCommand.TrailerType.SINGLE, List.of(Pattern.compile(".*value")))))
                     .build();
 
             // Populate the projects repository


### PR DESCRIPTION
This patch is trying to add list value support for trailer configuration.
As Erik proposed in the issue, I added a new field "type", it takes the values "single" or "list". The "values" field continues to accept either a single string or an array of strings. The difference is that when type is "list", then each item in a comma separated list is matched against any of the regexps found in "values".

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2709](https://bugs.openjdk.org/browse/SKARA-2709): Trailer config support for list of values (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1769/head:pull/1769` \
`$ git checkout pull/1769`

Update a local copy of the PR: \
`$ git checkout pull/1769` \
`$ git pull https://git.openjdk.org/skara.git pull/1769/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1769`

View PR using the GUI difftool: \
`$ git pr show -t 1769`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1769.diff">https://git.openjdk.org/skara/pull/1769.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1769#issuecomment-4329816222)
</details>
