### PR TITLE
2723: Skara bot should print more helpful message when issue title doesn't match the pattern

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestCheckIssueVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -298,8 +298,16 @@ class PullRequestCheckIssueVisitor implements IssueVisitor {
 
     @Override
     public void visit(IssuesIssue issue) {
-        addMessage(issue.check(), "The commit message does not reference any issue. To add an issue reference to this PR, " +
-                "edit the title to be of the format `issue number`: `message`.", issue.severity());
+        if (issue.reason() == IssuesIssue.Reason.INVALID_FORMAT) {
+            var issueReference = issue.issue().orElseThrow();
+            var pattern = issue.pattern().orElseThrow();
+            addMessage(issue.check(), "The commit message references issue `" + issueReference + "`, but that issue reference " +
+                    "does not match the issue format configured for this repository: `" + pattern + "`. " +
+                    "Update the issue reference so the generated commit message matches this format.", issue.severity());
+        } else {
+            addMessage(issue.check(), "The commit message does not reference any issue. To add an issue reference to this PR, " +
+                    "edit the title to be of the format `issue number`: `message`.", issue.severity());
+        }
         setNotReadyForReviewOnError(issue.severity());
     }
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -827,6 +827,57 @@ class CheckTests {
     }
 
     @Test
+    void issuePatternMismatchMessage(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory()) {
+            var author = credentials.getHostedRepository();
+            var reviewer = credentials.getHostedRepository();
+            var issues = credentials.getIssueProject();
+
+            var censusBuilder = credentials.getCensusBuilder()
+                                           .addAuthor(author.forge().currentUser().id())
+                                           .addReviewer(reviewer.forge().currentUser().id());
+            var issuePRMap = new HashMap<String, List<PRRecord>>();
+            var checkBot = PullRequestBot.newBuilder()
+                                         .repo(author)
+                                         .censusRepo(censusBuilder.build())
+                                         .issueProject(issues)
+                                         .issuePRMap(issuePRMap)
+                                         .build();
+
+            var issue = issues.createIssue("My first bug", List.of("A bug"), Map.of());
+            var numericId = issue.id().split("-")[1];
+
+            var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType(), Path.of("appendable.txt"),
+                                                     Set.of("issues"), null);
+            var checkConf = tempFolder.path().resolve(".jcheck/conf");
+            var defaultConf = Files.readString(checkConf);
+            var newConf = defaultConf.replace("[checks \"whitespace\"]",
+                    "[checks \"issues\"]\npattern=^([0-9]{7}): (\\S.*)$\n\n[checks \"whitespace\"]");
+            Files.writeString(checkConf, newConf);
+            localRepo.add(checkConf);
+            var masterHash = localRepo.commit("Configure issue pattern", "testauthor", "ta@none.none");
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+
+            var editHash = CheckableRepository.appendAndCommit(localRepo);
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
+            var pr = credentials.createPullRequest(author, "master", "edit", numericId);
+
+            TestBotRunner.runPeriodicItems(checkBot);
+
+            assertEquals(numericId + ": " + issue.title(), pr.store().title());
+            var check = pr.checks(editHash).get("jcheck");
+            assertEquals(CheckStatus.FAILURE, check.status());
+            var summary = check.summary().orElseThrow();
+            assertTrue(summary.contains("references issue `" + numericId + ": " + issue.title() + "`"));
+            assertTrue(summary.contains("does not match the issue format configured for this repository"));
+            assertTrue(summary.contains("Update the issue reference so the generated commit message matches this format"));
+            assertTrue(summary.contains("^([0-9]{7}): (\\S.*)$"));
+            assertFalse(summary.contains("does not reference any issue"));
+        }
+    }
+
+    @Test
     void issueTitleCutOff(TestInfo testInfo) throws IOException {
         try (var credentials = new HostCredentials(testInfo);
              var tempFolder = new TemporaryDirectory()) {

--- a/cli/src/main/java/org/openjdk/skara/cli/JCheckCLIVisitor.java
+++ b/cli/src/main/java/org/openjdk/skara/cli/JCheckCLIVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -244,7 +244,12 @@ class JCheckCLIVisitor implements IssueVisitor {
 
     public void visit(IssuesIssue i) {
         if (!ignore.contains(i.check().name()) && !isLax) {
-            println(i, "missing reference to JBS issue in commit message");
+            if (i.reason() == IssuesIssue.Reason.INVALID_FORMAT) {
+                println(i, "issue reference '" + i.issue().orElseThrow() +
+                        "' does not match configured pattern '" + i.pattern().orElseThrow() + "'");
+            } else {
+                println(i, "missing reference to JBS issue in commit message");
+            }
             for (var line : i.commit().message()) {
                 System.out.println("> " + line);
             }

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/IssuesCheck.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/IssuesCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,13 +48,14 @@ public class IssuesCheck extends CommitCheck {
         if (conf.checks().issues().required() &&
             (commit.message().isEmpty() || message.issues().isEmpty())) {
             log.finer("issue: no reference to a JBS issue");
-            return iterator(new IssuesIssue(metadata));
+            return iterator(new IssuesIssue(metadata, IssuesIssue.Reason.MISSING, null, null));
         }
 
         var pattern = Pattern.compile(conf.checks().issues().pattern());
         for (var issue : message.issues()) {
             if (!pattern.matcher(issue.toString()).matches()) {
-                return iterator(new IssuesIssue(metadata));
+                log.finer("issue: reference does not match configured pattern: " + issue);
+                return iterator(new IssuesIssue(metadata, IssuesIssue.Reason.INVALID_FORMAT, issue.toString(), conf.checks().issues().pattern()));
             }
         }
 

--- a/jcheck/src/main/java/org/openjdk/skara/jcheck/IssuesIssue.java
+++ b/jcheck/src/main/java/org/openjdk/skara/jcheck/IssuesIssue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,9 +22,35 @@
  */
 package org.openjdk.skara.jcheck;
 
+import java.util.Optional;
+
 public class IssuesIssue extends CommitIssue {
-    IssuesIssue(CommitIssue.Metadata metadata) {
+    public enum Reason {
+        MISSING,
+        INVALID_FORMAT
+    }
+
+    private final Reason reason;
+    private final String issue;
+    private final String pattern;
+
+    IssuesIssue(CommitIssue.Metadata metadata, Reason reason, String issue, String pattern) {
         super(metadata);
+        this.reason = reason;
+        this.issue = issue;
+        this.pattern = pattern;
+    }
+
+    public Reason reason() {
+        return reason;
+    }
+
+    public Optional<String> issue() {
+        return Optional.ofNullable(issue);
+    }
+
+    public Optional<String> pattern() {
+        return Optional.ofNullable(pattern);
     }
 
     @Override
@@ -32,4 +58,3 @@ public class IssuesIssue extends CommitIssue {
         visitor.visit(this);
     }
 }
-

--- a/jcheck/src/test/java/org/openjdk/skara/jcheck/IssuesCheckTests.java
+++ b/jcheck/src/test/java/org/openjdk/skara/jcheck/IssuesCheckTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,8 +35,8 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ArrayList;
+import java.util.Optional;
 import java.time.ZonedDateTime;
-import java.io.IOException;
 
 class IssuesCheckTests {
     private final Utilities utils = new Utilities();
@@ -112,6 +112,7 @@ class IssuesCheckTests {
         assertEquals(message, issue.message());
         assertEquals(Severity.ERROR, issue.severity());
         assertEquals(check.getClass(), issue.check().getClass());
+        assertEquals(IssuesIssue.Reason.MISSING, issue.reason());
     }
 
     @Test
@@ -195,6 +196,9 @@ class IssuesCheckTests {
         assertEquals(message, issue.message());
         assertEquals(Severity.ERROR, issue.severity());
         assertEquals(check.getClass(), issue.check().getClass());
+        assertEquals(IssuesIssue.Reason.INVALID_FORMAT, issue.reason());
+        assertEquals(Optional.of("1234567: A bug"), issue.issue());
+        assertEquals(Optional.of("^(PROJ-[1-9][0-9]+): (\\S.*)$"), issue.pattern());
     }
 
     @Test


### PR DESCRIPTION
For https://github.com/openjdk/valhalla/pull/2411, the bot auto-filled the issue in the PR title and added it to the Issue section, but jcheck still failed.
The actual problem is that the issue title does not match the configured issue pattern.

However, the current error message is misleading:
"The commit message does not reference any issue. To add an issue reference to this PR, edit the title to be of the format issue number: message."

We should make the error clearer by indicating that the referenced issue was found, but its title does not match the expected configuration pattern.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2723](https://bugs.openjdk.org/browse/SKARA-2723): Skara bot should print more helpful message when issue title doesn't match the pattern (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1770/head:pull/1770` \
`$ git checkout pull/1770`

Update a local copy of the PR: \
`$ git checkout pull/1770` \
`$ git pull https://git.openjdk.org/skara.git pull/1770/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1770`

View PR using the GUI difftool: \
`$ git pr show -t 1770`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1770.diff">https://git.openjdk.org/skara/pull/1770.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1770#issuecomment-4480994084)
</details>
