### PR TITLE
2057: Race in BotRunner

### DIFF
--- a/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotRunner.java
@@ -244,10 +244,10 @@ public class BotRunner {
                     synchronized (executor) {
                         scratchPaths.addLast(scratchPath);
                         done(item);
+                        if (followUpItems != null) {
+                            followUpItems.forEach(BotRunner.this::submitOrSchedule);
+                        }
                     }
-                }
-                if (followUpItems != null) {
-                    followUpItems.forEach(BotRunner.this::submitOrSchedule);
                 }
 
                 synchronized (executor) {


### PR DESCRIPTION
This patch is trying to fix a race in BotRunner.
Previously, done(item) released the executor lock before followUp items were scheduled. That made it possible for drain() to see both active and pending maps as empty.
Now, followUp Items are scheduled before the executor lock is released.

I have run the BotRunnerTests::dependentItems 100 times.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2057](https://bugs.openjdk.org/browse/SKARA-2057): Race in BotRunner (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1774/head:pull/1774` \
`$ git checkout pull/1774`

Update a local copy of the PR: \
`$ git checkout pull/1774` \
`$ git pull https://git.openjdk.org/skara.git pull/1774/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1774`

View PR using the GUI difftool: \
`$ git pr show -t 1774`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1774.diff">https://git.openjdk.org/skara/pull/1774.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1774#issuecomment-4503225395)
</details>
