### PR TITLE
2724: Improve logging to include bot field for exceptions

### DIFF
--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
@@ -465,21 +465,23 @@ public class BotRunner {
                 for (var bot : bots) {
                     Instant botStart = Instant.now();
                     try (var ___ = new LogContext("bot", bot.toString())) {
-                        log.fine("Start of checking for periodic items for " + bot);
-                        var items = bot.getPeriodicItems();
-                        for (var item : items) {
-                            submitOrSchedule(item);
+                        try {
+                            log.fine("Start of checking for periodic items for " + bot);
+                            var items = bot.getPeriodicItems();
+                            for (var item : items) {
+                                submitOrSchedule(item);
+                            }
+                        } catch (UncheckedRestException e) {
+                            // Log as WARNING to avoid triggering alarms. Failed REST calls are tracked
+                            // using metrics.
+                            log.log(Level.WARNING, "RestException during periodic items checking: " + e.getMessage(), e);
+                        } catch (RuntimeException e) {
+                            log.log(Level.SEVERE, "Exception during periodic items checking: " + e.getMessage(), e);
+                        } finally {
+                            var duration = Duration.between(botStart, Instant.now());
+                            log.log(Level.FINE, "Checking for periodic items for " + bot + " took " + duration, duration);
+                            PERIODIC_CHECK_TIME.labels(bot.name()).inc(duration.toMillis() / 1_000.0);
                         }
-                    } catch (UncheckedRestException e) {
-                        // Log as WARNING to avoid triggering alarms. Failed REST calls are tracked
-                        // using metrics.
-                        log.log(Level.WARNING, "RestException during periodic items checking: " + e.getMessage(), e);
-                    } catch (RuntimeException e) {
-                        log.log(Level.SEVERE, "Exception during periodic items checking: " + e.getMessage(), e);
-                    } finally {
-                        var duration = Duration.between(botStart, Instant.now());
-                        log.log(Level.FINE, "Checking for periodic items for " + bot + " took " + duration, duration);
-                        PERIODIC_CHECK_TIME.labels(bot.name()).inc(duration.toMillis() / 1_000.0);
                     }
                 }
             } finally {

--- a/bot/src/test/java/org/openjdk/skara/bot/BotRunnerTests.java
+++ b/bot/src/test/java/org/openjdk/skara/bot/BotRunnerTests.java
@@ -278,6 +278,45 @@ class BotRunnerTests {
     }
 
     @Test
+    void periodItemsThrowIncludesBotContext() throws TimeoutException {
+        var errors = new ArrayList<String>();
+        var botContexts = new ArrayList<String>();
+        var log = Logger.getLogger("org.openjdk.skara.bot");
+        var handler = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                if (record.getLevel().equals(Level.SEVERE)) {
+                    errors.add(record.getMessage());
+                    botContexts.add(LogContextMap.get("bot"));
+                }
+            }
+
+            @Override
+            public void flush() {
+            }
+
+            @Override
+            public void close() throws SecurityException {
+            }
+        };
+        log.addHandler(handler);
+        TestBot bot;
+        try {
+            bot = new TestBot(() -> {
+                throw new NullPointerException();
+            });
+
+            new BotRunner(config(), List.of(bot)).runOnce(Duration.ofSeconds(10));
+        } finally {
+            log.removeHandler(handler);
+        }
+
+        assertTrue(errors.stream()
+                .anyMatch(message -> message.equals("Exception during periodic items checking: null")));
+        assertTrue(botContexts.contains(bot.toString()));
+    }
+
+    @Test
     void discardAdditionalBlockedItems() throws TimeoutException {
         var item1 = new TestWorkItem(i -> false, "Item 1");
         var item2 = new TestWorkItem(i -> false, "Item 2");


### PR DESCRIPTION
Currently, from the skara bot logs, we can randomly see "Exception during periodic items checking: null" from different containers, an important field "bot" is missing now. This patch adds the bot field to context when exception is throwing.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2724](https://bugs.openjdk.org/browse/SKARA-2724): Improve logging to include bot field for exceptions (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1771/head:pull/1771` \
`$ git checkout pull/1771`

Update a local copy of the PR: \
`$ git checkout pull/1771` \
`$ git pull https://git.openjdk.org/skara.git pull/1771/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1771`

View PR using the GUI difftool: \
`$ git pr show -t 1771`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1771.diff">https://git.openjdk.org/skara/pull/1771.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1771#issuecomment-4482980208)
</details>
