### PR TITLE
2726: Handle empty response bodies on paginated REST requests

### DIFF
--- a/network/src/main/java/org/openjdk/skara/network/RestRequest.java
+++ b/network/src/main/java/org/openjdk/skara/network/RestRequest.java
@@ -421,6 +421,14 @@ public class RestRequest {
         }
     }
 
+    private void failOnEmptyResponse(HttpResponse<String> response, QueryBuilder queryBuilder) {
+        if (queryBuilder.failOnEmptyResponse && response.body().isBlank()) {
+            throw new UncheckedRestException("Empty response body"
+                    + response.headers().firstValue("Location").map(s -> ", redirect: " + s).orElse(""),
+                    response.statusCode(), response.request());
+        }
+    }
+
     private HttpRequest.Builder createRequest(RequestType requestType, String endpoint, String body,
                                               List<QueryBuilder.Param> params, Map<String, String> headers,
                                               boolean isJSON, String sha256Header, Duration timeout) {
@@ -537,11 +545,7 @@ public class RestRequest {
             return errorTransform.get();
         }
 
-        if (queryBuilder.failOnEmptyResponse && response.body().isBlank()) {
-            throw new UncheckedRestException("Empty response body"
-                    + response.headers().firstValue("Location").map(s -> ", redirect: " + s).orElse(""),
-                    response.statusCode(), request.build());
-        }
+        failOnEmptyResponse(response, queryBuilder);
 
         var nextRequest = nextLinkExtractor.getNextLinkRequest(response);
         if (nextRequest.isEmpty() || queryBuilder.maxPages < 2) {
@@ -563,6 +567,8 @@ public class RestRequest {
             if (errorTransform.isPresent()) {
                 return errorTransform.get();
             }
+
+            failOnEmptyResponse(response, queryBuilder);
 
             nextRequest = nextLinkExtractor.getNextLinkRequest(response);
 

--- a/network/src/test/java/org/openjdk/skara/network/RestRequestTests.java
+++ b/network/src/test/java/org/openjdk/skara/network/RestRequestTests.java
@@ -190,6 +190,17 @@ class RestRequestTests {
     }
 
     @Test
+    void paginationEmptyPageFails() throws IOException {
+        var page1 = "[ { \"a\": 1 } ]";
+        var page2 = "";
+        try (var receiver = new RestReceiver(List.of(page1, page2))) {
+            var request = new RestRequest(receiver.getEndpoint());
+            var exception = assertThrows(UncheckedRestException.class, () -> request.get("/test").execute());
+            assertTrue(exception.getMessage().contains("Empty response body"));
+        }
+    }
+
+    @Test
     void fieldPagination() throws IOException {
         var page1 = "{ \"a\": 1, \"b\": [ 1, 2, 3 ] }";
         var page2 = "{ \"a\": 1, \"b\": [ 4, 5, 6 ] }";


### PR DESCRIPTION
After [SKARA-2724](https://bugs.openjdk.org/browse/SKARA-2724) is deployed, we got the full stack trace of the randomly NullPointerException.

After investigation, I realized that RestRequest currently checks for empty response bodies only on the first page of a request. For paginated requests, a later page can return an empty body and be parsed as JSON null, which then causes a NullPointerException when combinePages tries to merge all pages. The empty response check should also be applied to subsequent paginated responses so the request fails with a clear UncheckedRestException instead of an NPE.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2726](https://bugs.openjdk.org/browse/SKARA-2726): Handle empty response bodies on paginated REST requests (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1772/head:pull/1772` \
`$ git checkout pull/1772`

Update a local copy of the PR: \
`$ git checkout pull/1772` \
`$ git pull https://git.openjdk.org/skara.git pull/1772/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1772`

View PR using the GUI difftool: \
`$ git pr show -t 1772`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1772.diff">https://git.openjdk.org/skara/pull/1772.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1772#issuecomment-4492368454)
</details>
